### PR TITLE
Fix count interpolation with computed values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -88,6 +88,8 @@ type Resource struct {
 	Provider     string
 	DependsOn    []string
 	Lifecycle    ResourceLifecycle
+
+	DeferCountComputation bool
 }
 
 // Copy returns a copy of this Resource. Helpful for avoiding shared
@@ -213,6 +215,10 @@ func (r *Module) Id() string {
 
 // Count returns the count of this resource.
 func (r *Resource) Count() (int, error) {
+	if r.DeferCountComputation {
+		return 1, nil
+	}
+
 	v, err := strconv.ParseInt(r.RawCount.Value().(string), 0, 0)
 	if err != nil {
 		return 0, err

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -77,4 +77,11 @@ type EvalContext interface {
 	// State returns the global state as well as the lock that should
 	// be used to modify that state.
 	State() (*State, *sync.RWMutex)
+
+	// True if we can ignore missing computed values when interpolating
+	// the count variable
+	//
+	// This is useful as we don't have the full tree during walkInput
+	// or walkValidate
+	CanIgnoreMissingCountExpansion() bool
 }

--- a/terraform/eval_context_builtin.go
+++ b/terraform/eval_context_builtin.go
@@ -39,8 +39,13 @@ type BuiltinEvalContext struct {
 	DiffLock            *sync.RWMutex
 	StateValue          *State
 	StateLock           *sync.RWMutex
+	IgnoreMissingCount  bool
 
 	once sync.Once
+}
+
+func (ctx *BuiltinEvalContext) CanIgnoreMissingCountExpansion() bool {
+	return ctx.IgnoreMissingCount
 }
 
 func (ctx *BuiltinEvalContext) Hook(fn func(Hook) (HookAction, error)) error {

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -198,3 +198,7 @@ func (c *MockEvalContext) State() (*State, *sync.RWMutex) {
 	c.StateCalled = true
 	return c.StateState, c.StateLock
 }
+
+func (c *MockEvalContext) CanIgnoreMissingCountExpansion() bool {
+	return false
+}

--- a/terraform/eval_count_computed.go
+++ b/terraform/eval_count_computed.go
@@ -6,19 +6,26 @@ import (
 	"github.com/hashicorp/terraform/config"
 )
 
-// EvalCountCheckComputed is an EvalNode that checks if a resource count
-// is computed and errors if so. This can possibly happen across a
-// module boundary and we don't yet support this.
-type EvalCountCheckComputed struct {
+// EvalCountFixComputed is an EvalNode that checks if a resource count
+// is computed and try to fix the value.
+// It can only be fixed if the walk operation is either walkInput or walkValidate
+// Otherwise it errors
+type EvalCountFixComputed struct {
 	Resource *config.Resource
 }
 
 // TODO: test
-func (n *EvalCountCheckComputed) Eval(ctx EvalContext) (interface{}, error) {
-	if n.Resource.RawCount.Value() == unknownValue() {
-		return nil, fmt.Errorf(
-			"%s: value of 'count' cannot be computed",
-			n.Resource.Id())
+func (n *EvalCountFixComputed) Eval(ctx EvalContext) (interface{}, error) {
+	if ctx.CanIgnoreMissingCountExpansion() {
+		n.Resource.DeferCountComputation = true
+	} else {
+		n.Resource.DeferCountComputation = false
+
+		if n.Resource.RawCount.Value() == unknownValue() {
+			return nil, fmt.Errorf(
+				"%s: value of 'count' cannot be computed",
+				n.Resource.Id())
+		}
 	}
 
 	return nil, nil

--- a/terraform/graph_config_node_resource.go
+++ b/terraform/graph_config_node_resource.go
@@ -221,7 +221,7 @@ func (n *GraphNodeConfigResource) EvalTree() EvalNode {
 	return &EvalSequence{
 		Nodes: []EvalNode{
 			&EvalInterpolate{Config: n.Resource.RawCount},
-			&EvalCountCheckComputed{Resource: n.Resource},
+			&EvalCountFixComputed{Resource: n.Resource},
 			&EvalOpFilter{
 				Ops:  []walkOperation{walkValidate},
 				Node: &EvalValidateCount{Resource: n.Resource},

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -64,6 +64,11 @@ func (w *ContextGraphWalker) EnterPath(path []string) EvalContext {
 	w.interpolaterVars[key] = variables
 	w.interpolaterVarLock.Unlock()
 
+	ignoreMissingCount := false
+	if w.Operation == walkInput || w.Operation == walkValidate {
+		ignoreMissingCount = true
+	}
+
 	ctx := &BuiltinEvalContext{
 		PathValue:           path,
 		Hooks:               w.Context.hooks,
@@ -89,6 +94,7 @@ func (w *ContextGraphWalker) EnterPath(path []string) EvalContext {
 		},
 		InterpolaterVars:    w.interpolaterVars,
 		InterpolaterVarLock: &w.interpolaterVarLock,
+		IgnoreMissingCount:  ignoreMissingCount,
 	}
 
 	w.contexts[key] = ctx

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -31,7 +31,7 @@ func (n *NodePlannableResource) EvalTree() EvalNode {
 			// into the proper number of instances.
 			&EvalInterpolate{Config: n.Config.RawCount},
 
-			&EvalCountCheckComputed{Resource: n.Config},
+			&EvalCountFixComputed{Resource: n.Config},
 			&EvalCountFixZeroOneBoundary{Resource: n.Config},
 		},
 	}


### PR DESCRIPTION
This commit enables the use computed values when interpolating
the count special variable.

This is achieved by defering the expansion of `count` during
walkInput and walkValidate as the real value isn't necessary
at this point.

The value will be resolved during walkRefresh and DynamicExpand
will work as expected.

Partially fixes #3888.

@edit
I'm not sure on how write tests for this. I tested with this snippet and it works: https://gist.github.com/greenboxal/113469077550fa1f6c65d4db7f22ba27

Can someone guide me on this?