### PR TITLE
[docs] Replace the deprecated atlas resource with data

### DIFF
--- a/website/source/docs/providers/atlas/index.html.markdown
+++ b/website/source/docs/providers/atlas/index.html.markdown
@@ -25,7 +25,7 @@ provider "atlas" {
 }
 
 # Fetch an artifact configuration
-resource "atlas_artifact" "web" {
+data "atlas_artifact" "web" {
     ...
 }
 ```


### PR DESCRIPTION
## Reasoning for docs update

The cli already told me that the atlas resource is deprecated, but when somebody navigates to the atlas provider in the docs, it still shows a deprecated usage example.