### PR TITLE
provider/docker: authentication via values instead of files

### DIFF
--- a/builtin/providers/docker/config.go
+++ b/builtin/providers/docker/config.go
@@ -21,7 +21,7 @@ type Config struct {
 func (c *Config) NewClient() (*dc.Client, error) {
 	if c.Ca != "" || c.Cert != "" || c.Key != "" {
 		if c.Ca == "" || c.Cert == "" || c.Key == "" {
-			return nil, fmt.Errorf("ca, cert, and key must be specified")
+			return nil, fmt.Errorf("ca_material, cert_material, and key_material must be specified")
 		}
 
 		return dc.NewTLSClientFromBytes(c.Host, []byte(c.Cert), []byte(c.Key), []byte(c.Ca))

--- a/builtin/providers/docker/config.go
+++ b/builtin/providers/docker/config.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"fmt"
 	"path/filepath"
 
 	dc "github.com/fsouza/go-dockerclient"
@@ -10,21 +11,32 @@ import (
 // Docker API compatible host.
 type Config struct {
 	Host     string
+	Ca       string
+	Cert     string
+	Key      string
 	CertPath string
 }
 
 // NewClient() returns a new Docker client.
 func (c *Config) NewClient() (*dc.Client, error) {
-	// If there is no cert information, then just return the direct client
-	if c.CertPath == "" {
-		return dc.NewClient(c.Host)
+	if c.Ca != "" || c.Cert != "" || c.Key != "" {
+		if c.Ca == "" || c.Cert == "" || c.Key == "" {
+			return nil, fmt.Errorf("ca, cert, and key must be specified")
+		}
+
+		return dc.NewTLSClientFromBytes(c.Host, []byte(c.Cert), []byte(c.Key), []byte(c.Ca))
 	}
 
-	// If there is cert information, load it and use it.
-	ca := filepath.Join(c.CertPath, "ca.pem")
-	cert := filepath.Join(c.CertPath, "cert.pem")
-	key := filepath.Join(c.CertPath, "key.pem")
-	return dc.NewTLSClient(c.Host, cert, key, ca)
+	if c.CertPath != "" {
+		// If there is cert information, load it and use it.
+		ca := filepath.Join(c.CertPath, "ca.pem")
+		cert := filepath.Join(c.CertPath, "cert.pem")
+		key := filepath.Join(c.CertPath, "key.pem")
+		return dc.NewTLSClient(c.Host, cert, key, ca)
+	}
+
+	// If there is no cert information, then just return the direct client
+	return dc.NewClient(c.Host)
 }
 
 // Data ia structure for holding data that we fetch from Docker.

--- a/builtin/providers/docker/provider.go
+++ b/builtin/providers/docker/provider.go
@@ -17,6 +17,25 @@ func Provider() terraform.ResourceProvider {
 				Description: "The Docker daemon address",
 			},
 
+			"ca": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
+				ConflictsWith: []string{"cert_path"},
+			},
+			"cert": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
+				ConflictsWith: []string{"cert_path"},
+			},
+			"key": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Default:       "",
+				ConflictsWith: []string{"cert_path"},
+			},
+
 			"cert_path": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -43,6 +62,9 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Host:     d.Get("host").(string),
+		Ca:       d.Get("ca").(string),
+		Cert:     d.Get("cert").(string),
+		Key:      d.Get("key").(string),
 		CertPath: d.Get("cert_path").(string),
 	}
 

--- a/builtin/providers/docker/provider.go
+++ b/builtin/providers/docker/provider.go
@@ -17,23 +17,26 @@ func Provider() terraform.ResourceProvider {
 				Description: "The Docker daemon address",
 			},
 
-			"ca": &schema.Schema{
+			"ca_material": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
-				Default:       "",
+				DefaultFunc:   schema.EnvDefaultFunc("DOCKER_CA_MATERIAL", ""),
 				ConflictsWith: []string{"cert_path"},
+				Description:   "PEM-encoded content of Docker host CA certificate",
 			},
-			"cert": &schema.Schema{
+			"cert_material": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
-				Default:       "",
+				DefaultFunc:   schema.EnvDefaultFunc("DOCKER_CERT_MATERIAL", ""),
 				ConflictsWith: []string{"cert_path"},
+				Description:   "PEM-encoded content of Docker client certificate",
 			},
-			"key": &schema.Schema{
+			"key_material": &schema.Schema{
 				Type:          schema.TypeString,
 				Optional:      true,
-				Default:       "",
+				DefaultFunc:   schema.EnvDefaultFunc("DOCKER_KEY_MATERIAL", ""),
 				ConflictsWith: []string{"cert_path"},
+				Description:   "PEM-encoded content of Docker client private key",
 			},
 
 			"cert_path": &schema.Schema{
@@ -62,9 +65,9 @@ func Provider() terraform.ResourceProvider {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		Host:     d.Get("host").(string),
-		Ca:       d.Get("ca").(string),
-		Cert:     d.Get("cert").(string),
-		Key:      d.Get("key").(string),
+		Ca:       d.Get("ca_material").(string),
+		Cert:     d.Get("cert_material").(string),
+		Key:      d.Get("key_material").(string),
 		CertPath: d.Get("cert_path").(string),
 	}
 

--- a/website/source/docs/providers/docker/index.html.markdown
+++ b/website/source/docs/providers/docker/index.html.markdown
@@ -57,6 +57,9 @@ The following arguments are supported:
   for connecting to the Docker host via TLS. If this is blank, the
   `DOCKER_CERT_PATH` will also be checked.
 
+* `ca`, `cert`, `key`, - (Optional) Content of `ca.pem`, `cert.pem`, and `key.pem` files
+  for TLS authentication. Cannot be used together with `cert_path`.
+
 ~> **NOTE on Certificates and `docker-machine`:**  As per [Docker Remote API
 documentation](https://docs.docker.com/engine/reference/api/docker_remote_api/),
 in any docker-machine environment, the Docker daemon uses an encrypted TCP

--- a/website/source/docs/providers/docker/index.html.markdown
+++ b/website/source/docs/providers/docker/index.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
   for connecting to the Docker host via TLS. If this is blank, the
   `DOCKER_CERT_PATH` will also be checked.
 
-* `ca`, `cert`, `key`, - (Optional) Content of `ca.pem`, `cert.pem`, and `key.pem` files
+* `ca_material`, `cert_material`, `key_material`, - (Optional) Content of `ca.pem`, `cert.pem`, and `key.pem` files
   for TLS authentication. Cannot be used together with `cert_path`.
 
 ~> **NOTE on Certificates and `docker-machine`:**  As per [Docker Remote API


### PR DESCRIPTION
This PR adds new parameters for configuring remote Docker host for encryption and client authentication via inline values instead of external files.
```
provider "docker" {
  host = "tcp://hostname:2376"
  ca = "${tls_self_signed_cert.docker_ca.cert_pem}"
  cert = "${tls_locally_signed_cert.docker_client.cert_pem}"
  key = "${tls_private_key.docker_client.private_key_pem}"
}
```

This allows referencing other resources, for example from TLS and Vault providers.

See a complete example at https://github.com/mkuzmin/terraform-demo/tree/a851f57feda0e694e6a908baff019d6ea79b0316