### PR TITLE
provider/aws: Fixed deletion of aws_api_gateway_base_path_mapping with empty path

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_base_path_mapping.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_base_path_mapping.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+const emptyBasePathMappingValue = "(none)"
+
 func resourceAwsApiGatewayBasePathMapping() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsApiGatewayBasePathMappingCreate,
@@ -19,22 +21,22 @@ func resourceAwsApiGatewayBasePathMapping() *schema.Resource {
 		Delete: resourceAwsApiGatewayBasePathMappingDelete,
 
 		Schema: map[string]*schema.Schema{
-			"api_id": &schema.Schema{
+			"api_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"base_path": &schema.Schema{
+			"base_path": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"stage_name": &schema.Schema{
+			"stage_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"domain_name": &schema.Schema{
+			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -87,6 +89,10 @@ func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta inter
 		return nil
 	}
 
+	if basePath == "" {
+		basePath = emptyBasePathMappingValue
+	}
+
 	mapping, err := conn.GetBasePathMapping(&apigateway.GetBasePathMappingInput{
 		DomainName: aws.String(domainName),
 		BasePath:   aws.String(basePath),
@@ -101,7 +107,13 @@ func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta inter
 		return fmt.Errorf("Error reading Gateway base path mapping: %s", err)
 	}
 
-	d.Set("base_path", mapping.BasePath)
+	mappingBasePath := *mapping.BasePath
+
+	if mappingBasePath == emptyBasePathMappingValue {
+		mappingBasePath = ""
+	}
+
+	d.Set("base_path", mappingBasePath)
 	d.Set("api_id", mapping.RestApiId)
 	d.Set("stage_name", mapping.Stage)
 
@@ -111,9 +123,15 @@ func resourceAwsApiGatewayBasePathMappingRead(d *schema.ResourceData, meta inter
 func resourceAwsApiGatewayBasePathMappingDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).apigateway
 
+	basePath := d.Get("base_path").(string)
+
+	if basePath == "" {
+		basePath = emptyBasePathMappingValue
+	}
+
 	_, err := conn.DeleteBasePathMapping(&apigateway.DeleteBasePathMappingInput{
 		DomainName: aws.String(d.Get("domain_name").(string)),
-		BasePath:   aws.String(d.Get("base_path").(string)),
+		BasePath:   aws.String(basePath),
 	})
 
 	if err != nil {

--- a/builtin/providers/aws/resource_aws_api_gateway_base_path_mapping_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_base_path_mapping_test.go
@@ -22,10 +22,32 @@ func TestAccAWSAPIGatewayBasePath_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayBasePathDestroy(name),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayBasePathConfig(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayBasePathExists("aws_api_gateway_base_path_mapping.test", name, &conf),
+				),
+			},
+		},
+	})
+}
+
+// https://github.com/hashicorp/terraform/issues/9212
+func TestAccAWSAPIGatewayEmptyBasePath_basic(t *testing.T) {
+	var conf apigateway.BasePathMapping
+
+	// Our test cert is for a wildcard on this domain
+	name := fmt.Sprintf("%s.tf-acc.invalid", resource.UniqueId())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSAPIGatewayBasePathDestroy(name),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSAPIGatewayEmptyBasePathConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayEmptyBasePathExists("aws_api_gateway_base_path_mapping.test", name, &conf),
 				),
 			},
 		},
@@ -56,6 +78,34 @@ func testAccCheckAWSAPIGatewayBasePathExists(n string, name string, res *apigate
 
 		if *describe.BasePath != "tf-acc" {
 			return fmt.Errorf("base path mapping not found")
+		}
+
+		*res = *describe
+
+		return nil
+	}
+}
+
+func testAccCheckAWSAPIGatewayEmptyBasePathExists(n string, name string, res *apigateway.BasePathMapping) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No API Gateway ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).apigateway
+
+		req := &apigateway.GetBasePathMappingInput{
+			DomainName: aws.String(name),
+			BasePath:   aws.String(""),
+		}
+		describe, err := conn.GetBasePathMapping(req)
+		if err != nil {
+			return err
 		}
 
 		*res = *describe
@@ -130,9 +180,54 @@ resource "aws_api_gateway_base_path_mapping" "test" {
 resource "aws_api_gateway_domain_name" "test" {
   domain_name = "%s"
   certificate_name = "tf-apigateway-base-path-mapping-test"
-  certificate_body = "%s"
-  certificate_chain = "%s"
-  certificate_private_key = "%s"
+  certificate_body = <<EOF
+%vEOF
+  certificate_chain = <<EOF
+%vEOF
+  certificate_private_key = <<EOF
+%vEOF
+}
+`, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
+}
+
+func testAccAWSAPIGatewayEmptyBasePathConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_rest_api" "test" {
+  name = "tf-acc-apigateway-base-path-mapping"
+  description = "Terraform Acceptance Tests"
+}
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  http_method = "GET"
+  authorization = "NONE"
+}
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+  type = "MOCK"
+}
+resource "aws_api_gateway_deployment" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  stage_name = "test"
+  depends_on = ["aws_api_gateway_integration.test"]
+}
+resource "aws_api_gateway_base_path_mapping" "test" {
+  api_id = "${aws_api_gateway_rest_api.test.id}"
+  base_path = ""
+  stage_name = "${aws_api_gateway_deployment.test.stage_name}"
+  domain_name = "${aws_api_gateway_domain_name.test.domain_name}"
+}
+resource "aws_api_gateway_domain_name" "test" {
+  domain_name = "%s"
+  certificate_name = "tf-apigateway-base-path-mapping-test"
+  certificate_body = <<EOF
+%vEOF
+  certificate_chain = <<EOF
+%vEOF
+  certificate_private_key = <<EOF
+%vEOF
 }
 `, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/9212

Here is the output when running it:
```
2016/11/16 23:16:49 [DEBUG] plugin: terraform: aws-provider (internal) 2016/11/16 23:16:49 [DEBUG] [aws-sdk-go] DEBUG: Request apigateway/CreateBasePathMapping Details:
2016/11/16 23:16:49 [DEBUG] plugin: terraform: ---[ REQUEST POST-SIGN ]-----------------------------
2016/11/16 23:16:49 [DEBUG] plugin: terraform: POST http://apigateway.eu-west-1.amazonaws.com/domainnames/12345.tf-acc.invalid/basepathmappings HTTP/1.1

...

2016/11/16 23:16:49 [DEBUG] plugin: terraform: 
2016/11/16 23:16:49 [DEBUG] plugin: terraform: {"basePath":"","restApiId":"c7hpqdek26","stage":"test"}
2016/11/16 23:16:49 [DEBUG] plugin: terraform: -----------------------------------------------------
2016/11/16 23:16:49 [DEBUG] plugin: terraform: aws-provider (internal) 2016/11/16 23:16:49 [DEBUG] [aws-sdk-go] DEBUG: Response apigateway/CreateBasePathMapping Details:
2016/11/16 23:16:49 [DEBUG] plugin: terraform: ---[ RESPONSE ]--------------------------------------

...

2016/11/16 23:16:49 [DEBUG] plugin: terraform: 
2016/11/16 23:16:49 [DEBUG] plugin: terraform: {"basePath":"(none)","restApiId":"c7hpqdek26","stage":"test"}
2016/11/16 23:16:49 [DEBUG] plugin: terraform: 
2016/11/16 23:16:49 [DEBUG] plugin: terraform: -----------------------------------------------------
2016/11/16 23:16:49 [DEBUG] plugin: terraform: aws-provider (internal) 2016/11/16 23:16:49 [DEBUG] [aws-sdk-go] DEBUG: Request apigateway/GetBasePathMapping Details:
2016/11/16 23:16:49 [DEBUG] plugin: terraform: ---[ REQUEST POST-SIGN ]-----------------------------
2016/11/16 23:16:49 [DEBUG] plugin: terraform: GET http://apigateway.eu-west-1.amazonaws.com/domainnames/12345.tf-acc.invalid/basepathmappings/ HTTP/1.1

...

2016/11/16 23:16:49 [DEBUG] plugin: terraform: 
2016/11/16 23:16:49 [DEBUG] plugin: terraform: 
2016/11/16 23:16:49 [DEBUG] plugin: terraform: -----------------------------------------------------
2016/11/16 23:16:49 [DEBUG] plugin: terraform: aws-provider (internal) 2016/11/16 23:16:49 [DEBUG] [aws-sdk-go] DEBUG: Response apigateway/GetBasePathMapping Details:
2016/11/16 23:16:49 [DEBUG] plugin: terraform: ---[ RESPONSE ]--------------------------------------

...

2016/11/16 23:16:49 [DEBUG] plugin: terraform: 
2016/11/16 23:16:49 [DEBUG] plugin: terraform: {"item":[{"basePath":"(none)","restApiId":"c7hpqdek26","stage":"test"}]}
2016/11/16 23:16:49 [DEBUG] plugin: terraform: 
2016/11/16 23:16:49 [DEBUG] plugin: terraform: -----------------------------------------------------
```
