### PR TITLE
provider/google: Add support for scope aliases to google_container_cluster

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -223,10 +223,15 @@ func resourceContainerCluster() *schema.Resource {
 
 						"oauth_scopes": &schema.Schema{
 							Type:     schema.TypeList,
-							Elem:     &schema.Schema{Type: schema.TypeString},
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeString,
+								StateFunc: func(v interface{}) string {
+									return canonicalizeServiceScope(v.(string))
+								},
+							},
 						},
 					},
 				},
@@ -340,7 +345,7 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 			scopesList := v.([]interface{})
 			scopes := []string{}
 			for _, v := range scopesList {
-				scopes = append(scopes, v.(string))
+				scopes = append(scopes, canonicalizeServiceScope(v.(string)))
 			}
 
 			cluster.NodeConfig.OauthScopes = scopes

--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -43,6 +43,23 @@ func TestAccContainerCluster_withNodeConfig(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withNodeConfigScopeAlias(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerCluster_withNodeConfigScopeAlias,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists(
+						"google_container_cluster.with_node_config_scope_alias"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_network(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -141,6 +158,24 @@ resource "google_container_cluster" "with_node_config" {
 			"https://www.googleapis.com/auth/logging.write",
 			"https://www.googleapis.com/auth/monitoring"
 		]
+	}
+}`, acctest.RandString(10))
+
+var testAccContainerCluster_withNodeConfigScopeAlias = fmt.Sprintf(`
+resource "google_container_cluster" "with_node_config_scope_alias" {
+	name = "cluster-test-%s"
+	zone = "us-central1-f"
+	initial_node_count = 1
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm"
+	}
+
+	node_config {
+		machine_type = "g1-small"
+		disk_size_gb = 15
+		oauth_scopes = [ "compute-rw", "storage-ro", "logging-write", "monitoring" ]
 	}
 }`, acctest.RandString(10))
 

--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -50,7 +50,8 @@ resource "google_container_cluster" "primary" {
 * `zone` - (Required) The zone that all resources should be created in.
 
 - - -
-* `addons_config` - (Optional) The configuration for addons supported by Google Container Engine
+* `addons_config` - (Optional) The configuration for addons supported by Google
+    Container Engine
 
 * `cluster_ipv4_cidr` - (Optional) The IP address range of the container pods in
     this cluster. Default is an automatically assigned CIDR.
@@ -66,8 +67,8 @@ resource "google_container_cluster" "primary" {
     `monitoring.googleapis.com` and `none`. Defaults to
     `monitoring.googleapis.com`
 
-* `network` - (Optional) The name or self_link of the Google Compute Engine network to which
-    the cluster is connected
+* `network` - (Optional) The name or self_link of the Google Compute Engine
+    network to which the cluster is connected
 
 * `node_config` -  (Optional) The machine type and image to use for all nodes in
     this cluster
@@ -79,7 +80,8 @@ resource "google_container_cluster" "primary" {
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `subnetwork` - (Optional) The name of the Google Compute Engine subnetwork in which the cluster's instances are launched
+* `subnetwork` - (Optional) The name of the Google Compute Engine subnetwork in
+which the cluster's instances are launched
 
 **Master Auth** supports the following arguments:
 
@@ -108,14 +110,17 @@ resource "google_container_cluster" "primary" {
 
 **Addons Config** supports the following addons:
 
-* `http_load_balancing` - (Optional) The status of the HTTP Load Balancing addon. It is enabled by default; set `disabled = true` to disable.
-* `horizontal_pod_autoscaling` - (Optional) The status of the Horizontal Pod Autoscaling addon. It is enabled by default; set `disabled = true` to disable.
+* `http_load_balancing` - (Optional) The status of the HTTP Load Balancing
+    add-on. It is enabled by default; set `disabled = true` to disable.
+* `horizontal_pod_autoscaling` - (Optional) The status of the Horizontal Pod
+    Autoscaling addon. It is enabled by default; set `disabled = true` to
+    disable.
 
 This example `addons_config` disables both addons:
 
 ```
 addons_config {
-  http_load_balancing { 
+  http_load_balancing {
     disabled = true
   }
   horizontal_pod_autoscaling {

--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -100,13 +100,16 @@ which the cluster's instances are launched
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
 
 * `oauth_scopes` - (Optional) The set of Google API scopes to be made available
-    on all of the node VMs under the "default" service account. The following
-    scopes are necessary to ensure the correct functioning of the cluster:
+    on all of the node VMs under the "default" service account. These can be
+    either FQDNs, or scope aliases. The following scopes are necessary to ensure
+    the correct functioning of the cluster:
 
-  * `https://www.googleapis.com/auth/compute`
-  * `https://www.googleapis.com/auth/devstorage.read_only`
-  * `https://www.googleapis.com/auth/logging.write` (if `logging_service` points to Google)
-  * `https://www.googleapis.com/auth/monitoring` (if `monitoring_service` points to Google)
+  * `compute-rw` (`https://www.googleapis.com/auth/compute`)
+  * `storage-ro` (`https://www.googleapis.com/auth/devstorage.read_only`)
+  * `logging-write` (`https://www.googleapis.com/auth/logging.write`),
+    if `logging_service` points to Google
+  * `monitoring` (`https://www.googleapis.com/auth/monitoring`),
+    if `monitoring_service` points to Google
 
 **Addons Config** supports the following addons:
 


### PR DESCRIPTION
This PR adds support for scope aliases to the `google_container_cluster` resource, and also cleans up the formatting on the related docs.