### PR TITLE
terraform: when promoting non-CBD to CBD, mark the config as such

### DIFF
--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -30,6 +30,20 @@ func (n *NodeDestroyResource) CreateBeforeDestroy() bool {
 	return n.Config.Lifecycle.CreateBeforeDestroy
 }
 
+// GraphNodeDestroyerCBD
+func (n *NodeDestroyResource) ModifyCreateBeforeDestroy(v bool) error {
+	// If we have no config, do nothing since it won't affect the
+	// create step anyways.
+	if n.Config == nil {
+		return nil
+	}
+
+	// Set CBD to true
+	n.Config.Lifecycle.CreateBeforeDestroy = true
+
+	return nil
+}
+
 // GraphNodeReferenceable, overriding NodeAbstractResource
 func (n *NodeDestroyResource) ReferenceableName() []string {
 	result := n.NodeAbstractResource.ReferenceableName()

--- a/terraform/test-fixtures/apply-cbd-depends-non-cbd/main.tf
+++ b/terraform/test-fixtures/apply-cbd-depends-non-cbd/main.tf
@@ -1,0 +1,12 @@
+resource "aws_instance" "foo" {
+  require_new = "yes"
+}
+
+resource "aws_instance" "bar" {
+  require_new = "yes"
+  value       = "${aws_instance.foo.id}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/terraform/transform_destroy_cbd_test.go
+++ b/terraform/transform_destroy_cbd_test.go
@@ -36,10 +36,53 @@ func TestCBDEdgeTransformer(t *testing.T) {
 	}
 }
 
+func TestCBDEdgeTransformer_depNonCBD(t *testing.T) {
+	g := Graph{Path: RootModulePath}
+	g.Add(&graphNodeCreatorTest{AddrString: "test.A"})
+	g.Add(&graphNodeCreatorTest{AddrString: "test.B"})
+	g.Add(&graphNodeDestroyerTest{AddrString: "test.A"})
+	g.Add(&graphNodeDestroyerTest{AddrString: "test.B", CBD: true})
+
+	module := testModule(t, "transform-destroy-edge-basic")
+
+	{
+		tf := &DestroyEdgeTransformer{
+			Module: module,
+		}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		tf := &CBDEdgeTransformer{Module: module}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testTransformCBDEdgeDepNonCBDStr)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
 const testTransformCBDEdgeBasicStr = `
 test.A
 test.A (destroy)
   test.A
   test.B
 test.B
+`
+
+const testTransformCBDEdgeDepNonCBDStr = `
+test.A
+test.A (destroy) (modified)
+  test.A
+  test.B
+  test.B (destroy)
+test.B
+test.B (destroy)
+  test.B
 `

--- a/terraform/transform_destroy_edge_test.go
+++ b/terraform/transform_destroy_edge_test.go
@@ -113,10 +113,25 @@ func (n *graphNodeCreatorTest) CreateAddr() *ResourceAddress {
 type graphNodeDestroyerTest struct {
 	AddrString string
 	CBD        bool
+	Modified   bool
 }
 
-func (n *graphNodeDestroyerTest) Name() string              { return n.DestroyAddr().String() + " (destroy)" }
+func (n *graphNodeDestroyerTest) Name() string {
+	result := n.DestroyAddr().String() + " (destroy)"
+	if n.Modified {
+		result += " (modified)"
+	}
+
+	return result
+}
+
 func (n *graphNodeDestroyerTest) CreateBeforeDestroy() bool { return n.CBD }
+
+func (n *graphNodeDestroyerTest) ModifyCreateBeforeDestroy(v bool) error {
+	n.Modified = true
+	return nil
+}
+
 func (n *graphNodeDestroyerTest) DestroyAddr() *ResourceAddress {
 	addr, err := ParseResourceAddress(n.AddrString)
 	if err != nil {


### PR DESCRIPTION
Fixes #10439

This fix is backported to legacy graphs, too.

When a CBD resource depends on a non-CBD resource, the non-CBD resource
is auto-promoted to CBD. This was done in
cf3a259cd9fd78bb9f2bc0949866b0708a48c10e. This PR makes it so that we
also set the config CBD to true. This causes the proper runtime
execution behavior to occur where we depose state and so on.

So in addition to simple graph edge tricks we also treat the non-CBD
resources as CBD resources.

As part of this process, I realized that the new graph doesn't support
this at all since there was no context test covering it! I added a
context test. This test also reproduced the error message in #10439
withou the config setting logic, so it shows it fixes that as well.