### PR TITLE
Increase `aws_emr_cluster` timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_emr_cluster.go
+++ b/builtin/providers/aws/resource_aws_emr_cluster.go
@@ -275,7 +275,7 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		Pending:    []string{"STARTING", "BOOTSTRAPPING"},
 		Target:     []string{"WAITING", "RUNNING"},
 		Refresh:    resourceAwsEMRClusterStateRefreshFunc(d, meta),
-		Timeout:    40 * time.Minute,
+		Timeout:    75 * time.Minute,
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}


### PR DESCRIPTION
### TODO
- [x] Boost timeout to 75 minutes

### Motivation
As has been done to other resources when the need arose, I've boosted the EMR resource timeout. I found that my EMR bootstrap scripts run longer than the default 40 minutes, due to custom compilation of some large libraries. 

Being able to control this timeout in external config would be nice, but for now these values seem hard-coded, hence this PR.