### PR TITLE
provider/aws: added auto_minor_version_upgrade on aws_rds_cluster_insstance

### DIFF
--- a/builtin/providers/aws/import_aws_db_instance_test.go
+++ b/builtin/providers/aws/import_aws_db_instance_test.go
@@ -14,11 +14,11 @@ func TestAccAWSDBInstance_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBInstanceConfig,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/10274

```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSClusterInstance_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/22 10:15:08 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSClusterInstance_basic -timeout 120m
=== RUN   TestAccAWSRDSClusterInstance_basic
--- PASS: TestAccAWSRDSClusterInstance_basic (1557.91s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1557.949s
```