### PR TITLE
provider/chef: Migrate Chef to use KEY_MATERIAL rather than using a Pem file

### DIFF
--- a/builtin/providers/chef/provider_test.go
+++ b/builtin/providers/chef/provider_test.go
@@ -56,7 +56,7 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("CHEF_CLIENT_NAME"); v == "" {
 		t.Fatal("CHEF_CLIENT_NAME must be set for acceptance tests")
 	}
-	if v := os.Getenv("CHEF_PRIVATE_KEY_FILE"); v == "" {
-		t.Fatal("CHEF_PRIVATE_KEY_FILE must be set for acceptance tests")
+	if v := os.Getenv("CHEF_KEY_MATERIAL"); v == "" {
+		t.Fatal("CHEF_KEY_MATERIAL must be set for acceptance tests")
 	}
 }

--- a/website/source/docs/providers/chef/index.html.markdown
+++ b/website/source/docs/providers/chef/index.html.markdown
@@ -23,7 +23,7 @@ provider "chef" {
 
      // You can set up a "Client" within the Chef Server management console.
      client_name = "terraform"
-     private_key_pem = "${file(\"chef-terraform.pem\")}"
+     key_material = "${file("chef-terraform.pem")}"
 }
 
 # Create a Chef Environment
@@ -51,9 +51,9 @@ The following arguments are supported:
 * `client_name` - (Required) The name of the client account to use when making
   requests. This must have been already configured on the Chef server.
   May be provided instead via the ``CHEF_CLIENT_NAME`` environment variable.
-* `private_key_pem` - (Required) The PEM-formatted private key belonging to
+* `key_material` - (Required) The PEM-formatted private key contents belonging to
   the configured client. This is issued by the server when a new client object
-  is created. May be provided instead in a file whose path is in the
+  is created. May be provided via the
   ``CHEF_PRIVATE_KEY_FILE`` environment variable.
 * `allow_unverified_ssl` - (Optional) Boolean indicating whether to make
   requests to a Chef server whose SSL certicate cannot be verified. Defaults


### PR DESCRIPTION
This will allow us to standardise on how we set KEY_MATERIAL