### PR TITLE
provider/aws: Add opsworks rds db resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -312,6 +312,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_opsworks_instance":                        resourceAwsOpsworksInstance(),
 			"aws_opsworks_user_profile":                    resourceAwsOpsworksUserProfile(),
 			"aws_opsworks_permission":                      resourceAwsOpsworksPermission(),
+			"aws_opsworks_rds_db_instance":                 resourceAwsOpsworksRdsDbInstance(),
 			"aws_placement_group":                          resourceAwsPlacementGroup(),
 			"aws_proxy_protocol_policy":                    resourceAwsProxyProtocolPolicy(),
 			"aws_rds_cluster":                              resourceAwsRDSCluster(),

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
@@ -3,8 +3,8 @@ package aws
 import (
 	"log"
 	"time"
-
 	"fmt"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/opsworks"
@@ -51,11 +51,6 @@ func resourceAwsOpsworksRdsDbInstanceUpdate(d *schema.ResourceData, meta interfa
 	client := meta.(*AWSClient).opsworksconn
 
 	d.Partial(true)
-
-	// @TODO if these two params force new resources, is the following necessary?
-	if d.HasChange("rds_db_instance_arn") || d.HasChange("stack_id") {
-		return fmt.Errorf("cannot change 'rds_db_instance_arn' and 'stack_id' for opsworks rds db. changes on these attributes will force a new resource")
-	}
 
 	d.SetPartial("rds_db_instance_arn")
 	req := &opsworks.UpdateRdsDbInstanceInput{

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
@@ -71,11 +71,8 @@ func resourceAwsOpsworksRdsDbInstanceUnregister(d *schema.ResourceData, meta int
 func resourceAwsOpsworksRdsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*AWSClient).opsworksconn
 
-	arns := []string{d.Get("rds_db_instance_arn").(string)}
-
 	req := &opsworks.DescribeRdsDbInstancesInput{
-		StackId:           aws.String(d.Get("stack_id").(string)),
-		RdsDbInstanceArns: aws.StringSlice(arns),
+		StackId: aws.String(d.Get("stack_id").(string)),
 	}
 
 	log.Printf("[DEBUG] Reading OpsWorks registerd rds db instances for stack: %s", d.Get("stack_id"))

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
@@ -1,0 +1,151 @@
+package aws
+
+import (
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsOpsworksRdsDbInstance() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsOpsworksRdsDbInstanceRegister,
+		Update: resourceAwsOpsworksRdsDbInstanceRegister,
+		Delete: resourceAwsOpsworksRdsDbInstanceUnregister,
+		Read:   resourceAwsOpsworksRdsDbInstanceRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"stack_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"rds_db_instance_arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"db_password": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"db_user": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceAwsOpsworksRdsDbInstanceUnregister(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).opsworksconn
+
+	req := &opsworks.DeregisterRdsDbInstanceInput{
+		RdsDbInstanceArn: aws.String(d.Get("rds_db_instance_arn").(string)),
+	}
+
+	log.Printf("[DEBUG] Unregistering rds db instance '%s' from stack: %s", d.Get("rds_db_instance_arn"), d.Get("stack_id"))
+
+	_, err := client.DeregisterRdsDbInstance(req)
+	if err != nil {
+		if awserr, ok := err.(awserr.Error); ok {
+			if awserr.Code() == "ResourceNotFoundException" {
+				log.Printf("[INFO] The db instance could not be found")
+				d.SetId("")
+
+				return nil
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func resourceAwsOpsworksRdsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).opsworksconn
+
+	arns := []string{d.Get("rds_db_instance_arn").(string)}
+
+	req := &opsworks.DescribeRdsDbInstancesInput{
+		StackId:           aws.String(d.Get("stack_id").(string)),
+		RdsDbInstanceArns: aws.StringSlice(arns),
+	}
+
+	log.Printf("[DEBUG] Reading OpsWorks registerd rds db instances for stack: %s", d.Get("stack_id"))
+
+	resp, err := client.DescribeRdsDbInstances(req)
+	if err != nil {
+		if awserr, ok := err.(awserr.Error); ok {
+			if awserr.Code() == "ResourceNotFoundException" {
+				log.Printf("[INFO] No instance found not found")
+				d.SetId("")
+
+				return nil
+			}
+		}
+		return err
+	}
+
+	found := false
+	id := ""
+	for _, instance := range resp.RdsDbInstances {
+		id = *instance.RdsDbInstanceArn + *instance.StackId
+
+		if d.Get("rds_db_instance_arn").(string)+d.Get("stack_id").(string) == id {
+			found = true
+			d.SetId(id)
+			d.Set("id", id)
+			d.Set("stack_id", instance.StackId)
+			d.Set("rds_db_instance_arn", instance.RdsDbInstanceArn)
+			d.Set("db_user", instance.DbUser)
+			d.Set("db_password", instance.DbPassword)
+		}
+
+	}
+
+	if false == found {
+		d.SetId("")
+		log.Printf("[INFO] The rds instance '%s' could not be found for stack: '%s'", d.Get("rds_db_instance_arn"), d.Get("stack_id"))
+	}
+
+	return nil
+}
+
+func resourceAwsOpsworksRdsDbInstanceRegister(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient).opsworksconn
+
+	req := &opsworks.RegisterRdsDbInstanceInput{
+		StackId:          aws.String(d.Get("stack_id").(string)),
+		RdsDbInstanceArn: aws.String(d.Get("rds_db_instance_arn").(string)),
+		DbUser:           aws.String(d.Get("db_user").(string)),
+		DbPassword:       aws.String(d.Get("db_password").(string)),
+	}
+
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		var cerr error
+		_, cerr = client.RegisterRdsDbInstance(req)
+		if cerr != nil {
+			log.Printf("[INFO] client error")
+			if opserr, ok := cerr.(awserr.Error); ok {
+				// XXX: handle errors
+				log.Printf("[ERROR] OpsWorks error: %s message: %s", opserr.Code(), opserr.Message())
+				return resource.RetryableError(cerr)
+			}
+			return resource.NonRetryableError(cerr)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsOpsworksRdsDbInstanceRead(d, meta)
+}

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
+	sName := fmt.Sprintf("test-db-instance-%d", acctest.RandInt())
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsOpsworksRdsDbInstance(sName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "foo",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccAwsOpsworksRdsDbInstance(name string) string {
+	return fmt.Sprintf(`
+resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+
+  rds_db_instance_arn = "${aws_db_instance.bar.arn}"
+  db_user = "${aws_db_instance.bar.username}"
+  db_password = "${aws_db_instance.bar.password}"
+}
+
+%s
+
+%s
+`, testAccAwsOpsworksStackConfigNoVpcCreate(name), testAccAWSDBInstanceConfig)
+}

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -15,10 +15,26 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAwsOpsworksRdsDbInstance(sName),
+				Config: testAccAwsOpsworksRdsDbInstance(sName, "foo", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "foo",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAwsOpsworksRdsDbInstance(sName, "bar", "barbarbarbar"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "bar",
+					),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAwsOpsworksRdsDbInstance(sName, "bar", "foofoofoofoofoo"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "bar",
 					),
 				),
 			},
@@ -26,18 +42,18 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 	})
 }
 
-func testAccAwsOpsworksRdsDbInstance(name string) string {
+func testAccAwsOpsworksRdsDbInstance(name, userName, password string) string {
 	return fmt.Sprintf(`
 resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
 
   rds_db_instance_arn = "${aws_db_instance.bar.arn}"
-  db_user = "foo"
-  db_password = "barbarbarbar"
+  db_user = "%s"
+  db_password = "%s"
 }
 
 %s
 
 %s
-`, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAWSDBInstanceConfig)
+`, userName, password, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAWSDBInstanceConfig)
 }

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -38,6 +38,14 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 					),
 				),
 			},
+			resource.TestStep{
+				Config: testAccAwsOpsworksRdsDbInstanceForceNew(sName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "foo",
+					),
+				),
+			},
 		},
 	})
 }
@@ -48,12 +56,37 @@ resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
 
   rds_db_instance_arn = "${aws_db_instance.bar.arn}"
-  db_user = "%s"
-  db_password = "%s"
+  db_user             = "%s"
+  db_password         = "%s"
 }
 
 %s
 
 %s
 `, userName, password, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAWSDBInstanceConfig)
+}
+
+func testAccAwsOpsworksRdsDbInstanceForceNew(name string) string {
+	return fmt.Sprintf(`
+resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+
+  rds_db_instance_arn = "${aws_db_instance.foo.arn}"
+  db_user             = "foo"
+  db_password         = "foofoofoofoo"
+}
+
+%s
+
+resource "aws_db_instance" "foo" {
+  allocated_storage    = 10
+  engine               = "MySQL"
+  engine_version       = "5.6.21"
+  instance_class       = "db.t1.micro"
+  name                 = "baz"
+  password             = "foofoofoofoo"
+  username             = "foo"
+  parameter_group_name = "default.mysql5.6"
+}
+`, testAccAwsOpsworksStackConfigVpcCreate(name))
 }

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -32,12 +32,12 @@ resource "aws_opsworks_rds_db_instance" "tf-acc-opsworks-db" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
 
   rds_db_instance_arn = "${aws_db_instance.bar.arn}"
-  db_user = "${aws_db_instance.bar.username}"
-  db_password = "${aws_db_instance.bar.password}"
+  db_user = "foo"
+  db_password = "barbarbarbar"
 }
 
 %s
 
 %s
-`, testAccAwsOpsworksStackConfigNoVpcCreate(name), testAccAWSDBInstanceConfig)
+`, testAccAwsOpsworksStackConfigVpcCreate(name), testAccAWSDBInstanceConfig)
 }

--- a/website/source/docs/providers/aws/r/opsworks_rds_db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_rds_db_instance.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aws"
+page_title: "AWS: aws_opsworks_rds_db_instance"
+sidebar_current: "docs-aws-resource-opsworks-rds-db-instance"
+description: |-
+  Provides an OpsWorks RDS DB Instance resource.
+------------------------------------------------
+
+# aws\_opsworks\_rds_db_instance
+
+Provides an OpsWorks RDS DB Instance resource.
+
+## Example Usage
+
+```
+resource "aws_opsworks_rds_db_instance" "my_instance" {
+  stack_id            = "${aws_opsworks_stack.my_stack.id}"
+  rds_db_instance_arn = "${aws_db_instance.my_instance.arn}"
+  db_user             = "someUser"
+  db_password         = "somePass"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `stack_id` - (Required) The stack to register a db inatance for 
+* `rds_db_instance_arn` - (Required) The db instance to register for this stack
+* `db_user` - (Required) A db username
+* `db_password` - (Required) A db password
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The computed id. Please note that this is only used internally to identify the stack <-> instance relation. This value is not used in aws.

--- a/website/source/docs/providers/aws/r/opsworks_rds_db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_rds_db_instance.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides an OpsWorks RDS DB Instance resource.
 ------------------------------------------------
 
-# aws\_opsworks\_rds_db_instance
+# aws\_opsworks\_rds\_db\_instance
 
 Provides an OpsWorks RDS DB Instance resource.
 
@@ -25,8 +25,8 @@ resource "aws_opsworks_rds_db_instance" "my_instance" {
 
 The following arguments are supported:
 
-* `stack_id` - (Required) The stack to register a db inatance for 
-* `rds_db_instance_arn` - (Required) The db instance to register for this stack
+* `stack_id` - (Required) The stack to register a db inatance for. Changing this will force a new resource.
+* `rds_db_instance_arn` - (Required) The db instance to register for this stack. Changing this will force a new resource.
 * `db_user` - (Required) A db username
 * `db_password` - (Required) A db password
 


### PR DESCRIPTION
This new resource registers a rds db instance to opsworks, which makes the provided credentials available to the opsworks chef process, so that an application can be automatically configured without storing db credentials in `custom_json`.

Acc tests pass.