### PR TITLE
Add new aws_vpc_endpoint_route_table_association resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -353,6 +353,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_vpc_peering_connection":                   resourceAwsVpcPeeringConnection(),
 			"aws_vpc":                                      resourceAwsVpc(),
 			"aws_vpc_endpoint":                             resourceAwsVpcEndpoint(),
+			"aws_vpc_endpoint_route_table_association":     resourceAwsVpcEndpointRouteTableAssociation(),
 			"aws_vpn_connection":                           resourceAwsVpnConnection(),
 			"aws_vpn_connection_route":                     resourceAwsVpnConnectionRoute(),
 			"aws_vpn_gateway":                              resourceAwsVpnGateway(),

--- a/builtin/providers/aws/resource_aws_vpc_endpoint.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint.go
@@ -45,6 +45,7 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 			"route_table_ids": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
@@ -1,0 +1,189 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsVpcEndpointRouteTableAssociation() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsVPCEndpointRouteTableAssociationCreate,
+		Read:   resourceAwsVPCEndpointRouteTableAssociationRead,
+		// "resource aws_vpc_endpoint_route_table_association: All fields are ForceNew or Computed w/out Optional, Update is superfluous"
+		// Update: resourceAwsVPCEndpointRouteTableAssociationUpdate,
+		Delete: resourceAwsVPCEndpointRouteTableAssociationDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"vpc_endpoint_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"route_table_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsVPCEndpointRouteTableAssociationCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	endpointId := d.Get("vpc_endpoint_id").(string)
+	rtId := d.Get("route_table_id").(string)
+
+	_, err := findResourceVPCEndpoint(conn, endpointId)
+	if err != nil {
+		return err
+	}
+
+	log.Printf(
+		"[INFO] Creating VPC Endpoint/Route Table association: %s => %s",
+		endpointId, rtId)
+
+	input := &ec2.ModifyVpcEndpointInput{
+		VpcEndpointId:    aws.String(endpointId),
+		AddRouteTableIds: aws.StringSlice([]string{rtId}),
+	}
+
+	_, err = conn.ModifyVpcEndpoint(input)
+	if err != nil {
+		return fmt.Errorf("Error creating VPC Endpoint/Route Table association: %s", err.Error())
+	}
+
+	return resourceAwsVPCEndpointRouteTableAssociationRead(d, meta)
+}
+
+func resourceAwsVPCEndpointRouteTableAssociationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	endpointId := d.Get("vpc_endpoint_id").(string)
+	rtId := d.Get("route_table_id").(string)
+
+	err := findResourceVPCEndpointRouteTableAssociation(conn, endpointId, rtId)
+	if _, notFound := err.(vpcEndpointNotFound); notFound {
+		// The VPC endpoint containing this association no longer exists.
+		d.SetId("")
+		return nil
+	}
+	if _, notFound := err.(vpcEndpointRouteTableAssociationNotFound); notFound {
+		// The association no longer exists.
+		d.SetId("")
+		return nil
+	}
+
+	id := vpcEndpointIdRouteTableIdHash(endpointId, rtId)
+	log.Printf("[DEBUG] Computed VPC Endpoint/Route Table ID %s", id)
+	d.SetId(id)
+
+	return nil
+}
+
+func resourceAwsVPCEndpointRouteTableAssociationDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	endpointId := d.Get("vpc_endpoint_id").(string)
+	rtId := d.Get("route_table_id").(string)
+
+	input := &ec2.ModifyVpcEndpointInput{
+		VpcEndpointId:       aws.String(endpointId),
+		RemoveRouteTableIds: aws.StringSlice([]string{rtId}),
+	}
+
+	_, err := conn.ModifyVpcEndpoint(input)
+	if err != nil {
+		ec2err, ok := err.(awserr.Error)
+		if !ok {
+			return fmt.Errorf("Error deleting VPC Endpoint/Route Table association: %s", err.Error())
+		}
+
+		switch ec2err.Code() {
+		case "InvalidVpcEndpointId.NotFound":
+			log.Printf("[DEBUG] VPC endpoint is already gone")
+		case "InvalidRouteTableId.NotFound":
+			log.Printf("[DEBUG] Route table is already gone")
+		case "InvalidParameter":
+			log.Printf("[DEBUG] VPC Endpoint/Route Table association is already gone")
+		default:
+			return fmt.Errorf("Error deleting VPC Endpoint/Route Table association: %s", err.Error())
+		}
+	}
+
+	log.Printf("[DEBUG] VPC Endpoint/Route Table association %q deleted", d.Id())
+	d.SetId("")
+
+	return nil
+}
+
+func findResourceVPCEndpoint(conn *ec2.EC2, id string) (*ec2.VpcEndpoint, error) {
+	input := &ec2.DescribeVpcEndpointsInput{
+		VpcEndpointIds: aws.StringSlice([]string{id}),
+	}
+
+	log.Printf("[DEBUG] Reading VPC Endpoint: %q", id)
+	output, err := conn.DescribeVpcEndpoints(input)
+	if err, ok := err.(awserr.Error); ok && err.Code() == "InvalidVpcEndpointId.NotFound" {
+		return nil, vpcEndpointNotFound{id, nil}
+	}
+	if err != nil {
+		return nil, err
+	}
+	if output == nil {
+		return nil, vpcEndpointNotFound{id, nil}
+	}
+	if len(output.VpcEndpoints) != 1 || output.VpcEndpoints[0] == nil {
+		return nil, vpcEndpointNotFound{id, output.VpcEndpoints}
+	}
+
+	return output.VpcEndpoints[0], nil
+}
+
+func findResourceVPCEndpointRouteTableAssociation(conn *ec2.EC2, endpointId string, rtId string) error {
+	vpce, err := findResourceVPCEndpoint(conn, endpointId)
+	if err != nil {
+		return err
+	}
+	for _, id := range vpce.RouteTableIds {
+		if id != nil && *id == rtId {
+			return nil
+		}
+	}
+
+	return vpcEndpointRouteTableAssociationNotFound{endpointId, rtId}
+}
+
+func vpcEndpointIdRouteTableIdHash(endpointId, rtId string) string {
+	return fmt.Sprintf("a-%s%d", endpointId, hashcode.String(rtId))
+}
+
+type vpcEndpointNotFound struct {
+	id           string
+	vpcEndpoints []*ec2.VpcEndpoint
+}
+
+func (err vpcEndpointNotFound) Error() string {
+	if err.vpcEndpoints == nil {
+		return fmt.Sprintf("No VPC endpoint with ID %q", err.id)
+	}
+	return fmt.Sprintf("Expected to find one VPC endpoint with ID %q, got: %#v",
+		err.id, err.vpcEndpoints)
+}
+
+type vpcEndpointRouteTableAssociationNotFound struct {
+	endpointId string
+	rtId       string
+}
+
+func (err vpcEndpointRouteTableAssociationNotFound) Error() string {
+	return fmt.Sprintf("Unable to find matching association for VPC endpoint (%s) and route table (%s)",
+		err.endpointId,
+		err.rtId)
+}

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
@@ -60,6 +60,10 @@ func resourceAwsVPCEndpointRouteTableAssociationCreate(d *schema.ResourceData, m
 	if err != nil {
 		return fmt.Errorf("Error creating VPC Endpoint/Route Table association: %s", err.Error())
 	}
+	id := vpcEndpointIdRouteTableIdHash(endpointId, rtId)
+	log.Printf("[DEBUG] VPC Endpoint/Route Table association %q created.", id)
+
+	d.SetId(id)
 
 	return resourceAwsVPCEndpointRouteTableAssociationRead(d, meta)
 }

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association.go
@@ -15,8 +15,6 @@ func resourceAwsVpcEndpointRouteTableAssociation() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsVPCEndpointRouteTableAssociationCreate,
 		Read:   resourceAwsVPCEndpointRouteTableAssociationRead,
-		// "resource aws_vpc_endpoint_route_table_association: All fields are ForceNew or Computed w/out Optional, Update is superfluous"
-		// Update: resourceAwsVPCEndpointRouteTableAssociationUpdate,
 		Delete: resourceAwsVPCEndpointRouteTableAssociationDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -73,13 +71,20 @@ func resourceAwsVPCEndpointRouteTableAssociationRead(d *schema.ResourceData, met
 	endpointId := d.Get("vpc_endpoint_id").(string)
 	rtId := d.Get("route_table_id").(string)
 
-	err := findResourceVPCEndpointRouteTableAssociation(conn, endpointId, rtId)
-	if _, notFound := err.(vpcEndpointNotFound); notFound {
-		// The VPC endpoint containing this association no longer exists.
+	vpce, err := findResourceVPCEndpoint(conn, endpointId)
+	if err, ok := err.(awserr.Error); ok && err.Code() == "InvalidVpcEndpointId.NotFound" {
 		d.SetId("")
 		return nil
 	}
-	if _, notFound := err.(vpcEndpointRouteTableAssociationNotFound); notFound {
+
+	found := false
+	for _, id := range vpce.RouteTableIds {
+		if id != nil && *id == rtId {
+			found = true
+			break
+		}
+	}
+	if !found {
 		// The association no longer exists.
 		d.SetId("")
 		return nil
@@ -111,9 +116,9 @@ func resourceAwsVPCEndpointRouteTableAssociationDelete(d *schema.ResourceData, m
 
 		switch ec2err.Code() {
 		case "InvalidVpcEndpointId.NotFound":
-			log.Printf("[DEBUG] VPC endpoint is already gone")
+			fallthrough
 		case "InvalidRouteTableId.NotFound":
-			log.Printf("[DEBUG] Route table is already gone")
+			fallthrough
 		case "InvalidParameter":
 			log.Printf("[DEBUG] VPC Endpoint/Route Table association is already gone")
 		default:
@@ -134,60 +139,13 @@ func findResourceVPCEndpoint(conn *ec2.EC2, id string) (*ec2.VpcEndpoint, error)
 
 	log.Printf("[DEBUG] Reading VPC Endpoint: %q", id)
 	output, err := conn.DescribeVpcEndpoints(input)
-	if err, ok := err.(awserr.Error); ok && err.Code() == "InvalidVpcEndpointId.NotFound" {
-		return nil, vpcEndpointNotFound{id, nil}
-	}
 	if err != nil {
 		return nil, err
-	}
-	if output == nil {
-		return nil, vpcEndpointNotFound{id, nil}
-	}
-	if len(output.VpcEndpoints) != 1 || output.VpcEndpoints[0] == nil {
-		return nil, vpcEndpointNotFound{id, output.VpcEndpoints}
 	}
 
 	return output.VpcEndpoints[0], nil
 }
 
-func findResourceVPCEndpointRouteTableAssociation(conn *ec2.EC2, endpointId string, rtId string) error {
-	vpce, err := findResourceVPCEndpoint(conn, endpointId)
-	if err != nil {
-		return err
-	}
-	for _, id := range vpce.RouteTableIds {
-		if id != nil && *id == rtId {
-			return nil
-		}
-	}
-
-	return vpcEndpointRouteTableAssociationNotFound{endpointId, rtId}
-}
-
 func vpcEndpointIdRouteTableIdHash(endpointId, rtId string) string {
 	return fmt.Sprintf("a-%s%d", endpointId, hashcode.String(rtId))
-}
-
-type vpcEndpointNotFound struct {
-	id           string
-	vpcEndpoints []*ec2.VpcEndpoint
-}
-
-func (err vpcEndpointNotFound) Error() string {
-	if err.vpcEndpoints == nil {
-		return fmt.Sprintf("No VPC endpoint with ID %q", err.id)
-	}
-	return fmt.Sprintf("Expected to find one VPC endpoint with ID %q, got: %#v",
-		err.id, err.vpcEndpoints)
-}
-
-type vpcEndpointRouteTableAssociationNotFound struct {
-	endpointId string
-	rtId       string
-}
-
-func (err vpcEndpointRouteTableAssociationNotFound) Error() string {
-	return fmt.Sprintf("Unable to find matching association for VPC endpoint (%s) and route table (%s)",
-		err.endpointId,
-		err.rtId)
 }

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSVpcEndpointRouteTableAssociation_basic(t *testing.T) {
+	var vpce ec2.VpcEndpoint
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcEndpointRouteTableAssociationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccVpcEndpointRouteTableAssociationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVpcEndpointRouteTableAssociationExists(
+						"aws_vpc_endpoint_route_table_association.a", &vpce),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckVpcEndpointRouteTableAssociationDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_vpc_endpoint_route_table_association" {
+			continue
+		}
+
+		// Try to find the resource
+		resp, err := conn.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: aws.StringSlice([]string{rs.Primary.Attributes["vpc_endpoint_id"]}),
+		})
+		if err != nil {
+			// Verify the error is what we want
+			ec2err, ok := err.(awserr.Error)
+			if !ok {
+				return err
+			}
+			if ec2err.Code() != "InvalidVpcEndpointId.NotFound" {
+				return err
+			}
+			return nil
+		}
+
+		vpce := resp.VpcEndpoints[0]
+		if len(vpce.RouteTableIds) > 0 {
+			return fmt.Errorf(
+				"VPC endpoint %s has route tables", *vpce.VpcEndpointId)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckVpcEndpointRouteTableAssociationExists(n string, vpce *ec2.VpcEndpoint) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		resp, err := conn.DescribeVpcEndpoints(&ec2.DescribeVpcEndpointsInput{
+			VpcEndpointIds: aws.StringSlice([]string{rs.Primary.Attributes["vpc_endpoint_id"]}),
+		})
+		if err != nil {
+			return err
+		}
+		if len(resp.VpcEndpoints) == 0 {
+			return fmt.Errorf("VPC endpoint not found")
+		}
+
+		*vpce = *resp.VpcEndpoints[0]
+
+		if len(vpce.RouteTableIds) == 0 {
+			return fmt.Errorf("no route table associations")
+		}
+
+		for _, id := range vpce.RouteTableIds {
+			if *id == rs.Primary.Attributes["route_table_id"] {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("route table association not found")
+	}
+}
+
+const testAccVpcEndpointRouteTableAssociationConfig = `
+resource "aws_vpc" "foo" {
+    cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_vpc_endpoint" "s3" {
+    vpc_id = "${aws_vpc.foo.id}"
+    service_name = "com.amazonaws.us-west-2.s3"
+}
+
+resource "aws_route_table" "rt" {
+    vpc_id = "${aws_vpc.foo.id}"
+
+    tags {
+        Name = "test"
+    }
+}
+
+resource "aws_vpc_endpoint_route_table_association" "a" {
+	vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
+	route_table_id  = "${aws_route_table.rt.id}"
+}
+`

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_route_table_association_test.go
@@ -103,6 +103,10 @@ func testAccCheckVpcEndpointRouteTableAssociationExists(n string, vpce *ec2.VpcE
 }
 
 const testAccVpcEndpointRouteTableAssociationConfig = `
+provider "aws" {
+    region = "us-west-2"
+}
+
 resource "aws_vpc" "foo" {
     cidr_block = "10.0.0.0/16"
 }

--- a/website/source/docs/providers/aws/r/vpc_endpoint.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_endpoint.html.markdown
@@ -10,6 +10,13 @@ description: |-
 
 Provides a VPC Endpoint resource.
 
+~> **NOTE on VPC Endpoints and VPC Endpoint Route Table Associations:** Terraform provides
+both a standalone [VPC Endpoint Route Table Association](vpc_endpoint_route_table_association.html)
+(an association between a VPC endpoint and a single `route_table_id`) and a VPC Endpoint resource
+with a `route_table_ids` attribute. Do not use the same route table ID in both a VPC Endpoint resource
+and a VPC Endpoint Route Table Association resource. Doing so will cause a conflict of associations
+and will overwrite the association.
+
 ## Example Usage
 
 Basic usage:
@@ -40,7 +47,7 @@ The following attributes are exported:
 
 ## Import
 
-VPC Endpoints can be imported using the `vpc endpoint id`, e.g. 
+VPC Endpoints can be imported using the `vpc endpoint id`, e.g.
 
 ```
 $ terraform import aws_vpc_endpoint.endpoint1 vpce-3ecf2a57

--- a/website/source/docs/providers/aws/r/vpc_endpoint_route_table_association.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_endpoint_route_table_association.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "aws"
+page_title: "AWS: aws_vpc_endpoint_route_table_association"
+sidebar_current: "docs-aws-resource-vpc-endpoint-route-table-association"
+description: |-
+  Provides a resource to create an association between a VPC endpoint and routing table.
+---
+
+# aws\_vpc\_endpoint\_route\_table\_association
+
+Provides a resource to create an association between a VPC endpoint and routing table.
+
+~> **NOTE on VPC Endpoints and VPC Endpoint Route Table Associations:** Terraform provides
+both a standalone VPC Endpoint Route Table Association (an association between a VPC endpoint
+and a single `route_table_id`) and a [VPC Endpoint](vpc_endpoint.html) resource with a `route_table_ids`
+attribute. Do not use the same route table ID in both a VPC Endpoint resource and a VPC Endpoint Route
+Table Association resource. Doing so will cause a conflict of associations and will overwrite the association.
+
+## Example Usage
+
+Basic usage:
+
+```
+resource "aws_vpc_endpoint_route_table_association" "private_s3" {
+    vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
+    route_table_id = "${aws_route_table.private.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vpc_endpoint_id` - (Required) The ID of the VPC endpoint with which the routing table will be associated.
+* `route_table_id` - (Required) The ID of the routing table to be associated with the VPC endpoint.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the association.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1063,6 +1063,10 @@
                             <a href="/docs/providers/aws/r/vpc_endpoint.html">aws_vpc_endpoint</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-vpc-endpoint-route-table-association") %>>
+                            <a href="/docs/providers/aws/r/vpc_endpoint_route_table_association.html">aws_vpc_endpoint_route_table_association</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-vpc-peering") %>>
                             <a href="/docs/providers/aws/r/vpc_peering.html">aws_vpc_peering_connection</a>
                         </li>


### PR DESCRIPTION
This PR follows on from #9244 and addresses #9138.
Here's the log from @kwilczynski's initial commit:
```
This commit adds a new resource which allows to a list of route tables to be
either added and/or removed from an existing VPC Endpoint. This resource would
also be complimentary to the existing `aws_vpc_endpoint` resource where the
route tables might not be specified (not a requirement for a VPC Endpoint to
be created successfully) during creation, especially where the workflow is
such where the route tables are not immediately known.
```
As it stands now the new `aws_vpc_endpoint_route_table_association` resource associates/dissociates as single `route_table_id` with a VPC endpoint.
Somehow I feel it's "better" Terraform to use a `count` attribute on the resource to associate multiple route tables with a VPC endpoint rather than accept a list of route tables in a single association, e.g.
```
resource "aws_vpc" "foo" {
    cidr_block = "10.0.0.0/16"
}

resource "aws_vpc_endpoint" "s3" {
    vpc_id = "${aws_vpc.foo.id}"
    service_name = "com.amazonaws.us-west-2.s3"
}

variable "c" {
    default = 2
}

resource "aws_route_table" "rt" {
    count = "${var.c}"

    vpc_id = "${aws_vpc.foo.id}"

    tags {
        Name = "test"
    }
}

resource "aws_vpc_endpoint_route_table_association" "a" {
    count = "${var.c}"

	vpc_endpoint_id = "${aws_vpc_endpoint.s3.id}"
	route_table_id  = "${element(aws_route_table.rt.*.id, count.index)}"
}
```
Since this is a "synthetic" resource (no underlying AWS resource maps exactly to this) this doesn't cause a cognitive disconnect, plus it greatly simplifies the implementation.
I welcome feedback on this, especially from @coen-hyde and @supergibbs who commented on the associated issue.