### PR TITLE
add support for create instance with eni

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1098,7 +1098,13 @@ func buildAwsInstanceOpts(
 		}
 	}
 
-	if hasSubnet && associatePublicIPAddress {
+  if v, ok := d.GetOk("network_interface_id"); ok {
+		ni := &ec2.InstanceNetworkInterfaceSpecification{
+			DeviceIndex:					aws.Int64(int64(0)),
+			NetworkInterfaceId:		aws.String(v.(string)),
+		}
+		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
+	} else if hasSubnet && associatePublicIPAddress {
 		// If we have a non-default VPC / Subnet specified, we can flag
 		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
 		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -131,6 +131,7 @@ func resourceAwsInstance() *schema.Resource {
 			"network_interface_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 
 			"public_ip": &schema.Schema{

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1043,6 +1043,7 @@ func buildAwsInstanceOpts(
 		EBSOptimized:          aws.Bool(d.Get("ebs_optimized").(bool)),
 		ImageID:               aws.String(d.Get("ami").(string)),
 		InstanceType:          aws.String(d.Get("instance_type").(string)),
+		NetworkInterfaceId:    aws.String(d.Get("network_interface_id").(string)),
 	}
 
 	if v := d.Get("instance_initiated_shutdown_behavior").(string); v != "" {

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1098,10 +1098,10 @@ func buildAwsInstanceOpts(
 		}
 	}
 
-	if v, ok := d.GetOk("network_interface_id"); ok {
+  if v, ok := d.GetOk("network_interface_id"); ok {
 		ni := &ec2.InstanceNetworkInterfaceSpecification{
-			DeviceIndex:        aws.Int64(int64(0)),
-			NetworkInterfaceId: aws.String(v.(string)),
+			DeviceIndex:					aws.Int64(int64(0)),
+			NetworkInterfaceId:		aws.String(v.(string)),
 		}
 		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
 	} else if hasSubnet && associatePublicIPAddress {

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1098,10 +1098,10 @@ func buildAwsInstanceOpts(
 		}
 	}
 
-  if v, ok := d.GetOk("network_interface_id"); ok {
+	if v, ok := d.GetOk("network_interface_id"); ok {
 		ni := &ec2.InstanceNetworkInterfaceSpecification{
-			DeviceIndex:					aws.Int64(int64(0)),
-			NetworkInterfaceId:		aws.String(v.(string)),
+			DeviceIndex:        aws.Int64(int64(0)),
+			NetworkInterfaceId: aws.String(v.(string)),
 		}
 		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
 	} else if hasSubnet && associatePublicIPAddress {

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1062,10 +1062,6 @@ func buildAwsInstanceOpts(
 
 	opts.UserData64 = aws.String(base64Encode([]byte(user_data)))
 
-	// check for non-default Subnet, and cast it to a String
-	subnet, hasSubnet := d.GetOk("subnet_id")
-	subnetID := subnet.(string)
-
 	// Placement is used for aws_instance; SpotPlacement is used for
 	// aws_spot_instance_request. They represent the same data. :-|
 	opts.Placement = &ec2.Placement{
@@ -1083,6 +1079,10 @@ func buildAwsInstanceOpts(
 	}
 
 	associatePublicIPAddress := d.Get("associate_public_ip_address").(bool)
+
+	// check for non-default Subnet, and cast it to a String
+	subnet, hasSubnet := d.GetOk("subnet_id")
+	subnetID := subnet.(string)
 
 	var groups []*string
 	if v := d.Get("security_groups"); v != nil {

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1043,7 +1043,6 @@ func buildAwsInstanceOpts(
 		EBSOptimized:          aws.Bool(d.Get("ebs_optimized").(bool)),
 		ImageID:               aws.String(d.Get("ami").(string)),
 		InstanceType:          aws.String(d.Get("instance_type").(string)),
-		NetworkInterfaceId:    aws.String(d.Get("network_interface_id").(string)),
 	}
 
 	if v := d.Get("instance_initiated_shutdown_behavior").(string); v != "" {

--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -60,6 +60,11 @@ func resourceAwsNetworkInterface() *schema.Resource {
 				Optional: true,
 			},
 
+			"network_interface_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"attachment": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -147,6 +152,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("private_ips", flattenNetworkInterfacesPrivateIPAddresses(eni.PrivateIpAddresses))
 	d.Set("security_groups", flattenGroupIdentifiers(eni.Groups))
 	d.Set("source_dest_check", eni.SourceDestCheck)
+	d.Set("network_interface_id", d.Id())
 
 	if eni.Description != nil {
 		d.Set("description", eni.Description)

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -54,9 +54,9 @@ The following arguments are supported:
      EBS-optimized.
 * `disable_api_termination` - (Optional) If true, enables [EC2 Instance
      Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination)
-* `instance_initiated_shutdown_behavior` - (Optional) Shutdown behavior for the 
-instance. Amazon defaults this to `stop` for EBS-backed instances and 
-`terminate` for instance-store instances. Cannot be set on instance-store 
+* `instance_initiated_shutdown_behavior` - (Optional) Shutdown behavior for the
+instance. Amazon defaults this to `stop` for EBS-backed instances and
+`terminate` for instance-store instances. Cannot be set on instance-store
 instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
 * `instance_type` - (Required) The type of instance to start
 * `key_name` - (Optional) The key name to use for the instance.
@@ -65,7 +65,8 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
    If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 * `vpc_security_group_ids` - (Optional) A list of security group IDs to associate with.
 * `subnet_id` - (Optional) The VPC Subnet ID to launch in.
-* `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.  Boolean value. 
+* `network_interface_id` - (Optional) The network interface ID to attach to the instance.
+* `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.  Boolean value.
 * `private_ip` - (Optional) Private IP address to associate with the
      instance in a VPC.
 * `source_dest_check` - (Optional) Controls if traffic is routed to the instance when
@@ -150,12 +151,12 @@ The following attributes are exported:
 * `availability_zone` - The availability zone of the instance.
 * `placement_group` - The placement group of the instance.
 * `key_name` - The key name of the instance
-* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this 
+* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this
   is only available if you've enabled DNS hostnames for your VPC
 * `public_ip` - The public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
 * `network_interface_id` - The ID of the network interface that was created with the instance.
-* `private_dns` - The private DNS name assigned to the instance. Can only be 
-  used inside the Amazon EC2, and only available if you've enabled DNS hostnames 
+* `private_dns` - The private DNS name assigned to the instance. Can only be
+  used inside the Amazon EC2, and only available if you've enabled DNS hostnames
   for your VPC
 * `private_ip` - The private IP address assigned to the instance
 * `security_groups` - The associated security groups.
@@ -165,7 +166,7 @@ The following attributes are exported:
 
 ## Import
 
-Instances can be imported using the `id`, e.g. 
+Instances can be imported using the `id`, e.g.
 
 ```
 $ terraform import aws_instance.web i-12345678


### PR DESCRIPTION
pretty unfamiliar with golang and codebase, but i'll give it a shot. hopefully ppl will help.
hopefully this will finish #1149 for real at some point.

it looks like it's still not set up to send the eni in the request.
idk how to get request logs from the aws go sdk while it's being used by tf, but the sts message i got back is consistent - says I can't use default sg/subnet - it's not taking the eni's sg/subnet.

hard to say whether being in vpc affects it, but i'm not encouraged to set up in a personal aws account to test.

ima keep working on it.