### PR TITLE
DebugVisitInfo

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -167,7 +167,7 @@ func (g *AcyclicGraph) Cycles() [][]Vertex {
 // This will walk nodes in parallel if it can. Because the walk is done
 // in parallel, the error returned will be a multierror.
 func (g *AcyclicGraph) Walk(cb WalkFunc) error {
-	defer g.debug.BeginOperation("Walk", "").End("")
+	defer g.debug.BeginOperation(typeWalk, "").End("")
 
 	// Cache the vertices since we use it multiple times
 	vertices := g.Vertices()
@@ -278,7 +278,7 @@ type vertexAtDepth struct {
 // the vertices in start. This is not exported now but it would make sense
 // to export this publicly at some point.
 func (g *AcyclicGraph) DepthFirstWalk(start []Vertex, f DepthWalkFunc) error {
-	defer g.debug.BeginOperation("DepthFirstWalk", "").End("")
+	defer g.debug.BeginOperation(typeDepthFirstWalk, "").End("")
 
 	seen := make(map[Vertex]struct{})
 	frontier := make([]*vertexAtDepth, len(start))
@@ -322,7 +322,7 @@ func (g *AcyclicGraph) DepthFirstWalk(start []Vertex, f DepthWalkFunc) error {
 // reverseDepthFirstWalk does a depth-first walk _up_ the graph starting from
 // the vertices in start.
 func (g *AcyclicGraph) ReverseDepthFirstWalk(start []Vertex, f DepthWalkFunc) error {
-	defer g.debug.BeginOperation("ReverseDepthFirstWalk", "").End("")
+	defer g.debug.BeginOperation(typeReverseDepthFirstWalk, "").End("")
 
 	seen := make(map[Vertex]struct{})
 	frontier := make([]*vertexAtDepth, len(start))

--- a/dag/graph.go
+++ b/dag/graph.go
@@ -339,22 +339,28 @@ func (g *Graph) MarshalJSON() ([]byte, error) {
 // information. After this is set, the graph will immediately encode itself to
 // the stream, and continue to record all subsequent operations.
 func (g *Graph) SetDebugWriter(w io.Writer) {
-	g.debug = &encoder{w}
+	g.debug = &encoder{w: w}
 	g.debug.Encode(newMarshalGraph("root", g))
 }
 
 // DebugVertexInfo encodes arbitrary information about a vertex in the graph
 // debug logs.
 func (g *Graph) DebugVertexInfo(v Vertex, info string) {
-	va := newVertexDebugInfo(v, info)
+	va := newVertexInfo(typeVertexInfo, v, info)
 	g.debug.Encode(va)
 }
 
 // DebugEdgeInfo encodes arbitrary information about an edge in the graph debug
 // logs.
 func (g *Graph) DebugEdgeInfo(e Edge, info string) {
-	ea := newEdgeDebugInfo(e, info)
+	ea := newEdgeInfo(typeEdgeInfo, e, info)
 	g.debug.Encode(ea)
+}
+
+// DebugVisitInfo records a visit to a Vertex during a walk operation.
+func (g *Graph) DebugVisitInfo(v Vertex, info string) {
+	vi := newVertexInfo(typeVisitInfo, v, info)
+	g.debug.Encode(vi)
 }
 
 // DebugOperation marks the start of a set of graph transformations in

--- a/terraform/debug.go
+++ b/terraform/debug.go
@@ -224,40 +224,6 @@ func (d *debugInfo) flush() {
 	}
 }
 
-// WriteGraph takes a DebugGraph and writes both the DebugGraph as a dot file
-// in the debug archive, and extracts any logs that the DebugGraph collected
-// and writes them to a log file in the archive.
-func (d *debugInfo) WriteGraph(name string, g *Graph) error {
-	if d == nil || g == nil {
-		return nil
-	}
-	d.Lock()
-	defer d.Unlock()
-
-	// If we crash, the file won't be correctly closed out, but we can rebuild
-	// the archive if we have to as long as every file has been flushed and
-	// sync'ed.
-	defer d.flush()
-
-	dotPath := fmt.Sprintf("%s/graphs/%d-%s-%s.dot", d.name, d.step, d.phase, name)
-	d.step++
-
-	dotBytes := g.Dot(nil)
-	hdr := &tar.Header{
-		Name: dotPath,
-		Mode: 0644,
-		Size: int64(len(dotBytes)),
-	}
-
-	err := d.tar.WriteHeader(hdr)
-	if err != nil {
-		return err
-	}
-
-	_, err = d.tar.Write(dotBytes)
-	return err
-}
-
 // WriteFile writes data as a single file to the debug arhive.
 func (d *debugInfo) WriteFile(name string, data []byte) error {
 	if d == nil {

--- a/terraform/debug_test.go
+++ b/terraform/debug_test.go
@@ -16,7 +16,6 @@ func TestDebugInfo_nil(t *testing.T) {
 	var d *debugInfo
 
 	d.SetPhase("none")
-	d.WriteGraph("", nil)
 	d.WriteFile("none", nil)
 	d.Close()
 }
@@ -120,9 +119,7 @@ func TestDebug_plan(t *testing.T) {
 	}
 	tr := tar.NewReader(gz)
 
-	files := 0
-	graphs := 0
-	json := 0
+	graphLogs := 0
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
@@ -134,28 +131,13 @@ func TestDebug_plan(t *testing.T) {
 
 		// record any file that contains data
 		if hdr.Size > 0 {
-			files++
-
-			// and any dot graph with data
-			if strings.HasSuffix(hdr.Name, ".dot") {
-				graphs++
-			}
-
 			if strings.HasSuffix(hdr.Name, "graph.json") {
-				json++
+				graphLogs++
 			}
 		}
 	}
 
-	if files == 0 {
-		t.Fatal("no files with data found")
-	}
-
-	if graphs == 0 {
-		t.Fatal("no no-empty graphs found")
-	}
-
-	if json == 0 {
+	if graphLogs == 0 {
 		t.Fatal("no json graphs")
 	}
 }

--- a/terraform/graph.go
+++ b/terraform/graph.go
@@ -246,6 +246,7 @@ func (g *Graph) walk(walker GraphWalker) error {
 	var walkFn dag.WalkFunc
 	walkFn = func(v dag.Vertex) (rerr error) {
 		log.Printf("[DEBUG] vertex '%s.%s': walking", path, dag.VertexName(v))
+		g.DebugVisitInfo(v, g.debugName)
 
 		// If we have a panic wrap GraphWalker and a panic occurs, recover
 		// and call that. We ensure the return value is an error, however,

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -58,18 +58,9 @@ func (b *BasicGraphBuilder) Build(path []string) (*Graph, error) {
 		}
 		debugOp.End(errMsg)
 
-		// always log the graph state to see what transformations may have happened
-		debugName := "build-" + stepName
-		if b.Name != "" {
-			debugName = b.Name + "-" + debugName
-		}
-
 		log.Printf(
 			"[TRACE] Graph after step %T:\n\n%s",
 			step, g.StringWithNodeTypes())
-
-		// TODO: replace entirely with the json logs
-		dbug.WriteGraph(debugName, g)
 
 		if err != nil {
 			return g, err

--- a/terraform/graph_builder.go
+++ b/terraform/graph_builder.go
@@ -30,7 +30,7 @@ type BasicGraphBuilder struct {
 func (b *BasicGraphBuilder) Build(path []string) (*Graph, error) {
 	g := &Graph{Path: path}
 
-	debugName := "build-graph.json"
+	debugName := "graph.json"
 	if b.Name != "" {
 		debugName = b.Name + "-" + debugName
 	}
@@ -125,7 +125,7 @@ func (b *BuiltinGraphBuilder) Build(path []string) (*Graph, error) {
 	basic := &BasicGraphBuilder{
 		Steps:    b.Steps(path),
 		Validate: b.Validate,
-		Name:     "builtin",
+		Name:     "BuiltinGraphBuilder",
 	}
 
 	return basic.Build(path)

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -40,7 +40,7 @@ func (b *ApplyGraphBuilder) Build(path []string) (*Graph, error) {
 	return (&BasicGraphBuilder{
 		Steps:    b.Steps(),
 		Validate: true,
-		Name:     "apply",
+		Name:     "ApplyGraphBuilder",
 	}).Build(path)
 }
 

--- a/terraform/graph_builder_destroy_plan.go
+++ b/terraform/graph_builder_destroy_plan.go
@@ -26,7 +26,7 @@ func (b *DestroyPlanGraphBuilder) Build(path []string) (*Graph, error) {
 	return (&BasicGraphBuilder{
 		Steps:    b.Steps(),
 		Validate: true,
-		Name:     "destroy",
+		Name:     "DestroyPlanGraphBuilder",
 	}).Build(path)
 }
 

--- a/terraform/graph_builder_import.go
+++ b/terraform/graph_builder_import.go
@@ -23,6 +23,7 @@ func (b *ImportGraphBuilder) Build(path []string) (*Graph, error) {
 	return (&BasicGraphBuilder{
 		Steps:    b.Steps(),
 		Validate: true,
+		Name:     "ImportGraphBuilder",
 	}).Build(path)
 }
 

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -38,7 +38,7 @@ func (b *PlanGraphBuilder) Build(path []string) (*Graph, error) {
 	return (&BasicGraphBuilder{
 		Steps:    b.Steps(),
 		Validate: true,
-		Name:     "plan",
+		Name:     "PlanGraphBuilder",
 	}).Build(path)
 }
 

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -191,7 +191,11 @@ func (n *GraphNodeConfigResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 	steps = append(steps, &RootTransformer{})
 
 	// Build the graph
-	b := &BasicGraphBuilder{Steps: steps, Validate: true}
+	b := &BasicGraphBuilder{
+		Steps:    steps,
+		Validate: true,
+		Name:     "GraphNodeConfigResource",
+	}
 	return b.Build(ctx.Path())
 }
 

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -74,7 +74,10 @@ func (n *NodeDestroyResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	steps = append(steps, &RootTransformer{})
 
 	// Build the graph
-	b := &BasicGraphBuilder{Steps: steps}
+	b := &BasicGraphBuilder{
+		Steps: steps,
+		Name:  "NodeResourceDestroy",
+	}
 	return b.Build(ctx.Path())
 }
 

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -101,6 +101,10 @@ func (n *NodePlannableResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	}
 
 	// Build the graph
-	b := &BasicGraphBuilder{Steps: steps, Validate: true}
+	b := &BasicGraphBuilder{
+		Steps:    steps,
+		Validate: true,
+		Name:     "NodePlannableResource",
+	}
 	return b.Build(ctx.Path())
 }

--- a/terraform/transform_destroy_cbd.go
+++ b/terraform/transform_destroy_cbd.go
@@ -142,6 +142,7 @@ func (t *CBDEdgeTransformer) depMap(
 			&AttachStateTransformer{State: t.State},
 			&ReferenceTransformer{},
 		},
+		Name: "CBDEdgeTransformer",
 	}).Build(nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This encodes vertex debug information into the graph log when a vertex
is visited during a walk operation. These can be ordered to show how the
Graph was walked.

Add a mutex to the encoder so it can be used during a parallel walk.

Moved string literal constants used for marshaling to pre-defined constants.
Did some renaming to make the marshal* structures more consistent.