### PR TITLE
provider/azurerm: move ConfigureFunc outside of Provider literal, fixes nil reference

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -107,8 +107,9 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_sql_firewall_rule": resourceArmSqlFirewallRule(),
 			"azurerm_sql_server":        resourceArmSqlServer(),
 		},
-		ConfigureFunc: providerConfigure(p),
 	}
+
+	p.ConfigureFunc = providerConfigure(p)
 
 	return p
 }


### PR DESCRIPTION
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMDnsARecord_basic -timeout 120m
=== RUN   TestAccAzureRMDnsARecord_basic
--- PASS: TestAccAzureRMDnsARecord_basic (91.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	91.994s
```