### PR TITLE
provider/aws: Added a s3_bucket domain name attribute

### DIFF
--- a/builtin/providers/aws/import_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/import_aws_s3_bucket_test.go
@@ -18,11 +18,11 @@ func TestAccAWSS3Bucket_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSS3BucketDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSS3BucketConfig(rInt),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -63,11 +63,11 @@ func TestAccAWSS3Bucket_importWithPolicy(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSS3BucketDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSS3BucketConfigWithPolicy(rInt),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:     "aws_s3_bucket.bucket",
 				ImportState:      true,
 				ImportStateCheck: checkFn,

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -34,6 +34,11 @@ func resourceAwsS3Bucket() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"bucket_domain_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"arn": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -527,6 +532,8 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	if _, ok := d.GetOk("bucket"); !ok {
 		d.Set("bucket", d.Id())
 	}
+
+	d.Set("bucket_domain_name", bucketDomainName(d.Get("bucket").(string)))
 
 	// Read the policy
 	if _, ok := d.GetOk("policy"); ok {
@@ -1193,6 +1200,10 @@ func websiteEndpoint(s3conn *s3.S3, d *schema.ResourceData) (*S3Website, error) 
 	}
 
 	return WebsiteEndpoint(bucket, region), nil
+}
+
+func bucketDomainName(bucket string) string {
+	return fmt.Sprintf("%s.s3.amazonaws.com", bucket)
 }
 
 func WebsiteEndpoint(bucket string, region string) *S3Website {

--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -44,6 +44,10 @@ func TestAccAWSS3Bucket_basic(t *testing.T) {
 						"aws_s3_bucket.bucket", "website_endpoint", ""),
 					resource.TestMatchResourceAttr(
 						"aws_s3_bucket.bucket", "arn", arnRegexp),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "bucket", testAccBucketName(rInt)),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "bucket_domain_name", testAccBucketDomainName(rInt)),
 				),
 			},
 		},
@@ -996,6 +1000,14 @@ func testAccCheckAWSS3BucketLogging(n, b, p string) resource.TestCheckFunc {
 
 // These need a bit of randomness as the name can only be used once globally
 // within AWS
+func testAccBucketName(randInt int) string {
+	return fmt.Sprintf("tf-test-bucket-%d", randInt)
+}
+
+func testAccBucketDomainName(randInt int) string {
+	return fmt.Sprintf("tf-test-bucket-%d.s3.amazonaws.com", randInt)
+}
+
 func testAccWebsiteEndpoint(randInt int) string {
 	return fmt.Sprintf("tf-test-bucket-%d.s3-website-us-west-2.amazonaws.com", randInt)
 }

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -36,7 +36,7 @@ resource "aws_s3_bucket" "b" {
 
 resource "aws_cloudfront_distribution" "s3_distribution" {
   origin {
-    domain_name = "${aws_s3_bucket.b.bucket}.s3.amazonaws.com"
+    domain_name = "${aws_s3_bucket.b.bucket_domain_name}"
     origin_id   = "myS3Origin"
 
     s3_origin_config {

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -379,6 +379,7 @@ The following attributes are exported:
 
 * `id` - The name of the bucket.
 * `arn` - The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
+* `bucket_domain_name` - The bucket domain name. Will be of format `bucketname.s3.amazonaws.com`.
 * `hosted_zone_id` - The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 * `region` - The AWS region this bucket resides in.
 * `website_endpoint` - The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.


### PR DESCRIPTION
This adds a new attribute to the s3_bucket resource called `bucket_domain_name`. It acts as a "helper" in the way it is computed on the Terraform side.

It just makes it easier to work with CloudFront when using S3 Origin Identities, and avoid #8668 for instance.
However, It is different from #10087 in the way that this work can be discussed (thus not mergeable now for example), whereas my other PR adds more insights on the documentation quickly.
