### PR TITLE
provider/google: Fix instance/template metadata support

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -111,10 +111,9 @@ func resourceComputeInstance() *schema.Resource {
 			},
 
 			"metadata": &schema.Schema{
-				Type:         schema.TypeMap,
-				Optional:     true,
-				Elem:         schema.TypeString,
-				ValidateFunc: validateInstanceMetadata,
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem:     schema.TypeString,
 			},
 
 			"metadata_startup_script": &schema.Schema{
@@ -634,10 +633,10 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	md := instance.Metadata
 
 	_md := MetadataFormatSchema(d.Get("metadata").(map[string]interface{}), md)
-	delete(_md, "startup-script")
 
 	if script, scriptExists := d.GetOk("metadata_startup_script"); scriptExists {
 		d.Set("metadata_startup_script", script)
+		delete(_md, "startup-script")
 	}
 
 	if err = d.Set("metadata", _md); err != nil {
@@ -1009,13 +1008,4 @@ func resourceInstanceTags(d *schema.ResourceData) *compute.Tags {
 	}
 
 	return tags
-}
-
-func validateInstanceMetadata(v interface{}, k string) (ws []string, es []error) {
-	mdMap := v.(map[string]interface{})
-	if _, ok := mdMap["startup-script"]; ok {
-		es = append(es, fmt.Errorf(
-			"Use metadata_startup_script instead of a startup-script key in %q.", k))
-	}
-	return
 }

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -136,6 +136,11 @@ The following arguments are supported:
 * `metadata` - (Optional) Metadata key/value pairs to make available from
     within instances created from this template.
 
+* `metadata_startup_script` - (Optional) An alternative to using the
+    startup-script metadata key, mostly to match the compute_instance resource.
+    This replaces the startup-script metadata key on the created instance and 
+    thus the two mechanisms are not allowed to be used simultaneously.
+
 * `network_interface` - (Required) Networks to attach to instances created from
     this template. This can be specified multiple times for multiple networks.
     Structure is documented below.


### PR DESCRIPTION
Update our instance template to include metadata_startup_script, to
match our instance resource. Also, we've resolved the diff errors around
metadata.startup-script, and people want to use that to create startup
scripts that don't force a restart when they're changed, so let's stop
disallowing it.

Also, we had a bunch of calls to `schema.ResourceData.Set` that ignored
the errors, so I added error handling for those calls. It's mostly
bundled with this code because I couldn't be sure whether it was the
root of bugs or not, so I took care of it while addressing the startup
script issue.

**Notes:**
* When _importing_ instance templates, we assume any startup scripts are for `metadata.startup-script`. This means we can't do an import test for `metadata_startup_script` because it will check for `metadata_startup_script` in the state, and it will get `metadata.startup-script` instead. We have to make this assumption because until we have state to work off, we can't detect that `metadata_startup_script` was used. Imports (to my knowledge?) don't have any state, so we can't figure out what the user specified. This does mean when a template is imported, then its conf file is created, if the conf file uses `metadata_startup_script`, the next `terraform plan` will show changes to use `metadata_startup_script` in the state, instead.
* Changing from `metadata.startup-script` to `metadata_startup_script` requires a destroy/create. I don't know of a good way around this, or if this should even be the desired behaviour.
* In the event that both `metadata.startup-script` _and_ `metadata_startup_script` are specified, `metadata_startup_script` wins.
* `metadata_startup_script` is for instances that should be destroyed/recreated when the startup script changes. `metadata.startup-script` is for instances that want to modify it without a destroy/recreate. Instance templates destroy and recreate on metadata changes, anyways, so there's no real reason to use `metadata_startup_script` in an instance template, but cutting down on the inconsistencies between resources seems like a nice thing to do.

This undoes the work @phinze did in #3507, so pinging him. See also #10227, where @JDiPierro, @cblecker, and @sparkprime weighed in on the importance of having both supported for instances.