### PR TITLE
config: validate that data sources don't have provisioners

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -610,6 +610,15 @@ func (c *Config) Validate() error {
 				"%s: lifecycle ignore_changes cannot contain interpolations",
 				n))
 		}
+
+		// If it is a data source then it can't have provisioners
+		if r.Mode == DataResourceMode {
+			if _, ok := r.RawConfig.Raw["provisioner"]; ok {
+				errs = append(errs, fmt.Errorf(
+					"%s: data sources cannot have provisioners",
+					n))
+			}
+		}
 	}
 
 	for source, vs := range vars {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -161,6 +161,13 @@ func TestConfigValidate_table(t *testing.T) {
 			true,
 			"non-existent module 'foo'",
 		},
+
+		{
+			"data source with provisioners",
+			"validate-data-provisioner",
+			true,
+			"data sources cannot have",
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/test-fixtures/validate-data-provisioner/main.tf
+++ b/config/test-fixtures/validate-data-provisioner/main.tf
@@ -1,0 +1,3 @@
+data "foo" "bar" {
+  provisioner "local-exec" {}
+}


### PR DESCRIPTION
Fixes #8046 

It may be that we want data sources to eventually support provisioners but as they stand now they don't and never have supported provisioners so we need to report errors properly.