### PR TITLE
provider/google: allow session affinity for compute_backend_service

### DIFF
--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -128,6 +128,12 @@ func resourceComputeBackendService() *schema.Resource {
 				Computed: true,
 			},
 
+			"session_affinity": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"timeout_sec": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,
@@ -165,6 +171,10 @@ func resourceComputeBackendServiceCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("protocol"); ok {
 		service.Protocol = v.(string)
+	}
+
+	if v, ok := d.GetOk("session_affinity"); ok {
+		service.SessionAffinity = v.(string)
 	}
 
 	if v, ok := d.GetOk("timeout_sec"); ok {
@@ -225,6 +235,7 @@ func resourceComputeBackendServiceRead(d *schema.ResourceData, meta interface{})
 	d.Set("enable_cdn", service.EnableCDN)
 	d.Set("port_name", service.PortName)
 	d.Set("protocol", service.Protocol)
+	d.Set("session_affinity", service.SessionAffinity)
 	d.Set("timeout_sec", service.TimeoutSec)
 	d.Set("fingerprint", service.Fingerprint)
 	d.Set("self_link", service.SelfLink)
@@ -270,6 +281,10 @@ func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{
 	}
 	if v, ok := d.GetOk("timeout_sec"); ok {
 		service.TimeoutSec = int64(v.(int))
+	}
+
+	if d.HasChange("session_affinity") {
+		service.SessionAffinity = d.Get("session_affinity").(string)
 	}
 
 	if d.HasChange("enable_cdn") {

--- a/builtin/providers/google/resource_compute_backend_service_test.go
+++ b/builtin/providers/google/resource_compute_backend_service_test.go
@@ -187,6 +187,40 @@ func TestAccComputeBackendService_withCDNEnabled(t *testing.T) {
 	}
 }
 
+func TestAccComputeBackendService_withSessionAffinity(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var svc compute.BackendService
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeBackendService_withSessionAffinity(
+					serviceName, checkName, "CLIENT_IP"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.foobar", &svc),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeBackendService_withSessionAffinity(
+					serviceName, checkName, "GENERATED_COOKIE"),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.foobar", &svc),
+				),
+			},
+		},
+	})
+
+	if svc.SessionAffinity != "GENERATED_COOKIE" {
+		t.Errorf("Expected SessionAffinity == \"GENERATED_COOKIE\", got %t", svc.SessionAffinity)
+	}
+}
+
 func testAccComputeBackendService_basic(serviceName, checkName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_backend_service" "foobar" {
@@ -290,4 +324,21 @@ resource "google_compute_http_health_check" "default" {
   timeout_sec        = 1
 }
 `, serviceName, timeout, igName, itName, checkName)
+}
+
+func testAccComputeBackendService_withSessionAffinity(serviceName, checkName, affinityName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name             = "%s"
+  health_checks    = ["${google_compute_http_health_check.zero.self_link}"]
+  session_affinity = "%s"
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, affinityName, checkName)
 }

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -89,6 +89,10 @@ The following arguments are supported:
 * `region` - (Optional) The Region in which the created address should reside.
     If it is not provided, the provider region is used.
 
+* `session_affinity` - (Optional) How to distribute load. Options are "NONE" (no
+    affinity), "CLIENT\_IP" (hash of the source/dest addresses / ports), and
+    "GENERATED\_COOKIE" (distribute load using a generated session cookie).
+
 * `timeout_sec` - (Optional) The number of secs to wait for a backend to respond
     to a request before considering the request failed. Defaults to `30`.
 


### PR DESCRIPTION
Google's Backend Services gives users control over the session affinity modes.
Let's allow Terraform users to leverage this option.
We don't change the default value ("NONE"), as provided by Google.

This is commited against master, but merges and works fine in main-0.7 too;).