### PR TITLE
Adding OneView Provider to Terraform

### DIFF
--- a/builtin/providers/oneview/config.go
+++ b/builtin/providers/oneview/config.go
@@ -1,0 +1,85 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"github.com/HewlettPackard/oneview-golang/i3s"
+	"github.com/HewlettPackard/oneview-golang/icsp"
+	"github.com/HewlettPackard/oneview-golang/ov"
+)
+
+type Config struct {
+	OVDomain     string
+	OVUsername   string
+	OVPassword   string
+	OVEndpoint   string
+	OVSSLVerify  bool
+	OVAPIVersion int
+
+	ICSPDomain     string
+	ICSPUsername   string
+	ICSPPassword   string
+	ICSPEndpoint   string
+	ICSPSSLVerify  bool
+	ICSPAPIVersion int
+
+	I3SEndpoint string
+
+	ovClient   *ov.OVClient
+	icspClient *icsp.ICSPClient
+	i3sClient  *i3s.I3SClient
+}
+
+func (c *Config) loadAndValidate() error {
+	var client2 *ov.OVClient
+
+	client := client2.NewOVClient(c.OVUsername, c.OVPassword, c.OVDomain, c.OVEndpoint, c.OVSSLVerify, c.OVAPIVersion)
+
+	c.ovClient = client
+
+	session, error := c.ovClient.SessionLogin()
+	c.ovClient.APIKey = session.ID
+
+	if error != nil {
+		return error
+	}
+
+	return nil
+}
+
+func (c *Config) loadAndValidateICSP() error {
+
+	var client2 *icsp.ICSPClient
+
+	client := client2.NewICSPClient(c.ICSPUsername, c.ICSPPassword, c.ICSPDomain, c.ICSPEndpoint, c.ICSPSSLVerify, c.ICSPAPIVersion)
+
+	c.icspClient = client
+
+	session, error := c.icspClient.SessionLogin()
+	session = session
+	if error != nil {
+		return error
+	}
+
+	return nil
+}
+
+func (c *Config) loadAndValidateI3S() error {
+
+	var client3 *i3s.I3SClient
+
+	client := client3.NewI3SClient(c.I3SEndpoint, c.OVSSLVerify, c.OVAPIVersion, c.ovClient.APIKey)
+
+	c.i3sClient = client
+
+	return nil
+}

--- a/builtin/providers/oneview/provider.go
+++ b/builtin/providers/oneview/provider.go
@@ -1,0 +1,143 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"github.com/hashicorp/terraform/helper/mutexkv"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var ovMutexKV = mutexkv.NewMutexKV()
+var serverHardwareURIs map[string]bool = make(map[string]bool)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"ov_domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_OV_DOMAIN", ""),
+			},
+			"ov_username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_OV_USER", ""),
+			},
+			"ov_password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_OV_PASSWORD", nil),
+			},
+			"ov_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_OV_ENDPOINT", nil),
+			},
+			"ov_sslverify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_OV_SSLVERIFY", true),
+			},
+			"ov_apiversion": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_OV_API_VERSION", 200),
+			},
+			"icsp_domain": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_ICSP_DOMAIN", ""),
+			},
+			"icsp_username": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_ICSP_USER", ""),
+			},
+			"icsp_password": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_ICSP_PASSWORD", ""),
+			},
+			"icsp_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_ICSP_ENDPOINT", ""),
+			},
+			"icsp_sslverify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_ICSP_SSLVERIFY", true),
+			},
+			"icsp_apiversion": {
+				Type:        schema.TypeInt,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_ICSP_API_VERSION", 200),
+			},
+			"i3s_endpoint": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("ONEVIEW_I3S_ENDPOINT", ""),
+			},
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"oneview_server_profile":             resourceServerProfile(),
+			"oneview_ethernet_network":           resourceEthernetNetwork(),
+			"oneview_network_set":                resourceNetworkSet(),
+			"oneview_fcoe_network":               resourceFCoENetwork(),
+			"oneview_fc_network":                 resourceFCNetwork(),
+			"oneview_server_profile_template":    resourceServerProfileTemplate(),
+			"oneview_logical_interconnect_group": resourceLogicalInterconnectGroup(),
+			"oneview_logical_switch_group":       resourceLogicalSwitchGroup(),
+			"oneview_icsp_server":                resourceIcspServer(),
+			"oneview_i3s_plan":                   resourceI3SPlan(),
+		},
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := Config{
+		OVDomain:     d.Get("ov_domain").(string),
+		OVUsername:   d.Get("ov_username").(string),
+		OVPassword:   d.Get("ov_password").(string),
+		OVEndpoint:   d.Get("ov_endpoint").(string),
+		OVSSLVerify:  d.Get("ov_sslverify").(bool),
+		OVAPIVersion: d.Get("ov_apiversion").(int),
+	}
+
+	if err := config.loadAndValidate(); err != nil {
+		return nil, err
+	}
+
+	if _, ok := d.GetOk("icsp_endpoint"); ok {
+		config.ICSPDomain = d.Get("icsp_domain").(string)
+		config.ICSPUsername = d.Get("icsp_username").(string)
+		config.ICSPPassword = d.Get("icsp_password").(string)
+		config.ICSPEndpoint = d.Get("icsp_endpoint").(string)
+		config.ICSPSSLVerify = d.Get("icsp_sslverify").(bool)
+		config.ICSPAPIVersion = d.Get("icsp_apiversion").(int)
+
+		if err := config.loadAndValidateICSP(); err != nil {
+			return nil, err
+		}
+	}
+
+	if val, ok := d.GetOk("i3s_endpoint"); ok {
+		config.I3SEndpoint = val.(string)
+		if err := config.loadAndValidateI3S(); err != nil {
+			return nil, err
+		}
+	}
+
+	return &config, nil
+}

--- a/builtin/providers/oneview/provider_test.go
+++ b/builtin/providers/oneview/provider_test.go
@@ -1,0 +1,71 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"oneview": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	v := os.Getenv("ONEVIEW_OV_ENDPOINT")
+	if v == "" {
+		t.Fatal("ONEVIEW_OV_ENDPOINT must be set for acceptance tests")
+	}
+
+	v = os.Getenv("ONEVIEW_OV_USER")
+	if v == "" {
+		t.Fatal("ONEVIEW_OV_USER must be set for acceptance test")
+	}
+
+	v = os.Getenv("ONEVIEW_OV_PASSWORD")
+	if v == "" {
+		t.Fatal("ONEVIEW_OV_PASSWORD must be set for acceptance test")
+	}
+
+	v = os.Getenv("ONEVIEW_SSLVERIFY")
+	if v == "" {
+		t.Fatal("ONEVIEW_OV_SSLVERIFY must be set for acceptance test")
+	}
+
+}
+
+func testProviderConfig() (*Config, error) {
+	config := testAccProvider.Meta().(*Config)
+	if config == nil {
+		return nil, fmt.Errorf("Unable to obtain provider config\n")
+	}
+	return config, nil
+}

--- a/builtin/providers/oneview/resource_ethernet_network.go
+++ b/builtin/providers/oneview/resource_ethernet_network.go
@@ -1,0 +1,188 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceEthernetNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceEthernetNetworkCreate,
+		Read:   resourceEthernetNetworkRead,
+		Update: resourceEthernetNetworkUpdate,
+		Delete: resourceEthernetNetworkDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vlanId": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"purpose": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "General",
+			},
+			"private_network": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"smart_link": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"ethernet_network_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Tagged",
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ethernet-networkV3",
+			},
+			"connection_template_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"fabric_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eTag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceEthernetNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	eNet := ov.EthernetNetwork{
+		Name:                d.Get("name").(string),
+		VlanId:              d.Get("vlanId").(int),
+		Purpose:             d.Get("purpose").(string),
+		SmartLink:           d.Get("smart_link").(bool),
+		PrivateNetwork:      d.Get("private_network").(bool),
+		EthernetNetworkType: d.Get("ethernet_network_type").(string),
+		Type:                d.Get("type").(string),
+		Description:         utils.NewNstring(d.Get("description").(string)),
+	}
+
+	eNetError := config.ovClient.CreateEthernetNetwork(eNet)
+	d.SetId(d.Get("name").(string))
+	if eNetError != nil {
+		d.SetId("")
+		return eNetError
+	}
+	return resourceEthernetNetworkRead(d, meta)
+}
+
+func resourceEthernetNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	eNet, err := config.ovClient.GetEthernetNetworkByName(d.Id())
+	if err != nil || eNet.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+	d.Set("name", eNet.Name)
+	d.Set("vlanId", eNet.VlanId)
+	d.Set("purpose", eNet.Purpose)
+	d.Set("smart_link", eNet.SmartLink)
+	d.Set("private_network", eNet.PrivateNetwork)
+	d.Set("ethernet_network_type", eNet.EthernetNetworkType)
+	d.Set("type", eNet.Type)
+	d.Set("created", eNet.Created)
+	d.Set("modified", eNet.Modified)
+	d.Set("uri", eNet.URI.String())
+	d.Set("connection_template_uri", eNet.ConnectionTemplateUri.String())
+	d.Set("status", eNet.Status)
+	d.Set("category", eNet.Category)
+	d.Set("state", eNet.State)
+	d.Set("fabric_uri", eNet.FabricUri.String())
+	d.Set("eTag", eNet.ETAG)
+	return nil
+}
+
+func resourceEthernetNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	newENet := ov.EthernetNetwork{
+		ETAG:                  d.Get("eTag").(string),
+		URI:                   utils.NewNstring(d.Get("uri").(string)),
+		VlanId:                d.Get("vlanId").(int),
+		Purpose:               d.Get("purpose").(string),
+		Name:                  d.Get("name").(string),
+		PrivateNetwork:        d.Get("private_network").(bool),
+		SmartLink:             d.Get("smart_link").(bool),
+		ConnectionTemplateUri: utils.NewNstring(d.Get("connection_template_uri").(string)),
+		Type: d.Get("type").(string),
+	}
+
+	err := config.ovClient.UpdateEthernetNetwork(newENet)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("name").(string))
+
+	return resourceEthernetNetworkRead(d, meta)
+}
+
+func resourceEthernetNetworkDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteEthernetNetwork(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}

--- a/builtin/providers/oneview/resource_ethernet_network_test.go
+++ b/builtin/providers/oneview/resource_ethernet_network_test.go
@@ -1,0 +1,94 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccEthernetNetwork_1(t *testing.T) {
+	var ethernetNetwork ov.EthernetNetwork
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEthernetNetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccEthernetNetwork,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEthernetNetworkExists(
+						"oneview_ethernet_network.test", &ethernetNetwork),
+					resource.TestCheckResourceAttr(
+						"oneview_ethernet_network.test", "name", "Terraform Ethernet Network 1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckEthernetNetworkExists(n string, ethernetNetwork *ov.EthernetNetwork) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testEthernetNetwork, err := config.ovClient.GetEthernetNetworkByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testEthernetNetwork.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*ethernetNetwork = testEthernetNetwork
+		return nil
+	}
+}
+
+func testAccCheckEthernetNetworkDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_ethernet_network" {
+			continue
+		}
+
+		testNet, _ := config.ovClient.GetEthernetNetworkByName(rs.Primary.ID)
+
+		if testNet.Name != "" {
+			return fmt.Errorf("EthernetNetwork still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccEthernetNetwork = `
+  resource "oneview_ethernet_network" "test" {
+    name = "Terraform Ethernet Network 1"
+    vlanId = "${117}"
+  }`

--- a/builtin/providers/oneview/resource_fc_network.go
+++ b/builtin/providers/oneview/resource_fc_network.go
@@ -1,0 +1,172 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceFCNetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceFCNetworkCreate,
+		Read:   resourceFCNetworkRead,
+		Update: resourceFCNetworkUpdate,
+		Delete: resourceFCNetworkDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"fabric_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "FabricAttach",
+			},
+			"link_stability_time": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  30,
+			},
+			"auto_login_redistribution": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"connection_template_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "fc-networkV2",
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eTag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceFCNetworkCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	fcNet := ov.FCNetwork{
+		Name:                    d.Get("name").(string),
+		FabricType:              d.Get("fabric_type").(string),
+		LinkStabilityTime:       d.Get("link_stability_time").(int),
+		AutoLoginRedistribution: d.Get("auto_login_redistribution").(bool),
+		Type:        d.Get("type").(string),
+		Description: d.Get("description").(string),
+	}
+
+	fcNetError := config.ovClient.CreateFCNetwork(fcNet)
+	d.SetId(d.Get("name").(string))
+	if fcNetError != nil {
+		d.SetId("")
+		return fcNetError
+	}
+	return resourceFCNetworkRead(d, meta)
+}
+
+func resourceFCNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	fcNet, error := config.ovClient.GetFCNetworkByName(d.Get("name").(string))
+	if error != nil || fcNet.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+	d.Set("name", fcNet.Name)
+	d.Set("fabric_type", fcNet.FabricType)
+	d.Set("link_stability_time", fcNet.LinkStabilityTime)
+	d.Set("auto_login_redistribution", fcNet.AutoLoginRedistribution)
+	d.Set("description", fcNet.Description)
+	d.Set("type", fcNet.Type)
+	d.Set("uri", fcNet.URI.String())
+	d.Set("connection_template_uri", fcNet.ConnectionTemplateUri.String())
+	d.Set("status", fcNet.Status)
+	d.Set("category", fcNet.Category)
+	d.Set("state", fcNet.State)
+	d.Set("fabric_uri", fcNet.FabricUri.String())
+	d.Set("created", fcNet.Created)
+	d.Set("modified", fcNet.Modified)
+	d.Set("eTag", fcNet.ETAG)
+	return nil
+}
+
+func resourceFCNetworkUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	fcNet := ov.FCNetwork{
+		ETAG:                    d.Get("eTag").(string),
+		URI:                     utils.NewNstring(d.Get("uri").(string)),
+		Name:                    d.Get("name").(string),
+		FabricType:              d.Get("fabric_type").(string),
+		LinkStabilityTime:       d.Get("link_stability_time").(int),
+		AutoLoginRedistribution: d.Get("auto_login_redistribution").(bool),
+		Type: d.Get("type").(string),
+		ConnectionTemplateUri: utils.NewNstring(d.Get("connection_template_uri").(string)),
+		Description:           d.Get("description").(string),
+	}
+
+	err := config.ovClient.UpdateFcNetwork(fcNet)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("name").(string))
+
+	return resourceFCNetworkRead(d, meta)
+}
+
+func resourceFCNetworkDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteFCNetwork(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}

--- a/builtin/providers/oneview/resource_fc_network_test.go
+++ b/builtin/providers/oneview/resource_fc_network_test.go
@@ -1,0 +1,93 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccFCNetwork_1(t *testing.T) {
+	var fcNetwork ov.FCNetwork
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFCNetworkDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccFCNetwork,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFCNetworkExists(
+						"oneview_fc_network.test", &fcNetwork),
+					resource.TestCheckResourceAttr(
+						"oneview_fc_network.test", "name", "Terraform FC Network 1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFCNetworkExists(n string, fcNetwork *ov.FCNetwork) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testFCNetwork, err := config.ovClient.GetFCNetworkByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testFCNetwork.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*fcNetwork = testFCNetwork
+		return nil
+	}
+}
+
+func testAccCheckFCNetworkDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_fc_network" {
+			continue
+		}
+
+		testFCNet, _ := config.ovClient.GetFCNetworkByName(rs.Primary.ID)
+
+		if testFCNet.Name != "" {
+			return fmt.Errorf("FCNetwork still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccFCNetwork = `resource "oneview_fc_network" "test" {
+  count = 1
+  name = "Terraform FC Network 1"
+}`

--- a/builtin/providers/oneview/resource_fcoe_network.go
+++ b/builtin/providers/oneview/resource_fcoe_network.go
@@ -1,0 +1,160 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceFCoENetwork() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceFCoENetworkCreate,
+		Read:   resourceFCoENetworkRead,
+		Update: resourceFCoENetworkUpdate,
+		Delete: resourceFCoENetworkDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"vlanId": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"connectionTemplateUri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "fcoe-network",
+			},
+			"managedSanUri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"fabricUri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"state": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eTag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceFCoENetworkCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	fcoeNet := ov.FCoENetwork{
+		Name:   d.Get("name").(string),
+		VlanId: d.Get("vlanId").(int),
+		Type:   d.Get("type").(string),
+	}
+
+	fcoeNetError := config.ovClient.CreateFCoENetwork(fcoeNet)
+	d.SetId(d.Get("name").(string))
+	if fcoeNetError != nil {
+		d.SetId("")
+		return fcoeNetError
+	}
+	return resourceFCoENetworkRead(d, meta)
+}
+
+func resourceFCoENetworkRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	fcoeNet, fcoeNetError := config.ovClient.GetFCoENetworkByName(d.Get("name").(string))
+	if fcoeNetError != nil || fcoeNet.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+	d.Set("created", fcoeNet.Created)
+	d.Set("modified", fcoeNet.Modified)
+	d.Set("uri", fcoeNet.URI.String())
+	d.Set("connectionTemplateUri", fcoeNet.ConnectionTemplateUri.String())
+	d.Set("status", fcoeNet.Status)
+	d.Set("category", fcoeNet.Category)
+	d.Set("state", fcoeNet.State)
+	d.Set("fabric_uri", fcoeNet.FabricUri.String())
+	d.Set("eTag", fcoeNet.ETAG)
+	d.Set("managedSanUri", fcoeNet.ManagedSanUri)
+	d.Set("description", fcoeNet.Description)
+
+	return nil
+}
+
+func resourceFCoENetworkUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	newFCoENet := ov.FCoENetwork{
+		ETAG:   d.Get("eTag").(string),
+		URI:    utils.NewNstring(d.Get("uri").(string)),
+		VlanId: d.Get("vlanId").(int),
+		Name:   d.Get("name").(string),
+		ConnectionTemplateUri: utils.NewNstring(d.Get("connectionTemplateUri").(string)),
+		Type: d.Get("type").(string),
+	}
+
+	err := config.ovClient.UpdateFCoENetwork(newFCoENet)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("name").(string))
+
+	return resourceFCoENetworkRead(d, meta)
+}
+
+func resourceFCoENetworkDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteFCoENetwork(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}

--- a/builtin/providers/oneview/resource_fcoe_network_test.go
+++ b/builtin/providers/oneview/resource_fcoe_network_test.go
@@ -1,0 +1,94 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccFCoENetwork_1(t *testing.T) {
+	var fcoeNetwork ov.FCoENetwork
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckFCoENetworkDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccFCoENetwork,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckFCoENetworkExists(
+						"oneview_fcoe_network.test", &fcoeNetwork),
+					resource.TestCheckResourceAttr(
+						"oneview_fcoe_network.test", "name", "Terraform FCoE Network 1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckFCoENetworkExists(n string, fcoeNetwork *ov.FCoENetwork) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testFCoENetwork, err := config.ovClient.GetFCoENetworkByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testFCoENetwork.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*fcoeNetwork = testFCoENetwork
+		return nil
+	}
+}
+
+func testAccCheckFCoENetworkDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_fcoe_network" {
+			continue
+		}
+
+		testFCoENet, _ := config.ovClient.GetFCoENetworkByName(rs.Primary.ID)
+
+		if testFCoENet.Name != "" {
+			return fmt.Errorf("FCoENetwork still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccFCoENetwork = `
+  resource "oneview_fcoe_network" "test" {
+    name = "Terraform FCoE Network 1"
+    vlanId = 157
+  }`

--- a/builtin/providers/oneview/resource_i3s_plan.go
+++ b/builtin/providers/oneview/resource_i3s_plan.go
@@ -1,0 +1,161 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceI3SPlan() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceI3SPlanCreate,
+		Read:   resourceI3SPlanRead,
+		Update: resourceI3SPlanUpdate,
+		Delete: resourceI3SPlanDelete,
+
+		Schema: map[string]*schema.Schema{
+			"server_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"os_deployment_plan": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"deployment_attribute": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"key": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceI3SPlanCreate(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	customizeServer := ov.CustomizeServer{
+		ProfileName:           d.Get("server_name").(string),
+		OSDeploymentBuildPlan: d.Get("os_deployment_plan").(string),
+	}
+
+	if _, ok := d.GetOk("deployment_attribute"); ok {
+		deploymentAttributeCount := d.Get("deployment_attribute.#").(int)
+		deploymentAttributes := make(map[string]string)
+		for i := 0; i < deploymentAttributeCount; i++ {
+			deploymentAttributePrefix := fmt.Sprintf("deployment_attribute.%d", i)
+			deploymentAttributes[d.Get(deploymentAttributePrefix+".key").(string)] = d.Get(deploymentAttributePrefix + ".value").(string)
+		}
+		customizeServer.OSDeploymentAttributes = deploymentAttributes
+	}
+
+	d.SetId(d.Get("server_name").(string))
+	err := config.ovClient.CustomizeServer(customizeServer)
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+
+	return resourceI3SPlanRead(d, meta)
+}
+
+func resourceI3SPlanRead(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	serverProfile, err := config.ovClient.GetProfileByName(d.Id())
+	if err != nil || serverProfile.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+	d.Set("server_name", serverProfile.Name)
+
+	osDeploymentPlan, err := config.ovClient.GetOSDeploymentPlan(serverProfile.OSDeploymentSettings.OSDeploymentPlanUri)
+	if err != nil || osDeploymentPlan.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+	d.Set("os_deployment_plan", osDeploymentPlan.Name)
+
+	/*
+	   if _, ok := d.GetOk("deployment_attribute"); ok {
+	       deploymentAttributeCount := d.Get("deployment_attribute.#").(int)
+	       deploymentAttributes := make([]interface{}, deploymentAttributeCount)
+	       for i := 0; i < deploymentAttributeCount; i++ {
+	           deploymentAttributePrefix := fmt.Sprintf("deployment_attribute.%d", i)
+	           for j := 0; j < len(serverProfile.OSDeploymentSettings.OSCustomAttributes); j++{
+	               if d.Get(deploymentAttributePrefix + ".key").(string) == serverProfile.OSDeploymentSettings.Name{
+	                   d.Set
+	               }
+	           }
+	       }
+	   }*/
+
+	return nil
+}
+
+func resourceI3SPlanUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteOSBuildPlanFromServer(d.Get("server_name").(string))
+	if error != nil {
+		return error
+	}
+
+	customizeServer := ov.CustomizeServer{
+		ProfileName:           d.Get("server_name").(string),
+		OSDeploymentBuildPlan: d.Get("os_deployment_plan").(string),
+	}
+
+	if _, ok := d.GetOk("deployment_attribute"); ok {
+		deploymentAttributeCount := d.Get("deployment_attribute.#").(int)
+		deploymentAttributes := make(map[string]string)
+		for i := 0; i < deploymentAttributeCount; i++ {
+			deploymentAttributePrefix := fmt.Sprintf("deployment_attribute.%d", i)
+			deploymentAttributes[d.Get(deploymentAttributePrefix+".key").(string)] = d.Get(deploymentAttributePrefix + ".value").(string)
+		}
+		customizeServer.OSDeploymentAttributes = deploymentAttributes
+	}
+
+	d.SetId(d.Get("server_name").(string))
+	err := config.ovClient.CustomizeServer(customizeServer)
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+
+	return resourceI3SPlanRead(d, meta)
+}
+
+func resourceI3SPlanDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteOSBuildPlanFromServer(d.Get("server_name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}

--- a/builtin/providers/oneview/resource_i3s_plan_test.go
+++ b/builtin/providers/oneview/resource_i3s_plan_test.go
@@ -1,0 +1,104 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccI3SPlan_1(t *testing.T) {
+	var server ov.ServerProfile
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckI3SPlanDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccI3SPlan,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckI3SPlanExists(
+						"oneview_i3s_plan.test", &server),
+					resource.TestCheckResourceAttr(
+						"oneview_i3s_plan.test", "name", "Terraform Server 1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckI3SPlanExists(n string, server *ov.ServerProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testServer, err := config.ovClient.GetProfileByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testServer.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*server = testServer
+		return nil
+	}
+}
+
+func testAccCheckI3SPlanDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_i3s_plan" {
+			continue
+		}
+
+		testServer, _ := config.ovClient.GetProfileByName(rs.Primary.ID)
+
+		if !testServer.OSDeploymentSettings.OSDeploymentPlanUri.IsNil() {
+			return fmt.Errorf("Deployment Plan still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccI3SPlan = `resource "oneview_server_profile" "test" {
+     count           = 1
+     name            = "terraform-test-${count.index}"
+     template = "Matthew-No-I3S"
+     hardware_name        = "Frame 0, bay 7"
+     type = "ServerProfileV6"
+   }
+
+   resource "oneview_i3s_plan" "test" {
+     count = 1
+     server_name = "${oneview_server_profile.test.name}"
+     os_deployment_plan = "dennis_dp_empty_volume"
+   }
+
+  `

--- a/builtin/providers/oneview/resource_icsp_server.go
+++ b/builtin/providers/oneview/resource_icsp_server.go
@@ -1,0 +1,248 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/icsp"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceIcspServer() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceIcspServerCreate,
+		Read:   resourceIcspServerRead,
+		Update: resourceIcspServerUpdate,
+		Delete: resourceIcspServerDelete,
+
+		Schema: map[string]*schema.Schema{
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"ilo_ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"port": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  443,
+			},
+			"user_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"password": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mid": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"serial_number": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"build_plans": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"public_mac": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_slot_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"host_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"custom_attribute": &schema.Schema{
+				Optional: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"scope": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "server",
+						},
+						"key": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"public_ipv4": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceIcspServerCreate(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	csa := icsp.CustomServerAttributes{}
+	initCsa := csa.New()
+
+	customizeServer := icsp.CustomizeServer{
+		SerialNumber:     d.Get("serial_number").(string),
+		ILoUser:          d.Get("user_name").(string),
+		IloIPAddress:     d.Get("ilo_ip").(string),
+		IloPort:          d.Get("port").(int),
+		IloPassword:      d.Get("password").(string),
+		ServerProperties: initCsa,
+	}
+
+	if _, ok := d.GetOk("build_plans"); ok {
+		rawBuildPlans := d.Get("build_plans").([]interface{})
+		buildPlans := make([]string, len(rawBuildPlans))
+		for i, raw := range rawBuildPlans {
+			buildPlans[i] = raw.(string)
+		}
+		customizeServer.OSBuildPlans = buildPlans
+	}
+
+	if _, ok := d.GetOk("custom_attribute"); ok {
+		customAttributeCount := d.Get("custom_attribute.#").(int)
+		for i := 0; i < customAttributeCount; i++ {
+			customAttributePrefix := fmt.Sprintf("custom_attribute.%d", i)
+			initCsa.Set(d.Get(customAttributePrefix+".key").(string), d.Get(customAttributePrefix+".value").(string))
+		}
+
+	}
+
+	if val, ok := d.GetOk("host_name"); ok {
+		customizeServer.HostName = val.(string)
+	}
+
+	if val, ok := d.GetOk("public_slot_id"); ok {
+		customizeServer.PublicSlotID = val.(int)
+	}
+
+	if val, ok := d.GetOk("public_mac"); ok {
+		customizeServer.PublicMAC = val.(string)
+	}
+
+	err := config.icspClient.CustomizeServer(customizeServer)
+	d.SetId(d.Get("ilo_ip").(string))
+	if err != nil {
+		return err
+	}
+
+	return resourceIcspServerRead(d, meta)
+
+}
+
+func resourceIcspServerRead(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	server, err := config.icspClient.GetServerByIP(d.Id())
+	if err != nil {
+		d.SetId("")
+		return err
+	}
+
+	d.Set("ilo_ip", server.ILO.IPAddress)
+	d.Set("mid", server.MID)
+	d.Set("host_name", server.HostName)
+
+	if publicMac, ok := d.GetOk("public_mac"); ok {
+		for _, network := range server.Interfaces {
+			if network.MACAddr == publicMac.(string) {
+				d.Set("public_ipv4", network.IPV4Addr)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceIcspServerUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	csa := icsp.CustomServerAttributes{}
+	initCsa := csa.New()
+
+	customizeServer := icsp.CustomizeServer{
+		SerialNumber:     d.Get("serial_number").(string),
+		ILoUser:          d.Get("user_name").(string),
+		IloIPAddress:     d.Get("ilo_ip").(string),
+		IloPort:          d.Get("port").(int),
+		IloPassword:      d.Get("password").(string),
+		ServerProperties: initCsa,
+	}
+
+	if _, ok := d.GetOk("build_plans"); ok {
+		rawBuildPlans := d.Get("build_plans").([]interface{})
+		buildPlans := make([]string, len(rawBuildPlans))
+		for i, raw := range rawBuildPlans {
+			buildPlans[i] = raw.(string)
+		}
+		customizeServer.OSBuildPlans = buildPlans
+	}
+
+	if _, ok := d.GetOk("custom_attribute"); ok {
+		customAttributeCount := d.Get("custom_attribute.#").(int)
+		for i := 0; i < customAttributeCount; i++ {
+			customAttributePrefix := fmt.Sprintf("custom_attribute.%d", i)
+			initCsa.Set(d.Get(customAttributePrefix+".key").(string), d.Get(customAttributePrefix+".value").(string))
+		}
+
+	}
+
+	if val, ok := d.GetOk("host_name"); ok {
+		customizeServer.HostName = val.(string)
+	}
+
+	if val, ok := d.GetOk("public_slot_id"); ok {
+		customizeServer.PublicSlotID = val.(int)
+	}
+
+	if val, ok := d.GetOk("public_mac"); ok {
+		customizeServer.PublicMAC = val.(string)
+	}
+
+	err := config.icspClient.CustomizeServer(customizeServer)
+	d.SetId(d.Get("ilo_ip").(string))
+	if err != nil {
+		return err
+	}
+
+	return resourceIcspServerRead(d, meta)
+}
+
+func resourceIcspServerDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	isDel, error := config.icspClient.DeleteServer(d.Get("mid").(string))
+	if error != nil {
+		return error
+	}
+	if !isDel {
+		return fmt.Errorf("Could not delete server")
+	}
+	return nil
+}

--- a/builtin/providers/oneview/resource_icsp_server_test.go
+++ b/builtin/providers/oneview/resource_icsp_server_test.go
@@ -1,0 +1,99 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/icsp"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccICSP_Server_1(t *testing.T) {
+	var icspServer icsp.Server
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckICSPServerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccICSPServer,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckICSPServerExists(
+						"oneview_icsp_server.test", &icspServer)),
+			},
+		},
+	})
+}
+
+func testAccCheckICSPServerExists(n string, icspServer *icsp.Server) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testICSPServer, err := config.icspClient.GetServerByIP(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testICSPServer.ILO.IPAddress != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*icspServer = testICSPServer
+		return nil
+	}
+}
+
+func testAccCheckICSPServerDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_icsp_server" {
+			continue
+		}
+
+		testICSPServer, _ := config.icspClient.GetServerByIP(rs.Primary.ID)
+
+		if testICSPServer.Name != "" {
+			return fmt.Errorf("ICSP server still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccICSPServer = `resource "oneview_server_profile" "test" {
+     count           = 1
+     name            = "terraform-test-${count.index}"
+     template = "UCP Template iSCSI"
+   }
+
+   resource "oneview_icsp_server" "test" {
+     count = 1
+     ilo_ip = "${element(oneview_server_profile.test.*.ilo_ip, count.index)}"
+     user_name = "ICspUser"
+     password = "@utoPr0vi$ion"
+     serial_number = "${element(oneview_server_profile.test.*.serial_number, count.index)}"
+   }
+  `

--- a/builtin/providers/oneview/resource_logical_interconnect_group.go
+++ b/builtin/providers/oneview/resource_logical_interconnect_group.go
@@ -1,0 +1,1442 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/hashicorp/terraform/helper/schema"
+	"reflect"
+	"strconv"
+)
+
+func resourceLogicalInterconnectGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLogicalInterconnectGroupCreate,
+		Read:   resourceLogicalInterconnectGroupRead,
+		Update: resourceLogicalInterconnectGroupUpdate,
+		Delete: resourceLogicalInterconnectGroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "logical-interconnect-groupV3",
+			},
+			"interconnect_map_entry_template": {
+				Optional: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"bay_number": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"interconnect_type_name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"enclosure_index": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  1,
+						},
+					},
+				},
+			},
+			"uplink_set": {
+				Optional: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"network_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Ethernet",
+						},
+						"ethernet_network_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"logical_port_config": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"desired_speed": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "Auto",
+									},
+									"port_num": {
+										Type:     schema.TypeSet,
+										Required: true,
+										Elem:     &schema.Schema{Type: schema.TypeInt},
+										Set: func(a interface{}) int {
+											return a.(int)
+										},
+									},
+									"bay_num": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+									"enclosure_num": {
+										Type:     schema.TypeInt,
+										Optional: true,
+										Default:  1,
+									},
+									"primary_port": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+								},
+							},
+						},
+						"mode": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Auto",
+						},
+						"network_uris": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"lacp_timer": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Short",
+						},
+						"native_network_uri": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"internal_network_uris": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"telemetry_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "telemetry-configuration",
+						},
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"sample_count": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  12,
+						},
+						"sample_interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  300,
+						},
+					},
+				},
+			},
+			"snmp_configuration": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "snmp-configuration",
+						},
+						"read_community": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "public",
+						},
+						"system_contact": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"snmp_access": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+						"trap_destination": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"community_string": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"enet_trap_categories": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Set:      schema.HashString,
+									},
+									"fc_trap_categories": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Set:      schema.HashString,
+									},
+									"vcm_trap_categories": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Set:      schema.HashString,
+									},
+									"trap_destination": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"trap_format": {
+										Type:     schema.TypeString,
+										Optional: true,
+										Default:  "SNMPv1",
+									},
+									"trap_severities": {
+										Type:     schema.TypeSet,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+										Set:      schema.HashString,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"interconnect_settings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "EthernetInterconnectSettingsV3",
+						},
+						"fast_mac_cache_failover": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"igmp_snooping": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"network_loop_protection": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"pause_flood_protection": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
+						"rich_tlv": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+						"igmp_timeout_interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  260,
+						},
+						"mac_refresh_interval": {
+							Type:     schema.TypeInt,
+							Optional: true,
+							Default:  5,
+						},
+					},
+				},
+			},
+			"quality_of_service": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "qos-aggregated-configuration",
+						},
+						"active_qos_config_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "QosConfiguration",
+						},
+						"config_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Passthrough",
+						},
+						"uplink_classification_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"downlink_classification_type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"qos_traffic_class": {
+							Type:     schema.TypeList,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"enabled": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  true,
+									},
+									"egress_dot1p_value": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+									"real_time": {
+										Type:     schema.TypeBool,
+										Optional: true,
+										Default:  false,
+									},
+									"bandwidth_share": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"max_bandwidth": {
+										Type:     schema.TypeInt,
+										Required: true,
+									},
+									"qos_classification_map": {
+										Type:     schema.TypeList,
+										Required: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"dot1p_class_map": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeInt},
+													Set: func(a interface{}) int {
+														return a.(int)
+													},
+												},
+												"dscp_class_map": {
+													Type:     schema.TypeSet,
+													Optional: true,
+													Elem:     &schema.Schema{Type: schema.TypeString},
+													Set:      schema.HashString,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"fabric_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eTag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLogicalInterconnectGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	lig := ov.LogicalInterconnectGroup{
+		Name: d.Get("name").(string),
+		Type: d.Get("type").(string),
+	}
+
+	interconnectMapEntryTemplateCount := d.Get("interconnect_map_entry_template.#").(int)
+	interconnectMapEntryTemplates := make([]ov.InterconnectMapEntryTemplate, 0)
+	for i := 0; i < interconnectMapEntryTemplateCount; i++ {
+		interconnectMapEntryTemplatePrefix := fmt.Sprintf("interconnect_map_entry_template.%d", i)
+		interconnectTypeName := d.Get(interconnectMapEntryTemplatePrefix + ".interconnect_type_name").(string)
+		interconnectType, err := config.ovClient.GetInterconnectTypeByName(interconnectTypeName)
+		if err != nil {
+			return err
+		}
+		if interconnectType.URI == "" {
+			return fmt.Errorf("Could not find Interconnect Type from name: %s", interconnectTypeName)
+		}
+
+		enclosureLocation := ov.LocationEntry{
+			RelativeValue: d.Get(interconnectMapEntryTemplatePrefix + ".enclosure_index").(int),
+			Type:          "Enclosure",
+		}
+		locationEntries := make([]ov.LocationEntry, 0)
+		locationEntries = append(locationEntries, enclosureLocation)
+
+		bayLocation := ov.LocationEntry{
+			RelativeValue: d.Get(interconnectMapEntryTemplatePrefix + ".bay_number").(int),
+			Type:          "Bay",
+		}
+		locationEntries = append(locationEntries, bayLocation)
+		logicalLocation := ov.LogicalLocation{
+			LocationEntries: locationEntries,
+		}
+		interconnectMapEntryTemplates = append(interconnectMapEntryTemplates, ov.InterconnectMapEntryTemplate{
+			LogicalLocation:              logicalLocation,
+			EnclosureIndex:               d.Get(interconnectMapEntryTemplatePrefix + ".enclosure_index").(int),
+			PermittedInterconnectTypeUri: interconnectType.URI,
+		})
+	}
+	interconnectMapTemplate := ov.InterconnectMapTemplate{
+		InterconnectMapEntryTemplates: interconnectMapEntryTemplates,
+	}
+	lig.InterconnectMapTemplate = &interconnectMapTemplate
+
+	uplinkSetCount := d.Get("uplink_set.#").(int)
+	uplinkSets := make([]ov.UplinkSet, 0)
+	for i := 0; i < uplinkSetCount; i++ {
+		uplinkSetPrefix := fmt.Sprintf("uplink_set.%d", i)
+		uplinkSet := ov.UplinkSet{}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".name"); ok {
+			uplinkSet.Name = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".network_type"); ok {
+			uplinkSet.NetworkType = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".ethernet_network_type"); ok {
+			uplinkSet.EthernetNetworkType = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".mode"); ok {
+			uplinkSet.Mode = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".lacp_timer"); ok {
+			uplinkSet.LacpTimer = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".native_network_uri"); ok {
+			uplinkSet.NativeNetworkUri = utils.NewNstring(val.(string))
+		}
+
+		logicalPortCount := d.Get(uplinkSetPrefix + ".logical_port_config.#").(int)
+		logicalPorts := make([]ov.LogicalPortConfigInfo, 0)
+		for i := 0; i < logicalPortCount; i++ {
+			logicalPortPrefix := fmt.Sprintf(uplinkSetPrefix+".logical_port_config.%d", i)
+			rawPortLocations := d.Get(logicalPortPrefix + ".port_num").(*schema.Set).List()
+			for _, raw := range rawPortLocations {
+				logicalPort := ov.LogicalPortConfigInfo{}
+
+				if val, ok := d.GetOk(logicalPortPrefix + ".desired_speed"); ok {
+					logicalPort.DesiredSpeed = val.(string)
+				}
+
+				locationEntries := make([]ov.LocationEntry, 0)
+				enclosureLocation := ov.LocationEntry{
+					RelativeValue: d.Get(logicalPortPrefix + ".enclosure_num").(int),
+					Type:          "Enclosure",
+				}
+				locationEntries = append(locationEntries, enclosureLocation)
+
+				bayLocation := ov.LocationEntry{
+					RelativeValue: d.Get(logicalPortPrefix + ".bay_num").(int),
+					Type:          "Bay",
+				}
+				locationEntries = append(locationEntries, bayLocation)
+
+				portLocation := ov.LocationEntry{
+					RelativeValue: raw.(int),
+					Type:          "Port",
+				}
+				locationEntries = append(locationEntries, portLocation)
+
+				logicalLocation := ov.LogicalLocation{
+					LocationEntries: locationEntries,
+				}
+
+				logicalPort.LogicalLocation = logicalLocation
+				if _, ok := d.GetOk(logicalPortPrefix + ".primary_port"); ok {
+					if uplinkSet.PrimaryPort == nil {
+						uplinkSet.PrimaryPort = &logicalLocation
+					}
+				}
+
+				logicalPorts = append(logicalPorts, logicalPort)
+			}
+
+		}
+		uplinkSet.LogicalPortConfigInfos = logicalPorts
+
+		rawNetUris := d.Get(uplinkSetPrefix + ".network_uris").(*schema.Set).List()
+		netUris := make([]utils.Nstring, 0)
+		for _, raw := range rawNetUris {
+			netUris = append(netUris, utils.NewNstring(raw.(string)))
+		}
+		uplinkSet.NetworkUris = netUris
+
+		uplinkSets = append(uplinkSets, uplinkSet)
+	}
+
+	lig.UplinkSets = uplinkSets
+
+	rawInternalNetUris := d.Get("internal_network_uris").(*schema.Set).List()
+	internalNetUris := make([]utils.Nstring, len(rawInternalNetUris))
+	for i, raw := range rawInternalNetUris {
+		internalNetUris[i] = utils.NewNstring(raw.(string))
+	}
+	lig.InternalNetworkUris = internalNetUris
+
+	telemetryConfigPrefix := fmt.Sprintf("telemetry_configuration.0")
+	telemetryConfiguration := ov.TelemetryConfiguration{}
+	if val, ok := d.GetOk(telemetryConfigPrefix + ".sample_count"); ok {
+		telemetryConfiguration.SampleCount = val.(int)
+	}
+	if val, ok := d.GetOk(telemetryConfigPrefix + ".sample_interval"); ok {
+		telemetryConfiguration.SampleInterval = val.(int)
+	}
+	if val, ok := d.GetOk(telemetryConfigPrefix + ".enabled"); ok {
+		enabled := val.(bool)
+		telemetryConfiguration.EnableTelemetry = &enabled
+	}
+	if telemetryConfiguration != (ov.TelemetryConfiguration{}) {
+		telemetryConfiguration.Type = d.Get(telemetryConfigPrefix + ".type").(string)
+		lig.TelemetryConfiguration = &telemetryConfiguration
+	}
+
+	snmpConfigPrefix := fmt.Sprintf("snmp_configuration.0")
+	snmpConfiguration := ov.SnmpConfiguration{}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".enabled"); ok {
+		enabled := val.(bool)
+		snmpConfiguration.Enabled = &enabled
+	}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".read_community"); ok {
+		snmpConfiguration.ReadCommunity = val.(string)
+	}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".system_contact"); ok {
+		snmpConfiguration.SystemContact = val.(string)
+	}
+	rawSnmpAccess := d.Get(snmpConfigPrefix + ".snmp_access").(*schema.Set).List()
+	snmpAccess := make([]string, len(rawSnmpAccess))
+	for i, raw := range rawSnmpAccess {
+		snmpAccess[i] = raw.(string)
+	}
+	snmpConfiguration.SnmpAccess = snmpAccess
+
+	trapDestinationCount := d.Get(snmpConfigPrefix + ".trap_destination.#").(int)
+	trapDestinations := make([]ov.TrapDestination, 0, trapDestinationCount)
+	for i := 0; i < trapDestinationCount; i++ {
+		trapDestinationPrefix := fmt.Sprintf(snmpConfigPrefix+".trap_destination.%d", i)
+
+		rawEnetTrapCategories := d.Get(trapDestinationPrefix + ".enet_trap_categories").(*schema.Set).List()
+		enetTrapCategories := make([]string, len(rawEnetTrapCategories))
+		for i, raw := range rawEnetTrapCategories {
+			enetTrapCategories[i] = raw.(string)
+		}
+
+		rawFcTrapCategories := d.Get(trapDestinationPrefix + ".fc_trap_categories").(*schema.Set).List()
+		fcTrapCategories := make([]string, len(rawFcTrapCategories))
+		for i, raw := range rawFcTrapCategories {
+			fcTrapCategories[i] = raw.(string)
+		}
+
+		rawVcmTrapCategories := d.Get(trapDestinationPrefix + ".vcm_trap_categories").(*schema.Set).List()
+		vcmTrapCategories := make([]string, len(rawVcmTrapCategories))
+		for i, raw := range rawVcmTrapCategories {
+			vcmTrapCategories[i] = raw.(string)
+		}
+
+		rawTrapSeverities := d.Get(trapDestinationPrefix + ".trap_severities").(*schema.Set).List()
+		trapSeverities := make([]string, len(rawTrapSeverities))
+		for i, raw := range rawTrapSeverities {
+			trapSeverities[i] = raw.(string)
+		}
+
+		trapDestination := ov.TrapDestination{
+			TrapDestination:    d.Get(trapDestinationPrefix + ".trap_destination").(string),
+			CommunityString:    d.Get(trapDestinationPrefix + ".community_string").(string),
+			TrapFormat:         d.Get(trapDestinationPrefix + ".trap_format").(string),
+			EnetTrapCategories: enetTrapCategories,
+			FcTrapCategories:   fcTrapCategories,
+			VcmTrapCategories:  vcmTrapCategories,
+			TrapSeverities:     trapSeverities,
+		}
+		trapDestinations = append(trapDestinations, trapDestination)
+	}
+	if trapDestinationCount > 0 {
+		snmpConfiguration.TrapDestinations = trapDestinations
+	}
+
+	if val, ok := d.GetOk(snmpConfigPrefix + ".type"); ok {
+		snmpConfiguration.Type = val.(string)
+		lig.SnmpConfiguration = &snmpConfiguration
+	}
+
+	interconnectSettingsPrefix := fmt.Sprintf("interconnect_settings.0")
+	if val, ok := d.GetOk(interconnectSettingsPrefix + ".type"); ok {
+		interconnectSettings := ov.EthernetSettings{}
+
+		macFailoverEnabled := d.Get(interconnectSettingsPrefix + ".fast_mac_cache_failover").(bool)
+		interconnectSettings.EnableFastMacCacheFailover = &macFailoverEnabled
+
+		networkLoopProtectionEnabled := d.Get(interconnectSettingsPrefix + ".network_loop_protection").(bool)
+		interconnectSettings.EnableNetworkLoopProtection = &networkLoopProtectionEnabled
+
+		pauseFloodProtectionEnabled := d.Get(interconnectSettingsPrefix + ".pause_flood_protection").(bool)
+		interconnectSettings.EnablePauseFloodProtection = &pauseFloodProtectionEnabled
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".rich_tlv"); ok {
+			enabled := val1.(bool)
+			interconnectSettings.EnableRichTLV = &enabled
+		}
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".igmp_snooping"); ok {
+			enabled := val1.(bool)
+			interconnectSettings.EnableIgmpSnooping = &enabled
+		}
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".igmp_timeout_interval"); ok {
+			interconnectSettings.IgmpIdleTimeoutInterval = val1.(int)
+		}
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".mac_refresh_interval"); ok {
+			interconnectSettings.MacRefreshInterval = val1.(int)
+		}
+
+		interconnectSettings.Type = val.(string)
+		lig.EthernetSettings = &interconnectSettings
+	}
+
+	qualityOfServicePrefix := fmt.Sprintf("quality_of_service.0")
+	activeQosConfig := ov.ActiveQosConfig{}
+
+	if val, ok := d.GetOk(qualityOfServicePrefix + ".config_type"); ok {
+		activeQosConfig.ConfigType = val.(string)
+	}
+
+	if val, ok := d.GetOk(qualityOfServicePrefix + ".uplink_classification_type"); ok {
+		activeQosConfig.UplinkClassificationType = val.(string)
+	}
+
+	if val, ok := d.GetOk(qualityOfServicePrefix + ".downlink_classification_type"); ok {
+		activeQosConfig.DownlinkClassificationType = val.(string)
+	}
+
+	qosTrafficClassCount := d.Get(qualityOfServicePrefix + ".qos_traffic_class.#").(int)
+	qosTrafficClassifiers := make([]ov.QosTrafficClassifier, 0, 1)
+	for i := 0; i < qosTrafficClassCount; i++ {
+		qosTrafficClassPrefix := fmt.Sprintf(qualityOfServicePrefix+".qos_traffic_class.%d", i)
+		qosTrafficClassifier := ov.QosTrafficClassifier{}
+		qosClassMap := ov.QosClassificationMap{}
+		qosTrafficClass := ov.QosTrafficClass{}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".name"); ok {
+			qosTrafficClass.ClassName = val.(string)
+		}
+		classEnabled := d.Get(qosTrafficClassPrefix + ".enabled").(bool)
+		qosTrafficClass.Enabled = &classEnabled
+
+		realTimeEnabled := d.Get(qosTrafficClassPrefix + ".real_time").(bool)
+		qosTrafficClass.RealTime = &realTimeEnabled
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".egress_dot1p_value"); ok {
+			qosTrafficClass.EgressDot1pValue = val.(int)
+		}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".bandwidth_share"); ok {
+			qosTrafficClass.BandwidthShare = val.(string)
+		}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".max_bandwidth"); ok {
+			qosTrafficClass.MaxBandwidth = val.(int)
+		}
+
+		qosTrafficClassifier.QosTrafficClass = qosTrafficClass
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".qos_classification_map.0.dscp_class_map"); ok {
+			rawDscpClassMapping := val.(*schema.Set).List()
+			dscpClassMapping := make([]string, len(rawDscpClassMapping))
+			for i, raw := range rawDscpClassMapping {
+				dscpClassMapping[i] = raw.(string)
+			}
+			qosClassMap.DscpClassMapping = dscpClassMapping
+		}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".qos_classification_map.0.dot1p_class_map"); ok {
+			rawDot1pClassMap := val.(*schema.Set).List()
+			dot1pClassMap := make([]int, len(rawDot1pClassMap))
+			for i, raw := range rawDot1pClassMap {
+				dot1pClassMap[i] = raw.(int)
+			}
+			qosClassMap.Dot1pClassMapping = dot1pClassMap
+		}
+
+		qosTrafficClassifier.QosClassificationMapping = &qosClassMap
+
+		qosTrafficClassifiers = append(qosTrafficClassifiers, qosTrafficClassifier)
+	}
+	activeQosConfig.QosTrafficClassifiers = qosTrafficClassifiers
+
+	if val, ok := d.GetOk(qualityOfServicePrefix + ".active_qos_config_type"); ok {
+		activeQosConfig.Type = val.(string)
+
+		qualityOfService := ov.QosConfiguration{
+			Type:            d.Get(qualityOfServicePrefix + ".type").(string),
+			ActiveQosConfig: activeQosConfig,
+		}
+
+		lig.QosConfiguration = &qualityOfService
+	}
+
+	ligError := config.ovClient.CreateLogicalInterconnectGroup(lig)
+	d.SetId(d.Get("name").(string))
+	if ligError != nil {
+		d.SetId("")
+		return ligError
+	}
+	return resourceLogicalInterconnectGroupRead(d, meta)
+}
+
+func resourceLogicalInterconnectGroupRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	logicalInterconnectGroup, err := config.ovClient.GetLogicalInterconnectGroupByName(d.Id())
+	if err != nil || logicalInterconnectGroup.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", logicalInterconnectGroup.Name)
+	d.Set("type", logicalInterconnectGroup.Type)
+	d.Set("created", logicalInterconnectGroup.Created)
+	d.Set("modified", logicalInterconnectGroup.Modified)
+	d.Set("uri", logicalInterconnectGroup.URI.String())
+	d.Set("status", logicalInterconnectGroup.Status)
+	d.Set("category", logicalInterconnectGroup.Category)
+	d.Set("state", logicalInterconnectGroup.State)
+	d.Set("fabric_uri", logicalInterconnectGroup.FabricUri.String())
+	d.Set("eTag", logicalInterconnectGroup.ETAG)
+	d.Set("description", logicalInterconnectGroup.Description)
+	d.Set("interconnect_settings.0.igmp_snooping", logicalInterconnectGroup.EthernetSettings.EnableIgmpSnooping)
+
+	interconnectMapEntryTemplates := make([]map[string]interface{}, 0, len(logicalInterconnectGroup.InterconnectMapTemplate.InterconnectMapEntryTemplates))
+	for _, interconnectMapEntryTemplate := range logicalInterconnectGroup.InterconnectMapTemplate.InterconnectMapEntryTemplates {
+		interconnectType, err := config.ovClient.GetInterconnectTypeByUri(interconnectMapEntryTemplate.PermittedInterconnectTypeUri)
+		if err != nil {
+			return err
+		}
+		if interconnectType.Name == "" {
+			return fmt.Errorf("Could not find interconnectType with URI %s", interconnectMapEntryTemplate.PermittedInterconnectTypeUri.String())
+		}
+		var bayNum int
+		var enclosureIndex int
+		if interconnectMapEntryTemplate.LogicalLocation.LocationEntries[0].Type == "Bay" {
+			bayNum = interconnectMapEntryTemplate.LogicalLocation.LocationEntries[0].RelativeValue
+			enclosureIndex = interconnectMapEntryTemplate.LogicalLocation.LocationEntries[1].RelativeValue
+		} else {
+			bayNum = interconnectMapEntryTemplate.LogicalLocation.LocationEntries[1].RelativeValue
+			enclosureIndex = interconnectMapEntryTemplate.LogicalLocation.LocationEntries[0].RelativeValue
+		}
+
+		interconnectMapEntryTemplates = append(interconnectMapEntryTemplates, map[string]interface{}{
+			"interconnect_type_name": interconnectType.Name,
+			"bay_number":             bayNum,
+			"enclosure_index":        enclosureIndex,
+		})
+	}
+
+	interconnectMapEntryTemplateCount := d.Get("interconnect_map_entry_template.#").(int)
+	for i := 0; i < interconnectMapEntryTemplateCount; i++ {
+		currBayNum := d.Get("interconnect_map_entry_template." + strconv.Itoa(i) + ".bay_number")
+		for j := 0; j < len(logicalInterconnectGroup.InterconnectMapTemplate.InterconnectMapEntryTemplates); j++ {
+			if currBayNum == interconnectMapEntryTemplates[j]["bay_number"] {
+				interconnectMapEntryTemplates[i], interconnectMapEntryTemplates[j] = interconnectMapEntryTemplates[j], interconnectMapEntryTemplates[i]
+			}
+		}
+	}
+	d.Set("interconnect_map_entry_template", interconnectMapEntryTemplates)
+
+	uplinkSets := make([]map[string]interface{}, 0, len(logicalInterconnectGroup.UplinkSets))
+	for i, uplinkSet := range logicalInterconnectGroup.UplinkSets {
+
+		primaryPortEnclosure := 0
+		primaryPortBay := 0
+		primaryPortPort := 0
+
+		if uplinkSet.PrimaryPort != nil {
+			for _, primaryPortLocation := range uplinkSet.PrimaryPort.LocationEntries {
+				if primaryPortLocation.Type == "Bay" {
+					primaryPortBay = primaryPortLocation.RelativeValue
+				}
+				if primaryPortLocation.Type == "Enclosure" {
+					primaryPortEnclosure = primaryPortLocation.RelativeValue
+				}
+				if primaryPortLocation.Type == "Port" {
+					primaryPortPort = primaryPortLocation.RelativeValue
+				}
+			}
+		}
+
+		logicalPortConfigs := make([]map[string]interface{}, 0, len(uplinkSet.LogicalPortConfigInfos))
+		for _, logicalPortConfigInfo := range uplinkSet.LogicalPortConfigInfos {
+			portEnclosure := 0
+			portBay := 0
+			portPort := 0
+			primaryPort := false
+			for _, portLocation := range logicalPortConfigInfo.LogicalLocation.LocationEntries {
+				if portLocation.Type == "Bay" {
+					portBay = portLocation.RelativeValue
+				}
+				if portLocation.Type == "Enclosure" {
+					portEnclosure = portLocation.RelativeValue
+				}
+				if portLocation.Type == "Port" {
+					portPort = portLocation.RelativeValue
+				}
+			}
+			if primaryPortEnclosure == portEnclosure && primaryPortBay == portBay && primaryPortPort == portPort {
+				primaryPort = true
+			}
+
+			portPorts := make([]interface{}, 0)
+			portPorts = append(portPorts, portPort)
+
+			included := false
+			for j, portConfig := range logicalPortConfigs {
+				if portConfig["bay_num"] == portBay && portConfig["enclosure_num"] == portEnclosure {
+					included = true
+					portSet := logicalPortConfigs[j]["port_num"].(*schema.Set)
+					portSet.Add(portPort)
+				}
+			}
+
+			if included == false {
+				logicalPortConfigs = append(logicalPortConfigs, map[string]interface{}{
+					"desired_speed": logicalPortConfigInfo.DesiredSpeed,
+					"primary_port":  primaryPort,
+					"port_num":      schema.NewSet(func(a interface{}) int { return a.(int) }, portPorts),
+					"bay_num":       portBay,
+					"enclosure_num": portEnclosure,
+				})
+			}
+		}
+
+		//Oneview returns an unordered list so order it to match the configuration file
+		logicalPortCount := d.Get("uplink_set." + strconv.Itoa(i) + ".logical_port_config.#").(int)
+		oneviewLogicalPortCount := len(logicalPortConfigs)
+		for j := 0; j < logicalPortCount; j++ {
+			currBay := d.Get("uplink_set." + strconv.Itoa(i) + ".logical_port_config." + strconv.Itoa(j) + ".bay_num").(int)
+			for k := 0; k < oneviewLogicalPortCount; k++ {
+				if currBay == logicalPortConfigs[k]["bay_num"] && j <= k {
+					logicalPortConfigs[j], logicalPortConfigs[k] = logicalPortConfigs[k], logicalPortConfigs[j]
+				}
+			}
+		}
+
+		networkUris := make([]interface{}, len(uplinkSet.NetworkUris))
+		for i, networkUri := range uplinkSet.NetworkUris {
+			networkUris[i] = networkUri.String()
+		}
+
+		uplinkSets = append(uplinkSets, map[string]interface{}{
+			"network_type":          uplinkSet.NetworkType,
+			"ethernet_network_type": uplinkSet.EthernetNetworkType,
+			"name":                  uplinkSet.Name,
+			"mode":                  uplinkSet.Mode,
+			"lacp_timer":            uplinkSet.LacpTimer,
+			"native_network_uri":    uplinkSet.NativeNetworkUri,
+			"logical_port_config":   logicalPortConfigs,
+			"network_uris":          schema.NewSet(schema.HashString, networkUris),
+		})
+	}
+	uplinkCount := d.Get("uplink_set.#").(int)
+	oneviewUplinkCount := len(uplinkSets)
+	for i := 0; i < uplinkCount; i++ {
+		currUplinkName := d.Get("uplink_set." + strconv.Itoa(i) + ".name").(string)
+		for j := 0; j < oneviewUplinkCount; j++ {
+			if currUplinkName == uplinkSets[j]["name"] && i <= j {
+				uplinkSets[i], uplinkSets[j] = uplinkSets[j], uplinkSets[i]
+			}
+		}
+	}
+	d.Set("uplink_set", uplinkSets)
+
+	internalNetworkUris := make([]interface{}, len(logicalInterconnectGroup.InternalNetworkUris))
+	for i, internalNetworkUri := range logicalInterconnectGroup.InternalNetworkUris {
+		internalNetworkUris[i] = internalNetworkUri
+	}
+	d.Set("internal_network_uris", internalNetworkUris)
+
+	telemetryConfigurations := make([]map[string]interface{}, 0, 1)
+	telemetryConfigurations = append(telemetryConfigurations, map[string]interface{}{
+		"enabled":         *logicalInterconnectGroup.TelemetryConfiguration.EnableTelemetry,
+		"sample_count":    logicalInterconnectGroup.TelemetryConfiguration.SampleCount,
+		"sample_interval": logicalInterconnectGroup.TelemetryConfiguration.SampleInterval,
+		"type":            logicalInterconnectGroup.TelemetryConfiguration.Type,
+	})
+	d.Set("telemetry_configuration", telemetryConfigurations)
+
+	trapDestinations := make([]map[string]interface{}, 0, 1)
+	for _, trapDestination := range logicalInterconnectGroup.SnmpConfiguration.TrapDestinations {
+
+		enetTrapCategories := make([]interface{}, len(trapDestination.EnetTrapCategories))
+		for i, enetTrapCategory := range trapDestination.EnetTrapCategories {
+			enetTrapCategories[i] = enetTrapCategory
+		}
+
+		fcTrapCategories := make([]interface{}, len(trapDestination.FcTrapCategories))
+		for i, fcTrapCategory := range trapDestination.FcTrapCategories {
+			fcTrapCategories[i] = fcTrapCategory
+		}
+
+		vcmTrapCategories := make([]interface{}, len(trapDestination.VcmTrapCategories))
+		for i, vcmTrapCategory := range trapDestination.VcmTrapCategories {
+			vcmTrapCategories[i] = vcmTrapCategory
+		}
+
+		trapSeverities := make([]interface{}, len(trapDestination.TrapSeverities))
+		for i, trapSeverity := range trapDestination.TrapSeverities {
+			trapSeverities[i] = trapSeverity
+		}
+
+		trapDestinations = append(trapDestinations, map[string]interface{}{
+			"trap_destination":     trapDestination.TrapDestination,
+			"community_string":     trapDestination.CommunityString,
+			"trap_format":          trapDestination.TrapFormat,
+			"enet_trap_categories": schema.NewSet(schema.HashString, enetTrapCategories),
+			"fc_trap_categories":   schema.NewSet(schema.HashString, fcTrapCategories),
+			"vcm_trap_categories":  schema.NewSet(schema.HashString, vcmTrapCategories),
+			"trap_severities":      schema.NewSet(schema.HashString, trapSeverities),
+		})
+	}
+
+	//Oneview returns an unordered list so order it to match the configuration file
+	trapDestinationCount := d.Get("snmp_configuration.0.trap_destination.#").(int)
+	oneviewTrapDestinationCount := len(trapDestinations)
+	for i := 0; i < trapDestinationCount; i++ {
+		currDest := d.Get("snmp_configuration.0.trap_destination." + strconv.Itoa(i) + ".trap_destination").(string)
+		for j := 0; j < oneviewTrapDestinationCount; j++ {
+			if currDest == trapDestinations[j]["trap_destination"] && i <= j {
+				trapDestinations[i], trapDestinations[j] = trapDestinations[j], trapDestinations[i]
+			}
+		}
+	}
+
+	snmpAccess := make([]interface{}, len(logicalInterconnectGroup.SnmpConfiguration.SnmpAccess))
+	for i, snmpAccessIP := range logicalInterconnectGroup.SnmpConfiguration.SnmpAccess {
+		snmpAccess[i] = snmpAccessIP
+	}
+
+	snmpConfiguration := make([]map[string]interface{}, 0, 1)
+	snmpConfiguration = append(snmpConfiguration, map[string]interface{}{
+		"enabled":          *logicalInterconnectGroup.SnmpConfiguration.Enabled,
+		"read_community":   logicalInterconnectGroup.SnmpConfiguration.ReadCommunity,
+		"snmp_access":      schema.NewSet(schema.HashString, snmpAccess),
+		"system_contact":   logicalInterconnectGroup.SnmpConfiguration.SystemContact,
+		"type":             logicalInterconnectGroup.SnmpConfiguration.Type,
+		"trap_destination": trapDestinations,
+	})
+	d.Set("snmp_configuration", snmpConfiguration)
+
+	interconnectSettings := make([]map[string]interface{}, 0, 1)
+	interconnectSettings = append(interconnectSettings, map[string]interface{}{
+		"type": logicalInterconnectGroup.EthernetSettings.Type,
+		"fast_mac_cache_failover": *logicalInterconnectGroup.EthernetSettings.EnableFastMacCacheFailover,
+		"igmp_snooping":           *logicalInterconnectGroup.EthernetSettings.EnableIgmpSnooping,
+		"network_loop_protection": *logicalInterconnectGroup.EthernetSettings.EnableNetworkLoopProtection,
+		"pause_flood_protection":  *logicalInterconnectGroup.EthernetSettings.EnablePauseFloodProtection,
+		"rich_tlv":                *logicalInterconnectGroup.EthernetSettings.EnableRichTLV,
+		"igmp_timeout_interval":   logicalInterconnectGroup.EthernetSettings.IgmpIdleTimeoutInterval,
+		"mac_refresh_interval":    logicalInterconnectGroup.EthernetSettings.MacRefreshInterval,
+	})
+	d.Set("interconnect_settings", interconnectSettings)
+
+	qosTrafficClasses := make([]map[string]interface{}, 0, 1)
+	for _, qosTrafficClass := range logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.QosTrafficClassifiers {
+
+		dscpClassMap := make([]interface{}, len(qosTrafficClass.QosClassificationMapping.DscpClassMapping))
+		for i, dscpValue := range qosTrafficClass.QosClassificationMapping.DscpClassMapping {
+			dscpClassMap[i] = dscpValue
+		}
+
+		dot1pClassMap := make([]interface{}, len(qosTrafficClass.QosClassificationMapping.Dot1pClassMapping))
+		for i, dot1pValue := range qosTrafficClass.QosClassificationMapping.Dot1pClassMapping {
+			dot1pClassMap[i] = dot1pValue
+		}
+		qosClassificationMap := make([]map[string]interface{}, 0, 1)
+		qosClassificationMap = append(qosClassificationMap, map[string]interface{}{
+			"dot1p_class_map": schema.NewSet(func(a interface{}) int { return a.(int) }, dot1pClassMap),
+			"dscp_class_map":  schema.NewSet(schema.HashString, dscpClassMap),
+		})
+
+		qosTrafficClasses = append(qosTrafficClasses, map[string]interface{}{
+			"name":                   qosTrafficClass.QosTrafficClass.ClassName,
+			"enabled":                *qosTrafficClass.QosTrafficClass.Enabled,
+			"egress_dot1p_value":     qosTrafficClass.QosTrafficClass.EgressDot1pValue,
+			"real_time":              *qosTrafficClass.QosTrafficClass.RealTime,
+			"bandwidth_share":        qosTrafficClass.QosTrafficClass.BandwidthShare,
+			"max_bandwidth":          qosTrafficClass.QosTrafficClass.MaxBandwidth,
+			"qos_classification_map": qosClassificationMap,
+		})
+	}
+	qosTrafficClassCount := d.Get("quality_of_service.0.qos_traffic_class.#").(int)
+	oneviewTrafficClassCount := len(qosTrafficClasses)
+	for i := 0; i < qosTrafficClassCount; i++ {
+		currName := d.Get("quality_of_service.0.qos_traffic_class." + strconv.Itoa(i) + ".name").(string)
+		for j := 0; j < oneviewTrafficClassCount; j++ {
+			if currName == qosTrafficClasses[j]["name"] && i <= j {
+				qosTrafficClasses[i], qosTrafficClasses[j] = qosTrafficClasses[j], qosTrafficClasses[i]
+			}
+		}
+	}
+
+	qualityOfService := make([]map[string]interface{}, 0, 1)
+	qualityOfService = append(qualityOfService, map[string]interface{}{
+		"type": logicalInterconnectGroup.QosConfiguration.Type,
+		"active_qos_config_type":       logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.Type,
+		"config_type":                  logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.ConfigType,
+		"uplink_classification_type":   logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.UplinkClassificationType,
+		"downlink_classification_type": logicalInterconnectGroup.QosConfiguration.ActiveQosConfig.DownlinkClassificationType,
+		"qos_traffic_class":            qosTrafficClasses,
+	})
+
+	d.Set("quality_of_service", qualityOfService)
+
+	return nil
+}
+
+func resourceLogicalInterconnectGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteLogicalInterconnectGroup(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}
+
+func resourceLogicalInterconnectGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	lig := ov.LogicalInterconnectGroup{
+		Name: d.Get("name").(string),
+		Type: d.Get("type").(string),
+		URI:  utils.NewNstring(d.Get("uri").(string)),
+	}
+
+	interconnectMapEntryTemplateCount := d.Get("interconnect_map_entry_template.#").(int)
+	interconnectMapEntryTemplates := make([]ov.InterconnectMapEntryTemplate, 0)
+	for i := 0; i < interconnectMapEntryTemplateCount; i++ {
+		interconnectMapEntryTemplatePrefix := fmt.Sprintf("interconnect_map_entry_template.%d", i)
+		interconnectTypeName := d.Get(interconnectMapEntryTemplatePrefix + ".interconnect_type_name").(string)
+		interconnectType, err := config.ovClient.GetInterconnectTypeByName(interconnectTypeName)
+		if err != nil {
+			return err
+		}
+		if interconnectType.URI == "" {
+			return fmt.Errorf("Could not find Interconnect Type from name: %s", interconnectTypeName)
+		}
+
+		enclosureLocation := ov.LocationEntry{
+			RelativeValue: d.Get(interconnectMapEntryTemplatePrefix + ".enclosure_index").(int),
+			Type:          "Enclosure",
+		}
+		locationEntries := make([]ov.LocationEntry, 0)
+		locationEntries = append(locationEntries, enclosureLocation)
+
+		bayLocation := ov.LocationEntry{
+			RelativeValue: d.Get(interconnectMapEntryTemplatePrefix + ".bay_number").(int),
+			Type:          "Bay",
+		}
+		locationEntries = append(locationEntries, bayLocation)
+		logicalLocation := ov.LogicalLocation{
+			LocationEntries: locationEntries,
+		}
+		interconnectMapEntryTemplates = append(interconnectMapEntryTemplates, ov.InterconnectMapEntryTemplate{
+			LogicalLocation:              logicalLocation,
+			EnclosureIndex:               d.Get(interconnectMapEntryTemplatePrefix + ".enclosure_index").(int),
+			PermittedInterconnectTypeUri: interconnectType.URI,
+		})
+	}
+
+	interconnectMapTemplate := ov.InterconnectMapTemplate{
+		InterconnectMapEntryTemplates: interconnectMapEntryTemplates,
+	}
+	lig.InterconnectMapTemplate = &interconnectMapTemplate
+
+	uplinkSetCount := d.Get("uplink_set.#").(int)
+	uplinkSets := make([]ov.UplinkSet, 0)
+	for i := 0; i < uplinkSetCount; i++ {
+		uplinkSetPrefix := fmt.Sprintf("uplink_set.%d", i)
+		uplinkSet := ov.UplinkSet{}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".name"); ok {
+			uplinkSet.Name = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".network_type"); ok {
+			uplinkSet.NetworkType = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".ethernet_network_type"); ok {
+			uplinkSet.EthernetNetworkType = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".mode"); ok {
+			uplinkSet.Mode = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".lacp_timer"); ok {
+			uplinkSet.LacpTimer = val.(string)
+		}
+		if val, ok := d.GetOk(uplinkSetPrefix + ".native_network_uri"); ok {
+			uplinkSet.NativeNetworkUri = utils.NewNstring(val.(string))
+		}
+
+		logicalPortCount := d.Get(uplinkSetPrefix + ".logical_port_config.#").(int)
+		logicalPorts := make([]ov.LogicalPortConfigInfo, 0)
+		for i := 0; i < logicalPortCount; i++ {
+			logicalPortPrefix := fmt.Sprintf(uplinkSetPrefix+".logical_port_config.%d", i)
+			rawPortLocations := d.Get(logicalPortPrefix + ".port_num").(*schema.Set).List()
+			for _, raw := range rawPortLocations {
+				logicalPort := ov.LogicalPortConfigInfo{}
+
+				if val, ok := d.GetOk(logicalPortPrefix + ".desired_speed"); ok {
+					logicalPort.DesiredSpeed = val.(string)
+				}
+
+				locationEntries := make([]ov.LocationEntry, 0)
+				enclosureLocation := ov.LocationEntry{
+					RelativeValue: d.Get(logicalPortPrefix + ".enclosure_num").(int),
+					Type:          "Enclosure",
+				}
+				locationEntries = append(locationEntries, enclosureLocation)
+
+				bayLocation := ov.LocationEntry{
+					RelativeValue: d.Get(logicalPortPrefix + ".bay_num").(int),
+					Type:          "Bay",
+				}
+				locationEntries = append(locationEntries, bayLocation)
+
+				portLocation := ov.LocationEntry{
+					RelativeValue: raw.(int),
+					Type:          "Port",
+				}
+				locationEntries = append(locationEntries, portLocation)
+
+				logicalLocation := ov.LogicalLocation{
+					LocationEntries: locationEntries,
+				}
+
+				logicalPort.LogicalLocation = logicalLocation
+				if _, ok := d.GetOk(logicalPortPrefix + ".primary_port"); ok {
+					if uplinkSet.PrimaryPort == nil {
+						uplinkSet.PrimaryPort = &logicalLocation
+					}
+				}
+
+				logicalPorts = append(logicalPorts, logicalPort)
+			}
+
+		}
+		uplinkSet.LogicalPortConfigInfos = logicalPorts
+
+		rawNetUris := d.Get(uplinkSetPrefix + ".network_uris").(*schema.Set).List()
+		netUris := make([]utils.Nstring, 0)
+		for _, raw := range rawNetUris {
+			netUris = append(netUris, utils.NewNstring(raw.(string)))
+		}
+		uplinkSet.NetworkUris = netUris
+
+		uplinkSets = append(uplinkSets, uplinkSet)
+	}
+	lig.UplinkSets = uplinkSets
+
+	rawInternalNetUris := d.Get("internal_network_uris").(*schema.Set).List()
+	internalNetUris := make([]utils.Nstring, len(rawInternalNetUris))
+	for i, raw := range rawInternalNetUris {
+		internalNetUris[i] = utils.NewNstring(raw.(string))
+	}
+	lig.InternalNetworkUris = internalNetUris
+
+	telemetryConfigPrefix := fmt.Sprintf("telemetry_configuration.0")
+	telemetryConfiguration := ov.TelemetryConfiguration{}
+	if val, ok := d.GetOk(telemetryConfigPrefix + ".sample_count"); ok {
+		telemetryConfiguration.SampleCount = val.(int)
+	}
+	if val, ok := d.GetOk(telemetryConfigPrefix + ".sample_interval"); ok {
+		telemetryConfiguration.SampleInterval = val.(int)
+	}
+	if val, ok := d.GetOk(telemetryConfigPrefix + ".enabled"); ok {
+		enabled := val.(bool)
+		telemetryConfiguration.EnableTelemetry = &enabled
+	}
+	if telemetryConfiguration != (ov.TelemetryConfiguration{}) {
+		telemetryConfiguration.Type = d.Get(telemetryConfigPrefix + ".type").(string)
+		lig.TelemetryConfiguration = &telemetryConfiguration
+	}
+
+	snmpConfigPrefix := fmt.Sprintf("snmp_configuration.0")
+	snmpConfiguration := ov.SnmpConfiguration{}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".enabled"); ok {
+		enabled := val.(bool)
+		snmpConfiguration.Enabled = &enabled
+	}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".read_community"); ok {
+		snmpConfiguration.ReadCommunity = val.(string)
+	}
+	if val, ok := d.GetOk(snmpConfigPrefix + ".system_contact"); ok {
+		snmpConfiguration.SystemContact = val.(string)
+	}
+	rawSnmpAccess := d.Get(snmpConfigPrefix + ".snmp_access").(*schema.Set).List()
+	snmpAccess := make([]string, len(rawSnmpAccess))
+	for i, raw := range rawSnmpAccess {
+		snmpAccess[i] = raw.(string)
+	}
+
+	trapDestinationCount := d.Get(snmpConfigPrefix + ".trap_destination.#").(int)
+	trapDestinations := make([]ov.TrapDestination, 0, trapDestinationCount)
+	for i := 0; i < trapDestinationCount; i++ {
+		trapDestinationPrefix := fmt.Sprintf(snmpConfigPrefix+".trap_destination.%d", i)
+
+		rawEnetTrapCategories := d.Get(trapDestinationPrefix + ".enet_trap_categories").(*schema.Set).List()
+		enetTrapCategories := make([]string, len(rawEnetTrapCategories))
+		for i, raw := range rawEnetTrapCategories {
+			enetTrapCategories[i] = raw.(string)
+		}
+
+		rawFcTrapCategories := d.Get(trapDestinationPrefix + ".fc_trap_categories").(*schema.Set).List()
+		fcTrapCategories := make([]string, len(rawFcTrapCategories))
+		for i, raw := range rawFcTrapCategories {
+			fcTrapCategories[i] = raw.(string)
+		}
+
+		rawVcmTrapCategories := d.Get(trapDestinationPrefix + ".vcm_trap_categories").(*schema.Set).List()
+		vcmTrapCategories := make([]string, len(rawVcmTrapCategories))
+		for i, raw := range rawVcmTrapCategories {
+			vcmTrapCategories[i] = raw.(string)
+		}
+
+		rawTrapSeverities := d.Get(trapDestinationPrefix + ".trap_severities").(*schema.Set).List()
+		trapSeverities := make([]string, len(rawTrapSeverities))
+		for i, raw := range rawTrapSeverities {
+			trapSeverities[i] = raw.(string)
+		}
+
+		trapDestination := ov.TrapDestination{
+			TrapDestination:    d.Get(trapDestinationPrefix + ".trap_destination").(string),
+			CommunityString:    d.Get(trapDestinationPrefix + ".community_string").(string),
+			TrapFormat:         d.Get(trapDestinationPrefix + ".trap_format").(string),
+			EnetTrapCategories: enetTrapCategories,
+			FcTrapCategories:   fcTrapCategories,
+			VcmTrapCategories:  vcmTrapCategories,
+			TrapSeverities:     trapSeverities,
+		}
+		trapDestinations = append(trapDestinations, trapDestination)
+	}
+	if trapDestinationCount > 0 {
+		snmpConfiguration.TrapDestinations = trapDestinations
+	}
+
+	snmpConfiguration.SnmpAccess = snmpAccess
+	if val, ok := d.GetOk(snmpConfigPrefix + ".type"); ok {
+		snmpConfiguration.Type = val.(string)
+		lig.SnmpConfiguration = &snmpConfiguration
+	}
+
+	interconnectSettingsPrefix := fmt.Sprintf("interconnect_settings.0")
+	if val, ok := d.GetOk(interconnectSettingsPrefix + ".type"); ok {
+		interconnectSettings := ov.EthernetSettings{}
+
+		macFailoverEnabled := d.Get(interconnectSettingsPrefix + ".fast_mac_cache_failover").(bool)
+		interconnectSettings.EnableFastMacCacheFailover = &macFailoverEnabled
+
+		networkLoopProtectionEnabled := d.Get(interconnectSettingsPrefix + ".network_loop_protection").(bool)
+		interconnectSettings.EnableNetworkLoopProtection = &networkLoopProtectionEnabled
+
+		pauseFloodProtectionEnabled := d.Get(interconnectSettingsPrefix + ".pause_flood_protection").(bool)
+		interconnectSettings.EnablePauseFloodProtection = &pauseFloodProtectionEnabled
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".rich_tlv"); ok {
+			enabled := val1.(bool)
+			interconnectSettings.EnableRichTLV = &enabled
+		}
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".igmp_snooping"); ok {
+			enabled := val1.(bool)
+			interconnectSettings.EnableIgmpSnooping = &enabled
+		}
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".igmp_timeout_interval"); ok {
+			interconnectSettings.IgmpIdleTimeoutInterval = val1.(int)
+		}
+
+		if val1, ok := d.GetOk(interconnectSettingsPrefix + ".mac_refresh_interval"); ok {
+			interconnectSettings.MacRefreshInterval = val1.(int)
+		}
+
+		interconnectSettings.Type = val.(string)
+		lig.EthernetSettings = &interconnectSettings
+	}
+
+	qualityOfServicePrefix := fmt.Sprintf("quality_of_service.0")
+	activeQosConfig := ov.ActiveQosConfig{}
+
+	if val, ok := d.GetOk(qualityOfServicePrefix + ".config_type"); ok {
+		activeQosConfig.ConfigType = val.(string)
+	}
+
+	if val, ok := d.GetOk(qualityOfServicePrefix + ".uplink_classification_type"); ok {
+		activeQosConfig.UplinkClassificationType = val.(string)
+	}
+
+	if val, ok := d.GetOk(qualityOfServicePrefix + ".downlink_classification_type"); ok {
+		activeQosConfig.DownlinkClassificationType = val.(string)
+	}
+
+	qosTrafficClassCount := d.Get(qualityOfServicePrefix + ".qos_traffic_class.#").(int)
+	qosTrafficClassifiers := make([]ov.QosTrafficClassifier, 0, 1)
+	for i := 0; i < qosTrafficClassCount; i++ {
+		qosTrafficClassPrefix := fmt.Sprintf(qualityOfServicePrefix+".qos_traffic_class.%d", i)
+		qosTrafficClassifier := ov.QosTrafficClassifier{}
+		qosClassMap := ov.QosClassificationMap{}
+		qosTrafficClass := ov.QosTrafficClass{}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".name"); ok {
+			qosTrafficClass.ClassName = val.(string)
+		}
+		classEnabled := d.Get(qosTrafficClassPrefix + ".enabled").(bool)
+		qosTrafficClass.Enabled = &classEnabled
+
+		realTimeEnabled := d.Get(qosTrafficClassPrefix + ".real_time").(bool)
+		qosTrafficClass.RealTime = &realTimeEnabled
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".egress_dot1p_value"); ok {
+			qosTrafficClass.EgressDot1pValue = val.(int)
+		}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".bandwidth_share"); ok {
+			qosTrafficClass.BandwidthShare = val.(string)
+		}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".max_bandwidth"); ok {
+			qosTrafficClass.MaxBandwidth = val.(int)
+		}
+
+		qosTrafficClassifier.QosTrafficClass = qosTrafficClass
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".qos_classification_map.0.dscp_class_map"); ok {
+			rawDscpClassMapping := val.(*schema.Set).List()
+			dscpClassMapping := make([]string, len(rawDscpClassMapping))
+			for i, raw := range rawDscpClassMapping {
+				dscpClassMapping[i] = raw.(string)
+			}
+			qosClassMap.DscpClassMapping = dscpClassMapping
+		}
+
+		if val, ok := d.GetOk(qosTrafficClassPrefix + ".qos_classification_map.0.dot1p_class_map"); ok {
+			rawDot1pClassMap := val.(*schema.Set).List()
+			dot1pClassMap := make([]int, len(rawDot1pClassMap))
+			for i, raw := range rawDot1pClassMap {
+				dot1pClassMap[i] = raw.(int)
+			}
+			qosClassMap.Dot1pClassMapping = dot1pClassMap
+		}
+
+		qosTrafficClassifier.QosClassificationMapping = &qosClassMap
+
+		qosTrafficClassifiers = append(qosTrafficClassifiers, qosTrafficClassifier)
+	}
+	activeQosConfig.QosTrafficClassifiers = qosTrafficClassifiers
+
+	if !reflect.DeepEqual(activeQosConfig, (ov.ActiveQosConfig{})) {
+		activeQosConfig.Type = d.Get(qualityOfServicePrefix + ".active_qos_config_type").(string)
+
+		qualityOfService := ov.QosConfiguration{
+			Type:            d.Get(qualityOfServicePrefix + ".type").(string),
+			ActiveQosConfig: activeQosConfig,
+		}
+
+		lig.QosConfiguration = &qualityOfService
+	}
+
+	err := config.ovClient.UpdateLogicalInterconnectGroup(lig)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("name").(string))
+
+	return resourceLogicalInterconnectGroupRead(d, meta)
+}

--- a/builtin/providers/oneview/resource_logical_interconnect_group_test.go
+++ b/builtin/providers/oneview/resource_logical_interconnect_group_test.go
@@ -1,0 +1,97 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccLogicalInterconnectGroup_1(t *testing.T) {
+	var logicalInterconnectGroup ov.LogicalInterconnectGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLogicalInterconnectGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccLogicalInterconnectGroup,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogicalInterconnectGroupExists(
+						"oneview_logical_interconnect_group.test", &logicalInterconnectGroup),
+					resource.TestCheckResourceAttr(
+						"oneview_logical_interconnect_group.test", "name", "terraform lig",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLogicalInterconnectGroupExists(n string, logicalInterconnectGroup *ov.LogicalInterconnectGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testLogicalInterconnectGroup, err := config.ovClient.GetLogicalInterconnectGroupByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testLogicalInterconnectGroup.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*logicalInterconnectGroup = testLogicalInterconnectGroup
+		return nil
+	}
+}
+
+func testAccCheckLogicalInterconnectGroupDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_logical_interconnect_group" {
+			continue
+		}
+
+		testLig, _ := config.ovClient.GetLogicalInterconnectGroupByName(rs.Primary.ID)
+
+		if testLig.Name != "" {
+			return fmt.Errorf("LogicalInterconenctGroup still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccLogicalInterconnectGroup = `resource "oneview_logical_interconnect_group" "test" {
+    count = 1
+    name = "terraform lig"
+    interconnect_settings {}
+    quality_of_service {}
+    snmp_configuration {}
+    telemetry_configuration {}
+  }`

--- a/builtin/providers/oneview/resource_logical_switch_group.go
+++ b/builtin/providers/oneview/resource_logical_switch_group.go
@@ -1,0 +1,226 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceLogicalSwitchGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceLogicalSwitchGroupCreate,
+		Read:   resourceLogicalSwitchGroupRead,
+		Update: resourceLogicalSwitchGroupUpdate,
+		Delete: resourceLogicalSwitchGroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "logical-switch-group",
+			},
+			"switch_type_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"switch_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"location_entry_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "StackingMemberId",
+			},
+			"created": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"fabric_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eTag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"switch_type_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceLogicalSwitchGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	switchType, err := config.ovClient.GetSwitchTypeByName(d.Get("switch_type_name").(string))
+	if err != nil {
+		return err
+	}
+	d.Set("switch_type_uri", switchType.URI)
+
+	if switchType.Name == "" {
+		return fmt.Errorf("Can't find %s switchType", d.Get("switch_type_name").(string))
+	}
+
+	switchMapEntryTemplates := make([]ov.SwitchMapEntry, d.Get("switch_count").(int))
+	for i := 0; i < d.Get("switch_count").(int); i++ {
+		locationEntries := make([]ov.LocationEntry, 1)
+		locationEntry := ov.LocationEntry{
+			RelativeValue: i + 1,
+			Type:          d.Get("location_entry_type").(string),
+		}
+		locationEntries[0] = locationEntry
+		logicalLocation := ov.LogicalLocation{
+			LocationEntries: locationEntries,
+		}
+		switchMapEntry := ov.SwitchMapEntry{
+			LogicalLocation:        logicalLocation,
+			PermittedSwitchTypeUri: switchType.URI,
+		}
+		switchMapEntryTemplates[i] = switchMapEntry
+	}
+
+	switchMapTemplate := ov.SwitchMapTemplate{
+		SwitchMapEntryTemplates: switchMapEntryTemplates,
+	}
+
+	logicalSwitchGroup := ov.LogicalSwitchGroup{
+		Name:              d.Get("name").(string),
+		Type:              d.Get("type").(string),
+		SwitchMapTemplate: switchMapTemplate,
+	}
+
+	logicalSwitchGroupError := config.ovClient.CreateLogicalSwitchGroup(logicalSwitchGroup)
+	d.SetId(d.Get("name").(string))
+	if logicalSwitchGroupError != nil {
+		d.SetId("")
+		return logicalSwitchGroupError
+	}
+	return resourceLogicalSwitchGroupRead(d, meta)
+}
+
+func resourceLogicalSwitchGroupRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	logicalSwitchGroup, err := config.ovClient.GetLogicalSwitchGroupByName(d.Id())
+	if err != nil || logicalSwitchGroup.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", logicalSwitchGroup.Name)
+	d.Set("type", logicalSwitchGroup.Type)
+	d.Set("switch_count", len(logicalSwitchGroup.SwitchMapTemplate.SwitchMapEntryTemplates))
+	d.Set("created", logicalSwitchGroup.Created)
+	d.Set("modified", logicalSwitchGroup.Modified)
+	d.Set("uri", logicalSwitchGroup.URI.String())
+	d.Set("status", logicalSwitchGroup.Status)
+	d.Set("category", logicalSwitchGroup.Category)
+	d.Set("state", logicalSwitchGroup.State)
+	d.Set("fabric_uri", logicalSwitchGroup.FabricUri.String())
+	d.Set("eTag", logicalSwitchGroup.ETAG)
+	d.Set("description", logicalSwitchGroup.Description)
+	return nil
+}
+
+func resourceLogicalSwitchGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteLogicalSwitchGroup(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}
+
+func resourceLogicalSwitchGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	switchType, err := config.ovClient.GetSwitchTypeByName(d.Get("switch_type_name").(string))
+	if err != nil {
+		return err
+	}
+	if switchType.Name == "" {
+		return fmt.Errorf("Can't find %s switchType", d.Get("switch_type_name").(string))
+	}
+
+	switchMapEntryTemplates := make([]ov.SwitchMapEntry, d.Get("switch_count").(int))
+	for i := 0; i < d.Get("switch_count").(int); i++ {
+		locationEntries := make([]ov.LocationEntry, 1)
+		locationEntry := ov.LocationEntry{
+			RelativeValue: i + 1,
+			Type:          d.Get("location_entry_type").(string),
+		}
+		locationEntries[0] = locationEntry
+		logicalLocation := ov.LogicalLocation{
+			LocationEntries: locationEntries,
+		}
+		switchMapEntry := ov.SwitchMapEntry{
+			LogicalLocation:        logicalLocation,
+			PermittedSwitchTypeUri: switchType.URI,
+		}
+		switchMapEntryTemplates[i] = switchMapEntry
+	}
+
+	switchMapTemplate := ov.SwitchMapTemplate{
+		SwitchMapEntryTemplates: switchMapEntryTemplates,
+	}
+
+	newLogicalSwitchGroup := ov.LogicalSwitchGroup{
+		ETAG:              d.Get("eTag").(string),
+		URI:               utils.NewNstring(d.Get("uri").(string)),
+		Name:              d.Get("name").(string),
+		Type:              d.Get("type").(string),
+		SwitchMapTemplate: switchMapTemplate,
+	}
+	err = config.ovClient.UpdateLogicalSwitchGroup(newLogicalSwitchGroup)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("name").(string))
+	return resourceLogicalSwitchGroupRead(d, meta)
+}

--- a/builtin/providers/oneview/resource_logical_switch_group_test.go
+++ b/builtin/providers/oneview/resource_logical_switch_group_test.go
@@ -1,0 +1,95 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccLogicalSwitchGroup_1(t *testing.T) {
+	var logicalSwitchGroup ov.LogicalSwitchGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLogicalSwitchGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccLogicalSwitchGroup,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLogicalSwitchGroupExists(
+						"oneview_logical_switch_group.test", &logicalSwitchGroup),
+					resource.TestCheckResourceAttr(
+						"oneview_logical_switch_group.test", "name", "terraform lsg",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckLogicalSwitchGroupExists(n string, logicalSwitchGroup *ov.LogicalSwitchGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testLogicalSwitchGroup, err := config.ovClient.GetLogicalSwitchGroupByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testLogicalSwitchGroup.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*logicalSwitchGroup = testLogicalSwitchGroup
+		return nil
+	}
+}
+
+func testAccCheckLogicalSwitchGroupDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_logical_switch_group" {
+			continue
+		}
+
+		testLSG, _ := config.ovClient.GetLogicalSwitchGroupByName(rs.Primary.ID)
+
+		if testLSG.Name != "" {
+			return fmt.Errorf("LogicalSwitchGroup still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccLogicalSwitchGroup = `resource "oneview_logical_switch_group" "test" {
+    count = 1
+    name = "terraform lsg"
+    switch_type_name = "Cisco Nexus 50xx"
+    switch_count = 2
+  }`

--- a/builtin/providers/oneview/resource_network_set.go
+++ b/builtin/providers/oneview/resource_network_set.go
@@ -1,0 +1,187 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceNetworkSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceNetworkSetCreate,
+		Read:   resourceNetworkSetRead,
+		Update: resourceNetworkSetUpdate,
+		Delete: resourceNetworkSetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"network_uris": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"native_network_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "network-set",
+			},
+			"connection_template_uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"created": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"modified": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"status": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"eTag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceNetworkSetCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	rawNetUris := d.Get("network_uris").(*schema.Set).List()
+	netUris := make([]utils.Nstring, len(rawNetUris))
+	for i, raw := range rawNetUris {
+		netUris[i] = utils.NewNstring(raw.(string))
+	}
+
+	netSet := ov.NetworkSet{
+		Name:             d.Get("name").(string),
+		NetworkUris:      netUris,
+		Type:             d.Get("type").(string),
+		NativeNetworkUri: utils.NewNstring(d.Get("native_network_uri").(string)),
+	}
+
+	netSetError := config.ovClient.CreateNetworkSet(netSet)
+	d.SetId(d.Get("name").(string))
+	if netSetError != nil {
+		d.SetId("")
+		return netSetError
+	}
+	return resourceNetworkSetRead(d, meta)
+}
+
+func resourceNetworkSetRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	netSet, err := config.ovClient.GetNetworkSetByName(d.Id())
+	if err != nil || netSet.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+	d.Set("name", netSet.Name)
+	d.Set("type", netSet.Type)
+	d.Set("created", netSet.Created)
+	d.Set("description", netSet.Description)
+	d.Set("eTag", netSet.ETAG)
+	d.Set("modified", netSet.Modified)
+	d.Set("native_network_uri", netSet.NativeNetworkUri)
+	d.Set("uri", netSet.URI.String())
+	d.Set("connection_template_uri", netSet.ConnectionTemplateUri.String())
+	d.Set("status", netSet.Status)
+	d.Set("category", netSet.Category)
+	d.Set("state", netSet.State)
+
+	networkUris := make([]interface{}, len(netSet.NetworkUris))
+	for i := 0; i < len(netSet.NetworkUris); i++ {
+		networkUris[i] = netSet.NetworkUris[i].String()
+	}
+
+	rawNetUris := d.Get("network_uris").(*schema.Set).List()
+	for i, currNetworkUri := range rawNetUris {
+		for j := 0; j < len(networkUris); j++ {
+			if currNetworkUri.(string) == networkUris[j] && i <= len(networkUris)-1 {
+				networkUris[i], networkUris[j] = networkUris[j], networkUris[i]
+			}
+		}
+	}
+	d.Set("network_uris", networkUris)
+
+	return nil
+
+}
+
+func resourceNetworkSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	rawNetUris := d.Get("network_uris").(*schema.Set).List()
+	netUris := make([]utils.Nstring, len(rawNetUris))
+	for i, raw := range rawNetUris {
+		netUris[i] = utils.NewNstring(raw.(string))
+	}
+	newNetSet := ov.NetworkSet{
+		ETAG: d.Get("eTag").(string),
+		URI:  utils.NewNstring(d.Get("uri").(string)),
+		Name: d.Get("name").(string),
+		ConnectionTemplateUri: utils.NewNstring(d.Get("connection_template_uri").(string)),
+		Type:             d.Get("type").(string),
+		NativeNetworkUri: utils.NewNstring(d.Get("native_network_uri").(string)),
+		NetworkUris:      netUris,
+	}
+
+	err := config.ovClient.UpdateNetworkSet(newNetSet)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("name").(string))
+
+	return resourceNetworkSetRead(d, meta)
+}
+
+func resourceNetworkSetDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteNetworkSet(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}

--- a/builtin/providers/oneview/resource_network_set_test.go
+++ b/builtin/providers/oneview/resource_network_set_test.go
@@ -1,0 +1,93 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccNetworkSet_1(t *testing.T) {
+	var networkSet ov.NetworkSet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkSet,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkSetExists(
+						"oneview_network_set.test", &networkSet),
+					resource.TestCheckResourceAttr(
+						"oneview_network_set.test", "name", "Terraform Network Set 1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckNetworkSetExists(n string, networkSet *ov.NetworkSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testNetworkSet, err := config.ovClient.GetNetworkSetByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testNetworkSet.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*networkSet = testNetworkSet
+		return nil
+	}
+}
+
+func testAccCheckNetworkSetDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_network_set" {
+			continue
+		}
+
+		testNet, _ := config.ovClient.GetNetworkSetByName(rs.Primary.ID)
+
+		if testNet.Name != "" {
+			return fmt.Errorf("NetworkSet still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccNetworkSet = `
+  resource "oneview_network_set" "test" {
+    name = "Terraform Network Set 1"
+  }`

--- a/builtin/providers/oneview/resource_server_profile.go
+++ b/builtin/providers/oneview/resource_server_profile.go
@@ -1,0 +1,184 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceServerProfile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServerProfileCreate,
+		Read:   resourceServerProfileRead,
+		Update: resourceServerProfileUpdate,
+		Delete: resourceServerProfileDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ServerProfileV5",
+			},
+			"template": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ilo_ip": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"hardware_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"hardware_uri": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"serial_number": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_connection": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"public_mac": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_slot_id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceServerProfileCreate(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	serverProfileTemplate, error := config.ovClient.GetProfileTemplateByName(d.Get("template").(string))
+	if error != nil || serverProfileTemplate.URI.IsNil() {
+		return fmt.Errorf("Could not find Server Profile Template\n%+v", d.Get("template").(string))
+	}
+	var serverHardware ov.ServerHardware
+	if val, ok := d.GetOk("hardware_name"); ok {
+		serverHardware, error = config.ovClient.GetServerHardwareByName(val.(string))
+		if error != nil {
+			return error
+		}
+	} else {
+		serverHardware, error = getServerHardware(config, serverProfileTemplate)
+		if error != nil {
+			return error
+		}
+	}
+
+	profileType := d.Get("type")
+	if profileType == "ServerProfileV6" {
+		SPerror := config.ovClient.CreateProfileFromTemplateWithI3S(d.Get("name").(string), serverProfileTemplate, serverHardware)
+		d.SetId(d.Get("name").(string))
+
+		if SPerror != nil {
+			d.SetId("")
+			return SPerror
+		}
+	} else {
+		SPerror := config.ovClient.CreateProfileFromTemplate(d.Get("name").(string), serverProfileTemplate, serverHardware)
+		d.SetId(d.Get("name").(string))
+
+		if SPerror != nil {
+			d.SetId("")
+			return SPerror
+		}
+	}
+
+	return resourceServerProfileRead(d, meta)
+}
+
+func resourceServerProfileRead(d *schema.ResourceData, meta interface{}) error {
+
+	config := meta.(*Config)
+
+	serverProfile, err := config.ovClient.GetProfileByName(d.Id())
+	if err != nil || serverProfile.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+
+	serverHardware, err := config.ovClient.GetServerHardware(serverProfile.ServerHardwareURI)
+	if err != nil {
+		return err
+	}
+
+	d.Set("ilo_ip", serverHardware.GetIloIPAddress())
+	d.Set("serial_number", serverProfile.SerialNumber.String())
+
+	if val, ok := d.GetOk("public_connection"); ok {
+		publicConnection, err := serverProfile.GetConnectionByName(val.(string))
+		if err != nil {
+			return err
+		}
+		d.Set("public_mac", publicConnection.MAC)
+		d.Set("public_slot_id", publicConnection.ID)
+	}
+
+	return nil
+}
+
+func resourceServerProfileUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	serverProfile, err := config.ovClient.GetProfileByName(d.Id())
+	if err != nil || serverProfile.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+
+	return resourceServerProfileRead(d, meta)
+}
+
+func resourceServerProfileDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteProfile(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}
+
+func getServerHardware(config *Config, serverProfileTemplate ov.ServerProfile) (hw ov.ServerHardware, err error) {
+
+	var availableHardware ov.ServerHardware
+	ovMutexKV.Lock(serverProfileTemplate.EnclosureGroupURI.String())
+	defer ovMutexKV.Unlock(serverProfileTemplate.EnclosureGroupURI.String())
+
+	for availableHardware.Created == "" {
+		serverHardware, error := config.ovClient.GetAvailableHardware(serverProfileTemplate.ServerHardwareTypeURI, serverProfileTemplate.EnclosureGroupURI)
+		if error != nil {
+			return availableHardware, error
+		}
+		if !serverHardwareURIs[serverHardware.URI.String()] {
+			availableHardware = serverHardware
+			serverHardwareURIs[serverHardware.URI.String()] = true
+		}
+	}
+	return availableHardware, nil
+}

--- a/builtin/providers/oneview/resource_server_profile_template.go
+++ b/builtin/providers/oneview/resource_server_profile_template.go
@@ -1,0 +1,331 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/HewlettPackard/oneview-golang/utils"
+	"github.com/hashicorp/terraform/helper/schema"
+	"strconv"
+)
+
+func resourceServerProfileTemplate() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceServerProfileTemplateCreate,
+		Read:   resourceServerProfileTemplateRead,
+		Update: resourceServerProfileTemplateUpdate,
+		Delete: resourceServerProfileTemplateDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"boot_order": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"network": {
+				Optional: true,
+				Type:     schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"function_type": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+						"network_uri": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"port_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "Lom 1:1-a",
+						},
+						"requested_mbps": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Default:  "2500",
+						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "ServerProfileTemplateV1",
+			},
+			"server_hardware_type": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"enclosure_group": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"affinity": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Bay",
+			},
+			"hide_unused_flex_nics": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"uri": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"etag": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"serial_number_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Virtual",
+				ForceNew: true,
+			},
+			"wwn_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Virtual",
+				ForceNew: true,
+			},
+			"mac_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Virtual",
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceServerProfileTemplateCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	serverProfileTemplate := ov.ServerProfile{
+		Name:               d.Get("name").(string),
+		Type:               d.Get("type").(string),
+		Affinity:           d.Get("affinity").(string),
+		SerialNumberType:   d.Get("serial_number_type").(string),
+		WWNType:            d.Get("wwn_type").(string),
+		MACType:            d.Get("mac_type").(string),
+		HideUnusedFlexNics: d.Get("hide_unused_flex_nics").(bool),
+	}
+
+	enclosureGroup, err := config.ovClient.GetEnclosureGroupByName(d.Get("enclosure_group").(string))
+	if err != nil {
+		return err
+	}
+	serverProfileTemplate.EnclosureGroupURI = enclosureGroup.URI
+
+	serverHardwareType, err := config.ovClient.GetServerHardwareTypeByName(d.Get("server_hardware_type").(string))
+	if err != nil {
+		return err
+	}
+	serverProfileTemplate.ServerHardwareTypeURI = serverHardwareType.URI
+
+	networkCount := d.Get("network.#").(int)
+	networks := make([]ov.Connection, 0)
+	for i := 0; i < networkCount; i++ {
+		networkPrefix := fmt.Sprintf("network.%d", i)
+		networks = append(networks, ov.Connection{
+			Name:          d.Get(networkPrefix + ".name").(string),
+			FunctionType:  d.Get(networkPrefix + ".function_type").(string),
+			NetworkURI:    utils.NewNstring(d.Get(networkPrefix + ".network_uri").(string)),
+			PortID:        d.Get(networkPrefix + ".port_id").(string),
+			RequestedMbps: d.Get(networkPrefix + ".requested_mbps").(string),
+			ID:            i + 1,
+		})
+	}
+	serverProfileTemplate.Connections = networks
+
+	if val, ok := d.GetOk("boot_order"); ok {
+		rawBootOrder := val.(*schema.Set).List()
+		bootOrder := make([]string, len(rawBootOrder))
+		for i, raw := range rawBootOrder {
+			bootOrder[i] = raw.(string)
+		}
+		serverProfileTemplate.Boot.ManageBoot = true
+		serverProfileTemplate.Boot.Order = bootOrder
+	}
+
+	sptError := config.ovClient.CreateProfileTemplate(serverProfileTemplate)
+	d.SetId(d.Get("name").(string))
+	if sptError != nil {
+		d.SetId("")
+		return sptError
+	}
+	return resourceServerProfileTemplateRead(d, meta)
+}
+
+func resourceServerProfileTemplateRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	spt, err := config.ovClient.GetProfileTemplateByName(d.Id())
+	if err != nil || spt.URI.IsNil() {
+		d.SetId("")
+		return nil
+	}
+
+	d.Set("name", spt.Name)
+	d.Set("type", spt.Type)
+
+	enclosureGroup, err := config.ovClient.GetEnclosureGroupByUri(spt.EnclosureGroupURI)
+	if err != nil {
+		return err
+	}
+	d.Set("enclosure_group_uri", enclosureGroup.Name)
+
+	serverHardwareType, err := config.ovClient.GetServerHardwareTypeByUri(spt.ServerHardwareTypeURI)
+	if err != nil {
+		return err
+	}
+	d.Set("server_hardware_type_uri", serverHardwareType.Name)
+	d.Set("affinity", spt.Affinity)
+	d.Set("uri", spt.URI.String())
+	d.Set("etag", spt.ETAG)
+	d.Set("serial_number_type", spt.SerialNumberType)
+	d.Set("wwn_type", spt.WWNType)
+	d.Set("mac_type", spt.MACType)
+	d.Set("hide_unused_flex_nics", spt.HideUnusedFlexNics)
+
+	networks := make([]map[string]interface{}, 0, len(spt.Connections))
+	for _, network := range spt.Connections {
+
+		networks = append(networks, map[string]interface{}{
+			"name":           network.Name,
+			"function_type":  network.FunctionType,
+			"network_uri":    network.NetworkURI,
+			"port_id":        network.PortID,
+			"requested_mbps": network.RequestedMbps,
+			"id":             network.ID,
+		})
+	}
+
+	networkCount := d.Get("network.#").(int)
+	if networkCount > 0 {
+		for i := 0; i < networkCount; i++ {
+			currNetworkId := d.Get("network." + strconv.Itoa(i) + ".id")
+			for j := 0; j < len(spt.Connections); j++ {
+				if spt.Connections[j].ID == currNetworkId && i <= len(spt.Connections)-1 {
+					networks[i], networks[j] = networks[j], networks[i]
+				}
+			}
+		}
+		d.Set("network", networks)
+	}
+
+	if spt.Boot.ManageBoot {
+		bootOrder := make([]interface{}, 0)
+		for _, currBoot := range spt.Boot.Order {
+			rawBootOrder := d.Get("boot_order").(*schema.Set).List()
+			for _, raw := range rawBootOrder {
+				if raw == currBoot {
+					bootOrder = append(bootOrder, currBoot)
+				}
+			}
+		}
+		d.Set("boot_order", bootOrder)
+	}
+	return nil
+}
+
+func resourceServerProfileTemplateUpdate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	serverProfileTemplate := ov.ServerProfile{
+		Name:               d.Get("name").(string),
+		Type:               d.Get("type").(string),
+		Affinity:           d.Get("affinity").(string),
+		URI:                utils.NewNstring(d.Get("uri").(string)),
+		ETAG:               d.Get("etag").(string),
+		SerialNumberType:   d.Get("serial_number_type").(string),
+		WWNType:            d.Get("wwn_type").(string),
+		MACType:            d.Get("mac_type").(string),
+		HideUnusedFlexNics: d.Get("hide_unused_flex_nics").(bool),
+	}
+
+	enclosureGroup, err := config.ovClient.GetEnclosureGroupByName(d.Get("enclosure_group").(string))
+	if err != nil {
+		return err
+	}
+	serverProfileTemplate.EnclosureGroupURI = enclosureGroup.URI
+
+	serverHardwareType, err := config.ovClient.GetServerHardwareTypeByName(d.Get("server_hardware_type").(string))
+	if err != nil {
+		return err
+	}
+	serverProfileTemplate.ServerHardwareTypeURI = serverHardwareType.URI
+
+	networkCount := d.Get("network.#").(int)
+	networks := make([]ov.Connection, 0)
+	for i := 0; i < networkCount; i++ {
+		networkPrefix := fmt.Sprintf("network.%d", i)
+		networks = append(networks, ov.Connection{
+			Name:          d.Get(networkPrefix + ".name").(string),
+			FunctionType:  d.Get(networkPrefix + ".function_type").(string),
+			NetworkURI:    utils.NewNstring(d.Get(networkPrefix + ".network_uri").(string)),
+			PortID:        d.Get(networkPrefix + ".port_id").(string),
+			RequestedMbps: d.Get(networkPrefix + ".requested_mbps").(string),
+			ID:            d.Get(networkPrefix + ".id").(int),
+		})
+	}
+	serverProfileTemplate.Connections = networks
+
+	if val, ok := d.GetOk("boot_order"); ok {
+		rawBootOrder := val.(*schema.Set).List()
+		bootOrder := make([]string, len(rawBootOrder))
+		for i, raw := range rawBootOrder {
+			bootOrder[i] = raw.(string)
+		}
+		serverProfileTemplate.Boot.ManageBoot = true
+		serverProfileTemplate.Boot.Order = bootOrder
+	}
+
+	err = config.ovClient.UpdateProfileTemplate(serverProfileTemplate)
+	if err != nil {
+		return err
+	}
+	d.SetId(d.Get("name").(string))
+
+	return resourceServerProfileTemplateRead(d, meta)
+	return nil
+}
+
+func resourceServerProfileTemplateDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	error := config.ovClient.DeleteProfileTemplate(d.Get("name").(string))
+	if error != nil {
+		return error
+	}
+	return nil
+}

--- a/builtin/providers/oneview/resource_server_profile_template_test.go
+++ b/builtin/providers/oneview/resource_server_profile_template_test.go
@@ -1,0 +1,95 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccServerProfileTemplate_1(t *testing.T) {
+	var serverProfileTemplate ov.ServerProfile
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServerProfileTemplateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccServerProfileTemplate,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerProfileTemplateExists(
+						"oneview_server_profile_template.test", &serverProfileTemplate),
+					resource.TestCheckResourceAttr(
+						"oneview_server_profile_template.test", "name", "terraform test spt",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckServerProfileTemplateExists(n string, serverProfileTemplate *ov.ServerProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testServerProfileTemplate, err := config.ovClient.GetProfileTemplateByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testServerProfileTemplate.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*serverProfileTemplate = testServerProfileTemplate
+		return nil
+	}
+}
+
+func testAccCheckServerProfileTemplateDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_server_profile_template" {
+			continue
+		}
+
+		testServerProfileTemplate, _ := config.ovClient.GetProfileTemplateByName(rs.Primary.ID)
+
+		if testServerProfileTemplate.Name != "" {
+			return fmt.Errorf("ServerProfileTemplate still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccServerProfileTemplate = `
+  resource "oneview_server_profile_template" "test" {
+    name = "terraform test spt"
+    server_hardware_type = "BL460c Gen9 1"
+    enclosure_group = "Houston"
+  }`

--- a/builtin/providers/oneview/resource_server_profile_test.go
+++ b/builtin/providers/oneview/resource_server_profile_test.go
@@ -1,0 +1,99 @@
+// (C) Copyright 2016 Hewlett Packard Enterprise Development LP
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+package oneview
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/HewlettPackard/oneview-golang/ov"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccServerProfile_1(t *testing.T) {
+	var serverProfile ov.ServerProfile
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServerProfileDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServerProfile,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServerProfileExists(
+						"oneview_server_profile.test", &serverProfile),
+					resource.TestCheckResourceAttr(
+						"oneview_server_profile.test", "name", "test"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckServerProfileExists(n string, serverProfile *ov.ServerProfile) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found :%v", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		config, err := testProviderConfig()
+		if err != nil {
+			return err
+		}
+
+		testServerProfile, err := config.ovClient.GetProfileByName(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		if testServerProfile.Name != rs.Primary.ID {
+			return fmt.Errorf("Instance not found")
+		}
+		*serverProfile = testServerProfile
+		return nil
+	}
+}
+
+func testAccCheckServerProfileDestroy(s *terraform.State) error {
+	config := testAccProvider.Meta().(*Config)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "oneview_machine" {
+			continue
+		}
+
+		_, err := config.ovClient.GetProfileByName(rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Instance still exists")
+		}
+	}
+
+	return nil
+}
+
+var testAccServerProfile = `
+  resource "oneview_server_profile_template" "test" {
+    name = "terraform test spt"
+    server_hardware_type = "BL460c Gen9 1"
+    enclosure_group = "Houston"
+  }
+
+  resource "oneview_server_profile" "test" {
+    name             = "test"
+    template  = "${oneview_server_profile_template.test.id}"
+  }`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -244,6 +244,12 @@
 			"revision": "0290933f5e8afd933f2823fce32bf2847e6ea603"
 		},
 		{
+			"checksumSHA1": "Ae3+suk6h+vfKb2+wEU2AjmusNs=",
+			"path": "github.com/HewlettPackard/oneview-golang",
+			"revision": "824ecdf6e3094c83cb54b800a6172ad2dbf416ee",
+			"revisionTime": "2016-11-22T00:02:32Z"
+		},
+		{
 			"path": "github.com/Unknwon/com",
 			"revision": "28b053d5a2923b87ce8c5a08f3af779894a72758"
 		},

--- a/website/source/docs/providers/oneview/index.html.markdown
+++ b/website/source/docs/providers/oneview/index.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "oneview"
+page_title: "Provider: OneView"
+sidebar_current: "docs-oneview-index"
+description: |-
+  The Oneview provider is used to interact with your on premise OneView system. The provider needs to be configured with the proper credentials before it can be used. 
+---
+
+#Oneview Provider 
+
+ The Oneview provider is used to interact with [OneView](https://www.hpe.com/us/en/integrated-systems/software.html). 
+ The provider needs to be configured with the proper credentials before it can be used. 
+
+##Example Usage
+```js
+//Configure the Oneview Provider
+provider "oneview" {
+  ov_username = "username"
+  ov_password = "password123"
+  ov_endpoint = oneview_url.com
+  ov_sslverify = true
+  ov_apiversion = 200
+}
+
+//Create a new ethernet network
+resource "oneview_ethernet_network" {
+  // ...
+}
+```
+## Authentication
+
+The Oneview provider supports static credentials and environment variables.
+
+##Configuration Reference
+
+The following keys can be used to configure the provider.
+
+* `ov_username` - (Optional) This is the OneView username. 
+  It must be provided or sourced from ONEVIEW_OV_USER environment variable.
+
+* `ov_password` - (Optional) This is the OneView password. 
+  It must be provided or sourced from ONEVIEW_OV_PASSWORD environment variable.
+  
+* `ov_endpoint` - (Optional) This is the OneView URL.
+  It must be provided or sourced from ONEVIEW_OV_ENDPOINT environment variable.
+
+* `ov_sslverify` - (Optional) This is a boolean value for whether ssl is enabled. 
+  It must be provided or sourced from ONEVIEW_OV_SSLVERIFY environment variable.
+
+* `ov_apiversion` - (Optional) This specifies what API version to use.
+  It must be provided or sourced from ONEVIEW_OV_API_VERSION environment variable.
+
+* `ov_domain` - (Optional) This is the domain to use for the oneview system.
+  It can be provided or sourced from ONEVIEW_OV_DOMAIN environment variable.
+  
+* `icsp_username` - (Optional) This is the username to connect to an ICSP instance
+  It can be provided or sourced from ONEVIEW_ICSP_USER environment variable.
+
+* `icsp_password` - (Optional) This is the password to connect to an ICSP instance
+  It can be provided or sourced from ONEVIEW_ICSP_PASSWORD environment variable.
+  
+* `icsp_endpoint` - (Optional) This is the url to connect to an ICSP instance
+  It can be provided or sourced from ONEVIEW_ICSP_ENDPOINT environment variable.
+ 
+* `icsp_sslverify` - (Optional) This is a boolean value for whether ssl is enabled to an ICSP instance
+  It can be provided or sourced from ONEVIEW_ICSP_SSLVERIFY environment variable.
+  
+* `icsp_apiversion` - (Optional) This is the api version to be used with an ICSP instance
+  It can be provided or sourced from ONEVIEW_ICSP_API_VERSION environment variable.
+  
+* `i3s_endpoint` - (Optional) This is the endpoint to connect to an image streamer instance
+  It can be provided or sourced from ONEVIEW_I3S_ENDPOINT environment variable.

--- a/website/source/docs/providers/oneview/r/enclosure_group.html.markdown
+++ b/website/source/docs/providers/oneview/r/enclosure_group.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "oneview"
+page_title: "Oneview: enclosure_group"
+sidebar_current: "docs-oneview-enclosure-group"
+description: |-
+  Creates an enclosure-group.
+---
+
+# oneview\_enclosure\_group
+
+Creates an enclosure group.
+
+## Example Usage
+
+```js
+resource "oneview_enclosure_group" "default" {
+  name = "default-enclosure-group"
+  logical_interconnect_broups = ["${oneview_logical_interconnect_group.primary.name}", 
+                                 "${oneview_logical_interconnect_group.secondary.name}"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+---
+
+* `logical_interconnect_groups` - (Optional) The set of logical interconnect group names to associate with the enclosure group.
+
+* `stacking mode` - (Optional) Stacking mode of the enclosure group. Defaults to Enclosure.
+
+* `number_of_bays` - (Optional) The number of interconnect bay mappings. Defaults to 8.
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.

--- a/website/source/docs/providers/oneview/r/ethernet_network.html.markdown
+++ b/website/source/docs/providers/oneview/r/ethernet_network.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "oneview"
+page_title: "Oneview: ethernet_network"
+sidebar_current: "docs-oneview-ethernet-network"
+description: |-
+  Creates an ethernet network.
+---
+
+# oneview\_ethernet\_network
+
+Creates an ethernet network.
+
+## Example Usage
+
+```js
+resource "oneview_ethernet_network" "default" {
+  name = "test-ethernet-network"
+  vlanId = 71
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+* `vlanId` - (Required) The Virtual LAN (VLAN) identification number (integer) assigned to the network. 
+Changing this forces a new resource.
+
+- - -
+
+* `purpose` - (Optional) A description of the network's role within the logical interconnect. 
+  This defaults to General.
+  
+* `private_network` - (Optional) When enabled, the network is configured so that all downlink (server) ports 
+  connected to the network are prevented from communicating with each other within the logical interconnect.
+  This defaults to false.
+
+* `smart_link` - (Optional) When enabled, the network is configured so that, within a logical interconnect, 
+  all uplinks that carry the network are monitored. This defaults to false.
+  
+* `ethernet_network_type` - (Optional) The type of Ethernet network. This defaults to Tagged.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.
+
+* `eTag` - Entity tag/version ID of the resource.

--- a/website/source/docs/providers/oneview/r/fc_network.html.markdown
+++ b/website/source/docs/providers/oneview/r/fc_network.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "oneview"
+page_title: "Oneview: fc_network"
+sidebar_current: "docs-oneview-fc-network"
+description: |-
+  Creates an fibre channel network.
+---
+
+# oneview\_fc\_network
+
+Creates an fc network.
+
+## Example Usage
+
+```js
+resource "oneview_fc_network" "default" {
+  name = "test-fc-network"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+- - -
+
+* `fabric_type` - (Optional) The supported Fibre Channel access method. 
+  This defaults to FabricAttach.
+  
+* `link_stability_time` - (Optional) The time interval, expressed in seconds, to 
+wait after a link that was previously offline becomes stable, before automatic redistribution occurs within the fabric. 
+This value is not effective if autoLoginRedistribution is false.
+This defaults to 30.
+
+* `auto_login_redistribution` - (Optional) Used for load balancing when logins are not 
+evenly distributed over the Fibre Channel links,such as when an uplink that was previously down becomes available. 
+This defaults to false.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.
+
+* `eTag` - Entity tag/version ID of the resource.

--- a/website/source/docs/providers/oneview/r/fcoe_network.html.markdown
+++ b/website/source/docs/providers/oneview/r/fcoe_network.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "oneview"
+page_title: "Oneview: fcoe_network"
+sidebar_current: "docs-oneview-fcoe-network"
+description: |-
+  Creates an fcoe network.
+---
+
+# oneview\_fcoe\_network
+
+Creates an fcoe network.
+
+## Example Usage
+
+```js
+resource "oneview_fcoe_network" "default" {
+  name = "test-fcoe-network"
+  vlanId = 71
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+* `vlanId` - (Required) The Virtual LAN (VLAN) identification number (integer) assigned to the network. 
+Changing this forces a new resource
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.
+
+* `eTag` - Entity tag/version ID of the resource.

--- a/website/source/docs/providers/oneview/r/i3s_plan.html.markdown
+++ b/website/source/docs/providers/oneview/r/i3s_plan.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "oneview"
+page_title: "Oneview: i3s_plan"
+sidebar_current: "docs-oneview-i3s-plan"
+description: |-
+  Adds a deployment plan to a server.
+---
+
+# oneview\_i3s\_plan
+
+Adds a deployment plan to a server.
+
+## Example Usage
+
+```js
+resource "oneview_i3s_plan" "default" {
+  server_name = "${oneview_server_profile.default.name}"
+  os_deployment_plan = "Ubuntu 16.04"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `server_name` - (Required) The name of the server that the deployment plan will be run on.
+
+* `os_deployment_plan` - (Required) The name of the deployment plan that will run on the server. 
+
+- - -
+
+* `deployment_attribute` - (Optional) A key/value pair that modifies the default values provided by the os deployment plan
+  This can be specified multiple times. Deployment Attribute is described below.
+  
+Deployment Attribute supports the following:
+
+* `key` - (Required) - The unique name of the attribute.
+
+* `value` - (Required) - The value of the attribute.
+
+

--- a/website/source/docs/providers/oneview/r/icsp_server.html.markdown
+++ b/website/source/docs/providers/oneview/r/icsp_server.html.markdown
@@ -1,0 +1,65 @@
+---
+layout: "oneview"
+page_title: "Oneview: icsp_server"
+sidebar_current: "docs-oneview-icsp-server"
+description: |-
+  Hooks a server profile created in OneView into ICSP.
+---
+
+# oneview\_icsp\_server
+
+Hooks a server profile created in OneView into ICSP.
+
+## Example Usage
+
+```js
+resource "icsp_server" "default" {
+  ilo_ip = "15.x.x.x"
+  user_name = "ilo_user"
+  password = "ilo_password"
+  serial_number = "${oneview_server_profile.default.serial_number}"
+  build_plans = ["/rest/os-deployment-build-plans/1570001"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `ilo_ip` - (Required) The IP address of the iLO of the server.
+
+* `user_name` - (Required) The user name required to log into the server's iLO.
+
+* `password` - (Required) The password required to log into the server's iLO.
+
+* `serial_number` - (Required) The serial number assigned to the Server.
+
+- - -
+
+* `port` - (Optional) The iLO port to use when logging in. 
+  This defaults to 443.
+  
+* `build_plans` - (Optional) An array of build plan uris that you want to run on the server.
+
+* `public_mac` - (Optional) The MAC address of the NIC that will be the public network connection.
+  
+* `public_slot_id` - (Optional) The slot id for the public network connection.
+
+* `custom_attribute` - (Optional) A key/value pair for a custom attribute you would like associated with 
+the server on icsp. Custom Attribute options specified below.
+
+Custom Attribute supports the following:
+
+* `key` - (Required) - The unique name of the attribute.
+
+* `value` - (Required) - The value of the attribute.
+
+* `scope` - (Optional) - The scope of the attribute. Defaults to `server`.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `mid` -  A unique ID assigned to the Server by Server Automation.
+
+* `public_ipv4` - The public ip address if `public_mac` and `public_slot_id` were specified in the configuration.

--- a/website/source/docs/providers/oneview/r/logical_interconnect_group.html.markdown
+++ b/website/source/docs/providers/oneview/r/logical_interconnect_group.html.markdown
@@ -1,0 +1,184 @@
+---
+layout: "oneview"
+page_title: "Oneview: logical_interconnect_group"
+sidebar_current: "docs-oneview-logical-interconnect-group"
+description: |-
+  Creates a logical interconnect group.
+---
+
+# oneview\_logical\_interconnect\_group
+
+Creates a logical interconnect group.
+
+## Example Usage
+
+```js
+resource "oneview_logical_interconnect_group" "default" {
+  name = "test-logical-interconnect-group"
+  
+  internal_network_uris = ["${oneview_ethernet_network.default.0.uri}"]
+  
+  interconnect_settings {
+    fast_mac_cache_failover = false
+    igmp_timeout_interval = 250
+  }
+  
+  interconnect_map_entry_template {
+    interconnect_type_name = "HP VC FlexFabric-20/40 F8 Module"
+    bay_number = 1
+  }
+  
+  snmp_configuration {
+    read_community = "Group 1"
+    system_contact = "admin"
+    snmp_access = ["192.168.1.101"]
+    
+    trap_destination {
+      trap_destination = "127.0.0.1"
+      enet_trap_categories = ["Port Thresholds", "Other"]
+      trap_severities = ["Info"]
+    }
+  }
+  
+  uplink_set {
+    name = "uplink-default"
+    network_uris = ["${oneview_ethernet_network.test.1.uri}"]
+    logical_port_config {
+      bay_num = 4
+      port_num = [20,21]
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+- - -
+
+* `internal_network_uris` - (Optional) A list of internal network URIs
+
+* `interconnect_settings` - (Optional) A interconnect settings block. If not supplied a default will be used.
+  Interconnect Settings documented below.
+
+* `telemetry_configuration` - (Optional) The controls for collection of interconnect statistics. 
+  If not supplied a default will be used. Telemetry Configuration documented below.
+  
+* `snmp_configuration` - (Optional) The SNMP configuration for the logical interconnect group. 
+  If not supplied a default will be used. Snmp Configuration is documented below.
+
+* `interconnect_map_entry_template` - (Optional) Interconnect map associated with the logical interconnect group.
+  This can be specified multiple times. Interconnect Map Entry Template is documented below. 
+
+* `uplink_set` - (Optional) List of uplink sets in the logical interconnect group.
+  This can be specified multiple times. Uplink Set is documented below. 
+
+Interconnect Settings support the following:
+
+* `fast_mac_cache_failover` - (Optional) This will cause Ethernet packets to be tranmitted on newly-active links.
+  Defaults to true.
+
+* `igmp_snooping` - (Optional) Allows modules to monitor the IGMP IP multicast membership activities.
+  Defaults to false.
+  
+* `network_loop_protection` - (Optional) Enables or disables network loop protection.
+  Defaults to true.
+  
+* `pause_flood_protection` - (Optional) Enables Pause Flood Control protection.
+  Defaults to true. 
+  
+* `igmp_timeout_interval` - (Optional) IGMP snooping idle time out intervals in seconds.
+  Defaults to 260
+  
+* `mac_refresh_interval` - (Optional)  MAC Cache Fail Over refresh intervals in seconds.
+  Defaults to 5
+
+Telemetry Configuration supports the following:
+
+* `enabled` - (Optional) Enables telemetry. Defaults to true.
+
+* `sample_count` - (Optional) Telemetry sample count. Defaults to 12.
+
+* `sample_interval` - (Optional) Telemetry sample interval in seconds. Defaults to 300.
+
+Snmp Configuration supports the following: 
+
+* `enabled` - (Optional) Enables SNMP. Defaults to true.
+
+* `read_community` - (Optional) Authentication string for read-only access.
+  Defaults to public.
+
+* `system_contact` - (Optional) Person to notify when system problems occur.
+
+* `snmp_access` - (Optional) The access list allowed for GET operations.
+
+* `trap_destination` - (Optional) The list of configured trap destinations.
+  This can be specified multiple times. Trap Destination options specified below.
+
+Trap Destination supports the following:
+
+* `trap_destination` - (Required) The trap destination IP address or host name.
+
+* `trap_format` - (Optional) The trap format (SNMP version) for this trap destination.
+  Defaults to SNMPv1.
+
+* `community_string` - (Optional)  Authentication string for the trap destination.
+  Defaults to public. 
+
+* `enet_trap_categories` - (Optional)  Filter the traps for this trap destination by the list of configured Ethernet traps.
+
+* `fc_trap_categories` - (Optional)  Filter the traps for this trap destination by the list of configured Fibre Channel traps.
+
+* `vcm_trap_categories` - (Optional) Filter the traps for this trap destination by the list of configured VCM traps.
+
+* `trap_severities` - (Optional) Filter the traps for this trap destination by the list of configured severities
+
+Interconnect Map Entry Template supports the following:
+
+* `interconnect_type_name` - (Required) The interconnect type name for the bay.
+
+* `bay_number` - (Required) The bay number to use. 
+
+* `enclosure_index` - (Optional) The enclosure to use. Defaults to 1.
+
+Uplink Set supports the following:
+
+* `name` - (Required) A unique name for the resource.
+
+* `network_uris` - (Optional) The set of network URIs. NOTE: for Ethernet Uplink Set Groups, 
+  all Ethernet Networks must have unique VLAN IDs.
+
+* `native_network_uri` - (Optional) The Ethernet native network URI.
+
+* `network_type` - (Optional) The type of network. Defaults to Ethernet.
+
+* `mode` - (Optional) The Ethernet uplink failover mode. Defaults to Auto.
+
+* `lacp_timer` - (Optional) The LACP timer. Defaults to Long.
+
+* `logical_port_config` - (Optional) The detailed configuration properties for the uplink ports.
+  Logical Port Config is documented below.
+
+Logical Port Config supports the followings:
+
+* `bay_num` - (Required) The bay number to use. 
+
+* `port_num` - (Required) The set of port numbers to use.
+
+* `enclosure_num` - (Optional) The enclosure to use. Defaults to 1.
+
+* `primary_port` - (Optional) The Ethernet primary failover port. Defaults to false.
+
+* `desired_speed` - (Optional) The port speed you prefer it to use. Defaults to Auto.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.
+
+* `eTag` - Entity tag/version ID of the resource.

--- a/website/source/docs/providers/oneview/r/logical_switch.html.markdown
+++ b/website/source/docs/providers/oneview/r/logical_switch.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "oneview"
+page_title: "Oneview: logical-switch"
+sidebar_current: "docs-oneview-logical-switch"
+description: |-
+  Creates a logical switch.
+---
+
+# oneview\_logical\_switch
+
+Creates a logical switch.
+
+## Example Usage
+
+```js
+resource "oneview_logical_switch" "default" {
+  name = "test-logical-switch"
+  switch_type_name = "Cisco Nexus 6xxx"
+  switch_count = 1
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+* `switch_type_name` - (Required) The name of the permitted switch type. 
+  If this name changes, it will recreate the resource. 
+
+* `switch_count` - (Required) The number of switches in your logical switch group. 
+  
+- - -
+
+* `location_entry_type` - (Optional) The type of the location. 
+  This defaults to StackingMemberId.
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.
+
+* `eTag` - Entity tag/version ID of the resource.

--- a/website/source/docs/providers/oneview/r/network_set.html.markdown
+++ b/website/source/docs/providers/oneview/r/network_set.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "oneview"
+page_title: "Oneview: network_set"
+sidebar_current: "docs-oneview-network-set"
+description: |-
+  Creates a network set.
+---
+
+# oneview\_network\_set
+
+Creates a network set.
+
+## Example Usage
+## Empty Network Set
+```js
+resource "oneview_network_set" "default" {
+  name = "test-network-set"
+}
+```
+## With networks 
+```js
+resource "oneview_network_set" "default" {
+  name = "test-network-set"
+  network_uris = ["${oneview_ethernet_network.default.*.uri}"]
+  native_network_uri = "${oneview_ethernet_network.default.1.uri}"
+}
+```
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+- - -
+
+* `network_uris` - (Optional) A set of Ethernet network URIs that will be members of this network set. 
+  NOTE: all Ethernet networks in a network set must have unique VLAN IDs.
+  
+* `native_network_uri` - (Optional) The URI of the network that will serve as the native network 
+  in the network set. It must be in the set of network_uris.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.
+
+* `eTag` - Entity tag/version ID of the resource.

--- a/website/source/docs/providers/oneview/r/server_profile.html.markdown
+++ b/website/source/docs/providers/oneview/r/server_profile.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "oneview"
+page_title: "Oneview: server_profile"
+sidebar_current: "docs-oneview-server-profile"
+description: |-
+  Creates a server profile.
+---
+
+# oneview\_server\_profile
+
+Creates a server profile.
+et
+## Example Usage
+
+```js
+resource "oneview_server_profile" "default" {
+  name = "test-server-profile"
+  template = "${oneview_server_profile_template.test.name}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+* `template` - (Required) The name of the template you will use for the server profile. 
+
+- - -
+
+* `public_connection` - (Optional) The name of the network that is going out to the public.
+
+* `hardware_name` - (Optional) The name of the Server Hardware the server will be provisioned on.
+  If this isn't used, a server hardware will be picked based on what hardware to use from the server profile template.
+
+* `type` - (Optional) The server profile version to be provisioned. Defaults to ServerProfileV5.
+  Use ServerProfileV6 to use Image Streamer.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `serial_number` - A 10-byte value that is exposed to the Operating System as the server hardware's
+  Serial Number. The value can be a virtual serial number, user defined serial number or physical serial
+  number read from the server's ROM. It cannot be modified after the profile is created.
+
+* `public_mac` - The MAC address of the NIC your public network is attached to.
+  Need to specify public_connection to access this value. 
+  
+* `public_slot_id` - The slot id of the NIC your public network is attached to.
+  Need to specify public_connection to access this value. 
+  
+* `ilo_ip` - The ILO ip address that is managing the server.
+
+* `hardware_uri` - The address of the hardware the server is provisioned on.

--- a/website/source/docs/providers/oneview/r/server_profile_template.html.markdown
+++ b/website/source/docs/providers/oneview/r/server_profile_template.html.markdown
@@ -1,0 +1,87 @@
+---
+layout: "oneview"
+page_title: "Oneview: server_profile_template"
+sidebar_current: "docs-oneview-server-profile-template"
+description: |-
+  Creates a server profile template.
+---
+
+# oneview\_server\_profile\_template
+
+Creates a server profile template.
+
+## Example Usage
+
+```js
+resource "oneview_server_profile_template" "default" {
+  name = "test-server-profile-template"
+  enclosure_group = "my_enclosure_group"
+  server_hardware_type = "BL460c Gen9 1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported: 
+
+* `name` - (Required) A unique name for the resource.
+
+* `enclosure_group` - (Required) Identifies the enclosure group name for which the Server Profile Template was designed. 
+The enclosure group is determined when the profile template is created and cannot be modified. 
+
+* `server_hardware_type` - (Required) Identifies the server hardware type name for which the Server Profile Template was 
+designed. The server hardware type is determined when the profile template is created and cannot be modified.
+
+- - -
+
+* `affinity` - (Optional) This identifies the behavior of the server profiles created from this template when the server 
+hardware is removed or replaced. This can be set to Bay or BayAndServer. 
+This defaults to Bay.
+  
+* `network` - (Optional) Network connection to be configured for the server. Can be specified multiple times. 
+Network configuration is specified below.
+  
+* `hide_unused_flex_nics` - (Optional) Hides flex nics that aren't in use.
+  This defaults to true.
+
+* `serial_number_type` - (Optional) Specifies the type of Serial Number and UUID to be programmed into the server ROM. 
+The value can be 'Virtual' or 'Physical'. Changing this forces a new resource.
+This defaults to 'Virtual'.
+  
+* `wwn_type` - (Optional) Specifies the type of WWN address to be programmed into the IO devices. The value can be 'Virtual' 
+or 'Physical'. Changing this forces a new resource. 
+This defaults to 'Virtual'.
+
+* `mac_type` - (Optional) Specifies the type of MAC address to be programmed into the IO devices. The value can be 'Virtual'
+or 'Physical'. Changing this forces a new resource.
+This defaults to 'Virtual'.
+
+* `mac_type` - (Optional) Specifies the type of MAC address to be programmed into the IO devices. The value can be 'Virtual'
+or 'Physical'. Changing this forces a new resource.
+This defaults to 'Virtual'.
+
+* `boot_order`- (Optional) Defines the order in which boot will be attempted on the available devices. Different hardware 
+take different boot orders. Refer to the api documentation for your specific boot order options.
+
+Network supports the following:
+
+* `name` - (Required) A unique name for the resource.
+
+* `function_type` - (Required) Type of function required for the connection. Values can be 'Ethernet' or 'FibreChannel'
+Changing this forces a new resoure.
+
+* `network_uri` - (Required) Identifies the network or network set to be connected. 
+
+* `port_id` - (Optional) Identifies the port (FlexNIC) used for this connection. Defaults to "Lom 1:1-a".
+
+* `requested_mbps` - (Optional) The transmit throughput (mbps) that should be allocated to this connection.
+Defaults to `2500`
+
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are exported:
+
+* `uri` - The URI of the created resource.
+
+* `eTag` - Entity tag/version ID of the resource.


### PR DESCRIPTION
This PR adds a new provider to Terraform that works against HPE OneView. Terraform can now manage about 10 resources in OneView with more to come. 

Because there is no public facing OneView instance, all acceptance tests had to be run internally...hopefully this isn't an issue! 

Any feedback is greatly appreciated and will be handled immediately.