### PR TITLE
Add -short flag to plan command

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -20,6 +20,7 @@ const periodicUiTimer = 10 * time.Second
 type UiHook struct {
 	terraform.NilHook
 
+	Short    bool
 	Colorize *colorstring.Colorize
 	Ui       cli.Ui
 
@@ -251,6 +252,10 @@ func (h *UiHook) PreRefresh(
 	n *terraform.InstanceInfo,
 	s *terraform.InstanceState) (terraform.HookAction, error) {
 	h.once.Do(h.init)
+
+	if h.Short {
+		return terraform.HookActionContinue, nil
+	}
 
 	id := n.HumanId()
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -50,6 +50,7 @@ type Meta struct {
 	// Targets for this context (private)
 	targets []string
 
+	short bool
 	color bool
 	oldUi cli.Ui
 
@@ -414,14 +415,17 @@ func (m *Meta) process(args []string, vars bool) []string {
 		m.Ui = m.oldUi
 	}
 
-	// Set colorization
+	// Set colorization or short
 	m.color = m.Color
-	for i, v := range args {
-		if v == "-no-color" {
+
+	for i := len(args) - 1; i >= 0; i-- {
+		if args[i] == "-no-color" {
 			m.color = false
 			m.Color = false
+
 			args = append(args[:i], args[i+1:]...)
-			break
+		} else if args[i] == "-short" {
+			m.short = true
 		}
 	}
 
@@ -464,6 +468,7 @@ func (m *Meta) process(args []string, vars bool) []string {
 func (m *Meta) uiHook() *UiHook {
 	return &UiHook{
 		Colorize: m.Colorize(),
+		Short:    m.short,
 		Ui:       m.Ui,
 	}
 }

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -54,6 +54,42 @@ func TestMetaColorize(t *testing.T) {
 	}
 }
 
+func TestMetaShort(t *testing.T) {
+	var m *Meta
+	var args, args2, args3 []string
+
+	// Test short is false by default
+	m = new(Meta)
+	args = m.process(args, false)
+	if m.short {
+		t.Fatal("should be disabled")
+	}
+
+	// Test setting short arg enables short flag
+	m = new(Meta)
+	args = []string{"foo", "-short", "bar"}
+	args2 = m.process(args, false)
+	if !m.short {
+		t.Fatal("should be enabled")
+	}
+
+	if !reflect.DeepEqual(args, args2) {
+		t.Fatalf("bad: %#v", args)
+	}
+
+	// Test setting no-color and short flag still enables short flag
+	m = new(Meta)
+	args2 = []string{"foo", "-no-color", "-short", "bar"}
+	args3 = m.process(args2, false)
+	if !m.short {
+		t.Fatal("should be enabled")
+	}
+
+	if !reflect.DeepEqual(args, args3) {
+		t.Fatalf("bad: %#v", args3)
+	}
+}
+
 func TestMetaInputMode(t *testing.T) {
 	test = false
 	defer func() { test = true }()

--- a/command/show.go
+++ b/command/show.go
@@ -96,6 +96,7 @@ func (c *ShowCommand) Run(args []string) int {
 			Plan:        plan,
 			Color:       c.Colorize(),
 			ModuleDepth: moduleDepth,
+			Short:       false,
 		}))
 		return 0
 	}

--- a/website/source/docs/commands/plan.html.markdown
+++ b/website/source/docs/commands/plan.html.markdown
@@ -50,6 +50,10 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-refresh=true` - Update the state prior to checking for differences.
 
+* `-short` - If set, only output the resource names being changed along
+             with the final summary line. The output will not show the
+             specific attributes of each resource being altered.
+
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
   Ignored when [remote state](/docs/state/remote/index.html) is used.
 


### PR DESCRIPTION
Fixes #10507

When using this flag only the resource names being changed along with the last summary line will be shown to the user.

Example usage: `terraform plan -short`

Example output change:
Before:
```
$terraform plan -destroy
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

aws_db_parameter_group.default: Refreshing state... (ID: <REDACTED>)
aws_security_group.rds_sg: Refreshing state... (ID: <REDACTED>)
aws_subnet.db_subnets.0: Refreshing state... (ID: <REDACTED>)
aws_subnet.db_subnets.1: Refreshing state... (ID: <REDACTED>)
module.rds.aws_db_subnet_group.main_db_subnet_group: Refreshing state... (ID: <REDACTED>)
module.rds.aws_db_instance.main_rds_instance: Refreshing state... (ID: <REDACTED>)

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

- aws_db_parameter_group.default

- aws_security_group.rds_sg

- aws_subnet.db_subnets.0

- aws_subnet.db_subnets.1

- module.rds.aws_db_instance.main_rds_instance

- module.rds.aws_db_subnet_group.main_db_subnet_group


Plan: 0 to add, 0 to change, 6 to destroy.

```

With -short flag:
```
$terraform plan -destroy -short
- aws_db_parameter_group.default
- aws_security_group.rds_sg
- aws_subnet.db_subnets.0
- aws_subnet.db_subnets.1
- module.rds.aws_db_instance.main_rds_instance
- module.rds.aws_db_subnet_group.main_db_subnet_group

Plan: 0 to add, 0 to change, 6 to destroy.
```

Note:
 * All errors are still shown in full.
 * This flag does not imply `-no-color`. Color will still be shown by default when using this flag, because the user can still use the `-no-color` flag
   with the `-short` flag if they wish not to see colors.


Please let me know if you think anything should be changed. It's a pretty small change without that one chunk of whitespace formatting.