### PR TITLE
providers/google: make projects importable.

### DIFF
--- a/builtin/providers/google/import_google_project_test.go
+++ b/builtin/providers/google/import_google_project_test.go
@@ -1,0 +1,29 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccGoogleProject_importBasic(t *testing.T) {
+	resourceName := "google_project.acceptance"
+	conf := fmt.Sprintf(testAccGoogleProject_basic, projectId)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: conf,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -29,6 +29,9 @@ func resourceGoogleProject() *schema.Resource {
 		Read:   resourceGoogleProjectRead,
 		Update: resourceGoogleProjectUpdate,
 		Delete: resourceGoogleProjectDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"id": &schema.Schema{

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -135,6 +135,7 @@ To make a resource importable, please see the
 * google_compute_instance_group_manager
 * google_compute_instance_template
 * google_compute_target_pool
+* google_project
 
 ### OpenStack
 


### PR DESCRIPTION
This change doesn't make much sense now, as projects are read-only
anyways, so there's not a lot that importing really does for you--you
can already reference pre-existing projects just by defining them in
your config.

But as we discussed #10425, this change made more and more sense. In a
world where projects can be created, we can no longer reference
pre-existing projects just by defining them in config. We get that
ability back by making projects importable.

/cc @evandbrown just so he's aware of this, as he mentioned being interested in seeing what it looks like