### PR TITLE
Remove darwin/386 from the build

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,7 +17,7 @@ GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
 # Determine the arch/os combos we're building for
 XC_ARCH=${XC_ARCH:-"386 amd64 arm"}
 XC_OS=${XC_OS:-linux darwin windows freebsd openbsd solaris}
-XC_EXCLUDE_OSARCH="!darwin/arm"
+XC_EXCLUDE_OSARCH="!darwin/arm !darwin/386"
 
 # Delete the old dir
 echo "==> Removing old directory..."


### PR DESCRIPTION
There isn't a supported configuration that runs darwin/386, so remove it from
the build.