### PR TITLE
build: Add test-compile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,14 @@ testacc: fmtcheck generate
 	fi
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m
 
+test-compile: fmtcheck generate
+	@if [ "$(TEST)" = "./..." ]; then \
+		echo "ERROR: Set TEST to a specific package. For example,"; \
+		echo "  make test-compile TEST=./builtin/providers/aws"; \
+		exit 1; \
+	fi
+	go test -c $(TEST) $(TESTARGS)
+
 # testrace runs the race checker
 testrace: fmtcheck generate
 	TF_ACC= go test -race $(TEST) $(TESTARGS)


### PR DESCRIPTION
This pull request adds a `make test-compile` target, which compiles the tests for a given package into a binary. This can be used as follows:

```
make test-compile TEST=./builtin/providers/aws TESTARGS="-o awstests"
```

In order to produce a binary named awstests containing the unit and acceptance tests for AWS.