### PR TITLE
provider/aws Return service CIDR blocks from aws_vpc_endpoint resource

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_endpoint.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint.go
@@ -52,6 +52,11 @@ func resourceAwsVpcEndpoint() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"cidr_blocks": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -155,7 +160,9 @@ func resourceAwsVPCEndpointRead(d *schema.ResourceData, meta interface{}) error 
 	if err := d.Set("route_table_ids", aws.StringValueSlice(vpce.RouteTableIds)); err != nil {
 		return err
 	}
-	d.Set("prefix_list_id", prefixListsOutput.PrefixLists[0].PrefixListId)
+	pl := prefixListsOutput.PrefixLists[0]
+	d.Set("prefix_list_id", pl.PrefixListId)
+	d.Set("cidr_blocks", aws.StringValueSlice(pl.Cidrs))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_endpoint_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -187,6 +188,18 @@ func testAccCheckVpcEndpointPrefixListAvailable(n string) resource.TestCheckFunc
 		}
 		if !strings.HasPrefix(prefixListID, "pl") {
 			return fmt.Errorf("Prefix list ID does not appear to be a valid value: '%s'", prefixListID)
+		}
+
+		var (
+			cidrBlockSize int
+			err           error
+		)
+
+		if cidrBlockSize, err = strconv.Atoi(rs.Primary.Attributes["cidr_blocks.#"]); err != nil {
+			return err
+		}
+		if cidrBlockSize < 1 {
+			return fmt.Errorf("cidr_blocks seem suspiciously low: %d", cidrBlockSize)
 		}
 
 		return nil

--- a/website/source/docs/providers/aws/r/vpc_endpoint.html.markdown
+++ b/website/source/docs/providers/aws/r/vpc_endpoint.html.markdown
@@ -36,6 +36,7 @@ The following attributes are exported:
 
 * `id` - The ID of the VPC endpoint.
 * `prefix_list_id` - The prefix list ID of the exposed service.
+* `cidr_blocks` - The list of CIDR blocks for the exposed service.
 
 
 ## Import


### PR DESCRIPTION
Return the list of CIDR blocks for the service exposed through an AWS VPC Endpoint.
Updated documentation.
Updated acceptance test:
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpcEndpoint_basic'
```