### PR TITLE
provider/aws: Added S3 Bucket replication

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -443,6 +443,46 @@ func validateS3BucketLifecycleStorageClass(v interface{}, k string) (ws []string
 	return
 }
 
+func validateS3BucketReplicationRuleId(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 255 characters: %q", k, value))
+	}
+
+	return
+}
+
+func validateS3BucketReplicationRulePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 1024 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 1024 characters: %q", k, value))
+	}
+
+	return
+}
+
+func validateS3BucketReplicationDestinationStorageClass(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value != s3.StorageClassStandard && value != s3.StorageClassStandardIa && value != s3.StorageClassReducedRedundancy {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of '%q', '%q' or '%q'", k, s3.StorageClassStandard, s3.StorageClassStandardIa, s3.StorageClassReducedRedundancy))
+	}
+
+	return
+}
+
+func validateS3BucketReplicationRuleStatus(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if value != s3.ReplicationRuleStatusEnabled && value != s3.ReplicationRuleStatusDisabled {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of '%q' or '%q'", k, s3.ReplicationRuleStatusEnabled, s3.ReplicationRuleStatusDisabled))
+	}
+
+	return
+}
+
 func validateS3BucketLifecycleRuleId(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if len(value) > 255 {

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
 )
 
 func TestValidateEcrRepositoryName(t *testing.T) {
@@ -466,6 +468,111 @@ func TestValidateS3BucketLifecycleStorageClass(t *testing.T) {
 		_, errors := validateS3BucketLifecycleStorageClass(v, "storage_class")
 		if len(errors) == 0 {
 			t.Fatalf("%q should be invalid storage class", v)
+		}
+	}
+}
+
+func TestValidateS3BucketReplicationRuleId(t *testing.T) {
+	validId := []string{
+		"YadaHereAndThere",
+		"Valid-5Rule_ID",
+		"This . is also %% valid@!)+*(:ID",
+		"1234",
+		strings.Repeat("W", 255),
+	}
+	for _, v := range validId {
+		_, errors := validateS3BucketReplicationRuleId(v, "id")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid lifecycle rule id: %q", v, errors)
+		}
+	}
+
+	invalidId := []string{
+		// length > 255
+		strings.Repeat("W", 256),
+	}
+	for _, v := range invalidId {
+		_, errors := validateS3BucketReplicationRuleId(v, "id")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid replication configuration rule id", v)
+		}
+	}
+}
+
+func TestValidateS3BucketReplicationRulePrefix(t *testing.T) {
+	validId := []string{
+		"YadaHereAndThere",
+		"Valid-5Rule_ID",
+		"This . is also %% valid@!)+*(:ID",
+		"1234",
+		strings.Repeat("W", 1024),
+	}
+	for _, v := range validId {
+		_, errors := validateS3BucketReplicationRulePrefix(v, "id")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid lifecycle rule id: %q", v, errors)
+		}
+	}
+
+	invalidId := []string{
+		// length > 1024
+		strings.Repeat("W", 1025),
+	}
+	for _, v := range invalidId {
+		_, errors := validateS3BucketReplicationRulePrefix(v, "id")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid replication configuration rule id", v)
+		}
+	}
+}
+
+func TestValidateS3BucketReplicationDestinationStorageClass(t *testing.T) {
+	validStorageClass := []string{
+		s3.StorageClassStandard,
+		s3.StorageClassStandardIa,
+		s3.StorageClassReducedRedundancy,
+	}
+
+	for _, v := range validStorageClass {
+		_, errors := validateS3BucketReplicationDestinationStorageClass(v, "storage_class")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be valid storage class: %q", v, errors)
+		}
+	}
+
+	invalidStorageClass := []string{
+		"FOO",
+		"1234",
+	}
+	for _, v := range invalidStorageClass {
+		_, errors := validateS3BucketReplicationDestinationStorageClass(v, "storage_class")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be invalid storage class", v)
+		}
+	}
+}
+
+func TestValidateS3BucketReplicationRuleStatus(t *testing.T) {
+	validRuleStatuses := []string{
+		s3.ReplicationRuleStatusEnabled,
+		s3.ReplicationRuleStatusDisabled,
+	}
+
+	for _, v := range validRuleStatuses {
+		_, errors := validateS3BucketReplicationRuleStatus(v, "status")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be valid rule status: %q", v, errors)
+		}
+	}
+
+	invalidRuleStatuses := []string{
+		"FOO",
+		"1234",
+	}
+	for _, v := range invalidRuleStatuses {
+		_, errors := validateS3BucketReplicationRuleStatus(v, "status")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be invalid rule status", v)
 		}
 	}
 }

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -158,6 +158,120 @@ resource "aws_s3_bucket" "versioning_bucket" {
 }
 ```
 
+### Using replication configuration
+
+```
+provider "aws" {
+  alias  = "west"
+  region = "eu-west-1"
+}
+
+provider "aws" {
+  alias  = "central"
+  region = "eu-central-1"
+}
+
+resource "aws_iam_role" "replication" {
+  name               = "tf-iam-role-replication-12345"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "s3.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy" "replication" {
+    name = "tf-iam-role-policy-replication-12345"
+    policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "s3:GetReplicationConfiguration",
+        "s3:ListBucket"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.bucket.arn}"
+      ]
+    },
+    {
+      "Action": [
+        "s3:GetObjectVersion",
+        "s3:GetObjectVersionAcl"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${aws_s3_bucket.bucket.arn}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:ReplicateObject",
+        "s3:ReplicateDelete"
+      ],
+      "Effect": "Allow",
+      "Resource": "${aws_s3_bucket.destination.arn}/*"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy_attachment" "replication" {
+    name = "tf-iam-role-attachment-replication-12345"
+    roles = ["${aws_iam_role.replication.name}"]
+    policy_arn = "${aws_iam_policy.replication.arn}"
+}
+
+resource "aws_s3_bucket" "destination" {
+    provider = "aws.west"
+    bucket   = "tf-test-bucket-destination-12345"
+    region   = "eu-west-1"
+
+    versioning {
+        enabled = true
+    }
+}
+
+resource "aws_s3_bucket" "bucket" {
+    provider = "aws.central"
+    bucket   = "tf-test-bucket-12345"
+    acl      = "private"
+    region   = "eu-central-1"
+
+    versioning {
+        enabled = true
+    }
+
+    replication_configuration {
+        role = "${aws_iam_role.replication.arn}"
+        rules {
+            id     = "foobar"
+            prefix = "foo"
+            status = "Enabled"
+
+            destination {
+                bucket        = "${aws_s3_bucket.destination.arn}"
+                storage_class = "STANDARD"
+            }
+        }
+    }
+}
+
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -179,6 +293,7 @@ The following arguments are supported:
 Can be either `BucketOwner` or `Requester`. By default, the owner of the S3 bucket would incur
 the costs of any data transfer. See [Requester Pays Buckets](http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html)
 developer guide for more information.
+* `replication_configuration` - (Optional) A configuration of [replication configuration](http://docs.aws.amazon.com/AmazonS3/latest/dev/crr.html) (documented below).
 
 ~> **NOTE:** You cannot use `acceleration_status` in `cn-north-1` or `us-gov-west-1`
 
@@ -241,12 +356,29 @@ The `noncurrent_version_transition` object supports the following
 * `days` (Required) Specifies the number of days an object is noncurrent object versions expire.
 * `storage_class` (Required) Specifies the Amazon S3 storage class to which you want the noncurrent versions object to transition. Can be `STANDARD_IA` or `GLACIER`.
 
+The `replication_configuration` object supports the following:
+
+* `role` - (Required) The ARN of the IAM role for Amazon S3 to assume when replicating the objects.
+* `rules` - (Required) Specifies the rules managing the replication (documented below).
+
+The `rules` object supports the following:
+
+* `id` - (Optional) Unique identifier for the rule.
+* `destination` - (Required) Specifies the destination for the rule (documented below).
+* `prefix` - (Required) Object keyname prefix identifying one or more objects to which the rule applies. Set as an empty string to replicate the whole bucket.
+* `status` - (Required) The status of the rule. Either `Enabled` or `Disabled`. The rule is ignored if status is not Enabled.
+
+The `destination` object supports the following:
+
+* `bucket` - (Required) The ARN of the S3 bucket where you want Amazon S3 to store replicas of the object identified by the rule.
+* `storage_class` - (Optional) The class of storage used to store the object.
+
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The name of the bucket.
-* `arn` - The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`
+* `arn` - The ARN of the bucket. Will be of format `arn:aws:s3:::bucketname`.
 * `hosted_zone_id` - The [Route 53 Hosted Zone ID](https://docs.aws.amazon.com/general/latest/gr/rande.html#s3_website_region_endpoints) for this bucket's region.
 * `region` - The AWS region this bucket resides in.
 * `website_endpoint` - The website endpoint, if the bucket is configured with a website. If not, this will be an empty string.


### PR DESCRIPTION
#### Reasonning
This adds the S3 Bucket replication.

#### Related Issues
Closes https://github.com/hashicorp/terraform/issues/7490

#### Acceptance tests
Sometimes, tests are failing and it is said that `S3Bucket error: BucketRegionError: incorrect region, the bucket is not in 'eu-west-1' region`, whereas buckets are created. I think it is related to the providerFactories stuff, but can't tell without any investigation. 

However, I used this configuration (the one i added to the documentation) to check the compiled binary, and played with it (adding, removing, updating, etc etc.):

```hcl
provider "aws" {
  alias  = "west"
  region = "eu-west-1"
}

provider "aws" {
  alias  = "central"
  region = "eu-central-1"
}

resource "aws_iam_role" "replication" {
  name               = "tf-iam-role-replication-12345"
  assume_role_policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": "sts:AssumeRole",
      "Principal": {
        "Service": "s3.amazonaws.com"
      },
      "Effect": "Allow",
      "Sid": ""
    }
  ]
}
POLICY
}

resource "aws_iam_policy" "replication" {
    name = "tf-iam-role-policy-replication-12345"
    policy = <<POLICY
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Action": [
        "s3:GetReplicationConfiguration",
        "s3:ListBucket"
      ],
      "Effect": "Allow",
      "Resource": [
        "${aws_s3_bucket.bucket.arn}"
      ]
    },
    {
      "Action": [
        "s3:GetObjectVersion",
        "s3:GetObjectVersionAcl"
      ],
      "Effect": "Allow",
      "Resource": [
        "${aws_s3_bucket.bucket.arn}/*"
      ]
    },
    {
      "Action": [
        "s3:ReplicateObject",
        "s3:ReplicateDelete"
      ],
      "Effect": "Allow",
      "Resource": "${aws_s3_bucket.destination.arn}/*"
    }
  ]
}
POLICY
}

resource "aws_iam_policy_attachment" "replication" {
    name = "tf-iam-role-attachment-replication-12345"
    roles = ["${aws_iam_role.replication.name}"]
    policy_arn = "${aws_iam_policy.replication.arn}"
}

resource "aws_s3_bucket" "destination" {
    provider = "aws.west"
    bucket   = "tf-test-bucket-destination-123456"
    region   = "eu-west-1"

    versioning {
        enabled = true
    }
}

resource "aws_s3_bucket" "bucket" {
    provider = "aws.central"
    bucket   = "tf-test-bucket-123456"
    acl      = "private"
    region   = "eu-central-1"

    versioning {
        enabled = true
    }

    replication_configuration {
        role = "${aws_iam_role.replication.arn}"
        rules {
            id     = "foobar"
            prefix = ""
            status = "Enabled"

            destination {
                bucket        = "${aws_s3_bucket.destination.arn}"
                storage_class = "STANDARD"
            }
        }
    }
}
```


```hcl
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3Bucket_Replication'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/06 23:04:30 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3Bucket_Replication -timeout 120m
=== RUN   TestAccAWSS3Bucket_Replication
--- PASS: TestAccAWSS3Bucket_Replication (61.29s)
=== RUN   TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError
--- PASS: TestAccAWSS3Bucket_ReplicationExpectVersioningValidationError (28.35s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	89.673s

$ make test TEST=./builtin/providers/aws TESTARGS='-run=TestValidateS3BucketReplicationRuleId'
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/07 22:53:33 Generated command/internal_plugin_list.go
TF_ACC= go test ./builtin/providers/aws -run=TestValidateS3BucketReplicationRuleId -timeout=30s -parallel=4
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.022s

$ make test TEST=./builtin/providers/aws TESTARGS='-run=TestValidateS3BucketReplicationRulePrefix'
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/07 22:54:20 Generated command/internal_plugin_list.go
TF_ACC= go test ./builtin/providers/aws -run=TestValidateS3BucketReplicationRulePrefix -timeout=30s -parallel=4
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.026s
```