### PR TITLE
Set proper Mode when moving a data source in state

### DIFF
--- a/terraform/state_add.go
+++ b/terraform/state_add.go
@@ -113,7 +113,7 @@ func stateAddFunc_Module_Module(s *State, fromAddr, addr *ResourceAddress, raw i
 		addrCopy.Type = resourceKey.Type
 		addrCopy.Name = resourceKey.Name
 		addrCopy.Index = resourceKey.Index
-		//addrCopy.Mode = resourceKey.Mode
+		addrCopy.Mode = resourceKey.Mode
 
 		// Perform an add
 		if err := s.Add(fromAddr.String(), addrCopy.String(), v); err != nil {
@@ -333,7 +333,7 @@ func stateAddInitAddr(s *State, addr *ResourceAddress) (interface{}, bool) {
 		Name:  addr.Name,
 		Type:  addr.Type,
 		Index: addr.Index,
-		//Mode:  addr.Mode,
+		Mode:  addr.Mode,
 	}).String()
 	exists = true
 	resource, ok := mod.Resources[resourceKey]

--- a/terraform/state_add.go
+++ b/terraform/state_add.go
@@ -1,8 +1,6 @@
 package terraform
 
-import (
-	"fmt"
-)
+import "fmt"
 
 // Add adds the item in the state at the given address.
 //
@@ -34,6 +32,7 @@ import (
 //
 func (s *State) Add(fromAddrRaw string, toAddrRaw string, raw interface{}) error {
 	// Parse the address
+
 	toAddr, err := ParseResourceAddress(toAddrRaw)
 	if err != nil {
 		return err
@@ -114,6 +113,7 @@ func stateAddFunc_Module_Module(s *State, fromAddr, addr *ResourceAddress, raw i
 		addrCopy.Type = resourceKey.Type
 		addrCopy.Name = resourceKey.Name
 		addrCopy.Index = resourceKey.Index
+		//addrCopy.Mode = resourceKey.Mode
 
 		// Perform an add
 		if err := s.Add(fromAddr.String(), addrCopy.String(), v); err != nil {
@@ -333,6 +333,7 @@ func stateAddInitAddr(s *State, addr *ResourceAddress) (interface{}, bool) {
 		Name:  addr.Name,
 		Type:  addr.Type,
 		Index: addr.Index,
+		//Mode:  addr.Mode,
 	}).String()
 	exists = true
 	resource, ok := mod.Resources[resourceKey]

--- a/terraform/state_add_test.go
+++ b/terraform/state_add_test.go
@@ -627,6 +627,41 @@ func TestStateAdd(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			"ModuleState => Module Addr (new with data source)",
+			false,
+			"",
+			"module.foo",
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"data.test_instance.foo": &ResourceState{
+						Type: "test_instance",
+						Primary: &InstanceState{
+							ID: "foo",
+						},
+					},
+				},
+			},
+
+			&State{},
+			&State{
+				Modules: []*ModuleState{
+					&ModuleState{
+						Path: []string{"root", "foo"},
+						Resources: map[string]*ResourceState{
+							"data.test_instance.foo": &ResourceState{
+								Type: "test_instance",
+								Primary: &InstanceState{
+									ID: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
ResourceAddr.Mode wasn't properly set when moving a module, so data
sources would lose the "data." prefix when their module was moved within
the State.

Fixes #9996 