### PR TITLE
Test for minimum replacement set when using splat operator

### DIFF
--- a/terraform/test-fixtures/apply-multi-var-replacement/main.tf
+++ b/terraform/test-fixtures/apply-multi-var-replacement/main.tf
@@ -1,0 +1,11 @@
+resource "aws_instance" "foo" {
+	count = 2
+    id = "foo-${count.index}"
+	foo = "ok"
+}
+
+resource "aws_instance" "bar" {
+	count = 2
+    id = "bar-${count.index}"
+    foo = "bar-${element(aws_instance.foo.*.id, count.index)}"
+}


### PR DESCRIPTION
See if we can reduce the replaced resources when a singe tainted node is referenced via the splat operator. 