### PR TITLE
provider/cloudstack: properly support secundary IP addresses

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_static_nat.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_static_nat.go
@@ -23,13 +23,6 @@ func resourceCloudStackStaticNAT() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"network_id": &schema.Schema{
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
-				Deprecated: "network_id is deprecated and can be safely omitted",
-			},
-
 			"virtual_machine_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
@@ -73,10 +66,18 @@ func resourceCloudStackStaticNATCreate(d *schema.ResourceData, meta interface{})
 		p.SetVmguestip(vmGuestIP.(string))
 
 		// Set the network ID based on the guest IP, needed when the public IP address
-		// is not associated with any network yet (VPC case)
+		// is not associated with any network yet
+	NICS:
 		for _, nic := range vm.Nic {
 			if vmGuestIP.(string) == nic.Ipaddress {
 				p.SetNetworkid(nic.Networkid)
+				break NICS
+			}
+			for _, ip := range nic.Secondaryip {
+				if vmGuestIP.(string) == ip.Ipaddress {
+					p.SetNetworkid(nic.Networkid)
+					break NICS
+				}
 			}
 		}
 	} else {

--- a/website/source/docs/providers/cloudstack/r/static_nat.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/static_nat.html.markdown
@@ -26,9 +26,6 @@ The following arguments are supported:
 * `ip_address_id` - (Required) The public IP address ID for which static
     NAT will be enabled. Changing this forces a new resource to be created.
 
-* `network_id` - (Deprecated) The network ID of the VM the static NAT will be
-    enabled for. This argument is no longer needed and can be safely omitted.
-
 * `virtual_machine_id` - (Required) The virtual machine ID to enable the
     static NAT feature for. Changing this forces a new resource to be created.
 


### PR DESCRIPTION
And remove the deprecated `network_id` field.