### PR TITLE
provider/aws: Instance start / stop functionality (issues #1579, #7262)

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -634,9 +634,8 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("instance_state") {
-		log.Printf("[INFO] Requested State %s", d.Get("instance_state"))
 		if d.Get("instance_state") == "stopped" {
-			log.Printf("[INFO] Updating instance state to %s for Instance %s", "stopped", d.Id())
+			log.Printf("[INFO] Updating instance state to '%s' for Instance %s", "stopped", d.Id())
 
 			_, err := conn.StopInstances(&ec2.StopInstancesInput{
 				InstanceIds: []*string{aws.String(d.Id())},
@@ -664,7 +663,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 			}
 
 		} else if d.Get("instance_state") == "running" {
-			log.Printf("[INFO] Updating instance state to %s for Instance %s", "running", d.Id())
+			log.Printf("[INFO] Updating instance state to '%s' for Instance %s", "running", d.Id())
 
 			_, err := conn.StartInstances(&ec2.StartInstancesInput{
 				InstanceIds:    []*string{aws.String(d.Id())},
@@ -691,6 +690,8 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 					"Error waiting for instance (%s) to start: %s", d.Id(), err)
 			}
 
+		} else if d.Get("instance_state") != nil {
+			return fmt.Errorf("Invalid instance_state specified. Use 'running' or 'stopped'.")
 		}
 
 	}

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -693,8 +693,8 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		} else if d.Get("instance_state") != nil {
 			return fmt.Errorf("Invalid instance_state specified. Use 'running' or 'stopped'.")
 		}
-
 	}
+
 	if d.HasChange("vpc_security_group_ids") {
 		var groups []*string
 		if v := d.Get("vpc_security_group_ids").(*schema.Set); v.Len() > 0 {

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -58,6 +58,7 @@ The following arguments are supported:
 instance. Amazon defaults this to `stop` for EBS-backed instances and 
 `terminate` for instance-store instances. Cannot be set on instance-store 
 instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
+* `instance_state` - (Optional) State of the instance can be specified either as `running` or `stopped`.
 * `instance_type` - (Required) The type of instance to start
 * `key_name` - (Optional) The key name to use for the instance.
 * `monitoring` - (Optional) If true, the launched EC2 instance will have detailed monitoring enabled. (Available since v0.6.0)


### PR DESCRIPTION
This adds functionality to specify instance_state under resource definitions. State can either be running or stopped.

```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/05 18:10:27 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_instanceState -timeout 120m
=== RUN   TestAccAWSInstance_instanceState
--- PASS: TestAccAWSInstance_instanceState (211.45s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	211.457s
```
