### PR TITLE
Use RDS::CreateDBInstance docs for more info on parameter values

### DIFF
--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -45,7 +45,7 @@ resource "aws_db_instance" "default" {
 ## Argument Reference
 
 For more detailed documentation about each argument, refer to
-the [AWS official documentation](https://docs.aws.amazon.com/AmazonRDS/latest/CommandLineReference/CLIReference-cmd-ModifyDBInstance.html).
+the [AWS official documentation](http://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html).
 
 The following arguments are supported:
 


### PR DESCRIPTION
The docs for the CreateDBInstance API call include quite a bit more information about each individual option, for example `Engine` has each of the possible options listed, whilst the cli reference doesn't include this level of detail. 