### PR TITLE
provider/aws: Add aws_snapshot_create_volume_permission resource (contd. #9891)

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -351,6 +351,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_spot_fleet_request":                       resourceAwsSpotFleetRequest(),
 			"aws_sqs_queue":                                resourceAwsSqsQueue(),
 			"aws_sqs_queue_policy":                         resourceAwsSqsQueuePolicy(),
+			"aws_snapshot_create_volume_permission":        resourceAwsSnapshotCreateVolumePermission(),
 			"aws_sns_topic":                                resourceAwsSnsTopic(),
 			"aws_sns_topic_policy":                         resourceAwsSnsTopicPolicy(),
 			"aws_sns_topic_subscription":                   resourceAwsSnsTopicSubscription(),

--- a/builtin/providers/aws/resource_aws_snapshot_create_volume_permission.go
+++ b/builtin/providers/aws/resource_aws_snapshot_create_volume_permission.go
@@ -1,0 +1,104 @@
+package aws
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSnapshotCreateVolumePermission() *schema.Resource {
+	return &schema.Resource{
+		Exists: resourceAwsSnapshotCreateVolumePermissionExists,
+		Create: resourceAwsSnapshotCreateVolumePermissionCreate,
+		Read:   resourceAwsSnapshotCreateVolumePermissionRead,
+		Delete: resourceAwsSnapshotCreateVolumePermissionDelete,
+
+		Schema: map[string]*schema.Schema{
+			"snapshot_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"account_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSnapshotCreateVolumePermissionExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*AWSClient).ec2conn
+
+	snapshot_id := d.Get("snapshot_id").(string)
+	account_id := d.Get("account_id").(string)
+	return hasCreateVolumePermission(conn, snapshot_id, account_id)
+}
+
+func resourceAwsSnapshotCreateVolumePermissionCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	snapshot_id := d.Get("snapshot_id").(string)
+	account_id := d.Get("account_id").(string)
+
+	_, err := conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
+		SnapshotId: aws.String(snapshot_id),
+		Attribute:  aws.String("createVolumePermission"),
+		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
+			Add: []*ec2.CreateVolumePermission{
+				&ec2.CreateVolumePermission{UserId: aws.String(account_id)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error creating snapshot volume permission: %s", err)
+	}
+
+	d.SetId(fmt.Sprintf("%s-%s", snapshot_id, account_id))
+	return nil
+}
+
+func resourceAwsSnapshotCreateVolumePermissionRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsSnapshotCreateVolumePermissionDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	snapshot_id := d.Get("snapshot_id").(string)
+	account_id := d.Get("account_id").(string)
+
+	_, err := conn.ModifySnapshotAttribute(&ec2.ModifySnapshotAttributeInput{
+		SnapshotId: aws.String(snapshot_id),
+		Attribute:  aws.String("createVolumePermission"),
+		CreateVolumePermission: &ec2.CreateVolumePermissionModifications{
+			Remove: []*ec2.CreateVolumePermission{
+				&ec2.CreateVolumePermission{UserId: aws.String(account_id)},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("error removing snapshot volume permission: %s", err)
+	}
+
+	return nil
+}
+
+func hasCreateVolumePermission(conn *ec2.EC2, snapshot_id string, account_id string) (bool, error) {
+	attrs, err := conn.DescribeSnapshotAttribute(&ec2.DescribeSnapshotAttributeInput{
+		SnapshotId: aws.String(snapshot_id),
+		Attribute:  aws.String("createVolumePermission"),
+	})
+	if err != nil {
+		return false, err
+	}
+
+	for _, vp := range attrs.CreateVolumePermissions {
+		if *vp.UserId == account_id {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/builtin/providers/aws/resource_aws_snapshot_create_volume_permission_test.go
+++ b/builtin/providers/aws/resource_aws_snapshot_create_volume_permission_test.go
@@ -1,0 +1,88 @@
+package aws
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSSnapshotCreateVolumePermission_Basic(t *testing.T) {
+	snapshot_id := ""
+	account_id := os.Getenv("AWS_ACCOUNT_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if os.Getenv("AWS_ACCOUNT_ID") == "" {
+				t.Fatal("AWS_ACCOUNT_ID must be set")
+			}
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Scaffold everything
+			resource.TestStep{
+				Config: testAccAWSSnapshotCreateVolumePermissionConfig(account_id, true),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckResourceGetAttr("aws_ami_copy.test", "block_device_mappings.0.ebs.snapshot_id", &snapshot_id),
+					testAccAWSSnapshotCreateVolumePermissionExists(account_id, &snapshot_id),
+				),
+			},
+			// Drop just create volume permission to test destruction
+			resource.TestStep{
+				Config: testAccAWSSnapshotCreateVolumePermissionConfig(account_id, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccAWSSnapshotCreateVolumePermissionDestroyed(account_id, &snapshot_id),
+				),
+			},
+		},
+	})
+}
+
+func testAccAWSSnapshotCreateVolumePermissionExists(account_id string, snapshot_id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		if has, err := hasCreateVolumePermission(conn, *snapshot_id, account_id); err != nil {
+			return err
+		} else if !has {
+			return fmt.Errorf("create volume permission does not exist for '%s' on '%s'", account_id, *snapshot_id)
+		}
+		return nil
+	}
+}
+
+func testAccAWSSnapshotCreateVolumePermissionDestroyed(account_id string, snapshot_id *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+		if has, err := hasCreateVolumePermission(conn, *snapshot_id, account_id); err != nil {
+			return err
+		} else if has {
+			return fmt.Errorf("create volume permission still exists for '%s' on '%s'", account_id, *snapshot_id)
+		}
+		return nil
+	}
+}
+
+func testAccAWSSnapshotCreateVolumePermissionConfig(account_id string, includeCreateVolumePermission bool) string {
+	base := `
+resource "aws_ami_copy" "test" {
+  name = "create-volume-permission-test"
+  description = "Create Volume Permission Test Copy"
+  source_ami_id = "ami-7172b611"
+  source_ami_region = "us-west-2"
+}
+`
+
+	if !includeCreateVolumePermission {
+		return base
+	}
+
+	return base + fmt.Sprintf(`
+resource "aws_snapshot_create_volume_permission" "self-test" {
+  snapshot_id   = "${lookup(lookup(element(aws_ami_copy.test.block_device_mappings, 0), "ebs"), "snapshot_id")}"
+  account_id = "%s"
+}
+`, account_id)
+}

--- a/website/source/docs/providers/aws/r/snapshot_create_volume_permission.html.markdown
+++ b/website/source/docs/providers/aws/r/snapshot_create_volume_permission.html.markdown
@@ -1,0 +1,42 @@
+---
+layout: "aws"
+page_title: "AWS: aws_snapshot_create_volume_permission"
+sidebar_current: "docs-aws-resource-snapshot-create-volume-permission"
+description: |-
+  Adds create volume permission to an EBS Snapshot
+---
+
+# aws\_snapshot\_create\_volume\_permission
+
+Adds permission to create volumes off of a given EBS Snapshot.
+
+## Example Usage
+
+```
+resource "aws_snapshot_create_volume_permission" "example_perm" {
+  snapshot_id = "${aws_ebs_snapshot.example_snapshot.id}"
+  account_id  = "12345678"
+}
+
+resource "aws_ebs_volume" "example" {
+  availability_zone = "us-west-2a"
+  size              = 40
+}
+
+resource "aws_ebs_snapshot" "example_snapshot" {
+  volume_id = "${aws_ebs_volume.example.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `snapshot_id` - (required) A snapshot ID
+  * `account_id` - (required) An AWS Account ID to add create volume permissions
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - A combination of "`snapshot_id`-`account_id`".

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -266,7 +266,7 @@
                 </li>
 
 
-                <li<%= sidebar_current(/^docs-aws-resource-(alb|ami|app|autoscaling|ebs|elb|eip|instance|launch|lb|proxy|spot|volume|placement|key-pair|elb_attachment|load-balancer)/) %>>
+                <li<%= sidebar_current(/^docs-aws-resource-(alb|ami|app|autoscaling|ebs|elb|eip|instance|launch|lb|proxy|snapshot|spot|volume|placement|key-pair|elb_attachment|load-balancer)/) %>>
                     <a href="#">EC2 Resources</a>
                     <ul class="nav nav-visible">
 
@@ -328,6 +328,10 @@
 
                         <li<%= sidebar_current("docs-aws-resource-autoscaling-schedule") %>>
                           <a href="/docs/providers/aws/r/autoscaling_schedule.html">aws_autoscaling_schedule</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-snapshot-create-volume-permission") %>>
+                          <a href="/docs/providers/aws/r/snapshot_create_volume_permission.html">aws_snapshot_create_volume_permission</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-ebs-snapshot") %>>


### PR DESCRIPTION
This is a continuation of #9891 , adding a new resource `aws_snapshot_create_volume_permission`. This PR just adds to #9891 by refactoring the test. @jeremy-asher please take a look!

Adds:

- [x] New test
- [x] Docs