### PR TITLE
Disaply interpolation strings for computed fields

### DIFF
--- a/command/format_plan.go
+++ b/command/format_plan.go
@@ -152,7 +152,7 @@ func formatPlanModuleExpand(
 			attrDiff := rdiff.Attributes[attrK]
 
 			v := attrDiff.New
-			if attrDiff.NewComputed {
+			if v == "" && attrDiff.NewComputed {
 				v = "<computed>"
 			}
 

--- a/command/format_plan_test.go
+++ b/command/format_plan_test.go
@@ -43,6 +43,50 @@ func TestFormatPlan_destroyDeposed(t *testing.T) {
 	}
 }
 
+// Test that computed fields with an interpolation string get displayed
+func TestFormatPlan_displayInterpolations(t *testing.T) {
+	plan := &terraform.Plan{
+		Diff: &terraform.Diff{
+			Modules: []*terraform.ModuleDiff{
+				&terraform.ModuleDiff{
+					Path: []string{"root"},
+					Resources: map[string]*terraform.InstanceDiff{
+						"aws_instance.foo": &terraform.InstanceDiff{
+							Attributes: map[string]*terraform.ResourceAttrDiff{
+								"computed_field": &terraform.ResourceAttrDiff{
+									New:         "${aws_instance.other.id}",
+									NewComputed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	opts := &FormatPlanOpts{
+		Plan: plan,
+		Color: &colorstring.Colorize{
+			Colors:  colorstring.DefaultColors,
+			Disable: true,
+		},
+		ModuleDepth: 1,
+	}
+
+	out := FormatPlan(opts)
+	lines := strings.Split(out, "\n")
+	if len(lines) != 2 {
+		t.Fatal("expected 2 lines of output, got:\n", out)
+	}
+
+	actual := strings.TrimSpace(lines[1])
+	expected := `computed_field: "" => "${aws_instance.other.id}"`
+
+	if actual != expected {
+		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, actual)
+	}
+}
+
 // Test that a root level data source gets a special plan output on create
 func TestFormatPlan_rootDataSource(t *testing.T) {
 	plan := &terraform.Plan{


### PR DESCRIPTION
Displaying interpolations strings when possible for computed fields in
the plan output makes for a nicer UX