### PR TITLE
providers/google: Create and manage Google Cloud Platform Projects

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/pubsub/v1"
+	"google.golang.org/api/servicemanagement/v1"
 	"google.golang.org/api/sqladmin/v1beta4"
 	"google.golang.org/api/storage/v1"
 )
@@ -38,6 +39,7 @@ type Config struct {
 	clientStorage         *storage.Service
 	clientSqlAdmin        *sqladmin.Service
 	clientIAM             *iam.Service
+	clientServiceMan      *servicemanagement.APIService
 }
 
 func (c *Config) loadAndValidate() error {
@@ -130,26 +132,33 @@ func (c *Config) loadAndValidate() error {
 	}
 	c.clientSqlAdmin.UserAgent = userAgent
 
-	log.Printf("[INFO] Instatiating Google Pubsub Client...")
+	log.Printf("[INFO] Instantiating Google Pubsub Client...")
 	c.clientPubsub, err = pubsub.New(client)
 	if err != nil {
 		return err
 	}
 	c.clientPubsub.UserAgent = userAgent
 
-	log.Printf("[INFO] Instatiating Google Cloud ResourceManager Client...")
+	log.Printf("[INFO] Instantiating Google Cloud ResourceManager Client...")
 	c.clientResourceManager, err = cloudresourcemanager.New(client)
 	if err != nil {
 		return err
 	}
 	c.clientResourceManager.UserAgent = userAgent
 
-	log.Printf("[INFO] Instatiating Google Cloud IAM Client...")
+	log.Printf("[INFO] Instantiating Google Cloud IAM Client...")
 	c.clientIAM, err = iam.New(client)
 	if err != nil {
 		return err
 	}
 	c.clientIAM.UserAgent = userAgent
+
+	log.Printf("[INFO] Instantiating Google Cloud Service Management Client...")
+	c.clientServiceMan, err = servicemanagement.New(client)
+	if err != nil {
+		return err
+	}
+	c.clientServiceMan.UserAgent = userAgent
 
 	return nil
 }

--- a/builtin/providers/google/import_google_project_test.go
+++ b/builtin/providers/google/import_google_project_test.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccGoogleProject_importBasic(t *testing.T) {
 	resourceName := "google_project.acceptance"
-	conf := fmt.Sprintf(testAccGoogleProject_basic, projectId)
+	projectId := "terraform-" + acctest.RandString(10)
+	conf := testAccGoogleProject_import(projectId, org, pname)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -26,4 +28,13 @@ func TestAccGoogleProject_importBasic(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccGoogleProject_import(pid, orgId, projectName string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    org_id = "%s"
+    name = "%s"
+}`, pid, orgId, projectName)
 }

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -96,6 +96,8 @@ func Provider() terraform.ResourceProvider {
 			"google_sql_database_instance":          resourceSqlDatabaseInstance(),
 			"google_sql_user":                       resourceSqlUser(),
 			"google_project":                        resourceGoogleProject(),
+			"google_project_iam_policy":             resourceGoogleProjectIamPolicy(),
+			"google_project_services":               resourceGoogleProjectServices(),
 			"google_pubsub_topic":                   resourcePubsubTopic(),
 			"google_pubsub_subscription":            resourcePubsubSubscription(),
 			"google_service_account":                resourceGoogleServiceAccount(),

--- a/builtin/providers/google/resource_google_project_iam_policy.go
+++ b/builtin/providers/google/resource_google_project_iam_policy.go
@@ -1,0 +1,417 @@
+package google
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func resourceGoogleProjectIamPolicy() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleProjectIamPolicyCreate,
+		Read:   resourceGoogleProjectIamPolicyRead,
+		Update: resourceGoogleProjectIamPolicyUpdate,
+		Delete: resourceGoogleProjectIamPolicyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"policy_data": &schema.Schema{
+				Type:             schema.TypeString,
+				Required:         true,
+				DiffSuppressFunc: jsonPolicyDiffSuppress,
+			},
+			"authoritative": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"etag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"restore_policy": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"disable_project": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceGoogleProjectIamPolicyCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid := d.Get("project").(string)
+	// Get the policy in the template
+	p, err := getResourceIamPolicy(d)
+	if err != nil {
+		return fmt.Errorf("Could not get valid 'policy_data' from resource: %v", err)
+	}
+
+	// An authoritative policy is applied without regard for any existing IAM
+	// policy.
+	if v, ok := d.GetOk("authoritative"); ok && v.(bool) {
+		log.Printf("[DEBUG] Setting authoritative IAM policy for project %q", pid)
+		err := setProjectIamPolicy(p, config, pid)
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Printf("[DEBUG] Setting non-authoritative IAM policy for project %q", pid)
+		// This is a non-authoritative policy, meaning it should be merged with
+		// any existing policy
+		ep, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return err
+		}
+
+		// First, subtract the policy defined in the template from the
+		// current policy in the project, and save the result. This will
+		// allow us to restore the original policy at some point (which
+		// assumes that Terraform owns any common policy that exists in
+		// the template and project at create time.
+		rp := subtractIamPolicy(ep, p)
+		rps, err := json.Marshal(rp)
+		if err != nil {
+			return fmt.Errorf("Error marshaling restorable IAM policy: %v", err)
+		}
+		d.Set("restore_policy", string(rps))
+
+		// Merge the policies together
+		mb := mergeBindings(append(p.Bindings, rp.Bindings...))
+		ep.Bindings = mb
+		if err = setProjectIamPolicy(ep, config, pid); err != nil {
+			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		}
+	}
+	d.SetId(pid)
+	return resourceGoogleProjectIamPolicyRead(d, meta)
+}
+
+func resourceGoogleProjectIamPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG]: Reading google_project_iam_policy")
+	config := meta.(*Config)
+	pid := d.Get("project").(string)
+
+	p, err := getProjectIamPolicy(pid, config)
+	if err != nil {
+		return err
+	}
+
+	var bindings []*cloudresourcemanager.Binding
+	if v, ok := d.GetOk("restore_policy"); ok {
+		var restored cloudresourcemanager.Policy
+		// if there's a restore policy, subtract it from the policy_data
+		err := json.Unmarshal([]byte(v.(string)), &restored)
+		if err != nil {
+			return fmt.Errorf("Error unmarshaling restorable IAM policy: %v", err)
+		}
+		subtracted := subtractIamPolicy(p, &restored)
+		bindings = subtracted.Bindings
+	} else {
+		bindings = p.Bindings
+	}
+	// we only marshal the bindings, because only the bindings get set in the config
+	pBytes, err := json.Marshal(&cloudresourcemanager.Policy{Bindings: bindings})
+	if err != nil {
+		return fmt.Errorf("Error marshaling IAM policy: %v", err)
+	}
+	log.Printf("[DEBUG]: Setting etag=%s", p.Etag)
+	d.Set("etag", p.Etag)
+	d.Set("policy_data", string(pBytes))
+	return nil
+}
+
+func resourceGoogleProjectIamPolicyUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG]: Updating google_project_iam_policy")
+	config := meta.(*Config)
+	pid := d.Get("project").(string)
+
+	// Get the policy in the template
+	p, err := getResourceIamPolicy(d)
+	if err != nil {
+		return fmt.Errorf("Could not get valid 'policy_data' from resource: %v", err)
+	}
+	pBytes, _ := json.Marshal(p)
+	log.Printf("[DEBUG] Got policy from config: %s", string(pBytes))
+
+	// An authoritative policy is applied without regard for any existing IAM
+	// policy.
+	if v, ok := d.GetOk("authoritative"); ok && v.(bool) {
+		log.Printf("[DEBUG] Updating authoritative IAM policy for project %q", pid)
+		err := setProjectIamPolicy(p, config, pid)
+		if err != nil {
+			return fmt.Errorf("Error setting project IAM policy: %v", err)
+		}
+		d.Set("restore_policy", "")
+	} else {
+		log.Printf("[DEBUG] Updating non-authoritative IAM policy for project %q", pid)
+		// Get the previous policy from state
+		pp, err := getPrevResourceIamPolicy(d)
+		if err != nil {
+			return fmt.Errorf("Error retrieving previous version of changed project IAM policy: %v", err)
+		}
+		ppBytes, _ := json.Marshal(pp)
+		log.Printf("[DEBUG] Got previous version of changed project IAM policy: %s", string(ppBytes))
+
+		// Get the existing IAM policy from the API
+		ep, err := getProjectIamPolicy(pid, config)
+		if err != nil {
+			return fmt.Errorf("Error retrieving IAM policy from project API: %v", err)
+		}
+		epBytes, _ := json.Marshal(ep)
+		log.Printf("[DEBUG] Got existing version of changed IAM policy from project API: %s", string(epBytes))
+
+		// Subtract the previous and current policies from the policy retrieved from the API
+		rp := subtractIamPolicy(ep, pp)
+		rpBytes, _ := json.Marshal(rp)
+		log.Printf("[DEBUG] After subtracting the previous policy from the existing policy, remaining policies: %s", string(rpBytes))
+		rp = subtractIamPolicy(rp, p)
+		rpBytes, _ = json.Marshal(rp)
+		log.Printf("[DEBUG] After subtracting the remaining policies from the config policy, remaining policies: %s", string(rpBytes))
+		rps, err := json.Marshal(rp)
+		if err != nil {
+			return fmt.Errorf("Error marhsaling restorable IAM policy: %v", err)
+		}
+		d.Set("restore_policy", string(rps))
+
+		// Merge the policies together
+		mb := mergeBindings(append(p.Bindings, rp.Bindings...))
+		ep.Bindings = mb
+		if err = setProjectIamPolicy(ep, config, pid); err != nil {
+			return fmt.Errorf("Error applying IAM policy to project: %v", err)
+		}
+	}
+
+	return resourceGoogleProjectIamPolicyRead(d, meta)
+}
+
+func resourceGoogleProjectIamPolicyDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG]: Deleting google_project_iam_policy")
+	config := meta.(*Config)
+	pid := d.Get("project").(string)
+
+	// Get the existing IAM policy from the API
+	ep, err := getProjectIamPolicy(pid, config)
+	if err != nil {
+		return fmt.Errorf("Error retrieving IAM policy from project API: %v", err)
+	}
+	// Deleting an authoritative policy will leave the project with no policy,
+	// and unaccessible by anyone without org-level privs. For this reason, the
+	// "disable_project" property must be set to true, forcing the user to ack
+	// this outcome
+	if v, ok := d.GetOk("authoritative"); ok && v.(bool) {
+		if v, ok := d.GetOk("disable_project"); !ok || !v.(bool) {
+			return fmt.Errorf("You must set 'disable_project' to true before deleting an authoritative IAM policy")
+		}
+		ep.Bindings = make([]*cloudresourcemanager.Binding, 0)
+
+	} else {
+		// A non-authoritative policy should set the policy to the value of "restore_policy" in state
+		// Get the previous policy from state
+		rp, err := getRestoreIamPolicy(d)
+		if err != nil {
+			return fmt.Errorf("Error retrieving previous version of changed project IAM policy: %v", err)
+		}
+		ep.Bindings = rp.Bindings
+	}
+	if err = setProjectIamPolicy(ep, config, pid); err != nil {
+		return fmt.Errorf("Error applying IAM policy to project: %v", err)
+	}
+	d.SetId("")
+	return nil
+}
+
+// Subtract all bindings in policy b from policy a, and return the result
+func subtractIamPolicy(a, b *cloudresourcemanager.Policy) *cloudresourcemanager.Policy {
+	am := rolesToMembersMap(a.Bindings)
+
+	for _, b := range b.Bindings {
+		if _, ok := am[b.Role]; ok {
+			for _, m := range b.Members {
+				delete(am[b.Role], m)
+			}
+			if len(am[b.Role]) == 0 {
+				delete(am, b.Role)
+			}
+		}
+	}
+	a.Bindings = rolesToMembersBinding(am)
+	return a
+}
+
+func setProjectIamPolicy(policy *cloudresourcemanager.Policy, config *Config, pid string) error {
+	// Apply the policy
+	pbytes, _ := json.Marshal(policy)
+	log.Printf("[DEBUG] Setting policy %#v for project: %s", string(pbytes), pid)
+	_, err := config.clientResourceManager.Projects.SetIamPolicy(pid,
+		&cloudresourcemanager.SetIamPolicyRequest{Policy: policy}).Do()
+
+	if err != nil {
+		return fmt.Errorf("Error applying IAM policy for project %q. Policy is %+s, error is %s", pid, policy, err)
+	}
+	return nil
+}
+
+// Get a cloudresourcemanager.Policy from a schema.ResourceData
+func getResourceIamPolicy(d *schema.ResourceData) (*cloudresourcemanager.Policy, error) {
+	ps := d.Get("policy_data").(string)
+	// The policy string is just a marshaled cloudresourcemanager.Policy.
+	policy := &cloudresourcemanager.Policy{}
+	if err := json.Unmarshal([]byte(ps), policy); err != nil {
+		return nil, fmt.Errorf("Could not unmarshal %s:\n: %v", ps, err)
+	}
+	return policy, nil
+}
+
+// Get the previous cloudresourcemanager.Policy from a schema.ResourceData if the
+// resource has changed
+func getPrevResourceIamPolicy(d *schema.ResourceData) (*cloudresourcemanager.Policy, error) {
+	var policy *cloudresourcemanager.Policy = &cloudresourcemanager.Policy{}
+	if d.HasChange("policy_data") {
+		v, _ := d.GetChange("policy_data")
+		if err := json.Unmarshal([]byte(v.(string)), policy); err != nil {
+			return nil, fmt.Errorf("Could not unmarshal previous policy %s:\n: %v", v, err)
+		}
+	}
+	return policy, nil
+}
+
+// Get the restore_policy that can be used to restore a project's IAM policy to its
+// state before it was adopted into Terraform
+func getRestoreIamPolicy(d *schema.ResourceData) (*cloudresourcemanager.Policy, error) {
+	if v, ok := d.GetOk("restore_policy"); ok {
+		policy := &cloudresourcemanager.Policy{}
+		if err := json.Unmarshal([]byte(v.(string)), policy); err != nil {
+			return nil, fmt.Errorf("Could not unmarshal previous policy %s:\n: %v", v, err)
+		}
+		return policy, nil
+	}
+	return nil, fmt.Errorf("Resource does not have a 'restore_policy' attribute defined.")
+}
+
+// Retrieve the existing IAM Policy for a Project
+func getProjectIamPolicy(project string, config *Config) (*cloudresourcemanager.Policy, error) {
+	p, err := config.clientResourceManager.Projects.GetIamPolicy(project,
+		&cloudresourcemanager.GetIamPolicyRequest{}).Do()
+
+	if err != nil {
+		return nil, fmt.Errorf("Error retrieving IAM policy for project %q: %s", project, err)
+	}
+	return p, nil
+}
+
+// Convert a map of roles->members to a list of Binding
+func rolesToMembersBinding(m map[string]map[string]bool) []*cloudresourcemanager.Binding {
+	bindings := make([]*cloudresourcemanager.Binding, 0)
+	for role, members := range m {
+		b := cloudresourcemanager.Binding{
+			Role:    role,
+			Members: make([]string, 0),
+		}
+		for m, _ := range members {
+			b.Members = append(b.Members, m)
+		}
+		bindings = append(bindings, &b)
+	}
+	return bindings
+}
+
+// Map a role to a map of members, allowing easy merging of multiple bindings.
+func rolesToMembersMap(bindings []*cloudresourcemanager.Binding) map[string]map[string]bool {
+	bm := make(map[string]map[string]bool)
+	// Get each binding
+	for _, b := range bindings {
+		// Initialize members map
+		if _, ok := bm[b.Role]; !ok {
+			bm[b.Role] = make(map[string]bool)
+		}
+		// Get each member (user/principal) for the binding
+		for _, m := range b.Members {
+			// Add the member
+			bm[b.Role][m] = true
+		}
+	}
+	return bm
+}
+
+// Merge multiple Bindings such that Bindings with the same Role result in
+// a single Binding with combined Members
+func mergeBindings(bindings []*cloudresourcemanager.Binding) []*cloudresourcemanager.Binding {
+	bm := rolesToMembersMap(bindings)
+	rb := make([]*cloudresourcemanager.Binding, 0)
+
+	for role, members := range bm {
+		var b cloudresourcemanager.Binding
+		b.Role = role
+		b.Members = make([]string, 0)
+		for m, _ := range members {
+			b.Members = append(b.Members, m)
+		}
+		rb = append(rb, &b)
+	}
+
+	return rb
+}
+
+func jsonPolicyDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
+	var oldPolicy, newPolicy cloudresourcemanager.Policy
+	if err := json.Unmarshal([]byte(old), &oldPolicy); err != nil {
+		log.Printf("[ERROR] Could not unmarshal old policy %s: %v", old, err)
+		return false
+	}
+	if err := json.Unmarshal([]byte(new), &newPolicy); err != nil {
+		log.Printf("[ERROR] Could not unmarshal new policy %s: %v", new, err)
+		return false
+	}
+	if newPolicy.Etag != oldPolicy.Etag {
+		return false
+	}
+	if newPolicy.Version != oldPolicy.Version {
+		return false
+	}
+	if len(newPolicy.Bindings) != len(oldPolicy.Bindings) {
+		return false
+	}
+	sort.Sort(sortableBindings(newPolicy.Bindings))
+	sort.Sort(sortableBindings(oldPolicy.Bindings))
+	for pos, newBinding := range newPolicy.Bindings {
+		oldBinding := oldPolicy.Bindings[pos]
+		if oldBinding.Role != newBinding.Role {
+			return false
+		}
+		if len(oldBinding.Members) != len(newBinding.Members) {
+			return false
+		}
+		sort.Strings(oldBinding.Members)
+		sort.Strings(newBinding.Members)
+		for i, newMember := range newBinding.Members {
+			oldMember := oldBinding.Members[i]
+			if newMember != oldMember {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+type sortableBindings []*cloudresourcemanager.Binding
+
+func (b sortableBindings) Len() int {
+	return len(b)
+}
+func (b sortableBindings) Swap(i, j int) {
+	b[i], b[j] = b[j], b[i]
+}
+func (b sortableBindings) Less(i, j int) bool {
+	return b[i].Role < b[j].Role
+}

--- a/builtin/providers/google/resource_google_project_iam_policy_test.go
+++ b/builtin/providers/google/resource_google_project_iam_policy_test.go
@@ -1,0 +1,626 @@
+package google
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+func TestSubtractIamPolicy(t *testing.T) {
+	table := []struct {
+		a      *cloudresourcemanager.Policy
+		b      *cloudresourcemanager.Policy
+		expect cloudresourcemanager.Policy
+	}{
+		{
+			a: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+				},
+			},
+			b: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"3",
+							"4",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+				},
+			},
+			expect: cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+				},
+			},
+		},
+		{
+			a: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+				},
+			},
+			b: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+						},
+					},
+				},
+			},
+			expect: cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{},
+			},
+		},
+		{
+			a: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"2",
+							"3",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+							"3",
+						},
+					},
+				},
+			},
+			b: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"3",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+							"3",
+						},
+					},
+				},
+			},
+			expect: cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"2",
+						},
+					},
+				},
+			},
+		},
+		{
+			a: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"2",
+							"3",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+							"3",
+						},
+					},
+				},
+			},
+			b: &cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{
+					{
+						Role: "a",
+						Members: []string{
+							"1",
+							"2",
+							"3",
+						},
+					},
+					{
+						Role: "b",
+						Members: []string{
+							"1",
+							"2",
+							"3",
+						},
+					},
+				},
+			},
+			expect: cloudresourcemanager.Policy{
+				Bindings: []*cloudresourcemanager.Binding{},
+			},
+		},
+	}
+
+	for _, test := range table {
+		c := subtractIamPolicy(test.a, test.b)
+		sort.Sort(sortableBindings(c.Bindings))
+		for i, _ := range c.Bindings {
+			sort.Strings(c.Bindings[i].Members)
+		}
+
+		if !reflect.DeepEqual(derefBindings(c.Bindings), derefBindings(test.expect.Bindings)) {
+			t.Errorf("\ngot %+v\nexpected %+v", derefBindings(c.Bindings), derefBindings(test.expect.Bindings))
+		}
+	}
+}
+
+// Test that an IAM policy can be applied to a project
+func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+			// Apply an IAM policy from a data source. The application
+			// merges policies, so we validate the expected state.
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociatePolicyBasic(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamPolicyIsMerged("google_project_iam_policy.acceptance", "data.google_iam_policy.admin", pid),
+				),
+			},
+			// Finally, remove the custom IAM policy from config and apply, then
+			// confirm that the project is in its original state.
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccGoogleProjectExistingPolicy(pid),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes, pid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Get the project resource
+		project, ok := s.RootModule().Resources[projectRes]
+		if !ok {
+			return fmt.Errorf("Not found: %s", projectRes)
+		}
+		// The project ID should match the config's project ID
+		if project.Primary.ID != pid {
+			return fmt.Errorf("Expected project %q to match ID %q in state", pid, project.Primary.ID)
+		}
+
+		var projectP, policyP cloudresourcemanager.Policy
+		// The project should have a policy
+		ps, ok := project.Primary.Attributes["policy_data"]
+		if !ok {
+			return fmt.Errorf("Project resource %q did not have a 'policy_data' attribute. Attributes were %#v", project.Primary.Attributes["id"], project.Primary.Attributes)
+		}
+		if err := json.Unmarshal([]byte(ps), &projectP); err != nil {
+			return fmt.Errorf("Could not unmarshal %s:\n: %v", ps, err)
+		}
+
+		// The data policy resource should have a policy
+		policy, ok := s.RootModule().Resources[policyRes]
+		if !ok {
+			return fmt.Errorf("Not found: %s", policyRes)
+		}
+		ps, ok = policy.Primary.Attributes["policy_data"]
+		if !ok {
+			return fmt.Errorf("Data policy resource %q did not have a 'policy_data' attribute. Attributes were %#v", policy.Primary.Attributes["id"], project.Primary.Attributes)
+		}
+		if err := json.Unmarshal([]byte(ps), &policyP); err != nil {
+			return err
+		}
+
+		// The bindings in both policies should be identical
+		sort.Sort(sortableBindings(projectP.Bindings))
+		sort.Sort(sortableBindings(policyP.Bindings))
+		if !reflect.DeepEqual(derefBindings(projectP.Bindings), derefBindings(policyP.Bindings)) {
+			return fmt.Errorf("Project and data source policies do not match: project policy is %+v, data resource policy is  %+v", derefBindings(projectP.Bindings), derefBindings(policyP.Bindings))
+		}
+
+		// Merge the project policy in Terraform state with the policy the project had before the config was applied
+		expected := make([]*cloudresourcemanager.Binding, 0)
+		expected = append(expected, originalPolicy.Bindings...)
+		expected = append(expected, projectP.Bindings...)
+		expectedM := mergeBindings(expected)
+
+		// Retrieve the actual policy from the project
+		c := testAccProvider.Meta().(*Config)
+		actual, err := getProjectIamPolicy(pid, c)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve IAM Policy for project %q: %s", pid, err)
+		}
+		actualM := mergeBindings(actual.Bindings)
+
+		sort.Sort(sortableBindings(actualM))
+		sort.Sort(sortableBindings(expectedM))
+		// The bindings should match, indicating the policy was successfully applied and merged
+		if !reflect.DeepEqual(derefBindings(actualM), derefBindings(expectedM)) {
+			return fmt.Errorf("Actual and expected project policies do not match: actual policy is %+v, expected policy is  %+v", derefBindings(actualM), derefBindings(expectedM))
+		}
+
+		return nil
+	}
+}
+
+func TestIamRolesToMembersBinding(t *testing.T) {
+	table := []struct {
+		expect []*cloudresourcemanager.Binding
+		input  map[string]map[string]bool
+	}{
+		{
+			expect: []*cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+			},
+			input: map[string]map[string]bool{
+				"role-1": map[string]bool{
+					"member-1": true,
+					"member-2": true,
+				},
+			},
+		},
+		{
+			expect: []*cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+			},
+			input: map[string]map[string]bool{
+				"role-1": map[string]bool{
+					"member-1": true,
+					"member-2": true,
+				},
+			},
+		},
+		{
+			expect: []*cloudresourcemanager.Binding{
+				{
+					Role:    "role-1",
+					Members: []string{},
+				},
+			},
+			input: map[string]map[string]bool{
+				"role-1": map[string]bool{},
+			},
+		},
+	}
+
+	for _, test := range table {
+		got := rolesToMembersBinding(test.input)
+
+		sort.Sort(sortableBindings(got))
+		for i, _ := range got {
+			sort.Strings(got[i].Members)
+		}
+
+		if !reflect.DeepEqual(derefBindings(got), derefBindings(test.expect)) {
+			t.Errorf("got %+v, expected %+v", derefBindings(got), derefBindings(test.expect))
+		}
+	}
+}
+func TestIamRolesToMembersMap(t *testing.T) {
+	table := []struct {
+		input  []*cloudresourcemanager.Binding
+		expect map[string]map[string]bool
+	}{
+		{
+			input: []*cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+			},
+			expect: map[string]map[string]bool{
+				"role-1": map[string]bool{
+					"member-1": true,
+					"member-2": true,
+				},
+			},
+		},
+		{
+			input: []*cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+						"member-1",
+						"member-2",
+					},
+				},
+			},
+			expect: map[string]map[string]bool{
+				"role-1": map[string]bool{
+					"member-1": true,
+					"member-2": true,
+				},
+			},
+		},
+		{
+			input: []*cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+				},
+			},
+			expect: map[string]map[string]bool{
+				"role-1": map[string]bool{},
+			},
+		},
+	}
+
+	for _, test := range table {
+		got := rolesToMembersMap(test.input)
+		if !reflect.DeepEqual(got, test.expect) {
+			t.Errorf("got %+v, expected %+v", got, test.expect)
+		}
+	}
+}
+
+func TestIamMergeBindings(t *testing.T) {
+	table := []struct {
+		input  []*cloudresourcemanager.Binding
+		expect []cloudresourcemanager.Binding
+	}{
+		{
+			input: []*cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-3",
+					},
+				},
+			},
+			expect: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+						"member-3",
+					},
+				},
+			},
+		},
+		{
+			input: []*cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-3",
+						"member-4",
+					},
+				},
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-2",
+						"member-1",
+					},
+				},
+				{
+					Role: "role-2",
+					Members: []string{
+						"member-1",
+					},
+				},
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-5",
+					},
+				},
+				{
+					Role: "role-3",
+					Members: []string{
+						"member-1",
+					},
+				},
+				{
+					Role: "role-2",
+					Members: []string{
+						"member-2",
+					},
+				},
+			},
+			expect: []cloudresourcemanager.Binding{
+				{
+					Role: "role-1",
+					Members: []string{
+						"member-1",
+						"member-2",
+						"member-3",
+						"member-4",
+						"member-5",
+					},
+				},
+				{
+					Role: "role-2",
+					Members: []string{
+						"member-1",
+						"member-2",
+					},
+				},
+				{
+					Role: "role-3",
+					Members: []string{
+						"member-1",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range table {
+		got := mergeBindings(test.input)
+		sort.Sort(sortableBindings(got))
+		for i, _ := range got {
+			sort.Strings(got[i].Members)
+		}
+
+		if !reflect.DeepEqual(derefBindings(got), test.expect) {
+			t.Errorf("\ngot %+v\nexpected %+v", derefBindings(got), test.expect)
+		}
+	}
+}
+
+func derefBindings(b []*cloudresourcemanager.Binding) []cloudresourcemanager.Binding {
+	db := make([]cloudresourcemanager.Binding, len(b))
+
+	for i, v := range b {
+		db[i] = *v
+		sort.Strings(db[i].Members)
+	}
+	return db
+}
+
+// Confirm that a project has an IAM policy with at least 1 binding
+func testAccGoogleProjectExistingPolicy(pid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		c := testAccProvider.Meta().(*Config)
+		var err error
+		originalPolicy, err = getProjectIamPolicy(pid, c)
+		if err != nil {
+			return fmt.Errorf("Failed to retrieve IAM Policy for project %q: %s", pid, err)
+		}
+		if len(originalPolicy.Bindings) == 0 {
+			return fmt.Errorf("Refuse to run test against project with zero IAM Bindings. This is likely an error in the test code that is not properly identifying the IAM policy of a project.")
+		}
+		return nil
+	}
+}
+
+func testAccGoogleProjectAssociatePolicyBasic(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+	name = "%s"
+	org_id = "%s"
+}
+resource "google_project_iam_policy" "acceptance" {
+    project = "${google_project.acceptance.id}"
+    policy_data = "${data.google_iam_policy.admin.policy_data}"
+}
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/storage.objectViewer"
+    members = [
+      "user:evanbrown@google.com",
+    ]
+  }
+  binding {
+    role = "roles/compute.instanceAdmin"
+    members = [
+      "user:evanbrown@google.com",
+      "user:evandbrown@gmail.com",
+    ]
+  }
+}
+`, pid, name, org)
+}
+
+func testAccGoogleProject_create(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+	name = "%s"
+	org_id = "%s"
+}`, pid, name, org)
+}

--- a/builtin/providers/google/resource_google_project_migrate.go
+++ b/builtin/providers/google/resource_google_project_migrate.go
@@ -1,0 +1,47 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceGoogleProjectMigrateState(v int, s *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if s.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return s, nil
+	}
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Google Project State v0; migrating to v1")
+		s, err := migrateGoogleProjectStateV0toV1(s, meta.(*Config))
+		if err != nil {
+			return s, err
+		}
+		return s, nil
+	default:
+		return s, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+// This migration adjusts google_project resources to include several additional attributes
+// required to support project creation/deletion that was added in V1.
+func migrateGoogleProjectStateV0toV1(s *terraform.InstanceState, config *Config) (*terraform.InstanceState, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", s.Attributes)
+
+	s.Attributes["skip_delete"] = "true"
+	s.Attributes["project_id"] = s.ID
+
+	if s.Attributes["policy_data"] != "" {
+		p, err := getProjectIamPolicy(s.ID, config)
+		if err != nil {
+			return s, fmt.Errorf("Could not retrieve project's IAM policy while attempting to migrate state from V0 to V1: %v", err)
+		}
+		s.Attributes["policy_etag"] = p.Etag
+	}
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", s.Attributes)
+	return s, nil
+}

--- a/builtin/providers/google/resource_google_project_migrate_test.go
+++ b/builtin/providers/google/resource_google_project_migrate_test.go
@@ -1,0 +1,70 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestGoogleProjectMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"deprecate policy_data and support creation/deletion": {
+			StateVersion: 0,
+			Attributes:   map[string]string{},
+			Expected: map[string]string{
+				"project_id":  "test-project",
+				"skip_delete": "true",
+			},
+			Meta: &Config{},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "test-project",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceGoogleProjectMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}
+
+func TestGoogleProjectMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta *Config
+
+	// should handle nil
+	is, err := resourceGoogleProjectMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceGoogleProjectMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}

--- a/builtin/providers/google/resource_google_project_services.go
+++ b/builtin/providers/google/resource_google_project_services.go
@@ -1,0 +1,214 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/servicemanagement/v1"
+)
+
+func resourceGoogleProjectServices() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGoogleProjectServicesCreate,
+		Read:   resourceGoogleProjectServicesRead,
+		Update: resourceGoogleProjectServicesUpdate,
+		Delete: resourceGoogleProjectServicesDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"services": {
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+		},
+	}
+}
+
+func resourceGoogleProjectServicesCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+	pid := d.Get("project").(string)
+
+	// Get services from config
+	cfgServices := getConfigServices(d)
+
+	// Get services from API
+	apiServices, err := getApiServices(pid, config)
+	if err != nil {
+		return fmt.Errorf("Error creating services: %v", err)
+	}
+
+	// This call disables any APIs that aren't defined in cfgServices,
+	// and enables all of those that are
+	err = reconcileServices(cfgServices, apiServices, config, pid)
+	if err != nil {
+		return fmt.Errorf("Error creating services: %v", err)
+	}
+
+	d.SetId(pid)
+	return resourceGoogleProjectServicesRead(d, meta)
+}
+
+func resourceGoogleProjectServicesRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	services, err := getApiServices(d.Id(), config)
+	if err != nil {
+		return err
+	}
+
+	d.Set("services", services)
+	return nil
+}
+
+func resourceGoogleProjectServicesUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG]: Updating google_project_services")
+	config := meta.(*Config)
+	pid := d.Get("project").(string)
+
+	// Get services from config
+	cfgServices := getConfigServices(d)
+
+	// Get services from API
+	apiServices, err := getApiServices(pid, config)
+	if err != nil {
+		return fmt.Errorf("Error updating services: %v", err)
+	}
+
+	// This call disables any APIs that aren't defined in cfgServices,
+	// and enables all of those that are
+	err = reconcileServices(cfgServices, apiServices, config, pid)
+	if err != nil {
+		return fmt.Errorf("Error updating services: %v", err)
+	}
+
+	return resourceGoogleProjectServicesRead(d, meta)
+}
+
+func resourceGoogleProjectServicesDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG]: Deleting google_project_services")
+	config := meta.(*Config)
+	services := resourceServices(d)
+	for _, s := range services {
+		disableService(s, d.Id(), config)
+	}
+	d.SetId("")
+	return nil
+}
+
+// This function ensures that the services enabled for a project exactly match that
+// in a config by disabling any services that are returned by the API but not present
+// in the config
+func reconcileServices(cfgServices, apiServices []string, config *Config, pid string) error {
+	// Helper to convert slice to map
+	m := func(vals []string) map[string]struct{} {
+		sm := make(map[string]struct{})
+		for _, s := range vals {
+			sm[s] = struct{}{}
+		}
+		return sm
+	}
+
+	cfgMap := m(cfgServices)
+	apiMap := m(apiServices)
+
+	for k, _ := range apiMap {
+		if _, ok := cfgMap[k]; !ok {
+			// The service in the API is not in the config; disable it.
+			err := disableService(k, pid, config)
+			if err != nil {
+				return err
+			}
+		} else {
+			// The service exists in the config and the API, so we don't need
+			// to re-enable it
+			delete(cfgMap, k)
+		}
+	}
+
+	for k, _ := range cfgMap {
+		err := enableService(k, pid, config)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Retrieve services defined in a config
+func getConfigServices(d *schema.ResourceData) (services []string) {
+	if v, ok := d.GetOk("services"); ok {
+		for _, svc := range v.(*schema.Set).List() {
+			services = append(services, svc.(string))
+		}
+	}
+	return
+}
+
+// Retrieve a project's services from the API
+func getApiServices(pid string, config *Config) ([]string, error) {
+	apiServices := make([]string, 0)
+	// Get services from the API
+	svcResp, err := config.clientServiceMan.Services.List().ConsumerId("project:" + pid).Do()
+	if err != nil {
+		return apiServices, err
+	}
+	for _, v := range svcResp.Services {
+		apiServices = append(apiServices, v.ServiceName)
+	}
+	return apiServices, nil
+}
+
+func enableService(s, pid string, config *Config) error {
+	esr := newEnableServiceRequest(pid)
+	sop, err := config.clientServiceMan.Services.Enable(s, esr).Do()
+	if err != nil {
+		return fmt.Errorf("Error enabling service %q for project %q: %v", s, pid, err)
+	}
+	// Wait for the operation to complete
+	waitErr := serviceManagementOperationWait(config, sop, "api to enable")
+	if waitErr != nil {
+		return waitErr
+	}
+	return nil
+}
+func disableService(s, pid string, config *Config) error {
+	dsr := newDisableServiceRequest(pid)
+	sop, err := config.clientServiceMan.Services.Disable(s, dsr).Do()
+	if err != nil {
+		return fmt.Errorf("Error disabling service %q for project %q: %v", s, pid, err)
+	}
+	// Wait for the operation to complete
+	waitErr := serviceManagementOperationWait(config, sop, "api to disable")
+	if waitErr != nil {
+		return waitErr
+	}
+	return nil
+}
+
+func newEnableServiceRequest(pid string) *servicemanagement.EnableServiceRequest {
+	return &servicemanagement.EnableServiceRequest{ConsumerId: "project:" + pid}
+}
+
+func newDisableServiceRequest(pid string) *servicemanagement.DisableServiceRequest {
+	return &servicemanagement.DisableServiceRequest{ConsumerId: "project:" + pid}
+}
+
+func resourceServices(d *schema.ResourceData) []string {
+	// Calculate the tags
+	var services []string
+	if s := d.Get("services"); s != nil {
+		ss := s.(*schema.Set)
+		services = make([]string, ss.Len())
+		for i, v := range ss.List() {
+			services[i] = v.(string)
+		}
+	}
+	return services
+}

--- a/builtin/providers/google/resource_google_project_services_test.go
+++ b/builtin/providers/google/resource_google_project_services_test.go
@@ -1,0 +1,178 @@
+package google
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"google.golang.org/api/servicemanagement/v1"
+)
+
+// Test that services can be enabled and disabled on a project
+func TestAccGoogleProjectServices_basic(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	services1 := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
+	services2 := []string{"cloudresourcemanager.googleapis.com"}
+	oobService := "iam.googleapis.com"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project with some services
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateServicesBasic(services1, pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testProjectServicesMatch(services1, pid),
+				),
+			},
+			// Update services to remove one
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociateServicesBasic(services2, pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testProjectServicesMatch(services2, pid),
+				),
+			},
+			// Add a service out-of-band and ensure it is removed
+			resource.TestStep{
+				PreConfig: func() {
+					config := testAccProvider.Meta().(*Config)
+					enableService(oobService, pid, config)
+				},
+				Config: testAccGoogleProjectAssociateServicesBasic(services2, pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testProjectServicesMatch(services2, pid),
+				),
+			},
+		},
+	})
+}
+
+// Test that services are authoritative when a project has existing
+// sevices not represented in config
+func TestAccGoogleProjectServices_authoritative(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	services := []string{"cloudresourcemanager.googleapis.com"}
+	oobService := "iam.googleapis.com"
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project with no services
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+				),
+			},
+			// Add a service out-of-band, then apply a config that creates a service.
+			// It should remove the out-of-band service.
+			resource.TestStep{
+				PreConfig: func() {
+					config := testAccProvider.Meta().(*Config)
+					enableService(oobService, pid, config)
+				},
+				Config: testAccGoogleProjectAssociateServicesBasic(services, pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testProjectServicesMatch(services, pid),
+				),
+			},
+		},
+	})
+}
+
+// Test that services are authoritative when a project has existing
+// sevices, some which are represented in the config and others
+// that are not
+func TestAccGoogleProjectServices_authoritative2(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	oobServices := []string{"iam.googleapis.com", "cloudresourcemanager.googleapis.com"}
+	services := []string{"iam.googleapis.com"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Create a new project with no services
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+				),
+			},
+			// Add a service out-of-band, then apply a config that creates a service.
+			// It should remove the out-of-band service.
+			resource.TestStep{
+				PreConfig: func() {
+					config := testAccProvider.Meta().(*Config)
+					for _, s := range oobServices {
+						enableService(s, pid, config)
+					}
+				},
+				Config: testAccGoogleProjectAssociateServicesBasic(services, pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testProjectServicesMatch(services, pid),
+				),
+			},
+		},
+	})
+}
+
+func testAccGoogleProjectAssociateServicesBasic(services []string, pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+  project_id = "%s"
+  name = "%s"
+  org_id = "%s"
+}
+resource "google_project_services" "acceptance" {
+  project = "${google_project.acceptance.project_id}"
+  services = [%s]
+}
+`, pid, name, org, testStringsToString(services))
+}
+
+func testProjectServicesMatch(services []string, pid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+
+		apiServices, err := getApiServices(pid, config)
+		if err != nil {
+			return fmt.Errorf("Error listing services for project %q: %v", pid, err)
+		}
+
+		sort.Strings(services)
+		sort.Strings(apiServices)
+		if !reflect.DeepEqual(services, apiServices) {
+			return fmt.Errorf("Services in config (%v) do not exactly match services returned by API (%v)", services, apiServices)
+		}
+
+		return nil
+	}
+}
+
+func testStringsToString(s []string) string {
+	var b bytes.Buffer
+	for i, v := range s {
+		b.WriteString(fmt.Sprintf("\"%s\"", v))
+		if i < len(s)-1 {
+			b.WriteString(",")
+		}
+	}
+	r := b.String()
+	log.Printf("[DEBUG]: Converted list of strings to %s", r)
+	return b.String()
+}
+
+func testManagedServicesToString(svcs []*servicemanagement.ManagedService) string {
+	var b bytes.Buffer
+	for _, s := range svcs {
+		b.WriteString(s.ServiceName)
+	}
+	return b.String()
+}

--- a/builtin/providers/google/resource_google_project_test.go
+++ b/builtin/providers/google/resource_google_project_test.go
@@ -1,24 +1,23 @@
 package google
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
-	"sort"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/cloudresourcemanager/v1"
 )
 
 var (
-	projectId = multiEnvSearch([]string{
-		"GOOGLE_PROJECT",
-		"GCLOUD_PROJECT",
-		"CLOUDSDK_CORE_PROJECT",
+	org = multiEnvSearch([]string{
+		"GOOGLE_ORG",
 	})
+
+	pname          = "Terraform Acceptance Tests"
+	originalPolicy *cloudresourcemanager.Policy
 )
 
 func multiEnvSearch(ks []string) string {
@@ -30,77 +29,26 @@ func multiEnvSearch(ks []string) string {
 	return ""
 }
 
-// Test that a Project resource can be created and destroyed
-func TestAccGoogleProject_associate(t *testing.T) {
+// Test that a Project resource can be created and an IAM policy
+// associated
+func TestAccGoogleProject_create(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
+			// This step imports an existing project
 			resource.TestStep{
-				Config: fmt.Sprintf(testAccGoogleProject_basic, projectId),
+				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectExists("google_project.acceptance"),
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 				),
 			},
 		},
 	})
 }
 
-// Test that a Project resource can be created, an IAM Policy
-// associated with it, and then destroyed
-func TestAccGoogleProject_iamPolicy1(t *testing.T) {
-	var policy *cloudresourcemanager.Policy
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGoogleProjectDestroy,
-		Steps: []resource.TestStep{
-			// First step inventories the project's existing IAM policy
-			resource.TestStep{
-				Config: fmt.Sprintf(testAccGoogleProject_basic, projectId),
-				Check: resource.ComposeTestCheckFunc(
-					testAccGoogleProjectExistingPolicy(policy),
-				),
-			},
-			// Second step applies an IAM policy from a data source. The application
-			// merges policies, so we validate the expected state.
-			resource.TestStep{
-				Config: fmt.Sprintf(testAccGoogleProject_policy1, projectId),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGoogleProjectExists("google_project.acceptance"),
-					testAccCheckGoogleProjectIamPolicyIsMerged("google_project.acceptance", "data.google_iam_policy.admin", policy),
-				),
-			},
-			// Finally, remove the custom IAM policy from config and apply, then
-			// confirm that the project is in its original state.
-			resource.TestStep{
-				Config: fmt.Sprintf(testAccGoogleProject_basic, projectId),
-			},
-		},
-	})
-}
-
-func testAccCheckGoogleProjectDestroy(s *terraform.State) error {
-	return nil
-}
-
-// Retrieve the existing policy (if any) for a GCP Project
-func testAccGoogleProjectExistingPolicy(p *cloudresourcemanager.Policy) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		c := testAccProvider.Meta().(*Config)
-		var err error
-		p, err = getProjectIamPolicy(projectId, c)
-		if err != nil {
-			return fmt.Errorf("Failed to retrieve IAM Policy for project %q: %s", projectId, err)
-		}
-		if len(p.Bindings) == 0 {
-			return fmt.Errorf("Refuse to run test against project with zero IAM Bindings. This is likely an error in the test code that is not properly identifying the IAM policy of a project.")
-		}
-		return nil
-	}
-}
-
-func testAccCheckGoogleProjectExists(r string) resource.TestCheckFunc {
+func testAccCheckGoogleProjectExists(r, pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
 		if !ok {
@@ -111,349 +59,29 @@ func testAccCheckGoogleProjectExists(r string) resource.TestCheckFunc {
 			return fmt.Errorf("No ID is set")
 		}
 
-		if rs.Primary.ID != projectId {
-			return fmt.Errorf("Expected project %q to match ID %q in state", projectId, rs.Primary.ID)
+		if rs.Primary.ID != pid {
+			return fmt.Errorf("Expected project %q to match ID %q in state", pid, rs.Primary.ID)
 		}
 
 		return nil
 	}
 }
 
-func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes string, original *cloudresourcemanager.Policy) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		// Get the project resource
-		project, ok := s.RootModule().Resources[projectRes]
-		if !ok {
-			return fmt.Errorf("Not found: %s", projectRes)
-		}
-		// The project ID should match the config's project ID
-		if project.Primary.ID != projectId {
-			return fmt.Errorf("Expected project %q to match ID %q in state", projectId, project.Primary.ID)
-		}
-
-		var projectP, policyP cloudresourcemanager.Policy
-		// The project should have a policy
-		ps, ok := project.Primary.Attributes["policy_data"]
-		if !ok {
-			return fmt.Errorf("Project resource %q did not have a 'policy_data' attribute. Attributes were %#v", project.Primary.Attributes["id"], project.Primary.Attributes)
-		}
-		if err := json.Unmarshal([]byte(ps), &projectP); err != nil {
-			return err
-		}
-
-		// The data policy resource should have a policy
-		policy, ok := s.RootModule().Resources[policyRes]
-		if !ok {
-			return fmt.Errorf("Not found: %s", policyRes)
-		}
-		ps, ok = policy.Primary.Attributes["policy_data"]
-		if !ok {
-			return fmt.Errorf("Data policy resource %q did not have a 'policy_data' attribute. Attributes were %#v", policy.Primary.Attributes["id"], project.Primary.Attributes)
-		}
-		if err := json.Unmarshal([]byte(ps), &policyP); err != nil {
-			return err
-		}
-
-		// The bindings in both policies should be identical
-		if !reflect.DeepEqual(derefBindings(projectP.Bindings), derefBindings(policyP.Bindings)) {
-			return fmt.Errorf("Project and data source policies do not match: project policy is %+v, data resource policy is  %+v", derefBindings(projectP.Bindings), derefBindings(policyP.Bindings))
-		}
-
-		// Merge the project policy in Terrafomr state with the policy the project had before the config was applied
-		expected := make([]*cloudresourcemanager.Binding, 0)
-		expected = append(expected, original.Bindings...)
-		expected = append(expected, projectP.Bindings...)
-		expectedM := mergeBindings(expected)
-
-		// Retrieve the actual policy from the project
-		c := testAccProvider.Meta().(*Config)
-		actual, err := getProjectIamPolicy(projectId, c)
-		if err != nil {
-			return fmt.Errorf("Failed to retrieve IAM Policy for project %q: %s", projectId, err)
-		}
-		actualM := mergeBindings(actual.Bindings)
-
-		// The bindings should match, indicating the policy was successfully applied and merged
-		if !reflect.DeepEqual(derefBindings(actualM), derefBindings(expectedM)) {
-			return fmt.Errorf("Actual and expected project policies do not match: actual policy is %+v, expected policy is  %+v", derefBindings(actualM), derefBindings(expectedM))
-		}
-
-		return nil
-	}
-}
-
-func TestIamRolesToMembersBinding(t *testing.T) {
-	table := []struct {
-		expect []*cloudresourcemanager.Binding
-		input  map[string]map[string]bool
-	}{
-		{
-			expect: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			input: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			expect: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			input: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			expect: []*cloudresourcemanager.Binding{
-				{
-					Role:    "role-1",
-					Members: []string{},
-				},
-			},
-			input: map[string]map[string]bool{
-				"role-1": map[string]bool{},
-			},
-		},
-	}
-
-	for _, test := range table {
-		got := rolesToMembersBinding(test.input)
-
-		sort.Sort(Binding(got))
-		for i, _ := range got {
-			sort.Strings(got[i].Members)
-		}
-
-		if !reflect.DeepEqual(derefBindings(got), derefBindings(test.expect)) {
-			t.Errorf("got %+v, expected %+v", derefBindings(got), derefBindings(test.expect))
-		}
-	}
-}
-func TestIamRolesToMembersMap(t *testing.T) {
-	table := []struct {
-		input  []*cloudresourcemanager.Binding
-		expect map[string]map[string]bool
-	}{
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			expect: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-						"member-1",
-						"member-2",
-					},
-				},
-			},
-			expect: map[string]map[string]bool{
-				"role-1": map[string]bool{
-					"member-1": true,
-					"member-2": true,
-				},
-			},
-		},
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-				},
-			},
-			expect: map[string]map[string]bool{
-				"role-1": map[string]bool{},
-			},
-		},
-	}
-
-	for _, test := range table {
-		got := rolesToMembersMap(test.input)
-		if !reflect.DeepEqual(got, test.expect) {
-			t.Errorf("got %+v, expected %+v", got, test.expect)
-		}
-	}
-}
-
-func TestIamMergeBindings(t *testing.T) {
-	table := []struct {
-		input  []*cloudresourcemanager.Binding
-		expect []cloudresourcemanager.Binding
-	}{
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-3",
-					},
-				},
-			},
-			expect: []cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-						"member-3",
-					},
-				},
-			},
-		},
-		{
-			input: []*cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-3",
-						"member-4",
-					},
-				},
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-2",
-						"member-1",
-					},
-				},
-				{
-					Role: "role-2",
-					Members: []string{
-						"member-1",
-					},
-				},
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-5",
-					},
-				},
-				{
-					Role: "role-3",
-					Members: []string{
-						"member-1",
-					},
-				},
-				{
-					Role: "role-2",
-					Members: []string{
-						"member-2",
-					},
-				},
-			},
-			expect: []cloudresourcemanager.Binding{
-				{
-					Role: "role-1",
-					Members: []string{
-						"member-1",
-						"member-2",
-						"member-3",
-						"member-4",
-						"member-5",
-					},
-				},
-				{
-					Role: "role-2",
-					Members: []string{
-						"member-1",
-						"member-2",
-					},
-				},
-				{
-					Role: "role-3",
-					Members: []string{
-						"member-1",
-					},
-				},
-			},
-		},
-	}
-
-	for _, test := range table {
-		got := mergeBindings(test.input)
-		sort.Sort(Binding(got))
-		for i, _ := range got {
-			sort.Strings(got[i].Members)
-		}
-
-		if !reflect.DeepEqual(derefBindings(got), test.expect) {
-			t.Errorf("\ngot %+v\nexpected %+v", derefBindings(got), test.expect)
-		}
-	}
-}
-
-func derefBindings(b []*cloudresourcemanager.Binding) []cloudresourcemanager.Binding {
-	db := make([]cloudresourcemanager.Binding, len(b))
-
-	for i, v := range b {
-		db[i] = *v
-	}
-	return db
-}
-
-type Binding []*cloudresourcemanager.Binding
-
-func (b Binding) Len() int {
-	return len(b)
-}
-func (b Binding) Swap(i, j int) {
-	b[i], b[j] = b[j], b[i]
-}
-func (b Binding) Less(i, j int) bool {
-	return b[i].Role < b[j].Role
-}
-
-var testAccGoogleProject_basic = `
+func testAccGoogleProjectImportExisting(pid string) string {
+	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    id = "%v"
-}`
+    project_id = "%s"
 
-var testAccGoogleProject_policy1 = `
+}
+`, pid)
+}
+
+func testAccGoogleProjectImportExistingWithIam(pid string) string {
+	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
-    id = "%v"
+    project_id = "%v"
     policy_data = "${data.google_iam_policy.admin.policy_data}"
 }
-
 data "google_iam_policy" "admin" {
   binding {
     role = "roles/storage.objectViewer"
@@ -468,4 +96,5 @@ data "google_iam_policy" "admin" {
       "user:evandbrown@gmail.com",
     ]
   }
-}`
+}`, pid)
+}

--- a/builtin/providers/google/resource_google_service_account_test.go
+++ b/builtin/providers/google/resource_google_service_account_test.go
@@ -9,6 +9,14 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+var (
+	projectId = multiEnvSearch([]string{
+		"GOOGLE_PROJECT",
+		"GCLOUD_PROJECT",
+		"CLOUDSDK_CORE_PROJECT",
+	})
+)
+
 // Test that a service account resource can be created, updated, and destroyed
 func TestAccGoogleServiceAccount_basic(t *testing.T) {
 	accountId := "a" + acctest.RandString(10)

--- a/builtin/providers/google/resourcemanager_operation.go
+++ b/builtin/providers/google/resourcemanager_operation.go
@@ -1,0 +1,64 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"google.golang.org/api/cloudresourcemanager/v1"
+)
+
+type ResourceManagerOperationWaiter struct {
+	Service *cloudresourcemanager.Service
+	Op      *cloudresourcemanager.Operation
+}
+
+func (w *ResourceManagerOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		op, err := w.Service.Operations.Get(w.Op.Name).Do()
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] Got %v while polling for operation %s's 'done' status", op.Done, w.Op.Name)
+
+		return op, fmt.Sprint(op.Done), nil
+	}
+}
+
+func (w *ResourceManagerOperationWaiter) Conf() *resource.StateChangeConf {
+	return &resource.StateChangeConf{
+		Pending: []string{"false"},
+		Target:  []string{"true"},
+		Refresh: w.RefreshFunc(),
+	}
+}
+
+func resourceManagerOperationWait(config *Config, op *cloudresourcemanager.Operation, activity string) error {
+	return resourceManagerOperationWaitTime(config, op, activity, 4)
+}
+
+func resourceManagerOperationWaitTime(config *Config, op *cloudresourcemanager.Operation, activity string, timeoutMin int) error {
+	w := &ResourceManagerOperationWaiter{
+		Service: config.clientResourceManager,
+		Op:      op,
+	}
+
+	state := w.Conf()
+	state.Delay = 10 * time.Second
+	state.Timeout = time.Duration(timeoutMin) * time.Minute
+	state.MinTimeout = 2 * time.Second
+	opRaw, err := state.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for %s: %s", activity, err)
+	}
+
+	op = opRaw.(*cloudresourcemanager.Operation)
+	if op.Error != nil {
+		return fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+	}
+
+	return nil
+}

--- a/builtin/providers/google/serviceman_operation.go
+++ b/builtin/providers/google/serviceman_operation.go
@@ -1,0 +1,67 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"google.golang.org/api/servicemanagement/v1"
+)
+
+type ServiceManagementOperationWaiter struct {
+	Service *servicemanagement.APIService
+	Op      *servicemanagement.Operation
+}
+
+func (w *ServiceManagementOperationWaiter) RefreshFunc() resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		var op *servicemanagement.Operation
+		var err error
+
+		op, err = w.Service.Operations.Get(w.Op.Name).Do()
+
+		if err != nil {
+			return nil, "", err
+		}
+
+		log.Printf("[DEBUG] Got %v while polling for operation %s's 'done' status", op.Done, w.Op.Name)
+
+		return op, fmt.Sprint(op.Done), nil
+	}
+}
+
+func (w *ServiceManagementOperationWaiter) Conf() *resource.StateChangeConf {
+	return &resource.StateChangeConf{
+		Pending: []string{"false"},
+		Target:  []string{"true"},
+		Refresh: w.RefreshFunc(),
+	}
+}
+
+func serviceManagementOperationWait(config *Config, op *servicemanagement.Operation, activity string) error {
+	return serviceManagementOperationWaitTime(config, op, activity, 4)
+}
+
+func serviceManagementOperationWaitTime(config *Config, op *servicemanagement.Operation, activity string, timeoutMin int) error {
+	w := &ServiceManagementOperationWaiter{
+		Service: config.clientServiceMan,
+		Op:      op,
+	}
+
+	state := w.Conf()
+	state.Delay = 10 * time.Second
+	state.Timeout = time.Duration(timeoutMin) * time.Minute
+	state.MinTimeout = 2 * time.Second
+	opRaw, err := state.WaitForState()
+	if err != nil {
+		return fmt.Errorf("Error waiting for %s: %s", activity, err)
+	}
+
+	op = opRaw.(*servicemanagement.Operation)
+	if op.Error != nil {
+		return fmt.Errorf("Error code %v, message: %s", op.Error.Code, op.Error.Message)
+	}
+
+	return nil
+}

--- a/vendor/google.golang.org/api/servicemanagement/v1/servicemanagement-api.json
+++ b/vendor/google.golang.org/api/servicemanagement/v1/servicemanagement-api.json
@@ -1,0 +1,2857 @@
+{
+  "id": "servicemanagement:v1",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        },
+        "https://www.googleapis.com/auth/cloud-platform.read-only": {
+          "description": "View your data across Google Cloud Platform services"
+        },
+        "https://www.googleapis.com/auth/service.management": {
+          "description": "Manage your Google API service configuration"
+        },
+        "https://www.googleapis.com/auth/service.management.readonly": {
+          "description": "View your Google API service configuration"
+        }
+      }
+    }
+  },
+  "description": "Google Service Management allows service producers to publish their services on Google Cloud Platform so that they can be discovered and used by service consumers.",
+  "protocol": "rest",
+  "title": "Google Service Management API",
+  "resources": {
+    "services": {
+      "resources": {
+        "rollouts": {
+          "methods": {
+            "get": {
+              "id": "servicemanagement.services.rollouts.get",
+              "response": {
+                "$ref": "Rollout"
+              },
+              "parameterOrder": [
+                "serviceName",
+                "rolloutId"
+              ],
+              "description": "Gets a service configuration rollout.",
+              "flatPath": "v1/services/{serviceName}/rollouts/{rolloutId}",
+              "httpMethod": "GET",
+              "parameters": {
+                "rolloutId": {
+                  "description": "The id of the rollout resource.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                },
+                "serviceName": {
+                  "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                }
+              },
+              "path": "v1/services/{serviceName}/rollouts/{rolloutId}",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+                "https://www.googleapis.com/auth/service.management",
+                "https://www.googleapis.com/auth/service.management.readonly"
+              ]
+            },
+            "create": {
+              "id": "servicemanagement.services.rollouts.create",
+              "response": {
+                "$ref": "Operation"
+              },
+              "parameterOrder": [
+                "serviceName"
+              ],
+              "description": "Creates a new service configuration rollout. Based on rollout, the\nGoogle Service Management will roll out the service configurations to\ndifferent backend services. For example, the logging configuration will be\npushed to Google Cloud Logging.\n\nPlease note that any previous pending and running Rollouts and associated\nOperations will be automatically cancelled so that the latest Rollout will\nnot be blocked by previous Rollouts.\n\nOperation\u003cresponse: Rollout\u003e",
+              "request": {
+                "$ref": "Rollout"
+              },
+              "flatPath": "v1/services/{serviceName}/rollouts",
+              "httpMethod": "POST",
+              "parameters": {
+                "serviceName": {
+                  "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                }
+              },
+              "path": "v1/services/{serviceName}/rollouts",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/service.management"
+              ]
+            },
+            "list": {
+              "id": "servicemanagement.services.rollouts.list",
+              "response": {
+                "$ref": "ListServiceRolloutsResponse"
+              },
+              "parameterOrder": [
+                "serviceName"
+              ],
+              "description": "Lists the history of the service configuration rollouts for a managed\nservice, from the newest to the oldest.",
+              "flatPath": "v1/services/{serviceName}/rollouts",
+              "httpMethod": "GET",
+              "parameters": {
+                "pageSize": {
+                  "description": "The max number of items to include in the response list.",
+                  "location": "query",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "serviceName": {
+                  "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                },
+                "pageToken": {
+                  "description": "The token of the page to retrieve.",
+                  "location": "query",
+                  "type": "string"
+                }
+              },
+              "path": "v1/services/{serviceName}/rollouts",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+                "https://www.googleapis.com/auth/service.management",
+                "https://www.googleapis.com/auth/service.management.readonly"
+              ]
+            }
+          }
+        },
+        "configs": {
+          "methods": {
+            "submit": {
+              "id": "servicemanagement.services.configs.submit",
+              "response": {
+                "$ref": "Operation"
+              },
+              "parameterOrder": [
+                "serviceName"
+              ],
+              "description": "Creates a new service configuration (version) for a managed service based\non\nuser-supplied configuration source files (for example: OpenAPI\nSpecification). This method stores the source configurations as well as the\ngenerated service configuration. To rollout the service configuration to\nother services,\nplease call CreateServiceRollout.\n\nOperation\u003cresponse: SubmitConfigSourceResponse\u003e",
+              "request": {
+                "$ref": "SubmitConfigSourceRequest"
+              },
+              "flatPath": "v1/services/{serviceName}/configs:submit",
+              "httpMethod": "POST",
+              "parameters": {
+                "serviceName": {
+                  "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                }
+              },
+              "path": "v1/services/{serviceName}/configs:submit",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/service.management"
+              ]
+            },
+            "get": {
+              "id": "servicemanagement.services.configs.get",
+              "response": {
+                "$ref": "Service"
+              },
+              "parameterOrder": [
+                "serviceName",
+                "configId"
+              ],
+              "description": "Gets a service configuration (version) for a managed service.",
+              "flatPath": "v1/services/{serviceName}/configs/{configId}",
+              "httpMethod": "GET",
+              "parameters": {
+                "configId": {
+                  "description": "The id of the service configuration resource.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                },
+                "serviceName": {
+                  "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                }
+              },
+              "path": "v1/services/{serviceName}/configs/{configId}",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+                "https://www.googleapis.com/auth/service.management",
+                "https://www.googleapis.com/auth/service.management.readonly"
+              ]
+            },
+            "create": {
+              "id": "servicemanagement.services.configs.create",
+              "response": {
+                "$ref": "Service"
+              },
+              "parameterOrder": [
+                "serviceName"
+              ],
+              "description": "Creates a new service configuration (version) for a managed service.\nThis method only stores the service configuration. To roll out the service\nconfiguration to backend systems please call\nCreateServiceRollout.",
+              "request": {
+                "$ref": "Service"
+              },
+              "flatPath": "v1/services/{serviceName}/configs",
+              "httpMethod": "POST",
+              "parameters": {
+                "serviceName": {
+                  "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                }
+              },
+              "path": "v1/services/{serviceName}/configs",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/service.management"
+              ]
+            },
+            "list": {
+              "id": "servicemanagement.services.configs.list",
+              "response": {
+                "$ref": "ListServiceConfigsResponse"
+              },
+              "parameterOrder": [
+                "serviceName"
+              ],
+              "description": "Lists the history of the service configuration for a managed service,\nfrom the newest to the oldest.",
+              "flatPath": "v1/services/{serviceName}/configs",
+              "httpMethod": "GET",
+              "parameters": {
+                "pageSize": {
+                  "description": "The max number of items to include in the response list.",
+                  "location": "query",
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "serviceName": {
+                  "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+                  "required": true,
+                  "location": "path",
+                  "type": "string"
+                },
+                "pageToken": {
+                  "description": "The token of the page to retrieve.",
+                  "location": "query",
+                  "type": "string"
+                }
+              },
+              "path": "v1/services/{serviceName}/configs",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/cloud-platform.read-only",
+                "https://www.googleapis.com/auth/service.management",
+                "https://www.googleapis.com/auth/service.management.readonly"
+              ]
+            }
+          }
+        }
+      },
+      "methods": {
+        "getIamPolicy": {
+          "id": "servicemanagement.services.getIamPolicy",
+          "response": {
+            "$ref": "Policy"
+          },
+          "parameterOrder": [
+            "resource"
+          ],
+          "description": "Gets the access control policy for a resource.\nReturns an empty policy if the resource exists and does not have a policy\nset.",
+          "request": {
+            "$ref": "GetIamPolicyRequest"
+          },
+          "flatPath": "v1/services/{servicesId}:getIamPolicy",
+          "httpMethod": "POST",
+          "parameters": {
+            "resource": {
+              "description": "REQUIRED: The resource for which the policy is being requested.\n`resource` is usually specified as a path. For example, a Project\nresource is specified as `projects/{project}`.",
+              "required": true,
+              "pattern": "^services/[^/]+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/{+resource}:getIamPolicy",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "disable": {
+          "id": "servicemanagement.services.disable",
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [
+            "serviceName"
+          ],
+          "description": "Disable a managed service for a project.\n\nOperation\u003cresponse: DisableServiceResponse\u003e",
+          "request": {
+            "$ref": "DisableServiceRequest"
+          },
+          "flatPath": "v1/services/{serviceName}:disable",
+          "httpMethod": "POST",
+          "parameters": {
+            "serviceName": {
+              "description": "Name of the service to disable. Specifying an unknown service name\nwill cause the request to fail.",
+              "required": true,
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/services/{serviceName}:disable",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "generateConfigReport": {
+          "id": "servicemanagement.services.generateConfigReport",
+          "response": {
+            "$ref": "GenerateConfigReportResponse"
+          },
+          "parameterOrder": [],
+          "description": "Generates and returns a report (errors, warnings and changes from\nexisting configurations) associated with\nGenerateConfigReportRequest.new_value\n\nIf GenerateConfigReportRequest.old_value is specified,\nGenerateConfigReportRequest will contain a single ChangeReport based on the\ncomparison between GenerateConfigReportRequest.new_value and\nGenerateConfigReportRequest.old_value.\nIf GenerateConfigReportRequest.old_value is not specified, this method\nwill compare GenerateConfigReportRequest.new_value with the last pushed\nservice configuration.",
+          "request": {
+            "$ref": "GenerateConfigReportRequest"
+          },
+          "flatPath": "v1/services:generateConfigReport",
+          "httpMethod": "POST",
+          "parameters": {},
+          "path": "v1/services:generateConfigReport",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "getConfig": {
+          "id": "servicemanagement.services.getConfig",
+          "response": {
+            "$ref": "Service"
+          },
+          "parameterOrder": [
+            "serviceName"
+          ],
+          "description": "Gets a service configuration (version) for a managed service.",
+          "flatPath": "v1/services/{serviceName}/config",
+          "httpMethod": "GET",
+          "parameters": {
+            "configId": {
+              "description": "The id of the service configuration resource.",
+              "location": "query",
+              "type": "string"
+            },
+            "serviceName": {
+              "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+              "required": true,
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/services/{serviceName}/config",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only",
+            "https://www.googleapis.com/auth/service.management",
+            "https://www.googleapis.com/auth/service.management.readonly"
+          ]
+        },
+        "undelete": {
+          "id": "servicemanagement.services.undelete",
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [
+            "serviceName"
+          ],
+          "description": "Revives a previously deleted managed service. The method restores the\nservice using the configuration at the time the service was deleted.\nThe target service must exist and must have been deleted within the\nlast 30 days.\n\nOperation\u003cresponse: UndeleteServiceResponse\u003e",
+          "flatPath": "v1/services/{serviceName}:undelete",
+          "httpMethod": "POST",
+          "parameters": {
+            "serviceName": {
+              "description": "The name of the service. See the [overview](/service-management/overview)\nfor naming requirements. For example: `example.googleapis.com`.",
+              "required": true,
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/services/{serviceName}:undelete",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "get": {
+          "id": "servicemanagement.services.get",
+          "response": {
+            "$ref": "ManagedService"
+          },
+          "parameterOrder": [
+            "serviceName"
+          ],
+          "description": "Gets a managed service. Authentication is required unless the service is\npublic.",
+          "flatPath": "v1/services/{serviceName}",
+          "httpMethod": "GET",
+          "parameters": {
+            "serviceName": {
+              "description": "The name of the service.  See the `ServiceManager` overview for naming\nrequirements.  For example: `example.googleapis.com`.",
+              "required": true,
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/services/{serviceName}",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only",
+            "https://www.googleapis.com/auth/service.management",
+            "https://www.googleapis.com/auth/service.management.readonly"
+          ]
+        },
+        "list": {
+          "id": "servicemanagement.services.list",
+          "response": {
+            "$ref": "ListServicesResponse"
+          },
+          "parameterOrder": [],
+          "description": "Lists all managed services. The result is limited to services that the\ncaller has \"servicemanagement.services.get\" permission for. If the request\nis made without authentication, it returns only public services that are\navailable to everyone.",
+          "flatPath": "v1/services",
+          "httpMethod": "GET",
+          "parameters": {
+            "pageSize": {
+              "description": "Requested size of the next page of data.",
+              "location": "query",
+              "type": "integer",
+              "format": "int32"
+            },
+            "producerProjectId": {
+              "description": "Include services produced by the specified project.",
+              "location": "query",
+              "type": "string"
+            },
+            "pageToken": {
+              "description": "Token identifying which result to start with; returned by a previous list\ncall.",
+              "location": "query",
+              "type": "string"
+            },
+            "consumerId": {
+              "description": "Include services consumed by the specified consumer.\n\nThe Google Service Management implementation accepts the following\nforms:\n- project:\u003cproject_id\u003e",
+              "location": "query",
+              "type": "string"
+            }
+          },
+          "path": "v1/services",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/cloud-platform.read-only",
+            "https://www.googleapis.com/auth/service.management",
+            "https://www.googleapis.com/auth/service.management.readonly"
+          ]
+        },
+        "create": {
+          "id": "servicemanagement.services.create",
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [],
+          "description": "Creates a new managed service.\nPlease note one producer project can own no more than 20 services.\n\nOperation\u003cresponse: ManagedService\u003e",
+          "request": {
+            "$ref": "ManagedService"
+          },
+          "flatPath": "v1/services",
+          "httpMethod": "POST",
+          "parameters": {},
+          "path": "v1/services",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "enable": {
+          "id": "servicemanagement.services.enable",
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [
+            "serviceName"
+          ],
+          "description": "Enable a managed service for a project with default setting.\n\nOperation\u003cresponse: EnableServiceResponse\u003e\n\ngoogle.rpc.Status errors may contain a\ngoogle.rpc.PreconditionFailure error detail.",
+          "request": {
+            "$ref": "EnableServiceRequest"
+          },
+          "flatPath": "v1/services/{serviceName}:enable",
+          "httpMethod": "POST",
+          "parameters": {
+            "serviceName": {
+              "description": "Name of the service to enable. Specifying an unknown service name will\ncause the request to fail.",
+              "required": true,
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/services/{serviceName}:enable",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "setIamPolicy": {
+          "id": "servicemanagement.services.setIamPolicy",
+          "response": {
+            "$ref": "Policy"
+          },
+          "parameterOrder": [
+            "resource"
+          ],
+          "description": "Sets the access control policy on the specified resource. Replaces any\nexisting policy.",
+          "request": {
+            "$ref": "SetIamPolicyRequest"
+          },
+          "flatPath": "v1/services/{servicesId}:setIamPolicy",
+          "httpMethod": "POST",
+          "parameters": {
+            "resource": {
+              "description": "REQUIRED: The resource for which the policy is being specified.\n`resource` is usually specified as a path. For example, a Project\nresource is specified as `projects/{project}`.",
+              "required": true,
+              "pattern": "^services/[^/]+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/{+resource}:setIamPolicy",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "delete": {
+          "id": "servicemanagement.services.delete",
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [
+            "serviceName"
+          ],
+          "description": "Deletes a managed service. This method will change the service to the\n`Soft-Delete` state for 30 days. Within this period, service producers may\ncall UndeleteService to restore the service.\nAfter 30 days, the service will be permanently deleted.\n\nOperation\u003cresponse: google.protobuf.Empty\u003e",
+          "flatPath": "v1/services/{serviceName}",
+          "httpMethod": "DELETE",
+          "parameters": {
+            "serviceName": {
+              "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+              "required": true,
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/services/{serviceName}",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        },
+        "testIamPermissions": {
+          "id": "servicemanagement.services.testIamPermissions",
+          "response": {
+            "$ref": "TestIamPermissionsResponse"
+          },
+          "parameterOrder": [
+            "resource"
+          ],
+          "description": "Returns permissions that a caller has on the specified resource.",
+          "request": {
+            "$ref": "TestIamPermissionsRequest"
+          },
+          "flatPath": "v1/services/{servicesId}:testIamPermissions",
+          "httpMethod": "POST",
+          "parameters": {
+            "resource": {
+              "description": "REQUIRED: The resource for which the policy detail is being requested.\n`resource` is usually specified as a path. For example, a Project\nresource is specified as `projects/{project}`.",
+              "required": true,
+              "pattern": "^services/[^/]+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/{+resource}:testIamPermissions",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        }
+      }
+    },
+    "operations": {
+      "methods": {
+        "get": {
+          "id": "servicemanagement.operations.get",
+          "response": {
+            "$ref": "Operation"
+          },
+          "parameterOrder": [
+            "name"
+          ],
+          "description": "Gets the latest state of a long-running operation.  Clients can use this\nmethod to poll the operation result at intervals as recommended by the API\nservice.",
+          "flatPath": "v1/operations/{operationsId}",
+          "httpMethod": "GET",
+          "parameters": {
+            "name": {
+              "description": "The name of the operation resource.",
+              "required": true,
+              "pattern": "^operations/.+$",
+              "location": "path",
+              "type": "string"
+            }
+          },
+          "path": "v1/{+name}",
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/service.management"
+          ]
+        }
+      }
+    }
+  },
+  "schemas": {
+    "Api": {
+      "description": "Api is a light-weight descriptor for a protocol buffer service.",
+      "type": "object",
+      "properties": {
+        "methods": {
+          "description": "The methods of this api, in unspecified order.",
+          "type": "array",
+          "items": {
+            "$ref": "Method"
+          }
+        },
+        "options": {
+          "description": "Any metadata attached to the API.",
+          "type": "array",
+          "items": {
+            "$ref": "Option"
+          }
+        },
+        "sourceContext": {
+          "description": "Source context for the protocol buffer service represented by this\nmessage.",
+          "$ref": "SourceContext"
+        },
+        "name": {
+          "description": "The fully qualified name of this api, including package name\nfollowed by the api's simple name.",
+          "type": "string"
+        },
+        "syntax": {
+          "description": "The source syntax of the service.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        },
+        "version": {
+          "description": "A version string for this api. If specified, must have the form\n`major-version.minor-version`, as in `1.10`. If the minor version\nis omitted, it defaults to zero. If the entire version field is\nempty, the major version is derived from the package name, as\noutlined below. If the field is not empty, the version in the\npackage name will be verified to be consistent with what is\nprovided here.\n\nThe versioning schema uses [semantic\nversioning](http://semver.org) where the major version number\nindicates a breaking change and the minor version an additive,\nnon-breaking change. Both version numbers are signals to users\nwhat to expect from different versions, and should be carefully\nchosen based on the product plan.\n\nThe major version is also reflected in the package name of the\nAPI, which must end in `v\u003cmajor-version\u003e`, as in\n`google.feature.v1`. For major versions 0 and 1, the suffix can\nbe omitted. Zero major versions must only be used for\nexperimental, none-GA apis.\n",
+          "type": "string"
+        },
+        "mixins": {
+          "description": "Included APIs. See Mixin.",
+          "type": "array",
+          "items": {
+            "$ref": "Mixin"
+          }
+        }
+      },
+      "id": "Api"
+    },
+    "SystemParameterRule": {
+      "description": "Define a system parameter rule mapping system parameter definitions to\nmethods.",
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "description": "Define parameters. Multiple names may be defined for a parameter.\nFor a given method call, only one of them should be used. If multiple\nnames are used the behavior is implementation-dependent.\nIf none of the specified names are present the behavior is\nparameter-dependent.",
+          "type": "array",
+          "items": {
+            "$ref": "SystemParameter"
+          }
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies. Use '*' to indicate all\nmethods in all APIs.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "id": "SystemParameterRule"
+    },
+    "Diagnostic": {
+      "description": "Represents a diagnostic message (error or warning)",
+      "type": "object",
+      "properties": {
+        "location": {
+          "description": "File name and line number of the error or warning.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of diagnostic information provided.",
+          "enum": [
+            "WARNING",
+            "ERROR"
+          ],
+          "enumDescriptions": [
+            "Warnings and errors",
+            "Only errors"
+          ],
+          "type": "string"
+        },
+        "message": {
+          "description": "Message describing the error or warning.",
+          "type": "string"
+        }
+      },
+      "id": "Diagnostic"
+    },
+    "ChangeReport": {
+      "description": "Change report associated with a particular service configuration.\n\nIt contains a list of ConfigChanges based on the comparison between\ntwo service configurations.",
+      "type": "object",
+      "properties": {
+        "configChanges": {
+          "description": "List of changes between two service configurations.\nThe changes will be alphabetically sorted based on the identifier\nof each change.\nA ConfigChange identifier is a dot separated path to the configuration.\nExample: visibility.rules[selector='LibraryService.CreateBook'].restriction",
+          "type": "array",
+          "items": {
+            "$ref": "ConfigChange"
+          }
+        }
+      },
+      "id": "ChangeReport"
+    },
+    "MonitoredResourceDescriptor": {
+      "description": "An object that describes the schema of a MonitoredResource object using a\ntype name and a set of labels.  For example, the monitored resource\ndescriptor for Google Compute Engine VM instances has a type of\n`\"gce_instance\"` and specifies the use of the labels `\"instance_id\"` and\n`\"zone\"` to identify particular VM instances.\n\nDifferent APIs can support different monitored resource types. APIs generally\nprovide a `list` method that returns the monitored resource descriptors used\nby the API.",
+      "type": "object",
+      "properties": {
+        "displayName": {
+          "description": "Optional. A concise name for the monitored resource type that might be\ndisplayed in user interfaces. It should be a Title Cased Noun Phrase,\nwithout any article or other determiners. For example,\n`\"Google Cloud SQL Database\"`.",
+          "type": "string"
+        },
+        "description": {
+          "description": "Optional. A detailed description of the monitored resource type that might\nbe used in documentation.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "Required. A set of labels used to describe instances of this monitored\nresource type. For example, an individual Google Cloud SQL database is\nidentified by values for the labels `\"database_id\"` and `\"zone\"`.",
+          "type": "array",
+          "items": {
+            "$ref": "LabelDescriptor"
+          }
+        },
+        "type": {
+          "description": "Required. The monitored resource type. For example, the type\n`\"cloudsql_database\"` represents databases in Google Cloud SQL.\nThe maximum length of this value is 256 characters.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Optional. The resource name of the monitored resource descriptor:\n`\"projects/{project_id}/monitoredResourceDescriptors/{type}\"` where\n{type} is the value of the `type` field in this object and\n{project_id} is a project ID that provides API-specific context for\naccessing the type.  APIs that do not use project information can use the\nresource name format `\"monitoredResourceDescriptors/{type}\"`.",
+          "type": "string"
+        }
+      },
+      "id": "MonitoredResourceDescriptor"
+    },
+    "LogConfig": {
+      "description": "Specifies what kind of log the caller must write\nIncrement a streamz counter with the specified metric and field names.\n\nMetric names should start with a '/', generally be lowercase-only,\nand end in \"_count\". Field names should not contain an initial slash.\nThe actual exported metric names will have \"/iam/policy\" prepended.\n\nField names correspond to IAM request parameters and field values are\ntheir respective values.\n\nAt present the only supported field names are\n   - \"iam_principal\", corresponding to IAMContext.principal;\n   - \"\" (empty string), resulting in one aggretated counter with no field.\n\nExamples:\n  counter { metric: \"/debug_access_count\"  field: \"iam_principal\" }\n  ==\u003e increment counter /iam/policy/backend_debug_access_count\n                        {iam_principal=[value of IAMContext.principal]}\n\nAt this time we do not support:\n* multiple field names (though this may be supported in the future)\n* decrementing the counter\n* incrementing it by anything other than 1",
+      "type": "object",
+      "properties": {
+        "dataAccess": {
+          "description": "Data access options.",
+          "$ref": "DataAccessOptions"
+        },
+        "counter": {
+          "description": "Counter options.",
+          "$ref": "CounterOptions"
+        },
+        "cloudAudit": {
+          "description": "Cloud audit options.",
+          "$ref": "CloudAuditOptions"
+        }
+      },
+      "id": "LogConfig"
+    },
+    "Mixin": {
+      "description": "Declares an API to be included in this API. The including API must\nredeclare all the methods from the included API, but documentation\nand options are inherited as follows:\n\n- If after comment and whitespace stripping, the documentation\n  string of the redeclared method is empty, it will be inherited\n  from the original method.\n\n- Each annotation belonging to the service config (http,\n  visibility) which is not set in the redeclared method will be\n  inherited.\n\n- If an http annotation is inherited, the path pattern will be\n  modified as follows. Any version prefix will be replaced by the\n  version of the including API plus the root path if specified.\n\nExample of a simple mixin:\n\n    package google.acl.v1;\n    service AccessControl {\n      // Get the underlying ACL object.\n      rpc GetAcl(GetAclRequest) returns (Acl) {\n        option (google.api.http).get = \"/v1/{resource=**}:getAcl\";\n      }\n    }\n\n    package google.storage.v2;\n    service Storage {\n      //       rpc GetAcl(GetAclRequest) returns (Acl);\n\n      // Get a data record.\n      rpc GetData(GetDataRequest) returns (Data) {\n        option (google.api.http).get = \"/v2/{resource=**}\";\n      }\n    }\n\nExample of a mixin configuration:\n\n    apis:\n    - name: google.storage.v2.Storage\n      mixins:\n      - name: google.acl.v1.AccessControl\n\nThe mixin construct implies that all methods in `AccessControl` are\nalso declared with same name and request/response types in\n`Storage`. A documentation generator or annotation processor will\nsee the effective `Storage.GetAcl` method after inherting\ndocumentation and annotations as follows:\n\n    service Storage {\n      // Get the underlying ACL object.\n      rpc GetAcl(GetAclRequest) returns (Acl) {\n        option (google.api.http).get = \"/v2/{resource=**}:getAcl\";\n      }\n      ...\n    }\n\nNote how the version in the path pattern changed from `v1` to `v2`.\n\nIf the `root` field in the mixin is specified, it should be a\nrelative path under which inherited HTTP paths are placed. Example:\n\n    apis:\n    - name: google.storage.v2.Storage\n      mixins:\n      - name: google.acl.v1.AccessControl\n        root: acls\n\nThis implies the following inherited HTTP annotation:\n\n    service Storage {\n      // Get the underlying ACL object.\n      rpc GetAcl(GetAclRequest) returns (Acl) {\n        option (google.api.http).get = \"/v2/acls/{resource=**}:getAcl\";\n      }\n      ...\n    }",
+      "type": "object",
+      "properties": {
+        "root": {
+          "description": "If non-empty specifies a path under which inherited HTTP paths\nare rooted.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The fully qualified name of the API which is included.",
+          "type": "string"
+        }
+      },
+      "id": "Mixin"
+    },
+    "Service": {
+      "description": "`Service` is the root object of Google service configuration schema. It\ndescribes basic information about a service, such as the name and the\ntitle, and delegates other aspects to sub-sections. Each sub-section is\neither a proto message or a repeated proto message that configures a\nspecific aspect, such as auth. See each proto message definition for details.\n\nExample:\n\n    type: google.api.Service\n    config_version: 3\n    name: calendar.googleapis.com\n    title: Google Calendar API\n    apis:\n    - name: google.calendar.v3.Calendar\n    backend:\n      rules:\n      - selector: \"google.calendar.v3.*\"\n        address: calendar.example.com",
+      "type": "object",
+      "properties": {
+        "id": {
+          "description": "A unique ID for a specific instance of this message, typically assigned\nby the client for tracking purpose. If empty, the server may choose to\ngenerate one instead.",
+          "type": "string"
+        },
+        "enums": {
+          "description": "A list of all enum types included in this API service.  Enums\nreferenced directly or indirectly by the `apis` are automatically\nincluded.  Enums which are not referenced but shall be included\nshould be listed here by name. Example:\n\n    enums:\n    - name: google.someapi.v1.SomeEnum",
+          "type": "array",
+          "items": {
+            "$ref": "Enum"
+          }
+        },
+        "usage": {
+          "description": "Configuration controlling usage of this service.",
+          "$ref": "Usage"
+        },
+        "control": {
+          "description": "Configuration for the service control plane.",
+          "$ref": "Control"
+        },
+        "title": {
+          "description": "The product title associated with this service.",
+          "type": "string"
+        },
+        "http": {
+          "description": "HTTP configuration.",
+          "$ref": "Http"
+        },
+        "systemTypes": {
+          "description": "A list of all proto message types included in this API service.\nIt serves similar purpose as [google.api.Service.types], except that\nthese types are not needed by user-defined APIs. Therefore, they will not\nshow up in the generated discovery doc. This field should only be used\nto define system APIs in ESF.",
+          "type": "array",
+          "items": {
+            "$ref": "Type"
+          }
+        },
+        "configVersion": {
+          "description": "The version of the service configuration. The config version may\ninfluence interpretation of the configuration, for example, to\ndetermine defaults. This is documented together with applicable\noptions. The current default for the config version itself is `3`.",
+          "type": "integer",
+          "format": "uint32"
+        },
+        "backend": {
+          "description": "API backend configuration.",
+          "$ref": "Backend"
+        },
+        "monitoring": {
+          "description": "Monitoring configuration.",
+          "$ref": "Monitoring"
+        },
+        "visibility": {
+          "description": "API visibility configuration.",
+          "$ref": "Visibility"
+        },
+        "logging": {
+          "description": "Logging configuration.",
+          "$ref": "Logging"
+        },
+        "customError": {
+          "description": "Custom error configuration.",
+          "$ref": "CustomError"
+        },
+        "context": {
+          "description": "Context configuration.",
+          "$ref": "Context"
+        },
+        "apis": {
+          "description": "A list of API interfaces exported by this service. Only the `name` field\nof the google.protobuf.Api needs to be provided by the configuration\nauthor, as the remaining fields will be derived from the IDL during the\nnormalization process. It is an error to specify an API interface here\nwhich cannot be resolved against the associated IDL files.",
+          "type": "array",
+          "items": {
+            "$ref": "Api"
+          }
+        },
+        "metrics": {
+          "description": "Defines the metrics used by this service.",
+          "type": "array",
+          "items": {
+            "$ref": "MetricDescriptor"
+          }
+        },
+        "systemParameters": {
+          "description": "System parameter configuration.",
+          "$ref": "SystemParameters"
+        },
+        "endpoints": {
+          "description": "Configuration for network endpoints.  If this is empty, then an endpoint\nwith the same name as the service is automatically generated to service all\ndefined APIs.",
+          "type": "array",
+          "items": {
+            "$ref": "Endpoint"
+          }
+        },
+        "name": {
+          "description": "The DNS address at which this service is available,\ne.g. `calendar.googleapis.com`.",
+          "type": "string"
+        },
+        "producerProjectId": {
+          "description": "The id of the Google developer project that owns the service.\nMembers of this project can manage the service configuration,\nmanage consumption of the service, etc.",
+          "type": "string"
+        },
+        "documentation": {
+          "description": "Additional API documentation.",
+          "$ref": "Documentation"
+        },
+        "monitoredResources": {
+          "description": "Defines the monitored resources used by this service. This is required\nby the Service.monitoring and Service.logging configurations.",
+          "type": "array",
+          "items": {
+            "$ref": "MonitoredResourceDescriptor"
+          }
+        },
+        "types": {
+          "description": "A list of all proto message types included in this API service.\nTypes referenced directly or indirectly by the `apis` are\nautomatically included.  Messages which are not referenced but\nshall be included, such as types used by the `google.protobuf.Any` type,\nshould be listed here by name. Example:\n\n    types:\n    - name: google.protobuf.Int32",
+          "type": "array",
+          "items": {
+            "$ref": "Type"
+          }
+        },
+        "logs": {
+          "description": "Defines the logs used by this service.",
+          "type": "array",
+          "items": {
+            "$ref": "LogDescriptor"
+          }
+        },
+        "authentication": {
+          "description": "Auth configuration.",
+          "$ref": "Authentication"
+        }
+      },
+      "id": "Service"
+    },
+    "SubmitConfigSourceResponse": {
+      "description": "Response message for SubmitConfigSource method.",
+      "type": "object",
+      "properties": {
+        "serviceConfig": {
+          "description": "The generated service configuration.",
+          "$ref": "Service"
+        }
+      },
+      "id": "SubmitConfigSourceResponse"
+    },
+    "Documentation": {
+      "description": "`Documentation` provides the information for describing a service.\n\nExample:\n\u003cpre\u003e\u003ccode\u003edocumentation:\n  summary: \u003e\n    The Google Calendar API gives access\n    to most calendar features.\n  pages:\n  - name: Overview\n    content: &#40;== include google/foo/overview.md ==&#41;\n  - name: Tutorial\n    content: &#40;== include google/foo/tutorial.md ==&#41;\n    subpages;\n    - name: Java\n      content: &#40;== include google/foo/tutorial_java.md ==&#41;\n  rules:\n  - selector: google.calendar.Calendar.Get\n    description: \u003e\n      ...\n  - selector: google.calendar.Calendar.Put\n    description: \u003e\n      ...\n\u003c/code\u003e\u003c/pre\u003e\nDocumentation is provided in markdown syntax. In addition to\nstandard markdown features, definition lists, tables and fenced\ncode blocks are supported. Section headers can be provided and are\ninterpreted relative to the section nesting of the context where\na documentation fragment is embedded.\n\nDocumentation from the IDL is merged with documentation defined\nvia the config at normalization time, where documentation provided\nby config rules overrides IDL provided.\n\nA number of constructs specific to the API platform are supported\nin documentation text.\n\nIn order to reference a proto element, the following\nnotation can be used:\n\u003cpre\u003e\u003ccode\u003e&#91;fully.qualified.proto.name]&#91;]\u003c/code\u003e\u003c/pre\u003e\nTo override the display text used for the link, this can be used:\n\u003cpre\u003e\u003ccode\u003e&#91;display text]&#91;fully.qualified.proto.name]\u003c/code\u003e\u003c/pre\u003e\nText can be excluded from doc using the following notation:\n\u003cpre\u003e\u003ccode\u003e&#40;-- internal comment --&#41;\u003c/code\u003e\u003c/pre\u003e\nComments can be made conditional using a visibility label. The below\ntext will be only rendered if the `BETA` label is available:\n\u003cpre\u003e\u003ccode\u003e&#40;--BETA: comment for BETA users --&#41;\u003c/code\u003e\u003c/pre\u003e\nA few directives are available in documentation. Note that\ndirectives must appear on a single line to be properly\nidentified. The `include` directive includes a markdown file from\nan external source:\n\u003cpre\u003e\u003ccode\u003e&#40;== include path/to/file ==&#41;\u003c/code\u003e\u003c/pre\u003e\nThe `resource_for` directive marks a message to be the resource of\na collection in REST view. If it is not specified, tools attempt\nto infer the resource from the operations in a collection:\n\u003cpre\u003e\u003ccode\u003e&#40;== resource_for v1.shelves.books ==&#41;\u003c/code\u003e\u003c/pre\u003e\nThe directive `suppress_warning` does not directly affect documentation\nand is documented together with service config validation.",
+      "type": "object",
+      "properties": {
+        "overview": {
+          "description": "Declares a single overview page. For example:\n\u003cpre\u003e\u003ccode\u003edocumentation:\n  summary: ...\n  overview: &#40;== include overview.md ==&#41;\n\u003c/code\u003e\u003c/pre\u003e\nThis is a shortcut for the following declaration (using pages style):\n\u003cpre\u003e\u003ccode\u003edocumentation:\n  summary: ...\n  pages:\n  - name: Overview\n    content: &#40;== include overview.md ==&#41;\n\u003c/code\u003e\u003c/pre\u003e\nNote: you cannot specify both `overview` field and `pages` field.",
+          "type": "string"
+        },
+        "documentationRootUrl": {
+          "description": "The URL to the root of documentation.",
+          "type": "string"
+        },
+        "pages": {
+          "description": "The top level pages for the documentation set.",
+          "type": "array",
+          "items": {
+            "$ref": "Page"
+          }
+        },
+        "summary": {
+          "description": "A short summary of what the service does. Can only be provided by\nplain text.",
+          "type": "string"
+        },
+        "rules": {
+          "description": "A list of documentation rules that apply to individual API elements.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "DocumentationRule"
+          }
+        }
+      },
+      "id": "Documentation"
+    },
+    "Policy": {
+      "description": "Defines an Identity and Access Management (IAM) policy. It is used to\nspecify access control policies for Cloud Platform resources.\n\n\nA `Policy` consists of a list of `bindings`. A `Binding` binds a list of\n`members` to a `role`, where the members can be user accounts, Google groups,\nGoogle domains, and service accounts. A `role` is a named list of permissions\ndefined by IAM.\n\n**Example**\n\n    {\n      \"bindings\": [\n        {\n          \"role\": \"roles/owner\",\n          \"members\": [\n            \"user:mike@example.com\",\n            \"group:admins@example.com\",\n            \"domain:google.com\",\n            \"serviceAccount:my-other-app@appspot.gserviceaccount.com\",\n          ]\n        },\n        {\n          \"role\": \"roles/viewer\",\n          \"members\": [\"user:sean@example.com\"]\n        }\n      ]\n    }\n\nFor a description of IAM and its features, see the\n[IAM developer's guide](https://cloud.google.com/iam).",
+      "type": "object",
+      "properties": {
+        "auditConfigs": {
+          "description": "Specifies audit logging configs for \"data access\".\n\"data access\": generally refers to data reads/writes and admin reads.\n\"admin activity\": generally refers to admin writes.\n\nNote: `AuditConfig` doesn't apply to \"admin activity\", which always\nenables audit logging.",
+          "type": "array",
+          "items": {
+            "$ref": "AuditConfig"
+          }
+        },
+        "rules": {
+          "description": "If more than one rule is specified, the rules are applied in the following\nmanner:\n- All matching LOG rules are always applied.\n- If any DENY/DENY_WITH_LOG rule matches, permission is denied.\n  Logging will be applied if one or more matching rule requires logging.\n- Otherwise, if any ALLOW/ALLOW_WITH_LOG rule matches, permission is\n  granted.\n  Logging will be applied if one or more matching rule requires logging.\n- Otherwise, if no rule applies, permission is denied.",
+          "type": "array",
+          "items": {
+            "$ref": "Rule"
+          }
+        },
+        "bindings": {
+          "description": "Associates a list of `members` to a `role`.\nMultiple `bindings` must not be specified for the same `role`.\n`bindings` with no members will result in an error.",
+          "type": "array",
+          "items": {
+            "$ref": "Binding"
+          }
+        },
+        "etag": {
+          "description": "`etag` is used for optimistic concurrency control as a way to help\nprevent simultaneous updates of a policy from overwriting each other.\nIt is strongly suggested that systems make use of the `etag` in the\nread-modify-write cycle to perform policy updates in order to avoid race\nconditions: An `etag` is returned in the response to `getIamPolicy`, and\nsystems are expected to put that etag in the request to `setIamPolicy` to\nensure that their change will be applied to the same version of the policy.\n\nIf no `etag` is provided in the call to `setIamPolicy`, then the existing\npolicy is overwritten blindly.",
+          "type": "string",
+          "format": "byte"
+        },
+        "iamOwned": {
+          "type": "boolean"
+        },
+        "version": {
+          "description": "Version of the `Policy`. The default version is 0.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "id": "Policy"
+    },
+    "OAuthRequirements": {
+      "description": "OAuth scopes are a way to define data and permissions on data. For example,\nthere are scopes defined for \"Read-only access to Google Calendar\" and\n\"Access to Cloud Platform\". Users can consent to a scope for an application,\ngiving it permission to access that data on their behalf.\n\nOAuth scope specifications should be fairly coarse grained; a user will need\nto see and understand the text description of what your scope means.\n\nIn most cases: use one or at most two OAuth scopes for an entire family of\nproducts. If your product has multiple APIs, you should probably be sharing\nthe OAuth scope across all of those APIs.\n\nWhen you need finer grained OAuth consent screens: talk with your product\nmanagement about how developers will use them in practice.\n\nPlease note that even though each of the canonical scopes is enough for a\nrequest to be accepted and passed to the backend, a request can still fail\ndue to the backend requiring additional scopes or permissions.",
+      "type": "object",
+      "properties": {
+        "canonicalScopes": {
+          "description": "The list of publicly documented OAuth scopes that are allowed access. An\nOAuth token containing any of these scopes will be accepted.\n\nExample:\n\n     canonical_scopes: https://www.googleapis.com/auth/calendar,\n                       https://www.googleapis.com/auth/calendar.read",
+          "type": "string"
+        }
+      },
+      "id": "OAuthRequirements"
+    },
+    "ListServicesResponse": {
+      "description": "Response message for `ListServices` method.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "Token that can be passed to `ListServices` to resume a paginated query.",
+          "type": "string"
+        },
+        "services": {
+          "description": "The returned services will only have the name field set.",
+          "type": "array",
+          "items": {
+            "$ref": "ManagedService"
+          }
+        }
+      },
+      "id": "ListServicesResponse"
+    },
+    "Step": {
+      "description": "Represents the status of one operation step.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "The short description of the step.",
+          "type": "string"
+        },
+        "status": {
+          "description": "The status code.",
+          "enum": [
+            "STATUS_UNSPECIFIED",
+            "DONE",
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "FAILED",
+            "CANCELLED"
+          ],
+          "enumDescriptions": [
+            "Unspecifed code.",
+            "The step has completed without errors.",
+            "The step has not started yet.",
+            "The step is in progress.",
+            "The step has completed with errors.",
+            "The step has completed with cancellation."
+          ],
+          "type": "string"
+        }
+      },
+      "id": "Step"
+    },
+    "Context": {
+      "description": "`Context` defines which contexts an API requests.\n\nExample:\n\n    context:\n      rules:\n      - selector: \"*\"\n        requested:\n        - google.rpc.context.ProjectContext\n        - google.rpc.context.OriginContext\n\nThe above specifies that all methods in the API request\n`google.rpc.context.ProjectContext` and\n`google.rpc.context.OriginContext`.\n\nAvailable context types are defined in package\n`google.rpc.context`.",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "description": "A list of RPC context rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "ContextRule"
+          }
+        }
+      },
+      "id": "Context"
+    },
+    "Monitoring": {
+      "description": "Monitoring configuration of the service.\n\nThe example below shows how to configure monitored resources and metrics\nfor monitoring. In the example, a monitored resource and two metrics are\ndefined. The `library.googleapis.com/book/returned_count` metric is sent\nto both producer and consumer projects, whereas the\n`library.googleapis.com/book/overdue_count` metric is only sent to the\nconsumer project.\n\n    monitored_resources:\n    - type: library.googleapis.com/branch\n      labels:\n      - key: /city\n        description: The city where the library branch is located in.\n      - key: /name\n        description: The name of the branch.\n    metrics:\n    - name: library.googleapis.com/book/returned_count\n      metric_kind: DELTA\n      value_type: INT64\n      labels:\n      - key: /customer_id\n    - name: library.googleapis.com/book/overdue_count\n      metric_kind: GAUGE\n      value_type: INT64\n      labels:\n      - key: /customer_id\n    monitoring:\n      producer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        metrics:\n        - library.googleapis.com/book/returned_count\n      consumer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        metrics:\n        - library.googleapis.com/book/returned_count\n        - library.googleapis.com/book/overdue_count",
+      "type": "object",
+      "properties": {
+        "producerDestinations": {
+          "description": "Monitoring configurations for sending metrics to the producer project.\nThere can be multiple producer destinations, each one must have a\ndifferent monitored resource type. A metric can be used in at most\none producer destination.",
+          "type": "array",
+          "items": {
+            "$ref": "MonitoringDestination"
+          }
+        },
+        "consumerDestinations": {
+          "description": "Monitoring configurations for sending metrics to the consumer project.\nThere can be multiple consumer destinations, each one must have a\ndifferent monitored resource type. A metric can be used in at most\none consumer destination.",
+          "type": "array",
+          "items": {
+            "$ref": "MonitoringDestination"
+          }
+        }
+      },
+      "id": "Monitoring"
+    },
+    "ManagedService": {
+      "description": "The full representation of a Service that is managed by\nGoogle Service Management.",
+      "type": "object",
+      "properties": {
+        "producerProjectId": {
+          "description": "ID of the project that produces and owns this service.",
+          "type": "string"
+        },
+        "serviceName": {
+          "description": "The name of the service. See the [overview](/service-management/overview)\nfor naming requirements.",
+          "type": "string"
+        }
+      },
+      "id": "ManagedService"
+    },
+    "ConfigFile": {
+      "description": "Generic specification of a source configuration file",
+      "type": "object",
+      "properties": {
+        "filePath": {
+          "description": "The file name of the configuration file (full or relative path).",
+          "type": "string"
+        },
+        "fileType": {
+          "description": "The type of configuration file this represents.",
+          "enum": [
+            "FILE_TYPE_UNSPECIFIED",
+            "SERVICE_CONFIG_YAML",
+            "OPEN_API_JSON",
+            "OPEN_API_YAML",
+            "FILE_DESCRIPTOR_SET_PROTO"
+          ],
+          "enumDescriptions": [
+            "Unknown file type.",
+            "YAML-specification of service.",
+            "OpenAPI specification, serialized in JSON.",
+            "OpenAPI specification, serialized in YAML.",
+            "FileDescriptorSet, generated by protoc.\n\nTo generate, use protoc with imports and source info included.\nFor an example test.proto file, the following command would put the value\nin a new file named out.pb.\n\n$protoc --include_imports --include_source_info test.proto -o out.pb"
+          ],
+          "type": "string"
+        },
+        "fileContents": {
+          "description": "The bytes that constitute the file.",
+          "type": "string",
+          "format": "byte"
+        }
+      },
+      "id": "ConfigFile"
+    },
+    "ListServiceConfigsResponse": {
+      "description": "Response message for ListServiceConfigs method.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "The token of the next page of results.",
+          "type": "string"
+        },
+        "serviceConfigs": {
+          "description": "The list of service configuration resources.",
+          "type": "array",
+          "items": {
+            "$ref": "Service"
+          }
+        }
+      },
+      "id": "ListServiceConfigsResponse"
+    },
+    "TrafficPercentStrategy": {
+      "description": "Strategy that specifies how Google Service Control should select\ndifferent\nversions of service configurations based on traffic percentage.\n\nOne example of how to gradually rollout a new service configuration using\nthis\nstrategy:\nDay 1\n\n    Rollout {\n      id: \"example.googleapis.com/rollout_20160206\"\n      traffic_percent_strategy {\n        percentages: {\n          \"example.googleapis.com/20160201\": 70.00\n          \"example.googleapis.com/20160206\": 30.00\n        }\n      }\n    }\n\nDay 2\n\n    Rollout {\n      id: \"example.googleapis.com/rollout_20160207\"\n      traffic_percent_strategy: {\n        percentages: {\n          \"example.googleapis.com/20160206\": 100.00\n        }\n      }\n    }",
+      "type": "object",
+      "properties": {
+        "percentages": {
+          "description": "Maps service configuration IDs to their corresponding traffic percentage.\nKey is the service configuration ID, Value is the traffic percentage\nwhich must be greater than 0.0 and the sum must equal to 100.0.",
+          "additionalProperties": {
+            "type": "number",
+            "format": "double"
+          },
+          "type": "object"
+        }
+      },
+      "id": "TrafficPercentStrategy"
+    },
+    "GenerateConfigReportRequest": {
+      "description": "Request message for GenerateConfigReport method.",
+      "type": "object",
+      "properties": {
+        "oldConfig": {
+          "description": "Service configuration against which the comparison will be done.\nFor this version of API, the supported types are\ngoogle.api.servicemanagement.v1.ConfigRef,\ngoogle.api.servicemanagement.v1.ConfigSource,\nand google.api.Service",
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "type": "object"
+        },
+        "newConfig": {
+          "description": "Service configuration for which we want to generate the report.\nFor this version of API, the supported types are\ngoogle.api.servicemanagement.v1.ConfigRef,\ngoogle.api.servicemanagement.v1.ConfigSource,\nand google.api.Service",
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "type": "object"
+        }
+      },
+      "id": "GenerateConfigReportRequest"
+    },
+    "GetIamPolicyRequest": {
+      "description": "Request message for `GetIamPolicy` method.",
+      "type": "object",
+      "properties": {},
+      "id": "GetIamPolicyRequest"
+    },
+    "LoggingDestination": {
+      "description": "Configuration of a specific logging destination (the producer project\nor the consumer project).",
+      "type": "object",
+      "properties": {
+        "monitoredResource": {
+          "description": "The monitored resource type. The type must be defined in the\nService.monitored_resources section.",
+          "type": "string"
+        },
+        "logs": {
+          "description": "Names of the logs to be sent to this destination. Each name must\nbe defined in the Service.logs section. If the log name is\nnot a domain scoped name, it will be automatically prefixed with\nthe service name followed by \"/\".",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "LoggingDestination"
+    },
+    "Authentication": {
+      "description": "`Authentication` defines the authentication configuration for an API.\n\nExample for an API targeted for external use:\n\n    name: calendar.googleapis.com\n    authentication:\n      rules:\n      - selector: \"*\"\n        oauth:\n          canonical_scopes: https://www.googleapis.com/auth/calendar\n\n      - selector: google.calendar.Delegate\n        oauth:\n          canonical_scopes: https://www.googleapis.com/auth/calendar.read",
+      "type": "object",
+      "properties": {
+        "providers": {
+          "description": "Defines a set of authentication providers that a service supports.",
+          "type": "array",
+          "items": {
+            "$ref": "AuthProvider"
+          }
+        },
+        "rules": {
+          "description": "A list of authentication rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "AuthenticationRule"
+          }
+        }
+      },
+      "id": "Authentication"
+    },
+    "Type": {
+      "description": "A protocol buffer message type.",
+      "type": "object",
+      "properties": {
+        "oneofs": {
+          "description": "The list of types appearing in `oneof` definitions in this type.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "options": {
+          "description": "The protocol buffer options.",
+          "type": "array",
+          "items": {
+            "$ref": "Option"
+          }
+        },
+        "sourceContext": {
+          "description": "The source context.",
+          "$ref": "SourceContext"
+        },
+        "fields": {
+          "description": "The list of fields.",
+          "type": "array",
+          "items": {
+            "$ref": "Field"
+          }
+        },
+        "name": {
+          "description": "The fully qualified message name.",
+          "type": "string"
+        },
+        "syntax": {
+          "description": "The source syntax.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        }
+      },
+      "id": "Type"
+    },
+    "Backend": {
+      "description": "`Backend` defines the backend configuration for a service.",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "description": "A list of API backend rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "BackendRule"
+          }
+        }
+      },
+      "id": "Backend"
+    },
+    "AuditConfig": {
+      "description": "Enables \"data access\" audit logging for a service and specifies a list\nof members that are log-exempted.",
+      "type": "object",
+      "properties": {
+        "service": {
+          "description": "Specifies a service that will be enabled for \"data access\" audit\nlogging.\nFor example, `resourcemanager`, `storage`, `compute`.\n`allServices` is a special value that covers all services.",
+          "type": "string"
+        },
+        "exemptedMembers": {
+          "description": "Specifies the identities that are exempted from \"data access\" audit\nlogging for the `service` specified above.\nFollows the same format of Binding.members.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "AuditConfig"
+    },
+    "ListServiceRolloutsResponse": {
+      "description": "Response message for ListServiceRollouts method.",
+      "type": "object",
+      "properties": {
+        "rollouts": {
+          "description": "The list of rollout resources.",
+          "type": "array",
+          "items": {
+            "$ref": "Rollout"
+          }
+        },
+        "nextPageToken": {
+          "description": "The token of the next page of results.",
+          "type": "string"
+        }
+      },
+      "id": "ListServiceRolloutsResponse"
+    },
+    "Rollout": {
+      "description": "A rollout resource that defines how service configuration versions are pushed\nto control plane systems. Typically, you create a new version of the\nservice config, and then create a Rollout to push the service config.",
+      "type": "object",
+      "properties": {
+        "createdBy": {
+          "description": "The user who created the Rollout. Readonly.",
+          "type": "string"
+        },
+        "trafficPercentStrategy": {
+          "description": "Google Service Control selects service configurations based on\ntraffic percentage.",
+          "$ref": "TrafficPercentStrategy"
+        },
+        "status": {
+          "description": "The status of this rollout. Readonly. In case of a failed rollout,\nthe system will automatically rollback to the current Rollout\nversion. Readonly.",
+          "enum": [
+            "ROLLOUT_STATUS_UNSPECIFIED",
+            "IN_PROGRESS",
+            "SUCCESS",
+            "CANCELLED",
+            "FAILED",
+            "PENDING"
+          ],
+          "enumDescriptions": [
+            "No status specified.",
+            "The Rollout is in progress.",
+            "The Rollout has completed successfully.",
+            "The Rollout has been cancelled. This can happen if you have overlapping\nRollout pushes, and the previous ones will be cancelled.",
+            "The Rollout has failed. It is typically caused by configuration errors.",
+            "The Rollout has not started yet and is pending for execution."
+          ],
+          "type": "string"
+        },
+        "deleteServiceStrategy": {
+          "description": "The strategy associated with a rollout to delete a `ManagedService`.\nReadonly.",
+          "$ref": "DeleteServiceStrategy"
+        },
+        "createTime": {
+          "description": "Creation time of the rollout. Readonly.",
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "serviceName": {
+          "description": "The name of the service associated with this Rollout.",
+          "type": "string"
+        },
+        "rolloutId": {
+          "description": "Optional unique identifier of this Rollout. Only lower case letters, digits\n and '-' are allowed.\n\nIf not specified by client, the server will generate one. The generated id\nwill have the form of \u003cdate\u003e\u003crevision number\u003e, where \"date\" is the create\ndate in ISO 8601 format.  \"revision number\" is a monotonically increasing\npositive number that is reset every day for each service.\nAn example of the generated rollout_id is '2016-02-16r1'",
+          "type": "string"
+        }
+      },
+      "id": "Rollout"
+    },
+    "ConfigSource": {
+      "description": "Represents a source file which is used to generate the service configuration\ndefined by `google.api.Service`.",
+      "type": "object",
+      "properties": {
+        "files": {
+          "description": "Set of source configuration files that are used to generate a service\nconfiguration (`google.api.Service`).",
+          "type": "array",
+          "items": {
+            "$ref": "ConfigFile"
+          }
+        },
+        "id": {
+          "description": "A unique ID for a specific instance of this message, typically assigned\nby the client for tracking purpose. If empty, the server may choose to\ngenerate one instead.",
+          "type": "string"
+        }
+      },
+      "id": "ConfigSource"
+    },
+    "Method": {
+      "description": "Method represents a method of an api.",
+      "type": "object",
+      "properties": {
+        "requestStreaming": {
+          "description": "If true, the request is streamed.",
+          "type": "boolean"
+        },
+        "options": {
+          "description": "Any metadata attached to the method.",
+          "type": "array",
+          "items": {
+            "$ref": "Option"
+          }
+        },
+        "requestTypeUrl": {
+          "description": "A URL of the input message type.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The simple name of this method.",
+          "type": "string"
+        },
+        "syntax": {
+          "description": "The source syntax of this method.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        },
+        "responseTypeUrl": {
+          "description": "The URL of the output message type.",
+          "type": "string"
+        },
+        "responseStreaming": {
+          "description": "If true, the response is streamed.",
+          "type": "boolean"
+        }
+      },
+      "id": "Method"
+    },
+    "Operation": {
+      "description": "This resource represents a long-running operation that is the result of a\nnetwork API call.",
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "The error result of the operation in case of failure or cancellation.",
+          "$ref": "Status"
+        },
+        "done": {
+          "description": "If the value is `false`, it means the operation is still in progress.\nIf true, the operation is completed, and either `error` or `response` is\navailable.",
+          "type": "boolean"
+        },
+        "metadata": {
+          "description": "Service-specific metadata associated with the operation.  It typically\ncontains progress information and common metadata such as create time.\nSome services might not provide such metadata.  Any method that returns a\nlong-running operation should document the metadata type, if any.",
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "type": "object"
+        },
+        "response": {
+          "description": "The normal response of the operation in case of success.  If the original\nmethod returns no data on success, such as `Delete`, the response is\n`google.protobuf.Empty`.  If the original method is standard\n`Get`/`Create`/`Update`, the response should be the resource.  For other\nmethods, the response should have the type `XxxResponse`, where `Xxx`\nis the original method name.  For example, if the original method name\nis `TakeSnapshot()`, the inferred response type is\n`TakeSnapshotResponse`.",
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "type": "object"
+        },
+        "name": {
+          "description": "The server-assigned name, which is only unique within the same service that\noriginally returns it. If you use the default HTTP mapping, the\n`name` should have the format of `operations/some/unique/name`.",
+          "type": "string"
+        }
+      },
+      "id": "Operation"
+    },
+    "Rule": {
+      "description": "A rule to be applied in a Policy.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Human-readable description of the rule.",
+          "type": "string"
+        },
+        "in": {
+          "description": "If one or more 'in' clauses are specified, the rule matches if\nthe PRINCIPAL/AUTHORITY_SELECTOR is in at least one of these entries.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "action": {
+          "description": "Required",
+          "enum": [
+            "NO_ACTION",
+            "ALLOW",
+            "ALLOW_WITH_LOG",
+            "DENY",
+            "DENY_WITH_LOG",
+            "LOG"
+          ],
+          "enumDescriptions": [
+            "Default no action.",
+            "Matching 'Entries' grant access.",
+            "Matching 'Entries' grant access and the caller promises to log\nthe request per the returned log_configs.",
+            "Matching 'Entries' deny access.",
+            "Matching 'Entries' deny access and the caller promises to log\nthe request per the returned log_configs.",
+            "Matching 'Entries' tell IAM.Check callers to generate logs."
+          ],
+          "type": "string"
+        },
+        "conditions": {
+          "description": "Additional restrictions that must be met",
+          "type": "array",
+          "items": {
+            "$ref": "Condition"
+          }
+        },
+        "notIn": {
+          "description": "If one or more 'not_in' clauses are specified, the rule matches\nif the PRINCIPAL/AUTHORITY_SELECTOR is in none of the entries.\nThe format for in and not_in entries is the same as for members in a\nBinding (see google/iam/v1/policy.proto).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "logConfig": {
+          "description": "The config returned to callers of tech.iam.IAM.CheckPolicy for any entries\nthat match the LOG action.",
+          "type": "array",
+          "items": {
+            "$ref": "LogConfig"
+          }
+        },
+        "permissions": {
+          "description": "A permission is a string of form '\u003cservice\u003e.\u003cresource type\u003e.\u003cverb\u003e'\n(e.g., 'storage.buckets.list'). A value of '*' matches all permissions,\nand a verb part of '*' (e.g., 'storage.buckets.*') matches all verbs.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "Rule"
+    },
+    "MetricDescriptor": {
+      "description": "Defines a metric type and its schema. Once a metric descriptor is created,\ndeleting or altering it stops data collection and makes the metric type's\nexisting data unusable.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "A detailed description of the metric, which can be used in documentation.",
+          "type": "string"
+        },
+        "unit": {
+          "description": "The unit in which the metric value is reported. It is only applicable\nif the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`. The\nsupported units are a subset of [The Unified Code for Units of\nMeasure](http://unitsofmeasure.org/ucum.html) standard:\n\n**Basic units (UNIT)**\n\n* `bit`   bit\n* `By`    byte\n* `s`     second\n* `min`   minute\n* `h`     hour\n* `d`     day\n\n**Prefixes (PREFIX)**\n\n* `k`     kilo    (10**3)\n* `M`     mega    (10**6)\n* `G`     giga    (10**9)\n* `T`     tera    (10**12)\n* `P`     peta    (10**15)\n* `E`     exa     (10**18)\n* `Z`     zetta   (10**21)\n* `Y`     yotta   (10**24)\n* `m`     milli   (10**-3)\n* `u`     micro   (10**-6)\n* `n`     nano    (10**-9)\n* `p`     pico    (10**-12)\n* `f`     femto   (10**-15)\n* `a`     atto    (10**-18)\n* `z`     zepto   (10**-21)\n* `y`     yocto   (10**-24)\n* `Ki`    kibi    (2**10)\n* `Mi`    mebi    (2**20)\n* `Gi`    gibi    (2**30)\n* `Ti`    tebi    (2**40)\n\n**Grammar**\n\nThe grammar includes the dimensionless unit `1`, such as `1/s`.\n\nThe grammar also includes these connectors:\n\n* `/`    division (as an infix operator, e.g. `1/s`).\n* `.`    multiplication (as an infix operator, e.g. `GBy.d`)\n\nThe grammar for a unit is as follows:\n\n    Expression = Component { \".\" Component } { \"/\" Component } ;\n\n    Component = [ PREFIX ] UNIT [ Annotation ]\n              | Annotation\n              | \"1\"\n              ;\n\n    Annotation = \"{\" NAME \"}\" ;\n\nNotes:\n\n* `Annotation` is just a comment if it follows a `UNIT` and is\n   equivalent to `1` if it is used alone. For examples,\n   `{requests}/s == 1/s`, `By{transmitted}/s == By/s`.\n* `NAME` is a sequence of non-blank printable ASCII characters not\n   containing '{' or '}'.",
+          "type": "string"
+        },
+        "labels": {
+          "description": "The set of labels that can be used to describe a specific\ninstance of this metric type. For example, the\n`appengine.googleapis.com/http/server/response_latencies` metric\ntype has a label for the HTTP response code, `response_code`, so\nyou can look at latencies for successful responses or just\nfor responses that failed.",
+          "type": "array",
+          "items": {
+            "$ref": "LabelDescriptor"
+          }
+        },
+        "metricKind": {
+          "description": "Whether the metric records instantaneous values, changes to a value, etc.\nSome combinations of `metric_kind` and `value_type` might not be supported.",
+          "enum": [
+            "METRIC_KIND_UNSPECIFIED",
+            "GAUGE",
+            "DELTA",
+            "CUMULATIVE"
+          ],
+          "enumDescriptions": [
+            "Do not use this default value.",
+            "An instantaneous measurement of a value.",
+            "The change in a value during a time interval.",
+            "A value accumulated over a time interval.  Cumulative\nmeasurements in a time series should have the same start time\nand increasing end times, until an event resets the cumulative\nvalue to zero and sets a new start time for the following\npoints."
+          ],
+          "type": "string"
+        },
+        "valueType": {
+          "description": "Whether the measurement is an integer, a floating-point number, etc.\nSome combinations of `metric_kind` and `value_type` might not be supported.",
+          "enum": [
+            "VALUE_TYPE_UNSPECIFIED",
+            "BOOL",
+            "INT64",
+            "DOUBLE",
+            "STRING",
+            "DISTRIBUTION",
+            "MONEY"
+          ],
+          "enumDescriptions": [
+            "Do not use this default value.",
+            "The value is a boolean.\nThis value type can be used only if the metric kind is `GAUGE`.",
+            "The value is a signed 64-bit integer.",
+            "The value is a double precision floating point number.",
+            "The value is a text string.\nThis value type can be used only if the metric kind is `GAUGE`.",
+            "The value is a `Distribution`.",
+            "The value is money."
+          ],
+          "type": "string"
+        },
+        "displayName": {
+          "description": "A concise name for the metric, which can be displayed in user interfaces.\nUse sentence case without an ending period, for example \"Request count\".",
+          "type": "string"
+        },
+        "name": {
+          "description": "The resource name of the metric descriptor. Depending on the\nimplementation, the name typically includes: (1) the parent resource name\nthat defines the scope of the metric type or of its data; and (2) the\nmetric's URL-encoded type, which also appears in the `type` field of this\ndescriptor. For example, following is the resource name of a custom\nmetric within the GCP project 123456789:\n\n    \"projects/123456789/metricDescriptors/custom.googleapis.com%2Finvoice%2Fpaid%2Famount\"",
+          "type": "string"
+        },
+        "type": {
+          "description": "The metric type, including its DNS name prefix. The type is not\nURL-encoded.  All user-defined metric types have the DNS name\n`custom.googleapis.com`.  Metric types should use a natural hierarchical\ngrouping. For example:\n\n    \"custom.googleapis.com/invoice/paid/amount\"\n    \"appengine.googleapis.com/http/server/response_latencies\"",
+          "type": "string"
+        }
+      },
+      "id": "MetricDescriptor"
+    },
+    "EnableServiceRequest": {
+      "description": "Request message for EnableService method.",
+      "type": "object",
+      "properties": {
+        "consumerId": {
+          "description": "The identity of consumer resource which service enablement will be\napplied to.\n\nThe Google Service Management implementation accepts the following\nforms:\n- \"project:\u003cproject_id\u003e\"\n\nNote: this is made compatible with\ngoogle.api.servicecontrol.v1.Operation.consumer_id.",
+          "type": "string"
+        }
+      },
+      "id": "EnableServiceRequest"
+    },
+    "DocumentationRule": {
+      "description": "A documentation rule provides information about individual API elements.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Description of the selected API(s).",
+          "type": "string"
+        },
+        "deprecationDescription": {
+          "description": "Deprecation description of the selected element(s). It can be provided if an\nelement is marked as `deprecated`.",
+          "type": "string"
+        },
+        "selector": {
+          "description": "The selector is a comma-separated list of patterns. Each pattern is a\nqualified name of the element which may end in \"*\", indicating a wildcard.\nWildcards are only allowed at the end and for a whole component of the\nqualified name, i.e. \"foo.*\" is ok, but not \"foo.b*\" or \"foo.*.bar\". To\nspecify a default for all applicable elements, the whole pattern \"*\"\nis used.",
+          "type": "string"
+        }
+      },
+      "id": "DocumentationRule"
+    },
+    "SetIamPolicyRequest": {
+      "description": "Request message for `SetIamPolicy` method.",
+      "type": "object",
+      "properties": {
+        "policy": {
+          "description": "REQUIRED: The complete policy to be applied to the `resource`. The size of\nthe policy is limited to a few 10s of KB. An empty policy is a\nvalid policy but certain Cloud Platform services (such as Projects)\nmight reject them.",
+          "$ref": "Policy"
+        }
+      },
+      "id": "SetIamPolicyRequest"
+    },
+    "CounterOptions": {
+      "description": "Options for counters",
+      "type": "object",
+      "properties": {
+        "metric": {
+          "description": "The metric to update.",
+          "type": "string"
+        },
+        "field": {
+          "description": "The field value to attribute.",
+          "type": "string"
+        }
+      },
+      "id": "CounterOptions"
+    },
+    "Condition": {
+      "description": "A condition to be met.",
+      "type": "object",
+      "properties": {
+        "sys": {
+          "description": "Trusted attributes supplied by any service that owns resources and uses\nthe IAM system for access control.",
+          "enum": [
+            "NO_ATTR",
+            "REGION",
+            "SERVICE",
+            "NAME",
+            "IP"
+          ],
+          "enumDescriptions": [
+            "Default non-attribute type",
+            "Region of the resource",
+            "Service name",
+            "Resource name",
+            "IP address of the caller"
+          ],
+          "type": "string"
+        },
+        "values": {
+          "description": "The objects of the condition. This is mutually exclusive with 'value'.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "iam": {
+          "description": "Trusted attributes supplied by the IAM system.",
+          "enum": [
+            "NO_ATTR",
+            "AUTHORITY",
+            "ATTRIBUTION"
+          ],
+          "enumDescriptions": [
+            "Default non-attribute.",
+            "Either principal or (if present) authority selector.",
+            "The principal (even if an authority selector is present), which\nmust only be used for attribution, not authorization."
+          ],
+          "type": "string"
+        },
+        "op": {
+          "description": "An operator to apply the subject with.",
+          "enum": [
+            "NO_OP",
+            "EQUALS",
+            "NOT_EQUALS",
+            "IN",
+            "NOT_IN",
+            "DISCHARGED"
+          ],
+          "enumDescriptions": [
+            "Default no-op.",
+            "DEPRECATED. Use IN instead.",
+            "DEPRECATED. Use NOT_IN instead.",
+            "Set-inclusion check.",
+            "Set-exclusion check.",
+            "Subject is discharged"
+          ],
+          "type": "string"
+        },
+        "value": {
+          "description": "DEPRECATED. Use 'values' instead.",
+          "type": "string"
+        },
+        "svc": {
+          "description": "Trusted attributes discharged by the service.",
+          "type": "string"
+        }
+      },
+      "id": "Condition"
+    },
+    "Status": {
+      "description": "The `Status` type defines a logical error model that is suitable for different\nprogramming environments, including REST APIs and RPC APIs. It is used by\n[gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error message,\nand error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` which can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting purpose.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "details": {
+          "description": "A list of messages that carry the error details.  There will be a\ncommon set of message types for APIs to use.",
+          "type": "array",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            },
+            "type": "object"
+          }
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        }
+      },
+      "id": "Status"
+    },
+    "Endpoint": {
+      "description": "`Endpoint` describes a network endpoint that serves a set of APIs.\nA service may expose any number of endpoints, and all endpoints share the\nsame service configuration, such as quota configuration and monitoring\nconfiguration.\n\nExample service configuration:\n\n    name: library-example.googleapis.com\n    endpoints:\n      # Below entry makes 'google.example.library.v1.Library'\n      # API be served from endpoint address library-example.googleapis.com.\n      # It also allows HTTP OPTIONS calls to be passed to the backend, for\n      # it to decide whether the subsequent cross-origin request is\n      # allowed to proceed.\n    - name: library-example.googleapis.com\n      apis: google.example.library.v1.Library\n      allow_cors: true\n      # Below entry makes 'google.example.library.v1.Library'\n      # API be served from endpoint address\n      # google.example.library-example.v1.LibraryManager.\n    - name: library-manager.googleapis.com\n      apis: google.example.library.v1.LibraryManager\n      # BNS address for a borg job. Can specify a task by appending\n      # \"/taskId\" (e.g. \"/0\") to the job spec.\n\nExample OpenAPI extension for endpoint with allow_cors set to true:\n\n    {\n      \"swagger\": \"2.0\",\n      \"info\": {\n        \"description\": \"A simple...\"\n      },\n      \"host\": \"MY_PROJECT_ID.appspot.com\",\n      \"x-google-endpoints\": [{\n        \"name\": \"MY_PROJECT_ID.appspot.com\",\n        \"allow_cors\": \"true\"\n      }]\n    }",
+      "type": "object",
+      "properties": {
+        "apis": {
+          "description": "The list of APIs served by this endpoint.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowCors": {
+          "description": "Allowing\n[CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing), aka\ncross-domain traffic, would allow the backends served from this endpoint to\nreceive and respond to HTTP OPTIONS requests. The response will be used by\nthe browser to determine whether the subsequent cross-origin request is\nallowed to proceed.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "The canonical name of this endpoint.",
+          "type": "string"
+        },
+        "aliases": {
+          "description": "DEPRECATED: This field is no longer supported. Instead of using aliases,\nplease specify multiple google.api.Endpoint for each of the intented\nalias.\n\nAdditional names that this endpoint will be hosted on.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "features": {
+          "description": "The list of features enabled on this endpoint.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "Endpoint"
+    },
+    "Page": {
+      "description": "Represents a documentation page. A page can contain subpages to represent\nnested documentation set structure.",
+      "type": "object",
+      "properties": {
+        "subpages": {
+          "description": "Subpages of this page. The order of subpages specified here will be\nhonored in the generated docset.",
+          "type": "array",
+          "items": {
+            "$ref": "Page"
+          }
+        },
+        "content": {
+          "description": "The Markdown content of the page. You can use \u003ccode\u003e&#40;== include {path} ==&#41;\u003c/code\u003e\nto include content from a Markdown file.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the page. It will be used as an identity of the page to\ngenerate URI of the page, text of the link to this page in navigation,\netc. The full page name (start from the root page name to this page\nconcatenated with `.`) can be used as reference to the page in your\ndocumentation. For example:\n\u003cpre\u003e\u003ccode\u003epages:\n- name: Tutorial\n  content: &#40;== include tutorial.md ==&#41;\n  subpages:\n  - name: Java\n    content: &#40;== include tutorial_java.md ==&#41;\n\u003c/code\u003e\u003c/pre\u003e\nYou can reference `Java` page using Markdown reference link syntax:\n`Java`.",
+          "type": "string"
+        }
+      },
+      "id": "Page"
+    },
+    "CustomErrorRule": {
+      "description": "A custom error rule.",
+      "type": "object",
+      "properties": {
+        "isErrorType": {
+          "description": "Mark this message as possible payload in error response.  Otherwise,\nobjects of this type will be filtered when they appear in error payload.",
+          "type": "boolean"
+        },
+        "selector": {
+          "description": "Selects messages to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "id": "CustomErrorRule"
+    },
+    "Option": {
+      "description": "A protocol buffer option, which can be attached to a message, field,\nenumeration, etc.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "The option's value. For example, `\"com.google.protobuf\"`.",
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "type": "object"
+        },
+        "name": {
+          "description": "The option's name. For example, `\"java_package\"`.",
+          "type": "string"
+        }
+      },
+      "id": "Option"
+    },
+    "HttpRule": {
+      "description": "`HttpRule` defines the mapping of an RPC method to one or more HTTP\nREST APIs.  The mapping determines what portions of the request\nmessage are populated from the path, query parameters, or body of\nthe HTTP request.  The mapping is typically specified as an\n`google.api.http` annotation, see \"google/api/annotations.proto\"\nfor details.\n\nThe mapping consists of a field specifying the path template and\nmethod kind.  The path template can refer to fields in the request\nmessage, as in the example below which describes a REST GET\noperation on a resource collection of messages:\n\n```proto\nservice Messaging {\n  rpc GetMessage(GetMessageRequest) returns (Message) {\n    option (google.api.http).get = \"/v1/messages/{message_id}/{sub.subfield}\";\n  }\n}\nmessage GetMessageRequest {\n  message SubMessage {\n    string subfield = 1;\n  }\n  string message_id = 1; // mapped to the URL\n  SubMessage sub = 2;    // `sub.subfield` is url-mapped\n}\nmessage Message {\n  string text = 1; // content of the resource\n}\n```\n\nThis definition enables an automatic, bidrectional mapping of HTTP\nJSON to RPC. Example:\n\nHTTP | RPC\n-----|-----\n`GET /v1/messages/123456/foo`  | `GetMessage(message_id: \"123456\" sub: SubMessage(subfield: \"foo\"))`\n\nIn general, not only fields but also field paths can be referenced\nfrom a path pattern. Fields mapped to the path pattern cannot be\nrepeated and must have a primitive (non-message) type.\n\nAny fields in the request message which are not bound by the path\npattern automatically become (optional) HTTP query\nparameters. Assume the following definition of the request message:\n\n```proto\nmessage GetMessageRequest {\n  message SubMessage {\n    string subfield = 1;\n  }\n  string message_id = 1; // mapped to the URL\n  int64 revision = 2;    // becomes a parameter\n  SubMessage sub = 3;    // `sub.subfield` becomes a parameter\n}\n```\n\nThis enables a HTTP JSON to RPC mapping as below:\n\nHTTP | RPC\n-----|-----\n`GET /v1/messages/123456?revision=2&sub.subfield=foo` | `GetMessage(message_id: \"123456\" revision: 2 sub: SubMessage(subfield: \"foo\"))`\n\nNote that fields which are mapped to HTTP parameters must have a\nprimitive type or a repeated primitive type. Message types are not\nallowed. In the case of a repeated type, the parameter can be\nrepeated in the URL, as in `...?param=A&param=B`.\n\nFor HTTP method kinds which allow a request body, the `body` field\nspecifies the mapping. Consider a REST update method on the\nmessage resource collection:\n\n```proto\nservice Messaging {\n  rpc UpdateMessage(UpdateMessageRequest) returns (Message) {\n    option (google.api.http) = {\n      put: \"/v1/messages/{message_id}\"\n      body: \"message\"\n    };\n  }\n}\nmessage UpdateMessageRequest {\n  string message_id = 1; // mapped to the URL\n  Message message = 2;   // mapped to the body\n}\n```\n\nThe following HTTP JSON to RPC mapping is enabled, where the\nrepresentation of the JSON in the request body is determined by\nprotos JSON encoding:\n\nHTTP | RPC\n-----|-----\n`PUT /v1/messages/123456 { \"text\": \"Hi!\" }` | `UpdateMessage(message_id: \"123456\" message { text: \"Hi!\" })`\n\nThe special name `*` can be used in the body mapping to define that\nevery field not bound by the path template should be mapped to the\nrequest body.  This enables the following alternative definition of\nthe update method:\n\n```proto\nservice Messaging {\n  rpc UpdateMessage(Message) returns (Message) {\n    option (google.api.http) = {\n      put: \"/v1/messages/{message_id}\"\n      body: \"*\"\n    };\n  }\n}\nmessage Message {\n  string message_id = 1;\n  string text = 2;\n}\n```\n\nThe following HTTP JSON to RPC mapping is enabled:\n\nHTTP | RPC\n-----|-----\n`PUT /v1/messages/123456 { \"text\": \"Hi!\" }` | `UpdateMessage(message_id: \"123456\" text: \"Hi!\")`\n\nNote that when using `*` in the body mapping, it is not possible to\nhave HTTP parameters, as all fields not bound by the path end in\nthe body. This makes this option more rarely used in practice of\ndefining REST APIs. The common usage of `*` is in custom methods\nwhich don't use the URL at all for transferring data.\n\nIt is possible to define multiple HTTP methods for one RPC by using\nthe `additional_bindings` option. Example:\n\n```proto\nservice Messaging {\n  rpc GetMessage(GetMessageRequest) returns (Message) {\n    option (google.api.http) = {\n      get: \"/v1/messages/{message_id}\"\n      additional_bindings {\n        get: \"/v1/users/{user_id}/messages/{message_id}\"\n      }\n    };\n  }\n}\nmessage GetMessageRequest {\n  string message_id = 1;\n  string user_id = 2;\n}\n```\n\nThis enables the following two alternative HTTP JSON to RPC\nmappings:\n\nHTTP | RPC\n-----|-----\n`GET /v1/messages/123456` | `GetMessage(message_id: \"123456\")`\n`GET /v1/users/me/messages/123456` | `GetMessage(user_id: \"me\" message_id: \"123456\")`\n\n# Rules for HTTP mapping\n\nThe rules for mapping HTTP path, query parameters, and body fields\nto the request message are as follows:\n\n1. The `body` field specifies either `*` or a field path, or is\n   omitted. If omitted, it assumes there is no HTTP body.\n2. Leaf fields (recursive expansion of nested messages in the\n   request) can be classified into three types:\n    (a) Matched in the URL template.\n    (b) Covered by body (if body is `*`, everything except (a) fields;\n        else everything under the body field)\n    (c) All other fields.\n3. URL query parameters found in the HTTP request are mapped to (c) fields.\n4. Any body sent with an HTTP request can contain only (b) fields.\n\nThe syntax of the path template is as follows:\n\n    Template = \"/\" Segments [ Verb ] ;\n    Segments = Segment { \"/\" Segment } ;\n    Segment  = \"*\" | \"**\" | LITERAL | Variable ;\n    Variable = \"{\" FieldPath [ \"=\" Segments ] \"}\" ;\n    FieldPath = IDENT { \".\" IDENT } ;\n    Verb     = \":\" LITERAL ;\n\nThe syntax `*` matches a single path segment. It follows the semantics of\n[RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String\nExpansion.\n\nThe syntax `**` matches zero or more path segments. It follows the semantics\nof [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.3 Reserved\nExpansion. NOTE: it must be the last segment in the path except the Verb.\n\nThe syntax `LITERAL` matches literal text in the URL path.\n\nThe syntax `Variable` matches the entire path as specified by its template;\nthis nested template must not contain further variables. If a variable\nmatches a single path segment, its template may be omitted, e.g. `{var}`\nis equivalent to `{var=*}`.\n\nNOTE: the field paths in variables and in the `body` must not refer to\nrepeated fields or map fields.\n\nUse CustomHttpPattern to specify any HTTP method that is not included in the\n`pattern` field, such as HEAD, or \"*\" to leave the HTTP method unspecified for\na given URL path rule. The wild-card rule is useful for services that provide\ncontent to Web (HTML) clients.",
+      "type": "object",
+      "properties": {
+        "custom": {
+          "description": "Custom pattern is used for defining custom verbs.",
+          "$ref": "CustomHttpPattern"
+        },
+        "responseBody": {
+          "description": "The name of the response field whose value is mapped to the HTTP body of\nresponse. Other response fields are ignored. This field is optional. When\nnot set, the response message will be used as HTTP body of response.\nNOTE: the referred field must be not a repeated field and must be present\nat the top-level of response message type.",
+          "type": "string"
+        },
+        "additionalBindings": {
+          "description": "Additional HTTP bindings for the selector. Nested bindings must\nnot contain an `additional_bindings` field themselves (that is,\nthe nesting may only be one level deep).",
+          "type": "array",
+          "items": {
+            "$ref": "HttpRule"
+          }
+        },
+        "mediaDownload": {
+          "description": "Do not use this. For media support, add instead\n[][google.bytestream.RestByteStream] as an API to your\nconfiguration.",
+          "$ref": "MediaDownload"
+        },
+        "body": {
+          "description": "The name of the request field whose value is mapped to the HTTP body, or\n`*` for mapping all fields not captured by the path pattern to the HTTP\nbody. NOTE: the referred field must not be a repeated field and must be\npresent at the top-level of response message type.",
+          "type": "string"
+        },
+        "put": {
+          "description": "Used for updating a resource.",
+          "type": "string"
+        },
+        "get": {
+          "description": "Used for listing and getting information about resources.",
+          "type": "string"
+        },
+        "selector": {
+          "description": "Selects methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        },
+        "post": {
+          "description": "Used for creating a resource.",
+          "type": "string"
+        },
+        "patch": {
+          "description": "Used for updating a resource.",
+          "type": "string"
+        },
+        "delete": {
+          "description": "Used for deleting a resource.",
+          "type": "string"
+        },
+        "mediaUpload": {
+          "description": "Do not use this. For media support, add instead\n[][google.bytestream.RestByteStream] as an API to your\nconfiguration.",
+          "$ref": "MediaUpload"
+        }
+      },
+      "id": "HttpRule"
+    },
+    "TestIamPermissionsRequest": {
+      "description": "Request message for `TestIamPermissions` method.",
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "description": "The set of permissions to check for the `resource`. Permissions with\nwildcards (such as '*' or 'storage.*') are not allowed. For more\ninformation see\n[IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "TestIamPermissionsRequest"
+    },
+    "TestIamPermissionsResponse": {
+      "description": "Response message for `TestIamPermissions` method.",
+      "type": "object",
+      "properties": {
+        "permissions": {
+          "description": "A subset of `TestPermissionsRequest.permissions` that the caller is\nallowed.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "TestIamPermissionsResponse"
+    },
+    "CustomError": {
+      "description": "Customize service error responses.  For example, list any service\nspecific protobuf types that can appear in error detail lists of\nerror responses.\n\nExample:\n\n    custom_error:\n      types:\n      - google.foo.v1.CustomError\n      - google.foo.v1.AnotherError",
+      "type": "object",
+      "properties": {
+        "types": {
+          "description": "The list of custom error detail types, e.g. 'google.foo.v1.CustomError'.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules": {
+          "description": "The list of custom error rules that apply to individual API messages.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "CustomErrorRule"
+          }
+        }
+      },
+      "id": "CustomError"
+    },
+    "MediaDownload": {
+      "description": "Do not use this. For media support, add instead\n[][google.bytestream.RestByteStream] as an API to your\nconfiguration.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether download is enabled.",
+          "type": "boolean"
+        }
+      },
+      "id": "MediaDownload"
+    },
+    "SubmitConfigSourceRequest": {
+      "description": "Request message for SubmitConfigSource method.",
+      "type": "object",
+      "properties": {
+        "configSource": {
+          "description": "The source configuration for the service.",
+          "$ref": "ConfigSource"
+        },
+        "validateOnly": {
+          "description": "Optional. If set, this will result in the generation of a\n`google.api.Service` configuration based on the `ConfigSource` provided,\nbut the generated config and the sources will NOT be persisted.",
+          "type": "boolean"
+        }
+      },
+      "id": "SubmitConfigSourceRequest"
+    },
+    "AuthenticationRule": {
+      "description": "Authentication rules for the service.\n\nBy default, if a method has any authentication requirements, every request\nmust include a valid credential matching one of the requirements.\nIt's an error to include more than one kind of credential in a single\nrequest.\n\nIf a method doesn't have any auth requirements, request credentials will be\nignored.",
+      "type": "object",
+      "properties": {
+        "oauth": {
+          "description": "The requirements for OAuth credentials.",
+          "$ref": "OAuthRequirements"
+        },
+        "allowWithoutCredential": {
+          "description": "Whether to allow requests without a credential. The credential can be\nan OAuth token, Google cookies (first-party auth) or EndUserCreds.\n\nFor requests without credentials, if the service control environment is\nspecified, each incoming request **must** be associated with a service\nconsumer. This can be done by passing an API key that belongs to a consumer\nproject.",
+          "type": "boolean"
+        },
+        "requirements": {
+          "description": "Requirements for additional authentication providers.",
+          "type": "array",
+          "items": {
+            "$ref": "AuthRequirement"
+          }
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "id": "AuthenticationRule"
+    },
+    "Logging": {
+      "description": "Logging configuration of the service.\n\nThe following example shows how to configure logs to be sent to the\nproducer and consumer projects. In the example, the `activity_history`\nlog is sent to both the producer and consumer projects, whereas the\n`purchase_history` log is only sent to the producer project.\n\n    monitored_resources:\n    - type: library.googleapis.com/branch\n      labels:\n      - key: /city\n        description: The city where the library branch is located in.\n      - key: /name\n        description: The name of the branch.\n    logs:\n    - name: activity_history\n      labels:\n      - key: /customer_id\n    - name: purchase_history\n    logging:\n      producer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        logs:\n        - activity_history\n        - purchase_history\n      consumer_destinations:\n      - monitored_resource: library.googleapis.com/branch\n        logs:\n        - activity_history",
+      "type": "object",
+      "properties": {
+        "producerDestinations": {
+          "description": "Logging configurations for sending logs to the producer project.\nThere can be multiple producer destinations, each one must have a\ndifferent monitored resource type. A log can be used in at most\none producer destination.",
+          "type": "array",
+          "items": {
+            "$ref": "LoggingDestination"
+          }
+        },
+        "consumerDestinations": {
+          "description": "Logging configurations for sending logs to the consumer project.\nThere can be multiple consumer destinations, each one must have a\ndifferent monitored resource type. A log can be used in at most\none consumer destination.",
+          "type": "array",
+          "items": {
+            "$ref": "LoggingDestination"
+          }
+        }
+      },
+      "id": "Logging"
+    },
+    "SystemParameter": {
+      "description": "Define a parameter's name and location. The parameter may be passed as either\nan HTTP header or a URL query parameter, and if both are passed the behavior\nis implementation-dependent.",
+      "type": "object",
+      "properties": {
+        "urlQueryParameter": {
+          "description": "Define the URL query parameter name to use for the parameter. It is case\nsensitive.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Define the name of the parameter, such as \"api_key\", \"alt\", \"callback\",\nand etc. It is case sensitive.",
+          "type": "string"
+        },
+        "httpHeader": {
+          "description": "Define the HTTP header name to use for the parameter. It is case\ninsensitive.",
+          "type": "string"
+        }
+      },
+      "id": "SystemParameter"
+    },
+    "Enum": {
+      "description": "Enum type definition.",
+      "type": "object",
+      "properties": {
+        "syntax": {
+          "description": "The source syntax.",
+          "enum": [
+            "SYNTAX_PROTO2",
+            "SYNTAX_PROTO3"
+          ],
+          "enumDescriptions": [
+            "Syntax `proto2`.",
+            "Syntax `proto3`."
+          ],
+          "type": "string"
+        },
+        "enumvalue": {
+          "description": "Enum value definitions.",
+          "type": "array",
+          "items": {
+            "$ref": "EnumValue"
+          }
+        },
+        "options": {
+          "description": "Protocol buffer options.",
+          "type": "array",
+          "items": {
+            "$ref": "Option"
+          }
+        },
+        "sourceContext": {
+          "description": "The source context.",
+          "$ref": "SourceContext"
+        },
+        "name": {
+          "description": "Enum type name.",
+          "type": "string"
+        }
+      },
+      "id": "Enum"
+    },
+    "GenerateConfigReportResponse": {
+      "description": "Response message for GenerateConfigReport method.",
+      "type": "object",
+      "properties": {
+        "serviceName": {
+          "description": "Name of the service this report belongs to.",
+          "type": "string"
+        },
+        "id": {
+          "description": "ID of the service configuration this report belongs to.",
+          "type": "string"
+        },
+        "changeReports": {
+          "description": "list of ChangeReport, each corresponding to comparison between two\nservice configurations.",
+          "type": "array",
+          "items": {
+            "$ref": "ChangeReport"
+          }
+        },
+        "diagnostics": {
+          "description": "Errors / Linter warnings associated with the service definition this\nreport\nbelongs to.",
+          "type": "array",
+          "items": {
+            "$ref": "Diagnostic"
+          }
+        }
+      },
+      "id": "GenerateConfigReportResponse"
+    },
+    "DeleteServiceStrategy": {
+      "description": "Strategy used to delete a service. This strategy is a placeholder only\nused by the system generated rollout to delete a service.",
+      "type": "object",
+      "properties": {},
+      "id": "DeleteServiceStrategy"
+    },
+    "OperationMetadata": {
+      "description": "The metadata associated with a long running operation resource.",
+      "type": "object",
+      "properties": {
+        "steps": {
+          "description": "Detailed status information for each step. The order is undetermined.",
+          "type": "array",
+          "items": {
+            "$ref": "Step"
+          }
+        },
+        "startTime": {
+          "description": "The start time of the operation.",
+          "type": "string",
+          "format": "google-datetime"
+        },
+        "resourceNames": {
+          "description": "The full name of the resources that this operation is directly\nassociated with.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "progressPercentage": {
+          "description": "Percentage of completion of this operation, ranging from 0 to 100.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "id": "OperationMetadata"
+    },
+    "DisableServiceRequest": {
+      "description": "Request message for DisableService method.",
+      "type": "object",
+      "properties": {
+        "consumerId": {
+          "description": "The identity of consumer resource which service disablement will be\napplied to.\n\nThe Google Service Management implementation accepts the following\nforms:\n- \"project:\u003cproject_id\u003e\"\n\nNote: this is made compatible with\ngoogle.api.servicecontrol.v1.Operation.consumer_id.",
+          "type": "string"
+        }
+      },
+      "id": "DisableServiceRequest"
+    },
+    "CustomHttpPattern": {
+      "description": "A custom pattern is used for defining custom HTTP verb.",
+      "type": "object",
+      "properties": {
+        "path": {
+          "description": "The path matched by this custom verb.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The name of this custom HTTP verb.",
+          "type": "string"
+        }
+      },
+      "id": "CustomHttpPattern"
+    },
+    "LogDescriptor": {
+      "description": "A description of a log type. Example in YAML format:\n\n    - name: library.googleapis.com/activity_history\n      description: The history of borrowing and returning library items.\n      display_name: Activity\n      labels:\n      - key: /customer_id\n        description: Identifier of a library customer",
+      "type": "object",
+      "properties": {
+        "labels": {
+          "description": "The set of labels that are available to describe a specific log entry.\nRuntime requests that contain labels not specified here are\nconsidered invalid.",
+          "type": "array",
+          "items": {
+            "$ref": "LabelDescriptor"
+          }
+        },
+        "description": {
+          "description": "A human-readable description of this log. This information appears in\nthe documentation and can contain details.",
+          "type": "string"
+        },
+        "displayName": {
+          "description": "The human-readable name for this log. This information appears on\nthe user interface and should be concise.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The name of the log. It must be less than 512 characters long and can\ninclude the following characters: upper- and lower-case alphanumeric\ncharacters [A-Za-z0-9], and punctuation characters including\nslash, underscore, hyphen, period [/_-.].",
+          "type": "string"
+        }
+      },
+      "id": "LogDescriptor"
+    },
+    "MonitoringDestination": {
+      "description": "Configuration of a specific monitoring destination (the producer project\nor the consumer project).",
+      "type": "object",
+      "properties": {
+        "monitoredResource": {
+          "description": "The monitored resource type. The type must be defined in\nService.monitored_resources section.",
+          "type": "string"
+        },
+        "metrics": {
+          "description": "Names of the metrics to report to this monitoring destination.\nEach name must be defined in Service.metrics section.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "MonitoringDestination"
+    },
+    "Field": {
+      "description": "A single field of a message type.",
+      "type": "object",
+      "properties": {
+        "defaultValue": {
+          "description": "The string value of the default value of this field. Proto2 syntax only.",
+          "type": "string"
+        },
+        "jsonName": {
+          "description": "The field JSON name.",
+          "type": "string"
+        },
+        "options": {
+          "description": "The protocol buffer options.",
+          "type": "array",
+          "items": {
+            "$ref": "Option"
+          }
+        },
+        "oneofIndex": {
+          "description": "The index of the field type in `Type.oneofs`, for message or enumeration\ntypes. The first type has index 1; zero means the type is not in the list.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "cardinality": {
+          "description": "The field cardinality.",
+          "enum": [
+            "CARDINALITY_UNKNOWN",
+            "CARDINALITY_OPTIONAL",
+            "CARDINALITY_REQUIRED",
+            "CARDINALITY_REPEATED"
+          ],
+          "enumDescriptions": [
+            "For fields with unknown cardinality.",
+            "For optional fields.",
+            "For required fields. Proto2 syntax only.",
+            "For repeated fields."
+          ],
+          "type": "string"
+        },
+        "typeUrl": {
+          "description": "The field type URL, without the scheme, for message or enumeration\ntypes. Example: `\"type.googleapis.com/google.protobuf.Timestamp\"`.",
+          "type": "string"
+        },
+        "name": {
+          "description": "The field name.",
+          "type": "string"
+        },
+        "packed": {
+          "description": "Whether to use alternative packed wire representation.",
+          "type": "boolean"
+        },
+        "number": {
+          "description": "The field number.",
+          "type": "integer",
+          "format": "int32"
+        },
+        "kind": {
+          "description": "The field type.",
+          "enum": [
+            "TYPE_UNKNOWN",
+            "TYPE_DOUBLE",
+            "TYPE_FLOAT",
+            "TYPE_INT64",
+            "TYPE_UINT64",
+            "TYPE_INT32",
+            "TYPE_FIXED64",
+            "TYPE_FIXED32",
+            "TYPE_BOOL",
+            "TYPE_STRING",
+            "TYPE_GROUP",
+            "TYPE_MESSAGE",
+            "TYPE_BYTES",
+            "TYPE_UINT32",
+            "TYPE_ENUM",
+            "TYPE_SFIXED32",
+            "TYPE_SFIXED64",
+            "TYPE_SINT32",
+            "TYPE_SINT64"
+          ],
+          "enumDescriptions": [
+            "Field type unknown.",
+            "Field type double.",
+            "Field type float.",
+            "Field type int64.",
+            "Field type uint64.",
+            "Field type int32.",
+            "Field type fixed64.",
+            "Field type fixed32.",
+            "Field type bool.",
+            "Field type string.",
+            "Field type group. Proto2 syntax only, and deprecated.",
+            "Field type message.",
+            "Field type bytes.",
+            "Field type uint32.",
+            "Field type enum.",
+            "Field type sfixed32.",
+            "Field type sfixed64.",
+            "Field type sint32.",
+            "Field type sint64."
+          ],
+          "type": "string"
+        }
+      },
+      "id": "Field"
+    },
+    "Binding": {
+      "description": "Associates `members` with a `role`.",
+      "type": "object",
+      "properties": {
+        "members": {
+          "description": "Specifies the identities requesting access for a Cloud Platform resource.\n`members` can have the following values:\n\n* `allUsers`: A special identifier that represents anyone who is\n   on the internet; with or without a Google account.\n\n* `allAuthenticatedUsers`: A special identifier that represents anyone\n   who is authenticated with a Google account or a service account.\n\n* `user:{emailid}`: An email address that represents a specific Google\n   account. For example, `alice@gmail.com` or `joe@example.com`.\n\n\n* `serviceAccount:{emailid}`: An email address that represents a service\n   account. For example, `my-other-app@appspot.gserviceaccount.com`.\n\n* `group:{emailid}`: An email address that represents a Google group.\n   For example, `admins@example.com`.\n\n* `domain:{domain}`: A Google Apps domain name that represents all the\n   users of that domain. For example, `google.com` or `example.com`.\n\n",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "role": {
+          "description": "Role that is assigned to `members`.\nFor example, `roles/viewer`, `roles/editor`, or `roles/owner`.\nRequired",
+          "type": "string"
+        }
+      },
+      "id": "Binding"
+    },
+    "ConfigRef": {
+      "description": "Represents a service configuration with its name and id.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Resource name of a service config. It must have the following\nformat: \"services/{service name}/configs/{config id}\".",
+          "type": "string"
+        }
+      },
+      "id": "ConfigRef"
+    },
+    "DataAccessOptions": {
+      "description": "Write a Data Access (Gin) log",
+      "type": "object",
+      "properties": {},
+      "id": "DataAccessOptions"
+    },
+    "AuthProvider": {
+      "description": "Configuration for an anthentication provider, including support for\n[JSON Web Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32).",
+      "type": "object",
+      "properties": {
+        "audiences": {
+          "description": "The list of JWT\n[audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.3).\nthat are allowed to access. A JWT containing any of these audiences will\nbe accepted. When this setting is absent, only JWTs with audience\n\"https://Service_name/API_name\"\nwill be accepted. For example, if no audiences are in the setting,\nLibraryService API will only accept JWTs with the following audience\n\"https://library-example.googleapis.com/google.example.library.v1.LibraryService\".\n\nExample:\n\n    audiences: bookstore_android.apps.googleusercontent.com,\n               bookstore_web.apps.googleusercontent.com",
+          "type": "string"
+        },
+        "jwksUri": {
+          "description": "URL of the provider's public key set to validate signature of the JWT. See\n[OpenID Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).\nOptional if the key set document:\n - can be retrieved from\n   [OpenID Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html\n   of the issuer.\n - can be inferred from the email domain of the issuer (e.g. a Google service account).\n\nExample: https://www.googleapis.com/oauth2/v1/certs",
+          "type": "string"
+        },
+        "id": {
+          "description": "The unique identifier of the auth provider. It will be referred to by\n`AuthRequirement.provider_id`.\n\nExample: \"bookstore_auth\".",
+          "type": "string"
+        },
+        "issuer": {
+          "description": "Identifies the principal that issued the JWT. See\nhttps://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.1\nUsually a URL or an email address.\n\nExample: https://securetoken.google.com\nExample: 1234567-compute@developer.gserviceaccount.com",
+          "type": "string"
+        }
+      },
+      "id": "AuthProvider"
+    },
+    "VisibilityRule": {
+      "description": "A visibility rule provides visibility configuration for an individual API\nelement.",
+      "type": "object",
+      "properties": {
+        "restriction": {
+          "description": "A comma-separated list of visibility labels that apply to the `selector`.\nAny of the listed labels can be used to grant the visibility.\n\nIf a rule has multiple labels, removing one of the labels but not all of\nthem can break clients.\n\nExample:\n\n    visibility:\n      rules:\n      - selector: google.calendar.Calendar.EnhancedSearch\n        restriction: GOOGLE_INTERNAL, TRUSTED_TESTER\n\nRemoving GOOGLE_INTERNAL from this restriction will break clients that\nrely on this method and only had access to it through GOOGLE_INTERNAL.",
+          "type": "string"
+        },
+        "selector": {
+          "description": "Selects methods, messages, fields, enums, etc. to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "id": "VisibilityRule"
+    },
+    "UndeleteServiceResponse": {
+      "description": "Response message for UndeleteService method.",
+      "type": "object",
+      "properties": {
+        "service": {
+          "description": "Revived service resource.",
+          "$ref": "ManagedService"
+        }
+      },
+      "id": "UndeleteServiceResponse"
+    },
+    "UsageRule": {
+      "description": "Usage configuration rules for the service.\n\nNOTE: Under development.\n\n\nUse this rule to configure unregistered calls for the service. Unregistered\ncalls are calls that do not contain consumer project identity.\n(Example: calls that do not contain an API key).\nBy default, API methods do not allow unregistered calls, and each method call\nmust be identified by a consumer project identity. Use this rule to\nallow/disallow unregistered calls.\n\nExample of an API that wants to allow unregistered calls for entire service.\n\n    usage:\n      rules:\n      - selector: \"*\"\n        allow_unregistered_calls: true\n\nExample of a method that wants to allow unregistered calls.\n\n    usage:\n      rules:\n      - selector: \"google.example.library.v1.LibraryService.CreateBook\"\n        allow_unregistered_calls: true",
+      "type": "object",
+      "properties": {
+        "allowUnregisteredCalls": {
+          "description": "True, if the method allows unregistered calls; false otherwise.",
+          "type": "boolean"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies. Use '*' to indicate all\nmethods in all APIs.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "id": "UsageRule"
+    },
+    "EnumValue": {
+      "description": "Enum value definition.",
+      "type": "object",
+      "properties": {
+        "options": {
+          "description": "Protocol buffer options.",
+          "type": "array",
+          "items": {
+            "$ref": "Option"
+          }
+        },
+        "name": {
+          "description": "Enum value name.",
+          "type": "string"
+        },
+        "number": {
+          "description": "Enum value number.",
+          "type": "integer",
+          "format": "int32"
+        }
+      },
+      "id": "EnumValue"
+    },
+    "MediaUpload": {
+      "description": "Do not use this. For media support, add instead\n[][google.bytestream.RestByteStream] as an API to your\nconfiguration.",
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "description": "Whether upload is enabled.",
+          "type": "boolean"
+        }
+      },
+      "id": "MediaUpload"
+    },
+    "BackendRule": {
+      "description": "A backend rule provides configuration for an individual API element.",
+      "type": "object",
+      "properties": {
+        "address": {
+          "description": "The address of the API backend.",
+          "type": "string"
+        },
+        "deadline": {
+          "description": "The number of seconds to wait for a response from a request.  The\ndefault depends on the deployment context.",
+          "type": "number",
+          "format": "double"
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        }
+      },
+      "id": "BackendRule"
+    },
+    "ContextRule": {
+      "description": "A context rule provides information about the context for an individual API\nelement.",
+      "type": "object",
+      "properties": {
+        "provided": {
+          "description": "A list of full type names of provided contexts.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "selector": {
+          "description": "Selects the methods to which this rule applies.\n\nRefer to selector for syntax details.",
+          "type": "string"
+        },
+        "requested": {
+          "description": "A list of full type names of requested contexts.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "ContextRule"
+    },
+    "Http": {
+      "description": "Defines the HTTP configuration for a service. It contains a list of\nHttpRule, each specifying the mapping of an RPC method\nto one or more HTTP REST API methods.",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "description": "A list of HTTP configuration rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "HttpRule"
+          }
+        }
+      },
+      "id": "Http"
+    },
+    "Visibility": {
+      "description": "`Visibility` defines restrictions for the visibility of service\nelements.  Restrictions are specified using visibility labels\n(e.g., TRUSTED_TESTER) that are elsewhere linked to users and projects.\n\nUsers and projects can have access to more than one visibility label. The\neffective visibility for multiple labels is the union of each label's\nelements, plus any unrestricted elements.\n\nIf an element and its parents have no restrictions, visibility is\nunconditionally granted.\n\nExample:\n\n    visibility:\n      rules:\n      - selector: google.calendar.Calendar.EnhancedSearch\n        restriction: TRUSTED_TESTER\n      - selector: google.calendar.Calendar.Delegate\n        restriction: GOOGLE_INTERNAL\n\nHere, all methods are publicly visible except for the restricted methods\nEnhancedSearch and Delegate.",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "description": "A list of visibility rules that apply to individual API elements.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "VisibilityRule"
+          }
+        }
+      },
+      "id": "Visibility"
+    },
+    "ConfigChange": {
+      "description": "Output generated from semantically comparing two versions of a service\nconfiguration.\n\nIncludes detailed information about a field that have changed with\napplicable advice about potential consequences for the change, such as\nbackwards-incompatibility.",
+      "type": "object",
+      "properties": {
+        "newValue": {
+          "description": "Value of the changed object in the new Service configuration,\nin JSON format. This field will not be populated if ChangeType == REMOVED.",
+          "type": "string"
+        },
+        "oldValue": {
+          "description": "Value of the changed object in the old Service configuration,\nin JSON format. This field will not be populated if ChangeType == ADDED.",
+          "type": "string"
+        },
+        "element": {
+          "description": "Object hierarchy path to the change, with levels separated by a '.'\ncharacter. For repeated fields, an applicable unique identifier field is\nused for the index (usually selector, name, or id). For maps, the term\n'key' is used. If the field has no unique identifier, the numeric index\nis used.\nExamples:\n- visibility.rules[selector==\"google.LibraryService.CreateBook\"].restriction\n- quota.metric_rules[selector==\"google\"].metric_costs[key==\"reads\"].value\n- logging.producer_destinations[0]",
+          "type": "string"
+        },
+        "changeType": {
+          "description": "The type for this change, either ADDED, REMOVED, or MODIFIED.",
+          "enum": [
+            "CHANGE_TYPE_UNSPECIFIED",
+            "ADDED",
+            "REMOVED",
+            "MODIFIED"
+          ],
+          "enumDescriptions": [
+            "No value was provided.",
+            "The changed object exists in the 'new' service configuration, but not\nin the 'old' service configuration.",
+            "The changed object exists in the 'old' service configuration, but not\nin the 'new' service configuration.",
+            "The changed object exists in both service configurations, but its value\nis different."
+          ],
+          "type": "string"
+        },
+        "advices": {
+          "description": "Collection of advice provided for this change, useful for determining the\npossible impact of this change.",
+          "type": "array",
+          "items": {
+            "$ref": "Advice"
+          }
+        }
+      },
+      "id": "ConfigChange"
+    },
+    "SystemParameters": {
+      "description": "### System parameter configuration\n\nA system parameter is a special kind of parameter defined by the API\nsystem, not by an individual API. It is typically mapped to an HTTP header\nand/or a URL query parameter. This configuration specifies which methods\nchange the names of the system parameters.",
+      "type": "object",
+      "properties": {
+        "rules": {
+          "description": "Define system parameters.\n\nThe parameters defined here will override the default parameters\nimplemented by the system. If this field is missing from the service\nconfig, default system parameters will be used. Default system parameters\nand names is implementation-dependent.\n\nExample: define api key and alt name for all methods\n\nsystem_parameters\n  rules:\n    - selector: \"*\"\n      parameters:\n        - name: api_key\n          url_query_parameter: api_key\n        - name: alt\n          http_header: Response-Content-Type\n\nExample: define 2 api key names for a specific method.\n\nsystem_parameters\n  rules:\n    - selector: \"/ListShelves\"\n      parameters:\n        - name: api_key\n          http_header: Api-Key1\n        - name: api_key\n          http_header: Api-Key2\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "SystemParameterRule"
+          }
+        }
+      },
+      "id": "SystemParameters"
+    },
+    "LabelDescriptor": {
+      "description": "A description of a label.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "A human-readable description for the label.",
+          "type": "string"
+        },
+        "valueType": {
+          "description": "The type of data that can be assigned to the label.",
+          "enum": [
+            "STRING",
+            "BOOL",
+            "INT64"
+          ],
+          "enumDescriptions": [
+            "A variable-length string. This is the default.",
+            "Boolean; true or false.",
+            "A 64-bit signed integer."
+          ],
+          "type": "string"
+        },
+        "key": {
+          "description": "The label key.",
+          "type": "string"
+        }
+      },
+      "id": "LabelDescriptor"
+    },
+    "Usage": {
+      "description": "Configuration controlling usage of a service.",
+      "type": "object",
+      "properties": {
+        "requirements": {
+          "description": "Requirements that must be satisfied before a consumer project can use the\nservice. Each requirement is of the form \u003cservice.name\u003e/\u003crequirement-id\u003e;\nfor example 'serviceusage.googleapis.com/billing-enabled'.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "rules": {
+          "description": "A list of usage rules that apply to individual API methods.\n\n**NOTE:** All service configuration rules follow \"last one wins\" order.",
+          "type": "array",
+          "items": {
+            "$ref": "UsageRule"
+          }
+        }
+      },
+      "id": "Usage"
+    },
+    "Advice": {
+      "description": "Generated advice about this change, used for providing more\ninformation about how a change will affect the existing service.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "Useful description for why this advice was applied and what actions should\nbe taken to mitigate any implied risks.",
+          "type": "string"
+        }
+      },
+      "id": "Advice"
+    },
+    "CloudAuditOptions": {
+      "description": "Write a Cloud Audit log",
+      "type": "object",
+      "properties": {},
+      "id": "CloudAuditOptions"
+    },
+    "AuthRequirement": {
+      "description": "User-defined authentication requirements, including support for\n[JSON Web Token (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32).",
+      "type": "object",
+      "properties": {
+        "audiences": {
+          "description": "NOTE: This will be deprecated soon, once AuthProvider.audiences is\nimplemented and accepted in all the runtime components.\n\nThe list of JWT\n[audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#section-4.1.3).\nthat are allowed to access. A JWT containing any of these audiences will\nbe accepted. When this setting is absent, only JWTs with audience\n\"https://Service_name/API_name\"\nwill be accepted. For example, if no audiences are in the setting,\nLibraryService API will only accept JWTs with the following audience\n\"https://library-example.googleapis.com/google.example.library.v1.LibraryService\".\n\nExample:\n\n    audiences: bookstore_android.apps.googleusercontent.com,\n               bookstore_web.apps.googleusercontent.com",
+          "type": "string"
+        },
+        "providerId": {
+          "description": "id from authentication provider.\n\nExample:\n\n    provider_id: bookstore_auth",
+          "type": "string"
+        }
+      },
+      "id": "AuthRequirement"
+    },
+    "Control": {
+      "description": "Selects and configures the service controller used by the service.  The\nservice controller handles features like abuse, quota, billing, logging,\nmonitoring, etc.",
+      "type": "object",
+      "properties": {
+        "environment": {
+          "description": "The service control environment to use. If empty, no control plane\nfeature (like quota and billing) will be enabled.",
+          "type": "string"
+        }
+      },
+      "id": "Control"
+    },
+    "SourceContext": {
+      "description": "`SourceContext` represents information about the source of a\nprotobuf element, like the file in which it is defined.",
+      "type": "object",
+      "properties": {
+        "fileName": {
+          "description": "The path-qualified name of the .proto file that contained the associated\nprotobuf element.  For example: `\"google/protobuf/source_context.proto\"`.",
+          "type": "string"
+        }
+      },
+      "id": "SourceContext"
+    }
+  },
+  "revision": "20161114",
+  "basePath": "",
+  "icons": {
+    "x32": "http://www.google.com/images/icons/product/search-32.gif",
+    "x16": "http://www.google.com/images/icons/product/search-16.gif"
+  },
+  "canonicalName": "Service Management",
+  "discoveryVersion": "v1",
+  "baseUrl": "https://servicemanagement.googleapis.com/",
+  "name": "servicemanagement",
+  "parameters": {
+    "access_token": {
+      "description": "OAuth access token.",
+      "type": "string",
+      "location": "query"
+    },
+    "prettyPrint": {
+      "description": "Returns response with indentations and line breaks.",
+      "default": "true",
+      "type": "boolean",
+      "location": "query"
+    },
+    "key": {
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string",
+      "location": "query"
+    },
+    "quotaUser": {
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string",
+      "location": "query"
+    },
+    "pp": {
+      "description": "Pretty-print response.",
+      "default": "true",
+      "type": "boolean",
+      "location": "query"
+    },
+    "fields": {
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string",
+      "location": "query"
+    },
+    "alt": {
+      "description": "Data format for response.",
+      "location": "query",
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "default": "json",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "type": "string"
+    },
+    "$.xgafv": {
+      "description": "V1 error format.",
+      "enum": [
+        "1",
+        "2"
+      ],
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "type": "string",
+      "location": "query"
+    },
+    "callback": {
+      "description": "JSONP",
+      "type": "string",
+      "location": "query"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "type": "string",
+      "location": "query"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "bearer_token": {
+      "description": "OAuth bearer token.",
+      "type": "string",
+      "location": "query"
+    },
+    "upload_protocol": {
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    }
+  },
+  "documentationLink": "https://cloud.google.com/service-management/",
+  "ownerDomain": "google.com",
+  "batchPath": "batch",
+  "servicePath": "",
+  "ownerName": "Google",
+  "version": "v1",
+  "rootUrl": "https://servicemanagement.googleapis.com/",
+  "kind": "discovery#restDescription"
+}

--- a/vendor/google.golang.org/api/servicemanagement/v1/servicemanagement-gen.go
+++ b/vendor/google.golang.org/api/servicemanagement/v1/servicemanagement-gen.go
@@ -1,0 +1,7946 @@
+// Package servicemanagement provides access to the Google Service Management API.
+//
+// See https://cloud.google.com/service-management/
+//
+// Usage example:
+//
+//   import "google.golang.org/api/servicemanagement/v1"
+//   ...
+//   servicemanagementService, err := servicemanagement.New(oauthHttpClient)
+package servicemanagement // import "google.golang.org/api/servicemanagement/v1"
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	context "golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
+	gensupport "google.golang.org/api/gensupport"
+	googleapi "google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = gensupport.MarshalJSON
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Canceled
+var _ = ctxhttp.Do
+
+const apiId = "servicemanagement:v1"
+const apiName = "servicemanagement"
+const apiVersion = "v1"
+const basePath = "https://servicemanagement.googleapis.com/"
+
+// OAuth2 scopes used by this API.
+const (
+	// View and manage your data across Google Cloud Platform services
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// View your data across Google Cloud Platform services
+	CloudPlatformReadOnlyScope = "https://www.googleapis.com/auth/cloud-platform.read-only"
+
+	// Manage your Google API service configuration
+	ServiceManagementScope = "https://www.googleapis.com/auth/service.management"
+
+	// View your Google API service configuration
+	ServiceManagementReadonlyScope = "https://www.googleapis.com/auth/service.management.readonly"
+)
+
+func New(client *http.Client) (*APIService, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &APIService{client: client, BasePath: basePath}
+	s.Operations = NewOperationsService(s)
+	s.Services = NewServicesService(s)
+	return s, nil
+}
+
+type APIService struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	Operations *OperationsService
+
+	Services *ServicesService
+}
+
+func (s *APIService) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewOperationsService(s *APIService) *OperationsService {
+	rs := &OperationsService{s: s}
+	return rs
+}
+
+type OperationsService struct {
+	s *APIService
+}
+
+func NewServicesService(s *APIService) *ServicesService {
+	rs := &ServicesService{s: s}
+	rs.Configs = NewServicesConfigsService(s)
+	rs.Rollouts = NewServicesRolloutsService(s)
+	return rs
+}
+
+type ServicesService struct {
+	s *APIService
+
+	Configs *ServicesConfigsService
+
+	Rollouts *ServicesRolloutsService
+}
+
+func NewServicesConfigsService(s *APIService) *ServicesConfigsService {
+	rs := &ServicesConfigsService{s: s}
+	return rs
+}
+
+type ServicesConfigsService struct {
+	s *APIService
+}
+
+func NewServicesRolloutsService(s *APIService) *ServicesRolloutsService {
+	rs := &ServicesRolloutsService{s: s}
+	return rs
+}
+
+type ServicesRolloutsService struct {
+	s *APIService
+}
+
+// Advice: Generated advice about this change, used for providing
+// more
+// information about how a change will affect the existing service.
+type Advice struct {
+	// Description: Useful description for why this advice was applied and
+	// what actions should
+	// be taken to mitigate any implied risks.
+	Description string `json:"description,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Advice) MarshalJSON() ([]byte, error) {
+	type noMethod Advice
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Api: Api is a light-weight descriptor for a protocol buffer service.
+type Api struct {
+	// Methods: The methods of this api, in unspecified order.
+	Methods []*Method `json:"methods,omitempty"`
+
+	// Mixins: Included APIs. See Mixin.
+	Mixins []*Mixin `json:"mixins,omitempty"`
+
+	// Name: The fully qualified name of this api, including package
+	// name
+	// followed by the api's simple name.
+	Name string `json:"name,omitempty"`
+
+	// Options: Any metadata attached to the API.
+	Options []*Option `json:"options,omitempty"`
+
+	// SourceContext: Source context for the protocol buffer service
+	// represented by this
+	// message.
+	SourceContext *SourceContext `json:"sourceContext,omitempty"`
+
+	// Syntax: The source syntax of the service.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// Version: A version string for this api. If specified, must have the
+	// form
+	// `major-version.minor-version`, as in `1.10`. If the minor version
+	// is omitted, it defaults to zero. If the entire version field
+	// is
+	// empty, the major version is derived from the package name,
+	// as
+	// outlined below. If the field is not empty, the version in the
+	// package name will be verified to be consistent with what is
+	// provided here.
+	//
+	// The versioning schema uses [semantic
+	// versioning](http://semver.org) where the major version
+	// number
+	// indicates a breaking change and the minor version an
+	// additive,
+	// non-breaking change. Both version numbers are signals to users
+	// what to expect from different versions, and should be
+	// carefully
+	// chosen based on the product plan.
+	//
+	// The major version is also reflected in the package name of the
+	// API, which must end in `v<major-version>`, as in
+	// `google.feature.v1`. For major versions 0 and 1, the suffix can
+	// be omitted. Zero major versions must only be used for
+	// experimental, none-GA apis.
+	//
+	Version string `json:"version,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Methods") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Methods") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Api) MarshalJSON() ([]byte, error) {
+	type noMethod Api
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuditConfig: Enables "data access" audit logging for a service and
+// specifies a list
+// of members that are log-exempted.
+type AuditConfig struct {
+	// ExemptedMembers: Specifies the identities that are exempted from
+	// "data access" audit
+	// logging for the `service` specified above.
+	// Follows the same format of Binding.members.
+	ExemptedMembers []string `json:"exemptedMembers,omitempty"`
+
+	// Service: Specifies a service that will be enabled for "data access"
+	// audit
+	// logging.
+	// For example, `resourcemanager`, `storage`, `compute`.
+	// `allServices` is a special value that covers all services.
+	Service string `json:"service,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ExemptedMembers") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ExemptedMembers") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuditConfig) MarshalJSON() ([]byte, error) {
+	type noMethod AuditConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuthProvider: Configuration for an anthentication provider, including
+// support for
+// [JSON Web Token
+// (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32)
+// .
+type AuthProvider struct {
+	// Audiences: The list of
+	// JWT
+	// [audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-
+	// token-32#section-4.1.3).
+	// that are allowed to access. A JWT containing any of these audiences
+	// will
+	// be accepted. When this setting is absent, only JWTs with
+	// audience
+	// "https://Service_name/API_name"
+	// will be accepted. For example, if no audiences are in the
+	// setting,
+	// LibraryService API will only accept JWTs with the following
+	// audience
+	// "https://library-example.googleapis.com/google.example.librar
+	// y.v1.LibraryService".
+	//
+	// Example:
+	//
+	//     audiences: bookstore_android.apps.googleusercontent.com,
+	//                bookstore_web.apps.googleusercontent.com
+	Audiences string `json:"audiences,omitempty"`
+
+	// Id: The unique identifier of the auth provider. It will be referred
+	// to by
+	// `AuthRequirement.provider_id`.
+	//
+	// Example: "bookstore_auth".
+	Id string `json:"id,omitempty"`
+
+	// Issuer: Identifies the principal that issued the JWT.
+	// See
+	// https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32#sec
+	// tion-4.1.1
+	// Usually a URL or an email address.
+	//
+	// Example: https://securetoken.google.com
+	// Example: 1234567-compute@developer.gserviceaccount.com
+	Issuer string `json:"issuer,omitempty"`
+
+	// JwksUri: URL of the provider's public key set to validate signature
+	// of the JWT. See
+	// [OpenID
+	// Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html#
+	// ProviderMetadata).
+	// Optional if the key set document:
+	//  - can be retrieved from
+	//    [OpenID
+	// Discovery](https://openid.net/specs/openid-connect-discovery-1_0.html
+	//
+	//    of the issuer.
+	//  - can be inferred from the email domain of the issuer (e.g. a Google
+	// service account).
+	//
+	// Example: https://www.googleapis.com/oauth2/v1/certs
+	JwksUri string `json:"jwksUri,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Audiences") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Audiences") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuthProvider) MarshalJSON() ([]byte, error) {
+	type noMethod AuthProvider
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuthRequirement: User-defined authentication requirements, including
+// support for
+// [JSON Web Token
+// (JWT)](https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-32)
+// .
+type AuthRequirement struct {
+	// Audiences: NOTE: This will be deprecated soon, once
+	// AuthProvider.audiences is
+	// implemented and accepted in all the runtime components.
+	//
+	// The list of
+	// JWT
+	// [audiences](https://tools.ietf.org/html/draft-ietf-oauth-json-web-
+	// token-32#section-4.1.3).
+	// that are allowed to access. A JWT containing any of these audiences
+	// will
+	// be accepted. When this setting is absent, only JWTs with
+	// audience
+	// "https://Service_name/API_name"
+	// will be accepted. For example, if no audiences are in the
+	// setting,
+	// LibraryService API will only accept JWTs with the following
+	// audience
+	// "https://library-example.googleapis.com/google.example.librar
+	// y.v1.LibraryService".
+	//
+	// Example:
+	//
+	//     audiences: bookstore_android.apps.googleusercontent.com,
+	//                bookstore_web.apps.googleusercontent.com
+	Audiences string `json:"audiences,omitempty"`
+
+	// ProviderId: id from authentication provider.
+	//
+	// Example:
+	//
+	//     provider_id: bookstore_auth
+	ProviderId string `json:"providerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Audiences") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Audiences") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuthRequirement) MarshalJSON() ([]byte, error) {
+	type noMethod AuthRequirement
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Authentication: `Authentication` defines the authentication
+// configuration for an API.
+//
+// Example for an API targeted for external use:
+//
+//     name: calendar.googleapis.com
+//     authentication:
+//       rules:
+//       - selector: "*"
+//         oauth:
+//           canonical_scopes:
+// https://www.googleapis.com/auth/calendar
+//
+//       - selector: google.calendar.Delegate
+//         oauth:
+//           canonical_scopes:
+// https://www.googleapis.com/auth/calendar.read
+type Authentication struct {
+	// Providers: Defines a set of authentication providers that a service
+	// supports.
+	Providers []*AuthProvider `json:"providers,omitempty"`
+
+	// Rules: A list of authentication rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*AuthenticationRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Providers") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Providers") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Authentication) MarshalJSON() ([]byte, error) {
+	type noMethod Authentication
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// AuthenticationRule: Authentication rules for the service.
+//
+// By default, if a method has any authentication requirements, every
+// request
+// must include a valid credential matching one of the
+// requirements.
+// It's an error to include more than one kind of credential in a
+// single
+// request.
+//
+// If a method doesn't have any auth requirements, request credentials
+// will be
+// ignored.
+type AuthenticationRule struct {
+	// AllowWithoutCredential: Whether to allow requests without a
+	// credential. The credential can be
+	// an OAuth token, Google cookies (first-party auth) or
+	// EndUserCreds.
+	//
+	// For requests without credentials, if the service control environment
+	// is
+	// specified, each incoming request **must** be associated with a
+	// service
+	// consumer. This can be done by passing an API key that belongs to a
+	// consumer
+	// project.
+	AllowWithoutCredential bool `json:"allowWithoutCredential,omitempty"`
+
+	// Oauth: The requirements for OAuth credentials.
+	Oauth *OAuthRequirements `json:"oauth,omitempty"`
+
+	// Requirements: Requirements for additional authentication providers.
+	Requirements []*AuthRequirement `json:"requirements,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "AllowWithoutCredential") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AllowWithoutCredential")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AuthenticationRule) MarshalJSON() ([]byte, error) {
+	type noMethod AuthenticationRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Backend: `Backend` defines the backend configuration for a service.
+type Backend struct {
+	// Rules: A list of API backend rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*BackendRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Backend) MarshalJSON() ([]byte, error) {
+	type noMethod Backend
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// BackendRule: A backend rule provides configuration for an individual
+// API element.
+type BackendRule struct {
+	// Address: The address of the API backend.
+	Address string `json:"address,omitempty"`
+
+	// Deadline: The number of seconds to wait for a response from a
+	// request.  The
+	// default depends on the deployment context.
+	Deadline float64 `json:"deadline,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Address") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Address") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *BackendRule) MarshalJSON() ([]byte, error) {
+	type noMethod BackendRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Binding: Associates `members` with a `role`.
+type Binding struct {
+	// Members: Specifies the identities requesting access for a Cloud
+	// Platform resource.
+	// `members` can have the following values:
+	//
+	// * `allUsers`: A special identifier that represents anyone who is
+	//    on the internet; with or without a Google account.
+	//
+	// * `allAuthenticatedUsers`: A special identifier that represents
+	// anyone
+	//    who is authenticated with a Google account or a service
+	// account.
+	//
+	// * `user:{emailid}`: An email address that represents a specific
+	// Google
+	//    account. For example, `alice@gmail.com` or `joe@example.com`.
+	//
+	//
+	// * `serviceAccount:{emailid}`: An email address that represents a
+	// service
+	//    account. For example,
+	// `my-other-app@appspot.gserviceaccount.com`.
+	//
+	// * `group:{emailid}`: An email address that represents a Google
+	// group.
+	//    For example, `admins@example.com`.
+	//
+	// * `domain:{domain}`: A Google Apps domain name that represents all
+	// the
+	//    users of that domain. For example, `google.com` or
+	// `example.com`.
+	//
+	//
+	Members []string `json:"members,omitempty"`
+
+	// Role: Role that is assigned to `members`.
+	// For example, `roles/viewer`, `roles/editor`, or
+	// `roles/owner`.
+	// Required
+	Role string `json:"role,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Members") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Members") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Binding) MarshalJSON() ([]byte, error) {
+	type noMethod Binding
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ChangeReport: Change report associated with a particular service
+// configuration.
+//
+// It contains a list of ConfigChanges based on the comparison
+// between
+// two service configurations.
+type ChangeReport struct {
+	// ConfigChanges: List of changes between two service
+	// configurations.
+	// The changes will be alphabetically sorted based on the identifier
+	// of each change.
+	// A ConfigChange identifier is a dot separated path to the
+	// configuration.
+	// Example:
+	// visibility.rules[selector='LibraryService.CreateBook'].restriction
+	ConfigChanges []*ConfigChange `json:"configChanges,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ConfigChanges") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConfigChanges") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ChangeReport) MarshalJSON() ([]byte, error) {
+	type noMethod ChangeReport
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CloudAuditOptions: Write a Cloud Audit log
+type CloudAuditOptions struct {
+}
+
+// Condition: A condition to be met.
+type Condition struct {
+	// Iam: Trusted attributes supplied by the IAM system.
+	//
+	// Possible values:
+	//   "NO_ATTR" - Default non-attribute.
+	//   "AUTHORITY" - Either principal or (if present) authority selector.
+	//   "ATTRIBUTION" - The principal (even if an authority selector is
+	// present), which
+	// must only be used for attribution, not authorization.
+	Iam string `json:"iam,omitempty"`
+
+	// Op: An operator to apply the subject with.
+	//
+	// Possible values:
+	//   "NO_OP" - Default no-op.
+	//   "EQUALS" - DEPRECATED. Use IN instead.
+	//   "NOT_EQUALS" - DEPRECATED. Use NOT_IN instead.
+	//   "IN" - Set-inclusion check.
+	//   "NOT_IN" - Set-exclusion check.
+	//   "DISCHARGED" - Subject is discharged
+	Op string `json:"op,omitempty"`
+
+	// Svc: Trusted attributes discharged by the service.
+	Svc string `json:"svc,omitempty"`
+
+	// Sys: Trusted attributes supplied by any service that owns resources
+	// and uses
+	// the IAM system for access control.
+	//
+	// Possible values:
+	//   "NO_ATTR" - Default non-attribute type
+	//   "REGION" - Region of the resource
+	//   "SERVICE" - Service name
+	//   "NAME" - Resource name
+	//   "IP" - IP address of the caller
+	Sys string `json:"sys,omitempty"`
+
+	// Value: DEPRECATED. Use 'values' instead.
+	Value string `json:"value,omitempty"`
+
+	// Values: The objects of the condition. This is mutually exclusive with
+	// 'value'.
+	Values []string `json:"values,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Iam") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Iam") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Condition) MarshalJSON() ([]byte, error) {
+	type noMethod Condition
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ConfigChange: Output generated from semantically comparing two
+// versions of a service
+// configuration.
+//
+// Includes detailed information about a field that have changed
+// with
+// applicable advice about potential consequences for the change, such
+// as
+// backwards-incompatibility.
+type ConfigChange struct {
+	// Advices: Collection of advice provided for this change, useful for
+	// determining the
+	// possible impact of this change.
+	Advices []*Advice `json:"advices,omitempty"`
+
+	// ChangeType: The type for this change, either ADDED, REMOVED, or
+	// MODIFIED.
+	//
+	// Possible values:
+	//   "CHANGE_TYPE_UNSPECIFIED" - No value was provided.
+	//   "ADDED" - The changed object exists in the 'new' service
+	// configuration, but not
+	// in the 'old' service configuration.
+	//   "REMOVED" - The changed object exists in the 'old' service
+	// configuration, but not
+	// in the 'new' service configuration.
+	//   "MODIFIED" - The changed object exists in both service
+	// configurations, but its value
+	// is different.
+	ChangeType string `json:"changeType,omitempty"`
+
+	// Element: Object hierarchy path to the change, with levels separated
+	// by a '.'
+	// character. For repeated fields, an applicable unique identifier field
+	// is
+	// used for the index (usually selector, name, or id). For maps, the
+	// term
+	// 'key' is used. If the field has no unique identifier, the numeric
+	// index
+	// is used.
+	// Examples:
+	// -
+	// visibility.rules[selector=="google.LibraryService.CreateBook"].restric
+	// tion
+	// -
+	// quota.metric_rules[selector=="google"].metric_costs[key=="reads"].valu
+	// e
+	// - logging.producer_destinations[0]
+	Element string `json:"element,omitempty"`
+
+	// NewValue: Value of the changed object in the new Service
+	// configuration,
+	// in JSON format. This field will not be populated if ChangeType ==
+	// REMOVED.
+	NewValue string `json:"newValue,omitempty"`
+
+	// OldValue: Value of the changed object in the old Service
+	// configuration,
+	// in JSON format. This field will not be populated if ChangeType ==
+	// ADDED.
+	OldValue string `json:"oldValue,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Advices") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Advices") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ConfigChange) MarshalJSON() ([]byte, error) {
+	type noMethod ConfigChange
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ConfigFile: Generic specification of a source configuration file
+type ConfigFile struct {
+	// FileContents: The bytes that constitute the file.
+	FileContents string `json:"fileContents,omitempty"`
+
+	// FilePath: The file name of the configuration file (full or relative
+	// path).
+	FilePath string `json:"filePath,omitempty"`
+
+	// FileType: The type of configuration file this represents.
+	//
+	// Possible values:
+	//   "FILE_TYPE_UNSPECIFIED" - Unknown file type.
+	//   "SERVICE_CONFIG_YAML" - YAML-specification of service.
+	//   "OPEN_API_JSON" - OpenAPI specification, serialized in JSON.
+	//   "OPEN_API_YAML" - OpenAPI specification, serialized in YAML.
+	//   "FILE_DESCRIPTOR_SET_PROTO" - FileDescriptorSet, generated by
+	// protoc.
+	//
+	// To generate, use protoc with imports and source info included.
+	// For an example test.proto file, the following command would put the
+	// value
+	// in a new file named out.pb.
+	//
+	// $protoc --include_imports --include_source_info test.proto -o out.pb
+	FileType string `json:"fileType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "FileContents") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "FileContents") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ConfigFile) MarshalJSON() ([]byte, error) {
+	type noMethod ConfigFile
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ConfigRef: Represents a service configuration with its name and id.
+type ConfigRef struct {
+	// Name: Resource name of a service config. It must have the
+	// following
+	// format: "services/{service name}/configs/{config id}".
+	Name string `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ConfigRef) MarshalJSON() ([]byte, error) {
+	type noMethod ConfigRef
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ConfigSource: Represents a source file which is used to generate the
+// service configuration
+// defined by `google.api.Service`.
+type ConfigSource struct {
+	// Files: Set of source configuration files that are used to generate a
+	// service
+	// configuration (`google.api.Service`).
+	Files []*ConfigFile `json:"files,omitempty"`
+
+	// Id: A unique ID for a specific instance of this message, typically
+	// assigned
+	// by the client for tracking purpose. If empty, the server may choose
+	// to
+	// generate one instead.
+	Id string `json:"id,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Files") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Files") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ConfigSource) MarshalJSON() ([]byte, error) {
+	type noMethod ConfigSource
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Context: `Context` defines which contexts an API
+// requests.
+//
+// Example:
+//
+//     context:
+//       rules:
+//       - selector: "*"
+//         requested:
+//         - google.rpc.context.ProjectContext
+//         - google.rpc.context.OriginContext
+//
+// The above specifies that all methods in the API
+// request
+// `google.rpc.context.ProjectContext`
+// and
+// `google.rpc.context.OriginContext`.
+//
+// Available context types are defined in package
+// `google.rpc.context`.
+type Context struct {
+	// Rules: A list of RPC context rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*ContextRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Context) MarshalJSON() ([]byte, error) {
+	type noMethod Context
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ContextRule: A context rule provides information about the context
+// for an individual API
+// element.
+type ContextRule struct {
+	// Provided: A list of full type names of provided contexts.
+	Provided []string `json:"provided,omitempty"`
+
+	// Requested: A list of full type names of requested contexts.
+	Requested []string `json:"requested,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Provided") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Provided") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ContextRule) MarshalJSON() ([]byte, error) {
+	type noMethod ContextRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Control: Selects and configures the service controller used by the
+// service.  The
+// service controller handles features like abuse, quota, billing,
+// logging,
+// monitoring, etc.
+type Control struct {
+	// Environment: The service control environment to use. If empty, no
+	// control plane
+	// feature (like quota and billing) will be enabled.
+	Environment string `json:"environment,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Environment") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Environment") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Control) MarshalJSON() ([]byte, error) {
+	type noMethod Control
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CounterOptions: Options for counters
+type CounterOptions struct {
+	// Field: The field value to attribute.
+	Field string `json:"field,omitempty"`
+
+	// Metric: The metric to update.
+	Metric string `json:"metric,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Field") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Field") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CounterOptions) MarshalJSON() ([]byte, error) {
+	type noMethod CounterOptions
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CustomError: Customize service error responses.  For example, list
+// any service
+// specific protobuf types that can appear in error detail lists
+// of
+// error responses.
+//
+// Example:
+//
+//     custom_error:
+//       types:
+//       - google.foo.v1.CustomError
+//       - google.foo.v1.AnotherError
+type CustomError struct {
+	// Rules: The list of custom error rules that apply to individual API
+	// messages.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*CustomErrorRule `json:"rules,omitempty"`
+
+	// Types: The list of custom error detail types, e.g.
+	// 'google.foo.v1.CustomError'.
+	Types []string `json:"types,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CustomError) MarshalJSON() ([]byte, error) {
+	type noMethod CustomError
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CustomErrorRule: A custom error rule.
+type CustomErrorRule struct {
+	// IsErrorType: Mark this message as possible payload in error response.
+	//  Otherwise,
+	// objects of this type will be filtered when they appear in error
+	// payload.
+	IsErrorType bool `json:"isErrorType,omitempty"`
+
+	// Selector: Selects messages to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "IsErrorType") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "IsErrorType") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CustomErrorRule) MarshalJSON() ([]byte, error) {
+	type noMethod CustomErrorRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CustomHttpPattern: A custom pattern is used for defining custom HTTP
+// verb.
+type CustomHttpPattern struct {
+	// Kind: The name of this custom HTTP verb.
+	Kind string `json:"kind,omitempty"`
+
+	// Path: The path matched by this custom verb.
+	Path string `json:"path,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CustomHttpPattern) MarshalJSON() ([]byte, error) {
+	type noMethod CustomHttpPattern
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DataAccessOptions: Write a Data Access (Gin) log
+type DataAccessOptions struct {
+}
+
+// DeleteServiceStrategy: Strategy used to delete a service. This
+// strategy is a placeholder only
+// used by the system generated rollout to delete a service.
+type DeleteServiceStrategy struct {
+}
+
+// Diagnostic: Represents a diagnostic message (error or warning)
+type Diagnostic struct {
+	// Kind: The kind of diagnostic information provided.
+	//
+	// Possible values:
+	//   "WARNING" - Warnings and errors
+	//   "ERROR" - Only errors
+	Kind string `json:"kind,omitempty"`
+
+	// Location: File name and line number of the error or warning.
+	Location string `json:"location,omitempty"`
+
+	// Message: Message describing the error or warning.
+	Message string `json:"message,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Diagnostic) MarshalJSON() ([]byte, error) {
+	type noMethod Diagnostic
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DisableServiceRequest: Request message for DisableService method.
+type DisableServiceRequest struct {
+	// ConsumerId: The identity of consumer resource which service
+	// disablement will be
+	// applied to.
+	//
+	// The Google Service Management implementation accepts the
+	// following
+	// forms:
+	// - "project:<project_id>"
+	//
+	// Note: this is made compatible
+	// with
+	// google.api.servicecontrol.v1.Operation.consumer_id.
+	ConsumerId string `json:"consumerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ConsumerId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumerId") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DisableServiceRequest) MarshalJSON() ([]byte, error) {
+	type noMethod DisableServiceRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Documentation: `Documentation` provides the information for
+// describing a service.
+//
+// Example:
+// <pre><code>documentation:
+//   summary: >
+//     The Google Calendar API gives access
+//     to most calendar features.
+//   pages:
+//   - name: Overview
+//     content: &#40;== include google/foo/overview.md ==&#41;
+//   - name: Tutorial
+//     content: &#40;== include google/foo/tutorial.md ==&#41;
+//     subpages;
+//     - name: Java
+//       content: &#40;== include google/foo/tutorial_java.md ==&#41;
+//   rules:
+//   - selector: google.calendar.Calendar.Get
+//     description: >
+//       ...
+//   - selector: google.calendar.Calendar.Put
+//     description: >
+//       ...
+// </code></pre>
+// Documentation is provided in markdown syntax. In addition to
+// standard markdown features, definition lists, tables and fenced
+// code blocks are supported. Section headers can be provided and
+// are
+// interpreted relative to the section nesting of the context where
+// a documentation fragment is embedded.
+//
+// Documentation from the IDL is merged with documentation defined
+// via the config at normalization time, where documentation provided
+// by config rules overrides IDL provided.
+//
+// A number of constructs specific to the API platform are supported
+// in documentation text.
+//
+// In order to reference a proto element, the following
+// notation can be
+// used:
+// <pre><code>&#91;fully.qualified.proto.name]&#91;]</code></pre>
+// T
+// o override the display text used for the link, this can be
+// used:
+// <pre><code>&#91;display
+// text]&#91;fully.qualified.proto.name]</code></pre>
+// Text can be excluded from doc using the following
+// notation:
+// <pre><code>&#40;-- internal comment --&#41;</code></pre>
+// Comments can be made conditional using a visibility label. The
+// below
+// text will be only rendered if the `BETA` label is
+// available:
+// <pre><code>&#40;--BETA: comment for BETA users --&#41;</code></pre>
+// A few directives are available in documentation. Note that
+// directives must appear on a single line to be properly
+// identified. The `include` directive includes a markdown file from
+// an external source:
+// <pre><code>&#40;== include path/to/file ==&#41;</code></pre>
+// The `resource_for` directive marks a message to be the resource of
+// a collection in REST view. If it is not specified, tools attempt
+// to infer the resource from the operations in a
+// collection:
+// <pre><code>&#40;== resource_for v1.shelves.books
+// ==&#41;</code></pre>
+// The directive `suppress_warning` does not directly affect
+// documentation
+// and is documented together with service config validation.
+type Documentation struct {
+	// DocumentationRootUrl: The URL to the root of documentation.
+	DocumentationRootUrl string `json:"documentationRootUrl,omitempty"`
+
+	// Overview: Declares a single overview page. For
+	// example:
+	// <pre><code>documentation:
+	//   summary: ...
+	//   overview: &#40;== include overview.md ==&#41;
+	// </code></pre>
+	// This is a shortcut for the following declaration (using pages
+	// style):
+	// <pre><code>documentation:
+	//   summary: ...
+	//   pages:
+	//   - name: Overview
+	//     content: &#40;== include overview.md ==&#41;
+	// </code></pre>
+	// Note: you cannot specify both `overview` field and `pages` field.
+	Overview string `json:"overview,omitempty"`
+
+	// Pages: The top level pages for the documentation set.
+	Pages []*Page `json:"pages,omitempty"`
+
+	// Rules: A list of documentation rules that apply to individual API
+	// elements.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*DocumentationRule `json:"rules,omitempty"`
+
+	// Summary: A short summary of what the service does. Can only be
+	// provided by
+	// plain text.
+	Summary string `json:"summary,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "DocumentationRootUrl") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DocumentationRootUrl") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Documentation) MarshalJSON() ([]byte, error) {
+	type noMethod Documentation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DocumentationRule: A documentation rule provides information about
+// individual API elements.
+type DocumentationRule struct {
+	// DeprecationDescription: Deprecation description of the selected
+	// element(s). It can be provided if an
+	// element is marked as `deprecated`.
+	DeprecationDescription string `json:"deprecationDescription,omitempty"`
+
+	// Description: Description of the selected API(s).
+	Description string `json:"description,omitempty"`
+
+	// Selector: The selector is a comma-separated list of patterns. Each
+	// pattern is a
+	// qualified name of the element which may end in "*", indicating a
+	// wildcard.
+	// Wildcards are only allowed at the end and for a whole component of
+	// the
+	// qualified name, i.e. "foo.*" is ok, but not "foo.b*" or "foo.*.bar".
+	// To
+	// specify a default for all applicable elements, the whole pattern
+	// "*"
+	// is used.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "DeprecationDescription") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DeprecationDescription")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DocumentationRule) MarshalJSON() ([]byte, error) {
+	type noMethod DocumentationRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// EnableServiceRequest: Request message for EnableService method.
+type EnableServiceRequest struct {
+	// ConsumerId: The identity of consumer resource which service
+	// enablement will be
+	// applied to.
+	//
+	// The Google Service Management implementation accepts the
+	// following
+	// forms:
+	// - "project:<project_id>"
+	//
+	// Note: this is made compatible
+	// with
+	// google.api.servicecontrol.v1.Operation.consumer_id.
+	ConsumerId string `json:"consumerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ConsumerId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumerId") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *EnableServiceRequest) MarshalJSON() ([]byte, error) {
+	type noMethod EnableServiceRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Endpoint: `Endpoint` describes a network endpoint that serves a set
+// of APIs.
+// A service may expose any number of endpoints, and all endpoints share
+// the
+// same service configuration, such as quota configuration and
+// monitoring
+// configuration.
+//
+// Example service configuration:
+//
+//     name: library-example.googleapis.com
+//     endpoints:
+//       # Below entry makes 'google.example.library.v1.Library'
+//       # API be served from endpoint address
+// library-example.googleapis.com.
+//       # It also allows HTTP OPTIONS calls to be passed to the
+// backend, for
+//       # it to decide whether the subsequent cross-origin request is
+//       # allowed to proceed.
+//     - name: library-example.googleapis.com
+//       apis: google.example.library.v1.Library
+//       allow_cors: true
+//       # Below entry makes 'google.example.library.v1.Library'
+//       # API be served from endpoint address
+//       # google.example.library-example.v1.LibraryManager.
+//     - name: library-manager.googleapis.com
+//       apis: google.example.library.v1.LibraryManager
+//       # BNS address for a borg job. Can specify a task by appending
+//       # "/taskId" (e.g. "/0") to the job spec.
+//
+// Example OpenAPI extension for endpoint with allow_cors set to true:
+//
+//     {
+//       "swagger": "2.0",
+//       "info": {
+//         "description": "A simple..."
+//       },
+//       "host": "MY_PROJECT_ID.appspot.com",
+//       "x-google-endpoints": [{
+//         "name": "MY_PROJECT_ID.appspot.com",
+//         "allow_cors": "true"
+//       }]
+//     }
+type Endpoint struct {
+	// Aliases: DEPRECATED: This field is no longer supported. Instead of
+	// using aliases,
+	// please specify multiple google.api.Endpoint for each of the
+	// intented
+	// alias.
+	//
+	// Additional names that this endpoint will be hosted on.
+	Aliases []string `json:"aliases,omitempty"`
+
+	// AllowCors:
+	// Allowing
+	// [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sh
+	// aring), aka
+	// cross-domain traffic, would allow the backends served from this
+	// endpoint to
+	// receive and respond to HTTP OPTIONS requests. The response will be
+	// used by
+	// the browser to determine whether the subsequent cross-origin request
+	// is
+	// allowed to proceed.
+	AllowCors bool `json:"allowCors,omitempty"`
+
+	// Apis: The list of APIs served by this endpoint.
+	Apis []string `json:"apis,omitempty"`
+
+	// Features: The list of features enabled on this endpoint.
+	Features []string `json:"features,omitempty"`
+
+	// Name: The canonical name of this endpoint.
+	Name string `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Aliases") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Aliases") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Endpoint) MarshalJSON() ([]byte, error) {
+	type noMethod Endpoint
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Enum: Enum type definition.
+type Enum struct {
+	// Enumvalue: Enum value definitions.
+	Enumvalue []*EnumValue `json:"enumvalue,omitempty"`
+
+	// Name: Enum type name.
+	Name string `json:"name,omitempty"`
+
+	// Options: Protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// SourceContext: The source context.
+	SourceContext *SourceContext `json:"sourceContext,omitempty"`
+
+	// Syntax: The source syntax.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Enumvalue") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Enumvalue") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Enum) MarshalJSON() ([]byte, error) {
+	type noMethod Enum
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// EnumValue: Enum value definition.
+type EnumValue struct {
+	// Name: Enum value name.
+	Name string `json:"name,omitempty"`
+
+	// Number: Enum value number.
+	Number int64 `json:"number,omitempty"`
+
+	// Options: Protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *EnumValue) MarshalJSON() ([]byte, error) {
+	type noMethod EnumValue
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Field: A single field of a message type.
+type Field struct {
+	// Cardinality: The field cardinality.
+	//
+	// Possible values:
+	//   "CARDINALITY_UNKNOWN" - For fields with unknown cardinality.
+	//   "CARDINALITY_OPTIONAL" - For optional fields.
+	//   "CARDINALITY_REQUIRED" - For required fields. Proto2 syntax only.
+	//   "CARDINALITY_REPEATED" - For repeated fields.
+	Cardinality string `json:"cardinality,omitempty"`
+
+	// DefaultValue: The string value of the default value of this field.
+	// Proto2 syntax only.
+	DefaultValue string `json:"defaultValue,omitempty"`
+
+	// JsonName: The field JSON name.
+	JsonName string `json:"jsonName,omitempty"`
+
+	// Kind: The field type.
+	//
+	// Possible values:
+	//   "TYPE_UNKNOWN" - Field type unknown.
+	//   "TYPE_DOUBLE" - Field type double.
+	//   "TYPE_FLOAT" - Field type float.
+	//   "TYPE_INT64" - Field type int64.
+	//   "TYPE_UINT64" - Field type uint64.
+	//   "TYPE_INT32" - Field type int32.
+	//   "TYPE_FIXED64" - Field type fixed64.
+	//   "TYPE_FIXED32" - Field type fixed32.
+	//   "TYPE_BOOL" - Field type bool.
+	//   "TYPE_STRING" - Field type string.
+	//   "TYPE_GROUP" - Field type group. Proto2 syntax only, and
+	// deprecated.
+	//   "TYPE_MESSAGE" - Field type message.
+	//   "TYPE_BYTES" - Field type bytes.
+	//   "TYPE_UINT32" - Field type uint32.
+	//   "TYPE_ENUM" - Field type enum.
+	//   "TYPE_SFIXED32" - Field type sfixed32.
+	//   "TYPE_SFIXED64" - Field type sfixed64.
+	//   "TYPE_SINT32" - Field type sint32.
+	//   "TYPE_SINT64" - Field type sint64.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: The field name.
+	Name string `json:"name,omitempty"`
+
+	// Number: The field number.
+	Number int64 `json:"number,omitempty"`
+
+	// OneofIndex: The index of the field type in `Type.oneofs`, for message
+	// or enumeration
+	// types. The first type has index 1; zero means the type is not in the
+	// list.
+	OneofIndex int64 `json:"oneofIndex,omitempty"`
+
+	// Options: The protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// Packed: Whether to use alternative packed wire representation.
+	Packed bool `json:"packed,omitempty"`
+
+	// TypeUrl: The field type URL, without the scheme, for message or
+	// enumeration
+	// types. Example: "type.googleapis.com/google.protobuf.Timestamp".
+	TypeUrl string `json:"typeUrl,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Cardinality") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Cardinality") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Field) MarshalJSON() ([]byte, error) {
+	type noMethod Field
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// GenerateConfigReportRequest: Request message for GenerateConfigReport
+// method.
+type GenerateConfigReportRequest struct {
+	// NewConfig: Service configuration for which we want to generate the
+	// report.
+	// For this version of API, the supported types
+	// are
+	// google.api.servicemanagement.v1.ConfigRef,
+	// google.api.servicemanag
+	// ement.v1.ConfigSource,
+	// and google.api.Service
+	NewConfig GenerateConfigReportRequestNewConfig `json:"newConfig,omitempty"`
+
+	// OldConfig: Service configuration against which the comparison will be
+	// done.
+	// For this version of API, the supported types
+	// are
+	// google.api.servicemanagement.v1.ConfigRef,
+	// google.api.servicemanag
+	// ement.v1.ConfigSource,
+	// and google.api.Service
+	OldConfig GenerateConfigReportRequestOldConfig `json:"oldConfig,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "NewConfig") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "NewConfig") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *GenerateConfigReportRequest) MarshalJSON() ([]byte, error) {
+	type noMethod GenerateConfigReportRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type GenerateConfigReportRequestNewConfig interface{}
+
+type GenerateConfigReportRequestOldConfig interface{}
+
+// GenerateConfigReportResponse: Response message for
+// GenerateConfigReport method.
+type GenerateConfigReportResponse struct {
+	// ChangeReports: list of ChangeReport, each corresponding to comparison
+	// between two
+	// service configurations.
+	ChangeReports []*ChangeReport `json:"changeReports,omitempty"`
+
+	// Diagnostics: Errors / Linter warnings associated with the service
+	// definition this
+	// report
+	// belongs to.
+	Diagnostics []*Diagnostic `json:"diagnostics,omitempty"`
+
+	// Id: ID of the service configuration this report belongs to.
+	Id string `json:"id,omitempty"`
+
+	// ServiceName: Name of the service this report belongs to.
+	ServiceName string `json:"serviceName,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "ChangeReports") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ChangeReports") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *GenerateConfigReportResponse) MarshalJSON() ([]byte, error) {
+	type noMethod GenerateConfigReportResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// GetIamPolicyRequest: Request message for `GetIamPolicy` method.
+type GetIamPolicyRequest struct {
+}
+
+// Http: Defines the HTTP configuration for a service. It contains a
+// list of
+// HttpRule, each specifying the mapping of an RPC method
+// to one or more HTTP REST API methods.
+type Http struct {
+	// Rules: A list of HTTP configuration rules that apply to individual
+	// API methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*HttpRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Http) MarshalJSON() ([]byte, error) {
+	type noMethod Http
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// HttpRule: `HttpRule` defines the mapping of an RPC method to one or
+// more HTTP
+// REST APIs.  The mapping determines what portions of the
+// request
+// message are populated from the path, query parameters, or body of
+// the HTTP request.  The mapping is typically specified as
+// an
+// `google.api.http` annotation, see "google/api/annotations.proto"
+// for details.
+//
+// The mapping consists of a field specifying the path template
+// and
+// method kind.  The path template can refer to fields in the
+// request
+// message, as in the example below which describes a REST GET
+// operation on a resource collection of messages:
+//
+// ```proto
+// service Messaging {
+//   rpc GetMessage(GetMessageRequest) returns (Message) {
+//     option (google.api.http).get =
+// "/v1/messages/{message_id}/{sub.subfield}";
+//   }
+// }
+// message GetMessageRequest {
+//   message SubMessage {
+//     string subfield = 1;
+//   }
+//   string message_id = 1; // mapped to the URL
+//   SubMessage sub = 2;    // `sub.subfield` is url-mapped
+// }
+// message Message {
+//   string text = 1; // content of the resource
+// }
+// ```
+//
+// This definition enables an automatic, bidrectional mapping of
+// HTTP
+// JSON to RPC. Example:
+//
+// HTTP | RPC
+// -----|-----
+// `GET /v1/messages/123456/foo`  | `GetMessage(message_id: "123456"
+// sub: SubMessage(subfield: "foo"))`
+//
+// In general, not only fields but also field paths can be
+// referenced
+// from a path pattern. Fields mapped to the path pattern cannot
+// be
+// repeated and must have a primitive (non-message) type.
+//
+// Any fields in the request message which are not bound by the
+// path
+// pattern automatically become (optional) HTTP query
+// parameters. Assume the following definition of the request
+// message:
+//
+// ```proto
+// message GetMessageRequest {
+//   message SubMessage {
+//     string subfield = 1;
+//   }
+//   string message_id = 1; // mapped to the URL
+//   int64 revision = 2;    // becomes a parameter
+//   SubMessage sub = 3;    // `sub.subfield` becomes a
+// parameter
+// }
+// ```
+//
+// This enables a HTTP JSON to RPC mapping as below:
+//
+// HTTP | RPC
+// -----|-----
+// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
+// `GetMessage(message_id: "123456" revision: 2 sub:
+// SubMessage(subfield: "foo"))`
+//
+// Note that fields which are mapped to HTTP parameters must have
+// a
+// primitive type or a repeated primitive type. Message types are
+// not
+// allowed. In the case of a repeated type, the parameter can
+// be
+// repeated in the URL, as in `...?param=A&param=B`.
+//
+// For HTTP method kinds which allow a request body, the `body`
+// field
+// specifies the mapping. Consider a REST update method on the
+// message resource collection:
+//
+// ```proto
+// service Messaging {
+//   rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//     option (google.api.http) = {
+//       put: "/v1/messages/{message_id}"
+//       body: "message"
+//     };
+//   }
+// }
+// message UpdateMessageRequest {
+//   string message_id = 1; // mapped to the URL
+//   Message message = 2;   // mapped to the body
+// }
+// ```
+//
+// The following HTTP JSON to RPC mapping is enabled, where
+// the
+// representation of the JSON in the request body is determined
+// by
+// protos JSON encoding:
+//
+// HTTP | RPC
+// -----|-----
+// `PUT /v1/messages/123456 { "text": "Hi!" }` |
+// `UpdateMessage(message_id: "123456" message { text: "Hi!" })`
+//
+// The special name `*` can be used in the body mapping to define
+// that
+// every field not bound by the path template should be mapped to
+// the
+// request body.  This enables the following alternative definition
+// of
+// the update method:
+//
+// ```proto
+// service Messaging {
+//   rpc UpdateMessage(Message) returns (Message) {
+//     option (google.api.http) = {
+//       put: "/v1/messages/{message_id}"
+//       body: "*"
+//     };
+//   }
+// }
+// message Message {
+//   string message_id = 1;
+//   string text = 2;
+// }
+// ```
+//
+// The following HTTP JSON to RPC mapping is enabled:
+//
+// HTTP | RPC
+// -----|-----
+// `PUT /v1/messages/123456 { "text": "Hi!" }` |
+// `UpdateMessage(message_id: "123456" text: "Hi!")`
+//
+// Note that when using `*` in the body mapping, it is not possible
+// to
+// have HTTP parameters, as all fields not bound by the path end in
+// the body. This makes this option more rarely used in practice
+// of
+// defining REST APIs. The common usage of `*` is in custom
+// methods
+// which don't use the URL at all for transferring data.
+//
+// It is possible to define multiple HTTP methods for one RPC by
+// using
+// the `additional_bindings` option. Example:
+//
+// ```proto
+// service Messaging {
+//   rpc GetMessage(GetMessageRequest) returns (Message) {
+//     option (google.api.http) = {
+//       get: "/v1/messages/{message_id}"
+//       additional_bindings {
+//         get: "/v1/users/{user_id}/messages/{message_id}"
+//       }
+//     };
+//   }
+// }
+// message GetMessageRequest {
+//   string message_id = 1;
+//   string user_id = 2;
+// }
+// ```
+//
+// This enables the following two alternative HTTP JSON to
+// RPC
+// mappings:
+//
+// HTTP | RPC
+// -----|-----
+// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me"
+// message_id: "123456")`
+//
+// # Rules for HTTP mapping
+//
+// The rules for mapping HTTP path, query parameters, and body fields
+// to the request message are as follows:
+//
+// 1. The `body` field specifies either `*` or a field path, or is
+//    omitted. If omitted, it assumes there is no HTTP body.
+// 2. Leaf fields (recursive expansion of nested messages in the
+//    request) can be classified into three types:
+//     (a) Matched in the URL template.
+//     (b) Covered by body (if body is `*`, everything except (a)
+// fields;
+//         else everything under the body field)
+//     (c) All other fields.
+// 3. URL query parameters found in the HTTP request are mapped to (c)
+// fields.
+// 4. Any body sent with an HTTP request can contain only (b)
+// fields.
+//
+// The syntax of the path template is as follows:
+//
+//     Template = "/" Segments [ Verb ] ;
+//     Segments = Segment { "/" Segment } ;
+//     Segment  = "*" | "**" | LITERAL | Variable ;
+//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//     FieldPath = IDENT { "." IDENT } ;
+//     Verb     = ":" LITERAL ;
+//
+// The syntax `*` matches a single path segment. It follows the
+// semantics of
+// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple
+// String
+// Expansion.
+//
+// The syntax `**` matches zero or more path segments. It follows the
+// semantics
+// of [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.3
+// Reserved
+// Expansion. NOTE: it must be the last segment in the path except the
+// Verb.
+//
+// The syntax `LITERAL` matches literal text in the URL path.
+//
+// The syntax `Variable` matches the entire path as specified by its
+// template;
+// this nested template must not contain further variables. If a
+// variable
+// matches a single path segment, its template may be omitted, e.g.
+// `{var}`
+// is equivalent to `{var=*}`.
+//
+// NOTE: the field paths in variables and in the `body` must not refer
+// to
+// repeated fields or map fields.
+//
+// Use CustomHttpPattern to specify any HTTP method that is not included
+// in the
+// `pattern` field, such as HEAD, or "*" to leave the HTTP method
+// unspecified for
+// a given URL path rule. The wild-card rule is useful for services that
+// provide
+// content to Web (HTML) clients.
+type HttpRule struct {
+	// AdditionalBindings: Additional HTTP bindings for the selector. Nested
+	// bindings must
+	// not contain an `additional_bindings` field themselves (that is,
+	// the nesting may only be one level deep).
+	AdditionalBindings []*HttpRule `json:"additionalBindings,omitempty"`
+
+	// Body: The name of the request field whose value is mapped to the HTTP
+	// body, or
+	// `*` for mapping all fields not captured by the path pattern to the
+	// HTTP
+	// body. NOTE: the referred field must not be a repeated field and must
+	// be
+	// present at the top-level of response message type.
+	Body string `json:"body,omitempty"`
+
+	// Custom: Custom pattern is used for defining custom verbs.
+	Custom *CustomHttpPattern `json:"custom,omitempty"`
+
+	// Delete: Used for deleting a resource.
+	Delete string `json:"delete,omitempty"`
+
+	// Get: Used for listing and getting information about resources.
+	Get string `json:"get,omitempty"`
+
+	// MediaDownload: Do not use this. For media support, add
+	// instead
+	// [][google.bytestream.RestByteStream] as an API to your
+	// configuration.
+	MediaDownload *MediaDownload `json:"mediaDownload,omitempty"`
+
+	// MediaUpload: Do not use this. For media support, add
+	// instead
+	// [][google.bytestream.RestByteStream] as an API to your
+	// configuration.
+	MediaUpload *MediaUpload `json:"mediaUpload,omitempty"`
+
+	// Patch: Used for updating a resource.
+	Patch string `json:"patch,omitempty"`
+
+	// Post: Used for creating a resource.
+	Post string `json:"post,omitempty"`
+
+	// Put: Used for updating a resource.
+	Put string `json:"put,omitempty"`
+
+	// ResponseBody: The name of the response field whose value is mapped to
+	// the HTTP body of
+	// response. Other response fields are ignored. This field is optional.
+	// When
+	// not set, the response message will be used as HTTP body of
+	// response.
+	// NOTE: the referred field must be not a repeated field and must be
+	// present
+	// at the top-level of response message type.
+	ResponseBody string `json:"responseBody,omitempty"`
+
+	// Selector: Selects methods to which this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "AdditionalBindings")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AdditionalBindings") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *HttpRule) MarshalJSON() ([]byte, error) {
+	type noMethod HttpRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LabelDescriptor: A description of a label.
+type LabelDescriptor struct {
+	// Description: A human-readable description for the label.
+	Description string `json:"description,omitempty"`
+
+	// Key: The label key.
+	Key string `json:"key,omitempty"`
+
+	// ValueType: The type of data that can be assigned to the label.
+	//
+	// Possible values:
+	//   "STRING" - A variable-length string. This is the default.
+	//   "BOOL" - Boolean; true or false.
+	//   "INT64" - A 64-bit signed integer.
+	ValueType string `json:"valueType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LabelDescriptor) MarshalJSON() ([]byte, error) {
+	type noMethod LabelDescriptor
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListServiceConfigsResponse: Response message for ListServiceConfigs
+// method.
+type ListServiceConfigsResponse struct {
+	// NextPageToken: The token of the next page of results.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// ServiceConfigs: The list of service configuration resources.
+	ServiceConfigs []*Service `json:"serviceConfigs,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "NextPageToken") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "NextPageToken") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListServiceConfigsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListServiceConfigsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListServiceRolloutsResponse: Response message for ListServiceRollouts
+// method.
+type ListServiceRolloutsResponse struct {
+	// NextPageToken: The token of the next page of results.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// Rollouts: The list of rollout resources.
+	Rollouts []*Rollout `json:"rollouts,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "NextPageToken") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "NextPageToken") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListServiceRolloutsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListServiceRolloutsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListServicesResponse: Response message for `ListServices` method.
+type ListServicesResponse struct {
+	// NextPageToken: Token that can be passed to `ListServices` to resume a
+	// paginated query.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// Services: The returned services will only have the name field set.
+	Services []*ManagedService `json:"services,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "NextPageToken") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "NextPageToken") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListServicesResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListServicesResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LogConfig: Specifies what kind of log the caller must write
+// Increment a streamz counter with the specified metric and field
+// names.
+//
+// Metric names should start with a '/', generally be
+// lowercase-only,
+// and end in "_count". Field names should not contain an initial
+// slash.
+// The actual exported metric names will have "/iam/policy"
+// prepended.
+//
+// Field names correspond to IAM request parameters and field values
+// are
+// their respective values.
+//
+// At present the only supported field names are
+//    - "iam_principal", corresponding to IAMContext.principal;
+//    - "" (empty string), resulting in one aggretated counter with no
+// field.
+//
+// Examples:
+//   counter { metric: "/debug_access_count"  field: "iam_principal" }
+//   ==> increment counter /iam/policy/backend_debug_access_count
+//                         {iam_principal=[value of
+// IAMContext.principal]}
+//
+// At this time we do not support:
+// * multiple field names (though this may be supported in the future)
+// * decrementing the counter
+// * incrementing it by anything other than 1
+type LogConfig struct {
+	// CloudAudit: Cloud audit options.
+	CloudAudit *CloudAuditOptions `json:"cloudAudit,omitempty"`
+
+	// Counter: Counter options.
+	Counter *CounterOptions `json:"counter,omitempty"`
+
+	// DataAccess: Data access options.
+	DataAccess *DataAccessOptions `json:"dataAccess,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CloudAudit") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CloudAudit") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LogConfig) MarshalJSON() ([]byte, error) {
+	type noMethod LogConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LogDescriptor: A description of a log type. Example in YAML format:
+//
+//     - name: library.googleapis.com/activity_history
+//       description: The history of borrowing and returning library
+// items.
+//       display_name: Activity
+//       labels:
+//       - key: /customer_id
+//         description: Identifier of a library customer
+type LogDescriptor struct {
+	// Description: A human-readable description of this log. This
+	// information appears in
+	// the documentation and can contain details.
+	Description string `json:"description,omitempty"`
+
+	// DisplayName: The human-readable name for this log. This information
+	// appears on
+	// the user interface and should be concise.
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Labels: The set of labels that are available to describe a specific
+	// log entry.
+	// Runtime requests that contain labels not specified here
+	// are
+	// considered invalid.
+	Labels []*LabelDescriptor `json:"labels,omitempty"`
+
+	// Name: The name of the log. It must be less than 512 characters long
+	// and can
+	// include the following characters: upper- and lower-case
+	// alphanumeric
+	// characters [A-Za-z0-9], and punctuation characters including
+	// slash, underscore, hyphen, period [/_-.].
+	Name string `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LogDescriptor) MarshalJSON() ([]byte, error) {
+	type noMethod LogDescriptor
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Logging: Logging configuration of the service.
+//
+// The following example shows how to configure logs to be sent to
+// the
+// producer and consumer projects. In the example, the
+// `activity_history`
+// log is sent to both the producer and consumer projects, whereas
+// the
+// `purchase_history` log is only sent to the producer project.
+//
+//     monitored_resources:
+//     - type: library.googleapis.com/branch
+//       labels:
+//       - key: /city
+//         description: The city where the library branch is located
+// in.
+//       - key: /name
+//         description: The name of the branch.
+//     logs:
+//     - name: activity_history
+//       labels:
+//       - key: /customer_id
+//     - name: purchase_history
+//     logging:
+//       producer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         logs:
+//         - activity_history
+//         - purchase_history
+//       consumer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         logs:
+//         - activity_history
+type Logging struct {
+	// ConsumerDestinations: Logging configurations for sending logs to the
+	// consumer project.
+	// There can be multiple consumer destinations, each one must have
+	// a
+	// different monitored resource type. A log can be used in at most
+	// one consumer destination.
+	ConsumerDestinations []*LoggingDestination `json:"consumerDestinations,omitempty"`
+
+	// ProducerDestinations: Logging configurations for sending logs to the
+	// producer project.
+	// There can be multiple producer destinations, each one must have
+	// a
+	// different monitored resource type. A log can be used in at most
+	// one producer destination.
+	ProducerDestinations []*LoggingDestination `json:"producerDestinations,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "ConsumerDestinations") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumerDestinations") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Logging) MarshalJSON() ([]byte, error) {
+	type noMethod Logging
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LoggingDestination: Configuration of a specific logging destination
+// (the producer project
+// or the consumer project).
+type LoggingDestination struct {
+	// Logs: Names of the logs to be sent to this destination. Each name
+	// must
+	// be defined in the Service.logs section. If the log name is
+	// not a domain scoped name, it will be automatically prefixed with
+	// the service name followed by "/".
+	Logs []string `json:"logs,omitempty"`
+
+	// MonitoredResource: The monitored resource type. The type must be
+	// defined in the
+	// Service.monitored_resources section.
+	MonitoredResource string `json:"monitoredResource,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Logs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Logs") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LoggingDestination) MarshalJSON() ([]byte, error) {
+	type noMethod LoggingDestination
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ManagedService: The full representation of a Service that is managed
+// by
+// Google Service Management.
+type ManagedService struct {
+	// ProducerProjectId: ID of the project that produces and owns this
+	// service.
+	ProducerProjectId string `json:"producerProjectId,omitempty"`
+
+	// ServiceName: The name of the service. See the
+	// [overview](/service-management/overview)
+	// for naming requirements.
+	ServiceName string `json:"serviceName,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "ProducerProjectId")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ProducerProjectId") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ManagedService) MarshalJSON() ([]byte, error) {
+	type noMethod ManagedService
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MediaDownload: Do not use this. For media support, add
+// instead
+// [][google.bytestream.RestByteStream] as an API to your
+// configuration.
+type MediaDownload struct {
+	// Enabled: Whether download is enabled.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Enabled") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Enabled") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MediaDownload) MarshalJSON() ([]byte, error) {
+	type noMethod MediaDownload
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MediaUpload: Do not use this. For media support, add
+// instead
+// [][google.bytestream.RestByteStream] as an API to your
+// configuration.
+type MediaUpload struct {
+	// Enabled: Whether upload is enabled.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Enabled") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Enabled") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MediaUpload) MarshalJSON() ([]byte, error) {
+	type noMethod MediaUpload
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Method: Method represents a method of an api.
+type Method struct {
+	// Name: The simple name of this method.
+	Name string `json:"name,omitempty"`
+
+	// Options: Any metadata attached to the method.
+	Options []*Option `json:"options,omitempty"`
+
+	// RequestStreaming: If true, the request is streamed.
+	RequestStreaming bool `json:"requestStreaming,omitempty"`
+
+	// RequestTypeUrl: A URL of the input message type.
+	RequestTypeUrl string `json:"requestTypeUrl,omitempty"`
+
+	// ResponseStreaming: If true, the response is streamed.
+	ResponseStreaming bool `json:"responseStreaming,omitempty"`
+
+	// ResponseTypeUrl: The URL of the output message type.
+	ResponseTypeUrl string `json:"responseTypeUrl,omitempty"`
+
+	// Syntax: The source syntax of this method.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Method) MarshalJSON() ([]byte, error) {
+	type noMethod Method
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MetricDescriptor: Defines a metric type and its schema. Once a metric
+// descriptor is created,
+// deleting or altering it stops data collection and makes the metric
+// type's
+// existing data unusable.
+type MetricDescriptor struct {
+	// Description: A detailed description of the metric, which can be used
+	// in documentation.
+	Description string `json:"description,omitempty"`
+
+	// DisplayName: A concise name for the metric, which can be displayed in
+	// user interfaces.
+	// Use sentence case without an ending period, for example "Request
+	// count".
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Labels: The set of labels that can be used to describe a
+	// specific
+	// instance of this metric type. For example,
+	// the
+	// `appengine.googleapis.com/http/server/response_latencies` metric
+	// type has a label for the HTTP response code, `response_code`, so
+	// you can look at latencies for successful responses or just
+	// for responses that failed.
+	Labels []*LabelDescriptor `json:"labels,omitempty"`
+
+	// MetricKind: Whether the metric records instantaneous values, changes
+	// to a value, etc.
+	// Some combinations of `metric_kind` and `value_type` might not be
+	// supported.
+	//
+	// Possible values:
+	//   "METRIC_KIND_UNSPECIFIED" - Do not use this default value.
+	//   "GAUGE" - An instantaneous measurement of a value.
+	//   "DELTA" - The change in a value during a time interval.
+	//   "CUMULATIVE" - A value accumulated over a time interval.
+	// Cumulative
+	// measurements in a time series should have the same start time
+	// and increasing end times, until an event resets the cumulative
+	// value to zero and sets a new start time for the following
+	// points.
+	MetricKind string `json:"metricKind,omitempty"`
+
+	// Name: The resource name of the metric descriptor. Depending on
+	// the
+	// implementation, the name typically includes: (1) the parent resource
+	// name
+	// that defines the scope of the metric type or of its data; and (2)
+	// the
+	// metric's URL-encoded type, which also appears in the `type` field of
+	// this
+	// descriptor. For example, following is the resource name of a
+	// custom
+	// metric within the GCP project 123456789:
+	//
+	//
+	// "projects/123456789/metricDescriptors/custom.googleapis.com%2Finvoice%
+	// 2Fpaid%2Famount"
+	Name string `json:"name,omitempty"`
+
+	// Type: The metric type, including its DNS name prefix. The type is
+	// not
+	// URL-encoded.  All user-defined metric types have the DNS
+	// name
+	// `custom.googleapis.com`.  Metric types should use a natural
+	// hierarchical
+	// grouping. For example:
+	//
+	//     "custom.googleapis.com/invoice/paid/amount"
+	//     "appengine.googleapis.com/http/server/response_latencies"
+	Type string `json:"type,omitempty"`
+
+	// Unit: The unit in which the metric value is reported. It is only
+	// applicable
+	// if the `value_type` is `INT64`, `DOUBLE`, or `DISTRIBUTION`.
+	// The
+	// supported units are a subset of [The Unified Code for Units
+	// of
+	// Measure](http://unitsofmeasure.org/ucum.html) standard:
+	//
+	// **Basic units (UNIT)**
+	//
+	// * `bit`   bit
+	// * `By`    byte
+	// * `s`     second
+	// * `min`   minute
+	// * `h`     hour
+	// * `d`     day
+	//
+	// **Prefixes (PREFIX)**
+	//
+	// * `k`     kilo    (10**3)
+	// * `M`     mega    (10**6)
+	// * `G`     giga    (10**9)
+	// * `T`     tera    (10**12)
+	// * `P`     peta    (10**15)
+	// * `E`     exa     (10**18)
+	// * `Z`     zetta   (10**21)
+	// * `Y`     yotta   (10**24)
+	// * `m`     milli   (10**-3)
+	// * `u`     micro   (10**-6)
+	// * `n`     nano    (10**-9)
+	// * `p`     pico    (10**-12)
+	// * `f`     femto   (10**-15)
+	// * `a`     atto    (10**-18)
+	// * `z`     zepto   (10**-21)
+	// * `y`     yocto   (10**-24)
+	// * `Ki`    kibi    (2**10)
+	// * `Mi`    mebi    (2**20)
+	// * `Gi`    gibi    (2**30)
+	// * `Ti`    tebi    (2**40)
+	//
+	// **Grammar**
+	//
+	// The grammar includes the dimensionless unit `1`, such as `1/s`.
+	//
+	// The grammar also includes these connectors:
+	//
+	// * `/`    division (as an infix operator, e.g. `1/s`).
+	// * `.`    multiplication (as an infix operator, e.g. `GBy.d`)
+	//
+	// The grammar for a unit is as follows:
+	//
+	//     Expression = Component { "." Component } { "/" Component } ;
+	//
+	//     Component = [ PREFIX ] UNIT [ Annotation ]
+	//               | Annotation
+	//               | "1"
+	//               ;
+	//
+	//     Annotation = "{" NAME "}" ;
+	//
+	// Notes:
+	//
+	// * `Annotation` is just a comment if it follows a `UNIT` and is
+	//    equivalent to `1` if it is used alone. For examples,
+	//    `{requests}/s == 1/s`, `By{transmitted}/s == By/s`.
+	// * `NAME` is a sequence of non-blank printable ASCII characters not
+	//    containing '{' or '}'.
+	Unit string `json:"unit,omitempty"`
+
+	// ValueType: Whether the measurement is an integer, a floating-point
+	// number, etc.
+	// Some combinations of `metric_kind` and `value_type` might not be
+	// supported.
+	//
+	// Possible values:
+	//   "VALUE_TYPE_UNSPECIFIED" - Do not use this default value.
+	//   "BOOL" - The value is a boolean.
+	// This value type can be used only if the metric kind is `GAUGE`.
+	//   "INT64" - The value is a signed 64-bit integer.
+	//   "DOUBLE" - The value is a double precision floating point number.
+	//   "STRING" - The value is a text string.
+	// This value type can be used only if the metric kind is `GAUGE`.
+	//   "DISTRIBUTION" - The value is a `Distribution`.
+	//   "MONEY" - The value is money.
+	ValueType string `json:"valueType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MetricDescriptor) MarshalJSON() ([]byte, error) {
+	type noMethod MetricDescriptor
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Mixin: Declares an API to be included in this API. The including API
+// must
+// redeclare all the methods from the included API, but
+// documentation
+// and options are inherited as follows:
+//
+// - If after comment and whitespace stripping, the documentation
+//   string of the redeclared method is empty, it will be inherited
+//   from the original method.
+//
+// - Each annotation belonging to the service config (http,
+//   visibility) which is not set in the redeclared method will be
+//   inherited.
+//
+// - If an http annotation is inherited, the path pattern will be
+//   modified as follows. Any version prefix will be replaced by the
+//   version of the including API plus the root path if
+// specified.
+//
+// Example of a simple mixin:
+//
+//     package google.acl.v1;
+//     service AccessControl {
+//       // Get the underlying ACL object.
+//       rpc GetAcl(GetAclRequest) returns (Acl) {
+//         option (google.api.http).get = "/v1/{resource=**}:getAcl";
+//       }
+//     }
+//
+//     package google.storage.v2;
+//     service Storage {
+//       //       rpc GetAcl(GetAclRequest) returns (Acl);
+//
+//       // Get a data record.
+//       rpc GetData(GetDataRequest) returns (Data) {
+//         option (google.api.http).get = "/v2/{resource=**}";
+//       }
+//     }
+//
+// Example of a mixin configuration:
+//
+//     apis:
+//     - name: google.storage.v2.Storage
+//       mixins:
+//       - name: google.acl.v1.AccessControl
+//
+// The mixin construct implies that all methods in `AccessControl`
+// are
+// also declared with same name and request/response types in
+// `Storage`. A documentation generator or annotation processor will
+// see the effective `Storage.GetAcl` method after
+// inherting
+// documentation and annotations as follows:
+//
+//     service Storage {
+//       // Get the underlying ACL object.
+//       rpc GetAcl(GetAclRequest) returns (Acl) {
+//         option (google.api.http).get = "/v2/{resource=**}:getAcl";
+//       }
+//       ...
+//     }
+//
+// Note how the version in the path pattern changed from `v1` to
+// `v2`.
+//
+// If the `root` field in the mixin is specified, it should be
+// a
+// relative path under which inherited HTTP paths are placed. Example:
+//
+//     apis:
+//     - name: google.storage.v2.Storage
+//       mixins:
+//       - name: google.acl.v1.AccessControl
+//         root: acls
+//
+// This implies the following inherited HTTP annotation:
+//
+//     service Storage {
+//       // Get the underlying ACL object.
+//       rpc GetAcl(GetAclRequest) returns (Acl) {
+//         option (google.api.http).get =
+// "/v2/acls/{resource=**}:getAcl";
+//       }
+//       ...
+//     }
+type Mixin struct {
+	// Name: The fully qualified name of the API which is included.
+	Name string `json:"name,omitempty"`
+
+	// Root: If non-empty specifies a path under which inherited HTTP
+	// paths
+	// are rooted.
+	Root string `json:"root,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Mixin) MarshalJSON() ([]byte, error) {
+	type noMethod Mixin
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MonitoredResourceDescriptor: An object that describes the schema of a
+// MonitoredResource object using a
+// type name and a set of labels.  For example, the monitored
+// resource
+// descriptor for Google Compute Engine VM instances has a type
+// of
+// "gce_instance" and specifies the use of the labels "instance_id"
+// and
+// "zone" to identify particular VM instances.
+//
+// Different APIs can support different monitored resource types. APIs
+// generally
+// provide a `list` method that returns the monitored resource
+// descriptors used
+// by the API.
+type MonitoredResourceDescriptor struct {
+	// Description: Optional. A detailed description of the monitored
+	// resource type that might
+	// be used in documentation.
+	Description string `json:"description,omitempty"`
+
+	// DisplayName: Optional. A concise name for the monitored resource type
+	// that might be
+	// displayed in user interfaces. It should be a Title Cased Noun
+	// Phrase,
+	// without any article or other determiners. For example,
+	// "Google Cloud SQL Database".
+	DisplayName string `json:"displayName,omitempty"`
+
+	// Labels: Required. A set of labels used to describe instances of this
+	// monitored
+	// resource type. For example, an individual Google Cloud SQL database
+	// is
+	// identified by values for the labels "database_id" and "zone".
+	Labels []*LabelDescriptor `json:"labels,omitempty"`
+
+	// Name: Optional. The resource name of the monitored resource
+	// descriptor:
+	// "projects/{project_id}/monitoredResourceDescriptors/{type
+	// }" where
+	// {type} is the value of the `type` field in this object
+	// and
+	// {project_id} is a project ID that provides API-specific context
+	// for
+	// accessing the type.  APIs that do not use project information can use
+	// the
+	// resource name format "monitoredResourceDescriptors/{type}".
+	Name string `json:"name,omitempty"`
+
+	// Type: Required. The monitored resource type. For example, the
+	// type
+	// "cloudsql_database" represents databases in Google Cloud SQL.
+	// The maximum length of this value is 256 characters.
+	Type string `json:"type,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MonitoredResourceDescriptor) MarshalJSON() ([]byte, error) {
+	type noMethod MonitoredResourceDescriptor
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Monitoring: Monitoring configuration of the service.
+//
+// The example below shows how to configure monitored resources and
+// metrics
+// for monitoring. In the example, a monitored resource and two metrics
+// are
+// defined. The `library.googleapis.com/book/returned_count` metric is
+// sent
+// to both producer and consumer projects, whereas
+// the
+// `library.googleapis.com/book/overdue_count` metric is only sent to
+// the
+// consumer project.
+//
+//     monitored_resources:
+//     - type: library.googleapis.com/branch
+//       labels:
+//       - key: /city
+//         description: The city where the library branch is located
+// in.
+//       - key: /name
+//         description: The name of the branch.
+//     metrics:
+//     - name: library.googleapis.com/book/returned_count
+//       metric_kind: DELTA
+//       value_type: INT64
+//       labels:
+//       - key: /customer_id
+//     - name: library.googleapis.com/book/overdue_count
+//       metric_kind: GAUGE
+//       value_type: INT64
+//       labels:
+//       - key: /customer_id
+//     monitoring:
+//       producer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         metrics:
+//         - library.googleapis.com/book/returned_count
+//       consumer_destinations:
+//       - monitored_resource: library.googleapis.com/branch
+//         metrics:
+//         - library.googleapis.com/book/returned_count
+//         - library.googleapis.com/book/overdue_count
+type Monitoring struct {
+	// ConsumerDestinations: Monitoring configurations for sending metrics
+	// to the consumer project.
+	// There can be multiple consumer destinations, each one must have
+	// a
+	// different monitored resource type. A metric can be used in at
+	// most
+	// one consumer destination.
+	ConsumerDestinations []*MonitoringDestination `json:"consumerDestinations,omitempty"`
+
+	// ProducerDestinations: Monitoring configurations for sending metrics
+	// to the producer project.
+	// There can be multiple producer destinations, each one must have
+	// a
+	// different monitored resource type. A metric can be used in at
+	// most
+	// one producer destination.
+	ProducerDestinations []*MonitoringDestination `json:"producerDestinations,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "ConsumerDestinations") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumerDestinations") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Monitoring) MarshalJSON() ([]byte, error) {
+	type noMethod Monitoring
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MonitoringDestination: Configuration of a specific monitoring
+// destination (the producer project
+// or the consumer project).
+type MonitoringDestination struct {
+	// Metrics: Names of the metrics to report to this monitoring
+	// destination.
+	// Each name must be defined in Service.metrics section.
+	Metrics []string `json:"metrics,omitempty"`
+
+	// MonitoredResource: The monitored resource type. The type must be
+	// defined in
+	// Service.monitored_resources section.
+	MonitoredResource string `json:"monitoredResource,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Metrics") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Metrics") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MonitoringDestination) MarshalJSON() ([]byte, error) {
+	type noMethod MonitoringDestination
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// OAuthRequirements: OAuth scopes are a way to define data and
+// permissions on data. For example,
+// there are scopes defined for "Read-only access to Google Calendar"
+// and
+// "Access to Cloud Platform". Users can consent to a scope for an
+// application,
+// giving it permission to access that data on their behalf.
+//
+// OAuth scope specifications should be fairly coarse grained; a user
+// will need
+// to see and understand the text description of what your scope
+// means.
+//
+// In most cases: use one or at most two OAuth scopes for an entire
+// family of
+// products. If your product has multiple APIs, you should probably be
+// sharing
+// the OAuth scope across all of those APIs.
+//
+// When you need finer grained OAuth consent screens: talk with your
+// product
+// management about how developers will use them in practice.
+//
+// Please note that even though each of the canonical scopes is enough
+// for a
+// request to be accepted and passed to the backend, a request can still
+// fail
+// due to the backend requiring additional scopes or permissions.
+type OAuthRequirements struct {
+	// CanonicalScopes: The list of publicly documented OAuth scopes that
+	// are allowed access. An
+	// OAuth token containing any of these scopes will be
+	// accepted.
+	//
+	// Example:
+	//
+	//      canonical_scopes: https://www.googleapis.com/auth/calendar,
+	//                        https://www.googleapis.com/auth/calendar.read
+	CanonicalScopes string `json:"canonicalScopes,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CanonicalScopes") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CanonicalScopes") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *OAuthRequirements) MarshalJSON() ([]byte, error) {
+	type noMethod OAuthRequirements
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Operation: This resource represents a long-running operation that is
+// the result of a
+// network API call.
+type Operation struct {
+	// Done: If the value is `false`, it means the operation is still in
+	// progress.
+	// If true, the operation is completed, and either `error` or `response`
+	// is
+	// available.
+	Done bool `json:"done,omitempty"`
+
+	// Error: The error result of the operation in case of failure or
+	// cancellation.
+	Error *Status `json:"error,omitempty"`
+
+	// Metadata: Service-specific metadata associated with the operation.
+	// It typically
+	// contains progress information and common metadata such as create
+	// time.
+	// Some services might not provide such metadata.  Any method that
+	// returns a
+	// long-running operation should document the metadata type, if any.
+	Metadata OperationMetadata `json:"metadata,omitempty"`
+
+	// Name: The server-assigned name, which is only unique within the same
+	// service that
+	// originally returns it. If you use the default HTTP mapping,
+	// the
+	// `name` should have the format of `operations/some/unique/name`.
+	Name string `json:"name,omitempty"`
+
+	// Response: The normal response of the operation in case of success.
+	// If the original
+	// method returns no data on success, such as `Delete`, the response
+	// is
+	// `google.protobuf.Empty`.  If the original method is
+	// standard
+	// `Get`/`Create`/`Update`, the response should be the resource.  For
+	// other
+	// methods, the response should have the type `XxxResponse`, where
+	// `Xxx`
+	// is the original method name.  For example, if the original method
+	// name
+	// is `TakeSnapshot()`, the inferred response type
+	// is
+	// `TakeSnapshotResponse`.
+	Response OperationResponse `json:"response,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Done") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Done") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Operation) MarshalJSON() ([]byte, error) {
+	type noMethod Operation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type OperationMetadata interface{}
+
+type OperationResponse interface{}
+
+// OperationMetadata1: The metadata associated with a long running
+// operation resource.
+type OperationMetadata1 struct {
+	// ProgressPercentage: Percentage of completion of this operation,
+	// ranging from 0 to 100.
+	ProgressPercentage int64 `json:"progressPercentage,omitempty"`
+
+	// ResourceNames: The full name of the resources that this operation is
+	// directly
+	// associated with.
+	ResourceNames []string `json:"resourceNames,omitempty"`
+
+	// StartTime: The start time of the operation.
+	StartTime string `json:"startTime,omitempty"`
+
+	// Steps: Detailed status information for each step. The order is
+	// undetermined.
+	Steps []*Step `json:"steps,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ProgressPercentage")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ProgressPercentage") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *OperationMetadata1) MarshalJSON() ([]byte, error) {
+	type noMethod OperationMetadata1
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Option: A protocol buffer option, which can be attached to a message,
+// field,
+// enumeration, etc.
+type Option struct {
+	// Name: The option's name. For example, "java_package".
+	Name string `json:"name,omitempty"`
+
+	// Value: The option's value. For example, "com.google.protobuf".
+	Value OptionValue `json:"value,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Option) MarshalJSON() ([]byte, error) {
+	type noMethod Option
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type OptionValue interface{}
+
+// Page: Represents a documentation page. A page can contain subpages to
+// represent
+// nested documentation set structure.
+type Page struct {
+	// Content: The Markdown content of the page. You can use <code>&#40;==
+	// include {path} ==&#41;</code>
+	// to include content from a Markdown file.
+	Content string `json:"content,omitempty"`
+
+	// Name: The name of the page. It will be used as an identity of the
+	// page to
+	// generate URI of the page, text of the link to this page in
+	// navigation,
+	// etc. The full page name (start from the root page name to this
+	// page
+	// concatenated with `.`) can be used as reference to the page in
+	// your
+	// documentation. For example:
+	// <pre><code>pages:
+	// - name: Tutorial
+	//   content: &#40;== include tutorial.md ==&#41;
+	//   subpages:
+	//   - name: Java
+	//     content: &#40;== include tutorial_java.md
+	// ==&#41;
+	// </code></pre>
+	// You can reference `Java` page using Markdown reference link
+	// syntax:
+	// `Java`.
+	Name string `json:"name,omitempty"`
+
+	// Subpages: Subpages of this page. The order of subpages specified here
+	// will be
+	// honored in the generated docset.
+	Subpages []*Page `json:"subpages,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Content") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Content") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Page) MarshalJSON() ([]byte, error) {
+	type noMethod Page
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Policy: Defines an Identity and Access Management (IAM) policy. It is
+// used to
+// specify access control policies for Cloud Platform resources.
+//
+//
+// A `Policy` consists of a list of `bindings`. A `Binding` binds a list
+// of
+// `members` to a `role`, where the members can be user accounts, Google
+// groups,
+// Google domains, and service accounts. A `role` is a named list of
+// permissions
+// defined by IAM.
+//
+// **Example**
+//
+//     {
+//       "bindings": [
+//         {
+//           "role": "roles/owner",
+//           "members": [
+//             "user:mike@example.com",
+//             "group:admins@example.com",
+//             "domain:google.com",
+//
+// "serviceAccount:my-other-app@appspot.gserviceaccount.com",
+//           ]
+//         },
+//         {
+//           "role": "roles/viewer",
+//           "members": ["user:sean@example.com"]
+//         }
+//       ]
+//     }
+//
+// For a description of IAM and its features, see the
+// [IAM developer's guide](https://cloud.google.com/iam).
+type Policy struct {
+	// AuditConfigs: Specifies audit logging configs for "data
+	// access".
+	// "data access": generally refers to data reads/writes and admin
+	// reads.
+	// "admin activity": generally refers to admin writes.
+	//
+	// Note: `AuditConfig` doesn't apply to "admin activity", which
+	// always
+	// enables audit logging.
+	AuditConfigs []*AuditConfig `json:"auditConfigs,omitempty"`
+
+	// Bindings: Associates a list of `members` to a `role`.
+	// Multiple `bindings` must not be specified for the same
+	// `role`.
+	// `bindings` with no members will result in an error.
+	Bindings []*Binding `json:"bindings,omitempty"`
+
+	// Etag: `etag` is used for optimistic concurrency control as a way to
+	// help
+	// prevent simultaneous updates of a policy from overwriting each
+	// other.
+	// It is strongly suggested that systems make use of the `etag` in
+	// the
+	// read-modify-write cycle to perform policy updates in order to avoid
+	// race
+	// conditions: An `etag` is returned in the response to `getIamPolicy`,
+	// and
+	// systems are expected to put that etag in the request to
+	// `setIamPolicy` to
+	// ensure that their change will be applied to the same version of the
+	// policy.
+	//
+	// If no `etag` is provided in the call to `setIamPolicy`, then the
+	// existing
+	// policy is overwritten blindly.
+	Etag string `json:"etag,omitempty"`
+
+	IamOwned bool `json:"iamOwned,omitempty"`
+
+	// Rules: If more than one rule is specified, the rules are applied in
+	// the following
+	// manner:
+	// - All matching LOG rules are always applied.
+	// - If any DENY/DENY_WITH_LOG rule matches, permission is denied.
+	//   Logging will be applied if one or more matching rule requires
+	// logging.
+	// - Otherwise, if any ALLOW/ALLOW_WITH_LOG rule matches, permission is
+	//   granted.
+	//   Logging will be applied if one or more matching rule requires
+	// logging.
+	// - Otherwise, if no rule applies, permission is denied.
+	Rules []*Rule `json:"rules,omitempty"`
+
+	// Version: Version of the `Policy`. The default version is 0.
+	Version int64 `json:"version,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "AuditConfigs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AuditConfigs") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Policy) MarshalJSON() ([]byte, error) {
+	type noMethod Policy
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Rollout: A rollout resource that defines how service configuration
+// versions are pushed
+// to control plane systems. Typically, you create a new version of
+// the
+// service config, and then create a Rollout to push the service config.
+type Rollout struct {
+	// CreateTime: Creation time of the rollout. Readonly.
+	CreateTime string `json:"createTime,omitempty"`
+
+	// CreatedBy: The user who created the Rollout. Readonly.
+	CreatedBy string `json:"createdBy,omitempty"`
+
+	// DeleteServiceStrategy: The strategy associated with a rollout to
+	// delete a `ManagedService`.
+	// Readonly.
+	DeleteServiceStrategy *DeleteServiceStrategy `json:"deleteServiceStrategy,omitempty"`
+
+	// RolloutId: Optional unique identifier of this Rollout. Only lower
+	// case letters, digits
+	//  and '-' are allowed.
+	//
+	// If not specified by client, the server will generate one. The
+	// generated id
+	// will have the form of <date><revision number>, where "date" is the
+	// create
+	// date in ISO 8601 format.  "revision number" is a monotonically
+	// increasing
+	// positive number that is reset every day for each service.
+	// An example of the generated rollout_id is '2016-02-16r1'
+	RolloutId string `json:"rolloutId,omitempty"`
+
+	// ServiceName: The name of the service associated with this Rollout.
+	ServiceName string `json:"serviceName,omitempty"`
+
+	// Status: The status of this rollout. Readonly. In case of a failed
+	// rollout,
+	// the system will automatically rollback to the current
+	// Rollout
+	// version. Readonly.
+	//
+	// Possible values:
+	//   "ROLLOUT_STATUS_UNSPECIFIED" - No status specified.
+	//   "IN_PROGRESS" - The Rollout is in progress.
+	//   "SUCCESS" - The Rollout has completed successfully.
+	//   "CANCELLED" - The Rollout has been cancelled. This can happen if
+	// you have overlapping
+	// Rollout pushes, and the previous ones will be cancelled.
+	//   "FAILED" - The Rollout has failed. It is typically caused by
+	// configuration errors.
+	//   "PENDING" - The Rollout has not started yet and is pending for
+	// execution.
+	Status string `json:"status,omitempty"`
+
+	// TrafficPercentStrategy: Google Service Control selects service
+	// configurations based on
+	// traffic percentage.
+	TrafficPercentStrategy *TrafficPercentStrategy `json:"trafficPercentStrategy,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "CreateTime") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CreateTime") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Rollout) MarshalJSON() ([]byte, error) {
+	type noMethod Rollout
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Rule: A rule to be applied in a Policy.
+type Rule struct {
+	// Action: Required
+	//
+	// Possible values:
+	//   "NO_ACTION" - Default no action.
+	//   "ALLOW" - Matching 'Entries' grant access.
+	//   "ALLOW_WITH_LOG" - Matching 'Entries' grant access and the caller
+	// promises to log
+	// the request per the returned log_configs.
+	//   "DENY" - Matching 'Entries' deny access.
+	//   "DENY_WITH_LOG" - Matching 'Entries' deny access and the caller
+	// promises to log
+	// the request per the returned log_configs.
+	//   "LOG" - Matching 'Entries' tell IAM.Check callers to generate logs.
+	Action string `json:"action,omitempty"`
+
+	// Conditions: Additional restrictions that must be met
+	Conditions []*Condition `json:"conditions,omitempty"`
+
+	// Description: Human-readable description of the rule.
+	Description string `json:"description,omitempty"`
+
+	// In: If one or more 'in' clauses are specified, the rule matches
+	// if
+	// the PRINCIPAL/AUTHORITY_SELECTOR is in at least one of these entries.
+	In []string `json:"in,omitempty"`
+
+	// LogConfig: The config returned to callers of tech.iam.IAM.CheckPolicy
+	// for any entries
+	// that match the LOG action.
+	LogConfig []*LogConfig `json:"logConfig,omitempty"`
+
+	// NotIn: If one or more 'not_in' clauses are specified, the rule
+	// matches
+	// if the PRINCIPAL/AUTHORITY_SELECTOR is in none of the entries.
+	// The format for in and not_in entries is the same as for members in
+	// a
+	// Binding (see google/iam/v1/policy.proto).
+	NotIn []string `json:"notIn,omitempty"`
+
+	// Permissions: A permission is a string of form '<service>.<resource
+	// type>.<verb>'
+	// (e.g., 'storage.buckets.list'). A value of '*' matches all
+	// permissions,
+	// and a verb part of '*' (e.g., 'storage.buckets.*') matches all verbs.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Action") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Action") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Rule) MarshalJSON() ([]byte, error) {
+	type noMethod Rule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Service: `Service` is the root object of Google service configuration
+// schema. It
+// describes basic information about a service, such as the name and
+// the
+// title, and delegates other aspects to sub-sections. Each sub-section
+// is
+// either a proto message or a repeated proto message that configures
+// a
+// specific aspect, such as auth. See each proto message definition for
+// details.
+//
+// Example:
+//
+//     type: google.api.Service
+//     config_version: 3
+//     name: calendar.googleapis.com
+//     title: Google Calendar API
+//     apis:
+//     - name: google.calendar.v3.Calendar
+//     backend:
+//       rules:
+//       - selector: "google.calendar.v3.*"
+//         address: calendar.example.com
+type Service struct {
+	// Apis: A list of API interfaces exported by this service. Only the
+	// `name` field
+	// of the google.protobuf.Api needs to be provided by the
+	// configuration
+	// author, as the remaining fields will be derived from the IDL during
+	// the
+	// normalization process. It is an error to specify an API interface
+	// here
+	// which cannot be resolved against the associated IDL files.
+	Apis []*Api `json:"apis,omitempty"`
+
+	// Authentication: Auth configuration.
+	Authentication *Authentication `json:"authentication,omitempty"`
+
+	// Backend: API backend configuration.
+	Backend *Backend `json:"backend,omitempty"`
+
+	// ConfigVersion: The version of the service configuration. The config
+	// version may
+	// influence interpretation of the configuration, for example,
+	// to
+	// determine defaults. This is documented together with
+	// applicable
+	// options. The current default for the config version itself is `3`.
+	ConfigVersion int64 `json:"configVersion,omitempty"`
+
+	// Context: Context configuration.
+	Context *Context `json:"context,omitempty"`
+
+	// Control: Configuration for the service control plane.
+	Control *Control `json:"control,omitempty"`
+
+	// CustomError: Custom error configuration.
+	CustomError *CustomError `json:"customError,omitempty"`
+
+	// Documentation: Additional API documentation.
+	Documentation *Documentation `json:"documentation,omitempty"`
+
+	// Endpoints: Configuration for network endpoints.  If this is empty,
+	// then an endpoint
+	// with the same name as the service is automatically generated to
+	// service all
+	// defined APIs.
+	Endpoints []*Endpoint `json:"endpoints,omitempty"`
+
+	// Enums: A list of all enum types included in this API service.
+	// Enums
+	// referenced directly or indirectly by the `apis` are
+	// automatically
+	// included.  Enums which are not referenced but shall be
+	// included
+	// should be listed here by name. Example:
+	//
+	//     enums:
+	//     - name: google.someapi.v1.SomeEnum
+	Enums []*Enum `json:"enums,omitempty"`
+
+	// Http: HTTP configuration.
+	Http *Http `json:"http,omitempty"`
+
+	// Id: A unique ID for a specific instance of this message, typically
+	// assigned
+	// by the client for tracking purpose. If empty, the server may choose
+	// to
+	// generate one instead.
+	Id string `json:"id,omitempty"`
+
+	// Logging: Logging configuration.
+	Logging *Logging `json:"logging,omitempty"`
+
+	// Logs: Defines the logs used by this service.
+	Logs []*LogDescriptor `json:"logs,omitempty"`
+
+	// Metrics: Defines the metrics used by this service.
+	Metrics []*MetricDescriptor `json:"metrics,omitempty"`
+
+	// MonitoredResources: Defines the monitored resources used by this
+	// service. This is required
+	// by the Service.monitoring and Service.logging configurations.
+	MonitoredResources []*MonitoredResourceDescriptor `json:"monitoredResources,omitempty"`
+
+	// Monitoring: Monitoring configuration.
+	Monitoring *Monitoring `json:"monitoring,omitempty"`
+
+	// Name: The DNS address at which this service is available,
+	// e.g. `calendar.googleapis.com`.
+	Name string `json:"name,omitempty"`
+
+	// ProducerProjectId: The id of the Google developer project that owns
+	// the service.
+	// Members of this project can manage the service configuration,
+	// manage consumption of the service, etc.
+	ProducerProjectId string `json:"producerProjectId,omitempty"`
+
+	// SystemParameters: System parameter configuration.
+	SystemParameters *SystemParameters `json:"systemParameters,omitempty"`
+
+	// SystemTypes: A list of all proto message types included in this API
+	// service.
+	// It serves similar purpose as [google.api.Service.types], except
+	// that
+	// these types are not needed by user-defined APIs. Therefore, they will
+	// not
+	// show up in the generated discovery doc. This field should only be
+	// used
+	// to define system APIs in ESF.
+	SystemTypes []*Type `json:"systemTypes,omitempty"`
+
+	// Title: The product title associated with this service.
+	Title string `json:"title,omitempty"`
+
+	// Types: A list of all proto message types included in this API
+	// service.
+	// Types referenced directly or indirectly by the `apis`
+	// are
+	// automatically included.  Messages which are not referenced but
+	// shall be included, such as types used by the `google.protobuf.Any`
+	// type,
+	// should be listed here by name. Example:
+	//
+	//     types:
+	//     - name: google.protobuf.Int32
+	Types []*Type `json:"types,omitempty"`
+
+	// Usage: Configuration controlling usage of this service.
+	Usage *Usage `json:"usage,omitempty"`
+
+	// Visibility: API visibility configuration.
+	Visibility *Visibility `json:"visibility,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Apis") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Apis") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Service) MarshalJSON() ([]byte, error) {
+	type noMethod Service
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SetIamPolicyRequest: Request message for `SetIamPolicy` method.
+type SetIamPolicyRequest struct {
+	// Policy: REQUIRED: The complete policy to be applied to the
+	// `resource`. The size of
+	// the policy is limited to a few 10s of KB. An empty policy is a
+	// valid policy but certain Cloud Platform services (such as
+	// Projects)
+	// might reject them.
+	Policy *Policy `json:"policy,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Policy") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Policy") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SetIamPolicyRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SetIamPolicyRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceContext: `SourceContext` represents information about the
+// source of a
+// protobuf element, like the file in which it is defined.
+type SourceContext struct {
+	// FileName: The path-qualified name of the .proto file that contained
+	// the associated
+	// protobuf element.  For example:
+	// "google/protobuf/source_context.proto".
+	FileName string `json:"fileName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "FileName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "FileName") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceContext) MarshalJSON() ([]byte, error) {
+	type noMethod SourceContext
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Status: The `Status` type defines a logical error model that is
+// suitable for different
+// programming environments, including REST APIs and RPC APIs. It is
+// used by
+// [gRPC](https://github.com/grpc). The error model is designed to
+// be:
+//
+// - Simple to use and understand for most users
+// - Flexible enough to meet unexpected needs
+//
+// # Overview
+//
+// The `Status` message contains three pieces of data: error code, error
+// message,
+// and error details. The error code should be an enum value
+// of
+// google.rpc.Code, but it may accept additional error codes if needed.
+// The
+// error message should be a developer-facing English message that
+// helps
+// developers *understand* and *resolve* the error. If a localized
+// user-facing
+// error message is needed, put the localized message in the error
+// details or
+// localize it in the client. The optional error details may contain
+// arbitrary
+// information about the error. There is a predefined set of error
+// detail types
+// in the package `google.rpc` which can be used for common error
+// conditions.
+//
+// # Language mapping
+//
+// The `Status` message is the logical representation of the error
+// model, but it
+// is not necessarily the actual wire format. When the `Status` message
+// is
+// exposed in different client libraries and different wire protocols,
+// it can be
+// mapped differently. For example, it will likely be mapped to some
+// exceptions
+// in Java, but more likely mapped to some error codes in C.
+//
+// # Other uses
+//
+// The error model and the `Status` message can be used in a variety
+// of
+// environments, either with or without APIs, to provide a
+// consistent developer experience across different
+// environments.
+//
+// Example uses of this error model include:
+//
+// - Partial errors. If a service needs to return partial errors to the
+// client,
+//     it may embed the `Status` in the normal response to indicate the
+// partial
+//     errors.
+//
+// - Workflow errors. A typical workflow has multiple steps. Each step
+// may
+//     have a `Status` message for error reporting purpose.
+//
+// - Batch operations. If a client uses batch request and batch
+// response, the
+//     `Status` message should be used directly inside batch response,
+// one for
+//     each error sub-response.
+//
+// - Asynchronous operations. If an API call embeds asynchronous
+// operation
+//     results in its response, the status of those operations should
+// be
+//     represented directly using the `Status` message.
+//
+// - Logging. If some API errors are stored in logs, the message
+// `Status` could
+//     be used directly after any stripping needed for security/privacy
+// reasons.
+type Status struct {
+	// Code: The status code, which should be an enum value of
+	// google.rpc.Code.
+	Code int64 `json:"code,omitempty"`
+
+	// Details: A list of messages that carry the error details.  There will
+	// be a
+	// common set of message types for APIs to use.
+	Details []StatusDetails `json:"details,omitempty"`
+
+	// Message: A developer-facing error message, which should be in
+	// English. Any
+	// user-facing error message should be localized and sent in
+	// the
+	// google.rpc.Status.details field, or localized by the client.
+	Message string `json:"message,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Code") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Code") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Status) MarshalJSON() ([]byte, error) {
+	type noMethod Status
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+type StatusDetails interface{}
+
+// Step: Represents the status of one operation step.
+type Step struct {
+	// Description: The short description of the step.
+	Description string `json:"description,omitempty"`
+
+	// Status: The status code.
+	//
+	// Possible values:
+	//   "STATUS_UNSPECIFIED" - Unspecifed code.
+	//   "DONE" - The step has completed without errors.
+	//   "NOT_STARTED" - The step has not started yet.
+	//   "IN_PROGRESS" - The step is in progress.
+	//   "FAILED" - The step has completed with errors.
+	//   "CANCELLED" - The step has completed with cancellation.
+	Status string `json:"status,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Step) MarshalJSON() ([]byte, error) {
+	type noMethod Step
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SubmitConfigSourceRequest: Request message for SubmitConfigSource
+// method.
+type SubmitConfigSourceRequest struct {
+	// ConfigSource: The source configuration for the service.
+	ConfigSource *ConfigSource `json:"configSource,omitempty"`
+
+	// ValidateOnly: Optional. If set, this will result in the generation of
+	// a
+	// `google.api.Service` configuration based on the `ConfigSource`
+	// provided,
+	// but the generated config and the sources will NOT be persisted.
+	ValidateOnly bool `json:"validateOnly,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ConfigSource") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConfigSource") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SubmitConfigSourceRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SubmitConfigSourceRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SubmitConfigSourceResponse: Response message for SubmitConfigSource
+// method.
+type SubmitConfigSourceResponse struct {
+	// ServiceConfig: The generated service configuration.
+	ServiceConfig *Service `json:"serviceConfig,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ServiceConfig") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ServiceConfig") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SubmitConfigSourceResponse) MarshalJSON() ([]byte, error) {
+	type noMethod SubmitConfigSourceResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SystemParameter: Define a parameter's name and location. The
+// parameter may be passed as either
+// an HTTP header or a URL query parameter, and if both are passed the
+// behavior
+// is implementation-dependent.
+type SystemParameter struct {
+	// HttpHeader: Define the HTTP header name to use for the parameter. It
+	// is case
+	// insensitive.
+	HttpHeader string `json:"httpHeader,omitempty"`
+
+	// Name: Define the name of the parameter, such as "api_key", "alt",
+	// "callback",
+	// and etc. It is case sensitive.
+	Name string `json:"name,omitempty"`
+
+	// UrlQueryParameter: Define the URL query parameter name to use for the
+	// parameter. It is case
+	// sensitive.
+	UrlQueryParameter string `json:"urlQueryParameter,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "HttpHeader") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "HttpHeader") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SystemParameter) MarshalJSON() ([]byte, error) {
+	type noMethod SystemParameter
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SystemParameterRule: Define a system parameter rule mapping system
+// parameter definitions to
+// methods.
+type SystemParameterRule struct {
+	// Parameters: Define parameters. Multiple names may be defined for a
+	// parameter.
+	// For a given method call, only one of them should be used. If
+	// multiple
+	// names are used the behavior is implementation-dependent.
+	// If none of the specified names are present the behavior
+	// is
+	// parameter-dependent.
+	Parameters []*SystemParameter `json:"parameters,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies. Use '*' to
+	// indicate all
+	// methods in all APIs.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Parameters") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Parameters") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SystemParameterRule) MarshalJSON() ([]byte, error) {
+	type noMethod SystemParameterRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SystemParameters: ### System parameter configuration
+//
+// A system parameter is a special kind of parameter defined by the
+// API
+// system, not by an individual API. It is typically mapped to an HTTP
+// header
+// and/or a URL query parameter. This configuration specifies which
+// methods
+// change the names of the system parameters.
+type SystemParameters struct {
+	// Rules: Define system parameters.
+	//
+	// The parameters defined here will override the default
+	// parameters
+	// implemented by the system. If this field is missing from the
+	// service
+	// config, default system parameters will be used. Default system
+	// parameters
+	// and names is implementation-dependent.
+	//
+	// Example: define api key and alt name for all
+	// methods
+	//
+	// system_parameters
+	//   rules:
+	//     - selector: "*"
+	//       parameters:
+	//         - name: api_key
+	//           url_query_parameter: api_key
+	//         - name: alt
+	//           http_header: Response-Content-Type
+	//
+	// Example: define 2 api key names for a specific
+	// method.
+	//
+	// system_parameters
+	//   rules:
+	//     - selector: "/ListShelves"
+	//       parameters:
+	//         - name: api_key
+	//           http_header: Api-Key1
+	//         - name: api_key
+	//           http_header: Api-Key2
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*SystemParameterRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SystemParameters) MarshalJSON() ([]byte, error) {
+	type noMethod SystemParameters
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TestIamPermissionsRequest: Request message for `TestIamPermissions`
+// method.
+type TestIamPermissionsRequest struct {
+	// Permissions: The set of permissions to check for the `resource`.
+	// Permissions with
+	// wildcards (such as '*' or 'storage.*') are not allowed. For
+	// more
+	// information see
+	// [IAM
+	// Overview](https://cloud.google.com/iam/docs/overview#permissions).
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Permissions") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsRequest) MarshalJSON() ([]byte, error) {
+	type noMethod TestIamPermissionsRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TestIamPermissionsResponse: Response message for `TestIamPermissions`
+// method.
+type TestIamPermissionsResponse struct {
+	// Permissions: A subset of `TestPermissionsRequest.permissions` that
+	// the caller is
+	// allowed.
+	Permissions []string `json:"permissions,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Permissions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Permissions") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TestIamPermissionsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod TestIamPermissionsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TrafficPercentStrategy: Strategy that specifies how Google Service
+// Control should select
+// different
+// versions of service configurations based on traffic percentage.
+//
+// One example of how to gradually rollout a new service configuration
+// using
+// this
+// strategy:
+// Day 1
+//
+//     Rollout {
+//       id: "example.googleapis.com/rollout_20160206"
+//       traffic_percent_strategy {
+//         percentages: {
+//           "example.googleapis.com/20160201": 70.00
+//           "example.googleapis.com/20160206": 30.00
+//         }
+//       }
+//     }
+//
+// Day 2
+//
+//     Rollout {
+//       id: "example.googleapis.com/rollout_20160207"
+//       traffic_percent_strategy: {
+//         percentages: {
+//           "example.googleapis.com/20160206": 100.00
+//         }
+//       }
+//     }
+type TrafficPercentStrategy struct {
+	// Percentages: Maps service configuration IDs to their corresponding
+	// traffic percentage.
+	// Key is the service configuration ID, Value is the traffic
+	// percentage
+	// which must be greater than 0.0 and the sum must equal to 100.0.
+	Percentages map[string]float64 `json:"percentages,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Percentages") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Percentages") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TrafficPercentStrategy) MarshalJSON() ([]byte, error) {
+	type noMethod TrafficPercentStrategy
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Type: A protocol buffer message type.
+type Type struct {
+	// Fields: The list of fields.
+	Fields []*Field `json:"fields,omitempty"`
+
+	// Name: The fully qualified message name.
+	Name string `json:"name,omitempty"`
+
+	// Oneofs: The list of types appearing in `oneof` definitions in this
+	// type.
+	Oneofs []string `json:"oneofs,omitempty"`
+
+	// Options: The protocol buffer options.
+	Options []*Option `json:"options,omitempty"`
+
+	// SourceContext: The source context.
+	SourceContext *SourceContext `json:"sourceContext,omitempty"`
+
+	// Syntax: The source syntax.
+	//
+	// Possible values:
+	//   "SYNTAX_PROTO2" - Syntax `proto2`.
+	//   "SYNTAX_PROTO3" - Syntax `proto3`.
+	Syntax string `json:"syntax,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Fields") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Fields") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Type) MarshalJSON() ([]byte, error) {
+	type noMethod Type
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// UndeleteServiceResponse: Response message for UndeleteService method.
+type UndeleteServiceResponse struct {
+	// Service: Revived service resource.
+	Service *ManagedService `json:"service,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Service") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Service") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *UndeleteServiceResponse) MarshalJSON() ([]byte, error) {
+	type noMethod UndeleteServiceResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Usage: Configuration controlling usage of a service.
+type Usage struct {
+	// Requirements: Requirements that must be satisfied before a consumer
+	// project can use the
+	// service. Each requirement is of the form
+	// <service.name>/<requirement-id>;
+	// for example 'serviceusage.googleapis.com/billing-enabled'.
+	Requirements []string `json:"requirements,omitempty"`
+
+	// Rules: A list of usage rules that apply to individual API
+	// methods.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*UsageRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Requirements") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Requirements") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Usage) MarshalJSON() ([]byte, error) {
+	type noMethod Usage
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// UsageRule: Usage configuration rules for the service.
+//
+// NOTE: Under development.
+//
+//
+// Use this rule to configure unregistered calls for the service.
+// Unregistered
+// calls are calls that do not contain consumer project
+// identity.
+// (Example: calls that do not contain an API key).
+// By default, API methods do not allow unregistered calls, and each
+// method call
+// must be identified by a consumer project identity. Use this rule
+// to
+// allow/disallow unregistered calls.
+//
+// Example of an API that wants to allow unregistered calls for entire
+// service.
+//
+//     usage:
+//       rules:
+//       - selector: "*"
+//         allow_unregistered_calls: true
+//
+// Example of a method that wants to allow unregistered calls.
+//
+//     usage:
+//       rules:
+//       - selector:
+// "google.example.library.v1.LibraryService.CreateBook"
+//         allow_unregistered_calls: true
+type UsageRule struct {
+	// AllowUnregisteredCalls: True, if the method allows unregistered
+	// calls; false otherwise.
+	AllowUnregisteredCalls bool `json:"allowUnregisteredCalls,omitempty"`
+
+	// Selector: Selects the methods to which this rule applies. Use '*' to
+	// indicate all
+	// methods in all APIs.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "AllowUnregisteredCalls") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AllowUnregisteredCalls")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *UsageRule) MarshalJSON() ([]byte, error) {
+	type noMethod UsageRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Visibility: `Visibility` defines restrictions for the visibility of
+// service
+// elements.  Restrictions are specified using visibility labels
+// (e.g., TRUSTED_TESTER) that are elsewhere linked to users and
+// projects.
+//
+// Users and projects can have access to more than one visibility label.
+// The
+// effective visibility for multiple labels is the union of each
+// label's
+// elements, plus any unrestricted elements.
+//
+// If an element and its parents have no restrictions, visibility
+// is
+// unconditionally granted.
+//
+// Example:
+//
+//     visibility:
+//       rules:
+//       - selector: google.calendar.Calendar.EnhancedSearch
+//         restriction: TRUSTED_TESTER
+//       - selector: google.calendar.Calendar.Delegate
+//         restriction: GOOGLE_INTERNAL
+//
+// Here, all methods are publicly visible except for the restricted
+// methods
+// EnhancedSearch and Delegate.
+type Visibility struct {
+	// Rules: A list of visibility rules that apply to individual API
+	// elements.
+	//
+	// **NOTE:** All service configuration rules follow "last one wins"
+	// order.
+	Rules []*VisibilityRule `json:"rules,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Rules") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rules") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Visibility) MarshalJSON() ([]byte, error) {
+	type noMethod Visibility
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// VisibilityRule: A visibility rule provides visibility configuration
+// for an individual API
+// element.
+type VisibilityRule struct {
+	// Restriction: A comma-separated list of visibility labels that apply
+	// to the `selector`.
+	// Any of the listed labels can be used to grant the visibility.
+	//
+	// If a rule has multiple labels, removing one of the labels but not all
+	// of
+	// them can break clients.
+	//
+	// Example:
+	//
+	//     visibility:
+	//       rules:
+	//       - selector: google.calendar.Calendar.EnhancedSearch
+	//         restriction: GOOGLE_INTERNAL, TRUSTED_TESTER
+	//
+	// Removing GOOGLE_INTERNAL from this restriction will break clients
+	// that
+	// rely on this method and only had access to it through
+	// GOOGLE_INTERNAL.
+	Restriction string `json:"restriction,omitempty"`
+
+	// Selector: Selects methods, messages, fields, enums, etc. to which
+	// this rule applies.
+	//
+	// Refer to selector for syntax details.
+	Selector string `json:"selector,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Restriction") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Restriction") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *VisibilityRule) MarshalJSON() ([]byte, error) {
+	type noMethod VisibilityRule
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// method id "servicemanagement.operations.get":
+
+type OperationsGetCall struct {
+	s            *APIService
+	name         string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets the latest state of a long-running operation.  Clients can
+// use this
+// method to poll the operation result at intervals as recommended by
+// the API
+// service.
+func (r *OperationsService) Get(name string) *OperationsGetCall {
+	c := &OperationsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.name = name
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *OperationsGetCall) Fields(s ...googleapi.Field) *OperationsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *OperationsGetCall) IfNoneMatch(entityTag string) *OperationsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *OperationsGetCall) Context(ctx context.Context) *OperationsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *OperationsGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *OperationsGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+name}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"name": c.name,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.operations.get" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *OperationsGetCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets the latest state of a long-running operation.  Clients can use this\nmethod to poll the operation result at intervals as recommended by the API\nservice.",
+	//   "flatPath": "v1/operations/{operationsId}",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.operations.get",
+	//   "parameterOrder": [
+	//     "name"
+	//   ],
+	//   "parameters": {
+	//     "name": {
+	//       "description": "The name of the operation resource.",
+	//       "location": "path",
+	//       "pattern": "^operations/.+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+name}",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.create":
+
+type ServicesCreateCall struct {
+	s              *APIService
+	managedservice *ManagedService
+	urlParams_     gensupport.URLParams
+	ctx_           context.Context
+	header_        http.Header
+}
+
+// Create: Creates a new managed service.
+// Please note one producer project can own no more than 20
+// services.
+//
+// Operation<response: ManagedService>
+func (r *ServicesService) Create(managedservice *ManagedService) *ServicesCreateCall {
+	c := &ServicesCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.managedservice = managedservice
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesCreateCall) Fields(s ...googleapi.Field) *ServicesCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesCreateCall) Context(ctx context.Context) *ServicesCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.managedservice)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.create" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesCreateCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new managed service.\nPlease note one producer project can own no more than 20 services.\n\nOperation\u003cresponse: ManagedService\u003e",
+	//   "flatPath": "v1/services",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.create",
+	//   "parameterOrder": [],
+	//   "parameters": {},
+	//   "path": "v1/services",
+	//   "request": {
+	//     "$ref": "ManagedService"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.delete":
+
+type ServicesDeleteCall struct {
+	s           *APIService
+	serviceName string
+	urlParams_  gensupport.URLParams
+	ctx_        context.Context
+	header_     http.Header
+}
+
+// Delete: Deletes a managed service. This method will change the
+// service to the
+// `Soft-Delete` state for 30 days. Within this period, service
+// producers may
+// call UndeleteService to restore the service.
+// After 30 days, the service will be permanently
+// deleted.
+//
+// Operation<response: google.protobuf.Empty>
+func (r *ServicesService) Delete(serviceName string) *ServicesDeleteCall {
+	c := &ServicesDeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesDeleteCall) Fields(s ...googleapi.Field) *ServicesDeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesDeleteCall) Context(ctx context.Context) *ServicesDeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesDeleteCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesDeleteCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("DELETE", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.delete" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesDeleteCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Deletes a managed service. This method will change the service to the\n`Soft-Delete` state for 30 days. Within this period, service producers may\ncall UndeleteService to restore the service.\nAfter 30 days, the service will be permanently deleted.\n\nOperation\u003cresponse: google.protobuf.Empty\u003e",
+	//   "flatPath": "v1/services/{serviceName}",
+	//   "httpMethod": "DELETE",
+	//   "id": "servicemanagement.services.delete",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.disable":
+
+type ServicesDisableCall struct {
+	s                     *APIService
+	serviceName           string
+	disableservicerequest *DisableServiceRequest
+	urlParams_            gensupport.URLParams
+	ctx_                  context.Context
+	header_               http.Header
+}
+
+// Disable: Disable a managed service for a
+// project.
+//
+// Operation<response: DisableServiceResponse>
+func (r *ServicesService) Disable(serviceName string, disableservicerequest *DisableServiceRequest) *ServicesDisableCall {
+	c := &ServicesDisableCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	c.disableservicerequest = disableservicerequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesDisableCall) Fields(s ...googleapi.Field) *ServicesDisableCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesDisableCall) Context(ctx context.Context) *ServicesDisableCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesDisableCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesDisableCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.disableservicerequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}:disable")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.disable" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesDisableCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Disable a managed service for a project.\n\nOperation\u003cresponse: DisableServiceResponse\u003e",
+	//   "flatPath": "v1/services/{serviceName}:disable",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.disable",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "Name of the service to disable. Specifying an unknown service name\nwill cause the request to fail.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}:disable",
+	//   "request": {
+	//     "$ref": "DisableServiceRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.enable":
+
+type ServicesEnableCall struct {
+	s                    *APIService
+	serviceName          string
+	enableservicerequest *EnableServiceRequest
+	urlParams_           gensupport.URLParams
+	ctx_                 context.Context
+	header_              http.Header
+}
+
+// Enable: Enable a managed service for a project with default
+// setting.
+//
+// Operation<response: EnableServiceResponse>
+//
+// google.rpc.Status errors may contain a
+// google.rpc.PreconditionFailure error detail.
+func (r *ServicesService) Enable(serviceName string, enableservicerequest *EnableServiceRequest) *ServicesEnableCall {
+	c := &ServicesEnableCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	c.enableservicerequest = enableservicerequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesEnableCall) Fields(s ...googleapi.Field) *ServicesEnableCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesEnableCall) Context(ctx context.Context) *ServicesEnableCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesEnableCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesEnableCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.enableservicerequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}:enable")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.enable" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesEnableCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Enable a managed service for a project with default setting.\n\nOperation\u003cresponse: EnableServiceResponse\u003e\n\ngoogle.rpc.Status errors may contain a\ngoogle.rpc.PreconditionFailure error detail.",
+	//   "flatPath": "v1/services/{serviceName}:enable",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.enable",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "Name of the service to enable. Specifying an unknown service name will\ncause the request to fail.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}:enable",
+	//   "request": {
+	//     "$ref": "EnableServiceRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.generateConfigReport":
+
+type ServicesGenerateConfigReportCall struct {
+	s                           *APIService
+	generateconfigreportrequest *GenerateConfigReportRequest
+	urlParams_                  gensupport.URLParams
+	ctx_                        context.Context
+	header_                     http.Header
+}
+
+// GenerateConfigReport: Generates and returns a report (errors,
+// warnings and changes from
+// existing configurations) associated
+// with
+// GenerateConfigReportRequest.new_value
+//
+// If GenerateConfigReportRequest.old_value is
+// specified,
+// GenerateConfigReportRequest will contain a single ChangeReport based
+// on the
+// comparison between GenerateConfigReportRequest.new_value
+// and
+// GenerateConfigReportRequest.old_value.
+// If GenerateConfigReportRequest.old_value is not specified, this
+// method
+// will compare GenerateConfigReportRequest.new_value with the last
+// pushed
+// service configuration.
+func (r *ServicesService) GenerateConfigReport(generateconfigreportrequest *GenerateConfigReportRequest) *ServicesGenerateConfigReportCall {
+	c := &ServicesGenerateConfigReportCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.generateconfigreportrequest = generateconfigreportrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesGenerateConfigReportCall) Fields(s ...googleapi.Field) *ServicesGenerateConfigReportCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesGenerateConfigReportCall) Context(ctx context.Context) *ServicesGenerateConfigReportCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesGenerateConfigReportCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesGenerateConfigReportCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.generateconfigreportrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services:generateConfigReport")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.generateConfigReport" call.
+// Exactly one of *GenerateConfigReportResponse or error will be
+// non-nil. Any non-2xx status code is an error. Response headers are in
+// either *GenerateConfigReportResponse.ServerResponse.Header or (if a
+// response was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ServicesGenerateConfigReportCall) Do(opts ...googleapi.CallOption) (*GenerateConfigReportResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &GenerateConfigReportResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Generates and returns a report (errors, warnings and changes from\nexisting configurations) associated with\nGenerateConfigReportRequest.new_value\n\nIf GenerateConfigReportRequest.old_value is specified,\nGenerateConfigReportRequest will contain a single ChangeReport based on the\ncomparison between GenerateConfigReportRequest.new_value and\nGenerateConfigReportRequest.old_value.\nIf GenerateConfigReportRequest.old_value is not specified, this method\nwill compare GenerateConfigReportRequest.new_value with the last pushed\nservice configuration.",
+	//   "flatPath": "v1/services:generateConfigReport",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.generateConfigReport",
+	//   "parameterOrder": [],
+	//   "parameters": {},
+	//   "path": "v1/services:generateConfigReport",
+	//   "request": {
+	//     "$ref": "GenerateConfigReportRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "GenerateConfigReportResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.get":
+
+type ServicesGetCall struct {
+	s            *APIService
+	serviceName  string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets a managed service. Authentication is required unless the
+// service is
+// public.
+func (r *ServicesService) Get(serviceName string) *ServicesGetCall {
+	c := &ServicesGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesGetCall) Fields(s ...googleapi.Field) *ServicesGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesGetCall) IfNoneMatch(entityTag string) *ServicesGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesGetCall) Context(ctx context.Context) *ServicesGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.get" call.
+// Exactly one of *ManagedService or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *ManagedService.ServerResponse.Header or (if a response was returned
+// at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ServicesGetCall) Do(opts ...googleapi.CallOption) (*ManagedService, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ManagedService{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets a managed service. Authentication is required unless the service is\npublic.",
+	//   "flatPath": "v1/services/{serviceName}",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.services.get",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the `ServiceManager` overview for naming\nrequirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}",
+	//   "response": {
+	//     "$ref": "ManagedService"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only",
+	//     "https://www.googleapis.com/auth/service.management",
+	//     "https://www.googleapis.com/auth/service.management.readonly"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.getConfig":
+
+type ServicesGetConfigCall struct {
+	s            *APIService
+	serviceName  string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// GetConfig: Gets a service configuration (version) for a managed
+// service.
+func (r *ServicesService) GetConfig(serviceName string) *ServicesGetConfigCall {
+	c := &ServicesGetConfigCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	return c
+}
+
+// ConfigId sets the optional parameter "configId": The id of the
+// service configuration resource.
+func (c *ServicesGetConfigCall) ConfigId(configId string) *ServicesGetConfigCall {
+	c.urlParams_.Set("configId", configId)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesGetConfigCall) Fields(s ...googleapi.Field) *ServicesGetConfigCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesGetConfigCall) IfNoneMatch(entityTag string) *ServicesGetConfigCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesGetConfigCall) Context(ctx context.Context) *ServicesGetConfigCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesGetConfigCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesGetConfigCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/config")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.getConfig" call.
+// Exactly one of *Service or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Service.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ServicesGetConfigCall) Do(opts ...googleapi.CallOption) (*Service, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Service{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets a service configuration (version) for a managed service.",
+	//   "flatPath": "v1/services/{serviceName}/config",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.services.getConfig",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "configId": {
+	//       "description": "The id of the service configuration resource.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/config",
+	//   "response": {
+	//     "$ref": "Service"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only",
+	//     "https://www.googleapis.com/auth/service.management",
+	//     "https://www.googleapis.com/auth/service.management.readonly"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.getIamPolicy":
+
+type ServicesGetIamPolicyCall struct {
+	s                   *APIService
+	resource            string
+	getiampolicyrequest *GetIamPolicyRequest
+	urlParams_          gensupport.URLParams
+	ctx_                context.Context
+	header_             http.Header
+}
+
+// GetIamPolicy: Gets the access control policy for a resource.
+// Returns an empty policy if the resource exists and does not have a
+// policy
+// set.
+func (r *ServicesService) GetIamPolicy(resource string, getiampolicyrequest *GetIamPolicyRequest) *ServicesGetIamPolicyCall {
+	c := &ServicesGetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.getiampolicyrequest = getiampolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesGetIamPolicyCall) Fields(s ...googleapi.Field) *ServicesGetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesGetIamPolicyCall) Context(ctx context.Context) *ServicesGetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesGetIamPolicyCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesGetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.getiampolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:getIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.getIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ServicesGetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets the access control policy for a resource.\nReturns an empty policy if the resource exists and does not have a policy\nset.",
+	//   "flatPath": "v1/services/{servicesId}:getIamPolicy",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.getIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being requested.\n`resource` is usually specified as a path. For example, a Project\nresource is specified as `projects/{project}`.",
+	//       "location": "path",
+	//       "pattern": "^services/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:getIamPolicy",
+	//   "request": {
+	//     "$ref": "GetIamPolicyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.list":
+
+type ServicesListCall struct {
+	s            *APIService
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Lists all managed services. The result is limited to services
+// that the
+// caller has "servicemanagement.services.get" permission for. If the
+// request
+// is made without authentication, it returns only public services that
+// are
+// available to everyone.
+func (r *ServicesService) List() *ServicesListCall {
+	c := &ServicesListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	return c
+}
+
+// ConsumerId sets the optional parameter "consumerId": Include services
+// consumed by the specified consumer.
+//
+// The Google Service Management implementation accepts the
+// following
+// forms:
+// - project:<project_id>
+func (c *ServicesListCall) ConsumerId(consumerId string) *ServicesListCall {
+	c.urlParams_.Set("consumerId", consumerId)
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": Requested size of
+// the next page of data.
+func (c *ServicesListCall) PageSize(pageSize int64) *ServicesListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": Token identifying
+// which result to start with; returned by a previous list
+// call.
+func (c *ServicesListCall) PageToken(pageToken string) *ServicesListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// ProducerProjectId sets the optional parameter "producerProjectId":
+// Include services produced by the specified project.
+func (c *ServicesListCall) ProducerProjectId(producerProjectId string) *ServicesListCall {
+	c.urlParams_.Set("producerProjectId", producerProjectId)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesListCall) Fields(s ...googleapi.Field) *ServicesListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesListCall) IfNoneMatch(entityTag string) *ServicesListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesListCall) Context(ctx context.Context) *ServicesListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.list" call.
+// Exactly one of *ListServicesResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListServicesResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ServicesListCall) Do(opts ...googleapi.CallOption) (*ListServicesResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListServicesResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists all managed services. The result is limited to services that the\ncaller has \"servicemanagement.services.get\" permission for. If the request\nis made without authentication, it returns only public services that are\navailable to everyone.",
+	//   "flatPath": "v1/services",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.services.list",
+	//   "parameterOrder": [],
+	//   "parameters": {
+	//     "consumerId": {
+	//       "description": "Include services consumed by the specified consumer.\n\nThe Google Service Management implementation accepts the following\nforms:\n- project:\u003cproject_id\u003e",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "Requested size of the next page of data.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "Token identifying which result to start with; returned by a previous list\ncall.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "producerProjectId": {
+	//       "description": "Include services produced by the specified project.",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services",
+	//   "response": {
+	//     "$ref": "ListServicesResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only",
+	//     "https://www.googleapis.com/auth/service.management",
+	//     "https://www.googleapis.com/auth/service.management.readonly"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ServicesListCall) Pages(ctx context.Context, f func(*ListServicesResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "servicemanagement.services.setIamPolicy":
+
+type ServicesSetIamPolicyCall struct {
+	s                   *APIService
+	resource            string
+	setiampolicyrequest *SetIamPolicyRequest
+	urlParams_          gensupport.URLParams
+	ctx_                context.Context
+	header_             http.Header
+}
+
+// SetIamPolicy: Sets the access control policy on the specified
+// resource. Replaces any
+// existing policy.
+func (r *ServicesService) SetIamPolicy(resource string, setiampolicyrequest *SetIamPolicyRequest) *ServicesSetIamPolicyCall {
+	c := &ServicesSetIamPolicyCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.setiampolicyrequest = setiampolicyrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesSetIamPolicyCall) Fields(s ...googleapi.Field) *ServicesSetIamPolicyCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesSetIamPolicyCall) Context(ctx context.Context) *ServicesSetIamPolicyCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesSetIamPolicyCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesSetIamPolicyCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.setiampolicyrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:setIamPolicy")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.setIamPolicy" call.
+// Exactly one of *Policy or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Policy.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ServicesSetIamPolicyCall) Do(opts ...googleapi.CallOption) (*Policy, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Policy{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Sets the access control policy on the specified resource. Replaces any\nexisting policy.",
+	//   "flatPath": "v1/services/{servicesId}:setIamPolicy",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.setIamPolicy",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy is being specified.\n`resource` is usually specified as a path. For example, a Project\nresource is specified as `projects/{project}`.",
+	//       "location": "path",
+	//       "pattern": "^services/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:setIamPolicy",
+	//   "request": {
+	//     "$ref": "SetIamPolicyRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Policy"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.testIamPermissions":
+
+type ServicesTestIamPermissionsCall struct {
+	s                         *APIService
+	resource                  string
+	testiampermissionsrequest *TestIamPermissionsRequest
+	urlParams_                gensupport.URLParams
+	ctx_                      context.Context
+	header_                   http.Header
+}
+
+// TestIamPermissions: Returns permissions that a caller has on the
+// specified resource.
+func (r *ServicesService) TestIamPermissions(resource string, testiampermissionsrequest *TestIamPermissionsRequest) *ServicesTestIamPermissionsCall {
+	c := &ServicesTestIamPermissionsCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.resource = resource
+	c.testiampermissionsrequest = testiampermissionsrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesTestIamPermissionsCall) Fields(s ...googleapi.Field) *ServicesTestIamPermissionsCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesTestIamPermissionsCall) Context(ctx context.Context) *ServicesTestIamPermissionsCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesTestIamPermissionsCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesTestIamPermissionsCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.testiampermissionsrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/{+resource}:testIamPermissions")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"resource": c.resource,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.testIamPermissions" call.
+// Exactly one of *TestIamPermissionsResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *TestIamPermissionsResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ServicesTestIamPermissionsCall) Do(opts ...googleapi.CallOption) (*TestIamPermissionsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &TestIamPermissionsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Returns permissions that a caller has on the specified resource.",
+	//   "flatPath": "v1/services/{servicesId}:testIamPermissions",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.testIamPermissions",
+	//   "parameterOrder": [
+	//     "resource"
+	//   ],
+	//   "parameters": {
+	//     "resource": {
+	//       "description": "REQUIRED: The resource for which the policy detail is being requested.\n`resource` is usually specified as a path. For example, a Project\nresource is specified as `projects/{project}`.",
+	//       "location": "path",
+	//       "pattern": "^services/[^/]+$",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/{+resource}:testIamPermissions",
+	//   "request": {
+	//     "$ref": "TestIamPermissionsRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "TestIamPermissionsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.undelete":
+
+type ServicesUndeleteCall struct {
+	s           *APIService
+	serviceName string
+	urlParams_  gensupport.URLParams
+	ctx_        context.Context
+	header_     http.Header
+}
+
+// Undelete: Revives a previously deleted managed service. The method
+// restores the
+// service using the configuration at the time the service was
+// deleted.
+// The target service must exist and must have been deleted within
+// the
+// last 30 days.
+//
+// Operation<response: UndeleteServiceResponse>
+func (r *ServicesService) Undelete(serviceName string) *ServicesUndeleteCall {
+	c := &ServicesUndeleteCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesUndeleteCall) Fields(s ...googleapi.Field) *ServicesUndeleteCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesUndeleteCall) Context(ctx context.Context) *ServicesUndeleteCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesUndeleteCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesUndeleteCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}:undelete")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.undelete" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesUndeleteCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Revives a previously deleted managed service. The method restores the\nservice using the configuration at the time the service was deleted.\nThe target service must exist and must have been deleted within the\nlast 30 days.\n\nOperation\u003cresponse: UndeleteServiceResponse\u003e",
+	//   "flatPath": "v1/services/{serviceName}:undelete",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.undelete",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "The name of the service. See the [overview](/service-management/overview)\nfor naming requirements. For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}:undelete",
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.configs.create":
+
+type ServicesConfigsCreateCall struct {
+	s           *APIService
+	serviceName string
+	service     *Service
+	urlParams_  gensupport.URLParams
+	ctx_        context.Context
+	header_     http.Header
+}
+
+// Create: Creates a new service configuration (version) for a managed
+// service.
+// This method only stores the service configuration. To roll out the
+// service
+// configuration to backend systems please call
+// CreateServiceRollout.
+func (r *ServicesConfigsService) Create(serviceName string, service *Service) *ServicesConfigsCreateCall {
+	c := &ServicesConfigsCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	c.service = service
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesConfigsCreateCall) Fields(s ...googleapi.Field) *ServicesConfigsCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesConfigsCreateCall) Context(ctx context.Context) *ServicesConfigsCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesConfigsCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesConfigsCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.service)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/configs")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.configs.create" call.
+// Exactly one of *Service or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Service.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ServicesConfigsCreateCall) Do(opts ...googleapi.CallOption) (*Service, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Service{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new service configuration (version) for a managed service.\nThis method only stores the service configuration. To roll out the service\nconfiguration to backend systems please call\nCreateServiceRollout.",
+	//   "flatPath": "v1/services/{serviceName}/configs",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.configs.create",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/configs",
+	//   "request": {
+	//     "$ref": "Service"
+	//   },
+	//   "response": {
+	//     "$ref": "Service"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.configs.get":
+
+type ServicesConfigsGetCall struct {
+	s            *APIService
+	serviceName  string
+	configId     string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets a service configuration (version) for a managed service.
+func (r *ServicesConfigsService) Get(serviceName string, configId string) *ServicesConfigsGetCall {
+	c := &ServicesConfigsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	c.configId = configId
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesConfigsGetCall) Fields(s ...googleapi.Field) *ServicesConfigsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesConfigsGetCall) IfNoneMatch(entityTag string) *ServicesConfigsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesConfigsGetCall) Context(ctx context.Context) *ServicesConfigsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesConfigsGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesConfigsGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/configs/{configId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+		"configId":    c.configId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.configs.get" call.
+// Exactly one of *Service or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Service.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ServicesConfigsGetCall) Do(opts ...googleapi.CallOption) (*Service, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Service{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets a service configuration (version) for a managed service.",
+	//   "flatPath": "v1/services/{serviceName}/configs/{configId}",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.services.configs.get",
+	//   "parameterOrder": [
+	//     "serviceName",
+	//     "configId"
+	//   ],
+	//   "parameters": {
+	//     "configId": {
+	//       "description": "The id of the service configuration resource.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/configs/{configId}",
+	//   "response": {
+	//     "$ref": "Service"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only",
+	//     "https://www.googleapis.com/auth/service.management",
+	//     "https://www.googleapis.com/auth/service.management.readonly"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.configs.list":
+
+type ServicesConfigsListCall struct {
+	s            *APIService
+	serviceName  string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Lists the history of the service configuration for a managed
+// service,
+// from the newest to the oldest.
+func (r *ServicesConfigsService) List(serviceName string) *ServicesConfigsListCall {
+	c := &ServicesConfigsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": The max number of
+// items to include in the response list.
+func (c *ServicesConfigsListCall) PageSize(pageSize int64) *ServicesConfigsListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": The token of the
+// page to retrieve.
+func (c *ServicesConfigsListCall) PageToken(pageToken string) *ServicesConfigsListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesConfigsListCall) Fields(s ...googleapi.Field) *ServicesConfigsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesConfigsListCall) IfNoneMatch(entityTag string) *ServicesConfigsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesConfigsListCall) Context(ctx context.Context) *ServicesConfigsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesConfigsListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesConfigsListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/configs")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.configs.list" call.
+// Exactly one of *ListServiceConfigsResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *ListServiceConfigsResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ServicesConfigsListCall) Do(opts ...googleapi.CallOption) (*ListServiceConfigsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListServiceConfigsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists the history of the service configuration for a managed service,\nfrom the newest to the oldest.",
+	//   "flatPath": "v1/services/{serviceName}/configs",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.services.configs.list",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "pageSize": {
+	//       "description": "The max number of items to include in the response list.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "The token of the page to retrieve.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/configs",
+	//   "response": {
+	//     "$ref": "ListServiceConfigsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only",
+	//     "https://www.googleapis.com/auth/service.management",
+	//     "https://www.googleapis.com/auth/service.management.readonly"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ServicesConfigsListCall) Pages(ctx context.Context, f func(*ListServiceConfigsResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "servicemanagement.services.configs.submit":
+
+type ServicesConfigsSubmitCall struct {
+	s                         *APIService
+	serviceName               string
+	submitconfigsourcerequest *SubmitConfigSourceRequest
+	urlParams_                gensupport.URLParams
+	ctx_                      context.Context
+	header_                   http.Header
+}
+
+// Submit: Creates a new service configuration (version) for a managed
+// service based
+// on
+// user-supplied configuration source files (for example:
+// OpenAPI
+// Specification). This method stores the source configurations as well
+// as the
+// generated service configuration. To rollout the service configuration
+// to
+// other services,
+// please call CreateServiceRollout.
+//
+// Operation<response: SubmitConfigSourceResponse>
+func (r *ServicesConfigsService) Submit(serviceName string, submitconfigsourcerequest *SubmitConfigSourceRequest) *ServicesConfigsSubmitCall {
+	c := &ServicesConfigsSubmitCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	c.submitconfigsourcerequest = submitconfigsourcerequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesConfigsSubmitCall) Fields(s ...googleapi.Field) *ServicesConfigsSubmitCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesConfigsSubmitCall) Context(ctx context.Context) *ServicesConfigsSubmitCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesConfigsSubmitCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesConfigsSubmitCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.submitconfigsourcerequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/configs:submit")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.configs.submit" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesConfigsSubmitCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new service configuration (version) for a managed service based\non\nuser-supplied configuration source files (for example: OpenAPI\nSpecification). This method stores the source configurations as well as the\ngenerated service configuration. To rollout the service configuration to\nother services,\nplease call CreateServiceRollout.\n\nOperation\u003cresponse: SubmitConfigSourceResponse\u003e",
+	//   "flatPath": "v1/services/{serviceName}/configs:submit",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.configs.submit",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/configs:submit",
+	//   "request": {
+	//     "$ref": "SubmitConfigSourceRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.rollouts.create":
+
+type ServicesRolloutsCreateCall struct {
+	s           *APIService
+	serviceName string
+	rollout     *Rollout
+	urlParams_  gensupport.URLParams
+	ctx_        context.Context
+	header_     http.Header
+}
+
+// Create: Creates a new service configuration rollout. Based on
+// rollout, the
+// Google Service Management will roll out the service configurations
+// to
+// different backend services. For example, the logging configuration
+// will be
+// pushed to Google Cloud Logging.
+//
+// Please note that any previous pending and running Rollouts and
+// associated
+// Operations will be automatically cancelled so that the latest Rollout
+// will
+// not be blocked by previous Rollouts.
+//
+// Operation<response: Rollout>
+func (r *ServicesRolloutsService) Create(serviceName string, rollout *Rollout) *ServicesRolloutsCreateCall {
+	c := &ServicesRolloutsCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	c.rollout = rollout
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesRolloutsCreateCall) Fields(s ...googleapi.Field) *ServicesRolloutsCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesRolloutsCreateCall) Context(ctx context.Context) *ServicesRolloutsCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesRolloutsCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesRolloutsCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.rollout)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/rollouts")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.rollouts.create" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ServicesRolloutsCreateCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a new service configuration rollout. Based on rollout, the\nGoogle Service Management will roll out the service configurations to\ndifferent backend services. For example, the logging configuration will be\npushed to Google Cloud Logging.\n\nPlease note that any previous pending and running Rollouts and associated\nOperations will be automatically cancelled so that the latest Rollout will\nnot be blocked by previous Rollouts.\n\nOperation\u003cresponse: Rollout\u003e",
+	//   "flatPath": "v1/services/{serviceName}/rollouts",
+	//   "httpMethod": "POST",
+	//   "id": "servicemanagement.services.rollouts.create",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/rollouts",
+	//   "request": {
+	//     "$ref": "Rollout"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/service.management"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.rollouts.get":
+
+type ServicesRolloutsGetCall struct {
+	s            *APIService
+	serviceName  string
+	rolloutId    string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets a service configuration rollout.
+func (r *ServicesRolloutsService) Get(serviceName string, rolloutId string) *ServicesRolloutsGetCall {
+	c := &ServicesRolloutsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	c.rolloutId = rolloutId
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesRolloutsGetCall) Fields(s ...googleapi.Field) *ServicesRolloutsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesRolloutsGetCall) IfNoneMatch(entityTag string) *ServicesRolloutsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesRolloutsGetCall) Context(ctx context.Context) *ServicesRolloutsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesRolloutsGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesRolloutsGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/rollouts/{rolloutId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+		"rolloutId":   c.rolloutId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.rollouts.get" call.
+// Exactly one of *Rollout or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Rollout.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ServicesRolloutsGetCall) Do(opts ...googleapi.CallOption) (*Rollout, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Rollout{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets a service configuration rollout.",
+	//   "flatPath": "v1/services/{serviceName}/rollouts/{rolloutId}",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.services.rollouts.get",
+	//   "parameterOrder": [
+	//     "serviceName",
+	//     "rolloutId"
+	//   ],
+	//   "parameters": {
+	//     "rolloutId": {
+	//       "description": "The id of the rollout resource.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/rollouts/{rolloutId}",
+	//   "response": {
+	//     "$ref": "Rollout"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only",
+	//     "https://www.googleapis.com/auth/service.management",
+	//     "https://www.googleapis.com/auth/service.management.readonly"
+	//   ]
+	// }
+
+}
+
+// method id "servicemanagement.services.rollouts.list":
+
+type ServicesRolloutsListCall struct {
+	s            *APIService
+	serviceName  string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Lists the history of the service configuration rollouts for a
+// managed
+// service, from the newest to the oldest.
+func (r *ServicesRolloutsService) List(serviceName string) *ServicesRolloutsListCall {
+	c := &ServicesRolloutsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.serviceName = serviceName
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": The max number of
+// items to include in the response list.
+func (c *ServicesRolloutsListCall) PageSize(pageSize int64) *ServicesRolloutsListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": The token of the
+// page to retrieve.
+func (c *ServicesRolloutsListCall) PageToken(pageToken string) *ServicesRolloutsListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ServicesRolloutsListCall) Fields(s ...googleapi.Field) *ServicesRolloutsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ServicesRolloutsListCall) IfNoneMatch(entityTag string) *ServicesRolloutsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ServicesRolloutsListCall) Context(ctx context.Context) *ServicesRolloutsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ServicesRolloutsListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ServicesRolloutsListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/services/{serviceName}/rollouts")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"serviceName": c.serviceName,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "servicemanagement.services.rollouts.list" call.
+// Exactly one of *ListServiceRolloutsResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *ListServiceRolloutsResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ServicesRolloutsListCall) Do(opts ...googleapi.CallOption) (*ListServiceRolloutsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListServiceRolloutsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Lists the history of the service configuration rollouts for a managed\nservice, from the newest to the oldest.",
+	//   "flatPath": "v1/services/{serviceName}/rollouts",
+	//   "httpMethod": "GET",
+	//   "id": "servicemanagement.services.rollouts.list",
+	//   "parameterOrder": [
+	//     "serviceName"
+	//   ],
+	//   "parameters": {
+	//     "pageSize": {
+	//       "description": "The max number of items to include in the response list.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "The token of the page to retrieve.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "serviceName": {
+	//       "description": "The name of the service.  See the [overview](/service-management/overview)\nfor naming requirements.  For example: `example.googleapis.com`.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/services/{serviceName}/rollouts",
+	//   "response": {
+	//     "$ref": "ListServiceRolloutsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/cloud-platform.read-only",
+	//     "https://www.googleapis.com/auth/service.management",
+	//     "https://www.googleapis.com/auth/service.management.readonly"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ServicesRolloutsListCall) Pages(ctx context.Context, f func(*ListServiceRolloutsResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2835,6 +2835,12 @@
 			"revisionTime": "2016-11-27T23:54:21Z"
 		},
 		{
+			"checksumSHA1": "4xiJmsULiSTn2iO4zUYtMgJqJSQ=",
+			"path": "google.golang.org/api/servicemanagement/v1",
+			"revision": "c8d75a8ec737f9b8b1ed2676c28feedbe21f543f",
+			"revisionTime": "2016-11-21T18:05:46Z"
+		},
+		{
 			"checksumSHA1": "moKPpECJZQR/mANGD26E7Pbxn4I=",
 			"path": "google.golang.org/api/sqladmin/v1beta4",
 			"revision": "3cc2e591b550923a2c5f0ab5a803feda924d5823",

--- a/website/source/docs/providers/google/r/google_project.html.markdown
+++ b/website/source/docs/providers/google/r/google_project.html.markdown
@@ -8,29 +8,24 @@ description: |-
 
 # google\_project
 
-Allows management of an existing Google Cloud Platform project, and is
-currently limited to adding or modifying the IAM Policy for the project.
+Allows creation and management of a Google Cloud Platform project and its
+associated enabled services/APIs.
 
-When adding a policy to a project, the policy will be merged with the
-project's existing policy. The policy is always specified in a
-`google_iam_policy` data source and referenced from the project's
-`policy_data` attribute.
+Projects created with this resource must be associated with an Organization.
+See the [Organization documentation](https://cloud.google.com/resource-manager/docs/quickstart) for more details.
+
+The service account used to run Terraform when creating a `google_project`
+resource must have `roles/resourcemanager.projectCreator`. See the
+[Access Control for Organizations Using IAM](https://cloud.google.com/resource-manager/docs/access-control-org)
+doc for more information.
 
 ## Example Usage
 
 ```js
 resource "google_project" "my_project" {
-    id = "your-project-id"
-    policy_data = "${data.google_iam_policy.admin.policy_data}"
-}
-
-data "google_iam_policy" "admin" {
-  binding {
-    role = "roles/storage.objectViewer"
-    members = [
-      "user:evandbrown@gmail.com",
-    ]
-  }
+    project_id = "your-project-id"
+    org_id = "1234567"
+    services = ["compute_component", "storage-component-json.googleapis.com", "iam.googleapis.com"]
 }
 ```
 
@@ -38,24 +33,55 @@ data "google_iam_policy" "admin" {
 
 The following arguments are supported:
 
-* `id` - (Required) The project ID.
-    Changing this forces a new project to be referenced.
+* `project_id` - (Optional) The project ID.
+    Changing this forces a new project to be created. If this attribute is not
+    set, `id` must be set. As `id` is deprecated, consider this attribute
+    required. If you are using `project_id` and creating a new project, the
+    `org_id` and `name` attributes are also required.
 
-* `policy` - (Optional) The `google_iam_policy` data source that represents
-    the IAM policy that will be applied to the project. The policy will be
-    merged with any existing policy applied to the project.
+* `id` - (Deprecated) The project ID.
+    This attribute has unexpected behaviour and probably does not work
+    as users would expect; it has been deprecated, and will be removed in future
+    versions of Terraform. The `project_id` attribute should be used instead. See
+    [below](#id-field) for more information about its behaviour.
 
-    Changing this updates the policy.
+* `project_id` - (Required) The project ID.
+    Changing this forces a new project to be created.
 
-    Deleting this removes the policy, but leaves the original project policy
-    intact. If there are overlapping `binding` entries between the original
-    project policy and the data source policy, they will be removed.
+* `org_id` - (Optional) The numeric ID of the organization this project belongs to.
+    This is required if you are creating a new project.
+    Changing this forces a new project to be created.
+
+* `name` - (Optional) The display name of the project.
+    This is required if you are creating a new project.
+
+* `services` - (Optional) The services/APIs that are enabled for this project.
+    For a list of available services, run `gcloud beta service-management list`
+
+* `skip_delete` - (Optional) If true, the Terraform resource can be deleted
+    without deleting the Project via the Google API.
+
+* `policy_data` - (Deprecated) The IAM policy associated with the project.
+    This argument is no longer supported, and will be removed in a future version
+    of Terraform. It should be replaced with a `google_project_iam_policy` resource.
 
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are
 exported:
 
-* `name` - The name of the project.
-
 * `number` - The numeric identifier of the project.
+* `policy_etag` - (Deprecated) The etag of the project's IAM policy, used to
+    determine if the IAM policy has changed. Please use `google_project_iam_policy`'s
+    `etag` property instead; future versions of Terraform will remove the `policy_etag`
+    attribute
+
+## ID Field
+
+In previous versions of Terraform, `google_project` resources used an `id` field in
+config files to specify the project ID. Unfortunately, due to limitations in Terraform,
+this field always looked empty to Terraform. Terraform fell back on using the project
+the Google Cloud provider is configured with. If you're using the `id` field in your
+configurations, know that it is being ignored, and its value will always be seen as the
+ID of the project being used to authenticate Terraform's requests. You should move to the
+`project_id` field as soon as possible.

--- a/website/source/docs/providers/google/r/google_project_iam_policy.html.markdown
+++ b/website/source/docs/providers/google/r/google_project_iam_policy.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "google"
+page_title: "Google: google_project_iam_policy"
+sidebar_current: "docs-google-project-iam-policy"
+description: |-
+ Allows management of an IAM policy for a Google Cloud Platform project. 
+---
+
+# google\_project\_iam\_policy
+
+Allows creation and management of an IAM policy for an existing Google Cloud
+Platform project.
+
+## Example Usage
+
+```js
+resource "google_project_iam_policy" "project" {
+    project = "your-project-id"
+    policy_data = "${data.google_iam_policy.admin.policy_data}"
+}
+
+data "google_iam_policy" "admin" {
+  binding {
+    role = "roles/editor"
+    members = [
+      "user:jane@example.com",
+    ]
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The project ID.
+    Changing this forces a new project to be created.
+
+* `policy_data` - (Required) The `google_iam_policy` data source that represents
+    the IAM policy that will be applied to the project. The policy will be
+    merged with any existing policy applied to the project.
+
+    Changing this updates the policy.
+
+    Deleting this removes the policy, but leaves the original project policy
+    intact. If there are overlapping `binding` entries between the original
+    project policy and the data source policy, they will be removed.
+
+* `authoritative` - (Optional) A boolean value indicating if this policy
+    should overwrite any existing IAM policy on the project. When set to true,
+    **any policies not in your config file will be removed**. This can **lock
+    you out** of your project until an Organization Administrator grants you
+    access again, so please exercise caution. If this argument is `true` and you
+    want to delete the resource, you must set the `disable_project` argument to
+    `true`, acknowledging that the project will be inaccessible to anyone but the
+    Organization Admins, as it will no longer have an IAM policy.
+
+* `disable_project` - (Optional) A boolean value that must be set to `true`
+    if you want to delete a `google_project_iam_policy` that is authoritative.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `etag` - (Computed) The etag of the project's IAM policy.
+
+* `restore_policy` - (Computed) The IAM policy that will be resotred when a
+    non-authoritative policy resource is deleted.

--- a/website/source/docs/providers/google/r/google_project_services.html.markdown
+++ b/website/source/docs/providers/google/r/google_project_services.html.markdown
@@ -1,0 +1,32 @@
+---
+layout: "google"
+page_title: "Google: google_project_services"
+sidebar_current: "docs-google-project-services"
+description: |-
+ Allows management of API services for a Google Cloud Platform project. 
+---
+
+# google\_project\_services
+
+Allows management of enabled API services for an existing Google Cloud
+Platform project. Services in an existing project that are not defined
+in the config will be removed.
+
+## Example Usage
+
+```js
+resource "google_project_services" "project" {
+  project_id = "your-project-id"
+  services = ["iam.googleapis.com", "cloudresourcemanager.googleapis.com"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project_id` - (Required) The project ID.
+    Changing this forces a new project to be created.
+
+* `services` - (Required) The list of services that are enabled. Supports
+    update.

--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -25,6 +25,12 @@
 			<li<%= sidebar_current("docs-google-project") %>>
 			<a href="/docs/providers/google/r/google_project.html">google_project</a>
             </li>
+            <li<%= sidebar_current("docs-google-project-iam-policy") %>>
+			<a href="/docs/providers/google/r/google_project_iam_policy.html">google_project_iam_policy</a>
+            </li>
+            <li<%= sidebar_current("docs-google-project-services") %>>
+			<a href="/docs/providers/google/r/google_project_services.html">google_project_services</a>
+            </li>
             <li<%= sidebar_current("docs-google-service-account") %>>
             <a href="/docs/providers/google/r/google_service_account.html">google_service_account</a>
             </li>


### PR DESCRIPTION
This proposal allows a GCP project to be created, modified, and deleted with Terraform. A project may be created, APIs enabled (e.g., Container Engine and GCS), and IAM policies applied.