### PR TITLE
Fixed some typos and formatting in AWS index docs

### DIFF
--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -30,7 +30,7 @@ resource "aws_instance" "web" {
 }
 ```
 
-## Authentication 
+## Authentication
 
 The AWS provider offers flexible means of providing credentials for
 authentication. The following methods are supported, in this order, and
@@ -69,7 +69,7 @@ provider "aws" {}
 Usage:
 
 ```
-$ export AWS_ACCESS_KEY_ID="anaccesskey" 
+$ export AWS_ACCESS_KEY_ID="anaccesskey"
 $ export AWS_SECRET_ACCESS_KEY="asecretkey"
 $ export AWS_DEFAULT_REGION="us-west-2"
 $ terraform plan
@@ -77,16 +77,17 @@ $ terraform plan
 
 ###Shared Credentials file
 
-You can use an AWS credentials file to specify your credentials. The default
-location is `$HOME/.aws/credentials` on Linux and OSX, or `"%USERPROFILE%\.aws\credentials"` 
-for Windows users. If we fail to detect credentials inline, or in the
-environment, Terraform will check this location. You can optionally specify a
-different location in the configuration by providing `shared_credentials_file`,
-or in the environment with the `AWS_SHARED_CREDENTIALS_FILE` variable. This
-method also supports a `profile` configuration and matching `AWS_PROFILE`
+You can use an AWS credentials file to specify your credentials. The
+default location is `$HOME/.aws/credentials` on Linux and OSX, or
+`"%USERPROFILE%\.aws\credentials"` for Windows users. If we fail to
+detect credentials inline, or in the environment, Terraform will check
+this location. You can optionally specify a different location in the
+configuration by providing `shared_credentials_file`, or in the
+environment with the `AWS_SHARED_CREDENTIALS_FILE` variable. This method
+also supports a `profile` configuration and matching `AWS_PROFILE`
 environment variable:
 
-Usage: 
+Usage:
 
 ```
 provider "aws" {

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -32,7 +32,7 @@ resource "aws_instance" "web" {
 
 ## Authentication
 
-The AWS provider offers flexible means of providing credentials for
+The AWS provider offers a flexible means of providing credentials for
 authentication. The following methods are supported, in this order, and
 explained below:
 
@@ -44,9 +44,9 @@ explained below:
 ### Static credentials ###
 
 Static credentials can be provided by adding an `access_key` and `secret_key` in-line in the
-aws provider block:
+AWS provider block:
 
-Usage: 
+Usage:
 
 ```
 provider "aws" {
@@ -56,11 +56,13 @@ provider "aws" {
 }
 ```
 
-###Environment variables
+### Environment variables
 
-You can provide your credentials via `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`, 
-environment variables, representing your AWS Access Key and AWS Secret Key, respectively.
-`AWS_DEFAULT_REGION` and `AWS_SESSION_TOKEN` are also used, if applicable:
+You can provide your credentials via the `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY`, environment variables, representing your AWS
+Access Key and AWS Secret Key, respectively.  The `AWS_DEFAULT_REGION`
+and `AWS_SESSION_TOKEN` environment variables are also used, if
+applicable:
 
 ```
 provider "aws" {}
@@ -75,17 +77,17 @@ $ export AWS_DEFAULT_REGION="us-west-2"
 $ terraform plan
 ```
 
-###Shared Credentials file
+### Shared Credentials file
 
 You can use an AWS credentials file to specify your credentials. The
-default location is `$HOME/.aws/credentials` on Linux and OSX, or
+default location is `$HOME/.aws/credentials` on Linux and OS X, or
 `"%USERPROFILE%\.aws\credentials"` for Windows users. If we fail to
 detect credentials inline, or in the environment, Terraform will check
 this location. You can optionally specify a different location in the
-configuration by providing `shared_credentials_file`, or in the
-environment with the `AWS_SHARED_CREDENTIALS_FILE` variable. This method
-also supports a `profile` configuration and matching `AWS_PROFILE`
-environment variable:
+configuration by providing the `shared_credentials_file` attribute, or
+in the environment with the `AWS_SHARED_CREDENTIALS_FILE` variable. This
+method also supports a `profile` configuration and matching
+`AWS_PROFILE` environment variable:
 
 Usage:
 
@@ -97,7 +99,7 @@ provider "aws" {
 }
 ```
 
-###EC2 Role
+### EC2 Role
 
 If you're running Terraform from an EC2 instance with IAM Instance Profile
 using IAM Role, Terraform will just ask
@@ -105,14 +107,13 @@ using IAM Role, Terraform will just ask
 endpoint for credentials.
 
 This is a preferred approach over any other when running in EC2 as you can avoid
-hardcoding credentials. Instead these are leased on-the-fly by Terraform
+hard coding credentials. Instead these are leased on-the-fly by Terraform
 which reduces the chance of leakage.
 
-You can provide custom metadata API endpoint via `AWS_METADATA_ENDPOINT` variable
-which expects the endpoint URL including the version
-and defaults to `http://169.254.169.254:80/latest`.
+You can provide the custom metadata API endpoint via the `AWS_METADATA_ENDPOINT` variable
+which expects the endpoint URL, including the version, and defaults to `http://169.254.169.254:80/latest`.
 
-###Assume role
+### Assume role
 
 If provided with a role ARN, Terraform will attempt to assume this role
 using the supplied credentials.
@@ -152,40 +153,45 @@ The following arguments are supported in the `provider` block:
   `assume_role` block may be in the configuration.
 
 * `shared_credentials_file` = (Optional) This is the path to the shared credentials file.
-  If this is not set and a profile is specified, ~/.aws/credentials will be used.
+  If this is not set and a profile is specified, `~/.aws/credentials` will be used.
 
 * `token` - (Optional) Use this to set an MFA token. It can also be sourced
   from the `AWS_SESSION_TOKEN` environment variable.
 
-* `max_retries` - (Optional) This is the maximum number of times an API call is
-  being retried in case requests are being throttled or experience transient failures.
-  The delay between the subsequent API calls increases exponentially.
+* `max_retries` - (Optional) This is the maximum number of times an API
+  call is retried, in the case where requests are being throttled or
+  experiencing transient failures. The delay between the subsequent API
+  calls increases exponentially.
 
-* `allowed_account_ids` - (Optional) List of allowed AWS account IDs (whitelist)
-  to prevent you mistakenly using a wrong one (and end up destroying live environment).
-  Conflicts with `forbidden_account_ids`.
+* `allowed_account_ids` - (Optional) List of allowed, white listed, AWS
+  account IDs to prevent you from mistakenly using an incorrect one (and
+  potentially end up destroying a live environment). Conflicts with
+  `forbidden_account_ids`.
 
-* `forbidden_account_ids` - (Optional) List of forbidden AWS account IDs (blacklist)
-  to prevent you mistakenly using a wrong one (and end up destroying live environment).
-  Conflicts with `allowed_account_ids`.
+* `forbidden_account_ids` - (Optional) List of forbidden, blacklisted,
+  AWS account IDs to prevent you mistakenly using a wrong one (and
+  potentially end up destroying a live environment). Conflicts with
+  `allowed_account_ids`.
 
-* `insecure` - (Optional) Optional) Explicitly allow the provider to
-  perform "insecure" SSL requests. If omitted, default value is `false`
+* `insecure` - (Optional) Explicitly allow the provider to
+  perform "insecure" SSL requests. If omitted, default value is `false`.
 
 * `dynamodb_endpoint` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
-  dynamodb-local.
+  `dynamodb-local`.
 
 * `kinesis_endpoint` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
-  kinesalite.
+  `kinesalite`.
 
-* `skip_credentials_validation` - (Optional) Skip the credentials validation via STS API.
-  Useful for AWS API implementations that do not have STS available/implemented.
+* `skip_credentials_validation` - (Optional) Skip the credentials
+  validation via the STS API. Useful for AWS API implementations that do
+  not have STS available or implemented.
 
-* `skip_requesting_account_id` - (Optional) Skip requesting the account ID.
-  Useful for AWS API implementations that do not have IAM/STS API and/or metadata API.
-  `true` (enabling this option) prevents you from managing any resource that requires Account ID to construct an ARN, e.g.
+* `skip_requesting_account_id` - (Optional) Skip requesting the account
+  ID.  Useful for AWS API implementations that do not have the IAM, STS
+  API, or metadata API.  When set to `true`, prevents you from managing
+  any resource that requires Account ID to construct an ARN, e.g.
   - `aws_db_instance`
   - `aws_db_option_group`
   - `aws_db_parameter_group`
@@ -198,15 +204,18 @@ The following arguments are supported in the `provider` block:
   - `aws_rds_cluster_parameter_group`
   - `aws_redshift_cluster`
 
-* `skip_metadata_api_check` - (Optional) Skip the AWS Metadata API check.
-  Useful for AWS API implementations that do not have a metadata API endpoint.
-  `true` prevents Terraform from authenticating via Metadata API - i.e. you may need to use other auth methods
-  (static credentials set as ENV vars or config)
+* `skip_metadata_api_check` - (Optional) Skip the AWS Metadata API
+  check.  Useful for AWS API implementations that do not have a metadata
+  API endpoint.  Setting to `true` prevents Terraform from authenticating
+  via the Metadata API. You may need to use other authentication methods
+  like static credentials, configuration variables, or environment
+  variables.
 
-* `s3_force_path_style` - (Optional) set this to true to force the request to use
-  path-style addressing, i.e., http://s3.amazonaws.com/BUCKET/KEY. By default, the
-  S3 client will use virtual hosted bucket addressing when possible
-  (http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.
+* `s3_force_path_style` - (Optional) Set this to `true` to force the
+  request to use path-style addressing, i.e.,
+  `http://s3.amazonaws.com/BUCKET/KEY`. By default, the S3 client will use
+  virtual hosted bucket addressing, `http://BUCKET.s3.amazonaws.com/KEY`,
+  when possible. Specific to the Amazon S3 service.
 
 The nested `assume_role` block supports the following:
 
@@ -216,43 +225,43 @@ The nested `assume_role` block supports the following:
   AssumeRole call.
 
 * `external_id` - (Optional) The external ID to use when making the
-  AssumeRole  call.
+  AssumeRole call.
 
 Nested `endpoints` block supports the following:
 
 * `iam` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
-  custom iam endpoints.
+  custom IAM endpoints.
 
 * `ec2` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
-  custom ec2 endpoints.
+  custom EC2 endpoints.
 
 * `elb` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
-  custom elb endpoints.
+  custom ELB endpoints.
 
 * `s3` - (Optional) Use this to override the default endpoint
   URL constructed from the `region`. It's typically used to connect to
-  custom s3 endpoints.
+  custom S3 endpoints.
 
 ## Getting the Account ID
 
 If you use either `allowed_account_ids` or `forbidden_account_ids`,
 Terraform uses several approaches to get the actual account ID
-in order to compare it with allowed/forbidden ones.
+in order to compare it with allowed or forbidden IDs.
 
-Approaches differ per auth providers:
+Approaches differ per authentication providers:
 
  * EC2 instance w/ IAM Instance Profile - [Metadata API](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
     is always used. Introduced in Terraform `0.6.16`.
- * All other providers (ENV vars, shared creds file, ...)
+ * All other providers (environment variable, shared credentials file, ...)
     will try two approaches in the following order
-   * `iam:GetUser` - typically useful for IAM Users. It also means
+   * `iam:GetUser` - Typically useful for IAM Users. It also means
       that each user needs to be privileged to call `iam:GetUser` for themselves.
    * `sts:GetCallerIdentity` - _Should_ work for both IAM Users and federated IAM Roles,
       introduced in Terraform `0.6.16`.
-   * `iam:ListRoles` - this is specifically useful for IdP-federated profiles
+   * `iam:ListRoles` - This is specifically useful for IdP-federated profiles
       which cannot use `iam:GetUser`. It also means that each federated user
       need to be _assuming_ an IAM role which allows `iam:ListRoles`.
       Used in Terraform `0.6.16+`.


### PR DESCRIPTION
1. Fixed some whitespace.
2. Fixed some formatting.
3. Fixed some grammar and structure.