### PR TITLE
terraform: user friendly error when using old map overrides

### DIFF
--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -44,6 +44,28 @@ func TestContext2Validate_badVar(t *testing.T) {
 	}
 }
 
+func TestContext2Validate_varMapOverrideOld(t *testing.T) {
+	m := testModule(t, "validate-module-pc-vars")
+	p := testProvider("aws")
+	c := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		Variables: map[string]interface{}{
+			"foo.foo": "bar",
+		},
+	})
+
+	w, e := c.Validate()
+	if len(w) > 0 {
+		t.Fatalf("bad: %#v", w)
+	}
+	if len(e) == 0 {
+		t.Fatalf("bad: %s", e)
+	}
+}
+
 func TestContext2Validate_varNoDefaultExplicitType(t *testing.T) {
 	m := testModule(t, "validate-var-no-default-explicit-type")
 	c := testContext2(t, &ContextOpts{

--- a/terraform/semantics_test.go
+++ b/terraform/semantics_test.go
@@ -24,7 +24,7 @@ func TestSMCUserVariables(t *testing.T) {
 		"foo":     "bar",
 		"map.foo": "baz",
 	})
-	if len(errs) != 0 {
+	if len(errs) == 0 {
 		t.Fatalf("err: %#v", errs)
 	}
 

--- a/terraform/test-fixtures/validate-var-map-override-old/main.tf
+++ b/terraform/test-fixtures/validate-var-map-override-old/main.tf
@@ -1,0 +1,1 @@
+variable "foo" { default = { foo = "bar" } }


### PR DESCRIPTION
Related to #8036

We have had this behavior for a _long_ time now (since 0.7.0) but it
seems people are still periodically getting bit by it. This adds an
explicit error message that explains that this kind of override isn't
allowed anymore.