### PR TITLE
Prevent null reference when reading boot_diagnostics settings.

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -792,7 +792,9 @@ func flattenAzureRmVirtualMachineDiagnosticsProfile(profile *compute.BootDiagnos
 	result := make(map[string]interface{})
 
 	result["enabled"] = *profile.Enabled
-	result["storage_uri"] = *profile.StorageURI
+	if profile.StorageURI != nil {
+		result["storage_uri"] = *profile.StorageURI
+	}
 
 	return []interface{}{result}
 }


### PR DESCRIPTION
I ran into this scenario on a few virtual machines. The rest response contained this:

2016/11/21 22:12:40 [DEBUG] plugin: terraform.exe:     "diagnosticsProfile": {
2016/11/21 22:12:40 [DEBUG] plugin: terraform.exe:       "bootDiagnostics": {
2016/11/21 22:12:40 [DEBUG] plugin: terraform.exe:         "enabled": false
2016/11/21 22:12:40 [DEBUG] plugin: terraform.exe:       }
2016/11/21 22:12:40 [DEBUG] plugin: terraform.exe:     },

Which caused the following panic in 0.7.10 and 0.7.11:

2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: panic: runtime error: invalid memory address or nil pointer dereference
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: [signal 0xc0000005 code=0x0 addr=0x0 pc=0xb1e6cb]
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: 
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: goroutine 3642 [running]:
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: panic(0x2a99da0, 0xc04200e090)
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: 	/opt/go/src/runtime/panic.go:500 +0x1af
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: github.com/hashicorp/terraform/builtin/providers/azurerm.resourceArmVirtualMachineRead(0xc042e762a0, 0x2cce4e0, 0xc042061a00, 0x0, 0x17)
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: 	/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/azurerm/resource_arm_virtual_machine.go:613 +0xedb
2016/11/21 21:48:10 [DEBUG] plugin: terraform.exe: github.com/hashicorp/terraform/helper/schema.(*Resource).Refresh(0xc0422fcae0, 0xc042ee20f0, 0x2cce4e0, 0xc042061a00, 0xc0420422b0, 0x1, 0x18)

This fix handles this case by preventing the nil dereference in this case. I'm not sure why only a few VMs experienced the initial issue but this solved it for me.
