### PR TITLE
provider/aws: Added SQS FIFO queues

### DIFF
--- a/builtin/providers/aws/import_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/import_aws_sqs_queue_test.go
@@ -18,14 +18,40 @@ func TestAccAWSSQSQueue_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSSQSConfigWithDefaults(queueName),
 			},
-
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "fifo_queue", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_importFifo(t *testing.T) {
+	resourceName := "aws_sqs_queue.queue"
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSFifoConfigWithDefaults(queueName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "fifo_queue", "true"),
+				),
 			},
 		},
 	})

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/jen20/awspolicyequivalence"
+	"regexp"
 )
 
 func TestAccAWSSQSQueue_basic(t *testing.T) {
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -43,8 +44,8 @@ func TestAccAWSSQSQueue_basic(t *testing.T) {
 }
 
 func TestAccAWSSQSQueue_policy(t *testing.T) {
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
-	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(5))
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
+	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
 
 	expectedPolicyText := fmt.Sprintf(
 		`{"Version": "2012-10-17","Id": "sqspolicy","Statement":[{"Sid": "Stmt1451501026839","Effect": "Allow","Principal":"*","Action":"sqs:SendMessage","Resource":"arn:aws:sqs:us-west-2:470663696735:%s","Condition":{"ArnEquals":{"aws:SourceArn":"arn:aws:sns:us-west-2:470663696735:%s"}}}]}`,
@@ -72,7 +73,7 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSQSConfigWithRedrive(acctest.RandStringFromCharSet(5, acctest.CharSetAlpha)),
+				Config: testAccAWSSQSConfigWithRedrive(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithDefaults("aws_sqs_queue.my_dead_letter_queue"),
 				),
@@ -83,8 +84,8 @@ func TestAccAWSSQSQueue_redrivePolicy(t *testing.T) {
 
 // Tests formatting and compacting of Policy, Redrive json
 func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
-	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
-	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(5))
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(10))
+	topicName := fmt.Sprintf("sns-topic-%s", acctest.RandString(10))
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -95,6 +96,70 @@ func TestAccAWSSQSQueue_Policybasic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSQSExistsWithOverrides("aws_sqs_queue.test-email-events"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_FIFO(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigWithFIFO(acctest.RandString(10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExists("aws_sqs_queue.queue"),
+					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "fifo_queue", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_FIFOExpectNameError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSSQSConfigWithFIFOExpectError(acctest.RandString(10)),
+				ExpectError: regexp.MustCompile(`Error validating the FIFO queue name`),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigWithFIFOContentBasedDeduplication(acctest.RandString(10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExists("aws_sqs_queue.queue"),
+					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "fifo_queue", "true"),
+					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "content_based_deduplication", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccExpectContentBasedDeduplicationError(acctest.RandString(10)),
+				ExpectError: regexp.MustCompile(`Content based deduplication can only be set with FIFO queues`),
 			},
 		},
 	})
@@ -163,6 +228,21 @@ func testAccCheckAWSQSHasPolicy(n string, expectedPolicyText string) resource.Te
 		if !equivalent {
 			return fmt.Errorf("Non-equivalent policy error:\n\nexpected: %s\n\n     got: %s\n",
 				expectedPolicyText, actualPolicyText)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSSQSExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Queue URL specified!")
 		}
 
 		return nil
@@ -277,6 +357,15 @@ resource "aws_sqs_queue" "queue" {
 `, r)
 }
 
+func testAccAWSSQSFifoConfigWithDefaults(r string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+    name = "%s.fifo"
+    fifo_queue = true
+}
+`, r)
+}
+
 func testAccAWSSQSConfigWithOverrides(r string) string {
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "queue" {
@@ -361,4 +450,41 @@ resource "aws_sns_topic_subscription" "test_queue_target" {
   endpoint  = "${aws_sqs_queue.test-email-events.arn}"
 }
 `, topic, queue)
+}
+
+func testAccAWSSQSConfigWithFIFO(queue string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+  name       = "%s.fifo"
+  fifo_queue = true
+}
+`, queue)
+}
+
+func testAccAWSSQSConfigWithFIFOContentBasedDeduplication(queue string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+  name                        = "%s.fifo"
+  fifo_queue                  = true
+  content_based_deduplication = true
+}
+`, queue)
+}
+
+func testAccAWSSQSConfigWithFIFOExpectError(queue string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+  name       = "%s"
+  fifo_queue = true
+}
+`, queue)
+}
+
+func testAccExpectContentBasedDeduplicationError(queue string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+  name                        = "%s"
+  content_based_deduplication = true
+}
+`, queue)
 }

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -499,3 +499,37 @@ func validateApiGatewayIntegrationType(v interface{}, k string) (ws []string, er
 	}
 	return
 }
+
+func validateSQSQueueName(v interface{}, k string) (errors []error) {
+	value := v.(string)
+	if len(value) > 80 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
+	}
+
+	if !regexp.MustCompile(`^[0-9A-Za-z-_]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("only alphanumeric characters and hyphens allowed in %q", k))
+	}
+	return
+}
+
+func validateSQSFifoQueueName(v interface{}, k string) (errors []error) {
+	value := v.(string)
+
+	if len(value) > 80 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 80 characters", k))
+	}
+
+	if !regexp.MustCompile(`^[0-9A-Za-z-_.]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("only alphanumeric characters and hyphens allowed in %q", k))
+	}
+
+	if regexp.MustCompile(`^[^a-zA-Z0-9-_]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("FIFO queue name must start with one of these characters [a-zA-Z0-9-_]: %v", value))
+	}
+
+	if !regexp.MustCompile(`\.fifo$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("FIFO queue name should ends with \".fifo\": %v", value))
+	}
+
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -684,6 +685,76 @@ func TestValidateApiGatewayIntegrationType(t *testing.T) {
 		_, errors := validateApiGatewayIntegrationType(tc.Value, "types")
 		if len(errors) != tc.ErrCount {
 			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
+		}
+	}
+}
+
+func TestValidateSQSQueueName(t *testing.T) {
+	validNames := []string{
+		"valid-name",
+		"valid02-name",
+		"Valid-Name1",
+		"_",
+		"-",
+		strings.Repeat("W", 80),
+	}
+	for _, v := range validNames {
+		if errors := validateSQSQueueName(v, "name"); len(errors) > 0 {
+			t.Fatalf("%q should be a valid SQS queue Name", v)
+		}
+	}
+
+	invalidNames := []string{
+		"Here is a name with: colon",
+		"another * invalid name",
+		"also $ invalid",
+		"This . is also %% invalid@!)+(",
+		"*",
+		"",
+		" ",
+		".",
+		strings.Repeat("W", 81), // length > 80
+	}
+	for _, v := range invalidNames {
+		if errors := validateSQSQueueName(v, "name"); len(errors) == 0 {
+			t.Fatalf("%q should be an invalid SQS queue Name", v)
+		}
+	}
+}
+
+func TestValidateSQSFifoQueueName(t *testing.T) {
+	validNames := []string{
+		"valid-name.fifo",
+		"valid02-name.fifo",
+		"Valid-Name1.fifo",
+		"_.fifo",
+		"a.fifo",
+		"A.fifo",
+		"9.fifo",
+		"-.fifo",
+		fmt.Sprintf("%s.fifo", strings.Repeat("W", 75)),
+	}
+	for _, v := range validNames {
+		if errors := validateSQSFifoQueueName(v, "name"); len(errors) > 0 {
+			t.Fatalf("%q should be a valid SQS FIFO queue Name: %v", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"Here is a name with: colon",
+		"another * invalid name",
+		"also $ invalid",
+		"This . is also %% invalid@!)+(",
+		".fifo",
+		"*",
+		"",
+		" ",
+		".",
+		strings.Repeat("W", 81), // length > 80
+	}
+	for _, v := range invalidNames {
+		if errors := validateSQSFifoQueueName(v, "name"); len(errors) == 0 {
+			t.Fatalf("%q should be an invalid SQS FIFO queue Name: %v", v, errors)
 		}
 	}
 }

--- a/website/source/docs/providers/aws/r/sqs_queue.html.markdown
+++ b/website/source/docs/providers/aws/r/sqs_queue.html.markdown
@@ -21,6 +21,16 @@ resource "aws_sqs_queue" "terraform_queue" {
 }
 ```
 
+## FIFO queue
+
+```
+resource "aws_sqs_queue" "terraform_queue" {
+  name = "terraform-example-queue.fifo"
+  fifo_queue = true
+  content_based_deduplication = true
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -32,7 +42,9 @@ The following arguments are supported:
 * `delay_seconds` - (Optional) The time in seconds that the delivery of all messages in the queue will be delayed. An integer from 0 to 900 (15 minutes). The default for this attribute is 0 seconds.
 * `receive_wait_time_seconds` - (Optional) The time for which a ReceiveMessage call will wait for a message to arrive (long polling) before returning. An integer from 0 to 20 (seconds). The default for this attribute is 0, meaning that the call will return immediately.
 * `policy` - (Optional) The JSON policy for the SQS queue
-* `redrive_policy` - (Optional) The JSON policy to set up the Dead Letter Queue, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html). **Note:** when specifying `maxReceiveCount`, you must specify it as an integer (`5`), and not a string (`"5"`). 
+* `redrive_policy` - (Optional) The JSON policy to set up the Dead Letter Queue, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html). **Note:** when specifying `maxReceiveCount`, you must specify it as an integer (`5`), and not a string (`"5"`).
+* `fifo_queue` - (Optional) Boolean designating a FIFO queue. If not set, it defaults to `false` making it standard.
+* `content_based_deduplication` - (Optional) Enables content-based deduplication for FIFO queues. For more information, see the [related documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
 
 ## Attributes Reference
 
@@ -43,7 +55,7 @@ The following attributes are exported:
 
 ## Import
 
-SQS Queues can be imported using the `queue url`, e.g. 
+SQS Queues can be imported using the `queue url`, e.g.
 
 ```
 $ terraform import aws_sqs_queue.public_queue https://queue.amazonaws.com/80398EXAMPLE/MyQueue


### PR DESCRIPTION
#### Description
This adds SQS FIFO queues.
When specifying a queue as FIFO, the attribute is sent to AWS and retrieved afterwards. However,
when setting a standard queue (non-fifo), the `FifoQueue` attribute is not  sent back by AWS, thus impacting some stuff. 

This forced me to enforce the setting of `fifo_queue` & `content_based_deduplication` after reading.

The final point of this work would be to find a way to handle regions not yet having SQS queues. 
For what I tested, AWS is simply ignoring the `FifoQueue` parameter. 

The remaining question would be about: do we want to manage this case by adding a guard somewhere?
Note: no errors are returned in this case.

#### Issues
Closes https://github.com/hashicorp/terraform/issues/10503

#### Acceptance tests
```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSQSQueue_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/11 01:10:33 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSQSQueue_ -timeout 120m
=== RUN   TestAccAWSSQSQueue_importBasic
--- PASS: TestAccAWSSQSQueue_importBasic (29.83s)
=== RUN   TestAccAWSSQSQueue_importFifo
--- PASS: TestAccAWSSQSQueue_importFifo (26.78s)
=== RUN   TestAccAWSSQSQueue_basic
--- PASS: TestAccAWSSQSQueue_basic (57.37s)
=== RUN   TestAccAWSSQSQueue_policy
--- PASS: TestAccAWSSQSQueue_policy (30.97s)
=== RUN   TestAccAWSSQSQueue_redrivePolicy
--- PASS: TestAccAWSSQSQueue_redrivePolicy (23.52s)
=== RUN   TestAccAWSSQSQueue_Policybasic
--- PASS: TestAccAWSSQSQueue_Policybasic (27.03s)
=== RUN   TestAccAWSSQSQueue_FIFO
--- PASS: TestAccAWSSQSQueue_FIFO (16.25s)
=== RUN   TestAccAWSSQSQueue_FIFOExpectNameError
--- PASS: TestAccAWSSQSQueue_FIFOExpectNameError (5.95s)
=== RUN   TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication
--- PASS: TestAccAWSSQSQueue_FIFOWithContentBasedDeduplication (15.87s)
=== RUN   TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError
--- PASS: TestAccAWSSQSQueue_ExpectContentBasedDeduplicationError (6.19s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	239.801s
```