### PR TITLE
provider/github: add GitHub labels resource

### DIFF
--- a/builtin/providers/github/provider.go
+++ b/builtin/providers/github/provider.go
@@ -38,6 +38,7 @@ func Provider() terraform.ResourceProvider {
 			"github_membership":              resourceGithubMembership(),
 			"github_repository":              resourceGithubRepository(),
 			"github_repository_collaborator": resourceGithubRepositoryCollaborator(),
+			"github_issue_label":             resourceGithubIssueLabel(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/github/resource_github_issue_label.go
+++ b/builtin/providers/github/resource_github_issue_label.go
@@ -1,0 +1,100 @@
+package github
+
+import (
+	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceGithubIssueLabel() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGithubIssueLabelCreate,
+		Read:   resourceGithubIssueLabelRead,
+		Update: resourceGithubIssueLabelUpdate,
+		Delete: resourceGithubIssueLabelDelete,
+
+		Schema: map[string]*schema.Schema{
+			"repository": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"color": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGithubIssueLabelCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+	r := d.Get("repository").(string)
+	n := d.Get("name").(string)
+	c := d.Get("color").(string)
+
+	_, _, err := client.Issues.CreateLabel(meta.(*Organization).name, r, &github.Label{
+		Name:  &n,
+		Color: &c,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildTwoPartID(&r, &n))
+
+	return resourceGithubIssueLabelRead(d, meta)
+}
+
+func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+	r := d.Get("repository").(string)
+	n := d.Get("name").(string)
+
+	githubLabel, _, err := client.Issues.GetLabel(meta.(*Organization).name, r, n)
+	if err != nil {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("color", githubLabel.Color)
+	d.Set("url", githubLabel.URL)
+
+	return nil
+}
+
+func resourceGithubIssueLabelUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+	r := d.Get("repository").(string)
+	n := d.Get("name").(string)
+	c := d.Get("color").(string)
+
+	_, originalName := parseTwoPartID(d.Id())
+	_, _, err := client.Issues.EditLabel(meta.(*Organization).name, r, originalName, &github.Label{
+		Name:  &n,
+		Color: &c,
+	})
+	if err != nil {
+		return err
+	}
+
+	d.SetId(buildTwoPartID(&r, &n))
+
+	return resourceGithubIssueLabelRead(d, meta)
+}
+
+func resourceGithubIssueLabelDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*Organization).client
+	r := d.Get("repository").(string)
+	n := d.Get("name").(string)
+
+	_, err := client.Issues.DeleteLabel(meta.(*Organization).name, r, n)
+	return err
+}

--- a/builtin/providers/github/resource_github_issue_label_test.go
+++ b/builtin/providers/github/resource_github_issue_label_test.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccGithubIssueLabel_basic(t *testing.T) {
+	var label github.Label
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubIssueLabelDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubIssueLabelConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubIssueLabelExists("github_issue_label.test", &label),
+					testAccCheckGithubIssueLabelAttributes(&label, "foo", "000000"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccGithubIssueLabelUpdateConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGithubIssueLabelExists("github_issue_label.test", &label),
+					testAccCheckGithubIssueLabelAttributes(&label, "bar", "FFFFFF"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGithubIssueLabelExists(n string, label *github.Label) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No issue label ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*Organization).client
+		o := testAccProvider.Meta().(*Organization).name
+		r, n := parseTwoPartID(rs.Primary.ID)
+
+		githubLabel, _, err := conn.Issues.GetLabel(o, r, n)
+		if err != nil {
+			return err
+		}
+
+		*label = *githubLabel
+		return nil
+	}
+}
+
+func testAccCheckGithubIssueLabelAttributes(label *github.Label, name, color string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *label.Name != name {
+			return fmt.Errorf("Issue label name does not match: %s, %s", *label.Name, name)
+		}
+
+		if *label.Color != color {
+			return fmt.Errorf("Issue label color does not match: %s, %s", *label.Color, color)
+		}
+
+		return nil
+	}
+}
+
+func testAccGithubIssueLabelDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*Organization).client
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "github_issue_label" {
+			continue
+		}
+
+		o := testAccProvider.Meta().(*Organization).name
+		r, n := parseTwoPartID(rs.Primary.ID)
+		label, res, err := conn.Issues.GetLabel(o, r, n)
+
+		if err == nil {
+			if label != nil &&
+				buildTwoPartID(label.Name, label.Color) == rs.Primary.ID {
+				return fmt.Errorf("Issue label still exists")
+			}
+		}
+		if res.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+var testAccGithubIssueLabelConfig string = fmt.Sprintf(`
+    resource "github_issue_label" "test" {
+      repository = "%s"
+      name       = "foo"
+      color      = "000000"
+    }
+`, testRepo)
+
+var testAccGithubIssueLabelUpdateConfig string = fmt.Sprintf(`
+    resource "github_issue_label" "test" {
+      repository = "%s"
+      name       = "bar"
+      color      = "FFFFFF"
+    }
+`, testRepo)

--- a/website/source/docs/providers/github/r/issue_label.html.markdown
+++ b/website/source/docs/providers/github/r/issue_label.html.markdown
@@ -1,0 +1,33 @@
+---
+layout: "github"
+page_title: "GitHub: github_issue_label"
+sidebar_current: "docs-github-resource-issue-label"
+description: |-
+  Provides a GitHub issue label resource.
+---
+
+# github\_issue_label
+
+Provides a GitHub issue label resource.
+
+This resource allows you to create and manage issue labels within your
+Github organization.
+
+## Example Usage
+
+```
+# Create a new, red colored label
+resource "github_issue_label" "test_repo" {
+  repository = "test-repo"
+  name       = "Urgent"
+  color      = "FF0000"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `repository` - (Required) The GitHub repository
+* `name` - (Required) The name of the label.
+* `color` - (Required) A 6 character hex code, without the leading #, identifying the color of the label.

--- a/website/source/layouts/github.erb
+++ b/website/source/layouts/github.erb
@@ -31,6 +31,9 @@
 					<li<%= sidebar_current("docs-github-resource-team-repository") %>>
 						<a href="/docs/providers/github/r/team_repository.html">github_team_repository</a>
 					</li>
+					<li<%= sidebar_current("docs-github-resource-issue-label") %>>
+						<a href="/docs/providers/github/r/issue_label.html">github_issue_label</a>
+					</li>
 				</ul>
 				</li>
 			</ul>


### PR DESCRIPTION
In terms of use-case, I'm not entirely sure how useful this'll be. But, I quite like the idea of being able to quickly manage all labels for current, and future repositories in a consistent manner. The default labels GitHub provides aren't ideal. Understandably, this doesn't wipe the default labels.

Thoughts, and suggestions welcomed (especially with regards to naming).

---

This resource allows easy management of issue labels for an organisation's repositories. A name, and a color can be set. These attributes can be updated without creating a new resource.
