### PR TITLE
provider/aws: AWS IAM, User and Role allow + in the name

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group.go
+++ b/builtin/providers/aws/resource_aws_iam_group.go
@@ -132,9 +132,9 @@ func resourceAwsIamGroupDelete(d *schema.ResourceData, meta interface{}) error {
 
 func validateAwsIamGroupName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols and equals signs allowed in %q: %q",
+			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs allowed in %q: %q",
 			k, value))
 	}
 	return

--- a/builtin/providers/aws/resource_aws_iam_group_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_test.go
@@ -21,6 +21,7 @@ func TestValidateIamGroupName(t *testing.T) {
 		"test.group",
 		"test.123,group",
 		"testgroup@hashicorp",
+		"test+group@hashicorp.com",
 	}
 	for _, v := range validNames {
 		_, errors := validateAwsIamGroupName(v, "name")

--- a/builtin/providers/aws/resource_aws_iam_user.go
+++ b/builtin/providers/aws/resource_aws_iam_user.go
@@ -216,9 +216,9 @@ func resourceAwsIamUserDelete(d *schema.ResourceData, meta interface{}) error {
 
 func validateAwsIamUserName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9A-Za-z=,.@\-_+]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols and equals signs allowed in %q: %q",
+			"only alphanumeric characters, hyphens, underscores, commas, periods, @ symbols, plus and equals signs allowed in %q: %q",
 			k, value))
 	}
 	return

--- a/builtin/providers/aws/resource_aws_iam_user_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_test.go
@@ -22,6 +22,7 @@ func TestValidateIamUserName(t *testing.T) {
 		"test.user",
 		"test.123,user",
 		"testuser@hashicorp",
+		"test+user@hashicorp.com",
 	}
 	for _, v := range validNames {
 		_, errors := validateAwsIamUserName(v, "name")


### PR DESCRIPTION
Fixes #9985

```
% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestValidateIamUserName'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/09 12:12:42 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestValidateIamUserName
-timeout 120m
=== RUN   TestValidateIamUserName
--- PASS: TestValidateIamUserName (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws0.026s
```