### PR TITLE
fix aws_availability_zone data source doc example

### DIFF
--- a/website/source/docs/providers/aws/d/availability_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/availability_zone.html.markdown
@@ -64,7 +64,7 @@ resource "aws_vpc" "example" {
 # Create a subnet for the AZ within the regional VPC
 resource "aws_subnet" "example" {
   vpc_id     = "${aws_vpc.example.id}"
-  cidr_block = "${cidrsubnet(aws_vpc.example.cidr_block, 4, var.az_number[data.aws_availability_zone.name_suffix])}"
+  cidr_block = "${cidrsubnet(aws_vpc.example.cidr_block, 4, var.az_number[data.aws_availability_zone.example.name_suffix])}"
 }
 ```
 


### PR DESCRIPTION
existing example returns an error like the following should you try to run `terraform plan` against it:

```
Error reading config for aws_subnet[example]: data.aws_availability_zone.name_suffix: data variables must be four parts: data.TYPE.NAME.ATTR in:

${cidrsubnet(aws_vpc.example.cidr_block, 4, var.az_number[data.aws_availability_zone.name_suffix])}
```