### PR TITLE
provider/aws: Fixed Lambda environment removal

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -495,6 +495,11 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 				}
 				configUpdate = true
 			}
+		} else {
+			configReq.Environment = &lambda.Environment{
+				Variables: aws.StringMap(map[string]string{}),
+			}
+			configUpdate = true
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -77,6 +77,16 @@ func TestAccAWSLambdaFunction_envVariables(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo1", "bar1"),
 				),
 			},
+			{
+				Config: testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, rName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, ":"+rName),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo", ""),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "environment.0.variables.foo1", ""),
+				),
+			},
 		},
 	})
 }
@@ -644,6 +654,17 @@ resource "aws_lambda_function" "lambda_function_test" {
             foo1 = "bar1"
         }
     }
+}
+`, rName)
+}
+
+func testAccAWSLambdaConfigEnvVariablesModifiedWithoutEnvironment(rName string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
 }
 `, rName)
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/10491

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLambdaFunction_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/02 14:41:01 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLambdaFunction_ -timeout 120m
=== RUN   TestAccAWSLambdaFunction_importLocalFile
--- PASS: TestAccAWSLambdaFunction_importLocalFile (35.89s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (38.10s)
=== RUN   TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_importS3 (36.41s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (35.33s)
=== RUN   TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_envVariables (88.49s)
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (76.40s)
=== RUN   TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_versioned (36.01s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (37.44s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (39.42s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (41.92s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (32.43s)
=== RUN   TestAccAWSLambdaFunction_s3Update
--- PASS: TestAccAWSLambdaFunction_s3Update (76.16s)
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (60.27s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	634.325s
```