### PR TITLE
provider/aws: Add aws_alb data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_alb.go
+++ b/builtin/providers/aws/data_source_aws_alb.go
@@ -1,0 +1,127 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elbv2"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsAlb() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsAlbRead,
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"arn_suffix": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"name": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"internal": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"security_groups": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"subnets": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+				Set:      schema.HashString,
+			},
+
+			"access_logs": {
+				Type:     schema.TypeList,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bucket": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"prefix": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
+						},
+					},
+				},
+			},
+
+			"enable_deletion_protection": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+
+			"idle_timeout": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"zone_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"dns_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsAlbRead(d *schema.ResourceData, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbv2conn
+	albArn := d.Get("arn").(string)
+	albName := d.Get("name").(string)
+
+	describeAlbOpts := &elbv2.DescribeLoadBalancersInput{}
+	switch {
+	case albArn != "":
+		describeAlbOpts.LoadBalancerArns = []*string{aws.String(albArn)}
+	case albName != "":
+		describeAlbOpts.Names = []*string{aws.String(albName)}
+	}
+
+	describeResp, err := elbconn.DescribeLoadBalancers(describeAlbOpts)
+	if err != nil {
+		return errwrap.Wrapf("Error retrieving ALB: {{err}}", err)
+	}
+	if len(describeResp.LoadBalancers) != 1 {
+		return fmt.Errorf("Your search returned %d results. Please narrow your search.", len(describeResp.LoadBalancers))
+	}
+	d.SetId(*describeResp.LoadBalancers[0].LoadBalancerArn)
+
+	return flattenAwsAlbResource(d, meta, describeResp.LoadBalancers[0])
+}

--- a/builtin/providers/aws/data_source_aws_alb.go
+++ b/builtin/providers/aws/data_source_aws_alb.go
@@ -119,7 +119,7 @@ func dataSourceAwsAlbRead(d *schema.ResourceData, meta interface{}) error {
 		return errwrap.Wrapf("Error retrieving ALB: {{err}}", err)
 	}
 	if len(describeResp.LoadBalancers) != 1 {
-		return fmt.Errorf("Your search returned %d results. Please narrow your search.", len(describeResp.LoadBalancers))
+		return fmt.Errorf("Search returned %d results, please revise so only one is returned", len(describeResp.LoadBalancers))
 	}
 	d.SetId(*describeResp.LoadBalancers[0].LoadBalancerArn)
 

--- a/builtin/providers/aws/data_source_aws_alb_test.go
+++ b/builtin/providers/aws/data_source_aws_alb_test.go
@@ -1,0 +1,124 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAWSALB_basic(t *testing.T) {
+	albName := fmt.Sprintf("testaccawsalb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAWSALBConfigBasic(albName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "name", albName),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "internal", "false"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "subnets.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "security_groups.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "tags.TestName", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "enable_deletion_protection", "false"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "idle_timeout", "30"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_arn", "vpc_id"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_arn", "zone_id"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_arn", "dns_name"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_arn", "arn"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "name", albName),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "internal", "false"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "subnets.#", "2"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "security_groups.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "tags.%", "1"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "tags.TestName", "TestAccAWSALB_basic"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "enable_deletion_protection", "false"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "idle_timeout", "30"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_name", "vpc_id"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_name", "zone_id"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_name", "dns_name"),
+					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_name", "arn"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAWSALBConfigBasic(albName string) string {
+	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
+  name            = "%s"
+  internal        = false
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+data "aws_alb" "alb_test_with_arn" {
+	arn = "${aws_alb.alb_test.arn}"
+}
+
+data "aws_alb" "alb_test_with_name" {
+	name = "${aws_alb.alb_test.name}"
+}`, albName)
+}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -144,6 +144,7 @@ func Provider() terraform.ResourceProvider {
 
 		DataSourcesMap: map[string]*schema.Resource{
 			"aws_acm_certificate":          dataSourceAwsAcmCertificate(),
+			"aws_alb":                      dataSourceAwsAlb(),
 			"aws_alb_listener":             dataSourceAwsAlbListener(),
 			"aws_ami":                      dataSourceAwsAmi(),
 			"aws_availability_zone":        dataSourceAwsAvailabilityZone(),

--- a/website/source/docs/providers/aws/d/alb.html.markdown
+++ b/website/source/docs/providers/aws/d/alb.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "aws"
+page_title: "AWS: aws_alb"
+sidebar_current: "docs-aws-datasource-alb"
+description: |-
+  Provides an Application Load Balancer resource.
+---
+
+# aws\_alb
+
+Provides information about an Application Load Balancer.
+
+This data source can prove useful when a module accepts an ALB as an input
+variable and needs to, for example, determine the security groups associated
+with it, etc.
+
+## Example Usage
+
+```
+variable "alb_arn" {
+  type    = "string"
+  default = ""
+}
+
+variable "alb_name" {
+  type    = "string"
+  default = ""
+}
+
+data "aws_alb" "test" {
+  arn  = "${var.alb_arn}"
+  name = "${var.alb_arn}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `arn` - (Optional) The full ARN of the load balancer.
+* `name` - (Optional) The unique name of the load balancer.
+
+~> **NOTE**: When both `arn` and `name` are specified, `arn` takes precedence.
+
+## Attributes Reference
+
+See the [ALB Resource](/docs/providers/aws/r/alb.html) for details on the
+returned attributes - they are identical.

--- a/website/source/docs/providers/aws/d/alb.html.markdown
+++ b/website/source/docs/providers/aws/d/alb.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_alb"
 sidebar_current: "docs-aws-datasource-alb"
 description: |-
-  Provides an Application Load Balancer resource.
+  Provides an Application Load Balancer data source.
 ---
 
 # aws\_alb

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -17,6 +17,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-acm-certificate") %>>
                             <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-alb") %>>
+                            <a href="/docs/providers/aws/d/alb.html">aws_alb</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-ami") %>>
                             <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
                         </li>


### PR DESCRIPTION
This adds the `aws_alb` data source for getting information on an AWS
Application Load Balancer.

The schema is nearly the same as the resource of the same name, with
most of the resource population logic de-coupled into its own function
so that they can be shared between the resource and data source.