### PR TITLE
ResourceConfig.get should never return (nil, true)

### DIFF
--- a/terraform/resource.go
+++ b/terraform/resource.go
@@ -316,7 +316,8 @@ func (c *ResourceConfig) get(
 			// prefix so were split as path components above.
 			actualKey := strings.Join(parts[i-1:], ".")
 			if prevMap, ok := previous.(map[string]interface{}); ok {
-				return prevMap[actualKey], true
+				v, ok := prevMap[actualKey]
+				return v, ok
 			}
 
 			return nil, false

--- a/terraform/resource_test.go
+++ b/terraform/resource_test.go
@@ -160,6 +160,18 @@ func TestResourceConfigGet(t *testing.T) {
 			Key:   "mapname.0.listkey.0.key",
 			Value: 3,
 		},
+
+		// A map assigned to a list via interpolation should Get a non-existent
+		// value. The test code now also checks that Get doesn't return (nil,
+		// true), which it previously did for this configuration.
+		{
+			Config: map[string]interface{}{
+				"maplist": "${var.maplist}",
+			},
+			Key:   "maplist.0",
+			Value: nil,
+		},
+
 		// FIXME: this is ambiguous, and matches the nested map
 		//        leaving here to catch this behaviour if it changes.
 		{
@@ -226,7 +238,11 @@ func TestResourceConfigGet(t *testing.T) {
 
 		// Test getting a key
 		t.Run(fmt.Sprintf("get-%d", i), func(t *testing.T) {
-			v, _ := rc.Get(tc.Key)
+			v, ok := rc.Get(tc.Key)
+			if ok && v == nil {
+				t.Fatal("(nil, true) returned from Get")
+			}
+
 			if !reflect.DeepEqual(v, tc.Value) {
 				t.Fatalf("%d bad: %#v", i, v)
 			}


### PR DESCRIPTION
Fixes a case where ResourceConfig.get inadvertently returns a nil value.

Add an integration test where assigning a map to a list via
interpolation would panic.

This fixes the crashes seen in #10187. 

The silent errors in the list-of-maps corner cases may need to wait until after 0.8, when we are planning on a larger-scale type refactor, removing the dotted string format. 