### PR TITLE
Add `aws_s3_bucket` to importable resources

### DIFF
--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -82,6 +82,7 @@ To make a resource importable, please see the
 * aws_route53_health_check
 * aws_route53_zone
 * aws_route_table
+* aws_s3_bucket
 * aws_security_group
 * aws_ses_receipt_filter
 * aws_ses_receipt_rule_set


### PR DESCRIPTION
According to the [`aws_s3_bucket` docs](https://www.terraform.io/docs/providers/aws/r/s3_bucket.html) it is importable.