### PR TITLE
provider/pagerduty: Add pagerduty_user data source

### DIFF
--- a/builtin/providers/pagerduty/data_source_pagerduty_user.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_user.go
@@ -1,0 +1,62 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+
+	pagerduty "github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourcePagerDutyUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyUserRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty user")
+
+	searchEmail := d.Get("email").(string)
+
+	o := &pagerduty.ListUsersOptions{
+		Query: searchEmail,
+	}
+
+	resp, err := client.ListUsers(*o)
+	if err != nil {
+		return err
+	}
+
+	var found *pagerduty.User
+
+	for _, user := range resp.Users {
+		if user.Email == searchEmail {
+			found = &user
+			break
+		}
+	}
+
+	if found == nil {
+		return fmt.Errorf("Unable to locate any user with the email: %s", searchEmail)
+	}
+
+	d.SetId(found.ID)
+	d.Set("name", found.Name)
+	d.Set("email", found.Email)
+
+	return nil
+}

--- a/builtin/providers/pagerduty/data_source_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_user_test.go
@@ -1,0 +1,64 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourcePagerDutyUser_Basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourcePagerDutyUserConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyUser("pagerduty_user.test", "data.pagerduty_user.by_email"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyUser(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get a user ID from PagerDuty")
+		}
+
+		testAtts := []string{"id", "name", "email"}
+
+		for _, att := range testAtts {
+			if a[att] != srcA[att] {
+				return fmt.Errorf("Expected the user %s to be: %s, but got: %s", att, srcA[att], a[att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyUserConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name = "TF User %[1]s"
+  email = "tf.%[1]s@example.com"
+}
+
+data "pagerduty_user" "by_email" {
+	email = "${pagerduty_user.test.email}"
+}
+`, rName)
+}

--- a/builtin/providers/pagerduty/provider.go
+++ b/builtin/providers/pagerduty/provider.go
@@ -19,6 +19,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"pagerduty_user":   dataSourcePagerDutyUser(),
 			"pagerduty_vendor": dataSourcePagerDutyVendor(),
 		},
 

--- a/website/source/docs/providers/pagerduty/d/user.html.markdown
+++ b/website/source/docs/providers/pagerduty/d/user.html.markdown
@@ -1,0 +1,44 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_user"
+sidebar_current: "docs-pagerduty-datasource-user"
+description: |-
+  Get information about a user that you can use for a service integration (e.g Amazon Cloudwatch, Splunk, Datadog).
+---
+
+# pagerduty\_user
+
+Use this data source to get information about a specific [user][1] that you can use for other Pager Duty resources.
+
+## Example Usage
+
+```
+data "pagerduty_user" "me" {
+  email = "me@example.com"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "Engineering Escalation Policy"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user"
+      id   = "${data.pagerduty_user.me.id}"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `email` - (Required) The email to use to find a user in the PagerDuty API.  
+
+## Attributes Reference
+* `name` - The short name of the found user.
+
+[1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Users/get_users

--- a/website/source/layouts/pagerduty.erb
+++ b/website/source/layouts/pagerduty.erb
@@ -13,6 +13,9 @@
         <li<%= sidebar_current(/^docs-pagerduty-datasource/) %>>
             <a href="#">Data Sources</a>
             <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-pagerduty-datasource-user") %>>
+                    <a href="/docs/providers/pagerduty/d/user.html">pagerduty_user</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-vendor") %>>
                     <a href="/docs/providers/pagerduty/d/vendor.html">pagerduty_vendor</a>
                 </li>


### PR DESCRIPTION
This data source allows you to query for a user ID by email address.  It doesn't provide any other means to query user data, but could be extended to support others.

```terraform
data "pagerduty_user" "me" {
  email = "me@example.com"
}

resource "pagerduty_escalation_policy" "foo" {
  name      = "Engineering Escalation Policy"
  num_loops = 2

  rule {
    escalation_delay_in_minutes = 10

    target {
      type = "user"
      id   = "${data.pagerduty_user.me.id}"
    }
  }
}
```