### PR TITLE
provider/aws: FIxed the api_gw_domain_name replace operation

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -21,43 +21,43 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 
-			"certificate_body": &schema.Schema{
+			"certificate_body": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"certificate_chain": &schema.Schema{
+			"certificate_chain": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"certificate_name": &schema.Schema{
+			"certificate_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"certificate_private_key": &schema.Schema{
+			"certificate_private_key": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"domain_name": &schema.Schema{
+			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"cloudfront_domain_name": &schema.Schema{
+			"cloudfront_domain_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"certificate_upload_date": &schema.Schema{
+			"certificate_upload_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"cloudfront_zone_id": &schema.Schema{
+			"cloudfront_zone_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -120,7 +120,7 @@ func resourceAwsApiGatewayDomainNameUpdateOperations(d *schema.ResourceData) []*
 	if d.HasChange("certificate_body") {
 		operations = append(operations, &apigateway.PatchOperation{
 			Op:    aws.String("replace"),
-			Path:  aws.String("/certificate_body"),
+			Path:  aws.String("/certificateBody"),
 			Value: aws.String(d.Get("certificate_body").(string)),
 		})
 	}
@@ -128,7 +128,7 @@ func resourceAwsApiGatewayDomainNameUpdateOperations(d *schema.ResourceData) []*
 	if d.HasChange("certificate_chain") {
 		operations = append(operations, &apigateway.PatchOperation{
 			Op:    aws.String("replace"),
-			Path:  aws.String("/certificate_chain"),
+			Path:  aws.String("/certificateChain"),
 			Value: aws.String(d.Get("certificate_chain").(string)),
 		})
 	}
@@ -136,7 +136,7 @@ func resourceAwsApiGatewayDomainNameUpdateOperations(d *schema.ResourceData) []*
 	if d.HasChange("certificate_name") {
 		operations = append(operations, &apigateway.PatchOperation{
 			Op:    aws.String("replace"),
-			Path:  aws.String("/certificate_name"),
+			Path:  aws.String("/certificateName"),
 			Value: aws.String(d.Get("certificate_name").(string)),
 		})
 	}
@@ -144,7 +144,7 @@ func resourceAwsApiGatewayDomainNameUpdateOperations(d *schema.ResourceData) []*
 	if d.HasChange("certificate_private_key") {
 		operations = append(operations, &apigateway.PatchOperation{
 			Op:    aws.String("replace"),
-			Path:  aws.String("/certificate_private_key"),
+			Path:  aws.String("/certificatePrivateKey"),
 			Value: aws.String(d.Get("certificate_private_key").(string)),
 		})
 	}

--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name_test.go
@@ -15,35 +15,37 @@ func TestAccAWSAPIGatewayDomainName_basic(t *testing.T) {
 	var conf apigateway.DomainName
 
 	// Our test cert is for a wildcard on this domain
-	name := fmt.Sprintf("%s.tf-acc.invalid", resource.UniqueId())
+	uniqueId := resource.UniqueId()
+	name := fmt.Sprintf("%s.tf-acc.invalid", uniqueId)
+	nameModified := fmt.Sprintf("test-acc.%s.tf-acc.invalid", uniqueId)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayDomainNameDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayDomainNameConfigCreate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayDomainNameExists("aws_api_gateway_domain_name.test", &conf),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_domain_name.test", "certificate_body", testAccAWSAPIGatewayCertBody,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_domain_name.test", "certificate_chain", testAccAWSAPIGatewayCertChain,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_domain_name.test", "certificate_name", "tf-acc-apigateway-domain-name",
-					),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_domain_name.test", "certificate_private_key", testAccAWSAPIGatewayCertPrivateKey,
-					),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_domain_name.test", "domain_name", name,
-					),
-					resource.TestCheckResourceAttrSet(
-						"aws_api_gateway_domain_name.test", "certificate_upload_date",
-					),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_body", testAccAWSAPIGatewayCertBody),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_chain", testAccAWSAPIGatewayCertChain),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_name", "tf-acc-apigateway-domain-name"),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_private_key", testAccAWSAPIGatewayCertPrivateKey),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "domain_name", name),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_domain_name.test", "certificate_upload_date"),
+				),
+			},
+			{
+				Config: testAccAWSAPIGatewayDomainNameConfigUpdate(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayDomainNameExists("aws_api_gateway_domain_name.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_body", testAccAWSAPIGatewayCertBody),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_chain", testAccAWSAPIGatewayCertChain),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_name", "tf-acc-apigateway-domain-name"),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "certificate_private_key", testAccAWSAPIGatewayCertPrivateKey),
+					resource.TestCheckResourceAttr("aws_api_gateway_domain_name.test", "domain_name", nameModified),
+					resource.TestCheckResourceAttrSet("aws_api_gateway_domain_name.test", "certificate_upload_date"),
 				),
 			},
 		},
@@ -205,10 +207,28 @@ func testAccAWSAPIGatewayDomainNameConfigCreate(name string) string {
 	return fmt.Sprintf(`
 resource "aws_api_gateway_domain_name" "test" {
   domain_name = "%s"
-  certificate_body = "%v"
-  certificate_chain = "%v"
+  certificate_body = <<EOF
+%vEOF
+  certificate_chain = <<EOF
+%vEOF
   certificate_name = "tf-acc-apigateway-domain-name"
-  certificate_private_key = "%v"
+  certificate_private_key = <<EOF
+%vEOF
+}
+`, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
+}
+
+func testAccAWSAPIGatewayDomainNameConfigUpdate(name string) string {
+	return fmt.Sprintf(`
+resource "aws_api_gateway_domain_name" "test" {
+  domain_name = "test-acc.%s"
+  certificate_body = <<EOF
+%vEOF
+  certificate_chain = <<EOF
+%vEOF
+  certificate_name = "tf-acc-apigateway-domain-name"
+  certificate_private_key = <<EOF
+%vEOF
 }
 `, name, testAccAWSAPIGatewayCertBody, testAccAWSAPIGatewayCertChain, testAccAWSAPIGatewayCertPrivateKey)
 }


### PR DESCRIPTION
This fixes partially https://github.com/hashicorp/terraform/issues/8789.

When you try to update the certificate_name, which is allowed per https://docs.aws.amazon.com/apigateway/api-reference/link-relation/domainname-update/, you get the following response:
> aws_api_gateway_domain_name.hsts: BadRequestException: Invalid patch path  '/certificate_name' specified for op 'replace'. Must be one of: [/certificateName]

This updates the replace paths in order to remove this error. This does not try to fix the issue about updating the certificate, which should be about forcing a new resource.

Another PR will follow which will be about forcing new resources for certificate changes.