### PR TITLE
provider/github: supports importing resources

### DIFF
--- a/builtin/providers/github/provider_test.go
+++ b/builtin/providers/github/provider_test.go
@@ -10,6 +10,9 @@ import (
 
 const testRepo string = "test-repo"
 
+var testUser string = os.Getenv("GITHUB_TEST_USER")
+var testCollaborator string = os.Getenv("GITHUB_TEST_COLLABORATOR")
+
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 

--- a/builtin/providers/github/resource_github_issue_label.go
+++ b/builtin/providers/github/resource_github_issue_label.go
@@ -11,6 +11,9 @@ func resourceGithubIssueLabel() *schema.Resource {
 		Read:   resourceGithubIssueLabelRead,
 		Update: resourceGithubIssueLabelUpdate,
 		Delete: resourceGithubIssueLabelDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"repository": &schema.Schema{
@@ -55,8 +58,7 @@ func resourceGithubIssueLabelCreate(d *schema.ResourceData, meta interface{}) er
 
 func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
-	r := d.Get("repository").(string)
-	n := d.Get("name").(string)
+	r, n := parseTwoPartID(d.Id())
 
 	githubLabel, _, err := client.Issues.GetLabel(meta.(*Organization).name, r, n)
 	if err != nil {
@@ -64,6 +66,8 @@ func resourceGithubIssueLabelRead(d *schema.ResourceData, meta interface{}) erro
 		return nil
 	}
 
+	d.Set("repository", r)
+	d.Set("name", n)
 	d.Set("color", githubLabel.Color)
 	d.Set("url", githubLabel.URL)
 

--- a/builtin/providers/github/resource_github_issue_label_test.go
+++ b/builtin/providers/github/resource_github_issue_label_test.go
@@ -35,6 +35,24 @@ func TestAccGithubIssueLabel_basic(t *testing.T) {
 	})
 }
 
+func TestAccGithubIssueLabel_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubIssueLabelDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubIssueLabelConfig,
+			},
+			resource.TestStep{
+				ResourceName:      "github_issue_label.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckGithubIssueLabelExists(n string, label *github.Label) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -101,42 +119,16 @@ func testAccGithubIssueLabelDestroy(s *terraform.State) error {
 }
 
 var testAccGithubIssueLabelConfig string = fmt.Sprintf(`
-resource "github_repository" "foo" {
-  name = "%s"
-  description = "Terraform acceptance tests!"
-  homepage_url = "http://example.com/"
-
-  # So that acceptance tests can be run in a github organization
-  # with no billing
-  private = false
-
-  has_issues = false
-  has_wiki = false
-  has_downloads = false
-}
 resource "github_issue_label" "test" {
-  repository = "${github_repository.foo.name}"
+  repository = "%s"
   name       = "foo"
   color      = "000000"
 }
 `, testRepo)
 
 var testAccGithubIssueLabelUpdateConfig string = fmt.Sprintf(`
-resource "github_repository" "foo" {
-  name = "%s"
-  description = "Terraform acceptance tests!"
-  homepage_url = "http://example.com/"
-
-  # So that acceptance tests can be run in a github organization
-  # with no billing
-  private = false
-
-  has_issues = false
-  has_wiki = false
-  has_downloads = false
-}
 resource "github_issue_label" "test" {
-  repository = "${github_repository.foo.name}"
+  repository = "%s"
   name       = "bar"
   color      = "FFFFFF"
 }

--- a/builtin/providers/github/resource_github_membership_test.go
+++ b/builtin/providers/github/resource_github_membership_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/google/go-github/github"
@@ -12,14 +11,6 @@ import (
 
 func TestAccGithubMembership_basic(t *testing.T) {
 	var membership github.Membership
-
-	testUser := os.Getenv("GITHUB_TEST_USER")
-	testAccGithubMembershipConfig := fmt.Sprintf(`
-		resource "github_membership" "test_org_membership" {
-			username = "%s"
-			role = "member"
-		}
-	`, testUser)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -32,6 +23,24 @@ func TestAccGithubMembership_basic(t *testing.T) {
 					testAccCheckGithubMembershipExists("github_membership.test_org_membership", &membership),
 					testAccCheckGithubMembershipRoleState("github_membership.test_org_membership", &membership),
 				),
+			},
+		},
+	})
+}
+
+func TestAccGithubMembership_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubMembershipDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubMembershipConfig,
+			},
+			resource.TestStep{
+				ResourceName:      "github_membership.test_org_membership",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -113,3 +122,10 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 		return nil
 	}
 }
+
+var testAccGithubMembershipConfig string = fmt.Sprintf(`
+  resource "github_membership" "test_org_membership" {
+    username = "%s"
+    role = "member"
+  }
+`, testUser)

--- a/builtin/providers/github/resource_github_repository.go
+++ b/builtin/providers/github/resource_github_repository.go
@@ -14,6 +14,9 @@ func resourceGithubRepository() *schema.Resource {
 		Read:   resourceGithubRepositoryRead,
 		Update: resourceGithubRepositoryUpdate,
 		Delete: resourceGithubRepositoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -134,6 +137,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		return err
 	}
+	d.Set("name", repoName)
 	d.Set("description", repo.Description)
 	d.Set("homepage_url", repo.Homepage)
 	d.Set("private", repo.Private)
@@ -154,10 +158,12 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 	repoReq := resourceGithubRepositoryObject(d)
 	repoName := d.Id()
 	log.Printf("[DEBUG] update github repository %s/%s", meta.(*Organization).name, repoName)
-	_, _, err := client.Repositories.Edit(meta.(*Organization).name, repoName, repoReq)
+	repo, _, err := client.Repositories.Edit(meta.(*Organization).name, repoName, repoReq)
 	if err != nil {
 		return err
 	}
+	d.SetId(*repo.Name)
+
 	return resourceGithubRepositoryRead(d, meta)
 }
 

--- a/builtin/providers/github/resource_github_repository_collaborator.go
+++ b/builtin/providers/github/resource_github_repository_collaborator.go
@@ -11,6 +11,9 @@ func resourceGithubRepositoryCollaborator() *schema.Resource {
 		Read:   resourceGithubRepositoryCollaboratorRead,
 		// editing repository collaborators are not supported by github api so forcing new on any changes
 		Delete: resourceGithubRepositoryCollaboratorDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"username": &schema.Schema{
@@ -54,8 +57,7 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 
 func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
-	u := d.Get("username").(string)
-	r := d.Get("repository").(string)
+	r, u := parseTwoPartID(d.Id())
 
 	isCollaborator, _, err := client.Repositories.IsCollaborator(meta.(*Organization).name, r, u)
 
@@ -79,6 +81,8 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 				return err
 			}
 
+			d.Set("repository", r)
+			d.Set("username", u)
 			d.Set("permission", permName)
 
 			return nil

--- a/builtin/providers/github/resource_github_repository_collaborator_test.go
+++ b/builtin/providers/github/resource_github_repository_collaborator_test.go
@@ -2,7 +2,6 @@ package github
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/google/go-github/github"
@@ -13,15 +12,6 @@ import (
 const expectedPermission string = "admin"
 
 func TestAccGithubRepositoryCollaborator_basic(t *testing.T) {
-	testCollaborator := os.Getenv("GITHUB_TEST_COLLABORATOR")
-	testAccGithubRepositoryCollaboratorConfig := fmt.Sprintf(`
-		resource "github_repository_collaborator" "test_repo_collaborator" {
-			repository = "%s"
-			username = "%s"
-			permission = "%s"
-		}
-	`, testRepo, testCollaborator, expectedPermission)
-
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -33,6 +23,24 @@ func TestAccGithubRepositoryCollaborator_basic(t *testing.T) {
 					testAccCheckGithubRepositoryCollaboratorExists("github_repository_collaborator.test_repo_collaborator"),
 					testAccCheckGithubRepositoryCollaboratorPermission("github_repository_collaborator.test_repo_collaborator"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccGithubRepositoryCollaborator_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubRepositoryCollaboratorDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubRepositoryCollaboratorConfig,
+			},
+			resource.TestStep{
+				ResourceName:      "github_repository_collaborator.test_repo_collaborator",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
 		},
 	})
@@ -133,3 +141,11 @@ func testAccCheckGithubRepositoryCollaboratorPermission(n string) resource.TestC
 		return fmt.Errorf("Repository collaborator did not appear in list of collaborators on repository")
 	}
 }
+
+var testAccGithubRepositoryCollaboratorConfig string = fmt.Sprintf(`
+  resource "github_repository_collaborator" "test_repo_collaborator" {
+    repository = "%s"
+    username = "%s"
+    permission = "%s"
+  }
+`, testRepo, testCollaborator, expectedPermission)

--- a/builtin/providers/github/resource_github_repository_test.go
+++ b/builtin/providers/github/resource_github_repository_test.go
@@ -49,6 +49,24 @@ func TestAccGithubRepository_basic(t *testing.T) {
 	})
 }
 
+func TestAccGithubRepository_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubRepositoryConfig,
+			},
+			resource.TestStep{
+				ResourceName:      "github_repository.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckGithubRepositoryExists(n string, repo *github.Repository) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]

--- a/builtin/providers/github/resource_github_team.go
+++ b/builtin/providers/github/resource_github_team.go
@@ -12,6 +12,9 @@ func resourceGithubTeam() *schema.Resource {
 		Read:   resourceGithubTeamRead,
 		Update: resourceGithubTeamUpdate,
 		Delete: resourceGithubTeamDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{

--- a/builtin/providers/github/resource_github_team_membership.go
+++ b/builtin/providers/github/resource_github_team_membership.go
@@ -14,6 +14,9 @@ func resourceGithubTeamMembership() *schema.Resource {
 		Read:   resourceGithubTeamMembershipRead,
 		// editing team memberships are not supported by github api so forcing new on any changes
 		Delete: resourceGithubTeamMembershipDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"team_id": &schema.Schema{
@@ -57,8 +60,7 @@ func resourceGithubTeamMembershipCreate(d *schema.ResourceData, meta interface{}
 
 func resourceGithubTeamMembershipRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
-	t := d.Get("team_id").(string)
-	n := d.Get("username").(string)
+	t, n := parseTwoPartID(d.Id())
 
 	membership, _, err := client.Organizations.GetTeamMembership(toGithubID(t), n)
 

--- a/builtin/providers/github/resource_github_team_repository.go
+++ b/builtin/providers/github/resource_github_team_repository.go
@@ -11,6 +11,9 @@ func resourceGithubTeamRepository() *schema.Resource {
 		Read:   resourceGithubTeamRepositoryRead,
 		Update: resourceGithubTeamRepositoryUpdate,
 		Delete: resourceGithubTeamRepositoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"team_id": &schema.Schema{
@@ -53,8 +56,7 @@ func resourceGithubTeamRepositoryCreate(d *schema.ResourceData, meta interface{}
 
 func resourceGithubTeamRepositoryRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*Organization).client
-	t := d.Get("team_id").(string)
-	r := d.Get("repository").(string)
+	t, r := parseTwoPartID(d.Id())
 
 	repo, _, repoErr := client.Organizations.IsTeamRepo(toGithubID(t), meta.(*Organization).name, r)
 
@@ -92,6 +94,8 @@ func resourceGithubTeamRepositoryUpdate(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+	d.SetId(buildTwoPartID(&t, &r))
+
 	return resourceGithubTeamRepositoryRead(d, meta)
 }
 

--- a/builtin/providers/github/resource_github_team_repository_test.go
+++ b/builtin/providers/github/resource_github_team_repository_test.go
@@ -35,6 +35,24 @@ func TestAccGithubTeamRepository_basic(t *testing.T) {
 	})
 }
 
+func TestAccGithubTeamRepository_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubTeamRepositoryConfig,
+			},
+			resource.TestStep{
+				ResourceName:      "github_team_repository.test_team_test_repo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccCheckGetPermissions(t *testing.T) {
 	pullMap := map[string]bool{"pull": true, "push": false, "admin": false}
 	pushMap := map[string]bool{"pull": true, "push": true, "admin": false}

--- a/builtin/providers/github/resource_github_team_test.go
+++ b/builtin/providers/github/resource_github_team_test.go
@@ -35,6 +35,24 @@ func TestAccGithubTeam_basic(t *testing.T) {
 	})
 }
 
+func TestAccGithubTeam_importBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGithubTeamDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGithubTeamConfig,
+			},
+			resource.TestStep{
+				ResourceName:      "github_team.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckGithubTeamExists(n string, team *github.Team) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
```
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccGithubIssueLabel_basic
--- PASS: TestAccGithubIssueLabel_basic (0.91s)
=== RUN   TestAccGithubIssueLabel_importBasic
--- PASS: TestAccGithubIssueLabel_importBasic (0.41s)
=== RUN   TestAccGithubMembership_basic
--- PASS: TestAccGithubMembership_basic (0.84s)
=== RUN   TestAccGithubMembership_importBasic
--- PASS: TestAccGithubMembership_importBasic (0.53s)
=== RUN   TestAccGithubRepositoryCollaborator_basic
--- PASS: TestAccGithubRepositoryCollaborator_basic (0.64s)
=== RUN   TestAccGithubRepositoryCollaborator_importBasic
--- PASS: TestAccGithubRepositoryCollaborator_importBasic (0.74s)
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (1.54s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (0.77s)
=== RUN   TestAccGithubTeamMembership_basic
--- PASS: TestAccGithubTeamMembership_basic (1.59s)
=== RUN   TestAccGithubTeamMembership_importBasic
--- PASS: TestAccGithubTeamMembership_importBasic (0.95s)
=== RUN   TestAccGithubTeamRepository_basic
--- PASS: TestAccGithubTeamRepository_basic (1.45s)
=== RUN   TestAccGithubTeamRepository_importBasic
--- PASS: TestAccGithubTeamRepository_importBasic (0.75s)
=== RUN   TestAccCheckGetPermissions
--- PASS: TestAccCheckGetPermissions (0.00s)
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (0.79s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (0.54s)
=== RUN   TestAccGithubUtilRole_validation
--- PASS: TestAccGithubUtilRole_validation (0.00s)
=== RUN   TestAccGithubUtilTwoPartID
--- PASS: TestAccGithubUtilTwoPartID (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/github 12.455s
```

/cc @sr