### PR TITLE
terraform: when returning a raw attribute value, use hil conversion

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -404,7 +404,8 @@ func (i *Interpolater) computeResourceVariable(
 	}
 
 	if attr, ok := r.Primary.Attributes[v.Field]; ok {
-		return &ast.Variable{Type: ast.TypeString, Value: attr}, nil
+		v, err := hil.InterfaceToVariable(attr)
+		return &v, err
 	}
 
 	// computed list or map attribute

--- a/vendor/github.com/hashicorp/hil/convert.go
+++ b/vendor/github.com/hashicorp/hil/convert.go
@@ -55,7 +55,7 @@ func InterfaceToVariable(input interface{}) (ast.Variable, error) {
 	if err := hilMapstructureWeakDecode(input, &stringVal); err == nil {
 		// Special case the unknown value to turn into "unknown"
 		if stringVal == UnknownValue {
-			return ast.Variable{Type: ast.TypeUnknown}, nil
+			return ast.Variable{Value: UnknownValue, Type: ast.TypeUnknown}, nil
 		}
 
 		// Otherwise return the string value

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1412,10 +1412,10 @@
 			"revisionTime": "2016-11-09T22:51:35Z"
 		},
 		{
-			"checksumSHA1": "mZhRldYjh9MAXzdi3zihMX0A/JU=",
+			"checksumSHA1": "PjLBj8sicHOz2ZzuaMTPZ09OuFs=",
 			"path": "github.com/hashicorp/hil",
-			"revision": "ce4ab742a9dd2bb6e55050337333b2c56666e5a0",
-			"revisionTime": "2016-10-27T15:25:34Z"
+			"revision": "a69e0a85dd050184c00f6080fce138f2dadb1a4c",
+			"revisionTime": "2016-11-11T01:09:07Z"
 		},
 		{
 			"checksumSHA1": "FFroNUb6Nn6xUQJMsVDTb4Cqzo4=",
@@ -1880,7 +1880,6 @@
 		},
 		{
 			"checksumSHA1": "DVXnx4zyb0wkeIdIRjwjvR7Dslo=",
-			"origin": "github.com/hashicorp/terraform/vendor/github.com/mitchellh/go-ps",
 			"path": "github.com/mitchellh/go-ps",
 			"revision": "e2d21980687ce16e58469d98dcee92d27fbbd7fb",
 			"revisionTime": "2016-08-22T16:54:47Z"


### PR DESCRIPTION
Because we now rely on HIL to do the computed calculation, we must make
sure the type is correct (TypeUnknown). Before, we'd just check for the
UUID in the string.

This changes all variable returns in the interpolater to run it through
`hil.InterfaceToVariable` which handles this lookup for us.