### PR TITLE
provider/aws: Patch issue with enable dns support

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -46,7 +46,7 @@ func resourceAwsVpc() *schema.Resource {
 			"enable_dns_support": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
+				Default:  true,
 			},
 
 			"enable_classiclink": {
@@ -251,13 +251,13 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		log.Printf(
-			"[INFO] Modifying enable_dns_support vpc attribute for %s: %#v",
+			"[INFO] Modifying enable_dns_hostnames vpc attribute for %s: %s",
 			d.Id(), modifyOpts)
 		if _, err := conn.ModifyVpcAttribute(modifyOpts); err != nil {
 			return err
 		}
 
-		d.SetPartial("enable_dns_support")
+		d.SetPartial("enable_dns_hostnames")
 	}
 
 	_, hasEnableDnsSupportOption := d.GetOk("enable_dns_support")
@@ -272,7 +272,7 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		log.Printf(
-			"[INFO] Modifying enable_dns_support vpc attribute for %s: %#v",
+			"[INFO] Modifying enable_dns_support vpc attribute for %s: %s",
 			d.Id(), modifyOpts)
 		if _, err := conn.ModifyVpcAttribute(modifyOpts); err != nil {
 			return err

--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -28,6 +28,8 @@ func TestAccAWSVpc_basic(t *testing.T) {
 						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
 					resource.TestCheckResourceAttrSet(
 						"aws_vpc.foo", "default_route_table_id"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.foo", "enable_dns_support", "true"),
 				),
 			},
 		},
@@ -298,7 +300,7 @@ resource "aws_vpc" "bar" {
 
 const testAccVpcConfig_DisabledDnsSupport = `
 provider "aws" {
-	region = "eu-central-1"
+	region = "us-west-2"
 }
 
 resource "aws_vpc" "bar" {


### PR DESCRIPTION
Fixes an issue where enable_dns_support was being toggled off if `enable_dns_support` wasn't specified in the configuration. Adds a check in the basic test to catch future regressions. 

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpc_ -timeout 120m
=== RUN   TestAccAWSVpc_importBasic
--- PASS: TestAccAWSVpc_importBasic (16.32s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (13.56s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (13.52s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (24.27s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (24.23s)
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (24.91s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (13.29s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (13.28s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	143.399s
Test:
```