### PR TITLE
provider/aws: Add support for AWS Lightsail Domain

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -285,6 +285,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lambda_alias":                             resourceAwsLambdaAlias(),
 			"aws_lambda_permission":                        resourceAwsLambdaPermission(),
 			"aws_launch_configuration":                     resourceAwsLaunchConfiguration(),
+			"aws_lightsail_domain":                         resourceAwsLightsailDomain(),
 			"aws_lightsail_instance":                       resourceAwsLightsailInstance(),
 			"aws_lightsail_key_pair":                       resourceAwsLightsailKeyPair(),
 			"aws_lb_cookie_stickiness_policy":              resourceAwsLBCookieStickinessPolicy(),

--- a/builtin/providers/aws/resource_aws_lightsail_domain.go
+++ b/builtin/providers/aws/resource_aws_lightsail_domain.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLightsailDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLightsailDomainCreate,
+		Read:   resourceAwsLightsailDomainRead,
+		Delete: resourceAwsLightsailDomainDelete,
+
+		Schema: map[string]*schema.Schema{
+			"domain_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsLightsailDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+	_, err := conn.CreateDomain(&lightsail.CreateDomainInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	})
+
+	if err != nil {
+		return err
+	}
+
+	d.SetId(d.Get("domain_name").(string))
+
+	return resourceAwsLightsailDomainRead(d, meta)
+}
+
+func resourceAwsLightsailDomainRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+	resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+		DomainName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				log.Printf("[WARN] Lightsail Domain (%s) not found, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+			return err
+		}
+		return err
+	}
+
+	d.Set("arn", resp.Domain.Arn)
+	return nil
+}
+
+func resourceAwsLightsailDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+	_, err := conn.DeleteDomain(&lightsail.DeleteDomainInput{
+		DomainName: aws.String(d.Id()),
+	})
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_lightsail_domain_test.go
+++ b/builtin/providers/aws/resource_aws_lightsail_domain_test.go
@@ -1,0 +1,139 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSLightsailDomain_basic(t *testing.T) {
+	var domain lightsail.Domain
+	lightsailDomainName := fmt.Sprintf("tf-test-lightsail-%s.com", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailDomainConfig_basic(lightsailDomainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailDomainExists("aws_lightsail_domain.domain_test", &domain),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLightsailDomain_disappears(t *testing.T) {
+	var domain lightsail.Domain
+	lightsailDomainName := fmt.Sprintf("tf-test-lightsail-%s.com", acctest.RandString(5))
+
+	domainDestroy := func(*terraform.State) error {
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+		_, err := conn.DeleteDomain(&lightsail.DeleteDomainInput{
+			DomainName: aws.String(lightsailDomainName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting Lightsail Domain in disapear test")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailDomainDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailDomainConfig_basic(lightsailDomainName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailDomainExists("aws_lightsail_domain.domain_test", &domain),
+					domainDestroy,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSLightsailDomainExists(n string, domain *lightsail.Domain) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Lightsail Domain ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.Domain == nil {
+			return fmt.Errorf("Domain (%s) not found", rs.Primary.ID)
+		}
+		*domain = *resp.Domain
+		return nil
+	}
+}
+
+func testAccCheckAWSLightsailDomainDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_domain" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetDomain(&lightsail.GetDomainInput{
+			DomainName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if resp.Domain != nil {
+				return fmt.Errorf("Lightsail Domain %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				return nil
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSLightsailDomainConfig_basic(lightsailDomainName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+resource "aws_lightsail_domain" "domain_test" {
+  domain_name = "%s"
+}
+`, lightsailDomainName)
+}

--- a/website/source/docs/providers/aws/r/lightsail_domain.html.markdown
+++ b/website/source/docs/providers/aws/r/lightsail_domain.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lightsail_domain"
+sidebar_current: "docs-aws-resource-lightsail-domain"
+description: |-
+  Provides an Lightsail Domain 
+---
+
+# aws\_lightsail\_domain
+
+Creates a domain resource for the specified domain (e.g., example.com).
+You cannot register a new domain name using Lightsail. You must register
+a domain name using Amazon Route 53 or another domain name registrar. 
+If you have already registered your domain, you can enter its name in 
+this parameter to manage the DNS records for that domain. 
+
+~> **Note:** Lightsail is currently only supported in `us-east-1` region.
+
+## Example Usage, creating a new domain
+
+```
+resource "aws_lightsail_domain" "domain_test" {
+  domain_name = "mydomain.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain_name` - (Required) The name of the Lightsail domain to manage
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `id` - The name used for this domain
+* `arn` - The ARN of the Lightsail domain

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -697,6 +697,10 @@
                     <a href="#">Lightsail Resources</a>
                     <ul class="nav nav-visible">
 
+                        <li<%= sidebar_current("docs-aws-resource-lightsail-domain") %>>
+                          <a href="/docs/providers/aws/r/lightsail_domain.html">aws_lightsail_domain</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-lightsail-instance") %>>
                             <a href="/docs/providers/aws/r/lightsail_instance.html">aws_lightsail_instance</a>
                         </li>


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLightsailDomain_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/09 15:19:58 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSLightsailDomain_ -timeout 120m
=== RUN   TestAccAWSLightsailDomain_basic
--- PASS: TestAccAWSLightsailDomain_basic (16.28s)
=== RUN   TestAccAWSLightsailDomain_disappears
--- PASS: TestAccAWSLightsailDomain_disappears (12.71s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws29.015s
```