### PR TITLE
state/remote/s3: Fix Bug with Assume Role for Federated IAM Account

### DIFF
--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -66,6 +66,7 @@ func s3Factory(conf map[string]string) (Client, error) {
 		Token:         conf["token"],
 		Profile:       conf["profile"],
 		CredsFilename: conf["shared_credentials_file"],
+		AssumeRoleARN: conf["role_arn"],
 	})
 	// Call Get to check for credential provider. If nothing found, we'll get an
 	// error, and we can present it nicely to the user

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -68,6 +68,10 @@ func s3Factory(conf map[string]string) (Client, error) {
 		CredsFilename: conf["shared_credentials_file"],
 		AssumeRoleARN: conf["role_arn"],
 	})
+	if err != nil {
+		return nil, err
+	}
+
 	// Call Get to check for credential provider. If nothing found, we'll get an
 	// error, and we can present it nicely to the user
 	_, err = creds.Get()

--- a/website/source/docs/state/remote/s3.html.md
+++ b/website/source/docs/state/remote/s3.html.md
@@ -98,3 +98,4 @@ The following configuration options or environment variables are supported:
    `~/.aws/credentials` will be used.
  * `token` - (Optional) Use this to set an MFA token. It can also be
    sourced from the `AWS_SESSION_TOKEN` environment variable.
+ * `role_arn` - (Optional) The role to be assumed


### PR DESCRIPTION
## what

Add missing `role_arn` parameter necessary for federated IAM accounts when using s3 for remote state. The attribute is named `role_arn` for consistency with AWS provider: https://www.terraform.io/docs/providers/aws/index.html#role_arn

## usage

```sh
terraform remote config -backend=s3 \
  -backend-config="bucket=<bucket>" \
  -backend-config="key=<key>"  \
  -backend-config="region=$AWS_REGION" \
  -backend-config="profile=$AWS_PROFILE" \
  -backend-config="role_arn=arn:aws:iam::<account_id>:role/<Role>"
```

## testing

I could not see a reasonable way to test this change.  The call to get the credentials returns an aws [Credential](https://github.com/aws/aws-sdk-go/blob/5b341290c488aa6bd76b335d819b4a68516ec3ab/aws/credentials/credentials.go#L155). This does not provide any means of inspecting its internals. Alternatively the `s3Factory` would need to support a way of mocking the [GetCredentials](https://github.com/hashicorp/terraform/blob/f4cf443368486efb37573c67412b7c7beeda9fab/state/remote/s3.go#L63) call

## why

Fixes #8739