### PR TITLE
provider/pagerduty pagerduty_schedule - support for start_day_of_week (schedule restriction)

### DIFF
--- a/builtin/providers/pagerduty/resource_pagerduty_schedule.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_schedule.go
@@ -95,6 +95,10 @@ func resourcePagerDutySchedule() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
+									"start_day_of_week": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
 									"duration_seconds": {
 										Type:     schema.TypeInt,
 										Required: true,

--- a/builtin/providers/pagerduty/resource_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_schedule_test.go
@@ -51,6 +51,52 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPagerDutyScheduleConfigWeek,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "time_zone", "Europe/Berlin"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.restriction.0.start_day_of_week", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckPagerDutyScheduleConfigWeekUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "name", "bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "description", "Managed by Terraform"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "time_zone", "America/New_York"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.restriction.0.start_day_of_week", "5"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccPagerDutySchedule_Multi(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,14 +113,57 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "time_zone", "America/New_York"),
+
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.#", "3"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.0.name", "foo"),
 					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.restriction.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.restriction.0.duration_seconds", "32101"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.restriction.0.start_time_of_day", "08:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rotation_turn_length_seconds", "86400"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.rotation_virtual_start", "2015-11-06T20:00:00-05:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.0.users.#", "1"),
+
+					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.1.name", "bar"),
 					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.restriction.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.restriction.0.duration_seconds", "32101"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.restriction.0.start_time_of_day", "08:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.restriction.0.start_day_of_week", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.rotation_turn_length_seconds", "86400"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.rotation_virtual_start", "2015-11-06T20:00:00-05:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.1.users.#", "1"),
+
+					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "layer.2.name", "foobar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.restriction.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.restriction.0.duration_seconds", "32101"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.restriction.0.start_time_of_day", "08:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.restriction.0.start_day_of_week", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.rotation_turn_length_seconds", "86400"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.rotation_virtual_start", "2015-11-06T20:00:00-05:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_schedule.foo", "layer.2.users.#", "1"),
 				),
 			},
 		},
@@ -178,6 +267,63 @@ resource "pagerduty_schedule" "foo" {
 }
 `
 
+const testAccCheckPagerDutyScheduleConfigWeek = `
+resource "pagerduty_user" "foo" {
+  name  = "foo"
+  email = "foo@bar.com"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "foo"
+
+  time_zone   = "Europe/Berlin"
+  description = "foo"
+
+  layer {
+    name                         = "foo"
+    start                        = "2015-11-06T20:00:00-05:00"
+    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    rotation_turn_length_seconds = 86400
+    users                        = ["${pagerduty_user.foo.id}"]
+
+    restriction {
+      type              = "weekly_restriction"
+      start_time_of_day = "08:00:00"
+			start_day_of_week = 1
+      duration_seconds  = 32101
+    }
+  }
+}
+`
+
+const testAccCheckPagerDutyScheduleConfigWeekUpdated = `
+resource "pagerduty_user" "foo" {
+  name        = "foo"
+  email       = "foo@bar.com"
+}
+
+resource "pagerduty_schedule" "foo" {
+  name = "bar"
+
+  time_zone = "America/New_York"
+
+  layer {
+    name                         = "foo"
+    start                        = "2015-11-06T20:00:00-05:00"
+    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    rotation_turn_length_seconds = 86400
+    users                        = ["${pagerduty_user.foo.id}"]
+
+		restriction {
+      type              = "weekly_restriction"
+      start_time_of_day = "08:00:00"
+			start_day_of_week = 5
+      duration_seconds  = 32101
+    }
+  }
+}
+`
+
 const testAccCheckPagerDutyScheduleConfigMulti = `
 resource "pagerduty_user" "foo" {
   name        = "foo"
@@ -212,8 +358,9 @@ resource "pagerduty_schedule" "foo" {
     users                        = ["${pagerduty_user.foo.id}"]
 
     restriction {
-      type              = "daily_restriction"
+      type              = "weekly_restriction"
       start_time_of_day = "08:00:00"
+			start_day_of_week = 5
       duration_seconds  = 32101
     }
   }
@@ -226,8 +373,9 @@ resource "pagerduty_schedule" "foo" {
     users                        = ["${pagerduty_user.foo.id}"]
 
     restriction {
-      type              = "daily_restriction"
+      type              = "weekly_restriction"
       start_time_of_day = "08:00:00"
+			start_day_of_week = 1
       duration_seconds  = 32101
     }
   }

--- a/builtin/providers/pagerduty/structure.go
+++ b/builtin/providers/pagerduty/structure.go
@@ -95,7 +95,7 @@ func expandScheduleLayers(list []interface{}) []pagerduty.ScheduleLayer {
 				pagerduty.Restriction{
 					Type:            restriction["type"].(string),
 					StartTimeOfDay:  restriction["start_time_of_day"].(string),
-					StartDayOfWeek:  restriction["start_day_of_week"].(int),
+					StartDayOfWeek:  uint(restriction["start_day_of_week"].(int)),
 					DurationSeconds: uint(restriction["duration_seconds"].(int)),
 				},
 			)
@@ -147,11 +147,17 @@ func flattenScheduleLayers(list []pagerduty.ScheduleLayer) []map[string]interfac
 		if len(i.Restrictions) > 0 {
 			restrictions := make([]map[string]interface{}, 0, len(i.Restrictions))
 			for _, r := range i.Restrictions {
-				restrictions = append(restrictions, map[string]interface{}{
+				restriction := map[string]interface{}{
 					"duration_seconds":  r.DurationSeconds,
 					"start_time_of_day": r.StartTimeOfDay,
 					"type":              r.Type,
-				})
+				}
+
+				if r.StartDayOfWeek > 0 {
+					restriction["start_day_of_week"] = r.StartDayOfWeek
+				}
+
+				restrictions = append(restrictions, restriction)
 			}
 			r["restriction"] = restrictions
 		}

--- a/builtin/providers/pagerduty/structure.go
+++ b/builtin/providers/pagerduty/structure.go
@@ -95,6 +95,7 @@ func expandScheduleLayers(list []interface{}) []pagerduty.ScheduleLayer {
 				pagerduty.Restriction{
 					Type:            restriction["type"].(string),
 					StartTimeOfDay:  restriction["start_time_of_day"].(string),
+					StartDayOfWeek:  restriction["start_day_of_week"].(int),
 					DurationSeconds: uint(restriction["duration_seconds"].(int)),
 				},
 			)

--- a/vendor/github.com/PagerDuty/go-pagerduty/schedule.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/schedule.go
@@ -2,14 +2,16 @@ package pagerduty
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
+
+	"github.com/google/go-querystring/query"
 )
 
 // Restriction limits on-call responsibility for a layer to certain times of the day or week.
 type Restriction struct {
 	Type            string `json:"type,omitempty"`
 	StartTimeOfDay  string `json:"start_time_of_day,omitempty"`
+	StartDayOfWeek  uint   `json:"start_day_of_week,omitempty"`
 	DurationSeconds uint   `json:"duration_seconds,omitempty"`
 }
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -324,10 +324,10 @@
 			"revisionTime": "2016-11-03T18:56:17Z"
 		},
 		{
-			"checksumSHA1": "O9o5S7D0E1PaN5ARQ72xLfOrIa0=",
+			"checksumSHA1": "yAhUY67XCnf+0jpIsQ53lirk+GM=",
 			"path": "github.com/PagerDuty/go-pagerduty",
-			"revision": "f4d5289481b2c05f2b23f81a64dff86aca960962",
-			"revisionTime": "2016-10-22T00:40:41Z"
+			"revision": "b98d93d395cd13b0438ad908b5f7c608f1f74c38",
+			"revisionTime": "2016-12-16T21:25:03Z"
 		},
 		{
 			"path": "github.com/Unknwon/com",


### PR DESCRIPTION
This should resolve #10033 (waiting for client library fix https://github.com/PagerDuty/go-pagerduty/pull/52 to be merged)