### PR TITLE
Catch map type errors on variable assignment

### DIFF
--- a/terraform/variables_test.go
+++ b/terraform/variables_test.go
@@ -136,6 +136,18 @@ func TestVariables(t *testing.T) {
 				"b": "1",
 			},
 		},
+
+		"override map with string": {
+			"vars-basic",
+			map[string]string{
+				"TF_VAR_c": `{"foo" = "a", "bar" = "baz"}`,
+			},
+			map[string]interface{}{
+				"c": "bar",
+			},
+			true,
+			nil,
+		},
 	}
 
 	for name, tc := range cases {


### PR DESCRIPTION
Because we merge maps immediately when assigning variables, it happens before the context can be validated. This means invalid user input could make it into the assignment and we need to return a useful error rather than panicking. 

We only need to check maps because of the merging behavior, and other invalid assignments are discovered during validation. 

Fixes #10155 