### PR TITLE
Forward SIGTERM and handle that as an interrupt

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -223,7 +223,8 @@ func makeShutdownCh() <-chan struct{} {
 	resultCh := make(chan struct{})
 
 	signalCh := make(chan os.Signal, 4)
-	signal.Notify(signalCh, interruptSignals...)
+	signal.Notify(signalCh, ignoreSignals...)
+	signal.Notify(signalCh, forwardSignals...)
 	go func() {
 		for {
 			<-signalCh

--- a/main.go
+++ b/main.go
@@ -60,7 +60,8 @@ func realMain() int {
 		wrapConfig.Handler = panicHandler(logTempFile)
 		wrapConfig.Writer = io.MultiWriter(logTempFile, logWriter)
 		wrapConfig.Stdout = outW
-		wrapConfig.IgnoreSignals = interruptSignals
+		wrapConfig.IgnoreSignals = ignoreSignals
+		wrapConfig.ForwardSignals = forwardSignals
 		exitStatus, err := panicwrap.Wrap(&wrapConfig)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Couldn't start Terraform: %s", err)

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -7,7 +7,5 @@ import (
 	"syscall"
 )
 
-var interruptSignals []os.Signal = []os.Signal{
-	os.Interrupt,
-	syscall.SIGTERM,
-}
+var ignoreSignals = []os.Signal{os.Interrupt}
+var forwardSignals = []os.Signal{syscall.SIGTERM}

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -6,4 +6,5 @@ import (
 	"os"
 )
 
-var interruptSignals []os.Signal = []os.Signal{os.Interrupt}
+var ignoreSignals = []os.Signal{os.Interrupt}
+var forwardSignals []os.Signal

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2079,10 +2079,10 @@
 			"revision": "314aad379a39f6ad5bcca278e6757d9abbb3a52e"
 		},
 		{
-			"checksumSHA1": "kTntIB9SdU1NsCqKwDkUr99qaj0=",
+			"checksumSHA1": "AykrbOR+O+Yp6DQHfwe31+iyFi0=",
 			"path": "github.com/mitchellh/panicwrap",
-			"revision": "fde185d0dfb5ecac6e6b201e8855da798ebcd76f",
-			"revisionTime": "2016-11-21T18:34:54Z"
+			"revision": "ba9e1a65e0f7975f055d50a2c0201c50d941c24c",
+			"revisionTime": "2016-12-08T17:03:02Z"
 		},
 		{
 			"path": "github.com/mitchellh/prefixedio",


### PR DESCRIPTION
SIGTERM, unlike SIGINT, isn't sent to the process group. It is only sent to the parent process. So we need to first manually forward this from panicwrap and then second handle it as part of our interrupt handling.