### PR TITLE
Correct parent zone reference in route53_zone docs

### DIFF
--- a/website/source/docs/providers/aws/r/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_zone.html.markdown
@@ -36,7 +36,7 @@ resource "aws_route53_zone" "dev" {
 }
 
 resource "aws_route53_record" "dev-ns" {
-    zone_id = "${aws_route53_zone.dev.zone_id}"
+    zone_id = "${aws_route53_zone.main.zone_id}"
     name = "dev.example.com"
     type = "NS"
     ttl = "30"


### PR DESCRIPTION
When creating a subdomain as exemplified in the docs, the NS records need to be added to the parent zone, and the docs had this reference pointed at the subdomain (rather than the parent).