### PR TITLE
Checkpoint signature fixes

### DIFF
--- a/config.go
+++ b/config.go
@@ -183,6 +183,8 @@ func (c1 *Config) Merge(c2 *Config) *Config {
 		}
 		result.Provisioners[k] = v
 	}
+	result.DisableCheckpoint = c1.DisableCheckpoint || c2.DisableCheckpoint
+	result.DisableCheckpointSignature = c1.DisableCheckpointSignature || c2.DisableCheckpointSignature
 
 	return &result
 }

--- a/main.go
+++ b/main.go
@@ -103,6 +103,24 @@ func wrappedMain() int {
 		return 1
 	}
 
+	// Load the configuration file if we have one, that can be used to
+	// define extra providers and provisioners.
+	clicfgFile, err := cliConfigFile()
+	if err != nil {
+		Ui.Error(fmt.Sprintf("Error loading CLI configuration: \n\n%s", err))
+		return 1
+	}
+
+	if clicfgFile != "" {
+		usrcfg, err := LoadConfig(clicfgFile)
+		if err != nil {
+			Ui.Error(fmt.Sprintf("Error loading CLI configuration: \n\n%s", err))
+			return 1
+		}
+
+		config = *config.Merge(usrcfg)
+	}
+
 	// Run checkpoint
 	go runCheckpoint(&config)
 
@@ -127,24 +145,6 @@ func wrappedMain() int {
 		Commands:   Commands,
 		HelpFunc:   helpFunc,
 		HelpWriter: os.Stdout,
-	}
-
-	// Load the configuration file if we have one, that can be used to
-	// define extra providers and provisioners.
-	clicfgFile, err := cliConfigFile()
-	if err != nil {
-		Ui.Error(fmt.Sprintf("Error loading CLI configuration: \n\n%s", err))
-		return 1
-	}
-
-	if clicfgFile != "" {
-		usrcfg, err := LoadConfig(clicfgFile)
-		if err != nil {
-			Ui.Error(fmt.Sprintf("Error loading CLI configuration: \n\n%s", err))
-			return 1
-		}
-
-		config = *config.Merge(usrcfg)
 	}
 
 	// Initialize the TFConfig settings for the commands...


### PR DESCRIPTION
- Currently the disable_checkpoint setting from $HOME/.terraformrc is never
respsected due to:
-- The runCheckpoint go routine being fired off prior to loading configuration
-- The config.Merge method not actually merging in the c2s settings