### PR TITLE
Implements import with specified provider

### DIFF
--- a/command/import.go
+++ b/command/import.go
@@ -32,6 +32,7 @@ func (c *ImportCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
 	cmdFlags.StringVar(&configPath, "config", pwd, "path")
+	cmdFlags.StringVar(&c.Meta.provider, "provider", "", "provider")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -62,8 +63,9 @@ func (c *ImportCommand) Run(args []string) int {
 	newState, err := ctx.Import(&terraform.ImportOpts{
 		Targets: []*terraform.ImportTarget{
 			&terraform.ImportTarget{
-				Addr: args[0],
-				ID:   args[1],
+				Addr:     args[0],
+				ID:       args[1],
+				Provider: c.Meta.provider,
 			},
 		},
 	})
@@ -137,6 +139,8 @@ Options:
 
   -state-out=path     Path to write updated state file. By default, the
                       "-state" path will be used.
+
+  -provider=provider  Provider used for import. Defaults to: ""
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/meta.go
+++ b/command/meta.go
@@ -72,11 +72,14 @@ type Meta struct {
 	// allowed when walking the graph
 	//
 	// shadow is used to enable/disable the shadow graph
+	//
+	// provider is to specify specific resource providers
 	statePath    string
 	stateOutPath string
 	backupPath   string
 	parallelism  int
 	shadow       bool
+	provider     string
 }
 
 // initStatePaths is used to initialize the default values for

--- a/terraform/context_import.go
+++ b/terraform/context_import.go
@@ -23,6 +23,9 @@ type ImportTarget struct {
 
 	// ID is the ID of the resource to import. This is resource-specific.
 	ID string
+
+	// Provider string
+	Provider string
 }
 
 // Import takes already-created external resources and brings them

--- a/terraform/transform_import_state.go
+++ b/terraform/transform_import_state.go
@@ -21,8 +21,9 @@ func (t *ImportStateTransformer) Transform(g *Graph) error {
 		}
 
 		nodes = append(nodes, &graphNodeImportState{
-			Addr: addr,
-			ID:   target.ID,
+			Addr:     addr,
+			ID:       target.ID,
+			Provider: target.Provider,
 		})
 	}
 
@@ -35,8 +36,9 @@ func (t *ImportStateTransformer) Transform(g *Graph) error {
 }
 
 type graphNodeImportState struct {
-	Addr *ResourceAddress // Addr is the resource address to import to
-	ID   string           // ID is the ID to import as
+	Addr     *ResourceAddress // Addr is the resource address to import to
+	ID       string           // ID is the ID to import as
+	Provider string           // Provider string
 
 	states []*InstanceState
 }
@@ -46,7 +48,7 @@ func (n *graphNodeImportState) Name() string {
 }
 
 func (n *graphNodeImportState) ProvidedBy() []string {
-	return []string{resourceProvider(n.Addr.Type, "")}
+	return []string{resourceProvider(n.Addr.Type, n.Provider)}
 }
 
 // GraphNodeSubPath
@@ -147,9 +149,10 @@ func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
 	// is safe.
 	for i, state := range n.states {
 		g.Add(&graphNodeImportStateSub{
-			Target: addrs[i],
-			Path_:  n.Path(),
-			State:  state,
+			Target:   addrs[i],
+			Path_:    n.Path(),
+			State:    state,
+			Provider: n.Provider,
 		})
 	}
 
@@ -167,9 +170,10 @@ func (n *graphNodeImportState) DynamicExpand(ctx EvalContext) (*Graph, error) {
 // and is part of the subgraph. This node is responsible for refreshing
 // and adding a resource to the state once it is imported.
 type graphNodeImportStateSub struct {
-	Target *ResourceAddress
-	State  *InstanceState
-	Path_  []string
+	Target   *ResourceAddress
+	State    *InstanceState
+	Path_    []string
+	Provider string
 }
 
 func (n *graphNodeImportStateSub) Name() string {
@@ -212,7 +216,7 @@ func (n *graphNodeImportStateSub) EvalTree() EvalNode {
 	return &EvalSequence{
 		Nodes: []EvalNode{
 			&EvalGetProvider{
-				Name:   resourceProvider(info.Type, ""),
+				Name:   resourceProvider(info.Type, n.Provider),
 				Output: &provider,
 			},
 			&EvalRefresh{
@@ -229,7 +233,7 @@ func (n *graphNodeImportStateSub) EvalTree() EvalNode {
 			&EvalWriteState{
 				Name:         key.String(),
 				ResourceType: info.Type,
-				Provider:     resourceProvider(info.Type, ""),
+				Provider:     resourceProvider(info.Type, n.Provider),
 				State:        &state,
 			},
 		},

--- a/website/source/docs/commands/import.html.md
+++ b/website/source/docs/commands/import.html.md
@@ -49,6 +49,9 @@ The command-line flags are all optional. The list of available flags are:
   the state path. Ignored when [remote state](/docs/state/remote/index.html) is
   used.
 
+* `-provider=provider` - Provider used for import. Defaults to the default
+  provider of the resource to import.
+
 ## Provider Configuration
 
 Terraform will attempt to load configuration files that configure the


### PR DESCRIPTION
This allows the import with a specified provider.
So far it was not possible to get resources imported from a different provider
than the default.

Example invocation that allows to import the specified AWS SQS queue with an AWS provider called "second":
`terraform import -provider=aws.second aws_sqs_queue.fancy https://sqs.us-east-1.amazonaws.com/123456789101/fancy`

This will fix #10029.