### PR TITLE
terraform: destroy graph must connect edges for proper target ordering

### DIFF
--- a/terraform/graph_builder_destroy_plan.go
+++ b/terraform/graph_builder_destroy_plan.go
@@ -45,11 +45,16 @@ func (b *DestroyPlanGraphBuilder) Steps() []GraphTransformer {
 			State:    b.State,
 		},
 
-		// Target
-		&TargetsTransformer{Targets: b.Targets},
-
 		// Attach the configuration to any resources
 		&AttachResourceConfigTransformer{Module: b.Module},
+
+		// Destruction ordering. We require this only so that
+		// targeting below will prune the correct things.
+		&DestroyEdgeTransformer{Module: b.Module, State: b.State},
+
+		// Target. Note we don't set "Destroy: true" here since we already
+		// created proper destroy ordering.
+		&TargetsTransformer{Targets: b.Targets},
 
 		// Single root
 		&RootTransformer{},

--- a/terraform/node_resource_plan_destroy.go
+++ b/terraform/node_resource_plan_destroy.go
@@ -10,6 +10,11 @@ type NodePlanDestroyableResource struct {
 	*NodeAbstractResource
 }
 
+// GraphNodeDestroyer
+func (n *NodePlanDestroyableResource) DestroyAddr() *ResourceAddress {
+	return n.Addr
+}
+
 // GraphNodeEvalable
 func (n *NodePlanDestroyableResource) EvalTree() EvalNode {
 	addr := n.NodeAbstractResource.Addr

--- a/terraform/test-fixtures/apply-destroy-targeted-count/main.tf
+++ b/terraform/test-fixtures/apply-destroy-targeted-count/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+  count = 3
+}
+
+resource "aws_instance" "bar" {
+  instances = ["${aws_instance.foo.*.id}"]
+}


### PR DESCRIPTION
This connects the destroy edges so that when a `-target` is specified on
a destroy, the proper dependencies get destroyed as well.

The `command` package actually caught this and I added a terraform 
context test as well. 