### PR TITLE
terraform: apply resource must depend on destroy deps

### DIFF
--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -88,6 +88,110 @@ func TestApplyGraphBuilder(t *testing.T) {
 	}
 }
 
+// This tests the ordering of two resources that are both CBD that
+// require destroy/create.
+func TestApplyGraphBuilder_doubleCBD(t *testing.T) {
+	diff := &Diff{
+		Modules: []*ModuleDiff{
+			&ModuleDiff{
+				Path: []string{"root"},
+				Resources: map[string]*InstanceDiff{
+					"aws_instance.A": &InstanceDiff{
+						Destroy: true,
+						Attributes: map[string]*ResourceAttrDiff{
+							"name": &ResourceAttrDiff{
+								Old: "",
+								New: "foo",
+							},
+						},
+					},
+
+					"aws_instance.B": &InstanceDiff{
+						Destroy: true,
+						Attributes: map[string]*ResourceAttrDiff{
+							"name": &ResourceAttrDiff{
+								Old: "",
+								New: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b := &ApplyGraphBuilder{
+		Module:        testModule(t, "graph-builder-apply-double-cbd"),
+		Diff:          diff,
+		Providers:     []string{"aws"},
+		Provisioners:  []string{"exec"},
+		DisableReduce: true,
+	}
+
+	g, err := b.Build(RootModulePath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(g.Path, RootModulePath) {
+		t.Fatalf("bad: %#v", g.Path)
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testApplyGraphBuilderDoubleCBDStr)
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
+// This tests the ordering of destroying a single count of a resource.
+func TestApplyGraphBuilder_destroyCount(t *testing.T) {
+	diff := &Diff{
+		Modules: []*ModuleDiff{
+			&ModuleDiff{
+				Path: []string{"root"},
+				Resources: map[string]*InstanceDiff{
+					"aws_instance.A.1": &InstanceDiff{
+						Destroy: true,
+					},
+
+					"aws_instance.B": &InstanceDiff{
+						Attributes: map[string]*ResourceAttrDiff{
+							"name": &ResourceAttrDiff{
+								Old: "",
+								New: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b := &ApplyGraphBuilder{
+		Module:        testModule(t, "graph-builder-apply-count"),
+		Diff:          diff,
+		Providers:     []string{"aws"},
+		Provisioners:  []string{"exec"},
+		DisableReduce: true,
+	}
+
+	g, err := b.Build(RootModulePath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !reflect.DeepEqual(g.Path, RootModulePath) {
+		t.Fatalf("bad: %#v", g.Path)
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(testApplyGraphBuilderDestroyCountStr)
+	if actual != expected {
+		t.Fatalf("bad: %s", actual)
+	}
+}
+
 const testApplyGraphBuilderStr = `
 aws_instance.create
   provider.aws
@@ -111,5 +215,41 @@ module.child.aws_instance.other
 module.child.provider.aws
   provider.aws
 module.child.provisioner.exec
+provider.aws
+`
+
+const testApplyGraphBuilderDoubleCBDStr = `
+aws_instance.A
+  provider.aws
+aws_instance.A (destroy)
+  aws_instance.A
+  aws_instance.B
+  aws_instance.B (destroy)
+  provider.aws
+aws_instance.B
+  aws_instance.A
+  provider.aws
+aws_instance.B (destroy)
+  aws_instance.B
+  provider.aws
+meta.count-boundary (count boundary fixup)
+  aws_instance.A
+  aws_instance.A (destroy)
+  aws_instance.B
+  aws_instance.B (destroy)
+  provider.aws
+provider.aws
+`
+
+const testApplyGraphBuilderDestroyCountStr = `
+aws_instance.A[1] (destroy)
+  provider.aws
+aws_instance.B
+  aws_instance.A[1] (destroy)
+  provider.aws
+meta.count-boundary (count boundary fixup)
+  aws_instance.A[1] (destroy)
+  aws_instance.B
+  provider.aws
 provider.aws
 `

--- a/terraform/test-fixtures/apply-multi-var-count-dec/main.tf
+++ b/terraform/test-fixtures/apply-multi-var-count-dec/main.tf
@@ -1,0 +1,10 @@
+variable "count" {}
+
+resource "aws_instance" "foo" {
+    count = "${var.count}"
+    value = "foo"
+}
+
+resource "aws_instance" "bar" {
+    value = "${join(",", aws_instance.foo.*.id)}"
+}

--- a/terraform/test-fixtures/graph-builder-apply-count/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-count/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "A" {
+  count = 1
+}
+
+resource "aws_instance" "B" {
+  value = ["${aws_instance.A.*.id}"]
+}

--- a/terraform/test-fixtures/graph-builder-apply-double-cbd/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-double-cbd/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "A" {
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_instance" "B" {
+  value = ["${aws_instance.A.*.id}"]
+
+  lifecycle { create_before_destroy = true }
+}

--- a/terraform/transform_destroy_edge_test.go
+++ b/terraform/transform_destroy_edge_test.go
@@ -98,6 +98,7 @@ func TestDestroyEdgeTransformer_module(t *testing.T) {
 
 type graphNodeCreatorTest struct {
 	AddrString string
+	Refs       []string
 }
 
 func (n *graphNodeCreatorTest) Name() string { return n.CreateAddr().String() }
@@ -109,6 +110,8 @@ func (n *graphNodeCreatorTest) CreateAddr() *ResourceAddress {
 
 	return addr
 }
+
+func (n *graphNodeCreatorTest) References() []string { return n.Refs }
 
 type graphNodeDestroyerTest struct {
 	AddrString string


### PR DESCRIPTION
Fixes #10440

This updates the behavior of "apply" resources to depend on the
destroy versions of their dependencies.

We make an exception to this behavior when the "apply" resource is CBD.
This is odd and not 100% correct, but it mimics the behavior of the
legacy graphs and avoids us having to do major core work to support the
100% correct solution.

I'll explain this in examples...

Given the following configuration:

    resource "null_resource" "a" {
       count = "${var.count}"
    }

    resource "null_resource" "b" {
      triggers { key = "${join(",", null_resource.a.*.id)}" }
    }

Assume we've successfully created this configuration with count = 2.
When going from count = 2 to count = 1, `null_resource.b` should wait
for `null_resource.a.1` to destroy.

If it doesn't, then it is a race: depending when we interpolate the
`triggers.key` attribute of `null_resource.b`, we may get 1 value or 2.
If `null_resource.a.1` is destroyed, we'll get 1. Otherwise, we'll get
2. This was the root cause of #10440

In the legacy graphs, `null_resource.b` would depend on the destruction
of any `null_resource.a` (orphans, tainted, anything!). This would
ensure proper ordering. We mimic that behavior here.

The difference is CBD. If `null_resource.b` has CBD enabled, then the
ordering **in the legacy graph** becomes:

  1. null_resource.b (create)
  2. null_resource.b (destroy)
  3. null_resource.a (destroy)

In this case, the update would always have 2 values for `triggers.key`,
even though we were destroying a resource later! This scenario required
two `terraform apply` operations.

This is what the CBD check is for in this PR. We do this to mimic the
behavior of the legacy graph.

The correct solution to do one day is to allow splat references
(`null_resource.a.*.id`) to happen in parallel and only read up to to
the `count` amount in the state. This requires some fairly significant
work close to the 0.8 release date, so we can defer this to later and
adopt the 0.7.x behavior for now.