### PR TITLE
provider/aws: Generate random names for Beanstalk tests resources

### DIFF
--- a/builtin/providers/aws/import_aws_elastic_beanstalk_application_test.go
+++ b/builtin/providers/aws/import_aws_elastic_beanstalk_application_test.go
@@ -1,28 +1,38 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAWSElasticBeanstalkApplication_importBasic(t *testing.T) {
 	resourceName := "aws_elastic_beanstalk_application.tftest"
+	config := fmt.Sprintf("tf-test-name-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBeanstalkAppDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccBeanstalkAppConfig,
+			{
+				Config: testAccBeanstalkAppImportConfig(config),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
 	})
+}
+
+func testAccBeanstalkAppImportConfig(name string) string {
+	return fmt.Sprintf(`resource "aws_elastic_beanstalk_application" "tftest" {
+	  name = "%s"
+	  description = "tf-test-desc"
+	}`, name)
 }

--- a/builtin/providers/aws/import_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/import_aws_elastic_beanstalk_environment_test.go
@@ -1,28 +1,46 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAWSElasticBeanstalkEnvironment_importBasic(t *testing.T) {
 	resourceName := "aws_elastic_beanstalk_application.tftest"
 
+	applicationName := fmt.Sprintf("tf-test-name-%d", acctest.RandInt())
+	environmentName := fmt.Sprintf("tf-test-env-name-%d", acctest.RandInt())
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckBeanstalkAppDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccBeanstalkEnvConfig,
+			{
+				Config: testAccBeanstalkEnvImportConfig(applicationName, environmentName),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
 		},
 	})
+}
+
+func testAccBeanstalkEnvImportConfig(appName, envName string) string {
+	return fmt.Sprintf(`resource "aws_elastic_beanstalk_application" "tftest" {
+	  name = "%s"
+	  description = "tf-test-desc"
+	}
+
+	resource "aws_elastic_beanstalk_environment" "tfenvtest" {
+	  name = "%s"
+	  application = "${aws_elastic_beanstalk_application.tftest.name}"
+	  solution_stack_name = "64bit Amazon Linux running Python"
+	}`, appName, envName)
 }


### PR DESCRIPTION
This pull request fixes concurrent runs of `TestAWSElasticBeanstalkEnvironment_importBasic` and `TestAccElasticBeanstalkApplicationImport`, preventing them using the same names in configurations.