### PR TITLE
Keep a consistent provider order.

### DIFF
--- a/website/source/docs/providers/scaleway/index.html.markdown
+++ b/website/source/docs/providers/scaleway/index.html.markdown
@@ -23,8 +23,8 @@ Here is an example that will setup the following:
 
 ```hcl
 provider "scaleway" {
-  access_key = ""
   organization = ""
+  access_key = ""
   region = "par1"
 }
 


### PR DESCRIPTION
In the rest of the document the order is organization, access_key. Except in this one spot.