### PR TITLE
provider/datadog #9375: Refactor tags to a list instead of a map.

### DIFF
--- a/builtin/providers/datadog/import_datadog_monitor_test.go
+++ b/builtin/providers/datadog/import_datadog_monitor_test.go
@@ -48,9 +48,6 @@ resource "datadog_monitor" "foo" {
   include_tags = true
   require_full_window = true
   locked = false
-  tags {
-    "foo" = "bar"
-    "bar" = "baz"
-  }
+  tags = ["foo:bar", "bar:baz"]
 }
 `

--- a/builtin/providers/datadog/resource_datadog_monitor.go
+++ b/builtin/providers/datadog/resource_datadog_monitor.go
@@ -119,13 +119,9 @@ func resourceDatadogMonitor() *schema.Resource {
 				Optional: true,
 			},
 			"tags": &schema.Schema{
-				Type:     schema.TypeMap,
+				Type:     schema.TypeList,
 				Optional: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-					Elem: &schema.Schema{
-						Type: schema.TypeString},
-				},
+				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 		},
 	}
@@ -193,11 +189,11 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 	}
 
 	if attr, ok := d.GetOk("tags"); ok {
-		s := make([]string, 0)
-		for k, v := range attr.(map[string]interface{}) {
-			s = append(s, fmt.Sprintf("%s:%s", k, v.(string)))
+		tags := []string{}
+		for _, s := range attr.([]interface{}) {
+			tags = append(tags, s.(string))
 		}
-		m.Tags = s
+		m.Tags = tags
 	}
 
 	return &m
@@ -263,10 +259,9 @@ func resourceDatadogMonitorRead(d *schema.ResourceData, meta interface{}) error 
 		}
 	}
 
-	tags := make(map[string]string)
+	tags := []string{}
 	for _, s := range m.Tags {
-		tag := strings.Split(s, ":")
-		tags[tag[0]] = tag[1]
+		tags = append(tags, s)
 	}
 
 	log.Printf("[DEBUG] monitor: %v", m)
@@ -313,8 +308,8 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 
 	if attr, ok := d.GetOk("tags"); ok {
 		s := make([]string, 0)
-		for k, v := range attr.(map[string]interface{}) {
-			s = append(s, fmt.Sprintf("%s:%s", k, v.(string)))
+		for _, v := range attr.([]interface{}) {
+			s = append(s, v.(string))
 		}
 		m.Tags = s
 	}

--- a/builtin/providers/datadog/resource_datadog_monitor_test.go
+++ b/builtin/providers/datadog/resource_datadog_monitor_test.go
@@ -42,9 +42,9 @@ func TestAccDatadogMonitor_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.foo", "bar"),
+						"datadog_monitor.foo", "tags.0", "foo:bar"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.bar", "baz"),
+						"datadog_monitor.foo", "tags.1", "baz"),
 				),
 			},
 		},
@@ -90,9 +90,9 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "false"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.foo", "bar"),
+						"datadog_monitor.foo", "tags.0", "foo:bar"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.bar", "baz"),
+						"datadog_monitor.foo", "tags.1", "baz"),
 				),
 			},
 			resource.TestStep{
@@ -134,9 +134,9 @@ func TestAccDatadogMonitor_Updated(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"datadog_monitor.foo", "locked", "true"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.baz", "qux"),
+						"datadog_monitor.foo", "tags.0", "baz:qux"),
 					resource.TestCheckResourceAttr(
-						"datadog_monitor.foo", "tags.quux", "corge"),
+						"datadog_monitor.foo", "tags.1", "quux"),
 				),
 			},
 		},
@@ -249,10 +249,7 @@ resource "datadog_monitor" "foo" {
   include_tags = true
   require_full_window = true
   locked = false
-  tags {
-	"foo" = "bar"
-	"bar" = "baz"
-  }
+  tags = ["foo:bar", "baz"]
 }
 `
 
@@ -279,10 +276,7 @@ resource "datadog_monitor" "foo" {
   require_full_window = true
   locked              = false
 
-  tags {
-    "foo" = "bar"
-    "bar" = "baz"
-  }
+  tags = ["foo:bar", "baz"]
 }
 `
 
@@ -309,10 +303,7 @@ resource "datadog_monitor" "foo" {
   require_full_window = true
   locked              = false
 
-  tags {
-    "foo" = "bar"
-    "bar" = "baz"
-  }
+  tags = ["foo:bar", "baz"]
 }
 `
 
@@ -343,10 +334,7 @@ resource "datadog_monitor" "foo" {
   silenced {
 	"*" = 0
   }
-  tags {
-	"baz"  = "qux"
-	"quux" = "corge"
-  }
+  tags = ["baz:qux", "quux"]
 }
 `
 

--- a/website/source/docs/providers/datadog/r/monitor.html.markdown
+++ b/website/source/docs/providers/datadog/r/monitor.html.markdown
@@ -37,10 +37,7 @@ resource "datadog_monitor" "foo" {
   silenced {
     "*" = 0
   }
-  tags {
-    "foo" = "bar"
-    "bar" = "baz"
-  }
+  tags = ["foo:bar", "baz"]
 }
 ```
 
@@ -77,13 +74,12 @@ The following arguments are supported:
     from a triggered state. Defaults to false.
 * `include_tags` (Optional) A boolean indicating whether notifications from this monitor will automatically insert its
     triggering tags into the title. Defaults to true.
-* `silenced` (Optional) Each scope will be muted until the given POSIX timestamp or forever if the value is 0.
 * `require_full_window` (Optional) A boolean indicating whether this monitor needs a full window of data before it's evaluated.
     We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.
     Default: True for "on average", "at all times" and "in total" aggregation. False otherwise.
 * `locked` (Optional) A boolean indicating whether changes to to this monitor should be restricted to the creator or admins. Defaults to False.
 * `tags` (Optional) A list of tags to associate with your monitor. This can help you categorize and filter monitors in the manage monitors page of the UI. Note: it's not currently possible to filter by these tags when querying via the API
-    
+* `silenced` (Optional) Each scope will be muted until the given POSIX timestamp or forever if the value is 0.
     To mute the alert completely:
     
         silenced {


### PR DESCRIPTION
Tags are allowed to be but not restricted to, key value pairs (ie: foo:bar)
but are esssentially strings.

This changes allows using, and mixing of tags with form "foo" and "foo:bar". It also allows using duplicate keys like "foo:bar" and "foo:baz".

Addresses https://github.com/hashicorp/terraform/issues/9375