### PR TITLE
plugin: bump protocol version

### DIFF
--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -14,7 +14,14 @@ const (
 
 // Handshake is the HandshakeConfig used to configure clients and servers.
 var Handshake = plugin.HandshakeConfig{
-	ProtocolVersion:  1,
+	// The ProtocolVersion is the version that must match between TF core
+	// and TF plugins. This should be bumped whenever a change happens in
+	// one or the other that makes it so that they can't safely communicate.
+	// This could be adding a new interface value, it could be how
+	// helper/schema computes diffs, etc.
+	ProtocolVersion: 2,
+
+	// The magic cookie values should NEVER be changed.
 	MagicCookieKey:   "TF_PLUGIN_MAGIC_COOKIE",
 	MagicCookieValue: "d602bf8f470bc67ca7faa0386276bbdd4330efaf76d1a219cb4d6991ca9872b2",
 }


### PR DESCRIPTION
This is necessary since the TypeUnknown HIL handling in helper/schema
makes providers compiled WITHOUT TypeUnknown incompatible with the way
core handles unknown values.