### PR TITLE
terraform: don't prune state on init()

### DIFF
--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -1695,16 +1695,34 @@ func TestStateModuleOrphans_empty(t *testing.T) {
 
 	// just calling this to check for panic
 	state.ModuleOrphans(RootModulePath, nil)
+}
 
-	for _, mod := range state.Modules {
-		if mod == nil {
-			t.Fatal("found nil module")
-		}
-		if mod.Path == nil {
-			t.Fatal("found nil module path")
-		}
-		if len(mod.Path) == 0 {
-			t.Fatal("found empty module path")
-		}
+func TestReadState_prune(t *testing.T) {
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{Path: rootModulePath},
+			nil,
+		},
+	}
+	state.init()
+
+	buf := new(bytes.Buffer)
+	if err := WriteState(state, buf); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual, err := ReadState(buf)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &State{
+		Version: state.Version,
+		Lineage: state.Lineage,
+	}
+	expected.init()
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("got:\n%#v", actual)
 	}
 }

--- a/terraform/transform_orphan_resource.go
+++ b/terraform/transform_orphan_resource.go
@@ -42,6 +42,10 @@ func (t *OrphanResourceTransformer) Transform(g *Graph) error {
 }
 
 func (t *OrphanResourceTransformer) transform(g *Graph, ms *ModuleState) error {
+	if ms == nil {
+		return nil
+	}
+
 	// Get the configuration for this path. The configuration might be
 	// nil if the module was removed from the configuration. This is okay,
 	// this just means that every resource is an orphan.

--- a/terraform/transform_orphan_resource_test.go
+++ b/terraform/transform_orphan_resource_test.go
@@ -59,6 +59,31 @@ func TestOrphanResourceTransformer(t *testing.T) {
 	}
 }
 
+func TestOrphanResourceTransformer_nilModule(t *testing.T) {
+	mod := testModule(t, "transform-orphan-basic")
+	state := &State{
+		Modules: []*ModuleState{nil},
+	}
+
+	g := Graph{Path: RootModulePath}
+	{
+		tf := &ConfigTransformer{Module: mod}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		tf := &OrphanResourceTransformer{
+			Concrete: testOrphanResourceConcreteFunc,
+			State:    state, Module: mod,
+		}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+}
+
 func TestOrphanResourceTransformer_countGood(t *testing.T) {
 	mod := testModule(t, "transform-orphan-count")
 	state := &State{


### PR DESCRIPTION
During graph execution, there are steps that expect that a state isn't
being actively pruned out from under it. Namely: writing deposed states.

Writing deposed states has no way to handle if a state changes
underneath it because the only way to uniquely identify a deposed state
is its index in the deposed array. When destroying deposed resources, we
set the value to `<nil>`. If the array is pruned before the next deposed
destroy, then the indexes have changed, and this can cause a crash.

This PR does the following (with more details below):

  * `init()` no longer prunes.

  * `ReadState()` always prunes before returning. I can't think of a
    scenario where this is unsafe since generally we can always START
    from a pruned state, its just causing problems to prune
    mid-execution.

  * Exported State APIs updated to be robust against nil ModuleStates.

Instead, I think we should adopt the following semantics for init/prune
in our structures that support it (Diff, for example). By having
consistent semantics around these functions, we can avoid this in the
future and have set expectations working with them.

  * `init()` (in anything) will only ever be additive, and won't change
    ordering or existing values. It won't remove values.

  * `prune()` is destructive, expectedly.

  * Deserialization can prune, but it also might not. No expectation should be made either way and anything that uses a deserialized structure should expect either (basically same as last point here to be robust).

  * Serialization **must not** prune. We often serialize mid-execution to back up and pruning mid-execution is not allowed. If you must, then DeepCopy prior to serializing. Though in cases like State, this is prohibitively expensive.

  * Functions on a structure must not assume a pruned structure 100% of
    the time. They must be robust to handle nils. This is especially
    important because in many cases values such as `Modules` in state
    are exported so end users can simply modify them outside of the
    exported APIs.

This PR may expose us to unknown crashes but I've tried to cover our
cases in exposed APIs by checking for nil.