### PR TITLE
Added 'connect_timeout' argument to provider 'postgresql'

### DIFF
--- a/builtin/providers/postgresql/config.go
+++ b/builtin/providers/postgresql/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	Username string
 	Password string
 	SslMode  string
+	Timeout  int
 }
 
 // Client struct holding connection string
@@ -24,7 +25,7 @@ type Client struct {
 
 // NewClient returns new client config
 func (c *Config) NewClient() (*Client, error) {
-	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=postgres sslmode=%s", c.Host, c.Port, c.Username, c.Password, c.SslMode)
+	connStr := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=postgres sslmode=%s connect_timeout=%d", c.Host, c.Port, c.Username, c.Password, c.SslMode, c.Timeout)
 
 	client := Client{
 		connStr:  connStr,

--- a/builtin/providers/postgresql/provider.go
+++ b/builtin/providers/postgresql/provider.go
@@ -40,6 +40,13 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("PGSSLMODE", "require"),
 				Description: "Connection mode for PostgreSQL server",
 			},
+			"connect_timeout": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Default:     15,
+				DefaultFunc: schema.EnvDefaultFunc("PGCONNECT_TIMEOUT", nil),
+				Description: "Maximum wait for connection, in seconds. Zero or not specified means wait indefinitely.",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -59,6 +66,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		Username: d.Get("username").(string),
 		Password: d.Get("password").(string),
 		SslMode:  d.Get("ssl_mode").(string),
+		Timeout:  d.Get("connect_timeout").(int),
 	}
 
 	client, err := config.NewClient()

--- a/website/source/docs/providers/postgresql/index.html.markdown
+++ b/website/source/docs/providers/postgresql/index.html.markdown
@@ -21,6 +21,7 @@ provider "postgresql" {
   username = "postgres_user"
   password = "postgres_password"
   ssl_mode = "require"
+  connect_timeout = 15
 }
 
 ```
@@ -63,5 +64,6 @@ The following arguments are supported:
 * `username` - (Required) Username for the server connection.
 * `password` - (Optional) Password for the server connection.
 * `ssl_mode` - (Optional) Set the priority for an SSL connection to the server.
+* `connect_timeout` - (Optional) Maximum wait for connection, in seconds. Zero means wait indefinitely, the default is `15`.
   The default is `prefer`; the full set of options and their implications
   can be seen [in the libpq SSL guide](http://www.postgresql.org/docs/9.4/static/libpq-ssl.html#LIBPQ-SSL-PROTECTION).


### PR DESCRIPTION
Any unavailable/filtered postgresql server puts terraform on the kneels in case of increased TCP retransmit time. I resolved infinite waiting, thanks.