### PR TITLE
Add name_prefix to aws_iam_policy

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_policy_test.go
@@ -1,0 +1,126 @@
+package aws
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSPolicy_namePrefix(t *testing.T) {
+	var out iam.GetPolicyOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSPolicyPrefixNameConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSPolicyExists("aws_iam_policy.policy", &out),
+					testAccCheckAWSPolicyGeneratedNamePrefix(
+						"aws_iam_policy.policy", "test-policy-"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSPolicyDestroy(s *terraform.State) error {
+	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iam_policy" {
+			continue
+		}
+
+		// Try to get policy
+		_, err := iamconn.GetPolicy(&iam.GetPolicyInput{
+			PolicyArn: aws.String(rs.Primary.Attributes["arn"]),
+		})
+		if err == nil {
+			return fmt.Errorf("still exist.")
+		}
+
+		// Verify the error is what we want
+		ec2err, ok := err.(awserr.Error)
+		if !ok {
+			return err
+		}
+		if ec2err.Code() != "NoSuchEntity" {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSPolicyExists(resource string, res *iam.GetPolicyOutput) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("Not found: %s", resource)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Policy name is set")
+		}
+
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+		resp, err := iamconn.GetPolicy(&iam.GetPolicyInput{
+			PolicyArn: aws.String(rs.Primary.Attributes["arn"]),
+		})
+		if err != nil {
+			return err
+		}
+
+		*res = *resp
+
+		return nil
+	}
+}
+
+func testAccCheckAWSPolicyGeneratedNamePrefix(resource, prefix string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r, ok := s.RootModule().Resources[resource]
+		if !ok {
+			return fmt.Errorf("Resource not found")
+		}
+		name, ok := r.Primary.Attributes["name"]
+		if !ok {
+			return fmt.Errorf("Name attr not found: %#v", r.Primary.Attributes)
+		}
+		if !strings.HasPrefix(name, prefix) {
+			return fmt.Errorf("Name: %q, does not have prefix: %q", name, prefix)
+		}
+		return nil
+	}
+}
+
+const testAccAWSPolicyPrefixNameConfig = `
+resource "aws_iam_policy" "policy" {
+	name_prefix = "test-policy-"
+	path = "/"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+`

--- a/website/source/docs/providers/aws/r/iam_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy.html.markdown
@@ -37,12 +37,14 @@ EOF
 The following arguments are supported:
 
 * `description` - (Optional) Description of the IAM policy.
+* `name` - (Optional, Forces new resource) The name of the policy.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the policy.
+  See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
 * `policy` - (Required) The policy document. This is a JSON formatted string.
   The heredoc syntax, `file` function, or the [`aws_iam_policy_document` data
   source](/docs/providers/aws/d/iam_policy_document.html)
   are all helpful here.
-* `name` (Required) - The name of the policy.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is intended to behave the same way as name_prefix does in `aws_iam_role`.

Fixes #10176

Feedback on the interface change would be highly appreciated. I was able to get the acceptance tests to run successfully thanks to some help from a peer, so I feel pretty confident about this.