### PR TITLE
increase aws_lambda_function timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -223,7 +223,7 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
 	// Error creating Lambda function: InvalidParameterValueException: The role defined for the task cannot be assumed by Lambda.
-	err := resource.Retry(1*time.Minute, func() *resource.RetryError {
+	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
 		_, err := conn.CreateFunction(params)
 		if err != nil {
 			log.Printf("[ERROR] Received %q, retrying CreateFunction", err)


### PR DESCRIPTION
I have been experiencing occasional timeouts creating a Lambda function on a good connection and consistent timeouts on slower ones with a 23 meg zip payload.  Based on testing on slow wifi I see the request taking 90-150 seconds.  This increases the timeout to a more reasonable 10 minutes.