### PR TITLE
Update opsworks_application.html.markdown

### DIFF
--- a/website/source/docs/providers/aws/r/opsworks_application.html.markdown
+++ b/website/source/docs/providers/aws/r/opsworks_application.html.markdown
@@ -79,7 +79,7 @@ An `environment` block supports the following arguments:
 
 * `key` - (Required) Variable name.
 * `value` - (Required) Variable value.
-* `secret` - (Optional) Set visibility of the variable value to `true` or `false`.
+* `secure` - (Optional) Set visibility of the variable value to `true` or `false`.
 
 A `ssl_configuration` block supports the following arguments (can only be defined once per resource):
 


### PR DESCRIPTION
'Secret' is incorrect in the environment argument documentation. It is used correctly in the example at the top as 'secure'.