### PR TITLE
Remove extra dot from state backup file

### DIFF
--- a/command/state_meta.go
+++ b/command/state_meta.go
@@ -28,7 +28,7 @@ func (c *StateMeta) State(m *Meta) (state.State, error) {
 	// Determine the backup path. stateOutPath is set to the resulting
 	// file where state is written (cached in the case of remote state)
 	backupPath := fmt.Sprintf(
-		"%s.%d.%s",
+		"%s.%d%s",
 		m.stateOutPath,
 		time.Now().UTC().Unix(),
 		DefaultBackupExtension)

--- a/command/state_test.go
+++ b/command/state_test.go
@@ -2,8 +2,11 @@ package command
 
 import (
 	"path/filepath"
+	"regexp"
 	"sort"
 	"testing"
+
+	"github.com/hashicorp/terraform/state"
 )
 
 // testStateBackups returns the list of backups in order of creation
@@ -19,4 +22,17 @@ func testStateBackups(t *testing.T, dir string) []string {
 	sort.Strings(list)
 
 	return list
+}
+
+func TestStateDefaultBackupExtension(t *testing.T) {
+	s, err := (&StateMeta{}).State(&Meta{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	backupPath := s.(*state.BackupState).Path
+	match := regexp.MustCompile(`terraform\.tfstate\.\d+\.backup$`).MatchString
+	if !match(backupPath) {
+		t.Fatal("Bad backup path:", backupPath)
+	}
 }


### PR DESCRIPTION
The state subcommand was adding an extra dot to the backup file