### PR TITLE
provider/aws: Add simple resource to attach ENI with instance

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -298,6 +298,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_default_route_table":                      resourceAwsDefaultRouteTable(),
 			"aws_network_acl_rule":                         resourceAwsNetworkAclRule(),
 			"aws_network_interface":                        resourceAwsNetworkInterface(),
+			"aws_network_interface_attachment":             resourceAwsNetworkInterfaceAttachment(),
 			"aws_opsworks_application":                     resourceAwsOpsworksApplication(),
 			"aws_opsworks_stack":                           resourceAwsOpsworksStack(),
 			"aws_opsworks_java_app_layer":                  resourceAwsOpsworksJavaAppLayer(),

--- a/builtin/providers/aws/resource_aws_network_interface_attachment.go
+++ b/builtin/providers/aws/resource_aws_network_interface_attachment.go
@@ -1,0 +1,116 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsNetworkInterfaceAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsNetworkInterfaceAttachmentCreate,
+		Read:   resourceAwsNetworkInterfaceRead,
+		Delete: resourceAwsNetworkInterfaceAttachmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"device_index": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"instance_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"network_interface_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsNetworkInterfaceAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	device_index := d.Get("device_index").(int)
+	instance_id := d.Get("instance_id").(string)
+	network_interface_id := d.Get("network_interface_id").(string)
+
+	opts := &ec2.AttachNetworkInterfaceInput{
+		DeviceIndex:        aws.Int64(int64(device_index)),
+		InstanceId:         aws.String(instance_id),
+		NetworkInterfaceId: aws.String(network_interface_id),
+	}
+
+	log.Printf("[DEBUG] Attaching network interface (%s) to instance (%s)", network_interface_id, instance_id)
+	resp, err := conn.AttachNetworkInterface(opts)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			return fmt.Errorf("[WARN] Error attaching network interface (%s) to instance (%s), message: \"%s\", code: \"%s\"",
+				network_interface_id, instance_id, awsErr.Message(), awsErr.Code())
+		}
+		return err
+	}
+
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"false"},
+		Target:     []string{"true"},
+		Refresh:    networkInterfaceAttachmentRefreshFunc(conn, network_interface_id),
+		Timeout:    5 * time.Minute,
+		Delay:      10 * time.Second,
+		MinTimeout: 3 * time.Second,
+	}
+
+	_, err = stateConf.WaitForState()
+	if err != nil {
+		return fmt.Errorf(
+			"Error waiting for Volume (%s) to attach to Instance: %s, error: %s", network_interface_id, instance_id, err)
+	}
+
+	d.SetId(*resp.AttachmentId)
+	return resourceAwsNetworkInterfaceRead(d, meta)
+}
+
+func resourceAwsNetworkInterfaceAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	network_interface_id := d.Get("network_interface_id").(string)
+
+	detach_request := &ec2.DetachNetworkInterfaceInput{
+		AttachmentId: aws.String(d.Id()),
+		Force:        aws.Bool(true),
+	}
+
+	_, detach_err := conn.DetachNetworkInterface(detach_request)
+	if detach_err != nil {
+		if awsErr, _ := detach_err.(awserr.Error); awsErr.Code() != "InvalidAttachmentID.NotFound" {
+			return fmt.Errorf("Error detaching ENI: %s", detach_err)
+		}
+	}
+
+	log.Printf("[DEBUG] Waiting for ENI (%s) to become dettached", network_interface_id)
+	stateConf := &resource.StateChangeConf{
+		Pending: []string{"true"},
+		Target:  []string{"false"},
+		Refresh: networkInterfaceAttachmentRefreshFunc(conn, network_interface_id),
+		Timeout: 10 * time.Minute,
+	}
+
+	if _, err := stateConf.WaitForState(); err != nil {
+		return fmt.Errorf(
+			"Error waiting for ENI (%s) to become dettached: %s", network_interface_id, err)
+	}
+
+	return nil
+}

--- a/website/source/docs/providers/aws/r/network_interface_attachment.markdown
+++ b/website/source/docs/providers/aws/r/network_interface_attachment.markdown
@@ -1,0 +1,36 @@
+---
+layout: "aws"
+page_title: "AWS: aws_network_interface_attachment"
+sidebar_current: "docs-aws-resource-network-interface-attachment"
+description: |-
+  Attach an Elastic network interface (ENI) resource with EC2 instance.
+---
+
+# aws\_network\_interface\_attachment
+
+Attach an Elastic network interface (ENI) resource with EC2 instance.
+
+## Example Usage
+
+```
+resource "aws_network_interface_attachment" "test" {
+    instance_id = "${aws_instance.test.id}"
+	network_interface_id = "${aws_network_interface.test.id}"
+	device_index = 0
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `instance_id` - (Required) Instance ID to attach.
+* `network_interface_id` - (Required) ENI ID to attach.
+* `device_index` - (Required) Network interface index (int).
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `instance_id` - Instance ID.
+* `network_interface_id` - Network interface ID.


### PR DESCRIPTION
Add new _resource_aws_network_interface_attachment_ to attach ENI and instance.

Reason for that functionality is to easily attach ENI without the fear of ENI being destroyed when the associated instance gets destroyed. Useful when user has special ENI with associated EIPs that can't ever recycle.