### PR TITLE
provider/azurerm: support import of routes, fix route_table

### DIFF
--- a/builtin/providers/azurerm/import_arm_route_table_test.go
+++ b/builtin/providers/azurerm/import_arm_route_table_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMRouteTable_importBasic(t *testing.T) {
+	resourceName := "azurerm_route_table.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMRouteTable_basic, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_route_test.go
+++ b/builtin/providers/azurerm/import_arm_route_test.go
@@ -1,0 +1,33 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMRoute_importBasic(t *testing.T) {
+	resourceName := "azurerm_route.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMRoute_basic, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMRouteDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_route.go
+++ b/builtin/providers/azurerm/resource_arm_route.go
@@ -3,6 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -14,6 +15,9 @@ func resourceArmRoute() *schema.Resource {
 		Read:   resourceArmRouteRead,
 		Update: resourceArmRouteCreate,
 		Delete: resourceArmRouteDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -43,6 +47,9 @@ func resourceArmRoute() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validateRouteTableNextHopType,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.ToLower(old) == strings.ToLower(new)
+				},
 			},
 
 			"next_hop_in_ip_address": {
@@ -118,6 +125,16 @@ func resourceArmRouteRead(d *schema.ResourceData, meta interface{}) error {
 			return nil
 		}
 		return fmt.Errorf("Error making Read request on Azure Route %s: %s", routeName, err)
+	}
+
+	d.Set("name", routeName)
+	d.Set("resource_group_name", resGroup)
+	d.Set("route_table_name", rtName)
+	d.Set("address_prefix", resp.Properties.AddressPrefix)
+	d.Set("next_hop_type", string(resp.Properties.NextHopType))
+
+	if resp.Properties.NextHopIPAddress != nil {
+		d.Set("next_hop_in_ip_address", resp.Properties.NextHopIPAddress)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_route_table_test.go
+++ b/builtin/providers/azurerm/resource_arm_route_table_test.go
@@ -262,8 +262,8 @@ resource "azurerm_route_table" "test" {
 
     route {
     	name = "route1"
-    	address_prefix = "*"
-    	next_hop_type = "internet"
+		address_prefix = "10.1.0.0/16"
+		next_hop_type = "vnetlocal"
     }
 }
 `
@@ -281,14 +281,14 @@ resource "azurerm_route_table" "test" {
 
     route {
     	name = "route1"
-    	address_prefix = "*"
-    	next_hop_type = "internet"
+		address_prefix = "10.1.0.0/16"
+		next_hop_type = "vnetlocal"
     }
 
     route {
     	name = "route2"
-    	address_prefix = "*"
-    	next_hop_type = "virtualappliance"
+		address_prefix = "10.2.0.0/16"
+		next_hop_type = "vnetlocal"
     }
 }
 `
@@ -306,8 +306,8 @@ resource "azurerm_route_table" "test" {
 
     route {
     	name = "route1"
-    	address_prefix = "*"
-    	next_hop_type = "internet"
+    	address_prefix = "10.1.0.0/16"
+    	next_hop_type = "vnetlocal"
     }
 
     tags {
@@ -330,8 +330,8 @@ resource "azurerm_route_table" "test" {
 
     route {
     	name = "route1"
-    	address_prefix = "*"
-    	next_hop_type = "internet"
+    	address_prefix = "10.1.0.0/16"
+    	next_hop_type = "vnetlocal"
     }
 
     tags {

--- a/website/source/docs/providers/azurerm/r/route.html.markdown
+++ b/website/source/docs/providers/azurerm/r/route.html.markdown
@@ -59,3 +59,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Route ID.
+
+## Import
+
+
+Routes can be imported using the `resource id`, e.g. 
+```
+terraform import azurerm_route.testRoute /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/routeTables/mytable1/routes/myroute1
+```

--- a/website/source/docs/providers/azurerm/r/route_table.html.markdown
+++ b/website/source/docs/providers/azurerm/r/route_table.html.markdown
@@ -25,8 +25,8 @@ resource "azurerm_route_table" "test" {
 
     route {
     	name = "route1"
-    	address_prefix = "*"
-    	next_hop_type = "internet"
+        address_prefix = "10.1.0.0/16"
+        next_hop_type = "vnetlocal"
     }
     
     tags {

--- a/website/source/docs/providers/azurerm/r/route_table.html.markdown
+++ b/website/source/docs/providers/azurerm/r/route_table.html.markdown
@@ -69,3 +69,11 @@ The following attributes are exported:
 
 * `id` - The Route Table ID.
 * `subnets` - The collection of Subnets associated with this route table.
+
+## Import
+
+
+Route Tables can be imported using the `resource id`, e.g. 
+```
+terraform import azurerm_route_table.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/routeTables/mytable1
+```


### PR DESCRIPTION
Added import functionality to:

* `azurerm_route`
* `azurerm_route_table`

Fix `azurerm_route_table` failing to actually set any routes declared within.