### PR TITLE
config: error when loading multiple lifecycle blocks

### DIFF
--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -781,6 +781,12 @@ func loadManagedResourcesHcl(list *ast.ObjectList) ([]*Resource, error) {
 		// destroying the existing instance
 		var lifecycle ResourceLifecycle
 		if o := listVal.Filter("lifecycle"); len(o.Items) > 0 {
+			if len(o.Items) > 1 {
+				return nil, fmt.Errorf(
+					"%s[%s]: Multiple lifecycle blocks found, expected one",
+					t, k)
+			}
+
 			// Check for invalid keys
 			valid := []string{"create_before_destroy", "ignore_changes", "prevent_destroy"}
 			if err := checkHCLKeys(o.Items[0].Val, valid); err != nil {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -78,6 +78,13 @@ func TestLoadFile_resourceArityMistake(t *testing.T) {
 	}
 }
 
+func TestLoadFile_resourceMultiLifecycle(t *testing.T) {
+	_, err := LoadFile(filepath.Join(fixtureDir, "resource-multi-lifecycle.tf"))
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}
+
 func TestLoadFile_dataSourceArityMistake(t *testing.T) {
 	_, err := LoadFile(filepath.Join(fixtureDir, "data-source-arity-mistake.tf"))
 	if err == nil {

--- a/config/test-fixtures/resource-multi-lifecycle.tf
+++ b/config/test-fixtures/resource-multi-lifecycle.tf
@@ -1,0 +1,4 @@
+resource "aws_instance" "foo" {
+    lifecycle {}
+    lifecycle {}
+}


### PR DESCRIPTION
Fixes #8776

This introduces an error when multiple `lifecycle` blocks exist on a
resource in the configuration.