### PR TITLE
provider/azurerm: SDK 7.0.1 - Fixing CDN

### DIFF
--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint.go
@@ -195,7 +195,7 @@ func resourceArmCdnEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
-	read, err := cdnEndpointsClient.Get(name, profileName, resGroup)
+	read, err := cdnEndpointsClient.Get(resGroup, profileName, name)
 	if err != nil {
 		return err
 	}
@@ -222,7 +222,7 @@ func resourceArmCdnEndpointRead(d *schema.ResourceData, meta interface{}) error 
 		profileName = id.Path["Profiles"]
 	}
 	log.Printf("[INFO] Trying to find the AzureRM CDN Endpoint %s (Profile: %s, RG: %s)", name, profileName, resGroup)
-	resp, err := cdnEndpointsClient.Get(name, profileName, resGroup)
+	resp, err := cdnEndpointsClient.Get(resGroup, profileName, name)
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -327,7 +327,7 @@ func resourceArmCdnEndpointDelete(d *schema.ResourceData, meta interface{}) erro
 	}
 	name := id.Path["endpoints"]
 
-	accResp, err := client.Delete(name, profileName, resGroup, make(chan struct{}))
+	accResp, err := client.Delete(resGroup, profileName, name, make(chan struct{}))
 	if err != nil {
 		if accResp.StatusCode == http.StatusNotFound {
 			return nil

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
@@ -104,7 +104,7 @@ func testCheckAzureRMCdnEndpointExists(name string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient
 
-		resp, err := conn.Get(name, profileName, resourceGroup)
+		resp, err := conn.Get(resourceGroup, profileName, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on cdnEndpointsClient: %s", err)
 		}
@@ -134,7 +134,7 @@ func testCheckAzureRMCdnEndpointDisappears(name string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnEndpointsClient
 
-		_, err := conn.Delete(name, profileName, resourceGroup, make(chan struct{}))
+		_, err := conn.Delete(resourceGroup, profileName, name, make(chan struct{}))
 		if err != nil {
 			return fmt.Errorf("Bad: Delete on cdnEndpointsClient: %s", err)
 		}
@@ -155,7 +155,7 @@ func testCheckAzureRMCdnEndpointDestroy(s *terraform.State) error {
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 		profileName := rs.Primary.Attributes["profile_name"]
 
-		resp, err := conn.Get(name, profileName, resourceGroup)
+		resp, err := conn.Get(resourceGroup, profileName, name)
 
 		if err != nil {
 			return nil

--- a/builtin/providers/azurerm/resource_arm_cdn_profile.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile.go
@@ -73,7 +73,7 @@ func resourceArmCdnProfileCreate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	read, err := cdnProfilesClient.Get(name, resGroup)
+	read, err := cdnProfilesClient.Get(resGroup, name)
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func resourceArmCdnProfileRead(d *schema.ResourceData, meta interface{}) error {
 	resGroup := id.ResourceGroup
 	name := id.Path["profiles"]
 
-	resp, err := cdnProfilesClient.Get(name, resGroup)
+	resp, err := cdnProfilesClient.Get(resGroup, name)
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -151,7 +151,7 @@ func resourceArmCdnProfileDelete(d *schema.ResourceData, meta interface{}) error
 	resGroup := id.ResourceGroup
 	name := id.Path["profiles"]
 
-	_, err = cdnProfilesClient.Delete(name, resGroup, make(chan struct{}))
+	_, err = cdnProfilesClient.Delete(resGroup, name, make(chan struct{}))
 	// TODO: check the status code
 
 	return err

--- a/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
@@ -124,7 +124,7 @@ func testCheckAzureRMCdnProfileExists(name string) resource.TestCheckFunc {
 
 		conn := testAccProvider.Meta().(*ArmClient).cdnProfilesClient
 
-		resp, err := conn.Get(name, resourceGroup)
+		resp, err := conn.Get(resourceGroup, name)
 		if err != nil {
 			return fmt.Errorf("Bad: Get on cdnProfilesClient: %s", err)
 		}
@@ -148,7 +148,7 @@ func testCheckAzureRMCdnProfileDestroy(s *terraform.State) error {
 		name := rs.Primary.Attributes["name"]
 		resourceGroup := rs.Primary.Attributes["resource_group_name"]
 
-		resp, err := conn.Get(name, resourceGroup)
+		resp, err := conn.Get(resourceGroup, name)
 
 		if err != nil {
 			return nil


### PR DESCRIPTION
v7.0.1 of the Azure SDK _helpfully_ changed the method signature from `name, provider, resourceGroup` to `resourceGroup, provider, name` - but the signature being the same meant it compiled.

This fixes it / the tests pass for Endpoints:

```
$ TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMCdnEndpoint -timeout 120m 2>~/.tf.log
=== RUN   TestAccAzureRMCdnEndpoint_importWithTags
--- PASS: TestAccAzureRMCdnEndpoint_importWithTags (238.21s)
=== RUN   TestAccAzureRMCdnEndpoint_basic
--- PASS: TestAccAzureRMCdnEndpoint_basic (215.58s)
=== RUN   TestAccAzureRMCdnEndpoint_disappears
--- PASS: TestAccAzureRMCdnEndpoint_disappears (215.99s)
=== RUN   TestAccAzureRMCdnEndpoint_withTags
--- PASS: TestAccAzureRMCdnEndpoint_withTags (235.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	905.724s
```

and Profiles:
```
$ TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMCdnProfile -timeout 120m 2>~/.tf.log
=== RUN   TestAccAzureRMCdnProfile_importWithTags
--- PASS: TestAccAzureRMCdnProfile_importWithTags (164.91s)
=== RUN   TestAccAzureRMCdnProfile_basic
--- PASS: TestAccAzureRMCdnProfile_basic (164.77s)
=== RUN   TestAccAzureRMCdnProfile_withTags
--- PASS: TestAccAzureRMCdnProfile_withTags (183.32s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	513.030s
```