### PR TITLE
Add `helpers.shema.Provisoner` base type for provisioners like there's one for providers

### DIFF
--- a/builtin/bins/provisioner-chef/main.go
+++ b/builtin/bins/provisioner-chef/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/chef"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(chef.ResourceProvisioner)
-		},
+		ProvisionerFunc: chef.ResourceProvisioner,
 	})
 }

--- a/builtin/bins/provisioner-file/main.go
+++ b/builtin/bins/provisioner-file/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/file"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(file.ResourceProvisioner)
-		},
+		ProvisionerFunc: file.ResourceProvisioner,
 	})
 }

--- a/builtin/bins/provisioner-local-exec/main.go
+++ b/builtin/bins/provisioner-local-exec/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/local-exec"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(localexec.ResourceProvisioner)
-		},
+		ProvisionerFunc: localexec.ResourceProvisioner,
 	})
 }

--- a/builtin/bins/provisioner-remote-exec/main.go
+++ b/builtin/bins/provisioner-remote-exec/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(remoteexec.ResourceProvisioner)
-		},
+		ProvisionerFunc: remoteexec.ResourceProvisioner,
 	})
 }

--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -26,7 +26,7 @@ func (p *Provisioner) linuxInstallChefClient(
 	if p.HTTPSProxy != "" {
 		prefix += fmt.Sprintf("https_proxy='%s' ", p.HTTPSProxy)
 	}
-	if p.NOProxy != nil {
+	if p.NOProxy != nil && len(p.NOProxy) > 0 {
 		prefix += fmt.Sprintf("no_proxy='%s' ", strings.Join(p.NOProxy, ","))
 	}
 

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -125,14 +125,13 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(tc.Config)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -264,7 +263,6 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
@@ -272,7 +270,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(tc.Config)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -131,7 +131,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -270,7 +270,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/go-linereader"
-	"github.com/mitchellh/mapstructure"
 )
 
 const (
@@ -84,33 +83,33 @@ enable_reporting false
 
 // Provisioner represents a Chef provisioner
 type Provisioner struct {
-	AttributesJSON        string   `mapstructure:"attributes_json"`
-	ClientOptions         []string `mapstructure:"client_options"`
-	DisableReporting      bool     `mapstructure:"disable_reporting"`
-	Environment           string   `mapstructure:"environment"`
-	FetchChefCertificates bool     `mapstructure:"fetch_chef_certificates"`
-	LogToFile             bool     `mapstructure:"log_to_file"`
-	UsePolicyfile         bool     `mapstructure:"use_policyfile"`
-	PolicyGroup           string   `mapstructure:"policy_group"`
-	PolicyName            string   `mapstructure:"policy_name"`
-	HTTPProxy             string   `mapstructure:"http_proxy"`
-	HTTPSProxy            string   `mapstructure:"https_proxy"`
-	NOProxy               []string `mapstructure:"no_proxy"`
-	NodeName              string   `mapstructure:"node_name"`
-	OhaiHints             []string `mapstructure:"ohai_hints"`
-	OSType                string   `mapstructure:"os_type"`
-	RecreateClient        bool     `mapstructure:"recreate_client"`
-	PreventSudo           bool     `mapstructure:"prevent_sudo"`
-	RunList               []string `mapstructure:"run_list"`
-	SecretKey             string   `mapstructure:"secret_key"`
-	ServerURL             string   `mapstructure:"server_url"`
-	SkipInstall           bool     `mapstructure:"skip_install"`
-	SkipRegister          bool     `mapstructure:"skip_register"`
-	SSLVerifyMode         string   `mapstructure:"ssl_verify_mode"`
-	UserName              string   `mapstructure:"user_name"`
-	UserKey               string   `mapstructure:"user_key"`
-	VaultJSON             string   `mapstructure:"vault_json"`
-	Version               string   `mapstructure:"version"`
+	AttributesJSON        string
+	ClientOptions         []string
+	DisableReporting      bool
+	Environment           string
+	FetchChefCertificates bool
+	LogToFile             bool
+	UsePolicyfile         bool
+	PolicyGroup           string
+	PolicyName            string
+	HTTPProxy             string
+	HTTPSProxy            string
+	NOProxy               []string
+	NodeName              string
+	OhaiHints             []string
+	OSType                string
+	RecreateClient        bool
+	PreventSudo           bool
+	RunList               []string
+	SecretKey             string
+	ServerURL             string
+	SkipInstall           bool
+	SkipRegister          bool
+	SSLVerifyMode         string
+	UserName              string
+	UserKey               string
+	VaultJSON             string
+	Version               string
 
 	attributes map[string]interface{}
 	vaults     map[string][]string
@@ -125,13 +124,150 @@ type Provisioner struct {
 	useSudo               bool
 
 	// Deprecated Fields
-	ValidationClientName string `mapstructure:"validation_client_name"`
-	ValidationKey        string `mapstructure:"validation_key"`
+	ValidationClientName string
+	ValidationKey        string
 }
 
 func ResourceProvisioner() terraform.ResourceProvisioner {
 	return &schema.Provisioner{
-		Schema:       nil, // TODO: Fill from Provisioner struct, note 'required' tag
+		Schema: map[string]*schema.Schema{
+			"attributes_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_options": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+			},
+			"disable_reporting": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"environment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"fetch_chef_certificates": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"log_to_file": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"use_policyfile": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"policy_group": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"http_proxy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"https_proxy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"no_proxy": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				Optional: true,
+			},
+			"node_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ohai_hints": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				Optional: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"recreate_client": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"prevent_sudo": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"run_list": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				Optional: true,
+			},
+			"secret_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"server_url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"skip_install": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"skip_register": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"ssl_verify_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vault_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			// Deprecated
+			"validation_client_name": {
+				Type:       schema.TypeString,
+				Deprecated: "Please use user_name instead",
+				Optional:   true,
+			},
+
+			"validation_key": {
+				Type:       schema.TypeString,
+				Deprecated: "Please use user_key instead",
+				Optional:   true,
+			},
+		},
 		ApplyFunc:    Apply,
 		ValidateFunc: Validate,
 	}
@@ -142,7 +278,7 @@ func Apply(
 	o terraform.UIOutput,
 	d *schema.ResourceData) error {
 	// Decode the raw config for this provisioner
-	p, err := decodeConfig(d.GetRawConfig()) // TODO: Get rid of GetRawConfig
+	p, err := decodeConfig(d)
 	if err != nil {
 		return err
 	}
@@ -255,20 +391,14 @@ func Apply(
 
 // Validate checks if the required arguments are configured
 func Validate(d *schema.ResourceData) (ws []string, es []error) {
-	p, err := decodeConfig(d.GetRawConfig()) // TODO: Get rid of GetRawConfig
+	p, err := decodeConfig(d)
 	if err != nil {
 		es = append(es, err)
 		return ws, es
 	}
 
-	if p.NodeName == "" {
-		es = append(es, errors.New("Key not found: node_name"))
-	}
 	if !p.UsePolicyfile && p.RunList == nil {
 		es = append(es, errors.New("Key not found: run_list"))
-	}
-	if p.ServerURL == "" {
-		es = append(es, errors.New("Key not found: server_url"))
 	}
 	if p.UsePolicyfile && p.PolicyName == "" {
 		es = append(es, errors.New("Policyfile enabled but key not found: policy_name"))
@@ -284,12 +414,7 @@ func Validate(d *schema.ResourceData) (ws []string, es []error) {
 		es = append(es, errors.New(
 			"One of user_key or the deprecated validation_key must be provided"))
 	}
-	if p.ValidationClientName != "" {
-		ws = append(ws, "validation_client_name is deprecated, please use user_name instead")
-	}
 	if p.ValidationKey != "" {
-		ws = append(ws, "validation_key is deprecated, please use user_key instead")
-
 		if p.RecreateClient {
 			es = append(es, errors.New(
 				"Cannot use recreate_client=true with the deprecated validation_key, please provide a user_key"))
@@ -303,38 +428,8 @@ func Validate(d *schema.ResourceData) (ws []string, es []error) {
 	return ws, es
 }
 
-func decodeConfig(c *terraform.ResourceConfig) (*Provisioner, error) {
-	p := new(Provisioner)
-
-	decConf := &mapstructure.DecoderConfig{
-		ErrorUnused:      true,
-		WeaklyTypedInput: true,
-		Result:           p,
-	}
-	dec, err := mapstructure.NewDecoder(decConf)
-	if err != nil {
-		return nil, err
-	}
-
-	// We need to merge both configs into a single map first. Order is
-	// important as we need to make sure interpolated values are used
-	// over raw values. This makes sure that all values are there even
-	// if some still need to be interpolated later on. Without this
-	// the validation will fail when using a variable for a required
-	// parameter (the node_name for example).
-	m := make(map[string]interface{})
-
-	for k, v := range c.Raw {
-		m[k] = v
-	}
-
-	for k, v := range c.Config {
-		m[k] = v
-	}
-
-	if err := dec.Decode(m); err != nil {
-		return nil, err
-	}
+func decodeConfig(d *schema.ResourceData) (*Provisioner, error) {
+	p := decodeDataToProvisioner(d)
 
 	// Make sure the supplied URL has a trailing slash
 	p.ServerURL = strings.TrimSuffix(p.ServerURL, "/") + "/"
@@ -359,17 +454,17 @@ func decodeConfig(c *terraform.ResourceConfig) (*Provisioner, error) {
 		p.UserKey = p.ValidationKey
 	}
 
-	if attrs, ok := c.Config["attributes_json"].(string); ok {
+	if attrs, ok := d.GetOk("attributes_json"); ok {
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(attrs), &m); err != nil {
+		if err := json.Unmarshal([]byte(attrs.(string)), &m); err != nil {
 			return nil, fmt.Errorf("Error parsing attributes_json: %v", err)
 		}
 		p.attributes = m
 	}
 
-	if vaults, ok := c.Config["vault_json"].(string); ok {
+	if vaults, ok := d.GetOk("vault_json"); ok {
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(vaults), &m); err != nil {
+		if err := json.Unmarshal([]byte(vaults.(string)), &m); err != nil {
 			return nil, fmt.Errorf("Error parsing vault_json: %v", err)
 		}
 
@@ -722,5 +817,59 @@ func retryFunc(timeout time.Duration, f func() error) error {
 			return err
 		case <-time.After(3 * time.Second):
 		}
+	}
+}
+
+func decodeDataToProvisioner(d *schema.ResourceData) *Provisioner {
+	return &Provisioner{
+		AttributesJSON:        d.Get("attributes_json").(string),
+		ClientOptions:         getStringList(d.Get("client_options")),
+		DisableReporting:      d.Get("disable_reporting").(bool),
+		Environment:           d.Get("environment").(string),
+		FetchChefCertificates: d.Get("fetch_chef_certificates").(bool),
+		LogToFile:             d.Get("log_to_file").(bool),
+		UsePolicyfile:         d.Get("use_policyfile").(bool),
+		PolicyGroup:           d.Get("policy_group").(string),
+		PolicyName:            d.Get("policy_name").(string),
+		HTTPProxy:             d.Get("http_proxy").(string),
+		HTTPSProxy:            d.Get("https_proxy").(string),
+		NOProxy:               getStringList(d.Get("no_proxy")),
+		NodeName:              d.Get("node_name").(string),
+		OhaiHints:             getStringList(d.Get("ohai_hints")),
+		OSType:                d.Get("os_type").(string),
+		RecreateClient:        d.Get("recreate_client").(bool),
+		PreventSudo:           d.Get("prevent_sudo").(bool),
+		RunList:               getStringList(d.Get("run_list")),
+		SecretKey:             d.Get("secret_key").(string),
+		ServerURL:             d.Get("server_url").(string),
+		SkipInstall:           d.Get("skip_install").(bool),
+		SkipRegister:          d.Get("skip_register").(bool),
+		SSLVerifyMode:         d.Get("ssl_verify_mode").(string),
+		UserName:              d.Get("user_name").(string),
+		UserKey:               d.Get("user_key").(string),
+		VaultJSON:             d.Get("vault_json").(string),
+		Version:               d.Get("version").(string),
+
+		// Deprecated
+		ValidationClientName: d.Get("validation_client_name").(string),
+		ValidationKey:        d.Get("validation_key").(string),
+	}
+}
+
+func getStringList(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+	switch l := v.(type) {
+	case []string:
+		return l
+	case []interface{}:
+		arr := make([]string, len(l))
+		for i, x := range l {
+			arr[i] = x.(string)
+		}
+		return arr
+	default:
+		panic(fmt.Sprintf("Unsupported type: %T", v))
 	}
 }

--- a/builtin/provisioners/chef/resource_provisioner_test.go
+++ b/builtin/provisioners/chef/resource_provisioner_test.go
@@ -140,7 +140,7 @@ func TestResourceProvider_runChefClient(t *testing.T) {
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -212,7 +212,7 @@ func TestResourceProvider_fetchChefCertificates(t *testing.T) {
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -336,7 +336,7 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -349,4 +349,8 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 			t.Fatalf("Test %q failed: %v", k, err)
 		}
 	}
+}
+
+func getTestResourceData(c *terraform.ResourceConfig) *schema.ResourceData {
+	return ResourceProvisioner().(*schema.Provisioner).TestResourceData(c)
 }

--- a/builtin/provisioners/chef/resource_provisioner_test.go
+++ b/builtin/provisioners/chef/resource_provisioner_test.go
@@ -7,11 +7,18 @@ import (
 
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestResourceProvisioner_impl(t *testing.T) {
-	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
+	var _ terraform.ResourceProvisioner = ResourceProvisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := ResourceProvisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestResourceProvider_Validate_good(t *testing.T) {
@@ -23,7 +30,7 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 		"user_name":   "bob",
 		"user_key":    "USER-KEY",
 	})
-	r := new(ResourceProvisioner)
+	r := ResourceProvisioner()
 	warn, errs := r.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -37,7 +44,7 @@ func TestResourceProvider_Validate_bad(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"invalid": "nope",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -127,14 +134,13 @@ func TestResourceProvider_runChefClient(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(tc.Config)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -200,14 +206,13 @@ func TestResourceProvider_fetchChefCertificates(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(tc.Config)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -325,14 +330,13 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(tc.Config)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -73,7 +73,6 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
@@ -81,7 +80,7 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		c.Commands = tc.Commands
 		c.UploadScripts = tc.UploadScripts
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(tc.Config)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -180,7 +179,6 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
@@ -188,7 +186,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(tc.Config)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -80,7 +80,7 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		c.Commands = tc.Commands
 		c.UploadScripts = tc.UploadScripts
 
-		p, err := decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -186,7 +186,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/file/resource_provisioner_test.go
+++ b/builtin/provisioners/file/resource_provisioner_test.go
@@ -4,11 +4,18 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestResourceProvisioner_impl(t *testing.T) {
-	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
+	var _ terraform.ResourceProvisioner = ResourceProvisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := ResourceProvisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestResourceProvider_Validate_good_source(t *testing.T) {
@@ -16,7 +23,7 @@ func TestResourceProvider_Validate_good_source(t *testing.T) {
 		"source":      "/tmp/foo",
 		"destination": "/tmp/bar",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -31,7 +38,7 @@ func TestResourceProvider_Validate_good_content(t *testing.T) {
 		"content":     "value to copy",
 		"destination": "/tmp/bar",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -45,7 +52,7 @@ func TestResourceProvider_Validate_bad_not_destination(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source": "nope",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -61,7 +68,7 @@ func TestResourceProvider_Validate_bad_to_many_src(t *testing.T) {
 		"content":     "value to copy",
 		"destination": "/tmp/bar",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)

--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 
 	"github.com/armon/circbuf"
-	"github.com/hashicorp/terraform/helper/config"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-linereader"
@@ -28,25 +27,16 @@ func ResourceProvisioner() terraform.ResourceProvisioner {
 				Required: true,
 			},
 		},
-		ApplyFunc:    Apply,
-		ValidateFunc: Validate,
+		ApplyFunc: Apply,
 	}
 }
 
 func Apply(
 	o terraform.UIOutput,
-	s *terraform.InstanceState,
-	c *terraform.ResourceConfig) error {
+	d *schema.ResourceData) error {
 
 	// Get the command
-	commandRaw, ok := c.Config["command"]
-	if !ok {
-		return fmt.Errorf("local-exec provisioner missing 'command'")
-	}
-	command, ok := commandRaw.(string)
-	if !ok {
-		return fmt.Errorf("local-exec provisioner command must be a string")
-	}
+	command := d.Get("command").(string)
 
 	// Execute the command using a shell
 	var shell, flag string
@@ -88,13 +78,6 @@ func Apply(
 	}
 
 	return nil
-}
-
-func Validate(c *terraform.ResourceConfig) ([]string, []error) {
-	validator := config.Validator{
-		Required: []string{"command"},
-	}
-	return validator.Validate(c)
 }
 
 func copyOutput(

--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -7,11 +7,18 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestResourceProvisioner_impl(t *testing.T) {
-	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
+	var _ terraform.ResourceProvisioner = ResourceProvisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := ResourceProvisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestResourceProvider_Apply(t *testing.T) {
@@ -21,7 +28,7 @@ func TestResourceProvider_Apply(t *testing.T) {
 	})
 
 	output := new(terraform.MockUIOutput)
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	if err := p.Apply(output, nil, c); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -43,7 +50,7 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"command": "echo foo",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -55,7 +62,7 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 
 func TestResourceProvider_Validate_missing(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -20,7 +20,7 @@ func TestProvisioner(t *testing.T) {
 	}
 }
 
-func TestResourceProvider_Validate_good(t *testing.T) {
+func TestResourceProvider_Validate_bad_old_inline_as_string(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"inline": "echo foo",
 	})
@@ -29,8 +29,8 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
-	if len(errs) > 0 {
-		t.Fatalf("Errors: %v", errs)
+	if len(errs) == 0 {
+		t.Fatalf("Should have errors")
 	}
 }
 

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -6,18 +6,25 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestResourceProvisioner_impl(t *testing.T) {
-	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
+	var _ terraform.ResourceProvisioner = ResourceProvisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := ResourceProvisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 }
 
 func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"inline": "echo foo",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -31,7 +38,7 @@ func TestResourceProvider_Validate_bad(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"invalid": "nope",
 	})
-	p := new(ResourceProvisioner)
+	p := ResourceProvisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -47,7 +54,6 @@ exit 0
 `
 
 func TestResourceProvider_generateScript(t *testing.T) {
-	p := new(ResourceProvisioner)
 	conf := testConfig(t, map[string]interface{}{
 		"inline": []interface{}{
 			"cd /tmp",
@@ -55,7 +61,7 @@ func TestResourceProvider_generateScript(t *testing.T) {
 			"exit 0",
 		},
 	})
-	out, err := p.generateScript(conf)
+	out, err := generateScript(conf)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -66,7 +72,6 @@ func TestResourceProvider_generateScript(t *testing.T) {
 }
 
 func TestResourceProvider_CollectScripts_inline(t *testing.T) {
-	p := new(ResourceProvisioner)
 	conf := testConfig(t, map[string]interface{}{
 		"inline": []interface{}{
 			"cd /tmp",
@@ -75,7 +80,7 @@ func TestResourceProvider_CollectScripts_inline(t *testing.T) {
 		},
 	})
 
-	scripts, err := p.collectScripts(conf)
+	scripts, err := collectScripts(conf)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -96,12 +101,11 @@ func TestResourceProvider_CollectScripts_inline(t *testing.T) {
 }
 
 func TestResourceProvider_CollectScripts_script(t *testing.T) {
-	p := new(ResourceProvisioner)
 	conf := testConfig(t, map[string]interface{}{
 		"script": "test-fixtures/script1.sh",
 	})
 
-	scripts, err := p.collectScripts(conf)
+	scripts, err := collectScripts(conf)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -122,7 +126,6 @@ func TestResourceProvider_CollectScripts_script(t *testing.T) {
 }
 
 func TestResourceProvider_CollectScripts_scripts(t *testing.T) {
-	p := new(ResourceProvisioner)
 	conf := testConfig(t, map[string]interface{}{
 		"scripts": []interface{}{
 			"test-fixtures/script1.sh",
@@ -131,7 +134,7 @@ func TestResourceProvider_CollectScripts_scripts(t *testing.T) {
 		},
 	})
 
-	scripts, err := p.collectScripts(conf)
+	scripts, err := collectScripts(conf)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -61,7 +61,7 @@ func TestResourceProvider_generateScript(t *testing.T) {
 			"exit 0",
 		},
 	})
-	out, err := generateScript(conf)
+	out, err := generateScript(getTestResourceData(conf))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestResourceProvider_CollectScripts_inline(t *testing.T) {
 		},
 	})
 
-	scripts, err := collectScripts(conf)
+	scripts, err := collectScripts(getTestResourceData(conf))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestResourceProvider_CollectScripts_script(t *testing.T) {
 		"script": "test-fixtures/script1.sh",
 	})
 
-	scripts, err := collectScripts(conf)
+	scripts, err := collectScripts(getTestResourceData(conf))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestResourceProvider_CollectScripts_scripts(t *testing.T) {
 		},
 	})
 
-	scripts, err := collectScripts(conf)
+	scripts, err := collectScripts(getTestResourceData(conf))
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -165,4 +165,8 @@ func testConfig(
 	}
 
 	return terraform.NewResourceConfig(r)
+}
+
+func getTestResourceData(c *terraform.ResourceConfig) *schema.ResourceData {
+	return ResourceProvisioner().(*schema.Provisioner).TestResourceData(c)
 }

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -62,7 +62,6 @@ import (
 	remoteexecresourceprovisioner "github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
 
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
@@ -119,8 +118,8 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 }
 
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{
-	"chef":        func() terraform.ResourceProvisioner { return new(chefresourceprovisioner.ResourceProvisioner) },
-	"file":        func() terraform.ResourceProvisioner { return new(fileresourceprovisioner.ResourceProvisioner) },
-	"local-exec":  func() terraform.ResourceProvisioner { return new(localexecresourceprovisioner.ResourceProvisioner) },
-	"remote-exec": func() terraform.ResourceProvisioner { return new(remoteexecresourceprovisioner.ResourceProvisioner) },
+	"chef":        chefresourceprovisioner.ResourceProvisioner,
+	"file":        fileresourceprovisioner.ResourceProvisioner,
+	"local-exec":  localexecresourceprovisioner.ResourceProvisioner,
+	"remote-exec": remoteexecresourceprovisioner.ResourceProvisioner,
 }

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -1,0 +1,66 @@
+package schema
+
+import (
+	"errors"
+	"fmt"
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+type Provisioner struct {
+	Schema       map[string]*Schema
+	ValidateFunc ValidateFunc
+	ApplyFunc    ApplyFunc
+}
+
+type ValidateFunc func(*terraform.ResourceConfig) ([]string, []error)
+type ApplyFunc func(terraform.UIOutput, *terraform.InstanceState, *terraform.ResourceConfig) error
+
+// InternalValidate should be called to validate the structure
+// of the provisioner.
+//
+// This should be called in a unit test for any provisioner to verify
+// before release that a provisioner is properly configured for use with
+// this library.
+func (p *Provisioner) InternalValidate() error {
+	if p == nil {
+		return errors.New("provisioner is nil")
+	}
+
+	var validationErrors error
+	sm := schemaMap(p.Schema)
+	if err := sm.InternalValidate(sm); err != nil {
+		validationErrors = multierror.Append(validationErrors, err)
+	}
+
+	return validationErrors
+}
+
+func (p *Provisioner) Validate(config *terraform.ResourceConfig) ([]string, []error) {
+	if err := p.InternalValidate(); err != nil {
+		return nil, []error{fmt.Errorf(
+			"Internal validation of the provisioner failed! This is always a bug\n"+
+				"with the provisioner itself, and not a user issue. Please report\n"+
+				"this bug:\n\n%s", err)}
+	}
+	w := []string{}
+	e := []error{}
+	if p.Schema != nil {
+		w2, e2 := schemaMap(p.Schema).Validate(config)
+		w = append(w, w2...)
+		e = append(e, e2...)
+	}
+	if p.ValidateFunc != nil {
+		w2, e2 := p.ValidateFunc(config)
+		w = append(w, w2...)
+		e = append(e, e2...)
+	}
+	return w, e
+}
+
+func (p *Provisioner) Apply(ui terraform.UIOutput, state *terraform.InstanceState, config *terraform.ResourceConfig) error {
+	if p.ApplyFunc == nil {
+		panic("ApplyFunc should be specified in provisioner")
+	}
+	return p.ApplyFunc(ui, state, config)
+}

--- a/helper/schema/provisioner_test.go
+++ b/helper/schema/provisioner_test.go
@@ -57,7 +57,7 @@ func TestProvisioner_Validate(t *testing.T) {
 		{
 			P: &Provisioner{
 				Schema: nil,
-				ValidateFunc: func(*terraform.ResourceConfig) (ws []string, errors []error) {
+				ValidateFunc: func(*ResourceData) (ws []string, errors []error) {
 					ws = append(ws, "Simple warning from provisioner ValidateFunc")
 					return
 				},

--- a/helper/schema/provisioner_test.go
+++ b/helper/schema/provisioner_test.go
@@ -1,0 +1,85 @@
+package schema
+
+import (
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/terraform"
+	"reflect"
+	"testing"
+)
+
+func TestProvisioner_init(t *testing.T) {
+	var _ terraform.ResourceProvisioner = new(Provisioner)
+}
+
+func TestProvisioner_Validate(t *testing.T) {
+	cases := []struct {
+		P      *Provisioner
+		Config map[string]interface{}
+		Warns  []string
+		Err    bool
+	}{
+		{
+			// Incorrect schema
+			P: &Provisioner{
+				Schema: map[string]*Schema{
+					"foo": {},
+				},
+			},
+			Config: nil,
+			Err:    true,
+		},
+		{
+			P: &Provisioner{
+				Schema: map[string]*Schema{
+					"foo": {
+						Type:     TypeString,
+						Optional: true,
+						ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+							ws = append(ws, "Simple warning from property validation")
+							return
+						},
+					},
+				},
+			},
+			Config: map[string]interface{}{
+				"foo": "",
+			},
+			Err:   false,
+			Warns: []string{"Simple warning from property validation"},
+		},
+		{
+			P: &Provisioner{
+				Schema: nil,
+			},
+			Config: nil,
+			Err:    false,
+		},
+		{
+			P: &Provisioner{
+				Schema: nil,
+				ValidateFunc: func(*terraform.ResourceConfig) (ws []string, errors []error) {
+					ws = append(ws, "Simple warning from provisioner ValidateFunc")
+					return
+				},
+			},
+			Config: nil,
+			Err:    false,
+			Warns:  []string{"Simple warning from provisioner ValidateFunc"},
+		},
+	}
+
+	for i, tc := range cases {
+		c, err := config.NewRawConfig(tc.Config)
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		ws, es := tc.P.Validate(terraform.NewResourceConfig(c))
+		if len(es) > 0 != tc.Err {
+			t.Fatalf("%d: %#v %s", i, es, es)
+		}
+		if (tc.Warns != nil || len(ws) != 0) && !reflect.DeepEqual(ws, tc.Warns) {
+			t.Fatalf("%d: warnings mismatch, actual: %#v", i, ws)
+		}
+	}
+}

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -463,8 +463,3 @@ func (d *ResourceData) get(addr []string, source getSource) getResult {
 		Schema:         schema,
 	}
 }
-
-// TODO: Get rid of usages and remove. Added to fix chef provisioner
-func (d *ResourceData) GetRawConfig() *terraform.ResourceConfig {
-	return d.config
-}

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -463,3 +463,8 @@ func (d *ResourceData) get(addr []string, source getSource) getResult {
 		Schema:         schema,
 	}
 }
+
+// TODO: Get rid of usages and remove. Added to fix chef provisioner
+func (d *ResourceData) GetRawConfig() *terraform.ResourceConfig {
+	return d.config
+}

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -82,16 +82,14 @@ func makeProviderMap(items []plugin) string {
 
 // makeProvisionerMap creates a map of provisioners like this:
 //
-//	"file":        func() terraform.ResourceProvisioner { return new(file.ResourceProvisioner) },
-//	"local-exec":  func() terraform.ResourceProvisioner { return new(localexec.ResourceProvisioner) },
-//	"remote-exec": func() terraform.ResourceProvisioner { return new(remoteexec.ResourceProvisioner) },
+//	"file":        fileresourceprovisioner.GetProvisioner,
+//	"local-exec":  localexecresourceprovisioner.GetProvisioner,
+//	"remote-exec": remoteexecresourceprovisioner.GetProvisioner,
 //
-// This is more verbose than the Provider case because there is no corresponding
-// Provisioner function.
 func makeProvisionerMap(items []plugin) string {
 	output := ""
 	for _, item := range items {
-		output += fmt.Sprintf("\t\"%s\": func() terraform.ResourceProvisioner { return new(%s.%s) },\n", item.PluginName, item.ImportName, item.TypeName)
+		output += fmt.Sprintf("\t\"%s\":   %s.%s,\n", item.PluginName, item.ImportName, item.TypeName)
 	}
 	return output
 }
@@ -254,8 +252,8 @@ func discoverProviders() ([]plugin, error) {
 
 func discoverProvisioners() ([]plugin, error) {
 	path := "./builtin/provisioners"
-	typeID := "ResourceProvisioner"
-	typeName := ""
+	typeID := "terraform.ResourceProvisioner"
+	typeName := "ResourceProvisioner"
 	return discoverTypesInPath(path, typeID, typeName)
 }
 
@@ -269,7 +267,6 @@ package command
 import (
 IMPORTS
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{

--- a/scripts/generate-plugins_test.go
+++ b/scripts/generate-plugins_test.go
@@ -27,9 +27,9 @@ func TestMakeProvisionerMap(t *testing.T) {
 		},
 	})
 
-	expected := `	"file": func() terraform.ResourceProvisioner { return new(fileresourceprovisioner.ResourceProvisioner) },
-	"local-exec": func() terraform.ResourceProvisioner { return new(localexecresourceprovisioner.ResourceProvisioner) },
-	"remote-exec": func() terraform.ResourceProvisioner { return new(remoteexecresourceprovisioner.ResourceProvisioner) },
+	expected := `	"file":   fileresourceprovisioner.ResourceProvisioner,
+	"local-exec":   localexecresourceprovisioner.ResourceProvisioner,
+	"remote-exec":   remoteexecresourceprovisioner.ResourceProvisioner,
 `
 
 	if p != expected {
@@ -86,7 +86,7 @@ func TestDiscoverTypesProviders(t *testing.T) {
 }
 
 func TestDiscoverTypesProvisioners(t *testing.T) {
-	plugins, err := discoverTypesInPath("../builtin/provisioners", "ResourceProvisioner", "")
+	plugins, err := discoverTypesInPath("../builtin/provisioners", "terraform.ResourceProvisioner", "ResourceProvisioner")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}


### PR DESCRIPTION
Migrate provisioners to providers-like hierarchy when all of then extends `schema.Provisioner`.
Built-in plugins were migrated.
Also added support for schema validation for built-in provisioners: file, local-exec, remote-exec.

AFAIU external plugins would still compile but functions `Apply` and `Validate` from `schema.Provisioner` would not be used, so change is quite safe. Tried that by [reverting cahnges in 'chef' provisioner in separate commit](https://github.com/VladRassokhin/terraform/commit/309e0710b7d8894be3ef73845e0d12cd82f6dbb8)