### PR TITLE
provider/openstack added back personality which was missing from the createmap request body

### DIFF
--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/servers/requests.go
@@ -260,6 +260,10 @@ func (opts CreateOpts) ToServerCreateMap() (map[string]interface{}, error) {
 		b["flavorRef"] = flavorID
 	}
 
+	if len(opts.Personality) > 0 {
+		b["personality"] = opts.Personality
+	}
+
 	return map[string]interface{}{"server": b}, nil
 }
 


### PR DESCRIPTION
when terraform migrated over from the rackspace/gophercloud project to the gophercloud/gophercloud project the personality capability was lost as it seems the block of code in the request createmap was missing.. This is required for booting with config_drive 