### PR TITLE
Have `terraform graph` use the plan builder

### DIFF
--- a/command/graph.go
+++ b/command/graph.go
@@ -59,7 +59,7 @@ func (c *GraphCommand) Run(args []string) int {
 
 	// Skip validation during graph generation - we want to see the graph even if
 	// it is invalid for some reason.
-	g, err := ctx.Graph(&terraform.ContextGraphOpts{
+	g, err := ctx.PlanGraph(&terraform.ContextGraphOpts{
 		Verbose:  verbose,
 		Validate: false,
 	})

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -193,6 +193,27 @@ func (c *Context) Graph(g *ContextGraphOpts) (*Graph, error) {
 	return c.graphBuilder(g).Build(RootModulePath)
 }
 
+// PlanGraph returns the graph for this config using the PlanGraphBuilder.
+func (c *Context) PlanGraph(g *ContextGraphOpts) (*Graph, error) {
+	X_legacyGraph := experiment.Enabled(experiment.X_legacyGraph)
+
+	// Build the graph.
+	var graph *Graph
+	var err error
+	if !X_legacyGraph {
+		graph, err = (&PlanGraphBuilder{
+			Module:    c.module,
+			State:     c.state,
+			Providers: c.components.ResourceProviders(),
+			Targets:   c.targets,
+		}).Build(RootModulePath)
+	} else {
+		graph, err = c.Graph(g)
+	}
+
+	return graph, err
+}
+
 // GraphBuilder returns the GraphBuilder that will be used to create
 // the graphs for this context.
 func (c *Context) graphBuilder(g *ContextGraphOpts) GraphBuilder {


### PR DESCRIPTION
The graph displayed based solely on config may be different than the
graph built using the new PlanGraphBuilder. Have `terraform graph` use
the same builder that will be used by `terraform plan`.