### PR TITLE
config: allow names to start with numbers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ import (
 
 // NameRegexp is the regular expression that all names (modules, providers,
 // resources, etc.) must follow.
-var NameRegexp = regexp.MustCompile(`(?i)\A[A-Z_][A-Z0-9\-\_]*\z`)
+var NameRegexp = regexp.MustCompile(`(?i)\A[A-Z0-9_][A-Z0-9\-\_]*\z`)
 
 // Config is the configuration that comes from loading a collection
 // of Terraform templates.

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -447,20 +447,6 @@ func TestLoadFile_variables(t *testing.T) {
 	}
 }
 
-func TestLoadFile_varInt(t *testing.T) {
-	_, err := LoadFile(filepath.Join(fixtureDir, "var_int.tf"))
-	if err == nil {
-		t.Fatal("should have error")
-	}
-}
-
-func TestLoadFile_varIntBare(t *testing.T) {
-	_, err := LoadFile(filepath.Join(fixtureDir, "var_int_bare.tf"))
-	if err == nil {
-		t.Fatal("should have error")
-	}
-}
-
 func TestLoadDir_basic(t *testing.T) {
 	dir := filepath.Join(fixtureDir, "dir-basic")
 	c, err := LoadDir(dir)

--- a/vendor/github.com/hashicorp/hil/parser/parser.go
+++ b/vendor/github.com/hashicorp/hil/parser/parser.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"strconv"
-	"strings"
 	"unicode/utf8"
 
 	"github.com/hashicorp/hil/ast"
@@ -483,26 +482,8 @@ func (p *parser) ParseScopeInteraction() (ast.Node, error) {
 		}, nil
 	}
 
-	varParts := []string{first.Content}
-	for p.peeker.Peek().Type == scanner.PERIOD {
-		p.peeker.Read() // eat period
-
-		// Read the next item, since variable access in HIL is composed
-		// of many things. For example: "var.0.bar" is the entire var access.
-		partTok := p.peeker.Read()
-		switch partTok.Type {
-		case scanner.IDENTIFIER:
-		case scanner.STAR:
-		case scanner.INTEGER:
-		default:
-			return nil, ExpectationError("identifier", partTok)
-		}
-
-		varParts = append(varParts, partTok.Content)
-	}
-	varName := strings.Join(varParts, ".")
 	varNode := &ast.VariableAccess{
-		Name: varName,
+		Name: first.Content,
 		Posx: startPos,
 	}
 

--- a/vendor/github.com/hashicorp/hil/scanner/scanner.go
+++ b/vendor/github.com/hashicorp/hil/scanner/scanner.go
@@ -479,9 +479,28 @@ func scanIdentifier(s string) (string, int) {
 		nextRune, size := utf8.DecodeRuneInString(s[byteLen:])
 		if !(nextRune == '_' ||
 			nextRune == '-' ||
+			nextRune == '.' ||
+			nextRune == '*' ||
 			unicode.IsNumber(nextRune) ||
 			unicode.IsLetter(nextRune) ||
 			unicode.IsMark(nextRune)) {
+			break
+		}
+
+		// If we reach a star, it must be between periods to be part
+		// of the same identifier.
+		if nextRune == '*' && s[byteLen-1] != '.' {
+			break
+		}
+
+		// If our previous character was a star, then the current must
+		// be period. Otherwise, undo that and exit.
+		if byteLen > 0 && s[byteLen-1] == '*' && nextRune != '.' {
+			byteLen--
+			if s[byteLen-1] == '.' {
+				byteLen--
+			}
+
 			break
 		}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1588,26 +1588,26 @@
 		{
 			"checksumSHA1": "xONRNgLDc5OqCUmyDN3iBRKmKB0=",
 			"path": "github.com/hashicorp/hil",
-			"revision": "bf046eec69cc383b7f32c47990336409601c8116",
-			"revisionTime": "2016-12-04T02:32:26Z"
+			"revision": "60db937199ba6f67251aa038cec18ce36a951312",
+			"revisionTime": "2016-12-09T17:20:46Z"
 		},
 		{
 			"checksumSHA1": "oZ2a2x9qyHqvqJdv/Du3LGeaFdA=",
 			"path": "github.com/hashicorp/hil/ast",
-			"revision": "bf046eec69cc383b7f32c47990336409601c8116",
-			"revisionTime": "2016-12-04T02:32:26Z"
+			"revision": "60db937199ba6f67251aa038cec18ce36a951312",
+			"revisionTime": "2016-12-09T17:20:46Z"
 		},
 		{
-			"checksumSHA1": "p/zZysJW/AaPXXPCI20nM2arPnw=",
+			"checksumSHA1": "P5PZ3k7SmqWmxgJ8Q0gLzeNpGhE=",
 			"path": "github.com/hashicorp/hil/parser",
-			"revision": "bf046eec69cc383b7f32c47990336409601c8116",
-			"revisionTime": "2016-12-04T02:32:26Z"
+			"revision": "60db937199ba6f67251aa038cec18ce36a951312",
+			"revisionTime": "2016-12-09T17:20:46Z"
 		},
 		{
-			"checksumSHA1": "FlzgVCYqnODad4pKujXhSaGcrIo=",
+			"checksumSHA1": "DC1k5kOua4oFqmo+JRt0YzfP44o=",
 			"path": "github.com/hashicorp/hil/scanner",
-			"revision": "bf046eec69cc383b7f32c47990336409601c8116",
-			"revisionTime": "2016-12-04T02:32:26Z"
+			"revision": "60db937199ba6f67251aa038cec18ce36a951312",
+			"revisionTime": "2016-12-09T17:20:46Z"
 		},
 		{
 			"path": "github.com/hashicorp/logutils",

--- a/website/source/upgrade-guides/0-8.html.markdown
+++ b/website/source/upgrade-guides/0-8.html.markdown
@@ -57,46 +57,6 @@ EOF
 
 **Action:** Use heredocs or escape sequences when you have a string with newlines.
 
-## Names Cannot Start with Integers or Hyphens
-
-Names of variables, resources, modules, etc. may no longer start with
-numbers or hyphens. These will now fail at the validation step.
-
-This change was necessary to remove ambiguities from parsing the
-interpolations. Most languages do not allow identifiers starting with
-these characters with good reason. We now follow that as well.
-
-An example of a configuration that no longer works:
-
-```
-variable "1x1" {}
-```
-
-This must now be changed to start with a letter or underscore:
-
-```
-variable "foo-1x1" {}
-variable "_1x1" {}
-```
-
-And so on...
-
-If you're changing resource names, this can cause Terraform to consider it
-a new resource and plan to destroy it. To work around these scenarios,
-please use the `terraform state mv` command:
-
-```
-terraform state mv aws_instance.1x1 aws_instance.foo-1x1
-```
-
-The `terraform state mv` command creates a backup for each operation,
-but to be safe you can still back up your state prior to doing these
-changes.
-
-**Action:** Rename variable, resources, modules, providers, outputs that
-start with a number or hyphen. If you rename a resource or module, use
-`terraform state mv` to fix the state.
-
 ## Math Order of Operations
 
 Math operations now follow standard mathematical order of operations.


### PR DESCRIPTION
This rolls back the change introduced in 0.8 RC3 and allows names to start with numbers.

In HIL, identifiers are still restricted to NOT start with numbers, but since identifiers in Terraform are always qualified with `var.` or `resource.` and so on, this becomes a non-issue for us.

This should significantly improve the upgrade process to 0.8. :)