### PR TITLE
state/remote/swift: Add support for versioning state file in swift, and expiring objects

### DIFF
--- a/website/source/docs/state/remote/swift.html.md
+++ b/website/source/docs/state/remote/swift.html.md
@@ -81,3 +81,9 @@ The following configuration options are supported:
 
  * `key` - (Optional) Specify client private key file for SSL client
    authentication. If omitted the `OS_KEY` environment variable is used.
+
+ * `archive_path` - (Optional) The path to store archived copied of `terraform.tfstate`.
+   If specified, Swift object versioning is enabled on the container created at `path`.
+
+ * `expire_after` - (Optional) How long should the `terraform.tfstate` created at `path`
+   be retained for? Supported durations: `m` - Minutes, `h` - Hours, `d` - Days.


### PR DESCRIPTION
state/remote/swift: Add support for versioning state file in swift, and expiring objects after period of time. 
Website docs updated with additional config values. 