### PR TITLE
provider/aws: Validate `effect` in aws_iam_policy_document data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_iam_policy_document.go
+++ b/builtin/providers/aws/data_source_aws_iam_policy_document.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+
 	"encoding/json"
 	"strings"
 
@@ -41,6 +43,15 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "Allow",
+							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
+								switch v.(string) {
+								case "Allow", "Deny":
+									return
+								default:
+									es = append(es, fmt.Errorf("%q must be either \"Allow\" or \"Deny\"", k))
+									return
+								}
+							},
 						},
 						"actions":        setOfString,
 						"not_actions":    setOfString,


### PR DESCRIPTION
AWS allows only the case-sensitive strings `Allow` and `Deny` to appear in the `Effect` fields of IAM policy documents. Catch deviations from this, including mis-casing, before hitting the API and generating an error (the error is a generic 400 and doesn't indicate what part of the policy doc is invalid).