### PR TITLE
provider/aws: Add JSON validation to the aws_iam_policy resource

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_policy.go
+++ b/builtin/providers/aws/resource_aws_iam_policy.go
@@ -32,8 +32,9 @@ func resourceAwsIamPolicy() *schema.Resource {
 				ForceNew: true,
 			},
 			"policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateJsonString,
 			},
 			"name": &schema.Schema{
 				Type:          schema.TypeString,


### PR DESCRIPTION
Although the aws_iam_policy has a problem of normalization (refs #8350),
I think it would be useful simply to add JSON syntax validation.
I wasted a lot of time with JSON syntax errors.

In this PR, I added the validation to the aws_iam_policy using the validateJsonString helper which introduced in #8028.