### PR TITLE
[aws] Expose RDS DB Instance HostedZoneId attribute

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -236,6 +236,11 @@ func resourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"zone_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"status": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -669,7 +674,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if v.Endpoint != nil {
 		d.Set("port", v.Endpoint.Port)
 		d.Set("address", v.Endpoint.Address)
-
+		d.Set("zone_id", v.Endpoint.HostedZoneId)
 		if v.Endpoint.Address != nil && v.Endpoint.Port != nil {
 			d.Set("endpoint",
 				fmt.Sprintf("%s:%d", *v.Endpoint.Address, *v.Endpoint.Port))

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -136,6 +136,7 @@ The following attributes are exported:
 * `status` - The RDS instance status
 * `username` - The master username for the database
 * `storage_encrypted` - Specifies whether the DB instance is encrypted
+* `zone_id` - The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record)
 
 On Oracle instances the following is exported additionally:
 


### PR DESCRIPTION
The RDS API exposes a HostedZoneId through its endpoint property (when doing DescribeDbInstance).

This pull requests makes it available to terraform as an exported attribute so it can be used in route53 for example.