### PR TITLE
provider/azurerm: fix servicebus_topic max_size_in_megabytes for premium namespaces

### DIFF
--- a/builtin/providers/azurerm/resource_arm_servicebus_topic.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic.go
@@ -79,10 +79,9 @@ func resourceArmServiceBusTopic() *schema.Resource {
 			},
 
 			"max_size_in_megabytes": {
-				Type:         schema.TypeInt,
-				Optional:     true,
-				Computed:     true,
-				ValidateFunc: validateArmServiceBusTopicMaxSize,
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
 			},
 
 			"requires_duplicate_detection": {
@@ -200,14 +199,23 @@ func resourceArmServiceBusTopicRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("requires_duplicate_detection", props.RequiresDuplicateDetection)
 	d.Set("support_ordering", props.SupportOrdering)
 
-	// if partitioning is enabled then the max size returned by the API will be
-	// 16 times greater than the value set by the user
+	maxSize := int(*props.MaxSizeInMegabytes)
+
+	// if the topic is in a premium namespace and partitioning is enabled then the
+	// max size returned by the API will be 16 times greater than the value set
 	if *props.EnablePartitioning {
-		const partitionCount = 16
-		d.Set("max_size_in_megabytes", int(*props.MaxSizeInMegabytes/partitionCount))
-	} else {
-		d.Set("max_size_in_megabytes", int(*props.MaxSizeInMegabytes))
+		namespace, err := meta.(*ArmClient).serviceBusNamespacesClient.Get(resGroup, namespaceName)
+		if err != nil {
+			return err
+		}
+
+		if namespace.Sku.Name != servicebus.Premium {
+			const partitionCount = 16
+			maxSize = int(*props.MaxSizeInMegabytes / partitionCount)
+		}
 	}
+
+	d.Set("max_size_in_megabytes", maxSize)
 
 	return nil
 }
@@ -226,13 +234,4 @@ func resourceArmServiceBusTopicDelete(d *schema.ResourceData, meta interface{}) 
 	_, err = client.Delete(resGroup, namespaceName, name)
 
 	return err
-}
-
-func validateArmServiceBusTopicMaxSize(i interface{}, k string) (s []string, es []error) {
-	v := i.(int)
-	if v%1024 != 0 || v < 0 || v > 5120 {
-		es = append(es, fmt.Errorf("%q must be a multiple of 1024 up to and including 5120", k))
-	}
-
-	return
 }

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
@@ -58,10 +58,10 @@ func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMServiceBusTopic_enablePartitioning(t *testing.T) {
+func TestAccAzureRMServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 	ri := acctest.RandInt()
 	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
-	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enablePartitioning, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enablePartitioningStandard, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,6 +82,35 @@ func TestAccAzureRMServiceBusTopic_enablePartitioning(t *testing.T) {
 					// Ensure size is read back in it's original value and not the x16 value returned by Azure
 					resource.TestCheckResourceAttr(
 						"azurerm_servicebus_topic.test", "max_size_in_megabytes", "5120"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMServiceBusTopic_enablePartitioningPremium(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enablePartitioningPremium, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMServiceBusTopicExists("azurerm_servicebus_topic.test"),
+				),
+			},
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"azurerm_servicebus_topic.test", "enable_partitioning", "true"),
+					resource.TestCheckResourceAttr(
+						"azurerm_servicebus_topic.test", "max_size_in_megabytes", "81920"),
 				),
 			},
 		},
@@ -194,6 +223,27 @@ resource "azurerm_servicebus_topic" "test" {
 }
 `
 
+var testAccAzureRMServiceBusTopic_basicPremium = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+    name = "acctestservicebusnamespace-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "premium"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+    name = "acctestservicebustopic-%d"
+    location = "West US"
+    namespace_name = "${azurerm_servicebus_namespace.test.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`
+
 var testAccAzureRMServiceBusTopic_update = `
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
@@ -217,7 +267,7 @@ resource "azurerm_servicebus_topic" "test" {
 }
 `
 
-var testAccAzureRMServiceBusTopic_enablePartitioning = `
+var testAccAzureRMServiceBusTopic_enablePartitioningStandard = `
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -237,6 +287,29 @@ resource "azurerm_servicebus_topic" "test" {
     resource_group_name = "${azurerm_resource_group.test.name}"
     enable_partitioning = true
 	max_size_in_megabytes = 5120
+}
+`
+
+var testAccAzureRMServiceBusTopic_enablePartitioningPremium = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_servicebus_namespace" "test" {
+    name = "acctestservicebusnamespace-%d"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    sku = "premium"
+}
+
+resource "azurerm_servicebus_topic" "test" {
+    name = "acctestservicebustopic-%d"
+    location = "West US"
+    namespace_name = "${azurerm_servicebus_namespace.test.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    enable_partitioning = true
+	max_size_in_megabytes = 81920
 }
 `
 

--- a/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
@@ -85,9 +85,8 @@ The following arguments are supported:
     Changing this forces a new resource to be created.
 
 * `max_size_in_megabytes` - (Optional) Integer value which controls the size of
-    memory allocated for the topic. Supported values are multiples of 1024 up to
-    5120, if `enable_partitioning` is enabled then 16 partitions will be created
-    per GB, making the maximum possible topic size 81920 (5120 * 16).
+    memory allocated for the topic. For supported values see the "Queue/topic size"
+    section of [this document](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-quotas).
 
 * `requires_duplicate_detection` - (Optional) Boolean flag which controls whether
     the Topic requires duplicate detection. Defaults to false. Changing this forces


### PR DESCRIPTION
The value is only multiplied by the API for topics in non-premium namespaces

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMServiceBusTopic_enablePartitioning -timeout 120m
=== RUN   TestAccAzureRMServiceBusTopic_enablePartitioningStandard
--- PASS: TestAccAzureRMServiceBusTopic_enablePartitioningStandard (378.80s)
=== RUN   TestAccAzureRMServiceBusTopic_enablePartitioningPremium
--- PASS: TestAccAzureRMServiceBusTopic_enablePartitioningPremium (655.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	1033.874s
```