### PR TITLE
provider/aws: Fix issue when protocol = -1 in aws_security_group_rule

### DIFF
--- a/website/source/docs/providers/aws/r/security_group_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group_rule.html.markdown
@@ -45,7 +45,8 @@ or `egress` (outbound).
 * `prefix_list_ids` - (Optional) List of prefix list IDs (for allowing access to VPC endpoints).
 Only valid with `egress`.
 * `from_port` - (Required) The start port (or ICMP type number if protocol is "icmp").
-* `protocol` - (Required) The protocol. If not icmp, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
+* `protocol` - (Required) The protocol. If you select a protocol of
+"-1", you must specify a "from_port" and "to_port" equal to 0. If not icmp, tcp, udp, or all use the [protocol number](https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml)
 * `security_group_id` - (Required) The security group to apply this rule to.
 * `source_security_group_id` - (Optional) The security group id to allow access to/from,
      depending on the `type`. Cannot be specified with `cidr_blocks`.


### PR DESCRIPTION
In the case of aws_security_group, if protocol = -1 and a port number other than 0 is specified, an error occurs during terraform apply. This is a workaround for AWS to ignore port numbers with protocol = -1. (refs: https://github.com/hashicorp/terraform/pull/1798)

However, aws_security_group_rule does not have this check and behavior is inconsistent.
I think aws_security_group_rule should have the same check.

### Before
```
$ terraform -v
Terraform v0.8.0-dev (5f7bc12941932e208d4a0c5a73673249b53d068e)
```

#### aws_security_group

An error occurs in case of aws_security_group.

```
provider "aws" {
  region = "ap-northeast-1"
}

resource "aws_security_group" "test" {
  name = "test"

  ingress {
    from_port   = 8080
    to_port     = 8080
    protocol    = "-1"
    cidr_blocks = ["0.0.0.0/0"]
  }
}
```

```
$ terraform plan

+ aws_security_group.test
    description:                          "Managed by Terraform"
    egress.#:                             "<computed>"
    ingress.#:                            "1"
    ingress.3223243718.cidr_blocks.#:     "1"
    ingress.3223243718.cidr_blocks.0:     "0.0.0.0/0"
    ingress.3223243718.from_port:         "8080"
    ingress.3223243718.protocol:          "-1"
    ingress.3223243718.security_groups.#: "0"
    ingress.3223243718.self:              "false"
    ingress.3223243718.to_port:           "8080"
    name:                                 "test"
    owner_id:                             "<computed>"
    vpc_id:                               "<computed>"


Plan: 1 to add, 0 to change, 0 to destroy.
```

```
$ terraform apply
aws_security_group.test: Creating...
  description:                          "" => "Managed by Terraform"
  egress.#:                             "" => "<computed>"
  ingress.#:                            "" => "1"
  ingress.3223243718.cidr_blocks.#:     "" => "1"
  ingress.3223243718.cidr_blocks.0:     "" => "0.0.0.0/0"
  ingress.3223243718.from_port:         "" => "8080"
  ingress.3223243718.protocol:          "" => "-1"
  ingress.3223243718.security_groups.#: "" => "0"
  ingress.3223243718.self:              "" => "false"
  ingress.3223243718.to_port:           "" => "8080"
  name:                                 "" => "test"
  owner_id:                             "" => "<computed>"
  vpc_id:                               "" => "<computed>"
Error applying plan:

1 error(s) occurred:

* aws_security_group.test: from_port (8080) and to_port (8080) must both be 0 to use the 'ALL' "-1" protocol!

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

```
$ aws ec2 describe-security-groups --group-names test
{
    "SecurityGroups": [
        {
            "IpPermissionsEgress": [],
            "Description": "Managed by Terraform",
            "IpPermissions": [],
            "GroupName": "test",
            "VpcId": "vpc-8456bae1",
            "OwnerId": "XXXXXXXXXXX",
            "GroupId": "sg-b317b5d4"
        }
    ]
}
```

#### aws_security_group_rule

In the case of aws_security_group_rule it is silently ignored.

```
provider "aws" {
  region = "ap-northeast-1"
}

resource "aws_security_group" "test" {
  name = "test"
}

resource "aws_security_group_rule" "test" {
  type        = "ingress"
  from_port   = 8080
  to_port     = 8080
  protocol    = "-1"
  cidr_blocks = ["0.0.0.0/0"]

  security_group_id = "${aws_security_group.test.id}"
}
```

```
$ terraform plan
+ aws_security_group.test
    description: "Managed by Terraform"
    egress.#:    "<computed>"
    ingress.#:   "<computed>"
    name:        "test"
    owner_id:    "<computed>"
    vpc_id:      "<computed>"

+ aws_security_group_rule.test
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "0.0.0.0/0"
    from_port:                "8080"
    protocol:                 "-1"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "8080"
    type:                     "ingress"


Plan: 2 to add, 0 to change, 0 to destroy.
```

```
$ terraform apply
aws_security_group.test: Creating...
  description: "" => "Managed by Terraform"
  egress.#:    "" => "<computed>"
  ingress.#:   "" => "<computed>"
  name:        "" => "test"
  owner_id:    "" => "<computed>"
  vpc_id:      "" => "<computed>"
aws_security_group.test: Creation complete
aws_security_group_rule.test: Creating...
  cidr_blocks.#:            "" => "1"
  cidr_blocks.0:            "" => "0.0.0.0/0"
  from_port:                "" => "8080"
  protocol:                 "" => "-1"
  security_group_id:        "" => "sg-9519bbf2"
  self:                     "" => "false"
  source_security_group_id: "" => "<computed>"
  to_port:                  "" => "8080"
  type:                     "" => "ingress"
aws_security_group_rule.test: Creation complete

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
```
```
$ aws ec2 describe-security-groups --group-names test
{
    "SecurityGroups": [
        {
            "IpPermissionsEgress": [],
            "Description": "Managed by Terraform",
            "IpPermissions": [
                {
                    "IpProtocol": "-1",
                    "IpRanges": [
                        {
                            "CidrIp": "0.0.0.0/0"
                        }
                    ],
                    "UserIdGroupPairs": [],
                    "PrefixListIds": []
                }
            ],
            "GroupName": "test",
            "VpcId": "vpc-8456bae1",
            "OwnerId": "XXXXXXXXXXX",
            "GroupId": "sg-9519bbf2"
        }
    ]
}
```

### After
#### aws_security_group_rule
Make an error on aws_security_group_rule.

```
$ terraform plan
+ aws_security_group.test
    description: "Managed by Terraform"
    egress.#:    "<computed>"
    ingress.#:   "<computed>"
    name:        "test"
    owner_id:    "<computed>"
    vpc_id:      "<computed>"

+ aws_security_group_rule.test
    cidr_blocks.#:            "1"
    cidr_blocks.0:            "0.0.0.0/0"
    from_port:                "8080"
    protocol:                 "-1"
    security_group_id:        "<computed>"
    self:                     "false"
    source_security_group_id: "<computed>"
    to_port:                  "8080"
    type:                     "ingress"


Plan: 2 to add, 0 to change, 0 to destroy.
```

```
$ terraform apply
aws_security_group.test: Creating...
  description: "" => "Managed by Terraform"
  egress.#:    "" => "<computed>"
  ingress.#:   "" => "<computed>"
  name:        "" => "test"
  owner_id:    "" => "<computed>"
  vpc_id:      "" => "<computed>"
aws_security_group.test: Creation complete
aws_security_group_rule.test: Creating...
  cidr_blocks.#:            "" => "1"
  cidr_blocks.0:            "" => "0.0.0.0/0"
  from_port:                "" => "8080"
  protocol:                 "" => "-1"
  security_group_id:        "" => "sg-a01cbec7"
  self:                     "" => "false"
  source_security_group_id: "" => "<computed>"
  to_port:                  "" => "8080"
  type:                     "" => "ingress"
Error applying plan:

1 error(s) occurred:

* aws_security_group_rule.test: from_port (8080) and to_port (8080) must both be 0 to use the 'ALL' "-1" protocol!

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

```
$ aws ec2 describe-security-groups --group-names test
{
    "SecurityGroups": [
        {
            "IpPermissionsEgress": [],
            "Description": "Managed by Terraform",
            "IpPermissions": [],
            "GroupName": "test",
            "VpcId": "vpc-8456bae1",
            "OwnerId": "XXXXXXXXXXX",
            "GroupId": "sg-a01cbec7"
        }
    ]
}
```
