### PR TITLE
provider/aws: remove opsworks restriction to us-east-1

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -282,7 +282,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.kinesisconn = kinesis.New(kinesisSess)
 	client.kmsconn = kms.New(sess)
 	client.lambdaconn = lambda.New(sess)
-	client.opsworksconn = opsworks.New(usEast1Sess)
+	client.opsworksconn = opsworks.New(sess)
 	client.r53conn = route53.New(usEast1Sess)
 	client.rdsconn = rds.New(sess)
 	client.redshiftconn = redshift.New(sess)

--- a/builtin/providers/aws/resource_aws_opsworks_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_instance_test.go
@@ -45,7 +45,7 @@ func TestAccAWSOpsworksInstance(t *testing.T) {
 						"aws_opsworks_instance.tf-acc", "architecture", "x86_64",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "os", "Amazon Linux 2014.09", // inherited from opsworks_stack_test
+						"aws_opsworks_instance.tf-acc", "os", "Amazon Linux 2016.09", // inherited from opsworks_stack_test
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_instance.tf-acc", "root_device_type", "ebs", // inherited from opsworks_stack_test

--- a/builtin/providers/aws/resource_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack_test.go
@@ -77,7 +77,7 @@ func testAccAwsOpsworksStackCheckResourceAttrsCreate(zone, stackName string) res
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
 			"default_os",
-			"Amazon Linux 2014.09",
+			"Amazon Linux 2016.09",
 		),
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
@@ -117,7 +117,7 @@ func testAccAwsOpsworksStackCheckResourceAttrsUpdate(zone, stackName string) res
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
 			"default_os",
-			"Amazon Linux 2014.09",
+			"Amazon Linux 2016.09",
 		),
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
@@ -420,7 +420,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   default_subnet_id = "${aws_subnet.tf-acc.id}"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
-  default_os = "Amazon Linux 2014.09"
+  default_os = "Amazon Linux 2016.09"
   default_root_device_type = "ebs"
   custom_json = "{\"key\": \"value\"}"
   configuration_manager_version = "11.10"
@@ -511,7 +511,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   default_subnet_id = "${aws_subnet.tf-acc.id}"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
-  default_os = "Amazon Linux 2014.09"
+  default_os = "Amazon Linux 2016.09"
   default_root_device_type = "ebs"
   custom_json = "{\"key\": \"value\"}"
   configuration_manager_version = "11.10"


### PR DESCRIPTION
Fixes #9826 

**Acceptance Tests**
Due to the fact that some Opsworks acceptance tests require EC2 Classic (#6201), I couldn't run all the tests. The ones that I can run, pass.
```` 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/25 08:03:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run TestAccAWSOpsworks\(\(CustomLayerImportBasic\)\|\(StackImportBasic\)\|\(Instance\)\|\(StackVpc\)\) -timeout 120m
=== RUN   TestAccAWSOpsworksCustomLayerImportBasic
--- PASS: TestAccAWSOpsworksCustomLayerImportBasic (108.54s)
=== RUN   TestAccAWSOpsworksStackImportBasic
--- PASS: TestAccAWSOpsworksStackImportBasic (94.11s)
=== RUN   TestAccAWSOpsworksInstance
--- PASS: TestAccAWSOpsworksInstance (180.15s)
=== RUN   TestAccAWSOpsworksStackVpc
--- PASS: TestAccAWSOpsworksStackVpc (144.68s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	527.512s
````

I'm not really sure how I would write a new acceptance test for this change. If anyone could point me to an example, I would be happy to.