### PR TITLE
provider/aws: Forces the API GW domain name certificates to recreate the resource

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -23,11 +23,13 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 
 			"certificate_body": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Required: true,
 			},
 
 			"certificate_chain": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Required: true,
 			},
 
@@ -38,6 +40,7 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 
 			"certificate_private_key": {
 				Type:     schema.TypeString,
+				ForceNew: true,
 				Required: true,
 			},
 
@@ -117,35 +120,11 @@ func resourceAwsApiGatewayDomainNameRead(d *schema.ResourceData, meta interface{
 func resourceAwsApiGatewayDomainNameUpdateOperations(d *schema.ResourceData) []*apigateway.PatchOperation {
 	operations := make([]*apigateway.PatchOperation, 0)
 
-	if d.HasChange("certificate_body") {
-		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
-			Path:  aws.String("/certificateBody"),
-			Value: aws.String(d.Get("certificate_body").(string)),
-		})
-	}
-
-	if d.HasChange("certificate_chain") {
-		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
-			Path:  aws.String("/certificateChain"),
-			Value: aws.String(d.Get("certificate_chain").(string)),
-		})
-	}
-
 	if d.HasChange("certificate_name") {
 		operations = append(operations, &apigateway.PatchOperation{
 			Op:    aws.String("replace"),
 			Path:  aws.String("/certificateName"),
 			Value: aws.String(d.Get("certificate_name").(string)),
-		})
-	}
-
-	if d.HasChange("certificate_private_key") {
-		operations = append(operations, &apigateway.PatchOperation{
-			Op:    aws.String("replace"),
-			Path:  aws.String("/certificatePrivateKey"),
-			Value: aws.String(d.Get("certificate_private_key").(string)),
 		})
 	}
 


### PR DESCRIPTION
This completes the process to fix #8789, following the initiation from #10179.

As per the [documentation](https://docs.aws.amazon.com/apigateway/api-reference/link-relation/domainname-update/), the only attribute that can be updated is the certificate name.
Thus, other attributes related to the certificate should trigger a recreation.

Not sure if a test for this is needed though! :)

```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayDomainName_basic'     
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/07 22:28:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAPIGatewayDomainName_basic -timeout 120m
=== RUN   TestAccAWSAPIGatewayDomainName_basic
--- PASS: TestAccAWSAPIGatewayDomainName_basic (55.06s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	55.083s
```