### PR TITLE
config: maintain slice index accounting for computed keys

### DIFF
--- a/config/interpolate_walk.go
+++ b/config/interpolate_walk.go
@@ -32,7 +32,7 @@ type interpolationWalker struct {
 	cs          []reflect.Value
 	csKey       []reflect.Value
 	csData      interface{}
-	sliceIndex  int
+	sliceIndex  []int
 	unknownKeys []string
 }
 
@@ -54,9 +54,6 @@ type interpolationWalkerContextFunc func(reflectwalk.Location, ast.Node)
 
 func (w *interpolationWalker) Enter(loc reflectwalk.Location) error {
 	w.loc = loc
-	if loc == reflectwalk.WalkLoc {
-		w.sliceIndex = -1
-	}
 	return nil
 }
 
@@ -75,7 +72,7 @@ func (w *interpolationWalker) Exit(loc reflectwalk.Location) error {
 		w.cs = w.cs[:len(w.cs)-1]
 	case reflectwalk.SliceElem:
 		w.csKey = w.csKey[:len(w.csKey)-1]
-		w.sliceIndex = -1
+		w.sliceIndex = w.sliceIndex[:len(w.sliceIndex)-1]
 	}
 
 	return nil
@@ -90,8 +87,8 @@ func (w *interpolationWalker) MapElem(m, k, v reflect.Value) error {
 	w.csData = k
 	w.csKey = append(w.csKey, k)
 
-	if w.sliceIndex != -1 {
-		w.key = append(w.key, fmt.Sprintf("%d.%s", w.sliceIndex, k.String()))
+	if l := len(w.sliceIndex); l > 0 {
+		w.key = append(w.key, fmt.Sprintf("%d.%s", w.sliceIndex[l-1], k.String()))
 	} else {
 		w.key = append(w.key, k.String())
 	}
@@ -107,7 +104,7 @@ func (w *interpolationWalker) Slice(s reflect.Value) error {
 
 func (w *interpolationWalker) SliceElem(i int, elem reflect.Value) error {
 	w.csKey = append(w.csKey, reflect.ValueOf(i))
-	w.sliceIndex = i
+	w.sliceIndex = append(w.sliceIndex, i)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #10075
Fixes #10013

This should be cherry picked into `maint-0.7` as well.

When interpolating, we were only maintaining the last known slice index.
If you had sibling slices then you could lose your slice index when
exiting the slice. The resulting behavior was that no some runs the
computed key would be: "slice.0.attr" and on others would be
"slice.attr", the latter being incorrect.

We now maintain a list of slice indexes so that as we unnest, we
properly restore the old value.

Surprisingly unrelated to the graph but the shadow graph caught this
which is great. :)