### PR TITLE
Argument for aws_key_pair resource is incorrectly documented as "required"

### DIFF
--- a/website/source/docs/providers/aws/r/key_pair.html.markdown
+++ b/website/source/docs/providers/aws/r/key_pair.html.markdown
@@ -31,8 +31,8 @@ resource "aws_key_pair" "deployer" {
 
 The following arguments are supported:
 
-* `key_name` - (Required) The name for the key pair.
 * `public_key` - (Required) The public key material. 
+* `key_name` - (Optional) The name for the key pair.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Reasoning for docs update 

The [documentation for aws_key_pair](https://www.terraform.io/docs/providers/aws/r/key_pair.html#key_name) resource indicates that the **key_name** argument is required. It is actually optional - omitting that argument will result in an auto-generated key name, prefixed with `terraform-`.

## Relevant Terraform version

Documentation is incorrect on current live site. Behaviour has been tested with Terraform `0.7.9` .