### PR TITLE
provider/aws: Add new aws_db_snapshot data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_ami.go
+++ b/builtin/providers/aws/data_source_aws_ami.go
@@ -179,7 +179,7 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	nameRegex, nameRegexOk := d.GetOk("name_regex")
 	owners, ownersOk := d.GetOk("owners")
 
-	if executableUsersOk == false && filtersOk == false && nameRegexOk == false && ownersOk == false {
+	if !executableUsersOk && !filtersOk && !nameRegexOk && !ownersOk {
 		return fmt.Errorf("One of executable_users, filters, name_regex, or owners must be assigned")
 	}
 

--- a/builtin/providers/aws/data_source_aws_db_snapshot.go
+++ b/builtin/providers/aws/data_source_aws_db_snapshot.go
@@ -2,6 +2,9 @@ package aws
 
 import (
 	"fmt"
+	"log"
+	"sort"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/rds"
@@ -14,31 +17,42 @@ func dataSourceAwsDbSnapshot() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			//selection criteria
-			"filter": dataSourceFiltersSchema(),
-
 			"db_instance_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"db_snapshot_identifier": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"snapshot_type": {
 				Type:     schema.TypeString,
 				Optional: true,
+				ForceNew: true,
 			},
 
 			"include_shared": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
+				Default:  false,
 			},
 
 			"include_public": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
+				Default:  false,
+			},
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
 			},
 
 			//Computed values returned
@@ -94,6 +108,10 @@ func dataSourceAwsDbSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"snapshot_create_time": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -114,30 +132,24 @@ func dataSourceAwsDbSnapshotRead(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*AWSClient).rdsconn
 
 	instanceIdentifier, instanceIdentifierOk := d.GetOk("db_instance_identifier")
-	filters, filtersOk := d.GetOk("filter")
 	snapshotIdentifier, snapshotIdentifierOk := d.GetOk("db_snapshot_identifier")
 
-	if instanceIdentifierOk == false && filtersOk == false && snapshotIdentifierOk == false {
-		return fmt.Errorf("One of db_snapshot_indentifier, db_instance_identifier or filter must be assigned")
+	if !instanceIdentifierOk && !snapshotIdentifierOk {
+		return fmt.Errorf("One of db_snapshot_indentifier or db_instance_identifier must be assigned")
 	}
 
-	params := &rds.DescribeDBSnapshotsInput{}
+	params := &rds.DescribeDBSnapshotsInput{
+		IncludePublic: aws.Bool(d.Get("include_public").(bool)),
+		IncludeShared: aws.Bool(d.Get("include_shared").(bool)),
+	}
+	if v, ok := d.GetOk("snapshot_type"); ok {
+		params.SnapshotType = aws.String(v.(string))
+	}
 	if instanceIdentifierOk {
 		params.DBInstanceIdentifier = aws.String(instanceIdentifier.(string))
 	}
 	if snapshotIdentifierOk {
 		params.DBSnapshotIdentifier = aws.String(snapshotIdentifier.(string))
-	}
-	if filtersOk {
-		params.Filters = buildAwsDataSourceFilters(filters.(*schema.Set))
-	}
-
-	if v, ok := d.GetOk("include_shared"); ok {
-		params.IncludeShared = aws.Bool(v.(bool))
-	}
-
-	if v, ok := d.GetOk("include_public"); ok {
-		params.IncludePublic = aws.Bool(v.(bool))
 	}
 
 	resp, err := conn.DescribeDBSnapshots(params)
@@ -149,11 +161,34 @@ func dataSourceAwsDbSnapshotRead(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
 	}
 
+	var snapshot *rds.DBSnapshot
 	if len(resp.DBSnapshots) > 1 {
-		return fmt.Errorf("Your query returned more than one result. Please try a more specific search criteria.")
+		recent := d.Get("most_recent").(bool)
+		log.Printf("[DEBUG] aws_db_snapshot - multiple results found and `most_recent` is set to: %t", recent)
+		if recent {
+			snapshot = mostRecentDbSnapshot(resp.DBSnapshots)
+		} else {
+			return fmt.Errorf("Your query returned more than one result. Please try a more specific search criteria.")
+		}
+	} else {
+		snapshot = resp.DBSnapshots[0]
 	}
 
-	return dbSnapshotDescriptionAttributes(d, resp.DBSnapshots[0])
+	return dbSnapshotDescriptionAttributes(d, snapshot)
+}
+
+type rdsSnapshotSort []*rds.DBSnapshot
+
+func (a rdsSnapshotSort) Len() int      { return len(a) }
+func (a rdsSnapshotSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a rdsSnapshotSort) Less(i, j int) bool {
+	return (*a[i].SnapshotCreateTime).Before(*a[j].SnapshotCreateTime)
+}
+
+func mostRecentDbSnapshot(snapshots []*rds.DBSnapshot) *rds.DBSnapshot {
+	sortedSnapshots := snapshots
+	sort.Sort(rdsSnapshotSort(sortedSnapshots))
+	return sortedSnapshots[len(sortedSnapshots)-1]
 }
 
 func dbSnapshotDescriptionAttributes(d *schema.ResourceData, snapshot *rds.DBSnapshot) error {
@@ -161,7 +196,6 @@ func dbSnapshotDescriptionAttributes(d *schema.ResourceData, snapshot *rds.DBSna
 	d.Set("db_instance_identifier", snapshot.DBInstanceIdentifier)
 	d.Set("db_snapshot_identifier", snapshot.DBSnapshotIdentifier)
 	d.Set("snapshot_type", snapshot.SnapshotType)
-
 	d.Set("allocated_storage", snapshot.AllocatedStorage)
 	d.Set("availability_zone", snapshot.AvailabilityZone)
 	d.Set("db_snapshot_arn", snapshot.DBSnapshotArn)
@@ -175,8 +209,9 @@ func dbSnapshotDescriptionAttributes(d *schema.ResourceData, snapshot *rds.DBSna
 	d.Set("port", snapshot.Port)
 	d.Set("source_db_snapshot_identifier", snapshot.SourceDBSnapshotIdentifier)
 	d.Set("source_region", snapshot.SourceRegion)
-	d.Set("sstatus", snapshot.Status)
+	d.Set("status", snapshot.Status)
 	d.Set("vpc_id", snapshot.VpcId)
+	d.Set("snapshot_create_time", snapshot.SnapshotCreateTime.Format(time.RFC3339))
 
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_db_snapshot_test.go
+++ b/builtin/providers/aws/data_source_aws_db_snapshot_test.go
@@ -1,0 +1,74 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDbSnapshotDataSource_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsDbSnapshotDataSourceConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsDbSnapshotDataSourceID("data.aws_db_snapshot.snapshot"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsDbSnapshotDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Volume data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot data source ID not set")
+		}
+		return nil
+	}
+}
+
+func testAccCheckAwsDbSnapshotDataSourceConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_db_instance" "bar" {
+	allocated_storage = 10
+	engine = "MySQL"
+	engine_version = "5.6.21"
+	instance_class = "db.t1.micro"
+	name = "baz"
+	password = "barbarbarbar"
+	username = "foo"
+
+
+	# Maintenance Window is stored in lower case in the API, though not strictly
+	# documented. Terraform will downcase this to match (as opposed to throw a
+	# validation error).
+	maintenance_window = "Fri:09:00-Fri:09:30"
+
+	backup_retention_period = 0
+
+	parameter_group_name = "default.mysql5.6"
+}
+
+data "aws_db_snapshot" "snapshot" {
+	most_recent = "true"
+	db_snapshot_identifier = "${aws_db_snapshot.test.id}"
+}
+
+
+resource "aws_db_snapshot" "test" {
+	db_instance_identifier = "${aws_db_instance.bar.id}"
+	db_snapshot_identifier = "testsnapshot%d"
+}`, rInt)
+}

--- a/builtin/providers/aws/data_source_aws_ebs_snapshot.go
+++ b/builtin/providers/aws/data_source_aws_ebs_snapshot.go
@@ -93,7 +93,7 @@ func dataSourceAwsEbsSnapshotRead(d *schema.ResourceData, meta interface{}) erro
 	snapshotIds, snapshotIdsOk := d.GetOk("snapshot_ids")
 	owners, ownersOk := d.GetOk("owners")
 
-	if restorableUsers == false && filtersOk == false && snapshotIds == false && ownersOk == false {
+	if !restorableUsersOk && !filtersOk && !snapshotIdsOk && !ownersOk {
 		return fmt.Errorf("One of snapshot_ids, filters, restorable_by_user_ids, or owners must be assigned")
 	}
 

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -172,6 +172,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_canonical_user_id":        dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_stack":     dataSourceAwsCloudFormationStack(),
 			"aws_db_instance":              dataSourceAwsDbInstance(),
+			"aws_db_snapshot":              dataSourceAwsDbSnapshot(),
 			"aws_ebs_snapshot":             dataSourceAwsEbsSnapshot(),
 			"aws_ebs_snapshot_ids":         dataSourceAwsEbsSnapshotIds(),
 			"aws_ebs_volume":               dataSourceAwsEbsVolume(),

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -277,6 +277,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_db_option_group":                          resourceAwsDbOptionGroup(),
 			"aws_db_parameter_group":                       resourceAwsDbParameterGroup(),
 			"aws_db_security_group":                        resourceAwsDbSecurityGroup(),
+			"aws_db_snapshot":                              resourceAwsDbSnapshot(),
 			"aws_db_subnet_group":                          resourceAwsDbSubnetGroup(),
 			"aws_directory_service_directory":              resourceAwsDirectoryServiceDirectory(),
 			"aws_dms_certificate":                          resourceAwsDmsCertificate(),

--- a/builtin/providers/aws/resource_aws_db_snapshot.go
+++ b/builtin/providers/aws/resource_aws_db_snapshot.go
@@ -1,0 +1,160 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDbSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsDbSnapshotCreate,
+		Read:   resourceAwsDbSnapshotRead,
+		Delete: resourceAwsDbSnapshotDelete,
+
+		Schema: map[string]*schema.Schema{
+			"db_snapshot_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"db_instance_identifier": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"allocated_storage": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"availability_zone": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"db_snapshot_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"encrypted": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"engine": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"iops": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"kms_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"license_model": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"option_group_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"source_db_snapshot_identifier": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"source_region": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"snapshot_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"storage_type": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsDbSnapshotCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	params := &rds.CreateDBSnapshotInput{
+		DBInstanceIdentifier: aws.String(d.Get("db_instance_identifier").(string)),
+		DBSnapshotIdentifier: aws.String(d.Get("db_snapshot_identifier").(string)),
+	}
+
+	_, err := conn.CreateDBSnapshot(params)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("db_snapshot_identifier").(string))
+	return resourceAwsDbSnapshotRead(d, meta)
+}
+
+func resourceAwsDbSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	params := &rds.DescribeDBSnapshotsInput{
+		DBSnapshotIdentifier: aws.String(d.Id()),
+	}
+	resp, err := conn.DescribeDBSnapshots(params)
+	if err != nil {
+		return err
+	}
+
+	snapshot := resp.DBSnapshots[0]
+
+	d.Set("allocated_storage", snapshot.AllocatedStorage)
+	d.Set("availability_zone", snapshot.AvailabilityZone)
+	d.Set("db_snapshot_arn", snapshot.DBSnapshotArn)
+	d.Set("encrypted", snapshot.Encrypted)
+	d.Set("engine", snapshot.Engine)
+	d.Set("engine_version", snapshot.EngineVersion)
+	d.Set("iops", snapshot.Iops)
+	d.Set("kms_key_id", snapshot.KmsKeyId)
+	d.Set("license_model", snapshot.LicenseModel)
+	d.Set("option_group_name", snapshot.OptionGroupName)
+	d.Set("port", snapshot.Port)
+	d.Set("source_db_snapshot_identifier", snapshot.SourceDBSnapshotIdentifier)
+	d.Set("source_region", snapshot.SourceRegion)
+	d.Set("snapshot_type", snapshot.SnapshotType)
+	d.Set("status", snapshot.Status)
+	d.Set("vpc_id", snapshot.VpcId)
+
+	return nil
+}
+
+func resourceAwsDbSnapshotDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).rdsconn
+
+	params := &rds.DeleteDBSnapshotInput{
+		DBSnapshotIdentifier: aws.String(d.Id()),
+	}
+	_, err := conn.DeleteDBSnapshot(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_db_snapshot_test.go
+++ b/builtin/providers/aws/resource_aws_db_snapshot_test.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDBSnapshot_basic(t *testing.T) {
+	var v rds.DBSnapshot
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsDbSnapshotConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDbSnapshotExists("aws_db_snapshot.test", &v),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDbSnapshotExists(n string, v *rds.DBSnapshot) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).rdsconn
+
+		request := &rds.DescribeDBSnapshotsInput{
+			DBSnapshotIdentifier: aws.String(rs.Primary.ID),
+		}
+
+		response, err := conn.DescribeDBSnapshots(request)
+		if err == nil {
+			if response.DBSnapshots != nil && len(response.DBSnapshots) > 0 {
+				*v = *response.DBSnapshots[0]
+				return nil
+			}
+		}
+		return fmt.Errorf("Error finding RDS DB Snapshot %s", rs.Primary.ID)
+	}
+}
+
+func testAccAwsDbSnapshotConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_db_instance" "bar" {
+	allocated_storage = 10
+	engine = "MySQL"
+	engine_version = "5.6.21"
+	instance_class = "db.t1.micro"
+	name = "baz"
+	password = "barbarbarbar"
+	username = "foo"
+
+
+	# Maintenance Window is stored in lower case in the API, though not strictly
+	# documented. Terraform will downcase this to match (as opposed to throw a
+	# validation error).
+	maintenance_window = "Fri:09:00-Fri:09:30"
+
+	backup_retention_period = 0
+
+	parameter_group_name = "default.mysql5.6"
+}
+
+resource "aws_db_snapshot" "test" {
+	db_instance_identifier = "${aws_db_instance.bar.id}"
+	db_snapshot_identifier = "testsnapshot%d"
+}`, rInt)
+}

--- a/builtin/providers/aws/resource_aws_db_snapshot_test.go
+++ b/builtin/providers/aws/resource_aws_db_snapshot_test.go
@@ -67,15 +67,13 @@ resource "aws_db_instance" "bar" {
 	password = "barbarbarbar"
 	username = "foo"
 
-
-	# Maintenance Window is stored in lower case in the API, though not strictly
-	# documented. Terraform will downcase this to match (as opposed to throw a
-	# validation error).
 	maintenance_window = "Fri:09:00-Fri:09:30"
 
 	backup_retention_period = 0
 
 	parameter_group_name = "default.mysql5.6"
+
+	skip_final_snapshot = true
 }
 
 resource "aws_db_snapshot" "test" {

--- a/website/source/docs/providers/aws/d/db_snapshot.html.markdown
+++ b/website/source/docs/providers/aws/d/db_snapshot.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "aws"
+page_title: "AWS: aws_db_snapshot"
+sidebar_current: "docs-aws-datasource-db-snapshot"
+description: |-
+  Get information on a DB Snapshot.
+---
+
+# aws\_db\_snapshot
+
+Use this data source to get information about a DB Snapshot for use when provisioning DB instances
+
+## Example Usage
+
+```
+resource "aws_db_instance" "default" {
+  allocated_storage    = 10
+  engine               = "mysql"
+  engine_version       = "5.6.17"
+  instance_class       = "db.t1.micro"
+  name                 = "mydb"
+  username             = "foo"
+  password             = "bar"
+  db_subnet_group_name = "my_database_subnet_group"
+  parameter_group_name = "default.mysql5.6"
+}
+
+data "aws_db_snapshot" "db_snapshot" {
+    most_recent = true
+    owners = ["self"]
+    db_instance_identifier = "${aws_db_instance.default.identifier}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `most_recent` - (Optional) If more than one result is returned, use the most
+recent Snapshot.
+
+* `db_instance_identifier` - (Optional) Returns the list of snapshots created by the specific db_instance
+
+* `db_snapshot_identifier` - (Optional) Returns information on a specific snapshot_id.
+
+* `snapshot_type` - (Optional) The type of snapshots to be returned. If you don't specify a SnapshotType 
+value, then both automated and manual snapshots are returned. Shared and public DB snapshots are not 
+included in the returned results by default. Possible values are, `automated`, `manual`, `shared` and `public`.
+
+* `include_shared` - (Optional) Set this value to true to include shared manual DB snapshots from other 
+AWS accounts that this AWS account has been given permission to copy or restore, otherwise set this value to false. 
+The default is `false`.
+
+* `include_public` - (Optional) Set this value to true to include manual DB snapshots that are public and can be 
+copied or restored by any AWS account, otherwise set this value to false. The default is `false`.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The snapshot ID.
+* `allocated_storage` - Specifies the allocated storage size in gigabytes (GB).
+* `availability_zone` - Specifies the name of the Availability Zone the DB instance was located in at the time of the DB snapshot.
+* `db_snapshot_arn` - The Amazon Resource Name (ARN) for the DB snapshot.
+* `encrypted` - Specifies whether the DB snapshot is encrypted.
+* `engine` - Specifies the name of the database engine.
+* `engine_version` - Specifies the version of the database engine.
+* `iops` - Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
+* `kms_key_id` - The ARN for the KMS encryption key.
+* `license_model` - License model information for the restored DB instance.
+* `option_group_name` - Provides the option group name for the DB snapshot.
+* `source_db_snapshot_identifier` - The DB snapshot Arn that the DB snapshot was copied from. It only has value in case of cross customer or cross region copy.
+* `source_region` - The region that the DB snapshot was created in or copied from.
+* `status` - Specifies the status of this DB snapshot.
+* `storage_type` - Specifies the storage type associated with DB snapshot.
+* `vpc_id` - Specifies the storage type associated with DB snapshot.
+* `snapshot_create_time` - Provides the time when the snapshot was taken, in Universal Coordinated Time (UTC).

--- a/website/source/docs/providers/aws/r/db_snapshot.html.md
+++ b/website/source/docs/providers/aws/r/db_snapshot.html.md
@@ -1,0 +1,62 @@
+---
+layout: "aws"
+page_title: "AWS: aws_db_snapshot"
+sidebar_current: "docs-aws-resource-db-snapshot"
+description: |-
+  Provides an DB Instance.
+---
+
+# aws\_db\_snapshot
+
+Creates a Snapshot of an DB Instance.
+
+## Example Usage
+
+```
+resource "aws_db_instance" "bar" {
+	allocated_storage = 10
+	engine = "MySQL"
+	engine_version = "5.6.21"
+	instance_class = "db.t1.micro"
+	name = "baz"
+	password = "barbarbarbar"
+	username = "foo"
+
+    maintenance_window = "Fri:09:00-Fri:09:30"
+	backup_retention_period = 0
+	parameter_group_name = "default.mysql5.6"
+}
+
+resource "aws_db_snapshot" "test" {
+	db_instance_identifier = "${aws_db_instance.bar.id}"
+	db_snapshot_identifier = "testsnapshot1234"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `db_instance_identifier` - (Required) The DB Instance Identifier from which to take the snapshot.
+* `db_snapshot_identifier` - (Required) The Identifier for the snapshot.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `allocated_storage` - Specifies the allocated storage size in gigabytes (GB).
+* `availability_zone` - Specifies the name of the Availability Zone the DB instance was located in at the time of the DB snapshot.
+* `db_snapshot_arn` - The Amazon Resource Name (ARN) for the DB snapshot.
+* `encrypted` - Specifies whether the DB snapshot is encrypted.
+* `engine` - Specifies the name of the database engine.
+* `engine_version` - Specifies the version of the database engine.
+* `iops` - Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
+* `kms_key_id` - The ARN for the KMS encryption key.
+* `license_model` - License model information for the restored DB instance.
+* `option_group_name` - Provides the option group name for the DB snapshot.
+* `source_db_snapshot_identifier` - The DB snapshot Arn that the DB snapshot was copied from. It only has value in case of cross customer or cross region copy.
+* `source_region` - The region that the DB snapshot was created in or copied from.
+* `status` - Specifies the status of this DB snapshot.
+* `storage_type` - Specifies the storage type associated with DB snapshot.
+* `vpc_id` - Specifies the storage type associated with DB snapshot.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -52,6 +52,8 @@
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-db-instance") %>>
                             <a href="/docs/providers/aws/d/db_instance.html">aws_db_instance</a>
+                        <li<%= sidebar_current("docs-aws-datasource-db-snapshot") %>>
+                          <a href="/docs/providers/aws/d/db_snapshot.html">aws_db_snapshot</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-ebs-snapshot") %>>
                           <a href="/docs/providers/aws/d/ebs_snapshot.html">aws_ebs_snapshot</a>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1036,6 +1036,10 @@
                             <a href="/docs/providers/aws/r/db_security_group.html">aws_db_security_group</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-db-snapshot") %>>
+                          <a href="/docs/providers/aws/r/db_snapshot.html">aws_db_snapshot</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-db-subnet-group") %>>
                             <a href="/docs/providers/aws/r/db_subnet_group.html">aws_db_subnet_group</a>
                         </li>


### PR DESCRIPTION
Fixes #10287

```
% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestAccAWSDbSnapshotDataSource_'     2 ↵ ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/22 18:55:08 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSDbSnapshotDataSource_ -timeout 120m
=== RUN   TestAccAWSDbSnapshotDataSource_basic
--- PASS: TestAccAWSDbSnapshotDataSource_basic (966.68s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws966.699s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBSnapshot_
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/22 18:24:05 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBSnapshot_ -timeout 120m
=== RUN   TestAccAWSDBSnapshot_basic
--- PASS: TestAccAWSDBSnapshot_basic (892.75s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    892.773s
```

------

**Note:** catsby marked this as `WIP` for now