### PR TITLE
Fix resource.UniqueId to be properly ordered

### DIFF
--- a/helper/resource/id_test.go
+++ b/helper/resource/id_test.go
@@ -6,8 +6,7 @@ import (
 	"testing"
 )
 
-var allDigits = regexp.MustCompile(`^\d+$`)
-var allBase32 = regexp.MustCompile(`^[a-z234567]+$`)
+var allHex = regexp.MustCompile(`^[a-f0-9]+$`)
 
 func TestUniqueId(t *testing.T) {
 	iterations := 10000
@@ -30,15 +29,8 @@ func TestUniqueId(t *testing.T) {
 			t.Fatalf("Post-prefix part has wrong length! %s", rest)
 		}
 
-		timestamp := rest[:23]
-		random := rest[23:]
-
-		if !allDigits.MatchString(timestamp) {
-			t.Fatalf("Timestamp not all digits! %s", timestamp)
-		}
-
-		if !allBase32.MatchString(random) {
-			t.Fatalf("Random part not all base32! %s", random)
+		if !allHex.MatchString(rest) {
+			t.Fatalf("Random part not all hex! %s", rest)
 		}
 
 		if lastId != "" && lastId >= id {


### PR DESCRIPTION
This isn't a major issue, and probably never encountered in real usage, but I was tired of my unit tests failing because time was used as a counter. 

`UniqueId` attempted to provide an ordered unique id by using a nanosecond
timestamp, but doesn't take into account that time is not monotonic
increasing, nor do many system clocks have the resolution to return different times
when called in quick succession. This provides an implementation that will always be
increasing.