### PR TITLE
Added create timeout for compute images and instances

### DIFF
--- a/builtin/providers/google/compute_operation.go
+++ b/builtin/providers/google/compute_operation.go
@@ -83,6 +83,10 @@ func (e ComputeOperationError) Error() string {
 }
 
 func computeOperationWaitGlobal(config *Config, op *compute.Operation, project string, activity string) error {
+	return computeOperationWaitGlobalTime(config, op, project, activity, 4)
+}
+
+func computeOperationWaitGlobalTime(config *Config, op *compute.Operation, project string, activity string, timeoutMin int) error {
 	w := &ComputeOperationWaiter{
 		Service: config.clientCompute,
 		Op:      op,
@@ -92,7 +96,7 @@ func computeOperationWaitGlobal(config *Config, op *compute.Operation, project s
 
 	state := w.Conf()
 	state.Delay = 10 * time.Second
-	state.Timeout = 4 * time.Minute
+	state.Timeout = time.Duration(timeoutMin) * time.Minute
 	state.MinTimeout = 2 * time.Second
 	opRaw, err := state.WaitForState()
 	if err != nil {

--- a/builtin/providers/google/resource_compute_image.go
+++ b/builtin/providers/google/resource_compute_image.go
@@ -78,6 +78,13 @@ func resourceComputeImage() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"create_timeout": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  4,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -122,6 +129,12 @@ func resourceComputeImageCreate(d *schema.ResourceData, meta interface{}) error 
 		image.RawDisk = imageRawDisk
 	}
 
+	// Read create timeout
+	var createTimeout int
+	if v, ok := d.GetOk("create_timeout"); ok {
+		createTimeout = v.(int)
+	}
+
 	// Insert the image
 	op, err := config.clientCompute.Images.Insert(
 		project, image).Do()
@@ -132,7 +145,7 @@ func resourceComputeImageCreate(d *schema.ResourceData, meta interface{}) error 
 	// Store the ID
 	d.SetId(image.Name)
 
-	err = computeOperationWaitGlobal(config, op, project, "Creating Image")
+	err = computeOperationWaitGlobalTime(config, op, project, "Creating Image", createTimeout)
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/google/resource_compute_image_test.go
+++ b/builtin/providers/google/resource_compute_image_test.go
@@ -101,6 +101,7 @@ resource "google_compute_image" "foobar" {
 	raw_disk {
 	  source = "https://storage.googleapis.com/bosh-cpi-artifacts/bosh-stemcell-3262.4-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz"
 	}
+	create_timeout = 5
 }`, acctest.RandString(10))
 
 var testAccComputeImage_basedondisk = fmt.Sprintf(`

--- a/builtin/providers/google/resource_compute_instance_test.go
+++ b/builtin/providers/google/resource_compute_instance_test.go
@@ -748,6 +748,8 @@ func testAccComputeInstance_basic(instance string) string {
 			baz = "qux"
 		}
 
+		create_timeout = 5
+
 		metadata_startup_script = "echo Hello"
 	}`, instance)
 }

--- a/website/source/docs/providers/google/r/compute_image.html.markdown
+++ b/website/source/docs/providers/google/r/compute_image.html.markdown
@@ -53,6 +53,9 @@ The following arguments are supported: (Note that one of either source_disk or
     Changing this forces a new resource to be created. Structure is documented
     below.
 
+* `create_timeout` - Configurable timeout in minutes for creating images. Default is 4 minutes.
+    Changing this forces a new resource to be created.
+
 The `raw_disk` block supports:
 
 * `source` - (Required) The full Google Cloud Storage URL where the disk

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -105,6 +105,9 @@ The following arguments are supported:
 
 * `tags` - (Optional) Tags to attach to the instance.
 
+* `create_timeout` - (Optional) Configurable timeout in minutes for creating instances. Default is 4 minutes.
+    Changing this forces a new resource to be created.
+
 The `disk` block supports: (Note that either disk or image is required, unless
 the type is "local-ssd", in which case scratch must be true).
 


### PR DESCRIPTION
- Prevents the corresponding terraform resource from timing out when the
  images or instances take longer than the default of 4 minutes to be
  created

In response to issue https://github.com/hashicorp/terraform/issues/9923