### PR TITLE
command/plan: user friendly error if plan file given to plan command

### DIFF
--- a/command/plan.go
+++ b/command/plan.go
@@ -61,7 +61,7 @@ func (c *PlanCommand) Run(args []string) int {
 	// This is going to keep track of shadow errors
 	var shadowErr error
 
-	ctx, _, err := c.Context(contextOpts{
+	ctx, planned, err := c.Context(contextOpts{
 		Destroy:     destroy,
 		Path:        path,
 		StatePath:   c.Meta.statePath,
@@ -69,6 +69,13 @@ func (c *PlanCommand) Run(args []string) int {
 	})
 	if err != nil {
 		c.Ui.Error(err.Error())
+		return 1
+	}
+	if planned {
+		c.Ui.Error(
+			"The plan command cannot be called with a saved plan file.\n\n" +
+				"The plan command expects a configuration directory as an argument.",
+		)
 		return 1
 	}
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -72,11 +72,15 @@ func (c *PlanCommand) Run(args []string) int {
 		return 1
 	}
 	if planned {
-		c.Ui.Error(
-			"The plan command cannot be called with a saved plan file.\n\n" +
-				"The plan command expects a configuration directory as an argument.",
-		)
-		return 1
+		c.Ui.Output(c.Colorize().Color(
+			"[reset][bold][yellow]" +
+				"The plan command received a saved plan file as input. This command\n" +
+				"will output the saved plan. This will not modify the already-existing\n" +
+				"plan. If you wish to generate a new plan, please pass in a configuration\n" +
+				"directory as an argument.\n\n"))
+
+		// Disable refreshing no matter what since we only want to show the plan
+		refresh = false
 	}
 
 	err = terraform.SetDebugInfo(DefaultDataDir)
@@ -178,7 +182,7 @@ func (c *PlanCommand) Run(args []string) int {
 
 func (c *PlanCommand) Help() string {
 	helpText := `
-Usage: terraform plan [options] [dir]
+Usage: terraform plan [options] [DIR-OR-PLAN]
 
   Generates an execution plan for Terraform.
 
@@ -186,6 +190,9 @@ Usage: terraform plan [options] [dir]
   sense for what Terraform will do. Optionally, the plan can be saved to
   a Terraform plan file, and apply can take this plan file to execute
   this plan exactly.
+
+  If a saved plan is passed as an argument, this command will output
+  the saved plan contents. It will not modify the given plan.
 
 Options:
 

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -37,6 +37,29 @@ func TestPlan(t *testing.T) {
 	}
 }
 
+func TestPlan_plan(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
+	planPath := testPlanFile(t, &terraform.Plan{
+		Module: testModule(t, "apply"),
+	})
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &PlanCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{planPath}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+}
+
 func TestPlan_destroy(t *testing.T) {
 	originalState := &terraform.State{
 		Modules: []*terraform.ModuleState{

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -55,8 +55,12 @@ func TestPlan_plan(t *testing.T) {
 	}
 
 	args := []string{planPath}
-	if code := c.Run(args); code != 1 {
+	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	if p.RefreshCalled {
+		t.Fatal("refresh should not be called")
 	}
 }
 

--- a/website/source/docs/commands/plan.html.markdown
+++ b/website/source/docs/commands/plan.html.markdown
@@ -16,10 +16,15 @@ to `terraform apply` to ensure only the pre-planned actions are executed.
 
 ## Usage
 
-Usage: `terraform plan [options] [dir]`
+Usage: `terraform plan [options] [dir-or-plan]`
 
 By default, `plan` requires no flags and looks in the current directory
 for the configuration and state file to refresh.
+
+If the command is given an existing saved plan as an argument, the
+command will output the contents of the saved plan. In this scenario,
+the `plan` command will not modify the given plan. This can be used to
+inspect a planfile.
 
 The command-line flags are all optional. The list of available flags are:
 


### PR DESCRIPTION
Fixes #10627 

This detects if a plan file was given to the `plan` command and gives an error. This didn't have any detrimental effect in practice but was just a weird case where we should be more explicit about what is happening. In practice it is a noop so we just show an error saying it isn't allowed since there is no practical reason to do it. 