### PR TITLE
provider/aws: Bump sdk to v1.5.12

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/CHANGELOG.md
+++ b/vendor/github.com/aws/aws-sdk-go/CHANGELOG.md
@@ -1,3 +1,44 @@
+Release v1.5.12 (2016-11-30)
+===
+
+Service Client Updates
+---
+`service/lightsail`: Adds new service
+`service/polly`: Adds new service
+`service/rekognition`: Adds new service
+`service/snowball`: Updates service API and documentation
+
+Release v1.5.11 (2016-11-29)
+===
+
+Service Client Updates
+---
+`service/s3`: Updates service API and documentation
+
+Release v1.5.10 (2016-11-22)
+===
+
+Service Client Updates
+---
+`service/cloudformation`: Updates service API and documentation
+`service/glacier`: Updates service API, documentation, and examples
+`service/route53`: Updates service API and documentation
+`service/s3`: Updates service API and documentation
+
+SDK Bug Fixes
+---
+* `private/protocol/xml/xmlutil`: Fixes xml marshaler to unmarshal properly
+into tagged fields 
+[#916](https://github.com/aws/aws-sdk-go/issues/916)
+
+Release v1.5.9 (2016-11-22)
+===
+
+Service Client Updates
+---
+`service/cloudtrail`: Updates service API and documentation
+`service/ecs`: Updates service API and documentation
+
 Release v1.5.8 (2016-11-18)
 ===
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/corehandlers/handlers.go
@@ -71,7 +71,7 @@ var reStatusCode = regexp.MustCompile(`^(\d{3})`)
 
 // ValidateReqSigHandler is a request handler to ensure that the request's
 // signature doesn't expire before it is sent. This can happen when a request
-// is built and signed signficantly before it is sent. Or signficant delays
+// is built and signed signficantly before it is sent. Or significant delays
 // occur whne retrying requests that would cause the signature to expire.
 var ValidateReqSigHandler = request.NamedHandler{
 	Name: "core.ValidateReqSigHandler",

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -34,7 +34,7 @@ type Session struct {
 // If the AWS_SDK_LOAD_CONFIG environment is set to a truthy value, the New
 // method could now encounter an error when loading the configuration. When
 // The environment variable is set, and an error occurs, New will return a
-// session that will fail all requests reporting the error that occured while
+// session that will fail all requests reporting the error that occurred while
 // loading the session. Use NewSession to get the error when creating the
 // session.
 //
@@ -59,7 +59,7 @@ func New(cfgs ...*aws.Config) *Session {
 			// needs to be replicated if an error occurs while creating
 			// the session.
 			msg := "failed to create session with AWS_SDK_LOAD_CONFIG enabled. " +
-				"Use session.NewSession to handle errors occuring during session creation."
+				"Use session.NewSession to handle errors occurring during session creation."
 
 			// Session creation failed, need to report the error and prevent
 			// any requests from succeeding.
@@ -89,7 +89,7 @@ func New(cfgs ...*aws.Config) *Session {
 // to be built with retrieving credentials with AssumeRole set in the config.
 //
 // See the NewSessionWithOptions func for information on how to override or
-// control through code how the Session will be created. Such as specifing the
+// control through code how the Session will be created. Such as specifying the
 // config profile, and controlling if shared config is enabled or not.
 func NewSession(cfgs ...*aws.Config) (*Session, error) {
 	envCfg := loadEnvConfig()
@@ -124,7 +124,7 @@ type Options struct {
 	// Provides config values for the SDK to use when creating service clients
 	// and making API requests to services. Any value set in with this field
 	// will override the associated value provided by the SDK defaults,
-	// environment or config files where relevent.
+	// environment or config files where relevant.
 	//
 	// If not set, configuration values from from SDK defaults, environment,
 	// config will be used.

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.5.8"
+const SDKVersion = "1.5.12"

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/rest/build.go
@@ -47,12 +47,22 @@ var BuildHandler = request.NamedHandler{Name: "awssdk.rest.Build", Fn: Build}
 func Build(r *request.Request) {
 	if r.ParamsFilled() {
 		v := reflect.ValueOf(r.Params).Elem()
-		buildLocationElements(r, v)
+		buildLocationElements(r, v, false)
 		buildBody(r, v)
 	}
 }
 
-func buildLocationElements(r *request.Request, v reflect.Value) {
+// BuildAsGET builds the REST component of a service request with the ability to hoist
+// data from the body.
+func BuildAsGET(r *request.Request) {
+	if r.ParamsFilled() {
+		v := reflect.ValueOf(r.Params).Elem()
+		buildLocationElements(r, v, true)
+		buildBody(r, v)
+	}
+}
+
+func buildLocationElements(r *request.Request, v reflect.Value, buildGETQuery bool) {
 	query := r.HTTPRequest.URL.Query()
 
 	for i := 0; i < v.NumField(); i++ {
@@ -84,6 +94,10 @@ func buildLocationElements(r *request.Request, v reflect.Value) {
 				err = buildURI(r.HTTPRequest.URL, m, name)
 			case "querystring":
 				err = buildQueryString(query, m, name)
+			default:
+				if buildGETQuery {
+					err = buildQueryString(query, m, name)
+				}
 			}
 			r.Error = err
 		}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/unmarshal.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/unmarshal.go
@@ -112,7 +112,7 @@ func parseStruct(r reflect.Value, node *XMLNode, tag reflect.StructTag) error {
 
 		if elems == nil { // try to find the field in attributes
 			for _, a := range node.Attr {
-				if name == a.Name.Local {
+				if name == strings.Join([]string{a.Name.Space, a.Name.Local}, ":") {
 					// turn this into a text node for de-serializing
 					elems = []*XMLNode{{Text: a.Value}}
 				}

--- a/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/xml_to_struct.go
+++ b/vendor/github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil/xml_to_struct.go
@@ -63,6 +63,8 @@ func XMLToStruct(d *xml.Decoder, s *xml.StartElement) (*XMLNode, error) {
 				return out, e
 			}
 			node.Name = typed.Name
+			node.Attr = out.Attr
+			node = adaptNode(node)
 			slice = append(slice, node)
 			out.Children[name] = slice
 		case xml.EndElement:
@@ -72,6 +74,26 @@ func XMLToStruct(d *xml.Decoder, s *xml.StartElement) (*XMLNode, error) {
 		}
 	}
 	return out, nil
+}
+
+func adaptNode(node *XMLNode) *XMLNode {
+	ns := map[string]string{}
+	for _, a := range node.Attr {
+		if a.Name.Space == "xmlns" {
+			ns[a.Value] = a.Name.Local
+			break
+		}
+	}
+
+	for i, a := range node.Attr {
+		if a.Name.Space == "xmlns" {
+			continue
+		}
+		if v, ok := ns[node.Attr[i].Name.Space]; ok {
+			node.Attr[i].Name.Space = v
+		}
+	}
+	return node
 }
 
 // StructToXML writes an XMLNode to a xml.Encoder as tokens.

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudtrail/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudtrail/api.go
@@ -56,7 +56,7 @@ func (c *CloudTrail) AddTagsRequest(input *AddTagsInput) (req *request.Request, 
 
 // AddTags API operation for AWS CloudTrail.
 //
-// Adds one or more tags to a trail, up to a limit of 10. Tags must be unique
+// Adds one or more tags to a trail, up to a limit of 50. Tags must be unique
 // per trail. Overwrites an existing tag's value when a new value is specified
 // for an existing tag key. If you specify a key without a value, the tag will
 // be created with the specified key and a value of null. You can tag a trail
@@ -86,7 +86,7 @@ func (c *CloudTrail) AddTagsRequest(input *AddTagsInput) (req *request.Request, 
 //
 //   * TagsLimitExceededException
 //   The number of tags per trail has exceeded the permitted amount. Currently,
-//   the limit is 10.
+//   the limit is 50.
 //
 //   * InvalidTrailNameException
 //   This exception is thrown when the provided trail name is not valid. Trail
@@ -417,6 +417,103 @@ func (c *CloudTrail) DescribeTrails(input *DescribeTrailsInput) (*DescribeTrails
 	return out, err
 }
 
+const opGetEventSelectors = "GetEventSelectors"
+
+// GetEventSelectorsRequest generates a "aws/request.Request" representing the
+// client's request for the GetEventSelectors operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetEventSelectors for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetEventSelectors method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetEventSelectorsRequest method.
+//    req, resp := client.GetEventSelectorsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *CloudTrail) GetEventSelectorsRequest(input *GetEventSelectorsInput) (req *request.Request, output *GetEventSelectorsOutput) {
+	op := &request.Operation{
+		Name:       opGetEventSelectors,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetEventSelectorsInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &GetEventSelectorsOutput{}
+	req.Data = output
+	return
+}
+
+// GetEventSelectors API operation for AWS CloudTrail.
+//
+// Describes the settings for the event selectors that you configured for your
+// trail. The information returned for your event selectors includes the following:
+//
+//    * The S3 objects that you are logging for data events.
+//
+//    * If your event selector includes management events.
+//
+//    * If your event selector includes read-only events, write-only events,
+//    or all.
+//
+// For more information, see Configuring Event Selectors for Trails (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-event-selectors-for-a-trail.html)
+// in the AWS CloudTrail User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CloudTrail's
+// API operation GetEventSelectors for usage and error information.
+//
+// Returned Error Codes:
+//   * TrailNotFoundException
+//   This exception is thrown when the trail with the given name is not found.
+//
+//   * InvalidTrailNameException
+//   This exception is thrown when the provided trail name is not valid. Trail
+//   names must meet the following requirements:
+//
+//      * Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores
+//      (_), or dashes (-)
+//
+//      * Start with a letter or number, and end with a letter or number
+//
+//      * Be between 3 and 128 characters
+//
+//      * Have no adjacent periods, underscores or dashes. Names like my-_namespace
+//      and my--namespace are invalid.
+//
+//      * Not be in IP address format (for example, 192.168.5.4)
+//
+//   * UnsupportedOperationException
+//   This exception is thrown when the requested operation is not supported.
+//
+//   * OperationNotPermittedException
+//   This exception is thrown when the requested operation is not permitted.
+//
+func (c *CloudTrail) GetEventSelectors(input *GetEventSelectorsInput) (*GetEventSelectorsOutput, error) {
+	req, out := c.GetEventSelectorsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opGetTrailStatus = "GetTrailStatus"
 
 // GetTrailStatusRequest generates a "aws/request.Request" representing the
@@ -729,13 +826,21 @@ func (c *CloudTrail) LookupEventsRequest(input *LookupEventsInput) (req *request
 // Looks up API activity events captured by CloudTrail that create, update,
 // or delete resources in your account. Events for a region can be looked up
 // for the times in which you had CloudTrail turned on in that region during
-// the last seven days. Lookup supports five different attributes: time range
-// (defined by a start time and end time), user name, event name, resource type,
-// and resource name. All attributes are optional. The maximum number of attributes
-// that can be specified in any one lookup request are time range and one other
-// attribute. The default number of results returned is 10, with a maximum of
-// 50 possible. The response includes a token that you can use to get the next
-// page of results.
+// the last seven days. Lookup supports the following attributes:
+//
+//    * Event ID
+//
+//    * Event name
+//
+//    * Resource name
+//
+//    * Resource type
+//
+//    * User name
+//
+// All attributes are optional. The default number of results returned is 10,
+// with a maximum of 50 possible. The response includes a token that you can
+// use to get the next page of results.
 //
 // The rate of lookup requests is limited to one per second per account. If
 // this limit is exceeded, a throttling error occurs.
@@ -767,6 +872,135 @@ func (c *CloudTrail) LookupEventsRequest(input *LookupEventsInput) (req *request
 //
 func (c *CloudTrail) LookupEvents(input *LookupEventsInput) (*LookupEventsOutput, error) {
 	req, out := c.LookupEventsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opPutEventSelectors = "PutEventSelectors"
+
+// PutEventSelectorsRequest generates a "aws/request.Request" representing the
+// client's request for the PutEventSelectors operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See PutEventSelectors for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the PutEventSelectors method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the PutEventSelectorsRequest method.
+//    req, resp := client.PutEventSelectorsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *CloudTrail) PutEventSelectorsRequest(input *PutEventSelectorsInput) (req *request.Request, output *PutEventSelectorsOutput) {
+	op := &request.Operation{
+		Name:       opPutEventSelectors,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &PutEventSelectorsInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &PutEventSelectorsOutput{}
+	req.Data = output
+	return
+}
+
+// PutEventSelectors API operation for AWS CloudTrail.
+//
+// Configures an event selector for your trail. Use event selectors to specify
+// the type of events that you want your trail to log. When an event occurs
+// in your account, CloudTrail evaluates the event selectors in all trails.
+// For each trail, if the event matches any event selector, the trail processes
+// and logs the event. If the event doesn't match any event selector, the trail
+// doesn't log the event.
+//
+// Example
+//
+// You create an event selector for a trail and specify that you want write-only
+// events.
+//
+// The EC2 GetConsoleOutput and RunInstances API operations occur in your account.
+//
+// CloudTrail evaluates whether the events match your event selectors.
+//
+// The RunInstances is a write-only event and it matches your event selector.
+// The trail logs the event.
+//
+// The GetConsoleOutput is a read-only event but it doesn't match your event
+// selector. The trail doesn't log the event.
+//
+// The PutEventSelectors operation must be called from the region in which the
+// trail was created; otherwise, an InvalidHomeRegionException is thrown.
+//
+// You can configure up to five event selectors for each trail. For more information,
+// see Configuring Event Selectors for Trails (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-event-selectors-for-a-trail.html)
+// in the AWS CloudTrail User Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for AWS CloudTrail's
+// API operation PutEventSelectors for usage and error information.
+//
+// Returned Error Codes:
+//   * TrailNotFoundException
+//   This exception is thrown when the trail with the given name is not found.
+//
+//   * InvalidTrailNameException
+//   This exception is thrown when the provided trail name is not valid. Trail
+//   names must meet the following requirements:
+//
+//      * Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores
+//      (_), or dashes (-)
+//
+//      * Start with a letter or number, and end with a letter or number
+//
+//      * Be between 3 and 128 characters
+//
+//      * Have no adjacent periods, underscores or dashes. Names like my-_namespace
+//      and my--namespace are invalid.
+//
+//      * Not be in IP address format (for example, 192.168.5.4)
+//
+//   * InvalidHomeRegionException
+//   This exception is thrown when an operation is called on a trail from a region
+//   other than the region in which the trail was created.
+//
+//   * InvalidEventSelectorsException
+//   This exception is thrown when the PutEventSelectors operation is called with
+//   an invalid number of event selectors, data resources, or an invalid value
+//   for a parameter:
+//
+//      * Specify a valid number of event selectors (1 to 5) for a trail.
+//
+//      * Specify a valid number of data resources (1 to 50) for an event selector.
+//
+//      * Specify a valid value for a parameter. For example, specifying the ReadWriteType
+//      parameter with a value of read-only is invalid.
+//
+//   * UnsupportedOperationException
+//   This exception is thrown when the requested operation is not supported.
+//
+//   * OperationNotPermittedException
+//   This exception is thrown when the requested operation is not permitted.
+//
+func (c *CloudTrail) PutEventSelectors(input *PutEventSelectorsInput) (*PutEventSelectorsOutput, error) {
+	req, out := c.PutEventSelectorsRequest(input)
 	err := req.Send()
 	return out, err
 }
@@ -1208,7 +1442,7 @@ type AddTagsInput struct {
 	// ResourceId is a required field
 	ResourceId *string `type:"string" required:"true"`
 
-	// Contains a list of CloudTrail tags, up to a limit of 10.
+	// Contains a list of CloudTrail tags, up to a limit of 50
 	TagsList []*Tag `type:"list"`
 }
 
@@ -1581,14 +1815,72 @@ func (s *CreateTrailOutput) SetTrailARN(v string) *CreateTrailOutput {
 	return s
 }
 
+// The Amazon S3 objects that you specify in your event selectors for your trail
+// to log data events. Data events are object level API operations that access
+// S3 objects, such as GetObject, DeleteObject, and PutObject. You can specify
+// up to 50 S3 buckets and object prefixes for an event selector.
+//
+// Example
+//
+// You create an event selector for a trail and specify an S3 bucket and an
+// empty prefix, such as arn:aws:s3:::bucket-1/.
+//
+// You upload an image file to bucket-1.
+//
+// The PutObject API operation occurs on an object in the S3 bucket that you
+// specified in the event selector. The trail processes and logs the event.
+//
+// You upload another image file to a different S3 bucket named arn:aws:s3:::bucket-2.
+//
+// The event occurs on an object in an S3 bucket that you didn't specify in
+// the event selector. The trail doesn’t log the event.
+type DataResource struct {
+	_ struct{} `type:"structure"`
+
+	// The resource type in which you want to log data events. You can specify only
+	// the following value: AWS::S3::Object.
+	Type *string `type:"string"`
+
+	// A list of ARN-like strings for the specified S3 objects.
+	//
+	// To log data events for all objects in an S3 bucket, specify the bucket and
+	// an empty object prefix such as arn:aws:s3:::bucket-1/. The trail logs data
+	// events for all objects in this S3 bucket.
+	//
+	// To log data events for specific objects, specify the S3 bucket and object
+	// prefix such as arn:aws:s3:::bucket-1/example-images. The trail logs data
+	// events for objects in this S3 bucket that match the prefix.
+	Values []*string `type:"list"`
+}
+
+// String returns the string representation
+func (s DataResource) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DataResource) GoString() string {
+	return s.String()
+}
+
+// SetType sets the Type field's value.
+func (s *DataResource) SetType(v string) *DataResource {
+	s.Type = &v
+	return s
+}
+
+// SetValues sets the Values field's value.
+func (s *DataResource) SetValues(v []*string) *DataResource {
+	s.Values = v
+	return s
+}
+
 // The request that specifies the name of a trail to delete.
 type DeleteTrailInput struct {
 	_ struct{} `type:"structure"`
 
 	// Specifies the name or the CloudTrail ARN of the trail to be deleted. The
-	// format of a trail ARN is:
-	//
-	// arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail
+	// format of a trail ARN is: arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail
 	//
 	// Name is a required field
 	Name *string `type:"string" required:"true"`
@@ -1731,6 +2023,9 @@ type Event struct {
 	// The name of the event returned.
 	EventName *string `type:"string"`
 
+	// The AWS service that the request was made to.
+	EventSource *string `type:"string"`
+
 	// The date and time of the event returned.
 	EventTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
@@ -1770,6 +2065,12 @@ func (s *Event) SetEventName(v string) *Event {
 	return s
 }
 
+// SetEventSource sets the EventSource field's value.
+func (s *Event) SetEventSource(v string) *Event {
+	s.EventSource = &v
+	return s
+}
+
 // SetEventTime sets the EventTime field's value.
 func (s *Event) SetEventTime(v time.Time) *Event {
 	s.EventTime = &v
@@ -1785,6 +2086,140 @@ func (s *Event) SetResources(v []*Resource) *Event {
 // SetUsername sets the Username field's value.
 func (s *Event) SetUsername(v string) *Event {
 	s.Username = &v
+	return s
+}
+
+// Use event selectors to specify the types of events that you want your trail
+// to log. When an event occurs in your account, CloudTrail evaluates the event
+// selector for all trails. For each trail, if the event matches any event selector,
+// the trail processes and logs the event. If the event doesn't match any event
+// selector, the trail doesn't log the event.
+//
+// You can configure up to five event selectors for a trail.
+type EventSelector struct {
+	_ struct{} `type:"structure"`
+
+	// CloudTrail supports logging only data events for S3 objects. You can specify
+	// up to 50 S3 buckets and object prefixes for an event selector.
+	//
+	// For more information, see Data Events (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-event-selectors-for-a-trail.html#data-events-resources)
+	// in the AWS CloudTrail User Guide.
+	DataResources []*DataResource `type:"list"`
+
+	// Specify if you want your event selector to include management events for
+	// your trail.
+	//
+	// For more information, see Management Events (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/create-event-selectors-for-a-trail.html#event-selector-for-management-events)
+	// in the AWS CloudTrail User Guide.
+	//
+	// By default, the value is true.
+	IncludeManagementEvents *bool `type:"boolean"`
+
+	// Specify if you want your trail to log read-only events, write-only events,
+	// or all. For example, the EC2 GetConsoleOutput is a read-only API operation
+	// and RunInstances is a write-only API operation.
+	//
+	// By default, the value is All.
+	ReadWriteType *string `type:"string" enum:"ReadWriteType"`
+}
+
+// String returns the string representation
+func (s EventSelector) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s EventSelector) GoString() string {
+	return s.String()
+}
+
+// SetDataResources sets the DataResources field's value.
+func (s *EventSelector) SetDataResources(v []*DataResource) *EventSelector {
+	s.DataResources = v
+	return s
+}
+
+// SetIncludeManagementEvents sets the IncludeManagementEvents field's value.
+func (s *EventSelector) SetIncludeManagementEvents(v bool) *EventSelector {
+	s.IncludeManagementEvents = &v
+	return s
+}
+
+// SetReadWriteType sets the ReadWriteType field's value.
+func (s *EventSelector) SetReadWriteType(v string) *EventSelector {
+	s.ReadWriteType = &v
+	return s
+}
+
+type GetEventSelectorsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the name of the trail or trail ARN. If you specify a trail name,
+	// the string must meet the following requirements:
+	//
+	//    * Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores
+	//    (_), or dashes (-)
+	//
+	//    * Start with a letter or number, and end with a letter or number
+	//
+	//    * Be between 3 and 128 characters
+	//
+	//    * Have no adjacent periods, underscores or dashes. Names like my-_namespace
+	//    and my--namespace are invalid.
+	//
+	//    * Not be in IP address format (for example, 192.168.5.4)
+	//
+	// If you specify a trail ARN, it must be in the format:
+	//
+	// arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail
+	TrailName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s GetEventSelectorsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetEventSelectorsInput) GoString() string {
+	return s.String()
+}
+
+// SetTrailName sets the TrailName field's value.
+func (s *GetEventSelectorsInput) SetTrailName(v string) *GetEventSelectorsInput {
+	s.TrailName = &v
+	return s
+}
+
+type GetEventSelectorsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The event selectors that are configured for the trail.
+	EventSelectors []*EventSelector `type:"list"`
+
+	// The specified trail ARN that has the event selectors.
+	TrailARN *string `type:"string"`
+}
+
+// String returns the string representation
+func (s GetEventSelectorsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetEventSelectorsOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventSelectors sets the EventSelectors field's value.
+func (s *GetEventSelectorsOutput) SetEventSelectors(v []*EventSelector) *GetEventSelectorsOutput {
+	s.EventSelectors = v
+	return s
+}
+
+// SetTrailARN sets the TrailARN field's value.
+func (s *GetEventSelectorsOutput) SetTrailARN(v string) *GetEventSelectorsOutput {
+	s.TrailARN = &v
 	return s
 }
 
@@ -2429,6 +2864,91 @@ func (s *PublicKey) SetValue(v []byte) *PublicKey {
 	return s
 }
 
+type PutEventSelectorsInput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the settings for your event selectors. You can configure up to
+	// five event selectors for a trail.
+	EventSelectors []*EventSelector `type:"list"`
+
+	// Specifies the name of the trail or trail ARN. If you specify a trail name,
+	// the string must meet the following requirements:
+	//
+	//    * Contain only ASCII letters (a-z, A-Z), numbers (0-9), periods (.), underscores
+	//    (_), or dashes (-)
+	//
+	//    * Start with a letter or number, and end with a letter or number
+	//
+	//    * Be between 3 and 128 characters
+	//
+	//    * Have no adjacent periods, underscores or dashes. Names like my-_namespace
+	//    and my--namespace are invalid.
+	//
+	//    * Not be in IP address format (for example, 192.168.5.4)
+	//
+	// If you specify a trail ARN, it must be in the format:
+	//
+	// arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail
+	TrailName *string `type:"string"`
+}
+
+// String returns the string representation
+func (s PutEventSelectorsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutEventSelectorsInput) GoString() string {
+	return s.String()
+}
+
+// SetEventSelectors sets the EventSelectors field's value.
+func (s *PutEventSelectorsInput) SetEventSelectors(v []*EventSelector) *PutEventSelectorsInput {
+	s.EventSelectors = v
+	return s
+}
+
+// SetTrailName sets the TrailName field's value.
+func (s *PutEventSelectorsInput) SetTrailName(v string) *PutEventSelectorsInput {
+	s.TrailName = &v
+	return s
+}
+
+type PutEventSelectorsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the event selectors configured for your trail.
+	EventSelectors []*EventSelector `type:"list"`
+
+	// Specifies the ARN of the trail that was updated with event selectors. The
+	// format of a trail ARN is:
+	//
+	// arn:aws:cloudtrail:us-east-1:123456789012:trail/MyTrail
+	TrailARN *string `type:"string"`
+}
+
+// String returns the string representation
+func (s PutEventSelectorsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutEventSelectorsOutput) GoString() string {
+	return s.String()
+}
+
+// SetEventSelectors sets the EventSelectors field's value.
+func (s *PutEventSelectorsOutput) SetEventSelectors(v []*EventSelector) *PutEventSelectorsOutput {
+	s.EventSelectors = v
+	return s
+}
+
+// SetTrailARN sets the TrailARN field's value.
+func (s *PutEventSelectorsOutput) SetTrailARN(v string) *PutEventSelectorsOutput {
+	s.TrailARN = &v
+	return s
+}
+
 // Specifies the tags to remove from a trail.
 type RemoveTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -2758,6 +3278,9 @@ type Trail struct {
 	// a user's log group.
 	CloudWatchLogsRoleArn *string `type:"string"`
 
+	// Specifies if the trail has custom event selectors.
+	HasCustomEventSelectors *bool `type:"boolean"`
+
 	// The region in which the trail was created.
 	HomeRegion *string `type:"string"`
 
@@ -2824,6 +3347,12 @@ func (s *Trail) SetCloudWatchLogsLogGroupArn(v string) *Trail {
 // SetCloudWatchLogsRoleArn sets the CloudWatchLogsRoleArn field's value.
 func (s *Trail) SetCloudWatchLogsRoleArn(v string) *Trail {
 	s.CloudWatchLogsRoleArn = &v
+	return s
+}
+
+// SetHasCustomEventSelectors sets the HasCustomEventSelectors field's value.
+func (s *Trail) SetHasCustomEventSelectors(v bool) *Trail {
+	s.HasCustomEventSelectors = &v
 	return s
 }
 
@@ -3219,4 +3748,18 @@ const (
 
 	// LookupAttributeKeyResourceName is a LookupAttributeKey enum value
 	LookupAttributeKeyResourceName = "ResourceName"
+
+	// LookupAttributeKeyEventSource is a LookupAttributeKey enum value
+	LookupAttributeKeyEventSource = "EventSource"
+)
+
+const (
+	// ReadWriteTypeReadOnly is a ReadWriteType enum value
+	ReadWriteTypeReadOnly = "ReadOnly"
+
+	// ReadWriteTypeWriteOnly is a ReadWriteType enum value
+	ReadWriteTypeWriteOnly = "WriteOnly"
+
+	// ReadWriteTypeAll is a ReadWriteType enum value
+	ReadWriteTypeAll = "All"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudtrail/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudtrail/service.go
@@ -29,8 +29,9 @@ import (
 // to download and install them, see the Tools for Amazon Web Services page
 // (http://aws.amazon.com/tools/).
 //
-// See the CloudTrail User Guide for information about the data that is included
-// with each AWS API call listed in the log files.
+// See the AWS CloudTrail User Guide (http://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-user-guide.html)
+// for information about the data that is included with each AWS API call listed
+// in the log files.
 //The service client's operations are safe to be used concurrently.
 // It is not safe to mutate any of the client's properties though.
 type CloudTrail struct {

--- a/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ecs/api.go
@@ -3268,6 +3268,15 @@ type ContainerInstance struct {
 	// ACTIVE indicates that the container instance can accept tasks.
 	Status *string `locationName:"status" type:"string"`
 
+	// The version counter for the container instance. Every time a container instance
+	// experiences a change that triggers a CloudWatch event, the version counter
+	// is incremented. If you are replicating your Amazon ECS container instance
+	// state with CloudWatch events, you can compare the version of a container
+	// instance reported by the Amazon ECS APIs with the version reported in CloudWatch
+	// events for the container instance (inside the detail object) to verify that
+	// the version in your event stream is current.
+	Version *int64 `locationName:"version" type:"long"`
+
 	// The version information for the Amazon ECS container agent and Docker daemon
 	// running on the container instance.
 	VersionInfo *VersionInfo `locationName:"versionInfo" type:"structure"`
@@ -3340,6 +3349,12 @@ func (s *ContainerInstance) SetRunningTasksCount(v int64) *ContainerInstance {
 // SetStatus sets the Status field's value.
 func (s *ContainerInstance) SetStatus(v string) *ContainerInstance {
 	s.Status = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *ContainerInstance) SetVersion(v int64) *ContainerInstance {
+	s.Version = &v
 	return s
 }
 
@@ -3954,8 +3969,7 @@ func (s *DeregisterContainerInstanceInput) SetForce(v bool) *DeregisterContainer
 type DeregisterContainerInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An EC2 instance that is running the Amazon ECS agent and has been registered
-	// with a cluster.
+	// The container instance that was deregistered.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 }
 
@@ -5661,8 +5675,7 @@ func (s *RegisterContainerInstanceInput) SetVersionInfo(v *VersionInfo) *Registe
 type RegisterContainerInstanceOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An EC2 instance that is running the Amazon ECS agent and has been registered
-	// with a cluster.
+	// The container instance that was registered.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 }
 
@@ -6418,7 +6431,7 @@ func (s *StopTaskInput) SetTask(v string) *StopTaskInput {
 type StopTaskOutput struct {
 	_ struct{} `type:"structure"`
 
-	// Details on a task in a cluster.
+	// The task that was stopped.
 	Task *Task `locationName:"task" type:"structure"`
 }
 
@@ -6662,6 +6675,14 @@ type Task struct {
 
 	// The Amazon Resource Name (ARN) of the task definition that creates the task.
 	TaskDefinitionArn *string `locationName:"taskDefinitionArn" type:"string"`
+
+	// The version counter for the task. Every time a task experiences a change
+	// that triggers a CloudWatch event, the version counter is incremented. If
+	// you are replicating your Amazon ECS task state with CloudWatch events, you
+	// can compare the version of a task reported by the Amazon ECS APIs with the
+	// version reported in CloudWatch events for the task (inside the detail object)
+	// to verify that the version in your event stream is current.
+	Version *int64 `locationName:"version" type:"long"`
 }
 
 // String returns the string representation
@@ -6749,6 +6770,12 @@ func (s *Task) SetTaskArn(v string) *Task {
 // SetTaskDefinitionArn sets the TaskDefinitionArn field's value.
 func (s *Task) SetTaskDefinitionArn(v string) *Task {
 	s.TaskDefinitionArn = &v
+	return s
+}
+
+// SetVersion sets the Version field's value.
+func (s *Task) SetVersion(v int64) *Task {
+	s.Version = &v
 	return s
 }
 
@@ -7024,8 +7051,7 @@ func (s *UpdateContainerAgentInput) SetContainerInstance(v string) *UpdateContai
 type UpdateContainerAgentOutput struct {
 	_ struct{} `type:"structure"`
 
-	// An EC2 instance that is running the Amazon ECS agent and has been registered
-	// with a cluster.
+	// The container instance for which the container agent was updated.
 	ContainerInstance *ContainerInstance `locationName:"containerInstance" type:"structure"`
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/glacier/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/glacier/api.go
@@ -75,7 +75,7 @@ func (c *Glacier) AbortMultipartUploadRequest(input *AbortMultipartUploadInput) 
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Working with Archives
+// For conceptual information and underlying REST API, see Working with Archives
 // in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html)
 // and Abort Multipart Upload (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html)
 // in the Amazon Glacier Developer Guide.
@@ -89,8 +89,8 @@ func (c *Glacier) AbortMultipartUploadRequest(input *AbortMultipartUploadInput) 
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -180,8 +180,8 @@ func (c *Glacier) AbortVaultLockRequest(input *AbortVaultLockInput) (req *reques
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -267,8 +267,8 @@ func (c *Glacier) AddTagsToVaultRequest(input *AddTagsToVaultInput) (req *reques
 //   Returned if a required header or parameter is missing from the request.
 //
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * LimitExceededException
 //   Returned if the request results in a vault or account limit being exceeded.
@@ -367,8 +367,8 @@ func (c *Glacier) CompleteMultipartUploadRequest(input *CompleteMultipartUploadI
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Uploading Large
-// Archives in Parts (Multipart Upload) (http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html)
+// For conceptual information and underlying REST API, see Uploading Large Archives
+// in Parts (Multipart Upload) (http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html)
 // and Complete Multipart Upload (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-complete-upload.html)
 // in the Amazon Glacier Developer Guide.
 //
@@ -381,8 +381,8 @@ func (c *Glacier) CompleteMultipartUploadRequest(input *CompleteMultipartUploadI
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -471,8 +471,8 @@ func (c *Glacier) CompleteVaultLockRequest(input *CompleteVaultLockInput) (req *
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -541,10 +541,10 @@ func (c *Glacier) CreateVaultRequest(input *CreateVaultInput) (req *request.Requ
 //
 // You must use the following guidelines when naming a vault.
 //
-// Names can be between 1 and 255 characters long.
+//    * Names can be between 1 and 255 characters long.
 //
-// Allowed characters are a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen), and
-// '.' (period).
+//    * Allowed characters are a-z, A-Z, 0-9, '_' (underscore), '-' (hyphen),
+//    and '.' (period).
 //
 // This operation is idempotent.
 //
@@ -554,7 +554,7 @@ func (c *Glacier) CreateVaultRequest(input *CreateVaultInput) (req *request.Requ
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Creating a Vault
+// For conceptual information and underlying REST API, see Creating a Vault
 // in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/creating-vaults.html)
 // and Create Vault  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-put.html)
 // in the Amazon Glacier Developer Guide.
@@ -639,9 +639,11 @@ func (c *Glacier) DeleteArchiveRequest(input *DeleteArchiveInput) (req *request.
 //    * If the archive retrieval job is actively preparing the data for download
 //    when Amazon Glacier receives the delete archive request, the archival
 //    retrieval operation might fail.
+//
 //    * If the archive retrieval job has successfully prepared the archive for
 //    download when Amazon Glacier receives the delete archive request, you
 //    will be able to download the output.
+//
 // This operation is idempotent. Attempting to delete an already-deleted archive
 // does not result in an error.
 //
@@ -651,7 +653,7 @@ func (c *Glacier) DeleteArchiveRequest(input *DeleteArchiveInput) (req *request.
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Deleting an Archive
+// For conceptual information and underlying REST API, see Deleting an Archive
 // in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/deleting-an-archive.html)
 // and Delete Archive (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-delete.html)
 // in the Amazon Glacier Developer Guide.
@@ -665,8 +667,8 @@ func (c *Glacier) DeleteArchiveRequest(input *DeleteArchiveInput) (req *request.
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -749,7 +751,7 @@ func (c *Glacier) DeleteVaultRequest(input *DeleteVaultInput) (req *request.Requ
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Deleting a Vault
+// For conceptual information and underlying REST API, see Deleting a Vault
 // in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/deleting-vaults.html)
 // and Delete Vault  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-delete.html)
 // in the Amazon Glacier Developer Guide.
@@ -763,8 +765,8 @@ func (c *Glacier) DeleteVaultRequest(input *DeleteVaultInput) (req *request.Requ
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -848,8 +850,8 @@ func (c *Glacier) DeleteVaultAccessPolicyRequest(input *DeleteVaultAccessPolicyI
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -924,7 +926,7 @@ func (c *Glacier) DeleteVaultNotificationsRequest(input *DeleteVaultNotification
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Configuring Vault
+// For conceptual information and underlying REST API, see Configuring Vault
 // Notifications in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/configuring-notifications.html)
 // and Delete Vault Notification Configuration  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-delete.html)
 // in the Amazon Glacier Developer Guide.
@@ -938,8 +940,8 @@ func (c *Glacier) DeleteVaultNotificationsRequest(input *DeleteVaultNotification
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1020,7 +1022,7 @@ func (c *Glacier) DescribeJobRequest(input *DescribeJobInput) (req *request.Requ
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For information about the underlying REST API, go to Working with Archives
+// For information about the underlying REST API, see Working with Archives
 // in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-describe-job-get.html)
 // in the Amazon Glacier Developer Guide.
 //
@@ -1033,8 +1035,8 @@ func (c *Glacier) DescribeJobRequest(input *DescribeJobInput) (req *request.Requ
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1112,7 +1114,7 @@ func (c *Glacier) DescribeVaultRequest(input *DescribeVaultInput) (req *request.
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Retrieving Vault
+// For conceptual information and underlying REST API, see Retrieving Vault
 // Metadata in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/retrieving-vault-info.html)
 // and Describe Vault  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-get.html)
 // in the Amazon Glacier Developer Guide.
@@ -1126,8 +1128,8 @@ func (c *Glacier) DescribeVaultRequest(input *DescribeVaultInput) (req *request.
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1265,35 +1267,35 @@ func (c *Glacier) GetJobOutputRequest(input *GetJobOutputInput) (req *request.Re
 // Depending on the job type you specified when you initiated the job, the output
 // will be either the content of an archive or a vault inventory.
 //
+// You can download all the job output or download a portion of the output by
+// specifying a byte range. In the case of an archive retrieval job, depending
+// on the byte range you specify, Amazon Glacier returns the checksum for the
+// portion of the data. You can compute the checksum on the client and verify
+// that the values match to ensure the portion you downloaded is the correct
+// data.
+//
 // A job ID will not expire for at least 24 hours after Amazon Glacier completes
+// the job. That a byte range. For both archive and inventory retrieval jobs,
+// you should verify the downloaded size against the size returned in the headers
+// from the Get Job Output response.
+//
+// For archive retrieval jobs, you should also verify that the size is what
+// you expected. If you download a portion of the output, the expected size
+// is based on the range of bytes you specified. For example, if you specify
+// a range of bytes=0-1048575, you should verify your download size is 1,048,576
+// bytes. If you download an entire archive, the expected size is the size of
+// the archive when you uploaded it to Amazon Glacier The expected size is also
+// returned in the headers from the Get Job Output response.
+//
+// In the case of an archive retrieval job, depending on the byte range you
+// specify, Amazon Glacier returns the checksum for the portion of the data.
+// To ensure the portion you downloaded is the correct data, compute the checksum
+// on the client, verify that the values match, and verify that the size is
+// what you expected.
+//
+// A job ID does not expire for at least 24 hours after Amazon Glacier completes
 // the job. That is, you can download the job output within the 24 hours period
 // after Amazon Glacier completes the job.
-//
-// If the job output is large, then you can use the Range request header to
-// retrieve a portion of the output. This allows you to download the entire
-// output in smaller chunks of bytes. For example, suppose you have 1 GB of
-// job output you want to download and you decide to download 128 MB chunks
-// of data at a time, which is a total of eight Get Job Output requests. You
-// use the following process to download the job output:
-//
-// Download a 128 MB chunk of output by specifying the appropriate byte range
-// using the Range header.
-//
-// Along with the data, the response includes a SHA256 tree hash of the payload.
-// You compute the checksum of the payload on the client and compare it with
-// the checksum you received in the response to ensure you received all the
-// expected data.
-//
-// Repeat steps 1 and 2 for all the eight 128 MB chunks of output data, each
-// time specifying the appropriate byte range.
-//
-// After downloading all the parts of the job output, you have a list of eight
-// checksum values. Compute the tree hash of these values to find the checksum
-// of the entire output. Using the DescribeJob API, obtain job information of
-// the job that provided you the output. The response includes the checksum
-// of the entire archive stored in Amazon Glacier. You compare this value with
-// the checksum you computed to ensure you have downloaded the entire archive
-// content with no errors.
 //
 // An AWS account has full permission to perform all operations (actions). However,
 // AWS Identity and Access Management (IAM) users don't have any permissions
@@ -1301,8 +1303,8 @@ func (c *Glacier) GetJobOutputRequest(input *GetJobOutputInput) (req *request.Re
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and the underlying REST API, go to Downloading
-// a Vault Inventory (http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html),
+// For conceptual information and the underlying REST API, see Downloading a
+// Vault Inventory (http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html),
 // Downloading an Archive (http://docs.aws.amazon.com/amazonglacier/latest/dev/downloading-an-archive.html),
 // and Get Job Output  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-job-output-get.html)
 //
@@ -1315,8 +1317,8 @@ func (c *Glacier) GetJobOutputRequest(input *GetJobOutputInput) (req *request.Re
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1394,8 +1396,8 @@ func (c *Glacier) GetVaultAccessPolicyRequest(input *GetVaultAccessPolicyInput) 
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1458,14 +1460,16 @@ func (c *Glacier) GetVaultLockRequest(input *GetVaultLockInput) (req *request.Re
 // GetVaultLock API operation for Amazon Glacier.
 //
 // This operation retrieves the following attributes from the lock-policy subresource
-// set on the specified vault: The vault lock policy set on the vault.
+// set on the specified vault:
 //
-// The state of the vault lock, which is either InProgess or Locked.
+//    * The vault lock policy set on the vault.
 //
-// When the lock ID expires. The lock ID is used to complete the vault locking
-// process.
+//    * The state of the vault lock, which is either InProgess or Locked.
 //
-// When the vault lock was initiated and put into the InProgress state.
+//    * When the lock ID expires. The lock ID is used to complete the vault
+//    locking process.
+//
+//    * When the vault lock was initiated and put into the InProgress state.
 //
 // A vault lock is put into the InProgress state by calling InitiateVaultLock.
 // A vault lock is put into the Locked state by calling CompleteVaultLock. You
@@ -1485,8 +1489,8 @@ func (c *Glacier) GetVaultLockRequest(input *GetVaultLockInput) (req *request.Re
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1563,7 +1567,7 @@ func (c *Glacier) GetVaultNotificationsRequest(input *GetVaultNotificationsInput
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Configuring Vault
+// For conceptual information and underlying REST API, see Configuring Vault
 // Notifications in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/configuring-notifications.html)
 // and Get Vault Notification Configuration  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-get.html)
 // in the Amazon Glacier Developer Guide.
@@ -1577,8 +1581,8 @@ func (c *Glacier) GetVaultNotificationsRequest(input *GetVaultNotificationsInput
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1753,9 +1757,29 @@ func (c *Glacier) InitiateJobRequest(input *InitiateJobInput) (req *request.Requ
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and the underlying REST API, go to Initiate a
-// Job (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html)
+// For conceptual information and the underlying REST API, see Initiate a Job
+// (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html)
 // and Downloading a Vault Inventory (http://docs.aws.amazon.com/amazonglacier/latest/dev/vault-inventory.html)
+//
+// Expedited and Bulk Archive Retrievals
+//
+// When retrieving an archive, you can specify one of the following options
+// in the Tier field of the request body:
+//
+//    * Standard The default type of retrieval, which allows access to any of
+//    your archives within several hours. Standard retrievals typically complete
+//    within 3–5 hours.
+//
+//    * Bulk Amazon Glacier’s lowest-cost retrieval option, which enables you
+//    to retrieve large amounts of data inexpensively in a day. Bulk retrieval
+//    requests typically complete within 5–12 hours.
+//
+//    * Expedited Amazon Glacier’s option for the fastest retrievals. Archives
+//    requested using the expedited retrievals typically become accessible within
+//    1–5 minutes.
+//
+// For more information about expedited and bulk retrievals, see Retrieving
+// Amazon Glacier Archives (http://docs.aws.amazon.com/amazonglacier/latest/dev/downloading-an-archive-two-steps.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1766,8 +1790,8 @@ func (c *Glacier) InitiateJobRequest(input *InitiateJobInput) (req *request.Requ
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * PolicyEnforcedException
 //   Returned if a retrieval job would exceed the current data policy's retrieval
@@ -1778,6 +1802,11 @@ func (c *Glacier) InitiateJobRequest(input *InitiateJobInput) (req *request.Requ
 //
 //   * MissingParameterValueException
 //   Returned if a required header or parameter is missing from the request.
+//
+//   * InsufficientCapacityException
+//   Returned if there is insufficient capacity to process this expedited request.
+//   This error only applies to expedited retrievals and not to standard or bulk
+//   retrievals.
 //
 //   * ServiceUnavailableException
 //   Returned if the service cannot complete the request.
@@ -1864,8 +1893,8 @@ func (c *Glacier) InitiateMultipartUploadRequest(input *InitiateMultipartUploadI
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Uploading Large
-// Archives in Parts (Multipart Upload) (http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html)
+// For conceptual information and underlying REST API, see Uploading Large Archives
+// in Parts (Multipart Upload) (http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html)
 // and Initiate Multipart Upload (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-initiate-upload.html)
 // in the Amazon Glacier Developer Guide.
 //
@@ -1878,8 +1907,8 @@ func (c *Glacier) InitiateMultipartUploadRequest(input *InitiateMultipartUploadI
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -1942,11 +1971,12 @@ func (c *Glacier) InitiateVaultLockRequest(input *InitiateVaultLockInput) (req *
 // InitiateVaultLock API operation for Amazon Glacier.
 //
 // This operation initiates the vault locking process by doing the following:
-// Installing a vault lock policy on the specified vault.
 //
-// Setting the lock state of vault lock to InProgress.
+//    * Installing a vault lock policy on the specified vault.
 //
-// Returning a lock ID, which is used to complete the vault locking process.
+//    * Setting the lock state of vault lock to InProgress.
+//
+//    * Returning a lock ID, which is used to complete the vault locking process.
 //
 // You can set one vault lock policy for each vault and this policy can be up
 // to 20 KB in size. For more information about vault lock policies, see Amazon
@@ -1979,8 +2009,8 @@ func (c *Glacier) InitiateVaultLockRequest(input *InitiateVaultLockInput) (req *
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -2063,31 +2093,31 @@ func (c *Glacier) ListJobsRequest(input *ListJobsInput) (req *request.Request, o
 //
 // To retrieve an archive or retrieve a vault inventory from Amazon Glacier,
 // you first initiate a job, and after the job completes, you download the data.
-// For an archive retrieval, the output is the archive data, and for an inventory
+// For an archive retrieval, the output is the archive data. For an inventory
 // retrieval, it is the inventory list. The List Job operation returns a list
 // of these jobs sorted by job initiation time.
 //
-// This List Jobs operation supports pagination. By default, this operation
-// returns up to 1,000 jobs in the response. You should always check the response
-// for a marker at which to continue the list; if there are no more items the
-// marker is null. To return a list of jobs that begins at a specific job, set
-// the marker request parameter to the value you obtained from a previous List
-// Jobs request. You can also limit the number of jobs returned in the response
-// by specifying the limit parameter in the request.
+// The List Jobs operation supports pagination. You should always check the
+// response Marker field. If there are no more jobs to list, the Marker field
+// is set to null. If there are more jobs to list, the Marker field is set to
+// a non-null value, which you can use to continue the pagination of the list.
+// To return a list of jobs that begins at a specific job, set the marker request
+// parameter to the Marker value for that job that you obtained from a previous
+// List Jobs request.
 //
-// Additionally, you can filter the jobs list returned by specifying an optional
-// statuscode (InProgress, Succeeded, or Failed) and completed (true, false)
-// parameter. The statuscode allows you to specify that only jobs that match
-// a specified status are returned. The completed parameter allows you to specify
-// that only jobs in a specific completion state are returned.
+// You can set a maximum limit for the number of jobs returned in the response
+// by specifying the limit parameter in the request. The default limit is 1000.
+// The number of jobs returned might be fewer than the limit, but the number
+// of returned jobs never exceeds the limit.
 //
-// An AWS account has full permission to perform all operations (actions). However,
-// AWS Identity and Access Management (IAM) users don't have any permissions
-// by default. You must grant them explicit permission to perform specific actions.
-// For more information, see Access Control Using AWS Identity and Access Management
-// (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
+// Additionally, you can filter the jobs list returned by specifying the optional
+// statuscode parameter or completed parameter, or both. Using the statuscode
+// parameter, you can specify to return only jobs that match either the InProgress,
+// Succeeded, or Failed status. Using the completed parameter, you can specify
+// to return only jobs that were completed (true) or jobs that were not completed
+// (false).
 //
-// For the underlying REST API, go to List Jobs  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-jobs-get.html)
+// For the underlying REST API, see List Jobs (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-jobs-get.html).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2098,8 +2128,8 @@ func (c *Glacier) ListJobsRequest(input *ListJobsInput) (req *request.Request, o
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -2218,7 +2248,7 @@ func (c *Glacier) ListMultipartUploadsRequest(input *ListMultipartUploadsInput) 
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and the underlying REST API, go to Working with
+// For conceptual information and the underlying REST API, see Working with
 // Archives in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html)
 // and List Multipart Uploads  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-list-uploads.html)
 // in the Amazon Glacier Developer Guide.
@@ -2232,8 +2262,8 @@ func (c *Glacier) ListMultipartUploadsRequest(input *ListMultipartUploadsInput) 
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -2346,7 +2376,7 @@ func (c *Glacier) ListPartsRequest(input *ListPartsInput) (req *request.Request,
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and the underlying REST API, go to Working with
+// For conceptual information and the underlying REST API, see Working with
 // Archives in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html)
 // and List Parts (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-list-parts.html)
 // in the Amazon Glacier Developer Guide.
@@ -2360,8 +2390,8 @@ func (c *Glacier) ListPartsRequest(input *ListPartsInput) (req *request.Request,
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -2401,6 +2431,76 @@ func (c *Glacier) ListPartsPages(input *ListPartsInput, fn func(p *ListPartsOutp
 	return page.EachPage(func(p interface{}, lastPage bool) bool {
 		return fn(p.(*ListPartsOutput), lastPage)
 	})
+}
+
+const opListProvisionedCapacity = "ListProvisionedCapacity"
+
+// ListProvisionedCapacityRequest generates a "aws/request.Request" representing the
+// client's request for the ListProvisionedCapacity operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListProvisionedCapacity for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListProvisionedCapacity method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListProvisionedCapacityRequest method.
+//    req, resp := client.ListProvisionedCapacityRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *Glacier) ListProvisionedCapacityRequest(input *ListProvisionedCapacityInput) (req *request.Request, output *ListProvisionedCapacityOutput) {
+	op := &request.Operation{
+		Name:       opListProvisionedCapacity,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{accountId}/provisioned-capacity",
+	}
+
+	if input == nil {
+		input = &ListProvisionedCapacityInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &ListProvisionedCapacityOutput{}
+	req.Data = output
+	return
+}
+
+// ListProvisionedCapacity API operation for Amazon Glacier.
+//
+// This operation lists the provisioned capacity for the specified AWS account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Glacier's
+// API operation ListProvisionedCapacity for usage and error information.
+//
+// Returned Error Codes:
+//   * InvalidParameterValueException
+//   Returned if a parameter of the request is incorrectly specified.
+//
+//   * MissingParameterValueException
+//   Returned if a required header or parameter is missing from the request.
+//
+//   * ServiceUnavailableException
+//   Returned if the service cannot complete the request.
+//
+func (c *Glacier) ListProvisionedCapacity(input *ListProvisionedCapacityInput) (*ListProvisionedCapacityOutput, error) {
+	req, out := c.ListProvisionedCapacityRequest(input)
+	err := req.Send()
+	return out, err
 }
 
 const opListTagsForVault = "ListTagsForVault"
@@ -2467,8 +2567,8 @@ func (c *Glacier) ListTagsForVaultRequest(input *ListTagsForVaultInput) (req *re
 //   Returned if a required header or parameter is missing from the request.
 //
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * ServiceUnavailableException
 //   Returned if the service cannot complete the request.
@@ -2547,7 +2647,7 @@ func (c *Glacier) ListVaultsRequest(input *ListVaultsInput) (req *request.Reques
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Retrieving Vault
+// For conceptual information and underlying REST API, see Retrieving Vault
 // Metadata in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/retrieving-vault-info.html)
 // and List Vaults  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vaults-get.html)
 // in the Amazon Glacier Developer Guide.
@@ -2561,8 +2661,8 @@ func (c *Glacier) ListVaultsRequest(input *ListVaultsInput) (req *request.Reques
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -2602,6 +2702,79 @@ func (c *Glacier) ListVaultsPages(input *ListVaultsInput, fn func(p *ListVaultsO
 	return page.EachPage(func(p interface{}, lastPage bool) bool {
 		return fn(p.(*ListVaultsOutput), lastPage)
 	})
+}
+
+const opPurchaseProvisionedCapacity = "PurchaseProvisionedCapacity"
+
+// PurchaseProvisionedCapacityRequest generates a "aws/request.Request" representing the
+// client's request for the PurchaseProvisionedCapacity operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See PurchaseProvisionedCapacity for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the PurchaseProvisionedCapacity method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the PurchaseProvisionedCapacityRequest method.
+//    req, resp := client.PurchaseProvisionedCapacityRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *Glacier) PurchaseProvisionedCapacityRequest(input *PurchaseProvisionedCapacityInput) (req *request.Request, output *PurchaseProvisionedCapacityOutput) {
+	op := &request.Operation{
+		Name:       opPurchaseProvisionedCapacity,
+		HTTPMethod: "POST",
+		HTTPPath:   "/{accountId}/provisioned-capacity",
+	}
+
+	if input == nil {
+		input = &PurchaseProvisionedCapacityInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &PurchaseProvisionedCapacityOutput{}
+	req.Data = output
+	return
+}
+
+// PurchaseProvisionedCapacity API operation for Amazon Glacier.
+//
+// This operation purchases a provisioned capacity unit for an AWS account.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Glacier's
+// API operation PurchaseProvisionedCapacity for usage and error information.
+//
+// Returned Error Codes:
+//   * InvalidParameterValueException
+//   Returned if a parameter of the request is incorrectly specified.
+//
+//   * MissingParameterValueException
+//   Returned if a required header or parameter is missing from the request.
+//
+//   * LimitExceededException
+//   Returned if the request results in a vault or account limit being exceeded.
+//
+//   * ServiceUnavailableException
+//   Returned if the service cannot complete the request.
+//
+func (c *Glacier) PurchaseProvisionedCapacity(input *PurchaseProvisionedCapacityInput) (*PurchaseProvisionedCapacityOutput, error) {
+	req, out := c.PurchaseProvisionedCapacityRequest(input)
+	err := req.Send()
+	return out, err
 }
 
 const opRemoveTagsFromVault = "RemoveTagsFromVault"
@@ -2672,8 +2845,8 @@ func (c *Glacier) RemoveTagsFromVaultRequest(input *RemoveTagsFromVaultInput) (r
 //   Returned if a required header or parameter is missing from the request.
 //
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * ServiceUnavailableException
 //   Returned if the service cannot complete the request.
@@ -2826,8 +2999,8 @@ func (c *Glacier) SetVaultAccessPolicyRequest(input *SetVaultAccessPolicyInput) 
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -2907,17 +3080,19 @@ func (c *Glacier) SetVaultNotificationsRequest(input *SetVaultNotificationsInput
 //    for an archive retrieval is completed (InitiateJob). The status of the
 //    completed job can be "Succeeded" or "Failed". The notification sent to
 //    the SNS topic is the same output as returned from DescribeJob.
+//
 //    * InventoryRetrievalCompleted This event occurs when a job that was initiated
 //    for an inventory retrieval is completed (InitiateJob). The status of the
 //    completed job can be "Succeeded" or "Failed". The notification sent to
 //    the SNS topic is the same output as returned from DescribeJob.
+//
 // An AWS account has full permission to perform all operations (actions). However,
 // AWS Identity and Access Management (IAM) users don't have any permissions
 // by default. You must grant them explicit permission to perform specific actions.
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Configuring Vault
+// For conceptual information and underlying REST API, see Configuring Vault
 // Notifications in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/configuring-notifications.html)
 // and Set Vault Notification Configuration  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-vault-notifications-put.html)
 // in the Amazon Glacier Developer Guide.
@@ -2931,8 +3106,8 @@ func (c *Glacier) SetVaultNotificationsRequest(input *SetVaultNotificationsInput
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -3026,7 +3201,7 @@ func (c *Glacier) UploadArchiveRequest(input *UploadArchiveInput) (req *request.
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Uploading an Archive
+// For conceptual information and underlying REST API, see Uploading an Archive
 // in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-an-archive.html)
 // and Upload Archive (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html)
 // in the Amazon Glacier Developer Guide.
@@ -3040,8 +3215,8 @@ func (c *Glacier) UploadArchiveRequest(input *UploadArchiveInput) (req *request.
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -3138,6 +3313,7 @@ func (c *Glacier) UploadMultipartPartRequest(input *UploadMultipartPartInput) (r
 //    valid part ranges. However, if you set a range value of 2 MB to 6 MB,
 //    the range does not align with the part size and the upload will fail.
 //
+//
 // This operation is idempotent. If you upload the same part multiple times,
 // the data included in the most recent request overwrites the previously uploaded
 // data.
@@ -3148,8 +3324,8 @@ func (c *Glacier) UploadMultipartPartRequest(input *UploadMultipartPartInput) (r
 // For more information, see Access Control Using AWS Identity and Access Management
 // (IAM) (http://docs.aws.amazon.com/amazonglacier/latest/dev/using-iam-with-amazon-glacier.html).
 //
-// For conceptual information and underlying REST API, go to Uploading Large
-// Archives in Parts (Multipart Upload) (http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html)
+// For conceptual information and underlying REST API, see Uploading Large Archives
+// in Parts (Multipart Upload) (http://docs.aws.amazon.com/amazonglacier/latest/dev/uploading-archive-mpu.html)
 // and Upload Part  (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-upload-part.html)
 // in the Amazon Glacier Developer Guide.
 //
@@ -3162,8 +3338,8 @@ func (c *Glacier) UploadMultipartPartRequest(input *UploadMultipartPartInput) (r
 //
 // Returned Error Codes:
 //   * ResourceNotFoundException
-//   Returned if the specified resource, such as a vault, upload ID, or job ID,
-//   does not exist.
+//   Returned if the specified resource (such as a vault, upload ID, or job ID)
+//   doesn't exist.
 //
 //   * InvalidParameterValueException
 //   Returned if a parameter of the request is incorrectly specified.
@@ -3186,18 +3362,17 @@ func (c *Glacier) UploadMultipartPart(input *UploadMultipartPartInput) (*UploadM
 
 // Provides options to abort a multipart upload identified by the upload ID.
 //
-// For information about the underlying REST API, go to Abort Multipart Upload
+// For information about the underlying REST API, see Abort Multipart Upload
 // (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-multipart-abort-upload.html).
-// For conceptual information, go to Working with Archives in Amazon Glacier
-// (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html).
+// For conceptual information, see Working with Archives in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html).
 type AbortMultipartUploadInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3280,10 +3455,10 @@ type AbortVaultLockInput struct {
 
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
-	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
+	// can either specify an AWS account ID or optionally a single '-' (hyphen),
 	// in which case Amazon Glacier uses the AWS account ID associated with the
 	// credentials used to sign the request. If you specify your account ID, do
-	// not include any hyphens (apos-apos) in the ID.
+	// not include any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3351,10 +3526,10 @@ type AddTagsToVaultInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3429,9 +3604,8 @@ func (s AddTagsToVaultOutput) GoString() string {
 
 // Contains the Amazon Glacier response to your request.
 //
-// For information about the underlying REST API, go to Upload Archive (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html).
-// For conceptual information, go to Working with Archives in Amazon Glacier
-// (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html).
+// For information about the underlying REST API, see Upload Archive (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-archive-post.html).
+// For conceptual information, see Working with Archives in Amazon Glacier (http://docs.aws.amazon.com/amazonglacier/latest/dev/working-with-archives.html).
 type ArchiveCreationOutput struct {
 	_ struct{} `type:"structure"`
 
@@ -3482,10 +3656,10 @@ type CompleteMultipartUploadInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3576,10 +3750,10 @@ type CompleteVaultLockInput struct {
 
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
-	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
+	// can either specify an AWS account ID or optionally a single '-' (hyphen),
 	// in which case Amazon Glacier uses the AWS account ID associated with the
 	// credentials used to sign the request. If you specify your account ID, do
-	// not include any hyphens (apos-apos) in the ID.
+	// not include any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3662,10 +3836,10 @@ type CreateVaultInput struct {
 
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
-	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
+	// can either specify an AWS account ID or optionally a single '-' (hyphen),
 	// in which case Amazon Glacier uses the AWS account ID associated with the
 	// credentials used to sign the request. If you specify your account ID, do
-	// not include any hyphens (apos-apos) in the ID.
+	// not include any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3807,10 +3981,10 @@ type DeleteArchiveInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3892,10 +4066,10 @@ type DeleteVaultAccessPolicyInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -3963,10 +4137,10 @@ type DeleteVaultInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4021,10 +4195,10 @@ type DeleteVaultNotificationsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4106,10 +4280,10 @@ type DescribeJobInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4177,10 +4351,10 @@ type DescribeVaultInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4233,22 +4407,23 @@ func (s *DescribeVaultInput) SetVaultName(v string) *DescribeVaultInput {
 type DescribeVaultOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The UTC date when the vault was created. A string representation of ISO 8601
-	// date format, for example, "2012-03-20T17:03:43.221Z".
+	// The Universal Coordinated Time (UTC) date when the vault was created. This
+	// value should be a string in the ISO 8601 date format, for example 2012-03-20T17:03:43.221Z.
 	CreationDate *string `type:"string"`
 
-	// The UTC date when Amazon Glacier completed the last vault inventory. A string
-	// representation of ISO 8601 date format, for example, "2012-03-20T17:03:43.221Z".
+	// The Universal Coordinated Time (UTC) date when Amazon Glacier completed the
+	// last vault inventory. This value should be a string in the ISO 8601 date
+	// format, for example 2012-03-20T17:03:43.221Z.
 	LastInventoryDate *string `type:"string"`
 
 	// The number of archives in the vault as of the last inventory date. This field
-	// will return null if an inventory has not yet run on the vault, for example,
+	// will return null if an inventory has not yet run on the vault, for example
 	// if you just created the vault.
 	NumberOfArchives *int64 `type:"long"`
 
 	// Total size, in bytes, of the archives in the vault as of the last inventory
 	// date. This field will return null if an inventory has not yet run on the
-	// vault, for example, if you just created the vault.
+	// vault, for example if you just created the vault.
 	SizeInBytes *int64 `type:"long"`
 
 	// The Amazon Resource Name (ARN) of the vault.
@@ -4310,10 +4485,10 @@ type GetDataRetrievalPolicyInput struct {
 
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
-	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
+	// can either specify an AWS account ID or optionally a single '-' (hyphen),
 	// in which case Amazon Glacier uses the AWS account ID associated with the
 	// credentials used to sign the request. If you specify your account ID, do
-	// not include any hyphens (apos-apos) in the ID.
+	// not include any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4377,10 +4552,10 @@ type GetJobOutputInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4391,8 +4566,34 @@ type GetJobOutputInput struct {
 	JobId *string `location:"uri" locationName:"jobId" type:"string" required:"true"`
 
 	// The range of bytes to retrieve from the output. For example, if you want
-	// to download the first 1,048,576 bytes, specify "Range: bytes=0-1048575".
+	// to download the first 1,048,576 bytes, specify the range as bytes=0-1048575.
 	// By default, this operation downloads the entire output.
+	//
+	// If the job output is large, then you can use a range to retrieve a portion
+	// of the output. This allows you to download the entire output in smaller chunks
+	// of bytes. For example, suppose you have 1 GB of job output you want to download
+	// and you decide to download 128 MB chunks of data at a time, which is a total
+	// of eight Get Job Output requests. You use the following process to download
+	// the job output:
+	//
+	// Download a 128 MB chunk of output by specifying the appropriate byte range.
+	// Verify that all 128 MB of data was received.
+	//
+	// Along with the data, the response includes a SHA256 tree hash of the payload.
+	// You compute the checksum of the payload on the client and compare it with
+	// the checksum you received in the response to ensure you received all the
+	// expected data.
+	//
+	// Repeat steps 1 and 2 for all the eight 128 MB chunks of output data, each
+	// time specifying the appropriate byte range.
+	//
+	// After downloading all the parts of the job output, you have a list of eight
+	// checksum values. Compute the tree hash of these values to find the checksum
+	// of the entire output. Using the DescribeJob API, obtain job information of
+	// the job that provided you the output. The response includes the checksum
+	// of the entire archive stored in Amazon Glacier. You compare this value with
+	// the checksum you computed to ensure you have downloaded the entire archive
+	// content with no errors.
 	Range *string `location:"header" locationName:"Range" type:"string"`
 
 	// The name of the vault.
@@ -4458,7 +4659,7 @@ func (s *GetJobOutputInput) SetVaultName(v string) *GetJobOutputInput {
 type GetJobOutputOutput struct {
 	_ struct{} `type:"structure" payload:"Body"`
 
-	// Indicates the range units accepted. For more information, go to RFC2616 (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
+	// Indicates the range units accepted. For more information, see RFC2616 (http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html).
 	AcceptRanges *string `location:"header" locationName:"Accept-Ranges" type:"string"`
 
 	// The description of an archive.
@@ -4469,17 +4670,20 @@ type GetJobOutputOutput struct {
 
 	// The checksum of the data in the response. This header is returned only when
 	// retrieving the output for an archive retrieval job. Furthermore, this header
-	// appears only under the following conditions: You get the entire range of
-	// the archive.
-	// You request a range to return of the archive that starts and ends on a multiple
-	// of 1 MB. For example, if you have an 3.1 MB archive and you specify a range
-	// to return that starts at 1 MB and ends at 2 MB, then the x-amz-sha256-tree-hash
-	// is returned as a response header.
-	// You request a range of the archive to return that starts on a multiple of
-	// 1 MB and goes to the end of the archive. For example, if you have a 3.1 MB
-	// archive and you specify a range that starts at 2 MB and ends at 3.1 MB (the
-	// end of the archive), then the x-amz-sha256-tree-hash is returned as a response
-	// header.
+	// appears only under the following conditions:
+	//
+	//    * You get the entire range of the archive.
+	//
+	//    * You request a range to return of the archive that starts and ends on
+	//    a multiple of 1 MB. For example, if you have an 3.1 MB archive and you
+	//    specify a range to return that starts at 1 MB and ends at 2 MB, then the
+	//    x-amz-sha256-tree-hash is returned as a response header.
+	//
+	//    * You request a range of the archive to return that starts on a multiple
+	//    of 1 MB and goes to the end of the archive. For example, if you have a
+	//    3.1 MB archive and you specify a range that starts at 2 MB and ends at
+	//    3.1 MB (the end of the archive), then the x-amz-sha256-tree-hash is returned
+	//    as a response header.
 	Checksum *string `location:"header" locationName:"x-amz-sha256-tree-hash" type:"string"`
 
 	// The range of bytes returned by Amazon Glacier. If only partial output is
@@ -4556,10 +4760,10 @@ type GetVaultAccessPolicyInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4637,10 +4841,10 @@ type GetVaultLockInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4748,10 +4952,10 @@ type GetVaultNotificationsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4829,10 +5033,10 @@ type InitiateJobInput struct {
 	_ struct{} `type:"structure" payload:"JobParameters"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -4928,10 +5132,10 @@ type InitiateMultipartUploadInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -5044,10 +5248,10 @@ type InitiateVaultLockInput struct {
 
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
-	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
+	// can either specify an AWS account ID or optionally a single '-' (hyphen),
 	// in which case Amazon Glacier uses the AWS account ID associated with the
 	// credentials used to sign the request. If you specify your account ID, do
-	// not include any hyphens (apos-apos) in the ID.
+	// not include any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -5134,17 +5338,17 @@ type InventoryRetrievalJobDescription struct {
 	_ struct{} `type:"structure"`
 
 	// The end of the date range in UTC for vault inventory retrieval that includes
-	// archives created before this date. A string representation of ISO 8601 date
-	// format, for example, 2013-03-20T17:03:43Z.
+	// archives created before this date. This value should be a string in the ISO
+	// 8601 date format, for example 2013-03-20T17:03:43Z.
 	EndDate *string `type:"string"`
 
 	// The output format for the vault inventory list, which is set by the InitiateJob
 	// request when initiating a job to retrieve a vault inventory. Valid values
-	// are "CSV" and "JSON".
+	// are CSV and JSON.
 	Format *string `type:"string"`
 
-	// Specifies the maximum number of inventory items returned per vault inventory
-	// retrieval request. This limit is set when initiating the job with the a InitiateJob
+	// The maximum number of inventory items returned per vault inventory retrieval
+	// request. This limit is set when initiating the job with the a InitiateJob
 	// request.
 	Limit *string `type:"string"`
 
@@ -5155,9 +5359,9 @@ type InventoryRetrievalJobDescription struct {
 	// (http://docs.aws.amazon.com/amazonglacier/latest/dev/api-initiate-job-post.html#api-initiate-job-post-vault-inventory-list-filtering).
 	Marker *string `type:"string"`
 
-	// The start of the date range in UTC for vault inventory retrieval that includes
-	// archives created on or after this date. A string representation of ISO 8601
-	// date format, for example, 2013-03-20T17:03:43Z.
+	// The start of the date range in Universal Coordinated Time (UTC) for vault
+	// inventory retrieval that includes archives created on or after this date.
+	// This value should be a string in the ISO 8601 date format, for example 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
 }
 
@@ -5206,8 +5410,8 @@ type InventoryRetrievalJobInput struct {
 	_ struct{} `type:"structure"`
 
 	// The end of the date range in UTC for vault inventory retrieval that includes
-	// archives created before this date. A string representation of ISO 8601 date
-	// format, for example, 2013-03-20T17:03:43Z.
+	// archives created before this date. This value should be a string in the ISO
+	// 8601 date format, for example 2013-03-20T17:03:43Z.
 	EndDate *string `type:"string"`
 
 	// Specifies the maximum number of inventory items returned per vault inventory
@@ -5221,8 +5425,8 @@ type InventoryRetrievalJobInput struct {
 	Marker *string `type:"string"`
 
 	// The start of the date range in UTC for vault inventory retrieval that includes
-	// archives created on or after this date. A string representation of ISO 8601
-	// date format, for example, 2013-03-20T17:03:43Z.
+	// archives created on or after this date. This value should be a string in
+	// the ISO 8601 date format, for example 2013-03-20T17:03:43Z.
 	StartDate *string `type:"string"`
 }
 
@@ -5319,13 +5523,14 @@ type JobDescription struct {
 	// For the specific case when the whole archive is retrieved, this value is
 	// the same as the ArchiveSHA256TreeHash value.
 	//
-	// This field is null in the following situations: Archive retrieval jobs that
-	// specify a range that is not tree-hash aligned.
+	// This field is null in the following situations:
 	//
-	// Archival jobs that specify a range that is equal to the whole archive and
-	// the job status is InProgress.
+	//    * Archive retrieval jobs that specify a range that is not tree-hash aligned.
 	//
-	// Inventory jobs.
+	//    * Archival jobs that specify a range that is equal to the whole archive
+	//    and the job status is InProgress.
+	//
+	//    * Inventory jobs.
 	SHA256TreeHash *string `type:"string"`
 
 	// An Amazon Simple Notification Service (Amazon SNS) topic that receives notification.
@@ -5337,6 +5542,10 @@ type JobDescription struct {
 
 	// A friendly message that describes the job status.
 	StatusMessage *string `type:"string"`
+
+	// The retrieval option to use for the archive retrieval. Valid values are Expedited,
+	// Standard, or Bulk. Standard is the default.
+	Tier *string `type:"string"`
 
 	// The Amazon Resource Name (ARN) of the vault from which the archive retrieval
 	// was requested.
@@ -5449,6 +5658,12 @@ func (s *JobDescription) SetStatusMessage(v string) *JobDescription {
 	return s
 }
 
+// SetTier sets the Tier field's value.
+func (s *JobDescription) SetTier(v string) *JobDescription {
+	s.Tier = &v
+	return s
+}
+
 // SetVaultARN sets the VaultARN field's value.
 func (s *JobDescription) SetVaultARN(v string) *JobDescription {
 	s.VaultARN = &v
@@ -5494,6 +5709,10 @@ type JobParameters struct {
 	// the job is completed and the output is ready for you to download. The specified
 	// topic publishes the notification to its subscribers. The SNS topic must exist.
 	SNSTopic *string `type:"string"`
+
+	// The retrieval option to use for the archive retrieval. Valid values are Expedited,
+	// Standard, or Bulk. Standard is the default.
+	Tier *string `type:"string"`
 
 	// The job type. You can initiate a job to retrieve an archive or get an inventory
 	// of a vault. Valid values are "archive-retrieval" and "inventory-retrieval".
@@ -5546,6 +5765,12 @@ func (s *JobParameters) SetSNSTopic(v string) *JobParameters {
 	return s
 }
 
+// SetTier sets the Tier field's value.
+func (s *JobParameters) SetTier(v string) *JobParameters {
+	s.Tier = &v
+	return s
+}
+
 // SetType sets the Type field's value.
 func (s *JobParameters) SetType(v string) *JobParameters {
 	s.Type = &v
@@ -5557,29 +5782,30 @@ type ListJobsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
 
-	// Specifies the state of the jobs to return. You can specify true or false.
+	// The state of the jobs to return. You can specify true or false.
 	Completed *string `location:"querystring" locationName:"completed" type:"string"`
 
-	// Specifies that the response be limited to the specified number of items or
-	// fewer. If not specified, the List Jobs operation returns up to 1,000 jobs.
+	// The maximum number of jobs to be returned. The default limit is 1000. The
+	// number of jobs returned might be fewer than the specified limit, but the
+	// number of returned jobs never exceeds the limit.
 	Limit *string `location:"querystring" locationName:"limit" type:"string"`
 
 	// An opaque string used for pagination. This value specifies the job at which
 	// the listing of jobs should begin. Get the marker value from a previous List
-	// Jobs response. You need only include the marker if you are continuing the
-	// pagination of results started in a previous List Jobs request.
+	// Jobs response. You only need to include the marker if you are continuing
+	// the pagination of results started in a previous List Jobs request.
 	Marker *string `location:"querystring" locationName:"marker" type:"string"`
 
-	// Specifies the type of job status to return. You can specify the following
-	// values: "InProgress", "Succeeded", or "Failed".
+	// The type of job status to return. You can specify the following values: InProgress,
+	// Succeeded, or Failed.
 	Statuscode *string `location:"querystring" locationName:"statuscode" type:"string"`
 
 	// The name of the vault.
@@ -5657,9 +5883,10 @@ type ListJobsOutput struct {
 	// A list of job objects. Each job object contains metadata describing the job.
 	JobList []*JobDescription `type:"list"`
 
-	// An opaque string that represents where to continue pagination of the results.
-	// You use this value in a new List Jobs request to obtain more jobs in the
-	// list. If there are no more jobs, this value is null.
+	// An opaque string used for pagination that specifies the job at which the
+	// listing of jobs should begin. You get the marker value from a previous List
+	// Jobs response. You only need to include the marker if you are continuing
+	// the pagination of the results started in a previous List Jobs request.
 	Marker *string `type:"string"`
 }
 
@@ -5691,10 +5918,10 @@ type ListMultipartUploadsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -5807,16 +6034,17 @@ type ListPartsInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
 
-	// Specifies the maximum number of parts returned in the response body. If this
-	// value is not specified, the List Parts operation returns up to 1,000 uploads.
+	// The maximum number of parts to be returned. The default limit is 1000. The
+	// number of parts returned might be fewer than the specified limit, but the
+	// number of returned parts never exceeds the limit.
 	Limit *string `location:"querystring" locationName:"limit" type:"string"`
 
 	// An opaque string used for pagination. This value specifies the part at which
@@ -5915,10 +6143,12 @@ type ListPartsOutput struct {
 	// The ID of the upload to which the parts are associated.
 	MultipartUploadId *string `type:"string"`
 
-	// The part size in bytes.
+	// The part size in bytes. This is the same value that you specified in the
+	// Initiate Multipart Upload request.
 	PartSizeInBytes *int64 `type:"long"`
 
-	// A list of the part sizes of the multipart upload.
+	// A list of the part sizes of the multipart upload. Each object in the array
+	// contains a RangeBytes and sha256-tree-hash name/value pair.
 	Parts []*PartListElement `type:"list"`
 
 	// The Amazon Resource Name (ARN) of the vault to which the multipart upload
@@ -5978,15 +6208,80 @@ func (s *ListPartsOutput) SetVaultARN(v string) *ListPartsOutput {
 	return s
 }
 
+type ListProvisionedCapacityInput struct {
+	_ struct{} `type:"structure"`
+
+	// The AccountId value is the AWS account ID of the account that owns the vault.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, don't include
+	// any hyphens ('-') in the ID.
+	//
+	// AccountId is a required field
+	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s ListProvisionedCapacityInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListProvisionedCapacityInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListProvisionedCapacityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListProvisionedCapacityInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *ListProvisionedCapacityInput) SetAccountId(v string) *ListProvisionedCapacityInput {
+	s.AccountId = &v
+	return s
+}
+
+type ListProvisionedCapacityOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The response body contains the following JSON fields.
+	ProvisionedCapacityList []*ProvisionedCapacityDescription `type:"list"`
+}
+
+// String returns the string representation
+func (s ListProvisionedCapacityOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListProvisionedCapacityOutput) GoString() string {
+	return s.String()
+}
+
+// SetProvisionedCapacityList sets the ProvisionedCapacityList field's value.
+func (s *ListProvisionedCapacityOutput) SetProvisionedCapacityList(v []*ProvisionedCapacityDescription) *ListProvisionedCapacityOutput {
+	s.ProvisionedCapacityList = v
+	return s
+}
+
 // The input value for ListTagsForVaultInput.
 type ListTagsForVaultInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -6066,16 +6361,17 @@ type ListVaultsInput struct {
 
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
-	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
+	// can either specify an AWS account ID or optionally a single '-' (hyphen),
 	// in which case Amazon Glacier uses the AWS account ID associated with the
 	// credentials used to sign the request. If you specify your account ID, do
-	// not include any hyphens (apos-apos) in the ID.
+	// not include any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
 
-	// The maximum number of items returned in the response. If you don't specify
-	// a value, the List Vaults operation returns up to 1,000 items.
+	// The maximum number of vaults to be returned. The default limit is 1000. The
+	// number of vaults returned might be fewer than the specified limit, but the
+	// number of returned vaults never exceeds the limit.
 	Limit *string `location:"querystring" locationName:"limit" type:"string"`
 
 	// A string used for pagination. The marker specifies the vault ARN after which
@@ -6192,15 +6488,124 @@ func (s *PartListElement) SetSHA256TreeHash(v string) *PartListElement {
 	return s
 }
 
+// The definition for a provisioned capacity unit.
+type ProvisionedCapacityDescription struct {
+	_ struct{} `type:"structure"`
+
+	// The ID that identifies the provisioned capacity unit.
+	CapacityId *string `type:"string"`
+
+	// The date that the provisioned capacity unit expires, in Universal Coordinated
+	// Time (UTC).
+	ExpirationDate *string `type:"string"`
+
+	// The date that the provisioned capacity unit was purchased, in Universal Coordinated
+	// Time (UTC).
+	StartDate *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ProvisionedCapacityDescription) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ProvisionedCapacityDescription) GoString() string {
+	return s.String()
+}
+
+// SetCapacityId sets the CapacityId field's value.
+func (s *ProvisionedCapacityDescription) SetCapacityId(v string) *ProvisionedCapacityDescription {
+	s.CapacityId = &v
+	return s
+}
+
+// SetExpirationDate sets the ExpirationDate field's value.
+func (s *ProvisionedCapacityDescription) SetExpirationDate(v string) *ProvisionedCapacityDescription {
+	s.ExpirationDate = &v
+	return s
+}
+
+// SetStartDate sets the StartDate field's value.
+func (s *ProvisionedCapacityDescription) SetStartDate(v string) *ProvisionedCapacityDescription {
+	s.StartDate = &v
+	return s
+}
+
+type PurchaseProvisionedCapacityInput struct {
+	_ struct{} `type:"structure"`
+
+	// The AWS account ID of the account that owns the vault. You can either specify
+	// an AWS account ID or optionally a single '-' (hyphen), in which case Amazon
+	// Glacier uses the AWS account ID associated with the credentials used to sign
+	// the request. If you use an account ID, don't include any hyphens ('-') in
+	// the ID.
+	//
+	// AccountId is a required field
+	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PurchaseProvisionedCapacityInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseProvisionedCapacityInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PurchaseProvisionedCapacityInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PurchaseProvisionedCapacityInput"}
+	if s.AccountId == nil {
+		invalidParams.Add(request.NewErrParamRequired("AccountId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *PurchaseProvisionedCapacityInput) SetAccountId(v string) *PurchaseProvisionedCapacityInput {
+	s.AccountId = &v
+	return s
+}
+
+type PurchaseProvisionedCapacityOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The ID that identifies the provisioned capacity unit.
+	CapacityId *string `location:"header" locationName:"x-amz-capacity-id" type:"string"`
+}
+
+// String returns the string representation
+func (s PurchaseProvisionedCapacityOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PurchaseProvisionedCapacityOutput) GoString() string {
+	return s.String()
+}
+
+// SetCapacityId sets the CapacityId field's value.
+func (s *PurchaseProvisionedCapacityOutput) SetCapacityId(v string) *PurchaseProvisionedCapacityOutput {
+	s.CapacityId = &v
+	return s
+}
+
 // The input value for RemoveTagsFromVaultInput.
 type RemoveTagsFromVaultInput struct {
 	_ struct{} `type:"structure"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -6278,10 +6683,10 @@ type SetDataRetrievalPolicyInput struct {
 
 	// The AccountId value is the AWS account ID. This value must match the AWS
 	// account ID associated with the credentials used to sign the request. You
-	// can either specify an AWS account ID or optionally a single apos-apos (hyphen),
+	// can either specify an AWS account ID or optionally a single '-' (hyphen),
 	// in which case Amazon Glacier uses the AWS account ID associated with the
 	// credentials used to sign the request. If you specify your account ID, do
-	// not include any hyphens (apos-apos) in the ID.
+	// not include any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -6344,10 +6749,10 @@ type SetVaultAccessPolicyInput struct {
 	_ struct{} `type:"structure" payload:"Policy"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -6425,10 +6830,10 @@ type SetVaultNotificationsInput struct {
 	_ struct{} `type:"structure" payload:"VaultNotificationConfig"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -6505,10 +6910,10 @@ type UploadArchiveInput struct {
 	_ struct{} `type:"structure" payload:"Body"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`
@@ -6652,10 +7057,10 @@ type UploadMultipartPartInput struct {
 	_ struct{} `type:"structure" payload:"Body"`
 
 	// The AccountId value is the AWS account ID of the account that owns the vault.
-	// You can either specify an AWS account ID or optionally a single apos-apos
-	// (hyphen), in which case Amazon Glacier uses the AWS account ID associated
-	// with the credentials used to sign the request. If you use an account ID,
-	// do not include any hyphens (apos-apos) in the ID.
+	// You can either specify an AWS account ID or optionally a single '-' (hyphen),
+	// in which case Amazon Glacier uses the AWS account ID associated with the
+	// credentials used to sign the request. If you use an account ID, do not include
+	// any hyphens ('-') in the ID.
 	//
 	// AccountId is a required field
 	AccountId *string `location:"uri" locationName:"accountId" type:"string" required:"true"`

--- a/vendor/github.com/aws/aws-sdk-go/service/glacier/service.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/glacier/service.go
@@ -24,8 +24,8 @@ import (
 // Amazon Glacier is a great storage choice when low storage cost is paramount,
 // your data is rarely retrieved, and retrieval latency of several hours is
 // acceptable. If your application requires fast or frequent access to your
-// data, consider using Amazon S3. For more information, go to Amazon Simple
-// Storage Service (Amazon S3) (http://aws.amazon.com/s3/).
+// data, consider using Amazon S3. For more information, see Amazon Simple Storage
+// Service (Amazon S3) (http://aws.amazon.com/s3/).
 //
 // You can store any kind of data in any format. There is no maximum limit on
 // the total amount of data you can store in Amazon Glacier.

--- a/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/route53/api.go
@@ -88,9 +88,8 @@ func (c *Route53) AssociateVPCWithHostedZoneRequest(input *AssociateVPCWithHoste
 //   authorized.
 //
 //   * InvalidVPCId
-//   The hosted zone you are trying to create for your VPC_ID does not belong
-//   to you. Amazon Route 53 returns this error when the VPC specified by VPCId
-//   does not belong to you.
+//   The VPC ID that you specified either isn't a valid ID or the current account
+//   is not authorized to access this VPC.
 //
 //   * InvalidInput
 //   The input is not valid.
@@ -199,40 +198,54 @@ func (c *Route53) ChangeResourceRecordSetsRequest(input *ChangeResourceRecordSet
 //
 //    * CREATE: Creates a resource record set that has the specified values.
 //
-//    * DELETE: Deletes an existing resource record set that has the applicable
-//    values for the following elements:
-//
-// Name: required to delete any resource record set
-//
-// Type: required to delete any resource record set
-//
-// AliasTarget, DNSName, EvaluateTargetHealth, and HostedZoneId: required to
-//    delete an alias resource record set
-//
-// SetIdentifier: required to delete a failover, geolocation, latency, or weighted
-//    resource record set
-//
-// TTL: required to delete any resource record set except an alias resource
-//    record set (For alias resource record sets, the TTL is determined by the
-//    AWS resource tat you're routing traffic to.)
+//    * DELETE: Deletes an existing resource record set that has the specified
+//    values.
 //
 //    * UPSERT: If a resource record set does not already exist, AWS creates
 //    it. If a resource set does exist, Amazon Route 53 updates it with the
-//    values in the request. Amazon Route 53 can update an existing resource
-//    record set only when all of the following values match: Name, Type, and
-//    Set Identifier (for weighted, latency, geolocation, and failover resource
-//    record sets).
+//    values in the request.
 //
-// In response to a ChangeResourceRecordSets request, the DNS data is changed
-// on all Amazon Route 53 DNS servers. Initially, the status of a change is
-// PENDING, meaning the change has not yet propagated to all the authoritative
-// Amazon Route 53 DNS servers. When the change is propagated to all hosts,
-// the change returns a status of INSYNC.
+// The values that you need to include in the request depend on the type of
+// resource record set that you're creating, deleting, or updating:
 //
-// After sending a change request, confirm your change has propagated to all
-// Amazon Route 53 DNS servers. Changes generally propagate to all Amazon Route
-// 53 name servers in a few minutes. In rare circumstances, propagation can
-// take up to 30 minutes. For more information, see GetChange.
+// Basic resource record sets (excluding alias, failover, geolocation, latency,
+// and weighted resource record sets)
+//
+//    * Name
+//
+//    * Type
+//
+//    * TTL
+//
+// Failover, geolocation, latency, or weighted resource record sets (excluding
+// alias resource record sets)
+//
+//    * Name
+//
+//    * Type
+//
+//    * TTL
+//
+//    * SetIdentifier
+//
+// Alias resource record sets (including failover alias, geolocation alias,
+// latency alias, and weighted alias resource record sets)
+//
+//    * Name
+//
+//    * Type
+//
+//    * AliasTarget (includes DNSName, EvaluateTargetHealth, and HostedZoneId)
+//
+//    * SetIdentifier (for failover, geolocation, latency, and weighted resource
+//    record sets)
+//
+// When you submit a ChangeResourceRecordSets request, Amazon Route 53 propagates
+// your changes to all of the Amazon Route 53 authoritative DNS servers. While
+// your changes are propagating, GetChange returns a status of PENDING. When
+// propagation is complete, GetChange returns a status of INSYNC. Changes generally
+// propagate to all Amazon Route 53 name servers in a few minutes. In rare circumstances,
+// propagation can take up to 30 minutes. For more information, see GetChange
 //
 // For information about the limits on a ChangeResourceRecordSets request, see
 // Limits (http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html)
@@ -572,9 +585,8 @@ func (c *Route53) CreateHostedZoneRequest(input *CreateHostedZoneInput) (req *re
 //   page.
 //
 //   * InvalidVPCId
-//   The hosted zone you are trying to create for your VPC_ID does not belong
-//   to you. Amazon Route 53 returns this error when the VPC specified by VPCId
-//   does not belong to you.
+//   The VPC ID that you specified either isn't a valid ID or the current account
+//   is not authorized to access this VPC.
 //
 //   * InvalidInput
 //   The input is not valid.
@@ -1040,9 +1052,8 @@ func (c *Route53) CreateVPCAssociationAuthorizationRequest(input *CreateVPCAssoc
 //   No hosted zone exists with the ID that you specified.
 //
 //   * InvalidVPCId
-//   The hosted zone you are trying to create for your VPC_ID does not belong
-//   to you. Amazon Route 53 returns this error when the VPC specified by VPCId
-//   does not belong to you.
+//   The VPC ID that you specified either isn't a valid ID or the current account
+//   is not authorized to access this VPC.
 //
 //   * InvalidInput
 //   The input is not valid.
@@ -1539,9 +1550,8 @@ func (c *Route53) DeleteVPCAssociationAuthorizationRequest(input *DeleteVPCAssoc
 //   No hosted zone exists with the ID that you specified.
 //
 //   * InvalidVPCId
-//   The hosted zone you are trying to create for your VPC_ID does not belong
-//   to you. Amazon Route 53 returns this error when the VPC specified by VPCId
-//   does not belong to you.
+//   The VPC ID that you specified either isn't a valid ID or the current account
+//   is not authorized to access this VPC.
 //
 //   * InvalidInput
 //   The input is not valid.
@@ -1621,9 +1631,8 @@ func (c *Route53) DisassociateVPCFromHostedZoneRequest(input *DisassociateVPCFro
 //   No hosted zone exists with the ID that you specified.
 //
 //   * InvalidVPCId
-//   The hosted zone you are trying to create for your VPC_ID does not belong
-//   to you. Amazon Route 53 returns this error when the VPC specified by VPCId
-//   does not belong to you.
+//   The VPC ID that you specified either isn't a valid ID or the current account
+//   is not authorized to access this VPC.
 //
 //   * VPCAssociationNotFound
 //   The specified VPC and hosted zone are not currently associated.
@@ -4774,30 +4783,58 @@ type Change struct {
 	//
 	//    * CREATE: Creates a resource record set that has the specified values.
 	//
-	//    * DELETE: Deletes a existing resource record set that has the specified
-	//    values for Name, Type, SetIdentifier (for latency, weighted, geolocation,
-	//    and failover resource record sets), and TTL (except alias resource record
-	//    sets, for which the TTL is determined by the AWS resource that you're
-	//    routing DNS queries to).
+	//    * DELETE: Deletes a existing resource record set.
 	//
 	// To delete the resource record set that is associated with a traffic policy
-	//    instance, use DeleteTrafficPolicyInstance. Amazon Route 53will delete
+	//    instance, use DeleteTrafficPolicyInstance. Amazon Route 53 will delete
 	//    the resource record set automatically. If you delete the resource record
 	//    set by using ChangeResourceRecordSets, Amazon Route 53 doesn't automatically
 	//    delete the traffic policy instance, and you'll continue to be charged
 	//    for it even though it's no longer in use.
 	//
-	//    * UPSERT: If a resource record set does not already exist, Amazon Route
+	//    * UPSERT: If a resource record set doesn't already exist, Amazon Route
 	//    53 creates it. If a resource record set does exist, Amazon Route 53 updates
-	//    it with the values in the request. Amazon Route 53 can update an existing
-	//    resource record set only when all of the following values match: Name,
-	//    Type, and SetIdentifier (for weighted, latency, geolocation, and failover
-	//    resource record sets).
+	//    it with the values in the request.
+	//
+	// The values that you need to include in the request depend on the type of
+	// resource record set that you're creating, deleting, or updating:
+	//
+	// Basic resource record sets (excluding alias, failover, geolocation, latency,
+	// and weighted resource record sets)
+	//
+	//    * Name
+	//
+	//    * Type
+	//
+	//    * TTL
+	//
+	// Failover, geolocation, latency, or weighted resource record sets (excluding
+	// alias resource record sets)
+	//
+	//    * Name
+	//
+	//    * Type
+	//
+	//    * TTL
+	//
+	//    * SetIdentifier
+	//
+	// Alias resource record sets (including failover alias, geolocation alias,
+	// latency alias, and weighted alias resource record sets)
+	//
+	//    * Name
+	//
+	//    * Type
+	//
+	//    * AliasTarget (includes DNSName, EvaluateTargetHealth, and HostedZoneId)
+	//
+	//    * SetIdentifier (for failover, geolocation, latency, and weighted resource
+	//    record sets)
 	//
 	// Action is a required field
 	Action *string `type:"string" required:"true" enum:"ChangeAction"`
 
-	// Information about the resource record set to create or delete.
+	// Information about the resource record set to create, delete, or update.
 	//
 	// ResourceRecordSet is a required field
 	ResourceRecordSet *ResourceRecordSet `type:"structure" required:"true"`
@@ -7858,13 +7895,16 @@ type HealthCheckConfig struct {
 
 	// Amazon Route 53 behavior depends on whether you specify a value for IPAddress.
 	//
-	// If you specifyIPAddress:
+	// If you specify a value forIPAddress:
 	//
-	// The value that you want Amazon Route 53 to pass in the Host header in all
-	// health checks except TCP health checks. This is typically the fully qualified
-	// DNS name of the website that you are attempting to health check. When Amazon
-	// Route 53 checks the health of an endpoint, here is how it constructs the
-	// Host header:
+	// Amazon Route 53 sends health check requests to the specified IPv4 or IPv6
+	// address and passes the value of FullyQualifiedDomainName in the Host header
+	// for all health checks except TCP health checks. This is typically the fully
+	// qualified DNS name of the endpoint on which you want Amazon Route 53 to perform
+	// health checks.
+	//
+	// When Amazon Route 53 checks the health of an endpoint, here is how it constructs
+	// the Host header:
 	//
 	//    * If you specify a value of 80 for Port and HTTP or HTTP_STR_MATCH for
 	//    Type, Amazon Route 53 passes the value of FullyQualifiedDomainName to
@@ -7882,12 +7922,16 @@ type HealthCheckConfig struct {
 	// substitutes the value of IPAddress in the Host header in each of the preceding
 	// cases.
 	//
-	// If you don't specifyIPAddress:
+	// If you don't specify a value for IPAddress:
 	//
-	// If you don't specify a value for IPAddress, Amazon Route 53 sends a DNS request
-	// to the domain that you specify in FullyQualifiedDomainName at the interval
-	// you specify in RequestInterval. Using an IP address that DNS returns, Amazon
-	// Route 53 then checks the health of the endpoint.
+	// Amazon Route 53 sends a DNS request to the domain that you specify for FullyQualifiedDomainName
+	// at the interval that you specify for RequestInterval. Using an IPv4 address
+	// that DNS returns, Amazon Route 53 then checks the health of the endpoint.
+	//
+	// If you don't specify a value for IPAddress, Amazon Route 53 uses only IPv4
+	// to send health checks to the endpoint. If there's no resource record set
+	// with a type of A for the name that you specify for FullyQualifiedDomainName,
+	// the health check fails with a "DNS resolution failed" error.
 	//
 	// If you want to check the health of weighted, latency, or failover resource
 	// record sets and you choose to specify the endpoint only by FullyQualifiedDomainName,
@@ -7923,11 +7967,11 @@ type HealthCheckConfig struct {
 	//    to be healthy.
 	HealthThreshold *int64 `type:"integer"`
 
-	// The IPv4 IP address of the endpoint on which you want Amazon Route 53 to
-	// perform health checks. If you don't specify a value for IPAddress, Amazon
-	// Route 53 sends a DNS request to resolve the domain name that you specify
+	// The IPv4 or IPv6 IP address of the endpoint that you want Amazon Route 53
+	// to perform health checks on. If you don't specify a value for IPAddress,
+	// Amazon Route 53 sends a DNS request to resolve the domain name that you specify
 	// in FullyQualifiedDomainName at the interval that you specify in RequestInterval.
-	// Using an IP address that DNS returns, Amazon Route 53 then checks the health
+	// Using an IP address returned by DNS, Amazon Route 53 then checks the health
 	// of the endpoint.
 	//
 	// If the endpoint is an EC2 instance, we recommend that you create an Elastic
@@ -7938,10 +7982,15 @@ type HealthCheckConfig struct {
 	// For more information, see HealthCheckConfig$FullyQualifiedDomainName.
 	//
 	// Constraints: Amazon Route 53 can't check the health of endpoints for which
-	// the IP address is in local, private, non-routable, or \ multicast ranges.
-	// For more information about IP addresses for which you can't create health
-	// checks, see RFC 5735, Special Use IPv4 Addresses (https://tools.ietf.org/html/rfc5735)
-	// and RFC 6598, IANA-Reserved IPv4 Prefix for Shared Address Space (https://tools.ietf.org/html/rfc6598).
+	// the IP address is in local, private, non-routable, or multicast ranges. For
+	// more information about IP addresses for which you can't create health checks,
+	// see the following documents:
+	//
+	//    * RFC 5735, Special Use IPv4 Addresses (https://tools.ietf.org/html/rfc5735)
+	//
+	//    * RFC 6598, IANA-Reserved IPv4 Prefix for Shared Address Space (https://tools.ietf.org/html/rfc6598)
+	//
+	//    * RFC 5156, Special-Use IPv6 Addresses (https://tools.ietf.org/html/rfc5156)
 	//
 	// When the value of Type is CALCULATED or CLOUDWATCH_METRIC, omit IPAddress.
 	IPAddress *string `type:"string"`
@@ -11676,13 +11725,16 @@ type UpdateHealthCheckInput struct {
 	// However, you can't update an existing health check to add or remove the value
 	// of IPAddress.
 	//
-	// If you specifyIPAddress:
+	// If you specify a value forIPAddress:
 	//
-	// The value that you want Amazon Route 53 to pass in the Host header in all
-	// health checks except TCP health checks. This is typically the fully qualified
-	// DNS name of the endpoint on which you want Amazon Route 53 to perform health
-	// checks. When Amazon Route 53 checks the health of an endpoint, here is how
-	// it constructs the Host header:
+	// Amazon Route 53 sends health check requests to the specified IPv4 or IPv6
+	// address and passes the value of FullyQualifiedDomainName in the Host header
+	// for all health checks except TCP health checks. This is typically the fully
+	// qualified DNS name of the endpoint on which you want Amazon Route 53 to perform
+	// health checks.
+	//
+	// When Amazon Route 53 checks the health of an endpoint, here is how it constructs
+	// the Host header:
 	//
 	//    * If you specify a value of 80 for Port and HTTP or HTTP_STR_MATCH for
 	//    Type, Amazon Route 53 passes the value of FullyQualifiedDomainName to
@@ -11700,12 +11752,17 @@ type UpdateHealthCheckInput struct {
 	// substitutes the value of IPAddress in the Host header in each of the above
 	// cases.
 	//
-	// If you don't specifyIPAddress:
+	// If you don't specify a value forIPAddress:
 	//
 	// If you don't specify a value for IPAddress, Amazon Route 53 sends a DNS request
 	// to the domain that you specify in FullyQualifiedDomainName at the interval
-	// you specify in RequestInterval. Using an IP address that DNS returns, Amazon
-	// Route 53 then checks the health of the endpoint.
+	// you specify in RequestInterval. Using an IPv4 address that is returned by
+	// DNS, Amazon Route 53 then checks the health of the endpoint.
+	//
+	// If you don't specify a value for IPAddress, Amazon Route 53 uses only IPv4
+	// to send health checks to the endpoint. If there's no resource record set
+	// with a type of A for the name that you specify for FullyQualifiedDomainName,
+	// the health check fails with a "DNS resolution failed" error.
 	//
 	// If you want to check the health of weighted, latency, or failover resource
 	// record sets and you choose to specify the endpoint only by FullyQualifiedDomainName,
@@ -11765,14 +11822,14 @@ type UpdateHealthCheckInput struct {
 	//    to be healthy.
 	HealthThreshold *int64 `type:"integer"`
 
-	// The IPv4 IP address of the endpoint on which you want Amazon Route 53 to
-	// perform health checks. If you don't specify a value for IPAddress, Amazon
-	// Route 53 sends a DNS request to resolve the domain name that you specify
-	// in FullyQualifiedDomainName at the interval you specify in RequestInterval.
-	// Using an IP address that DNS returns, Amazon Route 53 then checks the health
-	// of the endpoint.
+	// The IPv4 or IPv6 IP address for the endpoint that you want Amazon Route 53
+	// to perform health checks on. If you don't specify a value for IPAddress,
+	// Amazon Route 53 sends a DNS request to resolve the domain name that you specify
+	// in FullyQualifiedDomainName at the interval that you specify in RequestInterval.
+	// Using an IP address that is returned by DNS, Amazon Route 53 then checks
+	// the health of the endpoint.
 	//
-	// f the endpoint is an EC2 instance, we recommend that you create an Elastic
+	// If the endpoint is an EC2 instance, we recommend that you create an Elastic
 	// IP address, associate it with your EC2 instance, and specify the Elastic
 	// IP address for IPAddress. This ensures that the IP address of your instance
 	// never changes. For more information, see Elastic IP Addresses (EIP) (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/elastic-ip-addresses-eip.html)
@@ -11783,6 +11840,17 @@ type UpdateHealthCheckInput struct {
 	// of IPAddress.
 	//
 	// For more information, see UpdateHealthCheckRequest$FullyQualifiedDomainName.
+	//
+	// Constraints: Amazon Route 53 can't check the health of endpoints for which
+	// the IP address is in local, private, non-routable, or multicast ranges. For
+	// more information about IP addresses for which you can't create health checks,
+	// see the following documents:
+	//
+	//    * RFC 5735, Special Use IPv4 Addresses (https://tools.ietf.org/html/rfc5735)
+	//
+	//    * RFC 6598, IANA-Reserved IPv4 Prefix for Shared Address Space (https://tools.ietf.org/html/rfc6598)
+	//
+	//    * RFC 5156, Special-Use IPv6 Addresses (https://tools.ietf.org/html/rfc5156)
 	IPAddress *string `type:"string"`
 
 	// When CloudWatch has insufficient data about the metric to determine the alarm

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/api.go
@@ -401,6 +401,68 @@ func (c *S3) DeleteBucket(input *DeleteBucketInput) (*DeleteBucketOutput, error)
 	return out, err
 }
 
+const opDeleteBucketAnalyticsConfiguration = "DeleteBucketAnalyticsConfiguration"
+
+// DeleteBucketAnalyticsConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteBucketAnalyticsConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DeleteBucketAnalyticsConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DeleteBucketAnalyticsConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DeleteBucketAnalyticsConfigurationRequest method.
+//    req, resp := client.DeleteBucketAnalyticsConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) DeleteBucketAnalyticsConfigurationRequest(input *DeleteBucketAnalyticsConfigurationInput) (req *request.Request, output *DeleteBucketAnalyticsConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opDeleteBucketAnalyticsConfiguration,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/{Bucket}?analytics",
+	}
+
+	if input == nil {
+		input = &DeleteBucketAnalyticsConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	output = &DeleteBucketAnalyticsConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// DeleteBucketAnalyticsConfiguration API operation for Amazon Simple Storage Service.
+//
+// Deletes an analytics configuration for the bucket (specified by the analytics
+// configuration ID).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation DeleteBucketAnalyticsConfiguration for usage and error information.
+func (c *S3) DeleteBucketAnalyticsConfiguration(input *DeleteBucketAnalyticsConfigurationInput) (*DeleteBucketAnalyticsConfigurationOutput, error) {
+	req, out := c.DeleteBucketAnalyticsConfigurationRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opDeleteBucketCors = "DeleteBucketCors"
 
 // DeleteBucketCorsRequest generates a "aws/request.Request" representing the
@@ -462,6 +524,68 @@ func (c *S3) DeleteBucketCors(input *DeleteBucketCorsInput) (*DeleteBucketCorsOu
 	return out, err
 }
 
+const opDeleteBucketInventoryConfiguration = "DeleteBucketInventoryConfiguration"
+
+// DeleteBucketInventoryConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteBucketInventoryConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DeleteBucketInventoryConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DeleteBucketInventoryConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DeleteBucketInventoryConfigurationRequest method.
+//    req, resp := client.DeleteBucketInventoryConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) DeleteBucketInventoryConfigurationRequest(input *DeleteBucketInventoryConfigurationInput) (req *request.Request, output *DeleteBucketInventoryConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opDeleteBucketInventoryConfiguration,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/{Bucket}?inventory",
+	}
+
+	if input == nil {
+		input = &DeleteBucketInventoryConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	output = &DeleteBucketInventoryConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// DeleteBucketInventoryConfiguration API operation for Amazon Simple Storage Service.
+//
+// Deletes an inventory configuration (identified by the inventory ID) from
+// the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation DeleteBucketInventoryConfiguration for usage and error information.
+func (c *S3) DeleteBucketInventoryConfiguration(input *DeleteBucketInventoryConfigurationInput) (*DeleteBucketInventoryConfigurationOutput, error) {
+	req, out := c.DeleteBucketInventoryConfigurationRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opDeleteBucketLifecycle = "DeleteBucketLifecycle"
 
 // DeleteBucketLifecycleRequest generates a "aws/request.Request" representing the
@@ -519,6 +643,68 @@ func (c *S3) DeleteBucketLifecycleRequest(input *DeleteBucketLifecycleInput) (re
 // API operation DeleteBucketLifecycle for usage and error information.
 func (c *S3) DeleteBucketLifecycle(input *DeleteBucketLifecycleInput) (*DeleteBucketLifecycleOutput, error) {
 	req, out := c.DeleteBucketLifecycleRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opDeleteBucketMetricsConfiguration = "DeleteBucketMetricsConfiguration"
+
+// DeleteBucketMetricsConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteBucketMetricsConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DeleteBucketMetricsConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DeleteBucketMetricsConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DeleteBucketMetricsConfigurationRequest method.
+//    req, resp := client.DeleteBucketMetricsConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) DeleteBucketMetricsConfigurationRequest(input *DeleteBucketMetricsConfigurationInput) (req *request.Request, output *DeleteBucketMetricsConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opDeleteBucketMetricsConfiguration,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/{Bucket}?metrics",
+	}
+
+	if input == nil {
+		input = &DeleteBucketMetricsConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	output = &DeleteBucketMetricsConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// DeleteBucketMetricsConfiguration API operation for Amazon Simple Storage Service.
+//
+// Deletes a metrics configuration (specified by the metrics configuration ID)
+// from the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation DeleteBucketMetricsConfiguration for usage and error information.
+func (c *S3) DeleteBucketMetricsConfiguration(input *DeleteBucketMetricsConfigurationInput) (*DeleteBucketMetricsConfigurationOutput, error) {
+	req, out := c.DeleteBucketMetricsConfigurationRequest(input)
 	err := req.Send()
 	return out, err
 }
@@ -828,6 +1014,65 @@ func (c *S3) DeleteObject(input *DeleteObjectInput) (*DeleteObjectOutput, error)
 	return out, err
 }
 
+const opDeleteObjectTagging = "DeleteObjectTagging"
+
+// DeleteObjectTaggingRequest generates a "aws/request.Request" representing the
+// client's request for the DeleteObjectTagging operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DeleteObjectTagging for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DeleteObjectTagging method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DeleteObjectTaggingRequest method.
+//    req, resp := client.DeleteObjectTaggingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) DeleteObjectTaggingRequest(input *DeleteObjectTaggingInput) (req *request.Request, output *DeleteObjectTaggingOutput) {
+	op := &request.Operation{
+		Name:       opDeleteObjectTagging,
+		HTTPMethod: "DELETE",
+		HTTPPath:   "/{Bucket}/{Key+}?tagging",
+	}
+
+	if input == nil {
+		input = &DeleteObjectTaggingInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &DeleteObjectTaggingOutput{}
+	req.Data = output
+	return
+}
+
+// DeleteObjectTagging API operation for Amazon Simple Storage Service.
+//
+// Removes the tag-set from an existing object.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation DeleteObjectTagging for usage and error information.
+func (c *S3) DeleteObjectTagging(input *DeleteObjectTaggingInput) (*DeleteObjectTaggingOutput, error) {
+	req, out := c.DeleteObjectTaggingRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opDeleteObjects = "DeleteObjects"
 
 // DeleteObjectsRequest generates a "aws/request.Request" representing the
@@ -1006,6 +1251,66 @@ func (c *S3) GetBucketAcl(input *GetBucketAclInput) (*GetBucketAclOutput, error)
 	return out, err
 }
 
+const opGetBucketAnalyticsConfiguration = "GetBucketAnalyticsConfiguration"
+
+// GetBucketAnalyticsConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the GetBucketAnalyticsConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetBucketAnalyticsConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetBucketAnalyticsConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetBucketAnalyticsConfigurationRequest method.
+//    req, resp := client.GetBucketAnalyticsConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) GetBucketAnalyticsConfigurationRequest(input *GetBucketAnalyticsConfigurationInput) (req *request.Request, output *GetBucketAnalyticsConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opGetBucketAnalyticsConfiguration,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}?analytics",
+	}
+
+	if input == nil {
+		input = &GetBucketAnalyticsConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &GetBucketAnalyticsConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// GetBucketAnalyticsConfiguration API operation for Amazon Simple Storage Service.
+//
+// Gets an analytics configuration for the bucket (specified by the analytics
+// configuration ID).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation GetBucketAnalyticsConfiguration for usage and error information.
+func (c *S3) GetBucketAnalyticsConfiguration(input *GetBucketAnalyticsConfigurationInput) (*GetBucketAnalyticsConfigurationOutput, error) {
+	req, out := c.GetBucketAnalyticsConfigurationRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opGetBucketCors = "GetBucketCors"
 
 // GetBucketCorsRequest generates a "aws/request.Request" representing the
@@ -1061,6 +1366,66 @@ func (c *S3) GetBucketCorsRequest(input *GetBucketCorsInput) (req *request.Reque
 // API operation GetBucketCors for usage and error information.
 func (c *S3) GetBucketCors(input *GetBucketCorsInput) (*GetBucketCorsOutput, error) {
 	req, out := c.GetBucketCorsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opGetBucketInventoryConfiguration = "GetBucketInventoryConfiguration"
+
+// GetBucketInventoryConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the GetBucketInventoryConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetBucketInventoryConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetBucketInventoryConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetBucketInventoryConfigurationRequest method.
+//    req, resp := client.GetBucketInventoryConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) GetBucketInventoryConfigurationRequest(input *GetBucketInventoryConfigurationInput) (req *request.Request, output *GetBucketInventoryConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opGetBucketInventoryConfiguration,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}?inventory",
+	}
+
+	if input == nil {
+		input = &GetBucketInventoryConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &GetBucketInventoryConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// GetBucketInventoryConfiguration API operation for Amazon Simple Storage Service.
+//
+// Returns an inventory configuration (identified by the inventory ID) from
+// the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation GetBucketInventoryConfiguration for usage and error information.
+func (c *S3) GetBucketInventoryConfiguration(input *GetBucketInventoryConfigurationInput) (*GetBucketInventoryConfigurationOutput, error) {
+	req, out := c.GetBucketInventoryConfigurationRequest(input)
 	err := req.Send()
 	return out, err
 }
@@ -1301,6 +1666,66 @@ func (c *S3) GetBucketLoggingRequest(input *GetBucketLoggingInput) (req *request
 // API operation GetBucketLogging for usage and error information.
 func (c *S3) GetBucketLogging(input *GetBucketLoggingInput) (*GetBucketLoggingOutput, error) {
 	req, out := c.GetBucketLoggingRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opGetBucketMetricsConfiguration = "GetBucketMetricsConfiguration"
+
+// GetBucketMetricsConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the GetBucketMetricsConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetBucketMetricsConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetBucketMetricsConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetBucketMetricsConfigurationRequest method.
+//    req, resp := client.GetBucketMetricsConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) GetBucketMetricsConfigurationRequest(input *GetBucketMetricsConfigurationInput) (req *request.Request, output *GetBucketMetricsConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opGetBucketMetricsConfiguration,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}?metrics",
+	}
+
+	if input == nil {
+		input = &GetBucketMetricsConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &GetBucketMetricsConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// GetBucketMetricsConfiguration API operation for Amazon Simple Storage Service.
+//
+// Gets a metrics configuration (specified by the metrics configuration ID)
+// from the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation GetBucketMetricsConfiguration for usage and error information.
+func (c *S3) GetBucketMetricsConfiguration(input *GetBucketMetricsConfigurationInput) (*GetBucketMetricsConfigurationOutput, error) {
+	req, out := c.GetBucketMetricsConfigurationRequest(input)
 	err := req.Send()
 	return out, err
 }
@@ -1908,6 +2333,65 @@ func (c *S3) GetObjectAcl(input *GetObjectAclInput) (*GetObjectAclOutput, error)
 	return out, err
 }
 
+const opGetObjectTagging = "GetObjectTagging"
+
+// GetObjectTaggingRequest generates a "aws/request.Request" representing the
+// client's request for the GetObjectTagging operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetObjectTagging for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetObjectTagging method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetObjectTaggingRequest method.
+//    req, resp := client.GetObjectTaggingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) GetObjectTaggingRequest(input *GetObjectTaggingInput) (req *request.Request, output *GetObjectTaggingOutput) {
+	op := &request.Operation{
+		Name:       opGetObjectTagging,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}/{Key+}?tagging",
+	}
+
+	if input == nil {
+		input = &GetObjectTaggingInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &GetObjectTaggingOutput{}
+	req.Data = output
+	return
+}
+
+// GetObjectTagging API operation for Amazon Simple Storage Service.
+//
+// Returns the tag-set of an object.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation GetObjectTagging for usage and error information.
+func (c *S3) GetObjectTagging(input *GetObjectTaggingInput) (*GetObjectTaggingOutput, error) {
+	req, out := c.GetObjectTaggingRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opGetObjectTorrent = "GetObjectTorrent"
 
 // GetObjectTorrentRequest generates a "aws/request.Request" representing the
@@ -2096,6 +2580,183 @@ func (c *S3) HeadObjectRequest(input *HeadObjectInput) (req *request.Request, ou
 //
 func (c *S3) HeadObject(input *HeadObjectInput) (*HeadObjectOutput, error) {
 	req, out := c.HeadObjectRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opListBucketAnalyticsConfigurations = "ListBucketAnalyticsConfigurations"
+
+// ListBucketAnalyticsConfigurationsRequest generates a "aws/request.Request" representing the
+// client's request for the ListBucketAnalyticsConfigurations operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListBucketAnalyticsConfigurations for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListBucketAnalyticsConfigurations method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListBucketAnalyticsConfigurationsRequest method.
+//    req, resp := client.ListBucketAnalyticsConfigurationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) ListBucketAnalyticsConfigurationsRequest(input *ListBucketAnalyticsConfigurationsInput) (req *request.Request, output *ListBucketAnalyticsConfigurationsOutput) {
+	op := &request.Operation{
+		Name:       opListBucketAnalyticsConfigurations,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}?analytics",
+	}
+
+	if input == nil {
+		input = &ListBucketAnalyticsConfigurationsInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &ListBucketAnalyticsConfigurationsOutput{}
+	req.Data = output
+	return
+}
+
+// ListBucketAnalyticsConfigurations API operation for Amazon Simple Storage Service.
+//
+// Lists the analytics configurations for the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation ListBucketAnalyticsConfigurations for usage and error information.
+func (c *S3) ListBucketAnalyticsConfigurations(input *ListBucketAnalyticsConfigurationsInput) (*ListBucketAnalyticsConfigurationsOutput, error) {
+	req, out := c.ListBucketAnalyticsConfigurationsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opListBucketInventoryConfigurations = "ListBucketInventoryConfigurations"
+
+// ListBucketInventoryConfigurationsRequest generates a "aws/request.Request" representing the
+// client's request for the ListBucketInventoryConfigurations operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListBucketInventoryConfigurations for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListBucketInventoryConfigurations method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListBucketInventoryConfigurationsRequest method.
+//    req, resp := client.ListBucketInventoryConfigurationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) ListBucketInventoryConfigurationsRequest(input *ListBucketInventoryConfigurationsInput) (req *request.Request, output *ListBucketInventoryConfigurationsOutput) {
+	op := &request.Operation{
+		Name:       opListBucketInventoryConfigurations,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}?inventory",
+	}
+
+	if input == nil {
+		input = &ListBucketInventoryConfigurationsInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &ListBucketInventoryConfigurationsOutput{}
+	req.Data = output
+	return
+}
+
+// ListBucketInventoryConfigurations API operation for Amazon Simple Storage Service.
+//
+// Returns a list of inventory configurations for the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation ListBucketInventoryConfigurations for usage and error information.
+func (c *S3) ListBucketInventoryConfigurations(input *ListBucketInventoryConfigurationsInput) (*ListBucketInventoryConfigurationsOutput, error) {
+	req, out := c.ListBucketInventoryConfigurationsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opListBucketMetricsConfigurations = "ListBucketMetricsConfigurations"
+
+// ListBucketMetricsConfigurationsRequest generates a "aws/request.Request" representing the
+// client's request for the ListBucketMetricsConfigurations operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See ListBucketMetricsConfigurations for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the ListBucketMetricsConfigurations method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the ListBucketMetricsConfigurationsRequest method.
+//    req, resp := client.ListBucketMetricsConfigurationsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) ListBucketMetricsConfigurationsRequest(input *ListBucketMetricsConfigurationsInput) (req *request.Request, output *ListBucketMetricsConfigurationsOutput) {
+	op := &request.Operation{
+		Name:       opListBucketMetricsConfigurations,
+		HTTPMethod: "GET",
+		HTTPPath:   "/{Bucket}?metrics",
+	}
+
+	if input == nil {
+		input = &ListBucketMetricsConfigurationsInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &ListBucketMetricsConfigurationsOutput{}
+	req.Data = output
+	return
+}
+
+// ListBucketMetricsConfigurations API operation for Amazon Simple Storage Service.
+//
+// Lists the metrics configurations for the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation ListBucketMetricsConfigurations for usage and error information.
+func (c *S3) ListBucketMetricsConfigurations(input *ListBucketMetricsConfigurationsInput) (*ListBucketMetricsConfigurationsOutput, error) {
+	req, out := c.ListBucketMetricsConfigurationsRequest(input)
 	err := req.Send()
 	return out, err
 }
@@ -2746,6 +3407,68 @@ func (c *S3) PutBucketAcl(input *PutBucketAclInput) (*PutBucketAclOutput, error)
 	return out, err
 }
 
+const opPutBucketAnalyticsConfiguration = "PutBucketAnalyticsConfiguration"
+
+// PutBucketAnalyticsConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the PutBucketAnalyticsConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See PutBucketAnalyticsConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the PutBucketAnalyticsConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the PutBucketAnalyticsConfigurationRequest method.
+//    req, resp := client.PutBucketAnalyticsConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) PutBucketAnalyticsConfigurationRequest(input *PutBucketAnalyticsConfigurationInput) (req *request.Request, output *PutBucketAnalyticsConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opPutBucketAnalyticsConfiguration,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/{Bucket}?analytics",
+	}
+
+	if input == nil {
+		input = &PutBucketAnalyticsConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	output = &PutBucketAnalyticsConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// PutBucketAnalyticsConfiguration API operation for Amazon Simple Storage Service.
+//
+// Sets an analytics configuration for the bucket (specified by the analytics
+// configuration ID).
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation PutBucketAnalyticsConfiguration for usage and error information.
+func (c *S3) PutBucketAnalyticsConfiguration(input *PutBucketAnalyticsConfigurationInput) (*PutBucketAnalyticsConfigurationOutput, error) {
+	req, out := c.PutBucketAnalyticsConfigurationRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opPutBucketCors = "PutBucketCors"
 
 // PutBucketCorsRequest generates a "aws/request.Request" representing the
@@ -2803,6 +3526,68 @@ func (c *S3) PutBucketCorsRequest(input *PutBucketCorsInput) (req *request.Reque
 // API operation PutBucketCors for usage and error information.
 func (c *S3) PutBucketCors(input *PutBucketCorsInput) (*PutBucketCorsOutput, error) {
 	req, out := c.PutBucketCorsRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opPutBucketInventoryConfiguration = "PutBucketInventoryConfiguration"
+
+// PutBucketInventoryConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the PutBucketInventoryConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See PutBucketInventoryConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the PutBucketInventoryConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the PutBucketInventoryConfigurationRequest method.
+//    req, resp := client.PutBucketInventoryConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) PutBucketInventoryConfigurationRequest(input *PutBucketInventoryConfigurationInput) (req *request.Request, output *PutBucketInventoryConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opPutBucketInventoryConfiguration,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/{Bucket}?inventory",
+	}
+
+	if input == nil {
+		input = &PutBucketInventoryConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	output = &PutBucketInventoryConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// PutBucketInventoryConfiguration API operation for Amazon Simple Storage Service.
+//
+// Adds an inventory configuration (identified by the inventory ID) from the
+// bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation PutBucketInventoryConfiguration for usage and error information.
+func (c *S3) PutBucketInventoryConfiguration(input *PutBucketInventoryConfigurationInput) (*PutBucketInventoryConfigurationOutput, error) {
+	req, out := c.PutBucketInventoryConfigurationRequest(input)
 	err := req.Send()
 	return out, err
 }
@@ -2992,6 +3777,68 @@ func (c *S3) PutBucketLoggingRequest(input *PutBucketLoggingInput) (req *request
 // API operation PutBucketLogging for usage and error information.
 func (c *S3) PutBucketLogging(input *PutBucketLoggingInput) (*PutBucketLoggingOutput, error) {
 	req, out := c.PutBucketLoggingRequest(input)
+	err := req.Send()
+	return out, err
+}
+
+const opPutBucketMetricsConfiguration = "PutBucketMetricsConfiguration"
+
+// PutBucketMetricsConfigurationRequest generates a "aws/request.Request" representing the
+// client's request for the PutBucketMetricsConfiguration operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See PutBucketMetricsConfiguration for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the PutBucketMetricsConfiguration method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the PutBucketMetricsConfigurationRequest method.
+//    req, resp := client.PutBucketMetricsConfigurationRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) PutBucketMetricsConfigurationRequest(input *PutBucketMetricsConfigurationInput) (req *request.Request, output *PutBucketMetricsConfigurationOutput) {
+	op := &request.Operation{
+		Name:       opPutBucketMetricsConfiguration,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/{Bucket}?metrics",
+	}
+
+	if input == nil {
+		input = &PutBucketMetricsConfigurationInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	req.Handlers.Unmarshal.Remove(restxml.UnmarshalHandler)
+	req.Handlers.Unmarshal.PushBackNamed(protocol.UnmarshalDiscardBodyHandler)
+	output = &PutBucketMetricsConfigurationOutput{}
+	req.Data = output
+	return
+}
+
+// PutBucketMetricsConfiguration API operation for Amazon Simple Storage Service.
+//
+// Sets a metrics configuration (specified by the metrics configuration ID)
+// for the bucket.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation PutBucketMetricsConfiguration for usage and error information.
+func (c *S3) PutBucketMetricsConfiguration(input *PutBucketMetricsConfigurationInput) (*PutBucketMetricsConfigurationOutput, error) {
+	req, out := c.PutBucketMetricsConfigurationRequest(input)
 	err := req.Send()
 	return out, err
 }
@@ -3618,6 +4465,65 @@ func (c *S3) PutObjectAcl(input *PutObjectAclInput) (*PutObjectAclOutput, error)
 	return out, err
 }
 
+const opPutObjectTagging = "PutObjectTagging"
+
+// PutObjectTaggingRequest generates a "aws/request.Request" representing the
+// client's request for the PutObjectTagging operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See PutObjectTagging for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the PutObjectTagging method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the PutObjectTaggingRequest method.
+//    req, resp := client.PutObjectTaggingRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+func (c *S3) PutObjectTaggingRequest(input *PutObjectTaggingInput) (req *request.Request, output *PutObjectTaggingOutput) {
+	op := &request.Operation{
+		Name:       opPutObjectTagging,
+		HTTPMethod: "PUT",
+		HTTPPath:   "/{Bucket}/{Key+}?tagging",
+	}
+
+	if input == nil {
+		input = &PutObjectTaggingInput{}
+	}
+
+	req = c.newRequest(op, input, output)
+	output = &PutObjectTaggingOutput{}
+	req.Data = output
+	return
+}
+
+// PutObjectTagging API operation for Amazon Simple Storage Service.
+//
+// Sets the supplied tag-set to an object that already exists in a bucket
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Simple Storage Service's
+// API operation PutObjectTagging for usage and error information.
+func (c *S3) PutObjectTagging(input *PutObjectTaggingInput) (*PutObjectTaggingOutput, error) {
+	req, out := c.PutObjectTaggingRequest(input)
+	err := req.Send()
+	return out, err
+}
+
 const opRestoreObject = "RestoreObject"
 
 // RestoreObjectRequest generates a "aws/request.Request" representing the
@@ -4002,6 +4908,309 @@ func (s *AccessControlPolicy) SetGrants(v []*Grant) *AccessControlPolicy {
 // SetOwner sets the Owner field's value.
 func (s *AccessControlPolicy) SetOwner(v *Owner) *AccessControlPolicy {
 	s.Owner = v
+	return s
+}
+
+type AnalyticsAndOperator struct {
+	_ struct{} `type:"structure"`
+
+	// The prefix to use when evaluating an AND predicate.
+	Prefix *string `type:"string"`
+
+	// The list of tags to use when evaluating an AND predicate.
+	Tags []*Tag `locationName:"Tag" locationNameList:"Tag" type:"list" flattened:"true"`
+}
+
+// String returns the string representation
+func (s AnalyticsAndOperator) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AnalyticsAndOperator) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AnalyticsAndOperator) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AnalyticsAndOperator"}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *AnalyticsAndOperator) SetPrefix(v string) *AnalyticsAndOperator {
+	s.Prefix = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *AnalyticsAndOperator) SetTags(v []*Tag) *AnalyticsAndOperator {
+	s.Tags = v
+	return s
+}
+
+type AnalyticsConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// The filter used to describe a set of objects for analyses. A filter must
+	// have exactly one prefix, one tag, or one conjunction (AnalyticsAndOperator).
+	// If no filter is provided, all objects will be considered in any analysis.
+	Filter *AnalyticsFilter `type:"structure"`
+
+	// The identifier used to represent an analytics configuration.
+	//
+	// Id is a required field
+	Id *string `type:"string" required:"true"`
+
+	// If present, it indicates that data related to access patterns will be collected
+	// and made available to analyze the tradeoffs between different storage classes.
+	//
+	// StorageClassAnalysis is a required field
+	StorageClassAnalysis *StorageClassAnalysis `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s AnalyticsConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AnalyticsConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AnalyticsConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AnalyticsConfiguration"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.StorageClassAnalysis == nil {
+		invalidParams.Add(request.NewErrParamRequired("StorageClassAnalysis"))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.StorageClassAnalysis != nil {
+		if err := s.StorageClassAnalysis.Validate(); err != nil {
+			invalidParams.AddNested("StorageClassAnalysis", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFilter sets the Filter field's value.
+func (s *AnalyticsConfiguration) SetFilter(v *AnalyticsFilter) *AnalyticsConfiguration {
+	s.Filter = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *AnalyticsConfiguration) SetId(v string) *AnalyticsConfiguration {
+	s.Id = &v
+	return s
+}
+
+// SetStorageClassAnalysis sets the StorageClassAnalysis field's value.
+func (s *AnalyticsConfiguration) SetStorageClassAnalysis(v *StorageClassAnalysis) *AnalyticsConfiguration {
+	s.StorageClassAnalysis = v
+	return s
+}
+
+type AnalyticsExportDestination struct {
+	_ struct{} `type:"structure"`
+
+	// A destination signifying output to an S3 bucket.
+	//
+	// S3BucketDestination is a required field
+	S3BucketDestination *AnalyticsS3BucketDestination `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s AnalyticsExportDestination) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AnalyticsExportDestination) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AnalyticsExportDestination) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AnalyticsExportDestination"}
+	if s.S3BucketDestination == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3BucketDestination"))
+	}
+	if s.S3BucketDestination != nil {
+		if err := s.S3BucketDestination.Validate(); err != nil {
+			invalidParams.AddNested("S3BucketDestination", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetS3BucketDestination sets the S3BucketDestination field's value.
+func (s *AnalyticsExportDestination) SetS3BucketDestination(v *AnalyticsS3BucketDestination) *AnalyticsExportDestination {
+	s.S3BucketDestination = v
+	return s
+}
+
+type AnalyticsFilter struct {
+	_ struct{} `type:"structure"`
+
+	// A conjunction (logical AND) of predicates, which is used in evaluating an
+	// analytics filter. The operator must have at least two predicates.
+	And *AnalyticsAndOperator `type:"structure"`
+
+	// The prefix to use when evaluating an analytics filter.
+	Prefix *string `type:"string"`
+
+	// The tag to use when evaluating an analytics filter.
+	Tag *Tag `type:"structure"`
+}
+
+// String returns the string representation
+func (s AnalyticsFilter) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AnalyticsFilter) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AnalyticsFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AnalyticsFilter"}
+	if s.And != nil {
+		if err := s.And.Validate(); err != nil {
+			invalidParams.AddNested("And", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Tag != nil {
+		if err := s.Tag.Validate(); err != nil {
+			invalidParams.AddNested("Tag", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAnd sets the And field's value.
+func (s *AnalyticsFilter) SetAnd(v *AnalyticsAndOperator) *AnalyticsFilter {
+	s.And = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *AnalyticsFilter) SetPrefix(v string) *AnalyticsFilter {
+	s.Prefix = &v
+	return s
+}
+
+// SetTag sets the Tag field's value.
+func (s *AnalyticsFilter) SetTag(v *Tag) *AnalyticsFilter {
+	s.Tag = v
+	return s
+}
+
+type AnalyticsS3BucketDestination struct {
+	_ struct{} `type:"structure"`
+
+	// The Amazon resource name (ARN) of the bucket to which data is exported.
+	//
+	// Bucket is a required field
+	Bucket *string `type:"string" required:"true"`
+
+	// The account ID that owns the destination bucket. If no account ID is provided,
+	// the owner will not be validated prior to exporting data.
+	BucketAccountId *string `type:"string"`
+
+	// The file format used when exporting data to Amazon S3.
+	//
+	// Format is a required field
+	Format *string `type:"string" required:"true" enum:"AnalyticsS3ExportFileFormat"`
+
+	// The prefix to use when exporting data. The exported data begins with this
+	// prefix.
+	Prefix *string `type:"string"`
+}
+
+// String returns the string representation
+func (s AnalyticsS3BucketDestination) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s AnalyticsS3BucketDestination) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *AnalyticsS3BucketDestination) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "AnalyticsS3BucketDestination"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Format == nil {
+		invalidParams.Add(request.NewErrParamRequired("Format"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *AnalyticsS3BucketDestination) SetBucket(v string) *AnalyticsS3BucketDestination {
+	s.Bucket = &v
+	return s
+}
+
+// SetBucketAccountId sets the BucketAccountId field's value.
+func (s *AnalyticsS3BucketDestination) SetBucketAccountId(v string) *AnalyticsS3BucketDestination {
+	s.BucketAccountId = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *AnalyticsS3BucketDestination) SetFormat(v string) *AnalyticsS3BucketDestination {
+	s.Format = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *AnalyticsS3BucketDestination) SetPrefix(v string) *AnalyticsS3BucketDestination {
+	s.Prefix = &v
 	return s
 }
 
@@ -4721,6 +5930,15 @@ type CopyObjectInput struct {
 	// The type of storage to use for the object. Defaults to 'STANDARD'.
 	StorageClass *string `location:"header" locationName:"x-amz-storage-class" type:"string" enum:"StorageClass"`
 
+	// The tag-set for the object destination object this value must be used in
+	// conjunction with the TaggingDirective. The tag-set must be encoded as URL
+	// Query parameters
+	Tagging *string `location:"header" locationName:"x-amz-tagging" type:"string"`
+
+	// Specifies whether the object tag-set are copied from the source object or
+	// replaced with tag-set provided in the request.
+	TaggingDirective *string `location:"header" locationName:"x-amz-tagging-directive" type:"string" enum:"TaggingDirective"`
+
 	// If the bucket is configured as a website, redirects requests for this object
 	// to another object in the same bucket or to an external URL. Amazon S3 stores
 	// the value of this header in the object metadata.
@@ -4936,6 +6154,18 @@ func (s *CopyObjectInput) SetServerSideEncryption(v string) *CopyObjectInput {
 // SetStorageClass sets the StorageClass field's value.
 func (s *CopyObjectInput) SetStorageClass(v string) *CopyObjectInput {
 	s.StorageClass = &v
+	return s
+}
+
+// SetTagging sets the Tagging field's value.
+func (s *CopyObjectInput) SetTagging(v string) *CopyObjectInput {
+	s.Tagging = &v
+	return s
+}
+
+// SetTaggingDirective sets the TaggingDirective field's value.
+func (s *CopyObjectInput) SetTaggingDirective(v string) *CopyObjectInput {
+	s.TaggingDirective = &v
 	return s
 }
 
@@ -5668,6 +6898,72 @@ func (s *Delete) SetQuiet(v bool) *Delete {
 	return s
 }
 
+type DeleteBucketAnalyticsConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket from which an analytics configuration is deleted.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The identifier used to represent an analytics configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteBucketAnalyticsConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketAnalyticsConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketAnalyticsConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketAnalyticsConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketAnalyticsConfigurationInput) SetBucket(v string) *DeleteBucketAnalyticsConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteBucketAnalyticsConfigurationInput) SetId(v string) *DeleteBucketAnalyticsConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+type DeleteBucketAnalyticsConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketAnalyticsConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketAnalyticsConfigurationOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketCorsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5754,6 +7050,72 @@ func (s *DeleteBucketInput) SetBucket(v string) *DeleteBucketInput {
 	return s
 }
 
+type DeleteBucketInventoryConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket containing the inventory configuration to delete.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The ID used to identify the inventory configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteBucketInventoryConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketInventoryConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketInventoryConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketInventoryConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketInventoryConfigurationInput) SetBucket(v string) *DeleteBucketInventoryConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteBucketInventoryConfigurationInput) SetId(v string) *DeleteBucketInventoryConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+type DeleteBucketInventoryConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketInventoryConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketInventoryConfigurationOutput) GoString() string {
+	return s.String()
+}
+
 type DeleteBucketLifecycleInput struct {
 	_ struct{} `type:"structure"`
 
@@ -5801,6 +7163,72 @@ func (s DeleteBucketLifecycleOutput) String() string {
 
 // GoString returns the string representation
 func (s DeleteBucketLifecycleOutput) GoString() string {
+	return s.String()
+}
+
+type DeleteBucketMetricsConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket containing the metrics configuration to delete.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The ID used to identify the metrics configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s DeleteBucketMetricsConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketMetricsConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteBucketMetricsConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteBucketMetricsConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteBucketMetricsConfigurationInput) SetBucket(v string) *DeleteBucketMetricsConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *DeleteBucketMetricsConfigurationInput) SetId(v string) *DeleteBucketMetricsConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+type DeleteBucketMetricsConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s DeleteBucketMetricsConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteBucketMetricsConfigurationOutput) GoString() string {
 	return s.String()
 }
 
@@ -6199,6 +7627,89 @@ func (s *DeleteObjectOutput) SetRequestCharged(v string) *DeleteObjectOutput {
 
 // SetVersionId sets the VersionId field's value.
 func (s *DeleteObjectOutput) SetVersionId(v string) *DeleteObjectOutput {
+	s.VersionId = &v
+	return s
+}
+
+type DeleteObjectTaggingInput struct {
+	_ struct{} `type:"structure"`
+
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// Key is a required field
+	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
+
+	// The versionId of the object that the tag-set will be removed from.
+	VersionId *string `location:"querystring" locationName:"versionId" type:"string"`
+}
+
+// String returns the string representation
+func (s DeleteObjectTaggingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteObjectTaggingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DeleteObjectTaggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DeleteObjectTaggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *DeleteObjectTaggingInput) SetBucket(v string) *DeleteObjectTaggingInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *DeleteObjectTaggingInput) SetKey(v string) *DeleteObjectTaggingInput {
+	s.Key = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeleteObjectTaggingInput) SetVersionId(v string) *DeleteObjectTaggingInput {
+	s.VersionId = &v
+	return s
+}
+
+type DeleteObjectTaggingOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The versionId of the object the tag-set was removed from.
+	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
+}
+
+// String returns the string representation
+func (s DeleteObjectTaggingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DeleteObjectTaggingOutput) GoString() string {
+	return s.String()
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *DeleteObjectTaggingOutput) SetVersionId(v string) *DeleteObjectTaggingOutput {
 	s.VersionId = &v
 	return s
 }
@@ -6662,6 +8173,81 @@ func (s *GetBucketAclOutput) SetOwner(v *Owner) *GetBucketAclOutput {
 	return s
 }
 
+type GetBucketAnalyticsConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket from which an analytics configuration is retrieved.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The identifier used to represent an analytics configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetBucketAnalyticsConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketAnalyticsConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketAnalyticsConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketAnalyticsConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketAnalyticsConfigurationInput) SetBucket(v string) *GetBucketAnalyticsConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *GetBucketAnalyticsConfigurationInput) SetId(v string) *GetBucketAnalyticsConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+type GetBucketAnalyticsConfigurationOutput struct {
+	_ struct{} `type:"structure" payload:"AnalyticsConfiguration"`
+
+	// The configuration and any analyses for the analytics filter.
+	AnalyticsConfiguration *AnalyticsConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketAnalyticsConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketAnalyticsConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetAnalyticsConfiguration sets the AnalyticsConfiguration field's value.
+func (s *GetBucketAnalyticsConfigurationOutput) SetAnalyticsConfiguration(v *AnalyticsConfiguration) *GetBucketAnalyticsConfigurationOutput {
+	s.AnalyticsConfiguration = v
+	return s
+}
+
 type GetBucketCorsInput struct {
 	_ struct{} `type:"structure"`
 
@@ -6717,6 +8303,81 @@ func (s GetBucketCorsOutput) GoString() string {
 // SetCORSRules sets the CORSRules field's value.
 func (s *GetBucketCorsOutput) SetCORSRules(v []*CORSRule) *GetBucketCorsOutput {
 	s.CORSRules = v
+	return s
+}
+
+type GetBucketInventoryConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket containing the inventory configuration to retrieve.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The ID used to identify the inventory configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetBucketInventoryConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketInventoryConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketInventoryConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketInventoryConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketInventoryConfigurationInput) SetBucket(v string) *GetBucketInventoryConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *GetBucketInventoryConfigurationInput) SetId(v string) *GetBucketInventoryConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+type GetBucketInventoryConfigurationOutput struct {
+	_ struct{} `type:"structure" payload:"InventoryConfiguration"`
+
+	// Specifies the inventory configuration.
+	InventoryConfiguration *InventoryConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketInventoryConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketInventoryConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetInventoryConfiguration sets the InventoryConfiguration field's value.
+func (s *GetBucketInventoryConfigurationOutput) SetInventoryConfiguration(v *InventoryConfiguration) *GetBucketInventoryConfigurationOutput {
+	s.InventoryConfiguration = v
 	return s
 }
 
@@ -6949,6 +8610,81 @@ func (s GetBucketLoggingOutput) GoString() string {
 // SetLoggingEnabled sets the LoggingEnabled field's value.
 func (s *GetBucketLoggingOutput) SetLoggingEnabled(v *LoggingEnabled) *GetBucketLoggingOutput {
 	s.LoggingEnabled = v
+	return s
+}
+
+type GetBucketMetricsConfigurationInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket containing the metrics configuration to retrieve.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The ID used to identify the metrics configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetBucketMetricsConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketMetricsConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetBucketMetricsConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetBucketMetricsConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *GetBucketMetricsConfigurationInput) SetBucket(v string) *GetBucketMetricsConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *GetBucketMetricsConfigurationInput) SetId(v string) *GetBucketMetricsConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+type GetBucketMetricsConfigurationOutput struct {
+	_ struct{} `type:"structure" payload:"MetricsConfiguration"`
+
+	// Specifies the metrics configuration.
+	MetricsConfiguration *MetricsConfiguration `type:"structure"`
+}
+
+// String returns the string representation
+func (s GetBucketMetricsConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetBucketMetricsConfigurationOutput) GoString() string {
+	return s.String()
+}
+
+// SetMetricsConfiguration sets the MetricsConfiguration field's value.
+func (s *GetBucketMetricsConfigurationOutput) SetMetricsConfiguration(v *MetricsConfiguration) *GetBucketMetricsConfigurationOutput {
+	s.MetricsConfiguration = v
 	return s
 }
 
@@ -7805,6 +9541,9 @@ type GetObjectOutput struct {
 
 	StorageClass *string `location:"header" locationName:"x-amz-storage-class" type:"string" enum:"StorageClass"`
 
+	// The number of tags, if any, on the object.
+	TagCount *int64 `location:"header" locationName:"x-amz-tagging-count" type:"integer"`
+
 	// Version of the object.
 	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
 
@@ -7974,6 +9713,12 @@ func (s *GetObjectOutput) SetStorageClass(v string) *GetObjectOutput {
 	return s
 }
 
+// SetTagCount sets the TagCount field's value.
+func (s *GetObjectOutput) SetTagCount(v int64) *GetObjectOutput {
+	s.TagCount = &v
+	return s
+}
+
 // SetVersionId sets the VersionId field's value.
 func (s *GetObjectOutput) SetVersionId(v string) *GetObjectOutput {
 	s.VersionId = &v
@@ -7983,6 +9728,100 @@ func (s *GetObjectOutput) SetVersionId(v string) *GetObjectOutput {
 // SetWebsiteRedirectLocation sets the WebsiteRedirectLocation field's value.
 func (s *GetObjectOutput) SetWebsiteRedirectLocation(v string) *GetObjectOutput {
 	s.WebsiteRedirectLocation = &v
+	return s
+}
+
+type GetObjectTaggingInput struct {
+	_ struct{} `type:"structure"`
+
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// Key is a required field
+	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
+
+	// VersionId is a required field
+	VersionId *string `location:"uri" locationName:"VersionId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s GetObjectTaggingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectTaggingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetObjectTaggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetObjectTaggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.VersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionId"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *GetObjectTaggingInput) SetBucket(v string) *GetObjectTaggingInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *GetObjectTaggingInput) SetKey(v string) *GetObjectTaggingInput {
+	s.Key = &v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *GetObjectTaggingInput) SetVersionId(v string) *GetObjectTaggingInput {
+	s.VersionId = &v
+	return s
+}
+
+type GetObjectTaggingOutput struct {
+	_ struct{} `type:"structure"`
+
+	// TagSet is a required field
+	TagSet []*Tag `locationNameList:"Tag" type:"list" required:"true"`
+
+	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
+}
+
+// String returns the string representation
+func (s GetObjectTaggingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetObjectTaggingOutput) GoString() string {
+	return s.String()
+}
+
+// SetTagSet sets the TagSet field's value.
+func (s *GetObjectTaggingOutput) SetTagSet(v []*Tag) *GetObjectTaggingOutput {
+	s.TagSet = v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *GetObjectTaggingOutput) SetVersionId(v string) *GetObjectTaggingOutput {
+	s.VersionId = &v
 	return s
 }
 
@@ -8078,6 +9917,44 @@ func (s *GetObjectTorrentOutput) SetBody(v io.ReadCloser) *GetObjectTorrentOutpu
 // SetRequestCharged sets the RequestCharged field's value.
 func (s *GetObjectTorrentOutput) SetRequestCharged(v string) *GetObjectTorrentOutput {
 	s.RequestCharged = &v
+	return s
+}
+
+type GlacierJobParameters struct {
+	_ struct{} `type:"structure"`
+
+	// Glacier retrieval tier at which the restore will be processed.
+	//
+	// Tier is a required field
+	Tier *string `type:"string" required:"true" enum:"Tier"`
+}
+
+// String returns the string representation
+func (s GlacierJobParameters) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GlacierJobParameters) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GlacierJobParameters) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GlacierJobParameters"}
+	if s.Tier == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tier"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetTier sets the Tier field's value.
+func (s *GlacierJobParameters) SetTier(v string) *GlacierJobParameters {
+	s.Tier = &v
 	return s
 }
 
@@ -8748,6 +10625,325 @@ func (s *Initiator) SetID(v string) *Initiator {
 	return s
 }
 
+type InventoryConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// Contains information about where to publish the inventory results.
+	//
+	// Destination is a required field
+	Destination *InventoryDestination `type:"structure" required:"true"`
+
+	// Specifies an inventory filter. The inventory only includes objects that meet
+	// the filter's criteria.
+	Filter *InventoryFilter `type:"structure"`
+
+	// The ID used to identify the inventory configuration.
+	//
+	// Id is a required field
+	Id *string `type:"string" required:"true"`
+
+	// Specifies which object version(s) to included in the inventory results.
+	//
+	// IncludedObjectVersions is a required field
+	IncludedObjectVersions *string `type:"string" required:"true" enum:"InventoryIncludedObjectVersions"`
+
+	// Specifies whether the inventory is enabled or disabled.
+	//
+	// IsEnabled is a required field
+	IsEnabled *bool `type:"boolean" required:"true"`
+
+	// Contains the optional fields that are included in the inventory results.
+	OptionalFields []*string `locationNameList:"Field" type:"list"`
+
+	// Specifies the schedule for generating inventory results.
+	//
+	// Schedule is a required field
+	Schedule *InventorySchedule `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s InventoryConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InventoryConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InventoryConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InventoryConfiguration"}
+	if s.Destination == nil {
+		invalidParams.Add(request.NewErrParamRequired("Destination"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.IncludedObjectVersions == nil {
+		invalidParams.Add(request.NewErrParamRequired("IncludedObjectVersions"))
+	}
+	if s.IsEnabled == nil {
+		invalidParams.Add(request.NewErrParamRequired("IsEnabled"))
+	}
+	if s.Schedule == nil {
+		invalidParams.Add(request.NewErrParamRequired("Schedule"))
+	}
+	if s.Destination != nil {
+		if err := s.Destination.Validate(); err != nil {
+			invalidParams.AddNested("Destination", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Schedule != nil {
+		if err := s.Schedule.Validate(); err != nil {
+			invalidParams.AddNested("Schedule", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestination sets the Destination field's value.
+func (s *InventoryConfiguration) SetDestination(v *InventoryDestination) *InventoryConfiguration {
+	s.Destination = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *InventoryConfiguration) SetFilter(v *InventoryFilter) *InventoryConfiguration {
+	s.Filter = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *InventoryConfiguration) SetId(v string) *InventoryConfiguration {
+	s.Id = &v
+	return s
+}
+
+// SetIncludedObjectVersions sets the IncludedObjectVersions field's value.
+func (s *InventoryConfiguration) SetIncludedObjectVersions(v string) *InventoryConfiguration {
+	s.IncludedObjectVersions = &v
+	return s
+}
+
+// SetIsEnabled sets the IsEnabled field's value.
+func (s *InventoryConfiguration) SetIsEnabled(v bool) *InventoryConfiguration {
+	s.IsEnabled = &v
+	return s
+}
+
+// SetOptionalFields sets the OptionalFields field's value.
+func (s *InventoryConfiguration) SetOptionalFields(v []*string) *InventoryConfiguration {
+	s.OptionalFields = v
+	return s
+}
+
+// SetSchedule sets the Schedule field's value.
+func (s *InventoryConfiguration) SetSchedule(v *InventorySchedule) *InventoryConfiguration {
+	s.Schedule = v
+	return s
+}
+
+type InventoryDestination struct {
+	_ struct{} `type:"structure"`
+
+	// Contains the bucket name, file format, bucket owner (optional), and prefix
+	// (optional) where inventory results are published.
+	//
+	// S3BucketDestination is a required field
+	S3BucketDestination *InventoryS3BucketDestination `type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s InventoryDestination) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InventoryDestination) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InventoryDestination) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InventoryDestination"}
+	if s.S3BucketDestination == nil {
+		invalidParams.Add(request.NewErrParamRequired("S3BucketDestination"))
+	}
+	if s.S3BucketDestination != nil {
+		if err := s.S3BucketDestination.Validate(); err != nil {
+			invalidParams.AddNested("S3BucketDestination", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetS3BucketDestination sets the S3BucketDestination field's value.
+func (s *InventoryDestination) SetS3BucketDestination(v *InventoryS3BucketDestination) *InventoryDestination {
+	s.S3BucketDestination = v
+	return s
+}
+
+type InventoryFilter struct {
+	_ struct{} `type:"structure"`
+
+	// The prefix that an object must have to be included in the inventory results.
+	//
+	// Prefix is a required field
+	Prefix *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s InventoryFilter) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InventoryFilter) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InventoryFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InventoryFilter"}
+	if s.Prefix == nil {
+		invalidParams.Add(request.NewErrParamRequired("Prefix"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *InventoryFilter) SetPrefix(v string) *InventoryFilter {
+	s.Prefix = &v
+	return s
+}
+
+type InventoryS3BucketDestination struct {
+	_ struct{} `type:"structure"`
+
+	// The ID of the account that owns the destination bucket.
+	AccountId *string `type:"string"`
+
+	// The Amazon resource name (ARN) of the bucket where inventory results will
+	// be published.
+	//
+	// Bucket is a required field
+	Bucket *string `type:"string" required:"true"`
+
+	// Specifies the output format of the inventory results.
+	//
+	// Format is a required field
+	Format *string `type:"string" required:"true" enum:"InventoryFormat"`
+
+	// The prefix that is prepended to all inventory results.
+	Prefix *string `type:"string"`
+}
+
+// String returns the string representation
+func (s InventoryS3BucketDestination) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InventoryS3BucketDestination) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InventoryS3BucketDestination) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InventoryS3BucketDestination"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Format == nil {
+		invalidParams.Add(request.NewErrParamRequired("Format"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAccountId sets the AccountId field's value.
+func (s *InventoryS3BucketDestination) SetAccountId(v string) *InventoryS3BucketDestination {
+	s.AccountId = &v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *InventoryS3BucketDestination) SetBucket(v string) *InventoryS3BucketDestination {
+	s.Bucket = &v
+	return s
+}
+
+// SetFormat sets the Format field's value.
+func (s *InventoryS3BucketDestination) SetFormat(v string) *InventoryS3BucketDestination {
+	s.Format = &v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *InventoryS3BucketDestination) SetPrefix(v string) *InventoryS3BucketDestination {
+	s.Prefix = &v
+	return s
+}
+
+type InventorySchedule struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies how frequently inventory results are produced.
+	//
+	// Frequency is a required field
+	Frequency *string `type:"string" required:"true" enum:"InventoryFrequency"`
+}
+
+// String returns the string representation
+func (s InventorySchedule) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s InventorySchedule) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *InventorySchedule) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "InventorySchedule"}
+	if s.Frequency == nil {
+		invalidParams.Add(request.NewErrParamRequired("Frequency"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFrequency sets the Frequency field's value.
+func (s *InventorySchedule) SetFrequency(v string) *InventorySchedule {
+	s.Frequency = &v
+	return s
+}
+
 // Container for object key name prefix and suffix filtering rules.
 type KeyFilter struct {
 	_ struct{} `type:"structure"`
@@ -8946,6 +11142,10 @@ type LifecycleRule struct {
 
 	Expiration *LifecycleExpiration `type:"structure"`
 
+	// The Filter is used to identify objects that a Lifecycle Rule applies to.
+	// A Filter must have exactly one of Prefix, Tag, or And specified.
+	Filter *LifecycleRuleFilter `type:"structure"`
+
 	// Unique identifier for the rule. The value cannot be longer than 255 characters.
 	ID *string `type:"string"`
 
@@ -8958,10 +11158,9 @@ type LifecycleRule struct {
 
 	NoncurrentVersionTransitions []*NoncurrentVersionTransition `locationName:"NoncurrentVersionTransition" type:"list" flattened:"true"`
 
-	// Prefix identifying one or more objects to which the rule applies.
-	//
-	// Prefix is a required field
-	Prefix *string `type:"string" required:"true"`
+	// Prefix identifying one or more objects to which the rule applies. This is
+	// deprecated; use Filter instead.
+	Prefix *string `deprecated:"true" type:"string"`
 
 	// If 'Enabled', the rule is currently being applied. If 'Disabled', the rule
 	// is not currently being applied.
@@ -8985,11 +11184,13 @@ func (s LifecycleRule) GoString() string {
 // Validate inspects the fields of the type to determine if they are valid.
 func (s *LifecycleRule) Validate() error {
 	invalidParams := request.ErrInvalidParams{Context: "LifecycleRule"}
-	if s.Prefix == nil {
-		invalidParams.Add(request.NewErrParamRequired("Prefix"))
-	}
 	if s.Status == nil {
 		invalidParams.Add(request.NewErrParamRequired("Status"))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
 	}
 
 	if invalidParams.Len() > 0 {
@@ -9007,6 +11208,12 @@ func (s *LifecycleRule) SetAbortIncompleteMultipartUpload(v *AbortIncompleteMult
 // SetExpiration sets the Expiration field's value.
 func (s *LifecycleRule) SetExpiration(v *LifecycleExpiration) *LifecycleRule {
 	s.Expiration = v
+	return s
+}
+
+// SetFilter sets the Filter field's value.
+func (s *LifecycleRule) SetFilter(v *LifecycleRuleFilter) *LifecycleRule {
+	s.Filter = v
 	return s
 }
 
@@ -9043,6 +11250,438 @@ func (s *LifecycleRule) SetStatus(v string) *LifecycleRule {
 // SetTransitions sets the Transitions field's value.
 func (s *LifecycleRule) SetTransitions(v []*Transition) *LifecycleRule {
 	s.Transitions = v
+	return s
+}
+
+// This is used in a Lifecycle Rule Filter to apply a logical AND to two or
+// more predicates. The Lifecycle Rule will apply to any object matching all
+// of the predicates configured inside the And operator.
+type LifecycleRuleAndOperator struct {
+	_ struct{} `type:"structure"`
+
+	Prefix *string `type:"string"`
+
+	// All of these tags must exist in the object's tag set in order for the rule
+	// to apply.
+	Tags []*Tag `locationName:"Tag" locationNameList:"Tag" type:"list" flattened:"true"`
+}
+
+// String returns the string representation
+func (s LifecycleRuleAndOperator) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleRuleAndOperator) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LifecycleRuleAndOperator) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LifecycleRuleAndOperator"}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *LifecycleRuleAndOperator) SetPrefix(v string) *LifecycleRuleAndOperator {
+	s.Prefix = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *LifecycleRuleAndOperator) SetTags(v []*Tag) *LifecycleRuleAndOperator {
+	s.Tags = v
+	return s
+}
+
+// The Filter is used to identify objects that a Lifecycle Rule applies to.
+// A Filter must have exactly one of Prefix, Tag, or And specified.
+type LifecycleRuleFilter struct {
+	_ struct{} `type:"structure"`
+
+	// This is used in a Lifecycle Rule Filter to apply a logical AND to two or
+	// more predicates. The Lifecycle Rule will apply to any object matching all
+	// of the predicates configured inside the And operator.
+	And *LifecycleRuleAndOperator `type:"structure"`
+
+	// Prefix identifying one or more objects to which the rule applies.
+	Prefix *string `type:"string"`
+
+	// This tag must exist in the object's tag set in order for the rule to apply.
+	Tag *Tag `type:"structure"`
+}
+
+// String returns the string representation
+func (s LifecycleRuleFilter) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s LifecycleRuleFilter) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *LifecycleRuleFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "LifecycleRuleFilter"}
+	if s.And != nil {
+		if err := s.And.Validate(); err != nil {
+			invalidParams.AddNested("And", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Tag != nil {
+		if err := s.Tag.Validate(); err != nil {
+			invalidParams.AddNested("Tag", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAnd sets the And field's value.
+func (s *LifecycleRuleFilter) SetAnd(v *LifecycleRuleAndOperator) *LifecycleRuleFilter {
+	s.And = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *LifecycleRuleFilter) SetPrefix(v string) *LifecycleRuleFilter {
+	s.Prefix = &v
+	return s
+}
+
+// SetTag sets the Tag field's value.
+func (s *LifecycleRuleFilter) SetTag(v *Tag) *LifecycleRuleFilter {
+	s.Tag = v
+	return s
+}
+
+type ListBucketAnalyticsConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket from which analytics configurations are retrieved.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The ContinuationToken that represents a placeholder from where this request
+	// should begin.
+	ContinuationToken *string `location:"querystring" locationName:"continuation-token" type:"string"`
+}
+
+// String returns the string representation
+func (s ListBucketAnalyticsConfigurationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketAnalyticsConfigurationsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListBucketAnalyticsConfigurationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListBucketAnalyticsConfigurationsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *ListBucketAnalyticsConfigurationsInput) SetBucket(v string) *ListBucketAnalyticsConfigurationsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListBucketAnalyticsConfigurationsInput) SetContinuationToken(v string) *ListBucketAnalyticsConfigurationsInput {
+	s.ContinuationToken = &v
+	return s
+}
+
+type ListBucketAnalyticsConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The list of analytics configurations for a bucket.
+	AnalyticsConfigurationList []*AnalyticsConfiguration `locationName:"AnalyticsConfiguration" type:"list" flattened:"true"`
+
+	// The ContinuationToken that represents where this request began.
+	ContinuationToken *string `type:"string"`
+
+	// Indicates whether the returned list of analytics configurations is complete.
+	// A value of true indicates that the list is not complete and the NextContinuationToken
+	// will be provided for a subsequent request.
+	IsTruncated *bool `type:"boolean"`
+
+	// NextContinuationToken is sent when isTruncated is true, which indicates that
+	// there are more analytics configurations to list. The next request must include
+	// this NextContinuationToken. The token is obfuscated and is not a usable value.
+	NextContinuationToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListBucketAnalyticsConfigurationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketAnalyticsConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetAnalyticsConfigurationList sets the AnalyticsConfigurationList field's value.
+func (s *ListBucketAnalyticsConfigurationsOutput) SetAnalyticsConfigurationList(v []*AnalyticsConfiguration) *ListBucketAnalyticsConfigurationsOutput {
+	s.AnalyticsConfigurationList = v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListBucketAnalyticsConfigurationsOutput) SetContinuationToken(v string) *ListBucketAnalyticsConfigurationsOutput {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListBucketAnalyticsConfigurationsOutput) SetIsTruncated(v bool) *ListBucketAnalyticsConfigurationsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetNextContinuationToken sets the NextContinuationToken field's value.
+func (s *ListBucketAnalyticsConfigurationsOutput) SetNextContinuationToken(v string) *ListBucketAnalyticsConfigurationsOutput {
+	s.NextContinuationToken = &v
+	return s
+}
+
+type ListBucketInventoryConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket containing the inventory configurations to retrieve.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The marker used to continue an inventory configuration listing that has been
+	// truncated. Use the NextContinuationToken from a previously truncated list
+	// response to continue the listing. The continuation token is an opaque value
+	// that Amazon S3 understands.
+	ContinuationToken *string `location:"querystring" locationName:"continuation-token" type:"string"`
+}
+
+// String returns the string representation
+func (s ListBucketInventoryConfigurationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketInventoryConfigurationsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListBucketInventoryConfigurationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListBucketInventoryConfigurationsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *ListBucketInventoryConfigurationsInput) SetBucket(v string) *ListBucketInventoryConfigurationsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListBucketInventoryConfigurationsInput) SetContinuationToken(v string) *ListBucketInventoryConfigurationsInput {
+	s.ContinuationToken = &v
+	return s
+}
+
+type ListBucketInventoryConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// If sent in the request, the marker that is used as a starting point for this
+	// inventory configuration list response.
+	ContinuationToken *string `type:"string"`
+
+	// The list of inventory configurations for a bucket.
+	InventoryConfigurationList []*InventoryConfiguration `locationName:"InventoryConfiguration" type:"list" flattened:"true"`
+
+	// Indicates whether the returned list of inventory configurations is truncated
+	// in this response. A value of true indicates that the list is truncated.
+	IsTruncated *bool `type:"boolean"`
+
+	// The marker used to continue this inventory configuration listing. Use the
+	// NextContinuationToken from this response to continue the listing in a subsequent
+	// request. The continuation token is an opaque value that Amazon S3 understands.
+	NextContinuationToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListBucketInventoryConfigurationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketInventoryConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListBucketInventoryConfigurationsOutput) SetContinuationToken(v string) *ListBucketInventoryConfigurationsOutput {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetInventoryConfigurationList sets the InventoryConfigurationList field's value.
+func (s *ListBucketInventoryConfigurationsOutput) SetInventoryConfigurationList(v []*InventoryConfiguration) *ListBucketInventoryConfigurationsOutput {
+	s.InventoryConfigurationList = v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListBucketInventoryConfigurationsOutput) SetIsTruncated(v bool) *ListBucketInventoryConfigurationsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetNextContinuationToken sets the NextContinuationToken field's value.
+func (s *ListBucketInventoryConfigurationsOutput) SetNextContinuationToken(v string) *ListBucketInventoryConfigurationsOutput {
+	s.NextContinuationToken = &v
+	return s
+}
+
+type ListBucketMetricsConfigurationsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The name of the bucket containing the metrics configurations to retrieve.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The marker that is used to continue a metrics configuration listing that
+	// has been truncated. Use the NextContinuationToken from a previously truncated
+	// list response to continue the listing. The continuation token is an opaque
+	// value that Amazon S3 understands.
+	ContinuationToken *string `location:"querystring" locationName:"continuation-token" type:"string"`
+}
+
+// String returns the string representation
+func (s ListBucketMetricsConfigurationsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketMetricsConfigurationsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *ListBucketMetricsConfigurationsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "ListBucketMetricsConfigurationsInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *ListBucketMetricsConfigurationsInput) SetBucket(v string) *ListBucketMetricsConfigurationsInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListBucketMetricsConfigurationsInput) SetContinuationToken(v string) *ListBucketMetricsConfigurationsInput {
+	s.ContinuationToken = &v
+	return s
+}
+
+type ListBucketMetricsConfigurationsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// The marker that is used as a starting point for this metrics configuration
+	// list response. This value is present if it was sent in the request.
+	ContinuationToken *string `type:"string"`
+
+	// Indicates whether the returned list of metrics configurations is complete.
+	// A value of true indicates that the list is not complete and the NextContinuationToken
+	// will be provided for a subsequent request.
+	IsTruncated *bool `type:"boolean"`
+
+	// The list of metrics configurations for a bucket.
+	MetricsConfigurationList []*MetricsConfiguration `locationName:"MetricsConfiguration" type:"list" flattened:"true"`
+
+	// The marker used to continue a metrics configuration listing that has been
+	// truncated. Use the NextContinuationToken from a previously truncated list
+	// response to continue the listing. The continuation token is an opaque value
+	// that Amazon S3 understands.
+	NextContinuationToken *string `type:"string"`
+}
+
+// String returns the string representation
+func (s ListBucketMetricsConfigurationsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s ListBucketMetricsConfigurationsOutput) GoString() string {
+	return s.String()
+}
+
+// SetContinuationToken sets the ContinuationToken field's value.
+func (s *ListBucketMetricsConfigurationsOutput) SetContinuationToken(v string) *ListBucketMetricsConfigurationsOutput {
+	s.ContinuationToken = &v
+	return s
+}
+
+// SetIsTruncated sets the IsTruncated field's value.
+func (s *ListBucketMetricsConfigurationsOutput) SetIsTruncated(v bool) *ListBucketMetricsConfigurationsOutput {
+	s.IsTruncated = &v
+	return s
+}
+
+// SetMetricsConfigurationList sets the MetricsConfigurationList field's value.
+func (s *ListBucketMetricsConfigurationsOutput) SetMetricsConfigurationList(v []*MetricsConfiguration) *ListBucketMetricsConfigurationsOutput {
+	s.MetricsConfigurationList = v
+	return s
+}
+
+// SetNextContinuationToken sets the NextContinuationToken field's value.
+func (s *ListBucketMetricsConfigurationsOutput) SetNextContinuationToken(v string) *ListBucketMetricsConfigurationsOutput {
+	s.NextContinuationToken = &v
 	return s
 }
 
@@ -10297,6 +12936,175 @@ func (s *LoggingEnabled) SetTargetPrefix(v string) *LoggingEnabled {
 	return s
 }
 
+type MetricsAndOperator struct {
+	_ struct{} `type:"structure"`
+
+	// The prefix used when evaluating an AND predicate.
+	Prefix *string `type:"string"`
+
+	// The list of tags used when evaluating an AND predicate.
+	Tags []*Tag `locationName:"Tag" locationNameList:"Tag" type:"list" flattened:"true"`
+}
+
+// String returns the string representation
+func (s MetricsAndOperator) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MetricsAndOperator) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MetricsAndOperator) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MetricsAndOperator"}
+	if s.Tags != nil {
+		for i, v := range s.Tags {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Tags", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *MetricsAndOperator) SetPrefix(v string) *MetricsAndOperator {
+	s.Prefix = &v
+	return s
+}
+
+// SetTags sets the Tags field's value.
+func (s *MetricsAndOperator) SetTags(v []*Tag) *MetricsAndOperator {
+	s.Tags = v
+	return s
+}
+
+type MetricsConfiguration struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies a metrics configuration filter. The metrics configuration will
+	// only include objects that meet the filter's criteria. A filter must be a
+	// prefix, a tag, or a conjunction (MetricsAndOperator).
+	Filter *MetricsFilter `type:"structure"`
+
+	// The ID used to identify the metrics configuration.
+	//
+	// Id is a required field
+	Id *string `type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s MetricsConfiguration) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MetricsConfiguration) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MetricsConfiguration) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MetricsConfiguration"}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.Filter != nil {
+		if err := s.Filter.Validate(); err != nil {
+			invalidParams.AddNested("Filter", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetFilter sets the Filter field's value.
+func (s *MetricsConfiguration) SetFilter(v *MetricsFilter) *MetricsConfiguration {
+	s.Filter = v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *MetricsConfiguration) SetId(v string) *MetricsConfiguration {
+	s.Id = &v
+	return s
+}
+
+type MetricsFilter struct {
+	_ struct{} `type:"structure"`
+
+	// A conjunction (logical AND) of predicates, which is used in evaluating a
+	// metrics filter. The operator must have at least two predicates, and an object
+	// must match all of the predicates in order for the filter to apply.
+	And *MetricsAndOperator `type:"structure"`
+
+	// The prefix used when evaluating a metrics filter.
+	Prefix *string `type:"string"`
+
+	// The tag used when evaluating a metrics filter.
+	Tag *Tag `type:"structure"`
+}
+
+// String returns the string representation
+func (s MetricsFilter) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s MetricsFilter) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *MetricsFilter) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "MetricsFilter"}
+	if s.And != nil {
+		if err := s.And.Validate(); err != nil {
+			invalidParams.AddNested("And", err.(request.ErrInvalidParams))
+		}
+	}
+	if s.Tag != nil {
+		if err := s.Tag.Validate(); err != nil {
+			invalidParams.AddNested("Tag", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAnd sets the And field's value.
+func (s *MetricsFilter) SetAnd(v *MetricsAndOperator) *MetricsFilter {
+	s.And = v
+	return s
+}
+
+// SetPrefix sets the Prefix field's value.
+func (s *MetricsFilter) SetPrefix(v string) *MetricsFilter {
+	s.Prefix = &v
+	return s
+}
+
+// SetTag sets the Tag field's value.
+func (s *MetricsFilter) SetTag(v *Tag) *MetricsFilter {
+	s.Tag = v
+	return s
+}
+
 type MultipartUpload struct {
 	_ struct{} `type:"structure"`
 
@@ -11041,6 +13849,91 @@ func (s PutBucketAclOutput) GoString() string {
 	return s.String()
 }
 
+type PutBucketAnalyticsConfigurationInput struct {
+	_ struct{} `type:"structure" payload:"AnalyticsConfiguration"`
+
+	// The configuration and any analyses for the analytics filter.
+	//
+	// AnalyticsConfiguration is a required field
+	AnalyticsConfiguration *AnalyticsConfiguration `locationName:"AnalyticsConfiguration" type:"structure" required:"true"`
+
+	// The name of the bucket to which an analytics configuration is stored.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The identifier used to represent an analytics configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PutBucketAnalyticsConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketAnalyticsConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketAnalyticsConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketAnalyticsConfigurationInput"}
+	if s.AnalyticsConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("AnalyticsConfiguration"))
+	}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.AnalyticsConfiguration != nil {
+		if err := s.AnalyticsConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("AnalyticsConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAnalyticsConfiguration sets the AnalyticsConfiguration field's value.
+func (s *PutBucketAnalyticsConfigurationInput) SetAnalyticsConfiguration(v *AnalyticsConfiguration) *PutBucketAnalyticsConfigurationInput {
+	s.AnalyticsConfiguration = v
+	return s
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketAnalyticsConfigurationInput) SetBucket(v string) *PutBucketAnalyticsConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *PutBucketAnalyticsConfigurationInput) SetId(v string) *PutBucketAnalyticsConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+type PutBucketAnalyticsConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketAnalyticsConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketAnalyticsConfigurationOutput) GoString() string {
+	return s.String()
+}
+
 type PutBucketCorsInput struct {
 	_ struct{} `type:"structure" payload:"CORSConfiguration"`
 
@@ -11105,6 +13998,91 @@ func (s PutBucketCorsOutput) String() string {
 
 // GoString returns the string representation
 func (s PutBucketCorsOutput) GoString() string {
+	return s.String()
+}
+
+type PutBucketInventoryConfigurationInput struct {
+	_ struct{} `type:"structure" payload:"InventoryConfiguration"`
+
+	// The name of the bucket where the inventory configuration will be stored.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The ID used to identify the inventory configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+
+	// Specifies the inventory configuration.
+	//
+	// InventoryConfiguration is a required field
+	InventoryConfiguration *InventoryConfiguration `locationName:"InventoryConfiguration" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s PutBucketInventoryConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketInventoryConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketInventoryConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketInventoryConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.InventoryConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("InventoryConfiguration"))
+	}
+	if s.InventoryConfiguration != nil {
+		if err := s.InventoryConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("InventoryConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketInventoryConfigurationInput) SetBucket(v string) *PutBucketInventoryConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *PutBucketInventoryConfigurationInput) SetId(v string) *PutBucketInventoryConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+// SetInventoryConfiguration sets the InventoryConfiguration field's value.
+func (s *PutBucketInventoryConfigurationInput) SetInventoryConfiguration(v *InventoryConfiguration) *PutBucketInventoryConfigurationInput {
+	s.InventoryConfiguration = v
+	return s
+}
+
+type PutBucketInventoryConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketInventoryConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketInventoryConfigurationOutput) GoString() string {
 	return s.String()
 }
 
@@ -11298,6 +14276,91 @@ func (s PutBucketLoggingOutput) String() string {
 
 // GoString returns the string representation
 func (s PutBucketLoggingOutput) GoString() string {
+	return s.String()
+}
+
+type PutBucketMetricsConfigurationInput struct {
+	_ struct{} `type:"structure" payload:"MetricsConfiguration"`
+
+	// The name of the bucket for which the metrics configuration is set.
+	//
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// The ID used to identify the metrics configuration.
+	//
+	// Id is a required field
+	Id *string `location:"querystring" locationName:"id" type:"string" required:"true"`
+
+	// Specifies the metrics configuration.
+	//
+	// MetricsConfiguration is a required field
+	MetricsConfiguration *MetricsConfiguration `locationName:"MetricsConfiguration" type:"structure" required:"true"`
+}
+
+// String returns the string representation
+func (s PutBucketMetricsConfigurationInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketMetricsConfigurationInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutBucketMetricsConfigurationInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutBucketMetricsConfigurationInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Id == nil {
+		invalidParams.Add(request.NewErrParamRequired("Id"))
+	}
+	if s.MetricsConfiguration == nil {
+		invalidParams.Add(request.NewErrParamRequired("MetricsConfiguration"))
+	}
+	if s.MetricsConfiguration != nil {
+		if err := s.MetricsConfiguration.Validate(); err != nil {
+			invalidParams.AddNested("MetricsConfiguration", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutBucketMetricsConfigurationInput) SetBucket(v string) *PutBucketMetricsConfigurationInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetId sets the Id field's value.
+func (s *PutBucketMetricsConfigurationInput) SetId(v string) *PutBucketMetricsConfigurationInput {
+	s.Id = &v
+	return s
+}
+
+// SetMetricsConfiguration sets the MetricsConfiguration field's value.
+func (s *PutBucketMetricsConfigurationInput) SetMetricsConfiguration(v *MetricsConfiguration) *PutBucketMetricsConfigurationInput {
+	s.MetricsConfiguration = v
+	return s
+}
+
+type PutBucketMetricsConfigurationOutput struct {
+	_ struct{} `type:"structure"`
+}
+
+// String returns the string representation
+func (s PutBucketMetricsConfigurationOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutBucketMetricsConfigurationOutput) GoString() string {
 	return s.String()
 }
 
@@ -12096,6 +15159,9 @@ type PutObjectInput struct {
 	// The type of storage to use for the object. Defaults to 'STANDARD'.
 	StorageClass *string `location:"header" locationName:"x-amz-storage-class" type:"string" enum:"StorageClass"`
 
+	// The tag-set for the object. The tag-set must be encoded as URL Query parameters
+	Tagging *string `location:"header" locationName:"x-amz-tagging" type:"string"`
+
 	// If the bucket is configured as a website, redirects requests for this object
 	// to another object in the same bucket or to an external URL. Amazon S3 stores
 	// the value of this header in the object metadata.
@@ -12269,6 +15335,12 @@ func (s *PutObjectInput) SetStorageClass(v string) *PutObjectInput {
 	return s
 }
 
+// SetTagging sets the Tagging field's value.
+func (s *PutObjectInput) SetTagging(v string) *PutObjectInput {
+	s.Tagging = &v
+	return s
+}
+
 // SetWebsiteRedirectLocation sets the WebsiteRedirectLocation field's value.
 func (s *PutObjectInput) SetWebsiteRedirectLocation(v string) *PutObjectInput {
 	s.WebsiteRedirectLocation = &v
@@ -12365,6 +15437,108 @@ func (s *PutObjectOutput) SetServerSideEncryption(v string) *PutObjectOutput {
 
 // SetVersionId sets the VersionId field's value.
 func (s *PutObjectOutput) SetVersionId(v string) *PutObjectOutput {
+	s.VersionId = &v
+	return s
+}
+
+type PutObjectTaggingInput struct {
+	_ struct{} `type:"structure" payload:"Tagging"`
+
+	// Bucket is a required field
+	Bucket *string `location:"uri" locationName:"Bucket" type:"string" required:"true"`
+
+	// Key is a required field
+	Key *string `location:"uri" locationName:"Key" min:"1" type:"string" required:"true"`
+
+	// Tagging is a required field
+	Tagging *Tagging `locationName:"Tagging" type:"structure" required:"true"`
+
+	// VersionId is a required field
+	VersionId *string `location:"uri" locationName:"VersionId" type:"string" required:"true"`
+}
+
+// String returns the string representation
+func (s PutObjectTaggingInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutObjectTaggingInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *PutObjectTaggingInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "PutObjectTaggingInput"}
+	if s.Bucket == nil {
+		invalidParams.Add(request.NewErrParamRequired("Bucket"))
+	}
+	if s.Key == nil {
+		invalidParams.Add(request.NewErrParamRequired("Key"))
+	}
+	if s.Key != nil && len(*s.Key) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("Key", 1))
+	}
+	if s.Tagging == nil {
+		invalidParams.Add(request.NewErrParamRequired("Tagging"))
+	}
+	if s.VersionId == nil {
+		invalidParams.Add(request.NewErrParamRequired("VersionId"))
+	}
+	if s.Tagging != nil {
+		if err := s.Tagging.Validate(); err != nil {
+			invalidParams.AddNested("Tagging", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetBucket sets the Bucket field's value.
+func (s *PutObjectTaggingInput) SetBucket(v string) *PutObjectTaggingInput {
+	s.Bucket = &v
+	return s
+}
+
+// SetKey sets the Key field's value.
+func (s *PutObjectTaggingInput) SetKey(v string) *PutObjectTaggingInput {
+	s.Key = &v
+	return s
+}
+
+// SetTagging sets the Tagging field's value.
+func (s *PutObjectTaggingInput) SetTagging(v *Tagging) *PutObjectTaggingInput {
+	s.Tagging = v
+	return s
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *PutObjectTaggingInput) SetVersionId(v string) *PutObjectTaggingInput {
+	s.VersionId = &v
+	return s
+}
+
+type PutObjectTaggingOutput struct {
+	_ struct{} `type:"structure"`
+
+	VersionId *string `location:"header" locationName:"x-amz-version-id" type:"string"`
+}
+
+// String returns the string representation
+func (s PutObjectTaggingOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s PutObjectTaggingOutput) GoString() string {
+	return s.String()
+}
+
+// SetVersionId sets the VersionId field's value.
+func (s *PutObjectTaggingOutput) SetVersionId(v string) *PutObjectTaggingOutput {
 	s.VersionId = &v
 	return s
 }
@@ -12906,6 +16080,9 @@ type RestoreRequest struct {
 	//
 	// Days is a required field
 	Days *int64 `type:"integer" required:"true"`
+
+	// Glacier related prameters pertaining to this job.
+	GlacierJobParameters *GlacierJobParameters `type:"structure"`
 }
 
 // String returns the string representation
@@ -12924,6 +16101,11 @@ func (s *RestoreRequest) Validate() error {
 	if s.Days == nil {
 		invalidParams.Add(request.NewErrParamRequired("Days"))
 	}
+	if s.GlacierJobParameters != nil {
+		if err := s.GlacierJobParameters.Validate(); err != nil {
+			invalidParams.AddNested("GlacierJobParameters", err.(request.ErrInvalidParams))
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -12934,6 +16116,12 @@ func (s *RestoreRequest) Validate() error {
 // SetDays sets the Days field's value.
 func (s *RestoreRequest) SetDays(v int64) *RestoreRequest {
 	s.Days = &v
+	return s
+}
+
+// SetGlacierJobParameters sets the GlacierJobParameters field's value.
+func (s *RestoreRequest) SetGlacierJobParameters(v *GlacierJobParameters) *RestoreRequest {
+	s.GlacierJobParameters = v
 	return s
 }
 
@@ -13100,6 +16288,102 @@ func (s *Rule) SetStatus(v string) *Rule {
 // SetTransition sets the Transition field's value.
 func (s *Rule) SetTransition(v *Transition) *Rule {
 	s.Transition = v
+	return s
+}
+
+type StorageClassAnalysis struct {
+	_ struct{} `type:"structure"`
+
+	// A container used to describe how data related to the storage class analysis
+	// should be exported.
+	DataExport *StorageClassAnalysisDataExport `type:"structure"`
+}
+
+// String returns the string representation
+func (s StorageClassAnalysis) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StorageClassAnalysis) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StorageClassAnalysis) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StorageClassAnalysis"}
+	if s.DataExport != nil {
+		if err := s.DataExport.Validate(); err != nil {
+			invalidParams.AddNested("DataExport", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDataExport sets the DataExport field's value.
+func (s *StorageClassAnalysis) SetDataExport(v *StorageClassAnalysisDataExport) *StorageClassAnalysis {
+	s.DataExport = v
+	return s
+}
+
+type StorageClassAnalysisDataExport struct {
+	_ struct{} `type:"structure"`
+
+	// The place to store the data for an analysis.
+	//
+	// Destination is a required field
+	Destination *AnalyticsExportDestination `type:"structure" required:"true"`
+
+	// The version of the output schema to use when exporting data. Must be V_1.
+	//
+	// OutputSchemaVersion is a required field
+	OutputSchemaVersion *string `type:"string" required:"true" enum:"StorageClassAnalysisSchemaVersion"`
+}
+
+// String returns the string representation
+func (s StorageClassAnalysisDataExport) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s StorageClassAnalysisDataExport) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *StorageClassAnalysisDataExport) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "StorageClassAnalysisDataExport"}
+	if s.Destination == nil {
+		invalidParams.Add(request.NewErrParamRequired("Destination"))
+	}
+	if s.OutputSchemaVersion == nil {
+		invalidParams.Add(request.NewErrParamRequired("OutputSchemaVersion"))
+	}
+	if s.Destination != nil {
+		if err := s.Destination.Validate(); err != nil {
+			invalidParams.AddNested("Destination", err.(request.ErrInvalidParams))
+		}
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetDestination sets the Destination field's value.
+func (s *StorageClassAnalysisDataExport) SetDestination(v *AnalyticsExportDestination) *StorageClassAnalysisDataExport {
+	s.Destination = v
+	return s
+}
+
+// SetOutputSchemaVersion sets the OutputSchemaVersion field's value.
+func (s *StorageClassAnalysisDataExport) SetOutputSchemaVersion(v string) *StorageClassAnalysisDataExport {
+	s.OutputSchemaVersion = &v
 	return s
 }
 
@@ -14063,6 +17347,11 @@ func (s *WebsiteConfiguration) SetRoutingRules(v []*RoutingRule) *WebsiteConfigu
 }
 
 const (
+	// AnalyticsS3ExportFileFormatCsv is a AnalyticsS3ExportFileFormat enum value
+	AnalyticsS3ExportFileFormatCsv = "CSV"
+)
+
+const (
 	// BucketAccelerateStatusEnabled is a BucketAccelerateStatus enum value
 	BucketAccelerateStatusEnabled = "Enabled"
 
@@ -14193,6 +17482,47 @@ const (
 
 	// FilterRuleNameSuffix is a FilterRuleName enum value
 	FilterRuleNameSuffix = "suffix"
+)
+
+const (
+	// InventoryFormatCsv is a InventoryFormat enum value
+	InventoryFormatCsv = "CSV"
+)
+
+const (
+	// InventoryFrequencyDaily is a InventoryFrequency enum value
+	InventoryFrequencyDaily = "Daily"
+
+	// InventoryFrequencyWeekly is a InventoryFrequency enum value
+	InventoryFrequencyWeekly = "Weekly"
+)
+
+const (
+	// InventoryIncludedObjectVersionsAll is a InventoryIncludedObjectVersions enum value
+	InventoryIncludedObjectVersionsAll = "All"
+
+	// InventoryIncludedObjectVersionsCurrent is a InventoryIncludedObjectVersions enum value
+	InventoryIncludedObjectVersionsCurrent = "Current"
+)
+
+const (
+	// InventoryOptionalFieldSize is a InventoryOptionalField enum value
+	InventoryOptionalFieldSize = "Size"
+
+	// InventoryOptionalFieldLastModifiedDate is a InventoryOptionalField enum value
+	InventoryOptionalFieldLastModifiedDate = "LastModifiedDate"
+
+	// InventoryOptionalFieldStorageClass is a InventoryOptionalField enum value
+	InventoryOptionalFieldStorageClass = "StorageClass"
+
+	// InventoryOptionalFieldEtag is a InventoryOptionalField enum value
+	InventoryOptionalFieldEtag = "ETag"
+
+	// InventoryOptionalFieldIsMultipartUploaded is a InventoryOptionalField enum value
+	InventoryOptionalFieldIsMultipartUploaded = "IsMultipartUploaded"
+
+	// InventoryOptionalFieldReplicationStatus is a InventoryOptionalField enum value
+	InventoryOptionalFieldReplicationStatus = "ReplicationStatus"
 )
 
 const (
@@ -14346,6 +17676,30 @@ const (
 
 	// StorageClassStandardIa is a StorageClass enum value
 	StorageClassStandardIa = "STANDARD_IA"
+)
+
+const (
+	// StorageClassAnalysisSchemaVersionV1 is a StorageClassAnalysisSchemaVersion enum value
+	StorageClassAnalysisSchemaVersionV1 = "V_1"
+)
+
+const (
+	// TaggingDirectiveCopy is a TaggingDirective enum value
+	TaggingDirectiveCopy = "COPY"
+
+	// TaggingDirectiveReplace is a TaggingDirective enum value
+	TaggingDirectiveReplace = "REPLACE"
+)
+
+const (
+	// TierStandard is a Tier enum value
+	TierStandard = "Standard"
+
+	// TierBulk is a Tier enum value
+	TierBulk = "Bulk"
+
+	// TierExpedited is a Tier enum value
+	TierExpedited = "Expedited"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/s3/host_style_bucket.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/s3/host_style_bucket.go
@@ -83,7 +83,7 @@ func updateEndpointForAccelerate(r *request.Request) {
 
 	if !hostCompatibleBucketName(r.HTTPRequest.URL, bucket) {
 		r.Error = awserr.New("InvalidParameterException",
-			fmt.Sprintf("bucket name %s is not compatibile with S3 Accelerate", bucket),
+			fmt.Sprintf("bucket name %s is not compatible with S3 Accelerate", bucket),
 			nil)
 		return
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -377,580 +377,580 @@
 			"revision": "4239b77079c7b5d1243b7b4736304ce8ddb6f0f2"
 		},
 		{
-			"checksumSHA1": "QLOmSL4B0UFqEIFwCe0TMwehlfE=",
+			"checksumSHA1": "DfYjL9TFXUaMV8bKlcC3VHzynHc=",
 			"path": "github.com/aws/aws-sdk-go",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "YOh82spUBNEjU+RS0ib7Z9W7Fp0=",
+			"checksumSHA1": "WEkryGXiu/uQv5woVvRm9hxf9lE=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "/232RBWA3KnT7U+wciPS2+wmvR0=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "c1N3Loy3AS9zD+m5CzpPNAED39U=",
+			"checksumSHA1": "Fl8vRSCY0MbM04cmiz/0MID+goA=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "zu5C95rmCZff6NYZb62lEaT5ibE=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "4Ipx+5xN0gso+cENC2MHMWmQlR4=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "DwhFsNluCFEwqzyp3hbJR3q2Wqs=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "5Ac22YMTBmrX/CXaEIXzWljr8UY=",
+			"checksumSHA1": "yVSL6yhjj0Pozx4NVrWA3aguENg=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "eOo6evLMAxQfo7Qkc5/h5euN1Sw=",
+			"checksumSHA1": "HT1op89NoiShWN5XBRGdZkQTf4A=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "bjf3WCqht846AsRh85c8d7iLmsk=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "Esab5F8KswqkTdB4TtjSvZgs56k=",
 			"path": "github.com/aws/aws-sdk-go/private/endpoints",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "pNeF0Ey7TfBArH5LBQhKOQXQbLY=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "5xzix1R8prUyWxgLnzUQoxTsfik=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "mLxtfPJvWIHdYPRY0f19kFuJ3u4=",
+			"checksumSHA1": "dUpGLm7IHo6A40vuaEKwaCLbqu8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "eUEkjyMPAuekKBE4ou+nM9tXEas=",
+			"checksumSHA1": "U30tX6Rd4LSOjrm/E2WB0TyFxr8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "Eo9yODN5U99BK0pMzoqnBm7PCrY=",
 			"path": "github.com/aws/aws-sdk-go/private/waiter",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "INWpIaoMQ5yhSUDuC6BI2tnT01w=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "6SZrpx+VJ7W/Xsozbn2UCIIMWug=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "DZc+6wpn5VIQEoFMxLIKwVYliJE=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "Y5ewqOw2oooAc17RZBLEfFe97NQ=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "WB73oYHFUA06n2Ulyr7BnzoL+Z4=",
+			"checksumSHA1": "e0qgGpjfhqhr2ka/IxWGVvtszzM=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "71H57UIgdJgkDZxJQsxJEB6ihqQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "qtBw7xNY8KKLCIlm7l+sKxKs6q4=",
+			"checksumSHA1": "1hnZsVUSJ0quZ37/xmwwCvQh2U8=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "3jnrRIRHqRiWDqb71FMSfs9AvXk=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "YLXFc6XhmmnVEfHPE0Bb8f5wndw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "bgkauNc4M46Pmyw7lHkvzw3sxiw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "rKsbQ6FWQSqiE+ujHG6HietgH5Y=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "YvpsgALidLyjzRgRHusdw7vS22k=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "3aRyyRHgUh+w26Wqrruxxa1VaxA=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "E5qjR1pDa/V2LEhXP36kZH2w91o=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "6h4tJ9wVtbYb9wG4srtUxyPoAYM=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "3wd5o69gQcsDpBIJU2QMAYu/Yjs=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "fHZ6TgcmZIoRDw38OJQnd7TT63A=",
+			"checksumSHA1": "99y497vsASAyQYAmAiGOgCFniiI=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "cAYa6uHNWAKex00wQZQh/3RIP20=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "e/nua6AZAM1DOX1s+qcuDaOqWYc=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "pyykYejfcLu54fhwe94WMujiWpE=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "z0ca3QajyQGpShh3psqolZLJt7Q=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "t/dBXjcSbc5phqiIoGtOIELycNg=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "X6fiZ2b/U1WpYBzw5fqm2Wm8Hr0=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "D+1s7cgL4iMtswW+x233jAV8eJI=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "+GSIhCXrofZZRF4Bz4XuX8B8o7U=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "71xHwOAjzdFQ+zQieThJWKObvS4=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "yF88SmWjcs87UkcJoaXVozxp050=",
+			"checksumSHA1": "SU/YDilOf4uh4tC3O4ZyKfu9Ca8=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "hQquEMm59E2CwVwfBvKRTVzBj/8=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "1pBbVKt2n6Z/59Nd8mXe20/JEV4=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "ghoZkkKxN0lAJZ6Nb0sJiiFiQAI=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "kb9gzhUSUeiJorMc73m13DK/3Qc=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "BZY0NsRwwIbs52ZSjaEGqgWHXyo=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "iGXoSzRemWsXcxdBLFqAaZ3ulf8=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "bxHXVhiqpF3njkRRNcLn+tyhwZQ=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "xxJsIDga1E+AuNTwEeL+6X9CSEA=",
+			"checksumSHA1": "i04x4j6gtaNDUHGlJa5bs+m4wlw=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
-			"checksumSHA1": "HtKiIAPKsBg2s1c5ytRkdZ/lqO8=",
+			"checksumSHA1": "lC6CowuZ0Zjvbcw3hjYSc1cxbPE=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "6TbKrx2keOneistnAS39cVXTunY=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "hp8JNTd1l4AvNps0/z3UsukvWsQ=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "eGU3IGTGnOKW8qUi80UJrtkcmRw=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "hTgsEbW3erfnTHok+7TKOSUlaYU=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "f0X7xjpA2JmDYc9xArgDI4mCO6I=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "ouwhxcAsIYQ6oJbMRdLW/Ys/iyg=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "BvZSVj6c/aEe0Ihf08fBXdIRz8A=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "898c81ba64b9a467379d35e3fabad133beae0ee4",
-			"revisionTime": "2016-11-18T23:08:35Z",
-			"version": "=v1.5.8",
-			"versionExact": "v1.5.8"
+			"revision": "e7849863adae563900a3474ee6feed65471ab070",
+			"revisionTime": "2016-11-30T19:57:18Z",
+			"version": "=v1.5.12",
+			"versionExact": "v1.5.12"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",


### PR DESCRIPTION
Update the aws/aws-sdk-go to v1.5.12, so we can get to work on new shiny things. 

Note: does not pull in the services listed [in the release notes](https://github.com/aws/aws-sdk-go/releases/tag/v1.5.12) because we don't yet actually consume them, but when we do, the PRs for them will have less noise around them as they won't need to bump the rest of the SDK