### PR TITLE
provider/aws: Fix aws_iam_role_test config

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_role_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_test.go
@@ -168,37 +168,17 @@ func testAccCheckAWSRoleAttributes(role *iam.GetRoleOutput) resource.TestCheckFu
 
 const testAccAWSRoleConfig = `
 resource "aws_iam_role" "role" {
-<<<<<<< HEAD
   name   = "test-role"
   path = "/"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
-=======
-	name   = "test-role"
-	path = "/"
-<<<<<<< HEAD
-	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
->>>>>>> 9c051a5... Tests for importing various iam resources
-=======
-	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
->>>>>>> daaae09... Add DiffSuppressFunc to support heredocs for aws_iam_role.assume_role_policy and aws_iam_policy.policy
 }
 `
 
 const testAccAWSRolePrefixNameConfig = `
 resource "aws_iam_role" "role" {
-<<<<<<< HEAD
   name_prefix = "test-role-"
   path = "/"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
-=======
-    name_prefix = "test-role-"
-    path = "/"
-<<<<<<< HEAD
-    assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
->>>>>>> 9c051a5... Tests for importing various iam resources
-=======
-    assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
->>>>>>> daaae09... Add DiffSuppressFunc to support heredocs for aws_iam_role.assume_role_policy and aws_iam_policy.policy
 }
 `
 


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws
% TESTARGS='-run=TestAccAWSRole_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/01 17:17:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRole_
-timeout 120m
=== RUN   TestAccAWSRole_basic
--- PASS: TestAccAWSRole_basic (15.38s)
=== RUN   TestAccAWSRole_namePrefix
--- PASS: TestAccAWSRole_namePrefix (14.89s)
=== RUN   TestAccAWSRole_testNameChange
--- PASS: TestAccAWSRole_testNameChange (34.43s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws64.729s
```