### PR TITLE
provider/scaleway: improve volume attachment

### DIFF
--- a/builtin/providers/scaleway/helpers.go
+++ b/builtin/providers/scaleway/helpers.go
@@ -84,7 +84,7 @@ func deleteStoppedServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) 
 // the helpers.go file pulls in quite a lot dependencies, and they're just convenience wrappers anyway
 
 func waitForServerState(scaleway *api.ScalewayAPI, serverID, targetState string) error {
-	return resource.Retry(20*time.Minute, func() *resource.RetryError {
+	return resource.Retry(60*time.Minute, func() *resource.RetryError {
 		s, err := scaleway.GetServer(serverID)
 
 		if err != nil {

--- a/builtin/providers/scaleway/helpers.go
+++ b/builtin/providers/scaleway/helpers.go
@@ -85,6 +85,8 @@ func deleteStoppedServer(scaleway *api.ScalewayAPI, server *api.ScalewayServer) 
 
 func waitForServerState(scaleway *api.ScalewayAPI, serverID, targetState string) error {
 	return resource.Retry(60*time.Minute, func() *resource.RetryError {
+		scaleway.ClearCache()
+
 		s, err := scaleway.GetServer(serverID)
 
 		if err != nil {

--- a/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
@@ -30,11 +30,20 @@ func resourceScalewayVolumeAttachment() *schema.Resource {
 	}
 }
 
+var errVolumeAlreadyAttached = fmt.Errorf("Scaleway volume already attached")
+
 func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
 	scaleway.ClearCache()
 
-	var startServerAgain = false
+	vol, err := scaleway.GetVolume(d.Get("volume").(string))
+	if err != nil {
+		return err
+	}
+	if vol.Server != nil {
+		log.Printf("[DEBUG] Scaleway volume %q already attached to %q.", vol.Identifier, vol.Server.Identifier)
+		return errVolumeAlreadyAttached
+	}
 
 	// guard against server shutdown/ startup race conditiond
 	serverID := d.Get("server").(string)
@@ -47,6 +56,7 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 		return err
 	}
 
+	var startServerAgain = false
 	// volumes can only be modified when the server is powered off
 	if server.State != "stopped" {
 		startServerAgain = true
@@ -64,10 +74,6 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 		volumes[i] = volume
 	}
 
-	vol, err := scaleway.GetVolume(d.Get("volume").(string))
-	if err != nil {
-		return err
-	}
 	volumes[fmt.Sprintf("%d", len(volumes)+1)] = *vol
 
 	// the API request requires most volume attributes to be unset to succeed

--- a/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_attachment.go
@@ -32,6 +32,7 @@ func resourceScalewayVolumeAttachment() *schema.Resource {
 
 func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
+	scaleway.ClearCache()
 
 	var startServerAgain = false
 
@@ -83,6 +84,8 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 	}
 
 	if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		scaleway.ClearCache()
+
 		var req = api.ScalewayServerPatchDefinition{
 			Volumes: &volumes,
 		}
@@ -121,6 +124,7 @@ func resourceScalewayVolumeAttachmentCreate(d *schema.ResourceData, m interface{
 
 func resourceScalewayVolumeAttachmentRead(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
+	scaleway.ClearCache()
 
 	server, err := scaleway.GetServer(d.Get("server").(string))
 	if err != nil {
@@ -160,6 +164,8 @@ func resourceScalewayVolumeAttachmentRead(d *schema.ResourceData, m interface{})
 
 func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
+	scaleway.ClearCache()
+
 	var startServerAgain = false
 
 	// guard against server shutdown/ startup race conditiond
@@ -204,6 +210,8 @@ func resourceScalewayVolumeAttachmentDelete(d *schema.ResourceData, m interface{
 	}
 
 	if err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		scaleway.ClearCache()
+
 		var req = api.ScalewayServerPatchDefinition{
 			Volumes: &volumes,
 		}

--- a/builtin/providers/scaleway/resource_scaleway_volume_attachment_test.go
+++ b/builtin/providers/scaleway/resource_scaleway_volume_attachment_test.go
@@ -70,24 +70,22 @@ func testAccCheckScalewayVolumeAttachmentExists(n string) resource.TestCheckFunc
 	}
 }
 
-var x86_64ImageIdentifier = "aecaed73-51a5-4439-a127-6d8229847145"
-
 var testAccCheckScalewayVolumeAttachmentConfig = fmt.Sprintf(`
 resource "scaleway_server" "base" {
   name = "test"
   # ubuntu 14.04
   image = "%s"
-  type = "C2S"
+  type = "C1"
   # state = "stopped"
 }
 
 resource "scaleway_volume" "test" {
   name = "test"
-  size_in_gb = 20
+  size_in_gb = 5
   type = "l_ssd"
 }
 
 resource "scaleway_volume_attachment" "test" {
   server = "${scaleway_server.base.id}"
   volume = "${scaleway_volume.test.id}"
-}`, x86_64ImageIdentifier)
+}`, armImageIdentifier)


### PR DESCRIPTION
this PR tries to improve the the issues troubling the `scaleway_volume_attachment` tests.

Some issues we're seeing:

### waiting for server times out.  
  this is related to the fact that you have to stop servers to change volumes, and this transfers ALL the data from the server to some storage medium. We've been using 20 minutes so far, and the [Scaleway community](https://community.online.net/t/solving-the-long-shutdown-boot-when-only-needed-to-attach-detach-a-volume/326) lists >1h times for bigger volumes. 
  For now, I've just bumped the limit to 60 minutes.

related tests: 
- https://travis-ci.org/hashicorp/terraform/builds/175439974
- https://travis-ci.org/hashicorp/terraform/builds/175273317

### verify volumes are unattached before proceeding.
  just to make sure that the attachment doesn't fail because of an already attached volume. Automatic detaching and reattaching is out of scope for now.

related tests:
- https://travis-ci.org/hashicorp/terraform/builds/175002940

### general stability
  I suspect that the `scaleway_volume_attachment` tests error because of the cache used within the official go sdk (state mismatch remote vs local). The easiest way to verify this for now is to just clear the cache when attaching/ detaching volumes.

ping @stack72 PTAL :)