### PR TITLE
Fixed private_key param

### DIFF
--- a/examples/openstack-with-networking/main.tf
+++ b/examples/openstack-with-networking/main.tf
@@ -73,7 +73,7 @@ resource "openstack_compute_instance_v2" "terraform" {
   provisioner "remote-exec" {
     connection {
       user     = "${var.ssh_user_name}"
-      key_file = "${var.ssh_key_file}"
+      private_key = "${file(var.ssh_key_file)}"
     }
 
     inline = [


### PR DESCRIPTION
The provisioned argument key_file has been deprecated.  Updated the example to use the new argument private_key.