### PR TITLE
provider/aws: Fix panic when passing statuses to aws_acm_certificate

### DIFF
--- a/builtin/providers/aws/data_source_aws_acm_certificate.go
+++ b/builtin/providers/aws/data_source_aws_acm_certificate.go
@@ -40,10 +40,10 @@ func dataSourceAwsAcmCertificateRead(d *schema.ResourceData, meta interface{}) e
 
 	statuses, ok := d.GetOk("statuses")
 	if ok {
-		statusStrings := statuses.([]string)
+		statusStrings := statuses.([]interface{})
 		statusList := make([]*string, len(statusStrings))
 		for i, status := range statusStrings {
-			statusList[i] = aws.String(strings.ToUpper(status))
+			statusList[i] = aws.String(strings.ToUpper(status.(string)))
 		}
 		params.CertificateStatuses = statusList
 	} else {


### PR DESCRIPTION
Fixes #9989

When passing a list of statuses to the acm_certificate data source, we
were trying to cast a schema.TypeList directly to []string

We need to do it via an []interface{} and then cast to string when
ranging over the results. Without this, we get a panic