### PR TITLE
provider/aws: Exercise instance's network_interface_id

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -129,8 +129,10 @@ func resourceAwsInstance() *schema.Resource {
 			},
 
 			"network_interface_id": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ConflictsWith: []string{"vpc_security_group_ids", "subnet_id", "associate_public_ip_address"},
 			},
 
 			"public_ip": &schema.Schema{
@@ -1108,6 +1110,13 @@ func buildAwsInstanceOpts(
 			for _, v := range v.List() {
 				ni.Groups = append(ni.Groups, aws.String(v.(string)))
 			}
+		}
+
+		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
+	} else if v, ok := d.GetOk("network_interface_id"); ok {
+		ni := &ec2.InstanceNetworkInterfaceSpecification{
+			DeviceIndex:        aws.Int64(int64(0)),
+			NetworkInterfaceId: aws.String(v.(string)),
 		}
 
 		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -54,9 +54,9 @@ The following arguments are supported:
      EBS-optimized.
 * `disable_api_termination` - (Optional) If true, enables [EC2 Instance
      Termination Protection](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingDisableAPITermination)
-* `instance_initiated_shutdown_behavior` - (Optional) Shutdown behavior for the 
-instance. Amazon defaults this to `stop` for EBS-backed instances and 
-`terminate` for instance-store instances. Cannot be set on instance-store 
+* `instance_initiated_shutdown_behavior` - (Optional) Shutdown behavior for the
+instance. Amazon defaults this to `stop` for EBS-backed instances and
+`terminate` for instance-store instances. Cannot be set on instance-store
 instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/terminating-instances.html#Using_ChangingInstanceInitiatedShutdownBehavior) for more information.
 * `instance_type` - (Required) The type of instance to start
 * `key_name` - (Optional) The key name to use for the instance.
@@ -65,7 +65,8 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
    If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 * `vpc_security_group_ids` - (Optional) A list of security group IDs to associate with.
 * `subnet_id` - (Optional) The VPC Subnet ID to launch in.
-* `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.  Boolean value. 
+* `network_interface_id` - (Optional) The network interface ID to attach to the instance.
+* `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.  Boolean value.
 * `private_ip` - (Optional) Private IP address to associate with the
      instance in a VPC.
 * `source_dest_check` - (Optional) Controls if traffic is routed to the instance when
@@ -149,12 +150,12 @@ The following attributes are exported:
 * `availability_zone` - The availability zone of the instance.
 * `placement_group` - The placement group of the instance.
 * `key_name` - The key name of the instance
-* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this 
+* `public_dns` - The public DNS name assigned to the instance. For EC2-VPC, this
   is only available if you've enabled DNS hostnames for your VPC
 * `public_ip` - The public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
 * `network_interface_id` - The ID of the network interface that was created with the instance.
-* `private_dns` - The private DNS name assigned to the instance. Can only be 
-  used inside the Amazon EC2, and only available if you've enabled DNS hostnames 
+* `private_dns` - The private DNS name assigned to the instance. Can only be
+  used inside the Amazon EC2, and only available if you've enabled DNS hostnames
   for your VPC
 * `private_ip` - The private IP address assigned to the instance
 * `security_groups` - The associated security groups.
@@ -164,7 +165,7 @@ The following attributes are exported:
 
 ## Import
 
-Instances can be imported using the `id`, e.g. 
+Instances can be imported using the `id`, e.g.
 
 ```
 $ terraform import aws_instance.web i-12345678


### PR DESCRIPTION
Allow _resource_aws_instance_ to specify network interface to be attached.

Reason for that functionality is that currently Terraform assumes first interface (eth0). Which makes it difficult (impossible?) for user to create its own special network interface, e.g. with multiple IPs ( #10590 ) and assign it from the beginning, as first and only interface.