### PR TITLE
provider/aws: Addition of suspended_processes to aws_autoscaling_group

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1050,6 +1050,16 @@ func flattenCloudFormationOutputs(cfOutputs []*cloudformation.Output) map[string
 	return outputs
 }
 
+func flattenAsgSuspendedProcesses(list []*autoscaling.SuspendedProcess) []string {
+	strs := make([]string, 0, len(list))
+	for _, r := range list {
+		if r.ProcessName != nil {
+			strs = append(strs, *r.ProcessName)
+		}
+	}
+	return strs
+}
+
 func flattenAsgEnabledMetrics(list []*autoscaling.EnabledMetric) []string {
 	strs := make([]string, 0, len(list))
 	for _, r := range list {

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -93,6 +93,8 @@ The following arguments are supported:
 * `target_group_arns` (Optional) A list of `aws_alb_target_group` ARNs, for use with
 Application Load Balancing
 * `termination_policies` (Optional) A list of policies to decide how the instances in the auto scale group should be terminated. The allowed values are `OldestInstance`, `NewestInstance`, `OldestLaunchConfiguration`, `ClosestToNextInstanceHour`, `Default`.
+* `suspended_processes` - (Optional) A list of processes to suspend for the AutoScaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`.
+Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your autoscaling group from functioning properly.
 * `tag` (Optional) A list of tag blocks. Tags documented below.
 * `placement_group` (Optional) The name of the placement group into which you'll launch your instances, if any.
 * `metrics_granularity` - (Optional) The granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.


### PR DESCRIPTION
Fixes #8954

Addition of the support of autoScaling group suspended_processes

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAutoScalingGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/14 09:26:46 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAutoScalingGroup_ -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_importBasic
--- PASS: TestAccAWSAutoScalingGroup_importBasic (168.81s)
=== RUN   TestAccAWSAutoScalingGroup_basic
--- PASS: TestAccAWSAutoScalingGroup_basic (249.96s)
=== RUN   TestAccAWSAutoScalingGroup_autoGeneratedName
--- PASS: TestAccAWSAutoScalingGroup_autoGeneratedName (45.19s)
=== RUN   TestAccAWSAutoScalingGroup_terminationPolicies
--- PASS: TestAccAWSAutoScalingGroup_terminationPolicies (76.54s)
=== RUN   TestAccAWSAutoScalingGroup_tags
--- PASS: TestAccAWSAutoScalingGroup_tags (335.68s)
=== RUN   TestAccAWSAutoScalingGroup_VpcUpdates
--- PASS: TestAccAWSAutoScalingGroup_VpcUpdates (109.83s)
=== RUN   TestAccAWSAutoScalingGroup_WithLoadBalancer
--- PASS: TestAccAWSAutoScalingGroup_WithLoadBalancer (581.32s)
=== RUN   TestAccAWSAutoScalingGroup_withPlacementGroup
--- PASS: TestAccAWSAutoScalingGroup_withPlacementGroup (143.59s)
=== RUN   TestAccAWSAutoScalingGroup_enablingMetrics
--- PASS: TestAccAWSAutoScalingGroup_enablingMetrics (204.27s)
=== RUN   TestAccAWSAutoScalingGroup_suspendingProcesses
--- PASS: TestAccAWSAutoScalingGroup_suspendingProcesses (250.06s)
=== RUN   TestAccAWSAutoScalingGroup_withMetrics
--- PASS: TestAccAWSAutoScalingGroup_withMetrics (44.23s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (181.99s)
=== RUN   TestAccAWSAutoScalingGroup_initialLifecycleHook
--- PASS: TestAccAWSAutoScalingGroup_initialLifecycleHook (322.36s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	2713.870s
```