### PR TITLE
Closes #1768 - Implements taint with wildcard

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1279,7 +1279,7 @@ func ParseResourceStateKey(k string) (*ResourceStateKey, error) {
 		Name:  parts[1],
 		Index: -1,
 	}
-	if len(parts) == 3 {
+	if len(parts) == 3 && parts[2] != "*" {
 		index, err := strconv.Atoi(parts[2])
 		if err != nil {
 			return nil, fmt.Errorf("Malformed resource state key index: %s", k)

--- a/website/source/docs/commands/taint.html.markdown
+++ b/website/source/docs/commands/taint.html.markdown
@@ -61,3 +61,17 @@ The command-line flags are all optional. The list of available flags are:
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when
   [remote state](/docs/state/remote/index.html) is used.
+
+## Example
+
+This example will taint all resources with a given type and name:
+
+```
+$ terraform taint -module=mymodule aws_instance.foo.*
+```
+
+This example will taint all resources with a given name:
+
+```
+$ terraform taint *.baz.*
+```


### PR DESCRIPTION
This implementation of wildcard functionality enables the following:

Given resources:
- test_instance.foo.a
- test_instance.foo.b
- test_instance.bar.a

Matches:

`test_instance.*`
- test_instance.foo.a
- test_instance.foo.b
- test_instance.bar.a

`test_instance.*.a`
- test_instance.foo.a
- test_instance.bar.a

`test_instance.foo.*`
- test_instance.foo.a
- test_instance.foo.b

`test_instance.foo*`
- Doesn't match anything

I'm sure I've broken some conventions along the way. I very much appreciate any feedback that is given. 

Cheers