### PR TITLE
Fix typo in test method name

### DIFF
--- a/helper/validation/validation_test.go
+++ b/helper/validation/validation_test.go
@@ -36,7 +36,7 @@ func TestValidationIntBetween(t *testing.T) {
 	})
 }
 
-func TestValidationSringInSlice(t *testing.T) {
+func TestValidationStringInSlice(t *testing.T) {
 	runTestCases(t, []testCase{
 		{
 			val: "ValidValue",


### PR DESCRIPTION
Minor test method name typo update, shouldn't affect any runtime functionality.