### PR TITLE
docs/aws: Ensure completeness of aws_api_gateway_domain_name example

### DIFF
--- a/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
@@ -45,6 +45,7 @@ resource "aws_route53_record" "example" {
   alias {
     name    = "${aws_api_gateway_domain_name.example.cloudfront_domain_name}"
     zone_id = "${aws_api_gateway_domain_name.example.cloudfront_zone_id}"
+    evaluate_target_health = true
   }
 }
 ```


### PR DESCRIPTION
Fixes #10493