### PR TITLE
[WIP] provider/aws: Add separate resource for aws_elb_listener

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -244,6 +244,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elastictranscoder_preset":                 resourceAwsElasticTranscoderPreset(),
 			"aws_elb":                                      resourceAwsElb(),
 			"aws_elb_attachment":                           resourceAwsElbAttachment(),
+			"aws_elb_listener":                             resourceAwsElbListener(),
 			"aws_emr_cluster":                              resourceAwsEMRCluster(),
 			"aws_emr_instance_group":                       resourceAwsEMRInstanceGroup(),
 			"aws_flow_log":                                 resourceAwsFlowLog(),

--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -143,6 +143,7 @@ func resourceAwsElb() *schema.Resource {
 			"listener": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"instance_port": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_elb_listener.go
+++ b/builtin/providers/aws/resource_aws_elb_listener.go
@@ -1,0 +1,175 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsElbListener() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsElbListenerCreate,
+		Read:   resourceAwsElbListenerRead,
+		Delete: resourceAwsElbListenerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"loadbalancer_names": {
+				Type:     schema.TypeList,
+				ForceNew: true,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instance_port": {
+				Type:     schema.TypeInt,
+				ForceNew: true,
+				Required: true,
+
+				ValidateFunc: validateIntegerInRange(1, 65535),
+			},
+
+			"instance_protocol": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateListenerProtocol,
+			},
+
+			"lb_port": {
+				Type:         schema.TypeInt,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateIntegerInRange(1, 65535),
+			},
+
+			"lb_protocol": {
+				Type:         schema.TypeString,
+				ForceNew:     true,
+				Required:     true,
+				ValidateFunc: validateListenerProtocol,
+			},
+
+			"ssl_certificate_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
+		},
+	}
+}
+func expandElbListener(d *schema.ResourceData) ([]*elb.Listener, error) {
+	listeners := make([]*elb.Listener, 0)
+	l := &elb.Listener{
+		InstancePort:     aws.Int64(int64(d.Get("instance_port").(int))),
+		InstanceProtocol: aws.String(d.Get("instance_protocol").(string)),
+		LoadBalancerPort: aws.Int64(int64(d.Get("lb_port").(int))),
+		Protocol:         aws.String(d.Get("lb_protocol").(string)),
+	}
+
+	if v, ok := d.GetOk("ssl_certificate_id"); ok {
+		l.SSLCertificateId = aws.String(v.(string))
+	}
+
+	var valid bool
+	if l.SSLCertificateId != nil && *l.SSLCertificateId != "" {
+		// validate the protocol is correct
+		for _, p := range []string{"https", "ssl"} {
+			if (strings.ToLower(*l.InstanceProtocol) == p) || (strings.ToLower(*l.Protocol) == p) {
+				valid = true
+			}
+		}
+	} else {
+		valid = true
+	}
+
+	if valid {
+		listeners = append(listeners, l)
+	} else {
+		return nil, fmt.Errorf("[ERR] ELB Listener: ssl_certificate_id may be set only when protocol is 'https' or 'ssl'")
+	}
+
+	return listeners, nil
+}
+
+func resourceAwsElbListenerCreate(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	listeners, elbErr := expandElbListener(d)
+	if elbErr != nil {
+		return elbErr
+	}
+
+	loadBalancers := d.Get("loadbalancer_names").([]interface{})
+	for _, lb := range loadBalancers {
+		input := &elb.CreateLoadBalancerListenersInput{
+			Listeners:        listeners,
+			LoadBalancerName: aws.String(lb.(string)),
+		}
+
+		_, err := elbconn.CreateLoadBalancerListeners(input)
+		if err != nil {
+			return err
+		}
+	}
+
+	d.SetId(strconv.Itoa(d.Get("lb_port").(int)))
+
+	return resourceAwsElbListenerRead(d, meta)
+}
+
+func resourceAwsElbListenerRead(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	lbnames := d.Get("loadbalancer_names").([]interface{})
+
+	resp, err := elbconn.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+		LoadBalancerNames: expandStringList(lbnames),
+	})
+	if err != nil {
+		return err
+	}
+	if len(resp.LoadBalancerDescriptions) != len(lbnames) {
+		log.Printf("[ERROR] Unable to find all of the LoadBalancers specified")
+	}
+
+	// for all of the loadbalancers in the resource
+	// range the listeners for the specific load balancer port
+	// if a listener with the specific port is not found, then error out
+	// otherwise continue
+	for _, lb := range resp.LoadBalancerDescriptions {
+		found := false
+		for _, listener := range lb.ListenerDescriptions {
+			if *listener.Listener.LoadBalancerPort == int64(d.Get("lb_port").(int)) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			log.Printf("[WARN] Listener with port %q not found in %q listener list", d.Get("lb_port").(int), *lb.LoadBalancerName)
+			d.SetId("")
+		}
+	}
+	return nil
+}
+func resourceAwsElbListenerDelete(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+	loadBalancers := d.Get("loadbalancer_names").([]interface{})
+	for _, lb := range loadBalancers {
+		input := &elb.DeleteLoadBalancerListenersInput{
+			LoadBalancerName:  aws.String(lb.(string)),
+			LoadBalancerPorts: []*int64{aws.Int64(int64(d.Get("lb_port").(int)))},
+		}
+
+		_, err := elbconn.DeleteLoadBalancerListeners(input)
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_elb_listener_test.go
+++ b/builtin/providers/aws/resource_aws_elb_listener_test.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/elb"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSELBListener_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSELBListenerDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSELBListenersConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSListenersExist("aws_elb_listener.bar"),
+				),
+			},
+		},
+	})
+}
+
+func getAWSElbListenerLBNames(lbnames string) []interface{} {
+	names := make([]interface{}, 0)
+
+	lbnamesSpilt := strings.Split(lbnames, ",")
+	for i, lbname := range lbnamesSpilt {
+		names[i] = lbname
+	}
+
+	return names
+}
+
+func testAccCheckAWSListenersExist(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ELB Listener ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).elbconn
+
+		lbNames, lbNamesOk := rs.Primary.Attributes["loadbalancer_names"]
+		if !lbNamesOk {
+			return fmt.Errorf("Cannot find loadbalancer names in state")
+		}
+		names := getAWSElbListenerLBNames(lbNames)
+
+		describe, err := conn.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+			LoadBalancerNames: expandStringList(names),
+		})
+
+		if err == nil {
+			if len(lbNames) != len(describe.LoadBalancerDescriptions) {
+				return fmt.Errorf("Not all loadbalancers found. Expected %d:, got %d", len(lbNames), len(describe.LoadBalancerDescriptions))
+			}
+
+			for _, lb := range describe.LoadBalancerDescriptions {
+				found := false
+				for _, listener := range lb.ListenerDescriptions {
+					if fmt.Sprintf("%s", *listener.Listener.LoadBalancerPort) == rs.Primary.ID {
+						found = true
+						break
+					}
+
+				}
+				if !found {
+					return fmt.Errorf("Cannot find Listener with port %d in LB %s", rs.Primary.ID)
+				}
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSELBListenerDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).elbconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_elb_listener" {
+			continue
+		}
+
+		lbNames, lbNamesOk := rs.Primary.Attributes["loadbalancer_names"]
+		if !lbNamesOk {
+			return fmt.Errorf("Cannot find loadbalancer names in state")
+		}
+		names := getAWSElbListenerLBNames(lbNames)
+
+		describe, err := conn.DescribeLoadBalancers(&elb.DescribeLoadBalancersInput{
+			LoadBalancerNames: expandStringList(names),
+		})
+
+		if err == nil {
+			for _, lb := range describe.LoadBalancerDescriptions {
+				for _, listener := range lb.ListenerDescriptions {
+					if fmt.Sprintf("%s", *listener.Listener.LoadBalancerPort) == rs.Primary.ID {
+						return fmt.Errorf("ELB Listener still exists")
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+const testAccAWSELBListenersConfig = `
+resource "aws_elb" "foo" {
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+  listener {
+    instance_port = 8000
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
+resource "aws_elb" "bar" {
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+  listener {
+    instance_port = 8000
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
+resource "aws_elb_listener" "another_listener" {
+  loadbalancer_names = ["${aws_elb.foo.name}", "${aws_elb.bar.name}"]
+  instance_port = 8500
+  instance_protocol = "http"
+  lb_port = 8500
+  lb_protocol = "http"
+}
+`

--- a/website/source/docs/providers/aws/r/elb_listener.html.markdown
+++ b/website/source/docs/providers/aws/r/elb_listener.html.markdown
@@ -1,0 +1,73 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elb_listener"
+sidebar_current: "docs-aws-resource-elb-listener"
+description: |-
+  Provides an Elastic Load Balancer Listener resource.
+---
+
+# aws\_elb\_listener
+
+Provides an Elastic Load Balancer Listener resource.
+
+~> **NOTE on ELB Listeners and ELB Listener:** Terraform currently provides
+both a standalone ELB Listener resource, and an [Elastic Load Balancer resource](elb.html) with
+`listener` defined in-line. At this time you cannot use an ELB with in-line
+listeners in conjunction with an ELB Listener resource. Doing so will cause a
+conflict and will overwrite attachments.
+## Example Usage
+
+```
+resource "aws_elb" "foo" {
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+  listener {
+    instance_port = 8000
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
+resource "aws_elb" "bar" {
+  availability_zones = ["us-west-2a", "us-west-2b", "us-west-2c"]
+
+  listener {
+    instance_port = 8000
+    instance_protocol = "http"
+    lb_port = 80
+    lb_protocol = "http"
+  }
+}
+
+resource "aws_elb_listener" "another_listener" {
+  loadbalancer_names = ["${aws_elb.foo.name}", "${aws_elb.bar.name}"]
+  instance_port = 8500
+  instance_protocol = "http"
+  lb_port = 8500
+  lb_protocol = "http"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `loadbalancer_names` - (Required) A list of the loadbalancers to which to
+attach the listener
+* `instance_port` - (Required) The port on the instance to route to
+* `instance_protocol` - (Required) The protocol to use to the instance. Valid
+  values are `HTTP`, `HTTPS`, `TCP`, or `SSL`
+* `lb_port` - (Required) The port to listen on for the load balancer
+* `lb_protocol` - (Required) The protocol to listen on. Valid values are `HTTP`,
+  `HTTPS`, `TCP`, or `SSL`
+* `ssl_certificate_id` - (Optional) The ARN of an SSL certificate you have
+uploaded to AWS IAM. **Note ECDSA-specific restrictions below.  Only valid when `lb_protocol` is either HTTPS or SSL**
+
+## Note on ECDSA Key Algorithm
+
+If the ARN of the `ssl_certificate_id` that is pointed to references a
+certificate that was signed by an ECDSA key, note that ELB only supports the
+P256 and P384 curves.  Using a certificate signed by a key using a different
+curve could produce the error `ERR_SSL_VERSION_OR_CIPHER_MISMATCH` in your
+browser.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -338,6 +338,10 @@
                             <a href="/docs/providers/aws/r/elb_attachment.html">aws_elb_attachment</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-elb-listener") %>>
+                          <a href="/docs/providers/aws/r/elb_listener.html">aws_elb_listener</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-instance") %>>
                             <a href="/docs/providers/aws/r/instance.html">aws_instance</a>
                         </li>


### PR DESCRIPTION
Fixes #9807

Allows similar listeners to be specified once and then attached to
multiple loadbalancers

Unfortunalely, the AWS SDK doesn't allow an AWS ELB to be created
without a Listener so we still have to keep that AWS ELB Listener
parameter as `required` - therefore, this may be blocked until AWS get
back to us on whether that is actually the usecase