### PR TITLE
provider/azurerm: enable import of more resources

### DIFF
--- a/builtin/providers/azurerm/import_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/import_arm_cdn_endpoint_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMCdnEndpoint_importWithTags(t *testing.T) {
+	resourceName := "azurerm_cdn_endpoint.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTags, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_dns_a_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_a_record_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsARecord_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_a_record.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsARecord_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsARecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_dns_aaaa_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_aaaa_record_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsAAAARecord_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_aaaa_record.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsAAAARecord_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsAAAARecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_dns_cname_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_cname_record_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsCNameRecord_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_cname_record.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsCNameRecord_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsCNameRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_dns_mx_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_mx_record_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsMxRecord_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_mx_record.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsMxRecord_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsMxRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_dns_ns_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_ns_record_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsNsRecord_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_ns_record.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsNsRecord_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsNsRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_dns_srv_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_srv_record_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsSrvRecord_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_srv_record.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsSrvRecord_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsSrvRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_dns_txt_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_txt_record_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMDnsTxtRecord_importBasic(t *testing.T) {
+	resourceName := "azurerm_dns_txt_record.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMDnsTxtRecord_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsTxtRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_servicebus_namespace_test.go
+++ b/builtin/providers/azurerm/import_arm_servicebus_namespace_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMServiceBusNamespace_importBasic(t *testing.T) {
+	resourceName := "azurerm_servicebus_namespace.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_sql_server_test.go
+++ b/builtin/providers/azurerm/import_arm_sql_server_test.go
@@ -8,25 +8,26 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAzureRMSqlFirewallRule_importBasic(t *testing.T) {
-	resourceName := "azurerm_sql_firewall_rule.test"
+func TestAccAzureRMSqlServer_importBasic(t *testing.T) {
+	resourceName := "azurerm_sql_server.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSqlFirewallRule_basic, ri, ri, ri)
+	config := fmt.Sprintf(testAccAzureRMSqlServer_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlFirewallRuleDestroy,
+		CheckDestroy: testCheckAzureRMSqlServerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
-				ImportState:       true,
-				ImportStateVerify: true,
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"administrator_login_password"},
 			},
 		},
 	})

--- a/builtin/providers/azurerm/import_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_machine_test.go
@@ -1,0 +1,37 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMVirtualMachine_importBasic(t *testing.T) {
+	resourceName := "azurerm_virtual_machine.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"delete_data_disks_on_termination",
+					"delete_os_disk_on_termination",
+				},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
@@ -18,6 +18,9 @@ func resourceArmCdnEndpoint() *schema.Resource {
 		Read:   resourceArmCdnEndpointRead,
 		Update: resourceArmCdnEndpointUpdate,
 		Delete: resourceArmCdnEndpointDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -234,6 +237,9 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
+	d.Set("profile_name", profileName)
 	d.Set("host_name", resp.Properties.HostName)
 	d.Set("is_compression_enabled", resp.Properties.IsCompressionEnabled)
 	d.Set("is_http_allowed", resp.Properties.IsHTTPAllowed)
@@ -245,7 +251,7 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 	if resp.Properties.OriginPath != nil && *resp.Properties.OriginPath != "" {
 		d.Set("origin_path", resp.Properties.OriginPath)
 	}
-	if resp.Properties.ContentTypesToCompress != nil && len(*resp.Properties.ContentTypesToCompress) > 0 {
+	if resp.Properties.ContentTypesToCompress != nil {
 		d.Set("content_types_to_compress", flattenAzureRMCdnEndpointContentTypes(resp.Properties.ContentTypesToCompress))
 	}
 	d.Set("origin", flattenAzureRMCdnEndpointOrigin(resp.Properties.Origins))

--- a/builtin/providers/azurerm/resource_arm_dns_a_record.go
+++ b/builtin/providers/azurerm/resource_arm_dns_a_record.go
@@ -14,6 +14,9 @@ func resourceArmDnsARecord() *schema.Resource {
 		Read:   resourceArmDnsARecordRead,
 		Update: resourceArmDnsARecordCreate,
 		Delete: resourceArmDnsARecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -111,6 +114,11 @@ func resourceArmDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	rivieraClient := client.rivieraClient
 
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
 	readRequest := rivieraClient.NewRequestForURI(d.Id())
 	readRequest.Command = &dns.GetARecordSet{}
 
@@ -126,6 +134,9 @@ func resourceArmDnsARecordRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp := readResponse.Parsed.(*dns.GetARecordSetResponse)
 
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("zone_name", id.Path["dnszones"])
 	d.Set("ttl", resp.TTL)
 
 	if resp.ARecords != nil {

--- a/builtin/providers/azurerm/resource_arm_dns_aaaa_record.go
+++ b/builtin/providers/azurerm/resource_arm_dns_aaaa_record.go
@@ -14,6 +14,9 @@ func resourceArmDnsAAAARecord() *schema.Resource {
 		Read:   resourceArmDnsAAAARecordRead,
 		Update: resourceArmDnsAAAARecordCreate,
 		Delete: resourceArmDnsAAAARecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -111,6 +114,11 @@ func resourceArmDnsAAAARecordRead(d *schema.ResourceData, meta interface{}) erro
 	client := meta.(*ArmClient)
 	rivieraClient := client.rivieraClient
 
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
 	readRequest := rivieraClient.NewRequestForURI(d.Id())
 	readRequest.Command = &dns.GetAAAARecordSet{}
 
@@ -126,6 +134,9 @@ func resourceArmDnsAAAARecordRead(d *schema.ResourceData, meta interface{}) erro
 
 	resp := readResponse.Parsed.(*dns.GetAAAARecordSetResponse)
 
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("zone_name", id.Path["dnszones"])
 	d.Set("ttl", resp.TTL)
 
 	if resp.AAAARecords != nil {

--- a/builtin/providers/azurerm/resource_arm_dns_cname_record.go
+++ b/builtin/providers/azurerm/resource_arm_dns_cname_record.go
@@ -14,6 +14,9 @@ func resourceArmDnsCNameRecord() *schema.Resource {
 		Read:   resourceArmDnsCNameRecordRead,
 		Update: resourceArmDnsCNameRecordCreate,
 		Delete: resourceArmDnsCNameRecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -111,6 +114,11 @@ func resourceArmDnsCNameRecordRead(d *schema.ResourceData, meta interface{}) err
 	client := meta.(*ArmClient)
 	rivieraClient := client.rivieraClient
 
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
 	readRequest := rivieraClient.NewRequestForURI(d.Id())
 	readRequest.Command = &dns.GetCNAMERecordSet{}
 
@@ -126,6 +134,9 @@ func resourceArmDnsCNameRecordRead(d *schema.ResourceData, meta interface{}) err
 
 	resp := readResponse.Parsed.(*dns.GetCNAMERecordSetResponse)
 
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("zone_name", id.Path["dnszones"])
 	d.Set("ttl", resp.TTL)
 	d.Set("record", resp.CNAMERecord.CNAME)
 

--- a/builtin/providers/azurerm/resource_arm_dns_ns_record.go
+++ b/builtin/providers/azurerm/resource_arm_dns_ns_record.go
@@ -14,6 +14,9 @@ func resourceArmDnsNsRecord() *schema.Resource {
 		Read:   resourceArmDnsNsRecordRead,
 		Update: resourceArmDnsNsRecordCreate,
 		Delete: resourceArmDnsNsRecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -114,6 +117,11 @@ func resourceArmDnsNsRecordRead(d *schema.ResourceData, meta interface{}) error 
 	client := meta.(*ArmClient)
 	rivieraClient := client.rivieraClient
 
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
 	readRequest := rivieraClient.NewRequestForURI(d.Id())
 	readRequest.Command = &dns.GetNSRecordSet{}
 
@@ -129,6 +137,9 @@ func resourceArmDnsNsRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 	resp := readResponse.Parsed.(*dns.GetNSRecordSetResponse)
 
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("zone_name", id.Path["dnszones"])
 	d.Set("ttl", resp.TTL)
 
 	if resp.NSRecords != nil {

--- a/builtin/providers/azurerm/resource_arm_dns_txt_record.go
+++ b/builtin/providers/azurerm/resource_arm_dns_txt_record.go
@@ -14,6 +14,9 @@ func resourceArmDnsTxtRecord() *schema.Resource {
 		Read:   resourceArmDnsTxtRecordRead,
 		Update: resourceArmDnsTxtRecordCreate,
 		Delete: resourceArmDnsTxtRecordDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -114,6 +117,11 @@ func resourceArmDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error
 	client := meta.(*ArmClient)
 	rivieraClient := client.rivieraClient
 
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
 	readRequest := rivieraClient.NewRequestForURI(d.Id())
 	readRequest.Command = &dns.GetTXTRecordSet{}
 
@@ -129,6 +137,9 @@ func resourceArmDnsTxtRecordRead(d *schema.ResourceData, meta interface{}) error
 
 	resp := readResponse.Parsed.(*dns.GetTXTRecordSetResponse)
 
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("zone_name", id.Path["dnszones"])
 	d.Set("ttl", resp.TTL)
 
 	if resp.TXTRecords != nil {

--- a/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
@@ -145,6 +145,8 @@ func resourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}
 	}
 
 	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 	d.Set("sku", strings.ToLower(string(resp.Sku.Name)))
 	d.Set("capacity", resp.Sku.Capacity)
 

--- a/builtin/providers/azurerm/resource_arm_sql_firewall_rule.go
+++ b/builtin/providers/azurerm/resource_arm_sql_firewall_rule.go
@@ -119,7 +119,9 @@ func resourceArmSqlFirewallRuleRead(d *schema.ResourceData, meta interface{}) er
 	resp := readResponse.Parsed.(*sql.GetFirewallRuleResponse)
 
 	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 	d.Set("name", resp.Name)
+	d.Set("server_name", id.Path["servers"])
 	d.Set("start_ip_address", resp.StartIPAddress)
 	d.Set("end_ip_address", resp.EndIPAddress)
 

--- a/builtin/providers/azurerm/resource_arm_sql_server.go
+++ b/builtin/providers/azurerm/resource_arm_sql_server.go
@@ -15,6 +15,9 @@ func resourceArmSqlServer() *schema.Resource {
 		Read:   resourceArmSqlServerRead,
 		Update: resourceArmSqlServerCreate,
 		Delete: resourceArmSqlServerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -111,6 +114,11 @@ func resourceArmSqlServerRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	rivieraClient := client.rivieraClient
 
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
 	readRequest := rivieraClient.NewRequestForURI(d.Id())
 	readRequest.Command = &sql.GetServer{}
 
@@ -126,6 +134,9 @@ func resourceArmSqlServerRead(d *schema.ResourceData, meta interface{}) error {
 
 	resp := readResponse.Parsed.(*sql.GetServerResponse)
 
+	d.Set("name", id.Path["servers"])
+	d.Set("resource_group_name", id.ResourceGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 	d.Set("fully_qualified_domain_name", resp.FullyQualifiedDomainName)
 	d.Set("administrator_login", resp.AdministratorLogin)
 	d.Set("version", resp.Version)

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -20,6 +20,9 @@ func resourceArmVirtualMachine() *schema.Resource {
 		Read:   resourceArmVirtualMachineRead,
 		Update: resourceArmVirtualMachineCreate,
 		Delete: resourceArmVirtualMachineDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -44,7 +47,6 @@ func resourceArmVirtualMachine() *schema.Resource {
 			"plan": {
 				Type:     schema.TypeSet,
 				Optional: true,
-				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -558,6 +560,10 @@ func resourceArmVirtualMachineRead(d *schema.ResourceData, meta interface{}) err
 		}
 		return fmt.Errorf("Error making Read request on Azure Virtual Machine %s: %s", name, err)
 	}
+
+	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", resp.Location)
 
 	if resp.Plan != nil {
 		if err := d.Set("plan", flattenAzureRmVirtualMachinePlan(resp.Plan)); err != nil {

--- a/website/source/docs/providers/azurerm/r/cdn_endpoint.html.markdown
+++ b/website/source/docs/providers/azurerm/r/cdn_endpoint.html.markdown
@@ -85,3 +85,11 @@ The `origin` block supports:
 The following attributes are exported:
 
 * `id` - The CDN Endpoint ID.
+
+## Import
+
+CDN Endpoints can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_cdn_endpoint.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Cdn/profiles/myprofile1/endpoints/myendpoint1
+```

--- a/website/source/docs/providers/azurerm/r/cdn_profile.html.markdown
+++ b/website/source/docs/providers/azurerm/r/cdn_profile.html.markdown
@@ -52,3 +52,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The CDN Profile ID.
+
+## Import
+
+CDN Profiles can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_cdn_profile.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Cdn/profiles/myprofile1
+```

--- a/website/source/docs/providers/azurerm/r/dns_a_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_a_record.html.markdown
@@ -51,3 +51,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The DNS A Record ID.
+
+## Import
+
+A records can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_dns_a_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/A/myrecord1
+```

--- a/website/source/docs/providers/azurerm/r/dns_aaaa_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_aaaa_record.html.markdown
@@ -51,3 +51,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The DNS AAAA Record ID.
+
+## Import
+
+AAAA records can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_dns_aaaa_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/AAAA/myrecord1
+```

--- a/website/source/docs/providers/azurerm/r/dns_cname_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_cname_record.html.markdown
@@ -51,3 +51,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The DNS CName Record ID.
+
+## Import
+
+CNAME records can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_dns_cname_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/CNAME/myrecord1
+```

--- a/website/source/docs/providers/azurerm/r/dns_mx_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_mx_record.html.markdown
@@ -70,3 +70,11 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS MX Record ID.
+
+## Import
+
+MX records can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_dns_mx_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/MX/myrecord1
+```

--- a/website/source/docs/providers/azurerm/r/dns_ns_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_ns_record.html.markdown
@@ -65,3 +65,11 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS NS Record ID.
+
+## Import
+
+NS records can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_dns_ns_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/NS/myrecord1
+```

--- a/website/source/docs/providers/azurerm/r/dns_srv_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_srv_record.html.markdown
@@ -72,3 +72,11 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS SRV Record ID.
+
+## Import
+
+SRV records can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_dns_srv_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/SRV/myrecord1
+```

--- a/website/source/docs/providers/azurerm/r/dns_txt_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_txt_record.html.markdown
@@ -64,3 +64,11 @@ The `record` block supports:
 The following attributes are exported:
 
 * `id` - The DNS TXT Record ID.
+
+## Import
+
+TXT records can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_dns_txt_record.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/dnsZones/zone1/TXT/myrecord1
+```

--- a/website/source/docs/providers/azurerm/r/network_interface.html.markdown
+++ b/website/source/docs/providers/azurerm/r/network_interface.html.markdown
@@ -101,3 +101,11 @@ The following attributes are exported:
 * `virtual_machine_id` - Reference to a VM with which this NIC has been associated.
 * `applied_dns_servers` - If the VM that uses this NIC is part of an Availability Set, then this list will have the union of all DNS servers from all NICs that are part of the Availability Set
 * `internal_fqdn` - Fully qualified DNS name supporting internal communications between VMs in the same VNet
+
+## Import
+
+Network Interfaces can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_network_interface.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/networkInterfaces/nic1
+```

--- a/website/source/docs/providers/azurerm/r/servicebus_namespace.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_namespace.html.markdown
@@ -66,3 +66,11 @@ The following attributes are exported only if there is an authorization rule nam
 * `default_primary_key` - The primary access key for the authorization rule `RootManageSharedAccessKey`.
 
 * `default_secondary_key` - The secondary access key for the authorization rule `RootManageSharedAccessKey`.
+
+## Import
+
+Service Bus Namespace can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_servicebus_namespace.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1
+```

--- a/website/source/docs/providers/azurerm/r/servicebus_subscription.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_subscription.html.markdown
@@ -105,3 +105,11 @@ used to represent a lengh of time. The supported format is documented [here](htt
 The following attributes are exported:
 
 * `id` - The ServiceBus Subscription ID.
+
+## Import
+
+Service Bus Subscriptions can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_servicebus_subscription.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1/topics/sntopic1/subscriptions/sbsub1
+```

--- a/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
@@ -106,3 +106,11 @@ used to represent a lengh of time. The supported format is documented [here](htt
 The following attributes are exported:
 
 * `id` - The ServiceBus Topic ID.
+
+## Import
+
+Service Bus Topics can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_servicebus_topic.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.servicebus/namespaces/sbns1/topics/sntopic1
+```

--- a/website/source/docs/providers/azurerm/r/sql_server.html.markdown
+++ b/website/source/docs/providers/azurerm/r/sql_server.html.markdown
@@ -55,3 +55,11 @@ The following attributes are exported:
 
 * `id` - The SQL Server ID.
 * `fully_qualified_domain_name` - The fully qualified domain name of the Azure SQL Server (e.g. myServerName.database.windows.net)
+
+## Import
+
+SQL Servers can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_sql_server.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myresourcegroup/providers/Microsoft.Sql/servers/myserver
+```

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -313,3 +313,11 @@ For more information on the different example configurations, please check out t
 The following attributes are exported:
 
 * `id` - The virtual machine ID.
+
+## Import
+
+Virtual Machines can be imported using the `resource id`, e.g. 
+
+```
+terraform import azurerm_virtual_machine.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.compute/virtualMachines/machine1
+```


### PR DESCRIPTION
```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run "TestAccAzureRMVirtualMachine_(basic|import)" -timeout 120m
=== RUN   TestAccAzureRMVirtualMachine_importBasic
--- PASS: TestAccAzureRMVirtualMachine_importBasic (561.08s)
=== RUN   TestAccAzureRMVirtualMachine_basicLinuxMachine
--- PASS: TestAccAzureRMVirtualMachine_basicLinuxMachine (677.49s)
=== RUN   TestAccAzureRMVirtualMachine_basicLinuxMachine_disappears
--- PASS: TestAccAzureRMVirtualMachine_basicLinuxMachine_disappears (674.21s)
=== RUN   TestAccAzureRMVirtualMachine_basicWindowsMachine
--- PASS: TestAccAzureRMVirtualMachine_basicWindowsMachine (1105.18s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	3017.970s
```