### PR TITLE
[WIP] support floating_ip when create instance with port

### DIFF
--- a/builtin/providers/openstack/devstack/deploy.sh
+++ b/builtin/providers/openstack/devstack/deploy.sh
@@ -147,11 +147,14 @@ wget http://download.cirros-cloud.net/0.3.4/cirros-0.3.4-x86_64-disk.img
 glance image-create --name CirrOS --disk-format qcow2 --container-format bare < cirros-0.3.4-x86_64-disk.img
 nova flavor-create m1.tform 99 512 5 1 --ephemeral 10
 _NETWORK_ID=$(nova net-list | grep private | awk -F\| '{print $2}' | tr -d ' ')
+neutron port-create --name test-port $_NETWORK_ID
+_PORT_ID=$(neutron port-list | grep test-port | awk -F\| '{print $2}' | tr -d ' ')
 _EXTGW_ID=$(nova net-list | grep public | awk -F\| '{print $2}' | tr -d ' ')
 _IMAGE_ID=$(nova image-list | grep CirrOS | awk -F\| '{print $2}' | tr -d ' ' | head -1)
 echo export OS_IMAGE_NAME="cirros-0.3.4-x86_64-uec" >> openrc
 echo export OS_IMAGE_ID="$_IMAGE_ID" >> openrc
 echo export OS_NETWORK_ID=$_NETWORK_ID >> openrc
+echo export OS_PORT_ID=$_PORT_ID >> openrc
 echo export OS_EXTGW_ID=$_EXTGW_ID >> openrc
 echo export OS_POOL_NAME="public" >> openrc
 echo export OS_FLAVOR_ID=99 >> openrc


### PR DESCRIPTION
Hello, I fix the following behavior.

1. I run `terraform apply` with following tf file.

```
resource "openstack_compute_instance_v2" "myserver" {
  name = "myserver"
  image_name = "${var.image}"
  flavor_name = "${var.flavor}"
  security_groups = "${var.security_groups}"

  network {
    port = "${openstack_networking_port_v2.myserver-port.id}"
    floating_ip = "${openstack_compute_floatingip_v2.myserver-floating-ip.address}"
    access_network = true
  }
}
```

Success to create instance with floating_ip.

2. run `terraform plan` with no changes

```
~ openstack_compute_instance_v2.myserver
    network.0.floating_ip: "" => "192.0.2.10"
```

myserver has floating_ip exists, but terraform to attach floating_ip.
I expect terraform plan say 'no changes', so I create this PR.

Thanks.
