### PR TITLE
command: use reset instead of reset_bold

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -129,7 +129,7 @@ func (h *UiHook) PreApply(
 	}
 
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-		"[reset][bold]%s: %s[reset_bold]%s",
+		"[reset][bold]%s: %s[reset]%s",
 		id,
 		operation,
 		attrString)))
@@ -165,7 +165,7 @@ func (h *UiHook) stillApplying(id string) {
 	}
 
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-		"[reset][bold]%s: %s (%s elapsed)[reset_bold]",
+		"[reset][bold]%s: %s (%s elapsed)[reset]",
 		id,
 		msg,
 		time.Now().Round(time.Second).Sub(state.Start),
@@ -204,7 +204,7 @@ func (h *UiHook) PostApply(
 	}
 
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-		"[reset][bold]%s: %s[reset_bold]",
+		"[reset][bold]%s: %s[reset]",
 		id, msg)))
 
 	return terraform.HookActionContinue, nil
@@ -221,7 +221,7 @@ func (h *UiHook) PreProvision(
 	provId string) (terraform.HookAction, error) {
 	id := n.HumanId()
 	h.ui.Output(h.Colorize.Color(fmt.Sprintf(
-		"[reset][bold]%s: Provisioning with '%s'...[reset_bold]",
+		"[reset][bold]%s: Provisioning with '%s'...[reset]",
 		id, provId)))
 	return terraform.HookActionContinue, nil
 }


### PR DESCRIPTION
Fixes #10337

The `reset_bold` escape code (21) causes the text on Windows command
prompts to just become invisible. `reset` does the same job for us in
this scenario so do that.

Looks like this (versus just being empty text in #10337):

![2016-11-29 at 10 01 am](https://cloud.githubusercontent.com/assets/1299/20722286/cc91bede-b61a-11e6-9231-7045f1a9afb3.png)
