### PR TITLE
provider/aws: Remove IAM user's MFA devices with `force_destroy` #5908

### DIFF
--- a/website/source/docs/providers/aws/r/iam_user.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user.html.markdown
@@ -48,8 +48,8 @@ The following arguments are supported:
 
 * `name` - (Required) The user's name. The name must consist of upper and lowercase alphanumeric characters with no spaces. You can also include any of the following characters: `=,.@-_.`. User names are not distinguished by case. For example, you cannot create users named both "TESTUSER" and "testuser".
 * `path` - (Optional, default "/") Path in which to create the user.
-* `force_destroy` - (Optional, default false) When destroying this user, destroy
-  even if it has non-Terraform-managed IAM access keys and login profile. Without `force_destroy`
+* `force_destroy` - (Optional, default false) When destroying this user, destroy even if it
+  has non-Terraform-managed IAM access keys, login profile or MFA devices. Without `force_destroy`
   a user with non-Terraform-managed access keys and login profile will fail to be destroyed.
 
 ## Attributes Reference


### PR DESCRIPTION
When `force_destroy` was specifed on an `aws_iam_user` resource, only IAM
access keys and the login profile were destroyed. If a mutli-factor auth
device had been activated for that user, deletion would fail as follows:

```
* aws_iam_user.testuser1: Error deleting IAM User testuser1: DeleteConflict: Cannot delete entity, must delete MFA device first.
    status code: 409, request id: aa41b1b7-ac4d-11e6-bb3f-3b4c7a310c65
```

This commit iterates over any of the user's MFA devices and deactivates
them before deleting the user. It follows a pattern similar to that used
to remove users' IAM access keys before deletion.

The code seems to "work", in the sense that I've run the existing acceptance
tests and have tested that IAM users with active MFA devices are now destroyed
without receiving an error, but I could use some guidance on the appropriate
amount of test coverage and strategy here.  I figured better to get some eyes on
it before doing anything else. Thanks!

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSUser_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/20 17:09:00 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSUser_ -timeout 120m
=== RUN   TestAccAWSUser_importBasic
--- PASS: TestAccAWSUser_importBasic (5.70s)
=== RUN   TestAccAWSUser_basic
--- PASS: TestAccAWSUser_basic (11.12s)
PASS
ok  	github.com/rhenning/terraform/builtin/providers/aws	 20.840s
```