### PR TITLE
provider/aws: Support import of aws_iam_instance_profile

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_instance_profile.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile.go
@@ -18,24 +18,27 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 		Read:   resourceAwsIamInstanceProfileRead,
 		Update: resourceAwsIamInstanceProfileUpdate,
 		Delete: resourceAwsIamInstanceProfileDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"create_date": &schema.Schema{
+			"create_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"unique_id": &schema.Schema{
+			"unique_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -56,7 +59,7 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				},
 			},
 
-			"name_prefix": &schema.Schema{
+			"name_prefix": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -75,14 +78,14 @@ func resourceAwsIamInstanceProfile() *schema.Resource {
 				},
 			},
 
-			"path": &schema.Schema{
+			"path": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "/",
 				ForceNew: true,
 			},
 
-			"roles": &schema.Schema{
+			"roles": {
 				Type:     schema.TypeSet,
 				Required: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -57,6 +57,7 @@ To make a resource importable, please see the
 * aws_glacier_vault
 * aws_iam_account_password_policy
 * aws_iam_group
+* aws_iam_instance_profile
 * aws_iam_saml_provider
 * aws_iam_user
 * aws_instance

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -59,3 +59,12 @@ The following arguments are supported:
 * `unique_id` - The [unique ID][1] assigned by AWS.
 
   [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html#GUIDs
+
+
+## Import
+
+Instance Profiles can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_iam_instance_profile.test_profile app-instance-profile-1
+```


### PR DESCRIPTION
Fixes #10341

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSIAMInstanceProfile_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/11/30 14:32:59 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSIAMInstanceProfile_ -timeout 120m
=== RUN   TestAccAWSIAMInstanceProfile_importBasic
--- PASS: TestAccAWSIAMInstanceProfile_importBasic (20.22s)
=== RUN   TestAccAWSIAMInstanceProfile_basic
--- PASS: TestAccAWSIAMInstanceProfile_basic (18.71s)
=== RUN   TestAccAWSIAMInstanceProfile_namePrefix
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (18.58s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws57.535s
```