### PR TITLE
provider/azurerm: allow updating load balancer sub-resources

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"regexp"
+
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -62,6 +64,61 @@ func TestAccAzureRMLoadBalancerNatPool_removal(t *testing.T) {
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatPoolNotExists(natPoolName, &lb),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerNatPool_update(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natPoolName := fmt.Sprintf("NatPool-%d", ri)
+	natPool2Name := fmt.Sprintf("NatPool-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerNatPool_multiplePools(ri, natPoolName, natPool2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
+					testCheckAzureRMLoadBalancerNatPoolExists(natPool2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_nat_pool.test2", "backend_port", "3390"),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadBalancerNatPool_multiplePoolsUpdate(ri, natPoolName, natPool2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
+					testCheckAzureRMLoadBalancerNatPoolExists(natPool2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_nat_pool.test2", "backend_port", "3391"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerNatPool_duplicate(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natPoolName := fmt.Sprintf("NatPool-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerNatPool_multiplePools(ri, natPoolName, natPoolName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatPoolExists(natPoolName, &lb),
+				),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("A NAT Pool with name %q already exists.", natPoolName)),
 			},
 		},
 	})
@@ -154,4 +211,108 @@ resource "azurerm_lb" "test" {
     }
 }
 `, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMLoadBalancerNatPool_multiplePools(rInt int, natPoolName, natPool2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_pool" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port_start = 80
+  frontend_port_end = 81
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+resource "azurerm_lb_nat_pool" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port_start = 82
+  frontend_port_end = 83
+  backend_port = 3390
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, natPoolName, rInt, natPool2Name, rInt)
+}
+
+func testAccAzureRMLoadBalancerNatPool_multiplePoolsUpdate(rInt int, natPoolName, natPool2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_pool" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port_start = 80
+  frontend_port_end = 81
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+resource "azurerm_lb_nat_pool" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port_start = 82
+  frontend_port_end = 83
+  backend_port = 3391
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, natPoolName, rInt, natPool2Name, rInt)
 }

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"regexp"
+
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -62,6 +64,63 @@ func TestAccAzureRMLoadBalancerNatRule_removal(t *testing.T) {
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerNatRuleNotExists(natRuleName, &lb),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerNatRule_update(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natRuleName := fmt.Sprintf("NatRule-%d", ri)
+	natRule2Name := fmt.Sprintf("NatRule-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerNatRule_multipleRules(ri, natRuleName, natRule2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
+					testCheckAzureRMLoadBalancerNatRuleExists(natRule2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_nat_rule.test2", "frontend_port", "3390"),
+					resource.TestCheckResourceAttr("azurerm_lb_nat_rule.test2", "backend_port", "3390"),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadBalancerNatRule_multipleRulesUpdate(ri, natRuleName, natRule2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
+					testCheckAzureRMLoadBalancerNatRuleExists(natRule2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_nat_rule.test2", "frontend_port", "3391"),
+					resource.TestCheckResourceAttr("azurerm_lb_nat_rule.test2", "backend_port", "3391"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerNatRule_duplicate(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	natRuleName := fmt.Sprintf("NatRule-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerNatRule_multipleRules(ri, natRuleName, natRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerNatRuleExists(natRuleName, &lb),
+				),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("A NAT Rule with name %q already exists.", natRuleName)),
 			},
 		},
 	})
@@ -153,4 +212,104 @@ resource "azurerm_lb" "test" {
     }
 }
 `, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMLoadBalancerNatRule_multipleRules(rInt int, natRuleName, natRule2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+resource "azurerm_lb_nat_rule" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port = 3390
+  backend_port = 3390
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, natRuleName, rInt, natRule2Name, rInt)
+}
+
+func testAccAzureRMLoadBalancerNatRule_multipleRulesUpdate(rInt int, natRuleName, natRule2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_nat_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+resource "azurerm_lb_nat_rule" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Tcp"
+  frontend_port = 3391
+  backend_port = 3391
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, natRuleName, rInt, natRule2Name, rInt)
 }

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -102,17 +102,23 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 
-	_, _, exists = findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
-	if exists {
-		return fmt.Errorf("A Probe with name %q already exists.", d.Get("name").(string))
-	}
-
 	newProbe, err := expandAzureRmLoadBalancerProbe(d, loadBalancer)
 	if err != nil {
 		return errwrap.Wrapf("Error Expanding Probe {{err}}", err)
 	}
 
 	probes := append(*loadBalancer.Properties.Probes, *newProbe)
+
+	existingProbe, existingProbeIndex, exists := findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
+	if exists {
+		if d.Id() == *existingProbe.ID {
+			// this probe is being updated remove old copy from the slice
+			probes = append(probes[:existingProbeIndex], probes[existingProbeIndex+1:]...)
+		} else {
+			return fmt.Errorf("A Probe with name %q already exists.", d.Get("name").(string))
+		}
+	}
+
 	loadBalancer.Properties.Probes = &probes
 	resGroup, loadBalancerName, err := resourceGroupAndLBNameFromId(d.Get("loadbalancer_id").(string))
 	if err != nil {

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"regexp"
+
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -62,6 +64,61 @@ func TestAccAzureRMLoadBalancerProbe_removal(t *testing.T) {
 					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
 					testCheckAzureRMLoadBalancerProbeNotExists(probeName, &lb),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerProbe_update(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	probeName := fmt.Sprintf("probe-%d", ri)
+	probe2Name := fmt.Sprintf("probe-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerProbe_multipleProbes(ri, probeName, probe2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probe2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_probe.test2", "port", "80"),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadBalancerProbe_multipleProbesUpdate(ri, probeName, probe2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probe2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_probe.test2", "port", "8080"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerProbe_duplicate(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	probeName := fmt.Sprintf("probe-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerProbe_multipleProbes(ri, probeName, probeName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
+				),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("A Probe with name %q already exists.", probeName)),
 			},
 		},
 	})
@@ -149,4 +206,90 @@ resource "azurerm_lb" "test" {
     }
 }
 `, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMLoadBalancerProbe_multipleProbes(rInt int, probeName, probe2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_probe" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  port = 22
+}
+
+resource "azurerm_lb_probe" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  port = 80
+}
+`, rInt, rInt, rInt, rInt, probeName, probe2Name)
+}
+
+func testAccAzureRMLoadBalancerProbe_multipleProbesUpdate(rInt int, probeName, probe2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_probe" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  port = 22
+}
+
+resource "azurerm_lb_probe" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  port = 8080
+}
+`, rInt, rInt, rInt, rInt, probeName, probe2Name)
 }

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"testing"
 
+	"regexp"
+
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -144,6 +146,82 @@ func TestAccAzureRMLoadBalancerRule_inconsistentReads(t *testing.T) {
 					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
 					testCheckAzureRMLoadBalancerProbeExists(probeName, &lb),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerRule_update(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+	lbRule2Name := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	lbRuleID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
+		subscriptionID, ri, ri, lbRuleName)
+
+	lbRule2ID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
+		subscriptionID, ri, ri, lbRule2Name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerRule_multipleRules(ri, lbRuleName, lbRule2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRule2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test", "id", lbRuleID),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test2", "id", lbRule2ID),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test2", "frontend_port", "3390"),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test2", "backend_port", "3390"),
+				),
+			},
+			{
+				Config: testAccAzureRMLoadBalancerRule_multipleRulesUpdate(ri, lbRuleName, lbRule2Name),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRule2Name, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test", "id", lbRuleID),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test2", "id", lbRule2ID),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test2", "frontend_port", "3391"),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test2", "backend_port", "3391"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMLoadBalancerRule_duplicateRules(t *testing.T) {
+	var lb network.LoadBalancer
+	ri := acctest.RandInt()
+	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+
+	subscriptionID := os.Getenv("ARM_SUBSCRIPTION_ID")
+	lbRuleID := fmt.Sprintf(
+		"/subscriptions/%s/resourceGroups/acctestrg-%d/providers/Microsoft.Network/loadBalancers/arm-test-loadbalancer-%d/loadBalancingRules/%s",
+		subscriptionID, ri, ri, lbRuleName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMLoadBalancerRule_multipleRules(ri, lbRuleName, lbRuleName),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMLoadBalancerExists("azurerm_lb.test", &lb),
+					testCheckAzureRMLoadBalancerRuleExists(lbRuleName, &lb),
+					resource.TestCheckResourceAttr("azurerm_lb_rule.test", "id", lbRuleID),
+				),
+				ExpectError: regexp.MustCompile(fmt.Sprintf("A LoadBalancer Rule with name %q already exists.", lbRuleName)),
 			},
 		},
 	})
@@ -290,4 +368,104 @@ resource "azurerm_lb_rule" "test" {
   frontend_ip_configuration_name = "one-%d"
 }
 `, rInt, rInt, rInt, rInt, backendPoolName, probeName, lbRuleName, rInt)
+}
+
+func testAccAzureRMLoadBalancerRule_multipleRules(rInt int, lbRuleName, lbRule2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Udp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+resource "azurerm_lb_rule" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Udp"
+  frontend_port = 3390
+  backend_port = 3390
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
+}
+
+func testAccAzureRMLoadBalancerRule_multipleRulesUpdate(rInt int, lbRuleName, lbRule2Name string) string {
+	return fmt.Sprintf(`
+resource "azurerm_resource_group" "test" {
+    name = "acctestrg-%d"
+    location = "West US"
+}
+
+resource "azurerm_public_ip" "test" {
+    name = "test-ip-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+    name = "arm-test-loadbalancer-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    frontend_ip_configuration {
+      name = "one-%d"
+      public_ip_address_id = "${azurerm_public_ip.test.id}"
+    }
+}
+
+resource "azurerm_lb_rule" "test" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Udp"
+  frontend_port = 3389
+  backend_port = 3389
+  frontend_ip_configuration_name = "one-%d"
+}
+
+resource "azurerm_lb_rule" "test2" {
+  location = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id = "${azurerm_lb.test.id}"
+  name = "%s"
+  protocol = "Udp"
+  frontend_port = 3391
+  backend_port = 3391
+  frontend_ip_configuration_name = "one-%d"
+}
+
+`, rInt, rInt, rInt, rInt, lbRuleName, rInt, lbRule2Name, rInt)
 }


### PR DESCRIPTION
* check if rule is being updated rather than assuming created
* added test to cover guard against multiple rules with the same name

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run "TestAccAzureRMLoadBalancerRule_" -timeout 120m
=== RUN   TestAccAzureRMLoadBalancerRule_basic
--- PASS: TestAccAzureRMLoadBalancerRule_basic (157.45s)
=== RUN   TestAccAzureRMLoadBalancerRule_removal
--- PASS: TestAccAzureRMLoadBalancerRule_removal (163.67s)
=== RUN   TestAccAzureRMLoadBalancerRule_inconsistentReads
--- PASS: TestAccAzureRMLoadBalancerRule_inconsistentReads (150.00s)
=== RUN   TestAccAzureRMLoadBalancerRule_update
--- PASS: TestAccAzureRMLoadBalancerRule_update (164.20s)
=== RUN   TestAccAzureRMLoadBalancerRule_duplicateRules
--- PASS: TestAccAzureRMLoadBalancerRule_duplicateRules (137.51s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	772.846s
```