### PR TITLE
terraform: destroy edge must include resources through outputs

### DIFF
--- a/terraform/test-fixtures/transform-destroy-edge-module/child/main.tf
+++ b/terraform/test-fixtures/transform-destroy-edge-module/child/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "b" {
+    value = "foo"
+}
+
+output "output" { value = "${aws_instance.b.value}" }

--- a/terraform/test-fixtures/transform-destroy-edge-module/main.tf
+++ b/terraform/test-fixtures/transform-destroy-edge-module/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "a" {
+    value = "${module.child.output}"
+}
+
+module "child" {
+    source = "./child"
+}

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -159,7 +159,7 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 	// Go through all the nodes in the graph and determine what they
 	// depend on.
 	for _, v := range tempDestroyed {
-		// Find all descendents of this to determine the edges we'll depend on
+		// Find all ancestors of this to determine the edges we'll depend on
 		vs, err := tempG.Ancestors(v)
 		if err != nil {
 			return err


### PR DESCRIPTION
This fixes: `TestContext2Apply_moduleDestroyOrder`

The new destroy graph wasn't properly creating edges that happened
_through_ an output, it was only created the edges for _direct_
dependents.

To fix this, the DestroyEdgeTransformer now creates the full transitive
list of destroy edges by walking all ancestors. This will create more
edges than are necessary but also will no longer miss resources through
an output.