### PR TITLE
terraform: output nodes can have `depends_on` 

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -154,6 +154,7 @@ type Variable struct {
 type Output struct {
 	Name      string
 	Sensitive bool
+	DependsOn []string
 	RawConfig *RawConfig
 }
 

--- a/config/config_string.go
+++ b/config/config_string.go
@@ -100,6 +100,13 @@ func outputsStr(os []*Output) string {
 
 		result += fmt.Sprintf("%s\n", n)
 
+		if len(o.DependsOn) > 0 {
+			result += fmt.Sprintf("  dependsOn\n")
+			for _, d := range o.DependsOn {
+				result += fmt.Sprintf("    %s\n", d)
+			}
+		}
+
 		if len(o.RawConfig.Variables) > 0 {
 			result += fmt.Sprintf("  vars\n")
 			for _, rawV := range o.RawConfig.Variables {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -286,6 +286,26 @@ func TestLoadFileBasic_modules(t *testing.T) {
 	}
 }
 
+func TestLoadFile_outputDependsOn(t *testing.T) {
+	c, err := LoadFile(filepath.Join(fixtureDir, "output-depends-on.tf"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	if c.Dir != "" {
+		t.Fatalf("bad: %#v", c.Dir)
+	}
+
+	actual := outputsStr(c.Outputs)
+	if actual != strings.TrimSpace(outputDependsOnStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestLoadJSONBasic(t *testing.T) {
 	raw, err := ioutil.ReadFile(filepath.Join(fixtureDir, "basic.tf.json"))
 	if err != nil {
@@ -1090,6 +1110,12 @@ aws_instance.web (x1)
   vars
     resource: aws_security_group.firewall.foo
     user: var.foo
+`
+
+const outputDependsOnStr = `
+value
+  dependsOn
+    foo
 `
 
 const variablesVariablesStr = `

--- a/config/test-fixtures/output-depends-on.tf
+++ b/config/test-fixtures/output-depends-on.tf
@@ -1,0 +1,4 @@
+output "value" {
+    value = "foo"
+    depends_on = ["foo"]
+}

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -37,6 +37,7 @@ func (n *NodeApplyableOutput) ReferenceableName() []string {
 // GraphNodeReferencer
 func (n *NodeApplyableOutput) References() []string {
 	var result []string
+	result = append(result, n.Config.DependsOn...)
 	result = append(result, ReferencesFromConfig(n.Config.RawConfig)...)
 	for _, v := range result {
 		split := strings.Split(v, "/")

--- a/terraform/test-fixtures/apply-output-depends-on/main.tf
+++ b/terraform/test-fixtures/apply-output-depends-on/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {}
+
+output "value" {
+    value = "result"
+
+    depends_on = ["aws_instance.foo"]
+}

--- a/website/source/docs/configuration/outputs.html.md
+++ b/website/source/docs/configuration/outputs.html.md
@@ -58,6 +58,11 @@ These are the parameters that can be set:
     or map. This usually includes an interpolation since outputs that are
     static aren't usually useful.
 
+  * `depends_on` (list of strings) - Explicit dependencies that this
+      output has. These dependencies will be created before this
+      output value is processed. The dependencies are in the format of
+      `TYPE.NAME`, for example `aws_instance.web`.
+
   * `sensitive` (optional, boolean) - See below.
 
 ## Syntax


### PR DESCRIPTION
This adds `depends_on` to `output`. 

The primary use case for this is to depend on resources that may have a side effect that the output is depending on. For example: a resource may be a local-exec provisioner to create a file that the output is reading with `${file()}`. 

Another reason to add this is to support module-level `depends_on` which would impose a `depends_on` on all contained items (resources, modules, etc.).

This doesn't put a "Dependencies" list into the state for outputs because dependency ordering only matters for creation and updates, not for orphan destruction.