### PR TITLE
Fix for #9811 revert previous changes that breaks associate_public_ip…

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -41,7 +41,6 @@ func resourceAwsInstance() *schema.Resource {
 			"associate_public_ip_address": &schema.Schema{
 				Type:     schema.TypeBool,
 				ForceNew: true,
-				Computed: true,
 				Optional: true,
 			},
 
@@ -507,7 +506,6 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 			if *ni.Attachment.DeviceIndex == 0 {
 				d.Set("subnet_id", ni.SubnetId)
 				d.Set("network_interface_id", ni.NetworkInterfaceId)
-				d.Set("associate_public_ip_address", ni.Association != nil)
 			}
 		}
 	} else {


### PR DESCRIPTION
Fix for #9811 revert previous changes that breaks associate_public_ip_address

As per #9811 associate_public_ip_address was broken due to PR 9453 and related
PR 9560. This commit reverts the previous two PR's since they break the normal
functioning of Terraform.

This would also mean that #8187 needs to be re-opened since that fix was the
cause of breaking handling associate_public_ip_address.