### PR TITLE
Add support for AWS CA Central 1 Region

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -309,6 +309,7 @@ func (c *Config) ValidateRegion() error {
 		"ap-south-1",
 		"ap-southeast-1",
 		"ap-southeast-2",
+		"ca-central-1",
 		"cn-north-1",
 		"eu-central-1",
 		"eu-west-1",

--- a/builtin/providers/aws/data_source_aws_elb_service_account.go
+++ b/builtin/providers/aws/data_source_aws_elb_service_account.go
@@ -13,6 +13,7 @@ var elbAccountIdPerRegionMap = map[string]string{
 	"ap-south-1":     "718504428378",
 	"ap-southeast-1": "114774131450",
 	"ap-southeast-2": "783225319266",
+	"ca-central-1":   "985666609251",
 	"cn-north-1":     "638102146993",
 	"eu-central-1":   "054676820928",
 	"eu-west-1":      "156460612806",

--- a/builtin/providers/aws/data_source_aws_redshift_service_account.go
+++ b/builtin/providers/aws/data_source_aws_redshift_service_account.go
@@ -17,6 +17,7 @@ var redshiftServiceAccountPerRegionMap = map[string]string{
 	"ap-southeast-1": "361669875840",
 	"ap-southeast-2": "762762565011",
 	"ap-northeast-1": "404641285394",
+	"ca-central-1":   "907379612154",
 	"eu-central-1":   "053454850223",
 	"eu-west-1":      "210876761215",
 }

--- a/builtin/providers/aws/hosted_zones.go
+++ b/builtin/providers/aws/hosted_zones.go
@@ -15,6 +15,7 @@ var hostedZoneIDsMap = map[string]string{
 	"ap-southeast-2": "Z1WCIGYICN2BYD",
 	"ap-northeast-1": "Z2M4EHUR26P7ZW",
 	"ap-northeast-2": "Z3W03O7B5YMIYP",
+	"ca-central-1":   "Z1QDHH18159H29",
 	"sa-east-1":      "Z7KQH4QJS55SO",
 	"us-gov-west-1":  "Z31GFT0UA1I2HV",
 }


### PR DESCRIPTION
New region `ca-central-1`, and [blog post](https://aws.amazon.com/about-aws/whats-new/2016/12/announcing-the-aws-canada-central-region/).

Closes https://github.com/hashicorp/terraform/issues/10617