### PR TITLE
providers/template: disallow file paths in `template`

### DIFF
--- a/builtin/providers/template/datasource_template_file_test.go
+++ b/builtin/providers/template/datasource_template_file_test.go
@@ -2,8 +2,6 @@ package template
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -26,6 +24,7 @@ func TestTemplateRendering(t *testing.T) {
 		{`{a="foo"}`, `$${a}`, `foo`},
 		{`{a="hello"}`, `$${replace(a, "ello", "i")}`, `hi`},
 		{`{}`, `${1+2+3}`, `6`},
+		{`{}`, `/`, `/`},
 	}
 
 	for _, tt := range cases {
@@ -44,30 +43,6 @@ func TestTemplateRendering(t *testing.T) {
 				},
 			},
 		})
-	}
-}
-
-func TestValidateTemplateAttribute(t *testing.T) {
-	file, err := ioutil.TempFile("", "testtemplate")
-	if err != nil {
-		t.Fatal(err)
-	}
-	file.WriteString("Hello world.")
-	file.Close()
-	defer os.Remove(file.Name())
-
-	ws, es := validateTemplateAttribute(file.Name(), "test")
-
-	if len(es) != 0 {
-		t.Fatalf("Unexpected errors: %#v", es)
-	}
-
-	if len(ws) != 1 {
-		t.Fatalf("Expected 1 warning, got %d", len(ws))
-	}
-
-	if !strings.Contains(ws[0], "Specifying a path directly is deprecated") {
-		t.Fatalf("Expected warning about path, got: %s", ws[0])
 	}
 }
 


### PR DESCRIPTION
Fixes #8660

This disallows file paths in `template`. This already had a deprecation
warning so we're just removing that.