### PR TITLE
providers/aws: cloudfront distribution 404 should mark as gone

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -522,6 +523,12 @@ func resourceAwsCloudFrontDistributionRead(d *schema.ResourceData, meta interfac
 
 	resp, err := conn.GetDistribution(params)
 	if err != nil {
+		if errcode, ok := err.(awserr.Error); ok && errcode.Code() == "NoSuchDistribution" {
+			log.Printf("[WARN] No Distribution found: %s", d.Id())
+			d.SetId("")
+			return nil
+		}
+
 		return err
 	}
 


### PR DESCRIPTION
@clint Let me know if there is prior examples of how to test this and I'll gladly do so.

Just ran into this while trying to reproduce another issue. 