### PR TITLE
provider/aws: Add aws_alb_listener data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_alb_listener.go
+++ b/builtin/providers/aws/data_source_aws_alb_listener.go
@@ -1,0 +1,62 @@
+package aws
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func dataSourceAwsAlbListener() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsAlbListenerRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"load_balancer_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"protocol": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ssl_policy": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"default_action": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"target_group_arn": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsAlbListenerRead(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(d.Get("arn").(string))
+	return resourceAwsAlbListenerRead(d, meta)
+}

--- a/builtin/providers/aws/data_source_aws_alb_listener_test.go
+++ b/builtin/providers/aws/data_source_aws_alb_listener_test.go
@@ -1,0 +1,318 @@
+package aws
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAWSALBListener_basic(t *testing.T) {
+	albName := fmt.Sprintf("testlistener-basic-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSALBListenerConfigBasic(albName, targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "protocol", "HTTP"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "port", "80"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "default_action.0.target_group_arn"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAWSALBListener_https(t *testing.T) {
+	albName := fmt.Sprintf("testlistener-https-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSALBListenerConfigHTTPS(albName, targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "load_balancer_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "arn"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "port", "443"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "default_action.0.type", "forward"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "default_action.0.target_group_arn"),
+					resource.TestCheckResourceAttrSet("data.aws_alb_listener.front_end", "certificate_arn"),
+					resource.TestCheckResourceAttr("data.aws_alb_listener.front_end", "ssl_policy", "ELBSecurityPolicy-2015-05"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSALBListenerConfigBasic(albName, targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_listener" "front_end" {
+   load_balancer_arn = "${aws_alb.alb_test.id}"
+   protocol = "HTTP"
+   port = "80"
+
+   default_action {
+     target_group_arn = "${aws_alb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_alb" "alb_test" {
+  name            = "%s"
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+data "aws_alb_listener" "front_end" {
+	arn = "${aws_alb_listener.front_end.arn}"
+}`, albName, targetGroupName)
+}
+
+func testAccDataSourceAWSALBListenerConfigHTTPS(albName, targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_listener" "front_end" {
+   load_balancer_arn = "${aws_alb.alb_test.id}"
+   protocol = "HTTPS"
+   port = "443"
+   ssl_policy = "ELBSecurityPolicy-2015-05"
+   certificate_arn = "${aws_iam_server_certificate.test_cert.arn}"
+
+   default_action {
+     target_group_arn = "${aws_alb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_alb" "alb_test" {
+  name            = "%s"
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_iam_server_certificate" "test_cert" {
+  name = "terraform-test-cert-%d"
+  certificate_body = <<EOF
+-----BEGIN CERTIFICATE-----
+MIIDBjCCAe4CCQCGWwBmOiHQdTANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJB
+VTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0
+cyBQdHkgTHRkMB4XDTE2MDYyMTE2MzM0MVoXDTE3MDYyMTE2MzM0MVowRTELMAkG
+A1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0
+IFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AL+LFlsCJG5txZp4yuu+lQnuUrgBXRG+irQqcTXlV91Bp5hpmRIyhnGCtWxxDBUL
+xrh4WN3VV/0jDzKT976oLgOy3hj56Cdqf+JlZ1qgMN5bHB3mm3aVWnrnsLbBsfwZ
+SEbk3Kht/cE1nK2toNVW+rznS3m+eoV3Zn/DUNwGlZr42hGNs6ETn2jURY78ETqR
+mW47xvjf86eIo7vULHJaY6xyarPqkL8DZazOmvY06hUGvGwGBny7gugfXqDG+I8n
+cPBsGJGSAmHmVV8o0RCB9UjY+TvSMQRpEDoVlvyrGuglsD8to/4+7UcsuDGlRYN6
+jmIOC37mOi/jwRfWL1YUa4MCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAPDxTH0oQ
+JjKXoJgkmQxurB81RfnK/NrswJVzWbOv6ejcbhwh+/ZgJTMc15BrYcxU6vUW1V/i
+Z7APU0qJ0icECACML+a2fRI7YdLCTiPIOmY66HY8MZHAn3dGjU5TeiUflC0n0zkP
+mxKJe43kcYLNDItbfvUDo/GoxTXrC3EFVZyU0RhFzoVJdODlTHXMVFCzcbQEBrBJ
+xKdShCEc8nFMneZcGFeEU488ntZoWzzms8/QpYrKa5S0Sd7umEU2Kwu4HTkvUFg/
+CqDUFjhydXxYRsxXBBrEiLOE5BdtJR1sH/QHxIJe23C9iHI2nS1NbLziNEApLwC4
+GnSud83VUo9G9w==
+-----END CERTIFICATE-----
+EOF
+
+	private_key =  <<EOF
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEAv4sWWwIkbm3FmnjK676VCe5SuAFdEb6KtCpxNeVX3UGnmGmZ
+EjKGcYK1bHEMFQvGuHhY3dVX/SMPMpP3vqguA7LeGPnoJ2p/4mVnWqAw3lscHeab
+dpVaeuewtsGx/BlIRuTcqG39wTWcra2g1Vb6vOdLeb56hXdmf8NQ3AaVmvjaEY2z
+oROfaNRFjvwROpGZbjvG+N/zp4iju9QsclpjrHJqs+qQvwNlrM6a9jTqFQa8bAYG
+fLuC6B9eoMb4jydw8GwYkZICYeZVXyjREIH1SNj5O9IxBGkQOhWW/Ksa6CWwPy2j
+/j7tRyy4MaVFg3qOYg4LfuY6L+PBF9YvVhRrgwIDAQABAoIBAFqJ4h1Om+3e0WK8
+6h4YzdYN4ue7LUTv7hxPW4gASlH5cMDoWURywX3yLNN/dBiWom4b5NWmvJqY8dwU
+eSyTznxNFhJ0PjozaxOWnw4FXlQceOPhV2bsHgKudadNU1Y4lSN9lpe+tg2Xy+GE
+ituM66RTKCf502w3DioiJpx6OEkxuhrnsQAWNcGB0MnTukm2f+629V+04R5MT5V1
+nY+5Phx2BpHgYzWBKh6Px1puu7xFv5SMQda1ndlPIKb4cNp0yYn+1lHNjbOE7QL/
+oEpWgrauS5Zk/APK33v/p3wVYHrKocIFHlPiCW0uIJJLsOZDY8pQXpTlc+/xGLLy
+WBu4boECgYEA6xO+1UNh6ndJ3xGuNippH+ucTi/uq1+0tG1bd63v+75tn5l4LyY2
+CWHRaWVlVn+WnDslkQTJzFD68X+9M7Cc4oP6WnhTyPamG7HlGv5JxfFHTC9GOKmz
+sSc624BDmqYJ7Xzyhe5kc3iHzqG/L72ZF1aijZdrodQMSY1634UX6aECgYEA0Jdr
+cBPSN+mgmEY6ogN5h7sO5uNV3TQQtW2IslfWZn6JhSRF4Rf7IReng48CMy9ZhFBy
+Q7H2I1pDGjEC9gQHhgVfm+FyMSVqXfCHEW/97pvvu9ougHA0MhPep1twzTGrqg+K
+f3PLW8hVkGyCrTfWgbDlPsHgsocA/wTaQOheaqMCgYBat5z+WemQfQZh8kXDm2xE
+KD2Cota9BcsLkeQpdFNXWC6f167cqydRSZFx1fJchhJOKjkeFLX3hgzBY6VVLEPu
+2jWj8imLNTv3Fhiu6RD5NVppWRkFRuAUbmo1SPNN2+Oa5YwGCXB0a0Alip/oQYex
+zPogIB4mLlmrjNCtL4SB4QKBgCEHKMrZSJrz0irqS9RlanPUaZqjenAJE3A2xMNA
+Z0FZXdsIEEyA6JGn1i1dkoKaR7lMp5sSbZ/RZfiatBZSMwLEjQv4mYUwoHP5Ztma
++wEyDbaX6G8L1Sfsv3+OWgETkVPfHBXsNtH0mZ/BnrtgsQVeBh52wmZiPAUlNo26
+fWCzAoGBAJOjqovLelLWzyQGqPFx/MwuI56UFXd1CmFlCIvF2WxCFmk3tlExoCN1
+HqSpt92vsgYgV7+lAb4U7Uy/v012gwiU1LK+vyAE9geo3pTjG73BNzG4H547xtbY
+dg+Sd4Wjm89UQoUUoiIcstY7FPbqfBtYKfh4RYHAHV2BwDFqzZCM
+-----END RSA PRIVATE KEY-----
+EOF
+}
+
+data "aws_alb_listener" "front_end" {
+	arn = "${aws_alb_listener.front_end.arn}"
+}`, albName, targetGroupName, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -144,6 +144,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"aws_acm_certificate":          dataSourceAwsAcmCertificate(),
+			"aws_alb_listener":             dataSourceAwsAlbListener(),
 			"aws_ami":                      dataSourceAwsAmi(),
 			"aws_availability_zone":        dataSourceAwsAvailabilityZone(),
 			"aws_availability_zones":       dataSourceAwsAvailabilityZones(),

--- a/website/source/docs/providers/aws/d/alb_listener.html.markdown
+++ b/website/source/docs/providers/aws/d/alb_listener.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "aws"
+page_title: "AWS: aws_alb_listener"
+sidebar_current: "docs-aws-datasource-alb-listener"
+description: |-
+  Provides an Application Load Balancer Listener data source.
+---
+
+# aws\_alb\_listener
+
+Provides information about an Application Load Balancer Listener.
+
+This data source can prove useful when a module accepts an ALB Listener as an
+input variable and needs to know the ALB it is attached to, or other
+information specific to the listener in question.
+
+## Example Usage
+
+```
+variable "listener_arn" {
+  type = "string"
+}
+
+data "aws_alb_listener" "listener" {
+  arn = "${var.listener_arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `arn` - (Required) The ARN of the listener.
+
+## Attributes Reference
+
+See the [ALB Listener Resource](/docs/providers/aws/r/alb_listener.html) for details
+on the returned attributes - they are identical.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -20,6 +20,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ami") %>>
                             <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-alb-listener") %>>
+                            <a href="/docs/providers/aws/d/alb_listener.html">aws_alb_listener</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-availability-zone") %>>
                             <a href="/docs/providers/aws/d/availability_zone.html">aws_availability_zone</a>
                         </li>


### PR DESCRIPTION
This adds the `aws_alb_listener` data source to get information on an AWS
Application Load Balancer listener.

The schema is slightly modified (only option-wise, attributes are the
same) and we use the `aws_alb_listener` resource read function to get the
data.

Note that the HTTPS test here may fail due until
hashicorp/terraform#10180 is merged.