### PR TITLE
provider/aws: data source for AWS Route Table

### DIFF
--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -1,0 +1,80 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsRouteTable() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsRouteTableRead,
+
+		Schema: map[string]*schema.Schema{
+			"subnet_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"vpc_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"filter": ec2CustomFiltersSchema(),
+
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"tags": tagsSchemaComputed(),
+		},
+	}
+}
+
+func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	req := &ec2.DescribeRouteTablesInput{}
+
+	req.Filters = buildEC2AttributeFilterList(
+		map[string]string{
+			"route-table-id":        d.Get("id").(string),
+			"vpc-id":                d.Get("vpc_id").(string),
+			"association.subnet-id": d.Get("subnet_id").(string),
+		},
+	)
+	req.Filters = append(req.Filters, buildEC2TagFilterList(
+		tagsFromMap(d.Get("tags").(map[string]interface{})),
+	)...)
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
+	if len(req.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] Describe Route Tables %v\n", req)
+	resp, err := conn.DescribeRouteTables(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil || len(resp.RouteTables) == 0 {
+		return fmt.Errorf("no matching Route Table found")
+	}
+	if len(resp.RouteTables) > 1 {
+		return fmt.Errorf("multiple Route Table matched; use additional constraints to reduce matches to a single Route Table")
+	}
+
+	rt := resp.RouteTables[0]
+
+	d.SetId(*rt.RouteTableId)
+	d.Set("id", *rt.RouteTableId)
+	d.Set("vpc_id", rt.VpcId)
+	d.Set("tags", tagsToMap(rt.Tags))
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -13,19 +13,19 @@ func dataSourceAwsRouteTable() *schema.Resource {
 		Read: dataSourceAwsRouteTableRead,
 
 		Schema: map[string]*schema.Schema{
-			"subnet_id": &schema.Schema{
+			"subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"vpc_id": &schema.Schema{
+			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 			"filter": ec2CustomFiltersSchema(),
 
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -72,7 +72,6 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	rt := resp.RouteTables[0]
 
 	d.SetId(*rt.RouteTableId)
-	d.Set("id", *rt.RouteTableId)
 	d.Set("vpc_id", rt.VpcId)
 	d.Set("tags", tagsToMap(rt.Tags))
 

--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsRouteTable(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsRouteTableGroupConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_id"),
+					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_tag"),
+					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_filter"),
+					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_subnet_id"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsRouteTableCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		rts, ok := s.RootModule().Resources["aws_route_table.test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_route_table.test in state")
+		}
+		vpcRs, ok := s.RootModule().Resources["aws_vpc.test"]
+		if !ok {
+			return fmt.Errorf("can't find aws_vpc.test in state")
+		}
+		attr := rs.Primary.Attributes
+
+		if attr["id"] != rts.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				attr["id"],
+				rts.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["vpc_id"] != vpcRs.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"vpc_id is %s; want %s",
+				attr["vpc_id"],
+				vpcRs.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["tags.Name"] != "terraform-testacc-routetable-data-source" {
+			return fmt.Errorf("bad Name tag %s", attr["tags.Name"])
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsRouteTableGroupConfig = `
+provider "aws" {
+  region = "eu-central-1"
+}
+resource "aws_vpc" "test" {
+  cidr_block = "172.16.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-data-source"
+  }
+}
+
+resource "aws_subnet" "test" {
+  cidr_block = "172.16.0.0/24"
+  vpc_id     = "${aws_vpc.test.id}"
+  tags {
+    Name = "terraform-testacc-data-source"
+  }
+}
+
+resource "aws_route_table" "test" {
+  vpc_id = "${aws_vpc.test.id}"
+  tags {
+    Name = "terraform-testacc-routetable-data-source"
+  }
+}
+
+resource "aws_route_table_association" "a" {
+    subnet_id = "${aws_subnet.test.id}"
+    route_table_id = "${aws_route_table.test.id}"
+}
+
+data "aws_route_table" "by_id" {
+  id = "${aws_route_table.test.id}"
+}
+
+data "aws_route_table" "by_subnet_id" {
+  subnet_id = "${aws_subnet.test.id}"
+  depends_on = ["aws_route_table_association.a"]
+}
+data "aws_route_table" "by_tag" {
+  tags {
+    Name = "${aws_route_table.test.tags["Name"]}"
+  }
+}
+
+data "aws_route_table" "by_filter" {
+  filter {
+    name = "association.subnet-id"
+    values = ["${aws_subnet.test.id}"]
+  }
+  depends_on = ["aws_route_table_association.a"]
+}
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -156,6 +156,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_prefix_list":              dataSourceAwsPrefixList(),
 			"aws_redshift_service_account": dataSourceAwsRedshiftServiceAccount(),
 			"aws_region":                   dataSourceAwsRegion(),
+			"aws_route_table":              dataSourceAwsRouteTable(),
 			"aws_s3_bucket_object":         dataSourceAwsS3BucketObject(),
 			"aws_subnet":                   dataSourceAwsSubnet(),
 			"aws_security_group":           dataSourceAwsSecurityGroup(),

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -67,3 +67,20 @@ result attributes. This data source will complete the data by populating
 any fields that are not included in the configuration with the data for
 the selected Route Table.
 
+`routes` are also exported with the following attributes, when there are relevants:
+Each route supports the following:
+
+* `cidr_block` - The CIDR block of the route.
+* `gateway_id` - The Internet Gateway ID.
+* `nat_gateway_id` - The NAT Gateway ID.
+* `instance_id` - The EC2 instance ID.
+* `vpc_peering_connection_id` - The VPC Peering ID.
+* `network_interface_id` - The ID of the elastic network interface (eni) to use.
+
+
+`associations` are also exported with the following attributes:
+
+* `route_table_association_id` - The Association ID .
+* `route_table_id` - The Route Table ID.
+* `subnet_id` - The Subnet ID.
+* `main` - If the Association due to the Main Route Table.

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -17,7 +17,7 @@ the Route Table.
 ## Example Usage
 
 The following example shows how one might accept a Route Table id as a variable
-and use this data source to obtain the data necessary to create a subnet.
+and use this data source to obtain the data necessary to create a route.
 
 ```
 variable "subnet_id" {}

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "aws"
+page_title: "AWS: aws_route_table"
+sidebar_current: "docs-aws-datasource-route-table"
+description: |-
+    Provides details about a specific Route Table
+---
+
+# aws\_route\_table
+
+`aws_route_table` provides details about a specific Route Table.
+
+This resource can prove useful when a module accepts a Subnet id as
+an input variable and needs to, for example, add a route in 
+the Route Table.
+
+## Example Usage
+
+The following example shows how one might accept a Route Table id as a variable
+and use this data source to obtain the data necessary to create a subnet.
+
+```
+variable "subnet_id" {}
+
+data "aws_route_table" "selected" {
+  subnet_id = "${var.subnet_id}"
+}
+
+resource "aws_route" "route" {
+  route_table_id = "${data.aws_route_table.selected.id}"
+  destination_cidr_block = "10.0.1.0/22"
+  vpc_peering_connection_id = "pcx-45ff3dc1"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available
+Route Table in the current region. The given filters must match exactly one
+Route Table whose data will be exported as attributes.
+
+
+* `filter` - (Optional) Custom filter block as described below.
+
+* `id` - (Optional) The id of the specific Route Table to retrieve.
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired Route Table.
+
+* `vpc_id` - (Optional) The id of the VPC that the desired Route Table belongs to.
+
+* `subnet_id` - (Optional) The id of a Subnet which is connected to the Route Table (not be exported if not given in parameter).
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html).
+
+* `values` - (Required) Set of values that are accepted for the given field.
+  A Route Table will be selected if any one of the given values matches.
+
+## Attributes Reference
+
+All of the argument attributes except `filter` and `subnet_id` blocks are also exported as
+result attributes. This data source will complete the data by populating
+any fields that are not included in the configuration with the data for
+the selected Route Table.
+

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -50,6 +50,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-region") %>>
                             <a href="/docs/providers/aws/d/region.html">aws_region</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-route-table") %>>
+                          <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-s3-bucket-object") %>>
                             <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>
                         </li>


### PR DESCRIPTION
Hi,

I added an AWS provider, aws_route_table.
We can retrieve, for example a route table from a subnet id and add a route with this route table
```
variable "subnet_id" {}

data "aws_route_table" "selected" {
  subnet_id = "${var.subnet_id}"
}

resource "aws_route" "route" {
  route_table_id = "${data.aws_route_table.selected.id}"
  destination_cidr_block = "10.0.1.0/22"
  vpc_peering_connection_id = "pcx-45ff3dc1"
}
```

Tests:

```
/opt/gopath/src/github.com/hashicorp/terraform$ TF_ACC=true go test -trace /tmp/toto.txt -v github.com/hashicorp/terraform/builtin/providers/aws -run ^TestAccDataSourceAwsRouteTable$
=== RUN   TestAccDataSourceAwsRouteTable
--- PASS: TestAccDataSourceAwsRouteTable (46.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	46.966s
```

