### PR TITLE
aws-emr-cluster: Assign correct number of core instances (n-1) on update

### DIFF
--- a/builtin/providers/aws/resource_aws_emr_cluster.go
+++ b/builtin/providers/aws/resource_aws_emr_cluster.go
@@ -377,7 +377,7 @@ func resourceAwsEMRClusterUpdate(d *schema.ResourceData, meta interface{}) error
 			InstanceGroups: []*emr.InstanceGroupModifyConfig{
 				{
 					InstanceGroupId: coreGroup.Id,
-					InstanceCount:   aws.Int64(int64(coreInstanceCount)),
+					InstanceCount:   aws.Int64(int64(coreInstanceCount) - 1),
 				},
 			},
 		}


### PR DESCRIPTION
Spotted during the tests for https://github.com/hashicorp/terraform/issues/9623