### PR TITLE
Documentation Update: launch configuration for aws provider

### DIFF
--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -210,6 +210,7 @@ configuration, resource recreation can be manually triggered by using the
 The following attributes are exported:
 
 * `id` - The ID of the launch configuration.
+* `name` - The name of the launch configuration.
 
 [1]: /docs/providers/aws/r/autoscaling_group.html
 [2]: /docs/configuration/resources.html#lifecycle


### PR DESCRIPTION
Documentation for aws resource aws_launch_configuration in the section Attributes Reference is missing information about attribute "name". But that attribute is used in example on the same document page. Search on the page for:

launch_configuration = "${aws_launch_configuration.as_conf.name}"