### PR TITLE
Update documentation for aws_security_group data source

### DIFF
--- a/website/source/docs/providers/aws/d/security_group.html.markdown
+++ b/website/source/docs/providers/aws/d/security_group.html.markdown
@@ -67,3 +67,4 @@ any fields that are not included in the configuration with the data for
 the selected Security Group.
 Additionally, the `description` attribute is exported.
 
+~> **Note:** The [default security group for a VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html#DefaultSecurityGroup) has the name `default`.


### PR DESCRIPTION
Add note to **aws_security_group** data source describing the default security group for a VPC.
Add a corresponding acceptance test:
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccDataSourceAwsSecurityGroup'
```