### PR TITLE
provider/aws: Added aws_instance network_interface_id (supersedes #4231)

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -32,67 +32,70 @@ func resourceAwsInstance() *schema.Resource {
 		MigrateState:  resourceAwsInstanceMigrateState,
 
 		Schema: map[string]*schema.Schema{
-			"ami": &schema.Schema{
+			"ami": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"associate_public_ip_address": &schema.Schema{
+			"associate_public_ip_address": {
 				Type:     schema.TypeBool,
 				ForceNew: true,
 				Computed: true,
 				Optional: true,
 			},
 
-			"availability_zone": &schema.Schema{
+			"availability_zone": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
 
-			"placement_group": &schema.Schema{
+			"placement_group": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
 
-			"instance_type": &schema.Schema{
+			"instance_type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"key_name": &schema.Schema{
+			"key_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
 			},
 
-			"subnet_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
+			"subnet_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"network_interface_id"},
 			},
 
-			"private_ip": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
+			"private_ip": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ConflictsWith: []string{"network_interface_id"},
 			},
 
-			"source_dest_check": &schema.Schema{
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  true,
+			"source_dest_check": {
+				Type:          schema.TypeBool,
+				Optional:      true,
+				Default:       true,
+				ConflictsWith: []string{"network_interface_id"},
 			},
 
-			"user_data": &schema.Schema{
+			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -106,76 +109,81 @@ func resourceAwsInstance() *schema.Resource {
 				},
 			},
 
-			"security_groups": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+			"security_groups": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
+				ConflictsWith: []string{"network_interface_id"},
 			},
 
-			"vpc_security_group_ids": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
-				Computed: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+			"vpc_security_group_ids": {
+				Type:          schema.TypeSet,
+				Optional:      true,
+				Computed:      true,
+				Elem:          &schema.Schema{Type: schema.TypeString},
+				Set:           schema.HashString,
+				ConflictsWith: []string{"network_interface_id"},
 			},
 
-			"public_dns": &schema.Schema{
+			"public_dns": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"network_interface_id": &schema.Schema{
+			"network_interface_id": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"subnet_id", "security_groups", "vpc_security_group_ids", "private_ip", "source_dest_check"},
+			},
+
+			"public_ip": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"public_ip": &schema.Schema{
+			"instance_state": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"instance_state": &schema.Schema{
+			"private_dns": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"private_dns": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
-			"ebs_optimized": &schema.Schema{
+			"ebs_optimized": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"disable_api_termination": &schema.Schema{
+			"disable_api_termination": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
 
-			"instance_initiated_shutdown_behavior": &schema.Schema{
+			"instance_initiated_shutdown_behavior": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"monitoring": &schema.Schema{
+			"monitoring": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
 
-			"iam_instance_profile": &schema.Schema{
+			"iam_instance_profile": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,
 			},
 
-			"tenancy": &schema.Schema{
+			"tenancy": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -184,60 +192,60 @@ func resourceAwsInstance() *schema.Resource {
 
 			"tags": tagsSchema(),
 
-			"block_device": &schema.Schema{
+			"block_device": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Removed:  "Split out into three sub-types; see Changelog and Docs",
 			},
 
-			"ebs_block_device": &schema.Schema{
+			"ebs_block_device": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"delete_on_termination": &schema.Schema{
+						"delete_on_termination": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  true,
 							ForceNew: true,
 						},
 
-						"device_name": &schema.Schema{
+						"device_name": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
 
-						"encrypted": &schema.Schema{
+						"encrypted": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
 
-						"iops": &schema.Schema{
+						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
 
-						"snapshot_id": &schema.Schema{
+						"snapshot_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
 
-						"volume_size": &schema.Schema{
+						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
 
-						"volume_type": &schema.Schema{
+						"volume_type": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
@@ -254,19 +262,19 @@ func resourceAwsInstance() *schema.Resource {
 				},
 			},
 
-			"ephemeral_block_device": &schema.Schema{
+			"ephemeral_block_device": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"device_name": &schema.Schema{
+						"device_name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"virtual_name": &schema.Schema{
+						"virtual_name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
@@ -281,7 +289,7 @@ func resourceAwsInstance() *schema.Resource {
 				},
 			},
 
-			"root_block_device": &schema.Schema{
+			"root_block_device": {
 				// TODO: This is a set because we don't support singleton
 				//       sub-resources today. We'll enforce that the set only ever has
 				//       length zero or one below. When TF gains support for
@@ -294,28 +302,28 @@ func resourceAwsInstance() *schema.Resource {
 					// Termination flag on the block device mapping entry for the root
 					// device volume." - bit.ly/ec2bdmap
 					Schema: map[string]*schema.Schema{
-						"delete_on_termination": &schema.Schema{
+						"delete_on_termination": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  true,
 							ForceNew: true,
 						},
 
-						"iops": &schema.Schema{
+						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
 
-						"volume_size": &schema.Schema{
+						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Computed: true,
 							ForceNew: true,
 						},
 
-						"volume_type": &schema.Schema{
+						"volume_type": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Computed: true,
@@ -1047,6 +1055,9 @@ func buildAwsInstanceOpts(
 	subnet, hasSubnet := d.GetOk("subnet_id")
 	subnetID := subnet.(string)
 
+	networkInterface, hasNetworkInterface := d.GetOk("network_interface_id")
+	networkInterfaceID := networkInterface.(string)
+
 	// Placement is used for aws_instance; SpotPlacement is used for
 	// aws_spot_instance_request. They represent the same data. :-|
 	opts.Placement = &ec2.Placement{
@@ -1080,7 +1091,13 @@ func buildAwsInstanceOpts(
 		}
 	}
 
-	if hasSubnet && associatePublicIPAddress {
+	if hasNetworkInterface {
+		ni := &ec2.InstanceNetworkInterfaceSpecification{
+			DeviceIndex:        aws.Int64(int64(0)),
+			NetworkInterfaceId: aws.String(networkInterfaceID),
+		}
+		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
+	} else if hasSubnet && associatePublicIPAddress {
 		// If we have a non-default VPC / Subnet specified, we can flag
 		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
 		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -45,7 +45,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			// Create a volume to cover #1249
-			resource.TestStep{
+			{
 				// Need a resource in this config so the provisioner will be available
 				Config: testAccInstanceConfig_pre,
 				Check: func(*terraform.State) error {
@@ -59,7 +59,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 				},
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
@@ -77,7 +77,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 			// We repeat the exact same test so that we can be sure
 			// that the user data hash stuff is working without generating
 			// an incorrect diff.
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
@@ -93,7 +93,7 @@ func TestAccAWSInstance_basic(t *testing.T) {
 			},
 
 			// Clean up volume created above
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfig,
 				Check: func(*terraform.State) error {
 					conn := testAccProvider.Meta().(*AWSClient).ec2conn
@@ -134,7 +134,7 @@ func TestAccAWSInstance_GP2IopsDevice(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceGP2IopsDevice,
 				//Config: testAccInstanceConfigBlockDevices,
 				Check: resource.ComposeTestCheckFunc(
@@ -199,7 +199,7 @@ func TestAccAWSInstance_blockDevices(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigBlockDevices,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
@@ -267,7 +267,7 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigSourceDestDisable,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -275,7 +275,7 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigSourceDestEnable,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -283,7 +283,7 @@ func TestAccAWSInstance_sourceDestCheck(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigSourceDestDisable,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -321,7 +321,7 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigDisableAPITermination(true),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -329,7 +329,7 @@ func TestAccAWSInstance_disableApiTermination(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigDisableAPITermination(false),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -350,7 +350,7 @@ func TestAccAWSInstance_vpc(t *testing.T) {
 		Providers:       testAccProviders,
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigVPC,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
@@ -384,7 +384,7 @@ func TestAccAWSInstance_multipleRegions(t *testing.T) {
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckInstanceDestroyWithProviders(&providers),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigMultipleRegions,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExistsWithProviders(
@@ -407,7 +407,7 @@ func TestAccAWSInstance_NetworkInstanceSecurityGroups(t *testing.T) {
 		Providers:       testAccProviders,
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceNetworkInstanceSecurityGroups,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
@@ -427,7 +427,7 @@ func TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceNetworkInstanceVPCSecurityGroupIDs,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists(
@@ -450,7 +450,7 @@ func TestAccAWSInstance_tags(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckInstanceConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -460,7 +460,7 @@ func TestAccAWSInstance_tags(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccCheckInstanceConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -491,7 +491,7 @@ func TestAccAWSInstance_privateIP(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigPrivateIP,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -522,7 +522,7 @@ func TestAccAWSInstance_associatePublicIPAndPrivateIP(t *testing.T) {
 		Providers:       testAccProviders,
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigAssociatePublicIPAndPrivateIP,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -558,7 +558,7 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 		Providers:       testAccProviders,
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigKeyPair,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -577,7 +577,7 @@ func TestAccAWSInstance_rootBlockDeviceMismatch(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigRootBlockDeviceMismatch,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -607,7 +607,7 @@ func TestAccAWSInstance_forceNewAndTagsDrift(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigForceNewAndTagsDrift,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -615,7 +615,7 @@ func TestAccAWSInstance_forceNewAndTagsDrift(t *testing.T) {
 				),
 				ExpectNonEmptyPlan: true,
 			},
-			resource.TestStep{
+			{
 				Config: testAccInstanceConfigForceNewAndTagsDrift_Update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
@@ -752,259 +752,259 @@ func driftTags(instance *ec2.Instance) resource.TestCheckFunc {
 
 const testAccInstanceConfig_pre = `
 resource "aws_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
-	description = "foo"
+  name = "tf_test_foo"
+  description = "foo"
 
-	ingress {
-		protocol = "icmp"
-		from_port = -1
-		to_port = -1
-		cidr_blocks = ["0.0.0.0/0"]
-	}
+  ingress {
+    protocol = "icmp"
+    from_port = -1
+    to_port = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 `
 
 const testAccInstanceConfig = `
 resource "aws_security_group" "tf_test_foo" {
-	name = "tf_test_foo"
-	description = "foo"
+  name = "tf_test_foo"
+  description = "foo"
 
-	ingress {
-		protocol = "icmp"
-		from_port = -1
-		to_port = -1
-		cidr_blocks = ["0.0.0.0/0"]
-	}
+  ingress {
+    protocol = "icmp"
+    from_port = -1
+    to_port = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	availability_zone = "us-west-2a"
+  # us-west-2
+  ami = "ami-4fccb37f"
+  availability_zone = "us-west-2a"
 
-	instance_type = "m1.small"
-	security_groups = ["${aws_security_group.tf_test_foo.name}"]
-	user_data = "foo:-with-character's"
+  instance_type = "m1.small"
+  security_groups = ["${aws_security_group.tf_test_foo.name}"]
+  user_data = "foo:-with-character's"
 }
 `
 
 const testAccInstanceGP2IopsDevice = `
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-55a7ea65"
+  # us-west-2
+  ami = "ami-55a7ea65"
 
-	# In order to attach an encrypted volume to an instance you need to have an
-	# m3.medium or larger. See "Supported Instance Types" in:
-	# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
-	instance_type = "m3.medium"
+  # In order to attach an encrypted volume to an instance you need to have an
+  # m3.medium or larger. See "Supported Instance Types" in:
+  # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
+  instance_type = "m3.medium"
 
-	root_block_device {
-		volume_type = "gp2"
-		volume_size = 11
-		iops = 330
-	}
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 11
+    iops = 330
+  }
 }
 `
 
 const testAccInstanceConfigBlockDevices = `
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-55a7ea65"
+  # us-west-2
+  ami = "ami-55a7ea65"
 
-	# In order to attach an encrypted volume to an instance you need to have an
-	# m3.medium or larger. See "Supported Instance Types" in:
-	# http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
-	instance_type = "m3.medium"
+  # In order to attach an encrypted volume to an instance you need to have an
+  # m3.medium or larger. See "Supported Instance Types" in:
+  # http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSEncryption.html
+  instance_type = "m3.medium"
 
-	root_block_device {
-		volume_type = "gp2"
-		volume_size = 11
-	}
-	ebs_block_device {
-		device_name = "/dev/sdb"
-		volume_size = 9
-	}
-	ebs_block_device {
-		device_name = "/dev/sdc"
-		volume_size = 10
-		volume_type = "io1"
-		iops = 100
-	}
+  root_block_device {
+    volume_type = "gp2"
+    volume_size = 11
+  }
+  ebs_block_device {
+    device_name = "/dev/sdb"
+    volume_size = 9
+  }
+  ebs_block_device {
+    device_name = "/dev/sdc"
+    volume_size = 10
+    volume_type = "io1"
+    iops = 100
+  }
 
-	# Encrypted ebs block device
-	ebs_block_device {
-		device_name = "/dev/sdd"
-		volume_size = 12
-		encrypted = true
-	}
+  # Encrypted ebs block device
+  ebs_block_device {
+    device_name = "/dev/sdd"
+    volume_size = 12
+    encrypted = true
+  }
 
-	ephemeral_block_device {
-		device_name = "/dev/sde"
-		virtual_name = "ephemeral0"
-	}
+  ephemeral_block_device {
+    device_name = "/dev/sde"
+    virtual_name = "ephemeral0"
+  }
 }
 `
 
 const testAccInstanceConfigSourceDestEnable = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.foo.id}"
+  # us-west-2
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  subnet_id = "${aws_subnet.foo.id}"
 }
 `
 
 const testAccInstanceConfigSourceDestDisable = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.foo.id}"
-	source_dest_check = false
+  # us-west-2
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  subnet_id = "${aws_subnet.foo.id}"
+  source_dest_check = false
 }
 `
 
 func testAccInstanceConfigDisableAPITermination(val bool) string {
 	return fmt.Sprintf(`
-	resource "aws_vpc" "foo" {
-		cidr_block = "10.1.0.0/16"
-	}
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+}
 
-	resource "aws_subnet" "foo" {
-		cidr_block = "10.1.1.0/24"
-		vpc_id = "${aws_vpc.foo.id}"
-	}
+resource "aws_subnet" "foo" {
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
+}
 
-	resource "aws_instance" "foo" {
-		# us-west-2
-		ami = "ami-4fccb37f"
-		instance_type = "m1.small"
-		subnet_id = "${aws_subnet.foo.id}"
-		disable_api_termination = %t
-	}
-	`, val)
+resource "aws_instance" "foo" {
+  # us-west-2
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  subnet_id = "${aws_subnet.foo.id}"
+  disable_api_termination = %t
+}
+  `, val)
 }
 
 const testAccInstanceConfigVPC = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	subnet_id = "${aws_subnet.foo.id}"
-	associate_public_ip_address = true
-	tenancy = "dedicated"
-	# pre-encoded base64 data
-	user_data = "3dc39dda39be1205215e776bad998da361a5955d"
+  # us-west-2
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  subnet_id = "${aws_subnet.foo.id}"
+  associate_public_ip_address = true
+  tenancy = "dedicated"
+  # pre-encoded base64 data
+  user_data = "3dc39dda39be1205215e776bad998da361a5955d"
 }
 `
 
 const testAccInstanceConfigMultipleRegions = `
 provider "aws" {
-	alias = "west"
-	region = "us-west-2"
+  alias = "west"
+  region = "us-west-2"
 }
 
 provider "aws" {
-	alias = "east"
-	region = "us-east-1"
+  alias = "east"
+  region = "us-east-1"
 }
 
 resource "aws_instance" "foo" {
-	# us-west-2
-	provider = "aws.west"
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
+  # us-west-2
+  provider = "aws.west"
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
 }
 
 resource "aws_instance" "bar" {
-	# us-east-1
-	provider = "aws.east"
-	ami = "ami-8c6ea9e4"
-	instance_type = "m1.small"
+  # us-east-1
+  provider = "aws.east"
+  ami = "ami-8c6ea9e4"
+  instance_type = "m1.small"
 }
 `
 
 const testAccCheckInstanceConfigTags = `
 resource "aws_instance" "foo" {
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	tags {
-		foo = "bar"
-	}
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  tags {
+   foo = "bar"
+  }
 }
 `
 
 const testAccCheckInstanceConfigTagsUpdate = `
 resource "aws_instance" "foo" {
-	ami = "ami-4fccb37f"
-	instance_type = "m1.small"
-	tags {
-		bar = "baz"
-	}
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  tags {
+   bar = "baz"
+  }
 }
 `
 
 const testAccInstanceConfigPrivateIP = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.foo.id}"
-	private_ip = "10.1.1.42"
+  ami = "ami-c5eabbf5"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.foo.id}"
+  private_ip = "10.1.1.42"
 }
 `
 
 const testAccInstanceConfigAssociatePublicIPAndPrivateIP = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	ami = "ami-c5eabbf5"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.foo.id}"
-	associate_public_ip_address = true
-	private_ip = "10.1.1.42"
+  ami = "ami-c5eabbf5"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.foo.id}"
+  associate_public_ip_address = true
+  private_ip = "10.1.1.42"
 }
 `
 
@@ -1015,9 +1015,9 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "tf-network-test"
-	}
+  tags {
+    Name = "tf-network-test"
+  }
 }
 
 resource "aws_security_group" "tf_test_foo" {
@@ -1044,13 +1044,13 @@ resource "aws_instance" "foo_instance" {
   vpc_security_group_ids = ["${aws_security_group.tf_test_foo.id}"]
   subnet_id = "${aws_subnet.foo.id}"
   associate_public_ip_address = true
-	depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.gw"]
 }
 
 resource "aws_eip" "foo_eip" {
   instance = "${aws_instance.foo_instance.id}"
   vpc = true
-	depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.gw"]
 }
 `
 
@@ -1061,9 +1061,9 @@ resource "aws_internet_gateway" "gw" {
 
 resource "aws_vpc" "foo" {
   cidr_block = "10.1.0.0/16"
-	tags {
-		Name = "tf-network-test"
-	}
+  tags {
+     Name = "tf-network-test"
+  }
 }
 
 resource "aws_security_group" "tf_test_foo" {
@@ -1089,87 +1089,87 @@ resource "aws_instance" "foo_instance" {
   instance_type = "t1.micro"
   vpc_security_group_ids = ["${aws_security_group.tf_test_foo.id}"]
   subnet_id = "${aws_subnet.foo.id}"
-	depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.gw"]
 }
 
 resource "aws_eip" "foo_eip" {
   instance = "${aws_instance.foo_instance.id}"
   vpc = true
-	depends_on = ["aws_internet_gateway.gw"]
+  depends_on = ["aws_internet_gateway.gw"]
 }
 `
 
 const testAccInstanceConfigKeyPair = `
 provider "aws" {
-	region = "us-east-1"
+  region = "us-east-1"
 }
 
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key"
-	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
+  key_name = "tmp-key"
+  public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
 resource "aws_instance" "foo" {
   ami = "ami-408c7f28"
   instance_type = "t1.micro"
   key_name = "${aws_key_pair.debugging.key_name}"
-	tags {
-		Name = "testAccInstanceConfigKeyPair_TestAMI"
-	}
+  tags {
+    Name = "testAccInstanceConfigKeyPair_TestAMI"
+  }
 }
 `
 
 const testAccInstanceConfigRootBlockDeviceMismatch = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	// This is an AMI with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
-	ami = "ami-ef5b69df"
-	instance_type = "t1.micro"
-	subnet_id = "${aws_subnet.foo.id}"
-	root_block_device {
-		volume_size = 13
-	}
+  // This is an AMI with RootDeviceName: "/dev/sda1"; actual root: "/dev/sda"
+  ami = "ami-ef5b69df"
+  instance_type = "t1.micro"
+  subnet_id = "${aws_subnet.foo.id}"
+  root_block_device {
+    volume_size = 13
+  }
 }
 `
 
 const testAccInstanceConfigForceNewAndTagsDrift = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.nano"
-	subnet_id = "${aws_subnet.foo.id}"
+  ami = "ami-22b9a343"
+  instance_type = "t2.nano"
+  subnet_id = "${aws_subnet.foo.id}"
 }
 `
 
 const testAccInstanceConfigForceNewAndTagsDrift_Update = `
 resource "aws_vpc" "foo" {
-	cidr_block = "10.1.0.0/16"
+  cidr_block = "10.1.0.0/16"
 }
 
 resource "aws_subnet" "foo" {
-	cidr_block = "10.1.1.0/24"
-	vpc_id = "${aws_vpc.foo.id}"
+  cidr_block = "10.1.1.0/24"
+  vpc_id = "${aws_vpc.foo.id}"
 }
 
 resource "aws_instance" "foo" {
-	ami = "ami-22b9a343"
-	instance_type = "t2.micro"
-	subnet_id = "${aws_subnet.foo.id}"
+  ami = "ami-22b9a343"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.foo.id}"
 }
 `

--- a/website/source/docs/providers/aws/r/network_interface.markdown
+++ b/website/source/docs/providers/aws/r/network_interface.markdown
@@ -45,6 +45,7 @@ The `attachment` block supports:
 
 The following attributes are exported:
 
+* `id` - The ENI ID.
 * `subnet_id` - Subnet ID the ENI is in.
 * `description` - A description for the network interface.
 * `private_ips` - List of private IPs assigned to the ENI.


### PR DESCRIPTION
#### Reasonning for this change
Continues #4231 with some minor updates.

This is the step 1 on 2 for https://github.com/hashicorp/terraform/issues/3105.
The second part will be to add a map of interfaces, with related indexes. I would prefer to do it in 2 works because of the refactoring required.

Be kind, still learning Go & Terraform stuff 😅 

#### Related issues
https://github.com/hashicorp/terraform/issues/2998
https://github.com/hashicorp/terraform/issues/3105

#### Acceptance tests:
```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSInstance_'                      
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/19 15:30:08 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_ -timeout 120m
=== RUN   TestAccAWSInstance_importBasic
--- PASS: TestAccAWSInstance_importBasic (133.63s)
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (258.72s)
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (104.56s)
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (126.30s)
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (346.26s)
=== RUN   TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (240.20s)
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (126.80s)
=== RUN   TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (149.48s)
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (173.55s)
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (198.45s)
=== RUN   TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (141.03s)
=== RUN   TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (261.10s)
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (270.19s)
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (124.38s)
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (147.35s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (243.66s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	3045.701s
```