### PR TITLE
provider/azurerm support `license_type` virtual_machine property for Windows machines.

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -75,9 +75,10 @@ func resourceArmVirtualMachine() *schema.Resource {
 			},
 
 			"license_type": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateLicenseType,
 			},
 
 			"vm_size": {
@@ -429,6 +430,15 @@ func resourceArmVirtualMachine() *schema.Resource {
 			"tags": tagsSchema(),
 		},
 	}
+}
+
+func validateLicenseType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value != "" && value != "Windows_Server" {
+		errors = append(errors, fmt.Errorf(
+			"[ERROR] license_type must be 'Windows_Server' or empty"))
+	}
+	return
 }
 
 func validateDiskSizeGB(v interface{}, k string) (ws []string, errors []error) {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -478,12 +478,14 @@ func resourceArmVirtualMachineCreate(d *schema.ResourceData, meta interface{}) e
 
 	networkProfile := expandAzureRmVirtualMachineNetworkProfile(d)
 	vmSize := d.Get("vm_size").(string)
+	licenseType := d.Get("license_type").(string)
 	properties := compute.VirtualMachineProperties{
 		NetworkProfile: &networkProfile,
 		HardwareProfile: &compute.HardwareProfile{
 			VMSize: compute.VirtualMachineSizeTypes(vmSize),
 		},
 		StorageProfile: &storageProfile,
+		LicenseType:    &licenseType,
 	}
 
 	if _, ok := d.GetOk("boot_diagnostics"); ok {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -515,6 +515,25 @@ func testCheckAzureRMVirtualMachineDisappears(name string, vm *compute.VirtualMa
 	}
 }
 
+func TestAccAzureRMVirtualMachine_windowsLicenseType(t *testing.T) {
+	var vm compute.VirtualMachine
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachine_windowsLicenseType, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test", &vm),
+				),
+			},
+		},
+	})
+}
+
 var testAccAzureRMVirtualMachine_basicLinuxMachine = `
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
@@ -2052,6 +2071,91 @@ resource "azurerm_virtual_machine" "test" {
     tags {
     	environment = "Production"
     	cost-center = "Ops"
+    }
+}
+`
+
+var testAccAzureRMVirtualMachine_windowsLicenseType = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accsa%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "westus"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine" "test" {
+    name = "acctvm-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    network_interface_ids = ["${azurerm_network_interface.test.id}"]
+    vm_size = "Standard_A0"
+    license_type = "Windows_Server"
+
+    storage_image_reference {
+	publisher = "MicrosoftWindowsServer"
+	offer = "WindowsServer-HUB"
+	sku = "2008-R2-SP1-HUB"
+	version = "latest"
+    }
+
+    storage_os_disk {
+        name = "myosdisk1"
+        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+        caching = "ReadWrite"
+        create_option = "FromImage"
+    }
+
+    os_profile {
+	computer_name = "winhost01"
+	admin_username = "testadmin"
+	admin_password = "Password1234!"
+    }
+
+    os_profile_windows_config {
+	enable_automatic_upgrades = false
+	provision_vm_agent = true
     }
 }
 `

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -215,7 +215,7 @@ The following arguments are supported:
 * `storage_data_disk` - (Optional) A list of Storage Data disk blocks as referenced below.
 * `delete_data_disks_on_termination` - (Optional) Flag to enable deletion of Storage Disk VHD blobs when the VM is deleted, defaults to `false`
 * `os_profile` - (Required) An OS Profile block as documented below.
-* `license_type` - (Optional, when a windows machine) Specifies the Windows OS license type. 
+* `license_type` - (Optional, when a windows machine) Specifies the Windows OS license type. The only allowable value, if supplied, is `Windows_Server`.
 * `os_profile_windows_config` - (Required, when a windows machine) A Windows config block as documented below.
 * `os_profile_linux_config` - (Required, when a linux machine) A Linux config block as documented below.
 * `os_profile_secrets` - (Optional) A collection of Secret blocks as documented below.

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -215,6 +215,7 @@ The following arguments are supported:
 * `storage_data_disk` - (Optional) A list of Storage Data disk blocks as referenced below.
 * `delete_data_disks_on_termination` - (Optional) Flag to enable deletion of Storage Disk VHD blobs when the VM is deleted, defaults to `false`
 * `os_profile` - (Required) An OS Profile block as documented below.
+* `license_type` - (Optional, when a windows machine) Specifies the Windows OS license type. 
 * `os_profile_windows_config` - (Required, when a windows machine) A Windows config block as documented below.
 * `os_profile_linux_config` - (Required, when a linux machine) A Linux config block as documented below.
 * `os_profile_secrets` - (Optional) A collection of Secret blocks as documented below.


### PR DESCRIPTION
The property `license_type` already exists in the resource `azurerm_virtual_machine`, however it was not being used [here](https://github.com/hashicorp/terraform/blob/master/builtin/providers/azurerm/resource_arm_virtual_machine.go#L77).

The azure golang SDK supports this as one of its properties [here](https://github.com/Azure/azure-sdk-for-go/blob/master/arm/compute/models.go#L834).

This PR is aimed at closing this gap, mainly to support [Microsoft Azure Hybrid Use Benefit](https://azure.microsoft.com/en-us/pricing/hybrid-use-benefit/).

 - [x] Proper formatting
 - [x] Updated Documentation
 - [x] Wrote additional acceptance test
 - [x] Passing Travis CI Build
