### PR TITLE
terraform: record dependency to self (other index)

### DIFF
--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -47,7 +47,10 @@ func (n *NodeApplyableResource) EvalTree() EvalNode {
 	// code for this that we've used for a long time.
 	var stateDeps []string
 	{
-		oldN := &graphNodeExpandedResource{Resource: n.Config}
+		oldN := &graphNodeExpandedResource{
+			Resource: n.Config,
+			Index:    addr.Index,
+		}
 		stateDeps = oldN.StateDependencies()
 	}
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -603,6 +603,27 @@ aws_instance.foo.2:
   type = aws_instance
 `
 
+const testTerraformApplyProvisionerMultiSelfRefSingleStr = `
+aws_instance.foo.0:
+  ID = foo
+  foo = number 0
+  type = aws_instance
+aws_instance.foo.1:
+  ID = foo
+  foo = number 1
+  type = aws_instance
+
+  Dependencies:
+    aws_instance.foo.0
+aws_instance.foo.2:
+  ID = foo
+  foo = number 2
+  type = aws_instance
+
+  Dependencies:
+    aws_instance.foo.0
+`
+
 const testTerraformApplyProvisionerDiffStr = `
 aws_instance.bar:
   ID = foo

--- a/terraform/test-fixtures/apply-provisioner-multi-self-ref-single/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-multi-self-ref-single/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "foo" {
+    count = 3
+    foo = "number ${count.index}"
+
+    provisioner "shell" {
+        command = "${aws_instance.foo.0.foo}"
+        order   = "${count.index}"
+    }
+}


### PR DESCRIPTION
Fixes #10313

The new graph wasn't properly recording resource dependencies to a
specific index of itself. For example: `foo.bar.2` depending on
`foo.bar.0` wasn't shown in the state when it should've been.

This adds a test to verify this and fixes it.