### PR TITLE
aws_prefix_list data source - Add ability to select PL by name

### DIFF
--- a/builtin/providers/aws/data_source_aws_prefix_list_test.go
+++ b/builtin/providers/aws/data_source_aws_prefix_list_test.go
@@ -17,7 +17,8 @@ func TestAccDataSourceAwsPrefixList(t *testing.T) {
 			resource.TestStep{
 				Config: testAccDataSourceAwsPrefixListConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3"),
+					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_id"),
+					testAccDataSourceAwsPrefixListCheck("data.aws_prefix_list.s3_by_name"),
 				),
 			},
 		},
@@ -61,7 +62,11 @@ provider "aws" {
   region = "us-west-2"
 }
 
-data "aws_prefix_list" "s3" {
+data "aws_prefix_list" "s3_by_id" {
   prefix_list_id = "pl-68a54001"
+}
+
+data "aws_prefix_list" "s3_by_name" {
+ name = "com.amazonaws.us-west-2.s3"
 }
 `

--- a/website/source/docs/providers/aws/d/prefix_list.html.markdown
+++ b/website/source/docs/providers/aws/d/prefix_list.html.markdown
@@ -49,7 +49,9 @@ The arguments of this data source act as filters for querying the available
 prefix lists. The given filters must match exactly one prefix list
 whose data will be exported as attributes.
 
-* `prefix_list_id` - (Required) The ID of the prefix list to select.
+* `prefix_list_id` - (Optional) The ID of the prefix list to select.
+
+* `name` - (Optional) The name of the prefix list to select.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add the ability to select a prefix list by name instead of/as well as by name.
I decided not to call the attribute **prefix_list_name** as we already have a **name** attribute, which I reused.
I wish I had done the same with the **id** attribute when I added this data source but I know now 😄.
Updated the documentation and acceptance tests:
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccDataSourceAwsPrefixList'
```