### PR TITLE
provider/cloudstack: remove the need for specifying a network ID

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_port_forward.go
@@ -154,8 +154,8 @@ func createPortForward(d *schema.ResourceData, meta interface{}, forward map[str
 	p := cs.Firewall.NewCreatePortForwardingRuleParams(d.Id(), forward["private_port"].(int),
 		forward["protocol"].(string), forward["public_port"].(int), vm.Id)
 
-	// Set the network ID of the default network, needed when public IP address
-	// is not associated with any Guest network yet (VPC case)
+	// Set the network ID, needed when the public IP address
+	// is not associated with any network yet (VPC case)
 	p.SetNetworkid(vm.Nic[0].Networkid)
 
 	// Do not open the firewall automatically in any case

--- a/builtin/providers/cloudstack/resource_cloudstack_static_nat.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_static_nat.go
@@ -24,10 +24,10 @@ func resourceCloudStackStaticNAT() *schema.Resource {
 			},
 
 			"network_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "network_id is deprecated and can be safely omitted",
 			},
 
 			"virtual_machine_id": &schema.Schema{
@@ -57,20 +57,34 @@ func resourceCloudStackStaticNATCreate(d *schema.ResourceData, meta interface{})
 	cs := meta.(*cloudstack.CloudStackClient)
 
 	ipaddressid := d.Get("ip_address_id").(string)
-	virtualmachineid := d.Get("virtual_machine_id").(string)
+
+	vm, _, err := cs.VirtualMachine.GetVirtualMachineByID(
+		d.Get("virtual_machine_id").(string),
+		cloudstack.WithProject(d.Get("project").(string)),
+	)
+	if err != nil {
+		return err
+	}
 
 	// Create a new parameter struct
-	p := cs.NAT.NewEnableStaticNatParams(ipaddressid, virtualmachineid)
-
-	if networkid, ok := d.GetOk("network_id"); ok {
-		p.SetNetworkid(networkid.(string))
-	}
+	p := cs.NAT.NewEnableStaticNatParams(ipaddressid, vm.Id)
 
 	if vmGuestIP, ok := d.GetOk("vm_guest_ip"); ok {
 		p.SetVmguestip(vmGuestIP.(string))
+
+		// Set the network ID based on the guest IP, needed when the public IP address
+		// is not associated with any network yet (VPC case)
+		for _, nic := range vm.Nic {
+			if vmGuestIP.(string) == nic.Ipaddress {
+				p.SetNetworkid(nic.Networkid)
+			}
+		}
+	} else {
+		// If no guest IP is configured, use the primary NIC
+		p.SetNetworkid(vm.Nic[0].Networkid)
 	}
 
-	_, err := cs.NAT.EnableStaticNat(p)
+	_, err = cs.NAT.EnableStaticNat(p)
 	if err != nil {
 		return fmt.Errorf("Error enabling static NAT: %s", err)
 	}
@@ -124,7 +138,6 @@ func resourceCloudStackStaticNATRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	d.Set("network_id", ip.Associatednetworkid)
 	d.Set("virtual_machine_id", ip.Virtualmachineid)
 	d.Set("vm_guest_ip", ip.Vmipaddress)
 

--- a/builtin/providers/cloudstack/resource_cloudstack_static_nat_test.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_static_nat_test.go
@@ -113,7 +113,6 @@ resource "cloudstack_ipaddress" "foo" {
 
 resource "cloudstack_static_nat" "foo" {
 	ip_address_id = "${cloudstack_ipaddress.foo.id}"
-	network_id = "${cloudstack_ipaddress.foo.network_id}"
   virtual_machine_id = "${cloudstack_instance.foobar.id}"
 }`,
 	CLOUDSTACK_SERVICE_OFFERING_1,

--- a/website/source/docs/providers/cloudstack/r/static_nat.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/static_nat.html.markdown
@@ -26,10 +26,8 @@ The following arguments are supported:
 * `ip_address_id` - (Required) The public IP address ID for which static
     NAT will be enabled. Changing this forces a new resource to be created.
 
-* `network_id` - (Optional) The network ID of the VM the static NAT will be
-    enabled for. Required when public IP address is not associated with any
-    guest network yet (VPC case). Changing this forces a new resource to be
-    created.
+* `network_id` - (Deprecated) The network ID of the VM the static NAT will be
+    enabled for. This argument is no longer needed and can be safely omitted.
 
 * `virtual_machine_id` - (Required) The virtual machine ID to enable the
     static NAT feature for. Changing this forces a new resource to be created.
@@ -46,6 +44,5 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The static nat ID.
-* `network` - The network the public IP address is associated with.
 * `vm_guest_ip` - The IP address of the virtual machine that is used
     for the port forwarding rule.


### PR DESCRIPTION
When using the static NAT resource, you no longer have to specify a `network_id`. This can be inferred from the choosen `virtual_machine_id` and/or the `vm_guest_ip`.