### PR TITLE
provider/openstack: openstack_blockstorage_volume_attach_v2 resource

### DIFF
--- a/builtin/providers/openstack/import_openstack_blockstorage_volume_attach_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_blockstorage_volume_attach_v2_test.go
@@ -1,0 +1,29 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccBlockStorageVolumeAttachV2_importBasic(t *testing.T) {
+	resourceName := "openstack_blockstorage_volume_attach_v2.va_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBlockStorageVolumeAttachV2Destroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageVolumeAttachV2_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"region"},
+			},
+		},
+	})
+}

--- a/builtin/providers/openstack/provider.go
+++ b/builtin/providers/openstack/provider.go
@@ -130,6 +130,7 @@ func Provider() terraform.ResourceProvider {
 		ResourcesMap: map[string]*schema.Resource{
 			"openstack_blockstorage_volume_v1":         resourceBlockStorageVolumeV1(),
 			"openstack_blockstorage_volume_v2":         resourceBlockStorageVolumeV2(),
+			"openstack_blockstorage_volume_attach_v2":  resourceBlockStorageVolumeAttachV2(),
 			"openstack_compute_instance_v2":            resourceComputeInstanceV2(),
 			"openstack_compute_keypair_v2":             resourceComputeKeypairV2(),
 			"openstack_compute_secgroup_v2":            resourceComputeSecGroupV2(),

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2.go
@@ -1,0 +1,254 @@
+package openstack
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceBlockStorageVolumeAttachV2() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBlockStorageVolumeAttachV2Create,
+		Read:   resourceBlockStorageVolumeAttachV2Read,
+		Update: nil,
+		Delete: resourceBlockStorageVolumeAttachV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"region": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_REGION_NAME", ""),
+			},
+
+			"volume_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"instance_id": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"host_name"},
+			},
+
+			"host_name": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"instance_id"},
+			},
+
+			"device": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"attach_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					value := v.(string)
+					if value != "ro" && value != "rw" {
+						errors = append(errors, fmt.Errorf(
+							"Only 'ro' and 'rw' are supported values for 'attach_mode'"))
+					}
+					return
+				},
+			},
+		},
+	}
+}
+
+func resourceBlockStorageVolumeAttachV2Create(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.blockStorageV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	// Check if either instance_id or host_name was set.
+	instanceId := d.Get("instance_id").(string)
+	hostName := d.Get("host_name").(string)
+	if instanceId == "" && hostName == "" {
+		return fmt.Errorf("One of 'instance_id' or 'host_name' must be set.")
+	}
+
+	volumeId := d.Get("volume_id").(string)
+
+	attachMode, err := blockStorageVolumeAttachV2AttachMode(d.Get("attach_mode").(string))
+	if err != nil {
+		return nil
+	}
+
+	attachOpts := &volumeactions.AttachOpts{
+		InstanceUUID: d.Get("instance_id").(string),
+		HostName:     d.Get("host_name").(string),
+		MountPoint:   d.Get("device").(string),
+		Mode:         attachMode,
+	}
+
+	log.Printf("[DEBUG] Attachment Options: %#v", attachOpts)
+
+	if err := volumeactions.Attach(client, volumeId, attachOpts).ExtractErr(); err != nil {
+		return err
+	}
+
+	// Wait for the volume to become available.
+	log.Printf("[DEBUG] Waiting for volume (%s) to become available", volumeId)
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"available", "attaching"},
+		Target:     []string{"in-use"},
+		Refresh:    VolumeV2StateRefreshFunc(client, volumeId),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for volume (%s) to become ready: %s", volumeId, err)
+	}
+
+	volume, err := volumes.Get(client, volumeId).Extract()
+	if err != nil {
+		return err
+	}
+
+	var attachmentId string
+	for _, attachment := range volume.Attachments {
+		if instanceId != "" && instanceId == attachment.ServerID {
+			attachmentId = attachment.AttachmentID
+		}
+
+		if hostName != "" && hostName == attachment.HostName {
+			attachmentId = attachment.AttachmentID
+		}
+	}
+
+	if attachmentId == "" {
+		return fmt.Errorf("Unable to determine attachment ID.")
+	}
+
+	// The ID must be a combination of the volume and attachment ID
+	// in order to import attachments.
+	id := fmt.Sprintf("%s/%s", volumeId, attachmentId)
+	d.SetId(id)
+
+	return resourceBlockStorageVolumeAttachV2Read(d, meta)
+}
+
+func resourceBlockStorageVolumeAttachV2Read(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.blockStorageV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	volumeId, attachmentId, err := blockStorageVolumeAttachV2ParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	volume, err := volumes.Get(client, volumeId).Extract()
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Retrieved volume %s: %#v", d.Id(), volume)
+
+	var attachment volumes.Attachment
+	for _, v := range volume.Attachments {
+		if attachmentId == v.AttachmentID {
+			attachment = v
+		}
+	}
+
+	log.Printf("[DEBUG] Retrieved volume attachment: %#v", attachment)
+
+	d.Set("volume_id", volumeId)
+	d.Set("attachment_id", attachmentId)
+	d.Set("device", attachment.Device)
+	d.Set("instance_id", attachment.ServerID)
+	d.Set("host_name", attachment.HostName)
+
+	return nil
+}
+
+func resourceBlockStorageVolumeAttachV2Delete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	client, err := config.blockStorageV2Client(d.Get("region").(string))
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	volumeId, attachmentId, err := blockStorageVolumeAttachV2ParseId(d.Id())
+	if err != nil {
+		return err
+	}
+
+	detachOpts := volumeactions.DetachOpts{
+		AttachmentID: attachmentId,
+	}
+
+	log.Printf("[DEBUG] Detachment Options: %#v", detachOpts)
+
+	if err := volumeactions.Detach(client, volumeId, detachOpts).ExtractErr(); err != nil {
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"in-use", "attaching", "detaching"},
+		Target:     []string{"available"},
+		Refresh:    VolumeV2StateRefreshFunc(client, volumeId),
+		Timeout:    10 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for volume (%s) to become available: %s", volumeId, err)
+	}
+
+	return nil
+}
+
+func blockStorageVolumeAttachV2AttachMode(v string) (volumeactions.AttachMode, error) {
+	var attachMode volumeactions.AttachMode
+	var attachError error
+	switch v {
+	case "":
+	case "ro":
+		attachMode = volumeactions.ReadOnly
+	case "rw":
+		attachMode = volumeactions.ReadWrite
+	default:
+		attachError = fmt.Errorf("Invalid attach_mode specified")
+	}
+
+	return attachMode, attachError
+}
+
+func blockStorageVolumeAttachV2ParseId(id string) (string, string, error) {
+	parts := strings.Split(id, "/")
+	if len(parts) < 2 {
+		return "", "", fmt.Errorf("Unable to determine attachment ID")
+	}
+
+	return parts[0], parts[1], nil
+}

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2.go
@@ -16,7 +16,6 @@ func resourceBlockStorageVolumeAttachV2() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceBlockStorageVolumeAttachV2Create,
 		Read:   resourceBlockStorageVolumeAttachV2Read,
-		Update: nil,
 		Delete: resourceBlockStorageVolumeAttachV2Delete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -233,6 +232,7 @@ func blockStorageVolumeAttachV2AttachMode(v string) (volumeactions.AttachMode, e
 	var attachError error
 	switch v {
 	case "":
+		attachMode = ""
 	case "ro":
 		attachMode = volumeactions.ReadOnly
 	case "rw":

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2_test.go
@@ -1,0 +1,126 @@
+package openstack
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
+)
+
+func TestAccBlockStorageVolumeAttachV2_basic(t *testing.T) {
+	var va volumes.Attachment
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBlockStorageVolumeAttachV2Destroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccBlockStorageVolumeAttachV2_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBlockStorageVolumeAttachV2Exists(t, "openstack_blockstorage_volume_attach_v2.va_1", &va),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBlockStorageVolumeAttachV2Destroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	client, err := config.blockStorageV2Client(OS_REGION_NAME)
+	if err != nil {
+		return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+	}
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "openstack_blockstorage_volume_attach_v2" {
+			continue
+		}
+
+		volumeId, attachmentId, err := blockStorageVolumeAttachV2ParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		volume, err := volumes.Get(client, volumeId).Extract()
+		if err != nil {
+			if _, ok := err.(gophercloud.ErrDefault404); ok {
+				return nil
+			}
+			return err
+		}
+
+		for _, v := range volume.Attachments {
+			if attachmentId == v.AttachmentID {
+				return fmt.Errorf("Volume attachment still exists")
+			}
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckBlockStorageVolumeAttachV2Exists(t *testing.T, n string, va *volumes.Attachment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		client, err := config.blockStorageV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack block storage client: %s", err)
+		}
+
+		volumeId, attachmentId, err := blockStorageVolumeAttachV2ParseId(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		volume, err := volumes.Get(client, volumeId).Extract()
+		if err != nil {
+			return err
+		}
+
+		var found bool
+		for _, v := range volume.Attachments {
+			if attachmentId == v.AttachmentID {
+				found = true
+				*va = v
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Volume Attachment not found")
+		}
+
+		return nil
+	}
+}
+
+var testAccBlockStorageVolumeAttachV2_basic = `
+	resource "openstack_blockstorage_volume_v2" "volume_1" {
+		name = "volume_1"
+		size = 1
+	}
+
+	resource "openstack_compute_instance_v2" "instance_1" {
+		name = "instance_1"
+		security_groups = ["default"]
+	}
+
+	resource "openstack_blockstorage_volume_attach_v2" "va_1" {
+		instance_id = "${openstack_compute_instance_v2.instance_1.id}"
+		volume_id = "${openstack_blockstorage_volume_v2.volume_1.id}"
+		device = "auto"
+	}
+`

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/doc.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/doc.go
@@ -1,0 +1,5 @@
+// Package volumeactions provides information and interaction with volumes in the
+// OpenStack Block Storage service. A volume is a detachable block storage
+// device, akin to a USB hard drive. It can only be attached to one instance at
+// a time.
+package volumeactions

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/requests.go
@@ -1,0 +1,216 @@
+package volumeactions
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// AttachOptsBuilder allows extensions to add additional parameters to the
+// Attach request.
+type AttachOptsBuilder interface {
+	ToVolumeAttachMap() (map[string]interface{}, error)
+}
+
+// AttachMode describes the attachment mode for volumes.
+type AttachMode string
+
+// These constants determine how a volume is attached
+const (
+	ReadOnly  AttachMode = "ro"
+	ReadWrite AttachMode = "rw"
+)
+
+// AttachOpts contains options for attaching a Volume.
+type AttachOpts struct {
+	// The mountpoint of this volume
+	MountPoint string `json:"mountpoint,omitempty"`
+	// The nova instance ID, can't set simultaneously with HostName
+	InstanceUUID string `json:"instance_uuid,omitempty"`
+	// The hostname of baremetal host, can't set simultaneously with InstanceUUID
+	HostName string `json:"host_name,omitempty"`
+	// Mount mode of this volume
+	Mode AttachMode `json:"mode,omitempty"`
+}
+
+// ToVolumeAttachMap assembles a request body based on the contents of a
+// AttachOpts.
+func (opts AttachOpts) ToVolumeAttachMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-attach")
+}
+
+// Attach will attach a volume based on the values in AttachOpts.
+func Attach(client *gophercloud.ServiceClient, id string, opts AttachOptsBuilder) (r AttachResult) {
+	b, err := opts.ToVolumeAttachMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(attachURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// BeginDetach will mark the volume as detaching
+func BeginDetaching(client *gophercloud.ServiceClient, id string) (r BeginDetachingResult) {
+	b := map[string]interface{}{"os-begin_detaching": make(map[string]interface{})}
+	_, r.Err = client.Post(beginDetachingURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// DetachOptsBuilder allows extensions to add additional parameters to the
+// Detach request.
+type DetachOptsBuilder interface {
+	ToVolumeDetachMap() (map[string]interface{}, error)
+}
+
+type DetachOpts struct {
+	AttachmentID string `json:"attachment_id,omitempty"`
+}
+
+// ToVolumeDetachMap assembles a request body based on the contents of a
+// DetachOpts.
+func (opts DetachOpts) ToVolumeDetachMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-detach")
+}
+
+// Detach will detach a volume based on volume id.
+func Detach(client *gophercloud.ServiceClient, id string, opts DetachOptsBuilder) (r DetachResult) {
+	b, err := opts.ToVolumeDetachMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(detachURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// Reserve will reserve a volume based on volume id.
+func Reserve(client *gophercloud.ServiceClient, id string) (r ReserveResult) {
+	b := map[string]interface{}{"os-reserve": make(map[string]interface{})}
+	_, r.Err = client.Post(reserveURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// Unreserve will unreserve a volume based on volume id.
+func Unreserve(client *gophercloud.ServiceClient, id string) (r UnreserveResult) {
+	b := map[string]interface{}{"os-unreserve": make(map[string]interface{})}
+	_, r.Err = client.Post(unreserveURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// InitializeConnectionOptsBuilder allows extensions to add additional parameters to the
+// InitializeConnection request.
+type InitializeConnectionOptsBuilder interface {
+	ToVolumeInitializeConnectionMap() (map[string]interface{}, error)
+}
+
+// InitializeConnectionOpts hosts options for InitializeConnection.
+type InitializeConnectionOpts struct {
+	IP        string   `json:"ip,omitempty"`
+	Host      string   `json:"host,omitempty"`
+	Initiator string   `json:"initiator,omitempty"`
+	Wwpns     []string `json:"wwpns,omitempty"`
+	Wwnns     string   `json:"wwnns,omitempty"`
+	Multipath *bool    `json:"multipath,omitempty"`
+	Platform  string   `json:"platform,omitempty"`
+	OSType    string   `json:"os_type,omitempty"`
+}
+
+// ToVolumeInitializeConnectionMap assembles a request body based on the contents of a
+// InitializeConnectionOpts.
+func (opts InitializeConnectionOpts) ToVolumeInitializeConnectionMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "connector")
+	return map[string]interface{}{"os-initialize_connection": b}, err
+}
+
+// InitializeConnection initializes iscsi connection.
+func InitializeConnection(client *gophercloud.ServiceClient, id string, opts InitializeConnectionOptsBuilder) (r InitializeConnectionResult) {
+	b, err := opts.ToVolumeInitializeConnectionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(initializeConnectionURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// TerminateConnectionOptsBuilder allows extensions to add additional parameters to the
+// TerminateConnection request.
+type TerminateConnectionOptsBuilder interface {
+	ToVolumeTerminateConnectionMap() (map[string]interface{}, error)
+}
+
+// TerminateConnectionOpts hosts options for TerminateConnection.
+type TerminateConnectionOpts struct {
+	IP        string   `json:"ip,omitempty"`
+	Host      string   `json:"host,omitempty"`
+	Initiator string   `json:"initiator,omitempty"`
+	Wwpns     []string `json:"wwpns,omitempty"`
+	Wwnns     string   `json:"wwnns,omitempty"`
+	Multipath *bool    `json:"multipath,omitempty"`
+	Platform  string   `json:"platform,omitempty"`
+	OSType    string   `json:"os_type,omitempty"`
+}
+
+// ToVolumeTerminateConnectionMap assembles a request body based on the contents of a
+// TerminateConnectionOpts.
+func (opts TerminateConnectionOpts) ToVolumeTerminateConnectionMap() (map[string]interface{}, error) {
+	b, err := gophercloud.BuildRequestBody(opts, "connector")
+	return map[string]interface{}{"os-terminate_connection": b}, err
+}
+
+// TerminateConnection terminates iscsi connection.
+func TerminateConnection(client *gophercloud.ServiceClient, id string, opts TerminateConnectionOptsBuilder) (r TerminateConnectionResult) {
+	b, err := opts.ToVolumeTerminateConnectionMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(teminateConnectionURL(client, id), b, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}
+
+// ExtendSizeOptsBuilder allows extensions to add additional parameters to the
+// ExtendSize request.
+type ExtendSizeOptsBuilder interface {
+	ToVolumeExtendSizeMap() (map[string]interface{}, error)
+}
+
+// ExtendSizeOpts contain options for extending the size of an existing Volume. This object is passed
+// to the volumes.ExtendSize function.
+type ExtendSizeOpts struct {
+	// NewSize is the new size of the volume, in GB
+	NewSize int `json:"new_size" required:"true"`
+}
+
+// ToVolumeExtendSizeMap assembles a request body based on the contents of an
+// ExtendSizeOpts.
+func (opts ExtendSizeOpts) ToVolumeExtendSizeMap() (map[string]interface{}, error) {
+	return gophercloud.BuildRequestBody(opts, "os-extend")
+}
+
+// ExtendSize will extend the size of the volume based on the provided information.
+// This operation does not return a response body.
+func ExtendSize(client *gophercloud.ServiceClient, id string, opts ExtendSizeOptsBuilder) (r ExtendSizeResult) {
+	b, err := opts.ToVolumeExtendSizeMap()
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(extendSizeURL(client, id), b, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{202},
+	})
+	return
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/results.go
@@ -1,0 +1,56 @@
+package volumeactions
+
+import "github.com/gophercloud/gophercloud"
+
+// AttachResult contains the response body and error from a Get request.
+type AttachResult struct {
+	gophercloud.ErrResult
+}
+
+// BeginDetachingResult contains the response body and error from a Get request.
+type BeginDetachingResult struct {
+	gophercloud.ErrResult
+}
+
+// DetachResult contains the response body and error from a Get request.
+type DetachResult struct {
+	gophercloud.ErrResult
+}
+
+// ReserveResult contains the response body and error from a Get request.
+type ReserveResult struct {
+	gophercloud.ErrResult
+}
+
+// UnreserveResult contains the response body and error from a Get request.
+type UnreserveResult struct {
+	gophercloud.ErrResult
+}
+
+// TerminateConnectionResult contains the response body and error from a Get request.
+type TerminateConnectionResult struct {
+	gophercloud.ErrResult
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// Extract will get the Volume object out of the commonResult object.
+func (r commonResult) Extract() (map[string]interface{}, error) {
+	var s struct {
+		ConnectionInfo map[string]interface{} `json:"connection_info"`
+	}
+	err := r.ExtractInto(&s)
+	return s.ConnectionInfo, err
+}
+
+// InitializeConnectionResult contains the response body and error from a Get request.
+type InitializeConnectionResult struct {
+	commonResult
+}
+
+// ExtendSizeResult contains the response body and error from an ExtendSize request.
+type ExtendSizeResult struct {
+	gophercloud.ErrResult
+}

--- a/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/urls.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions/urls.go
@@ -1,0 +1,35 @@
+package volumeactions
+
+import "github.com/gophercloud/gophercloud"
+
+func attachURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("volumes", id, "action")
+}
+
+func beginDetachingURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}
+
+func detachURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}
+
+func reserveURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}
+
+func unreserveURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}
+
+func initializeConnectionURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}
+
+func teminateConnectionURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}
+
+func extendSizeURL(c *gophercloud.ServiceClient, id string) string {
+	return attachURL(c, id)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1008,6 +1008,12 @@
 			"revisionTime": "2016-10-25T18:03:21Z"
 		},
 		{
+			"checksumSHA1": "XAKLUSwXSMGtbp+U874qU4MzT/A=",
+			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions",
+			"revision": "d5eda9707e146108e4d424062b602fd97a71c2e6",
+			"revisionTime": "2016-11-14T18:28:31Z"
+		},
+		{
 			"checksumSHA1": "PFD8SEqhArAy/6jRbIlYb5lp64k=",
 			"path": "github.com/gophercloud/gophercloud/openstack/blockstorage/v1/volumes",
 			"revision": "e3d6384a3714b335d075862e6eb0a681180643df",

--- a/website/source/docs/providers/openstack/r/blockstorage_volume_attach_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/blockstorage_volume_attach_v2.html.markdown
@@ -53,6 +53,7 @@ The following arguments are supported:
 
 * `attach_mode` - (Optional) Specify whether to attach the volume as Read-Only
   (`ro`) or Read-Write (`rw`). Only values of `ro` and `rw` are accepted.
+  If left unspecified, the Block Storage API will apply a default of `rw`.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/openstack/r/blockstorage_volume_attach_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/blockstorage_volume_attach_v2.html.markdown
@@ -1,0 +1,79 @@
+---
+layout: "openstack"
+page_title: "OpenStack: openstack_blockstorage_volume_attach_v2"
+sidebar_current: "docs-openstack-resource-blockstorage-volume-attach-v2"
+description: |-
+  Attaches a Block Storage Volume to an Instance.
+---
+
+# openstack\_blockstorage\_volume_attach_v2
+
+Attaches a Block Storage Volume to an Instance using the OpenStack
+Block Storage (Cinder) v2 API.
+
+## Example Usage
+
+```
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  size = 1
+}
+
+resource "openstack_blockstorage_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+}
+
+resource "openstack_blockstorage_volume_attach_v2" "va_1" {
+  instance_id = "${openstack_blockstorage_instance_v2.instance_1.id}"
+  volume_id = "${openstack_blockstorage_volume_v2.volume_1.id}"
+  device = "auto"
+  attach_mode = "rw"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `region` - (Required) The region in which to obtain the V2 Block Storage
+    client. A Block Storage client is needed to create a volume attachment.
+    If omitted, the `OS_REGION_NAME` environment variable is used. Changing
+    this creates a new volume attachment.
+
+* `volume_id` - (Required) The ID of the Volume to attach to an Instance.
+
+* `instance_id` - (Required if `host_name` is not used) The ID of the Instance
+  to attach the Volume to.
+
+* `host_name` - (Required if `instance_id` is not used) The host to attach the
+  volume to.
+
+* `device` - (Optional) The device to attach the volume as.
+
+* `attach_mode` - (Optional) Specify whether to attach the volume as Read-Only
+  (`ro`) or Read-Write (`rw`). Only values of `ro` and `rw` are accepted.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `region` - See Argument Reference above.
+* `volume_id` - See Argument Reference above.
+* `instance_id` - See Argument Reference above.
+* `host_name` - See Argument Reference above.
+* `attach_mode` - See Argument Reference above.
+* `device` - See Argument Reference above.
+  _NOTE_: Whether or not this is really the device the volume was attached
+  as depends on the hypervisor being used in the OpenStack cloud. Do not
+  consider this an authoritative piece of information.
+
+## Import
+
+Volume Attachments can be imported using the Volume and Attachment ID
+separated by a slash, e.g.
+
+```
+$ terraform import openstack_blockstorage_volume_attach_v2.va_1 89c60255-9bd6-460c-822a-e2b959ede9d2/45670584-225f-46c3-b33e-6707b589b666
+```
+

--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -19,6 +19,9 @@
             <li<%= sidebar_current("docs-openstack-resource-blockstorage-volume-v2") %>>
               <a href="/docs/providers/openstack/r/blockstorage_volume_v2.html">openstack_blockstorage_volume_v2</a>
             </li>
+            <li<%= sidebar_current("docs-openstack-resource-blockstorage-volume-attach-v2") %>>
+              <a href="/docs/providers/openstack/r/blockstorage_volume_attach_v2.html">openstack_blockstorage_volume_attach_v2</a>
+            </li>
           </ul>
         </li>
 


### PR DESCRIPTION
This commit adds the openstack_blockstorage_volume_attach_v2 resource. This
resource enables a volume to be attached to an instance by using the OpenStack
Block Storage (Cinder) v2 API.