### PR TITLE
provider/azurerm: make DiskSizeGB optional for data disks

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -195,7 +195,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 
 						"disk_size_gb": {
 							Type:         schema.TypeInt,
-							Required:     true,
+							Optional:     true,
 							ValidateFunc: validateDiskSizeGB,
 						},
 
@@ -840,7 +840,9 @@ func flattenAzureRmVirtualMachineDataDisk(disks *[]compute.DataDisk) interface{}
 		l["name"] = *disk.Name
 		l["vhd_uri"] = *disk.Vhd.URI
 		l["create_option"] = disk.CreateOption
-		l["disk_size_gb"] = *disk.DiskSizeGB
+		if disk.DiskSizeGB != nil {
+			l["disk_size_gb"] = *disk.DiskSizeGB
+		}
 		l["lun"] = *disk.Lun
 
 		result[i] = l


### PR DESCRIPTION
Terraform crashes when DiskSizeGB field is missing from the Azure response.

This patch makes DiskSizeGB optional for data disks, like OS disks.

**Azure response**

> {
           "lun": 0,
           "name": "kubernetes-dynamic-pvc-90b65d1d-a52e-11e6-8331-000d3a26fb6b.vhd",
           "createOption": "Attach",
           "vhd": {
             "uri": "https://storageaccount/vhds/kubernetes-dynamic-pvc-90b65d1d-a52e-11e6-8331-000d3a26fb6b.vhd"
           },
           "caching": "None"
         },

**Crash log**

> 2016/11/18 23:17:54 [DEBUG] plugin: terraform: panic: runtime error: invalid memory address or nil pointer dereference
2016/11/18 23:17:54 [DEBUG] plugin: terraform: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xb23a68]
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 
2016/11/18 23:17:54 [DEBUG] plugin: terraform: goroutine 852 [running]:
2016/11/18 23:17:54 [DEBUG] plugin: terraform: panic(0x2c01620, 0xc42000e150)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/usr/lib/go/src/runtime/panic.go:500 +0x1a1
2016/11/18 23:17:54 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/azurerm.flattenAzureRmVirtualMachineDataDisk(0xc4203c6c20, 0x32294f2, 0xf)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/home/ck/go/bin/src/github.com/hashicorp/terraform/builtin/providers/azurerm/resource_arm_virtual_machine.go:843 +0x338
2016/11/18 23:17:54 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/azurerm.resourceArmVirtualMachineRead(0xc4208d4000, 0x2e3fbe0, 0xc420223a00, 0x0, 0x17)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/home/ck/go/bin/src/github.com/hashicorp/terraform/builtin/providers/azurerm/resource_arm_virtual_machine.go:585 +0x1555
2016/11/18 23:17:54 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc420367ec0, 0xc4200f6050, 0x2e3fbe0, 0xc420223a00, 0xc420218250, 0x1, 0x18)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/home/ck/go/bin/src/github.com/hashicorp/terraform/helper/schema/resource.go:259 +0x131
2016/11/18 23:17:54 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*Provider).Refresh(0xc420020f60, 0xc4200f6000, 0xc4200f6050, 0x0, 0x2, 0xa7c)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/home/ck/go/bin/src/github.com/hashicorp/terraform/helper/schema/provider.go:237 +0x91
2016/11/18 23:17:54 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Refresh(0xc420276300, 0xc4200f8130, 0xc4200f92b0, 0x0, 0x0)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/home/ck/go/bin/src/github.com/hashicorp/terraform/plugin/resource_provider.go:510 +0x4e
2016/11/18 23:17:54 [DEBUG] plugin: terraform: reflect.Value.call(0xc420366a80, 0xc420488610, 0x13, 0x320a761, 0x4, 0xc4209c9ed0, 0x3, 0x3, 0xc42058c000, 0x7f66440a9960, ...)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/usr/lib/go/src/reflect/value.go:434 +0x5c8
2016/11/18 23:17:54 [DEBUG] plugin: terraform: reflect.Value.Call(0xc420366a80, 0xc420488610, 0x13, 0xc4209c9ed0, 0x3, 0x3, 0x0, 0x0, 0xc420498fa0)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/usr/lib/go/src/reflect/value.go:302 +0xa4
2016/11/18 23:17:54 [DEBUG] plugin: terraform: net/rpc.(*service).call(0xc420270880, 0xc420270840, 0xc4202739a8, 0xc420300d80, 0xc42047c1e0, 0x293e420, 0xc4200f8130, 0x16, 0x293e460, 0xc4200f92b0, ...)
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/usr/lib/go/src/net/rpc/server.go:383 +0x148
2016/11/18 23:17:54 [DEBUG] plugin: terraform: created by net/rpc.(*Server).ServeCodec
2016/11/18 23:17:54 [DEBUG] plugin: terraform: 	/usr/lib/go/src/net/rpc/server.go:477 +0x421
`