### PR TITLE
Fix some cases for nested maps and lists

### DIFF
--- a/helper/schema/field_reader.go
+++ b/helper/schema/field_reader.go
@@ -75,6 +75,8 @@ func addrToSchema(addr []string, schemaMap map[string]*Schema) []*Schema {
 				return nil
 			}
 		case TypeList, TypeSet:
+			isIndex := len(addr) > 0 && addr[0] == "#"
+
 			switch v := current.Elem.(type) {
 			case *Resource:
 				current = &Schema{
@@ -83,20 +85,52 @@ func addrToSchema(addr []string, schemaMap map[string]*Schema) []*Schema {
 				}
 			case *Schema:
 				current = v
+			case ValueType:
+				current = &Schema{Type: v}
 			default:
+				// we may not know the Elem type and are just looking for the
+				// index
+				if isIndex {
+					break
+				}
+
+				if len(addr) == 0 {
+					// we've processed the address, so return what we've
+					// collected
+					return result
+				}
+
+				if len(addr) == 1 {
+					if _, err := strconv.Atoi(addr[0]); err == nil {
+						// we're indexing a value without a schema. This can
+						// happen if the list is nested in another schema type.
+						// Default to a TypeString like we do with a map
+						current = &Schema{Type: TypeString}
+						break
+					}
+				}
+
 				return nil
 			}
 
 			// If we only have one more thing and the next thing
 			// is a #, then we're accessing the index which is always
 			// an int.
-			if len(addr) > 0 && addr[0] == "#" {
+			if isIndex {
 				current = &Schema{Type: TypeInt}
 				break
 			}
+
 		case TypeMap:
 			if len(addr) > 0 {
-				current = &Schema{Type: TypeString}
+				switch v := current.Elem.(type) {
+				case ValueType:
+					current = &Schema{Type: v}
+				default:
+					// maps default to string values. This is all we can have
+					// if this is nested in another list or map.
+					current = &Schema{Type: TypeString}
+				}
 			}
 		case typeObject:
 			// If we're already in the object, then we want to handle Sets

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -104,7 +104,18 @@ func (r *ConfigFieldReader) readMap(k string, schema *Schema) (FieldReadResult, 
 	// the type of the raw value.
 	mraw, ok := r.Config.GetRaw(k)
 	if !ok {
-		return FieldReadResult{}, nil
+		// check if this is from an interpolated field by seeing if it exists
+		// in the config
+		_, ok := r.Config.Get(k)
+		if !ok {
+			// this really doesn't exist
+			return FieldReadResult{}, nil
+		}
+
+		// We couldn't fetch the value from a nested data structure, so treat the
+		// raw value as an interpolation string. The mraw value is only used
+		// for the type switch below.
+		mraw = "${INTERPOLATED}"
 	}
 
 	result := make(map[string]interface{})


### PR DESCRIPTION
When referencing a list of maps variable from within a resource, only
the first list element is included the plan. This is because GetRaw
can't access the interpolated values. Add some tests to document this
behavior for both Get and GetRaw.

In helper/schema, this now checks for interpolated values when reading a map.
Accessing an interpolated value in a map through ConfigFieldReader can
fail, because GetRaw can't access interpolated values, so we check if the
value exists at all by looking in the config. If the config has a value,
assume our map's value is interpolated and proceed as such.

We also need to lookup the correct schema to properly read a field from
a nested structure.

- Maps previously always defaulted to TypeString. Now
check if Elem is a ValueType and use that if applicable
- Lists now return the schema for nested element types, defaulting to a
  TypeString like maps.

This only allows maps and lists to be nested one level deep in a schema, and the
inner map or list must only contain string values.