### PR TITLE
Revert "provider/aws: Validate `effect` in aws_iam_policy_document data source"

### DIFF
--- a/builtin/providers/aws/data_source_aws_iam_policy_document.go
+++ b/builtin/providers/aws/data_source_aws_iam_policy_document.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"fmt"
-
 	"encoding/json"
 	"strings"
 
@@ -43,15 +41,6 @@ func dataSourceAwsIamPolicyDocument() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "Allow",
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								switch v.(string) {
-								case "Allow", "Deny":
-									return
-								default:
-									es = append(es, fmt.Errorf("%q must be either \"Allow\" or \"Deny\"", k))
-									return
-								}
-							},
 						},
 						"actions":        setOfString,
 						"not_actions":    setOfString,


### PR DESCRIPTION
Reverts hashicorp/terraform#10021

Removal of the Pr from 0.7-maint branch 