### PR TITLE
Explicitly state the count parameter cannot be used by modules

### DIFF
--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -47,6 +47,8 @@ There are **meta-parameters** available to all resources:
       This doesn't apply to all resources. For details on using variables in
       conjunction with count, see [Using Variables with
      `count`](#using-variables-with-count) below.
+     ~> **NOTE:** modules don't currently support the `count` parameter.
+
 
   * `depends_on` (list of strings) - Explicit dependencies that this
       resource has. These dependencies will be created before this


### PR DESCRIPTION
As pointed out [in the Google Group today](https://groups.google.com/forum/#!msg/terraform-tool/T3eB4pZ6waU/5hqs2SyGCAAJ), the `count` parameter is ineffective when used in modules.

In order to avoid confusion and doubts, this PR makes it explicit in the documentation so that future comers will have a definitive answer should they have the same question in mind. 