### PR TITLE
Skip VPC endpoint routes when removing default route table's routes

### DIFF
--- a/builtin/providers/aws/resource_aws_default_route_table.go
+++ b/builtin/providers/aws/resource_aws_default_route_table.go
@@ -188,6 +188,11 @@ func revokeAllRouteTableRules(defaultRouteTableId string, meta interface{}) erro
 		if r.GatewayId != nil && *r.GatewayId == "local" {
 			continue
 		}
+		if r.DestinationPrefixListId != nil {
+			// Skipping because VPC endpoint routes are handled separately
+			// See aws_vpc_endpoint
+			continue
+		}
 		log.Printf(
 			"[INFO] Deleting route from %s: %s",
 			defaultRouteTableId, *r.DestinationCidrBlock)


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/10295.
Added an acceptance test:
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDefaultRouteTable_'
```