### PR TITLE
[WIP] Allow multiple targets in an AWS ALB target group attachment

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group_attachment.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_attachment.go
@@ -26,15 +26,41 @@ func resourceAwsAlbTargetGroupAttachment() *schema.Resource {
 			},
 
 			"target_id": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Required: true,
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				Deprecated:    "Use field target instead",
+				ConflictsWith: []string{"target"},
 			},
 
 			"port": {
-				Type:     schema.TypeInt,
-				ForceNew: true,
-				Required: true,
+				Type:          schema.TypeInt,
+				ForceNew:      true,
+				Optional:      true,
+				Deprecated:    "Use field target instead",
+				ConflictsWith: []string{"target"},
+			},
+
+			"target": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"target_id", "port"},
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_id": {
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+						},
+
+						"port": {
+							Type:     schema.TypeInt,
+							ForceNew: true,
+							Required: true,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -45,16 +71,30 @@ func resourceAwsAlbAttachmentCreate(d *schema.ResourceData, meta interface{}) er
 
 	params := &elbv2.RegisterTargetsInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets: []*elbv2.TargetDescription{
-			{
-				Id:   aws.String(d.Get("target_id").(string)),
-				Port: aws.Int64(int64(d.Get("port").(int))),
-			},
-		},
 	}
 
-	log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
-		d.Get("port").(int), d.Get("target_group_arn").(string))
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id:   aws.String(d.Get("target_id").(string)),
+			Port: aws.Int64(int64(d.Get("port").(int))),
+		}
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+
+		targets := d.Get("target").(*schema.Set)
+		for _, target := range targets.List() {
+			tp := target.(map[string]interface{})
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id:   aws.String(tp["target_id"].(string)),
+				Port: aws.Int64(int64(tp["port"].(int))),
+			}
+			params.Targets = append(params.Targets, targetPortToAdd)
+
+		}
+
+	}
 
 	_, err := elbconn.RegisterTargets(params)
 	if err != nil {
@@ -71,12 +111,29 @@ func resourceAwsAlbAttachmentDelete(d *schema.ResourceData, meta interface{}) er
 
 	params := &elbv2.DeregisterTargetsInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets: []*elbv2.TargetDescription{
-			{
-				Id:   aws.String(d.Get("target_id").(string)),
-				Port: aws.Int64(int64(d.Get("port").(int))),
-			},
-		},
+	}
+
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id:   aws.String(d.Get("target_id").(string)),
+			Port: aws.Int64(int64(d.Get("port").(int))),
+		}
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+
+		targets := d.Get("target").(*schema.Set)
+		for _, target := range targets.List() {
+			tp := target.(map[string]interface{})
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id:   aws.String(tp["target_id"].(string)),
+				Port: aws.Int64(int64(tp["port"].(int))),
+			}
+			params.Targets = append(params.Targets, targetPortToAdd)
+
+		}
+
 	}
 
 	_, err := elbconn.DeregisterTargets(params)
@@ -93,15 +150,36 @@ func resourceAwsAlbAttachmentDelete(d *schema.ResourceData, meta interface{}) er
 // target, so there is no work to do beyond ensuring that the target and group still exist.
 func resourceAwsAlbAttachmentRead(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
-	resp, err := elbconn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
+
+	params := &elbv2.DescribeTargetHealthInput{
 		TargetGroupArn: aws.String(d.Get("target_group_arn").(string)),
-		Targets: []*elbv2.TargetDescription{
-			{
-				Id:   aws.String(d.Get("target_id").(string)),
-				Port: aws.Int64(int64(d.Get("port").(int))),
-			},
-		},
-	})
+	}
+
+	if _, ok := d.GetOk("target_id"); ok {
+		targetPortToAdd := &elbv2.TargetDescription{
+			Id:   aws.String(d.Get("target_id").(string)),
+			Port: aws.Int64(int64(d.Get("port").(int))),
+		}
+		params.Targets = append(params.Targets, targetPortToAdd)
+		log.Printf("[INFO] Registering Target %s (%d) with Target Group %s", d.Get("target_id").(string),
+			d.Get("port").(int), d.Get("target_group_arn").(string))
+	} else {
+
+		targets := d.Get("target").(*schema.Set)
+		for _, target := range targets.List() {
+			tp := target.(map[string]interface{})
+			targetPortToAdd := &elbv2.TargetDescription{
+				Id:   aws.String(tp["target_id"].(string)),
+				Port: aws.Int64(int64(tp["port"].(int))),
+			}
+			params.Targets = append(params.Targets, targetPortToAdd)
+
+		}
+
+	}
+
+	resp, err := elbconn.DescribeTargetHealth(params)
+
 	if err != nil {
 		if isTargetGroupNotFound(err) {
 			log.Printf("[WARN] Target group does not exist, removing target attachment %s", d.Id())


### PR DESCRIPTION
#9948 

```
resource "aws_alb_target_group_attachment" "test" {
  target_group_arn = "${aws_alb_target_group.test.arn}"
  targets {
   target_id = "${aws_instance.test.id}"
   port = 80
  }
  targets {
   target_id = "${aws_instance.demo.id}"
   port = 8080
  }
}
resource "aws_instance" "demo" {
  ami = "ami-f701cb97"
  instance_type = "t2.micro"
  subnet_id = "${aws_subnet.subnet.id}"
}
resource "aws_instance" "test" {
  ami = "ami-f701cb97"
  instance_type = "t2.micro"
  subnet_id = "${aws_subnet.subnet.id}"
}
resource "aws_alb_target_group" "test" {
  name = "awsalbtargetgrouptest"
  port = 443
  protocol = "HTTPS"
  vpc_id = "${aws_vpc.test.id}"
  deregistration_delay = 200
  stickiness {
    type = "lb_cookie"
    cookie_duration = 10000
  }
  health_check {
    path = "/health"
    interval = 60
    port = 8081
    protocol = "HTTP"
    timeout = 3
    healthy_threshold = 3
    unhealthy_threshold = 3
    matcher = "200-299"
  }
}
resource "aws_subnet" "subnet" {
  cidr_block = "10.0.1.0/24"
  vpc_id = "${aws_vpc.test.id}"
}
resource "aws_vpc" "test" {
  cidr_block = "10.0.0.0/16"
}
```
This allows adding multiple targets with port to aws_alb_target_group_attachment but this will break existing rules. I am not sure what else we can do here.

P.S i know this code can refactored not well written i will refactor but just to get heads up. 

@stack72 @paddyforan wdyt ?

References:
1) http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-elasticloadbalancingv2-targetgroup.html#cfn-elasticloadbalancingv2-targetgroup-targetattributes
2) https://github.com/aws/aws-sdk-go/blob/master/service/elbv2/examples_test.go#L594-L603