### PR TITLE
terraform: allow indexing into a computed list for multi-count resources

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -1319,6 +1319,31 @@ func TestContext2Plan_computedList(t *testing.T) {
 	}
 }
 
+// GH-8695. This tests that you can index into a computed list on a
+// splatted resource.
+func TestContext2Plan_computedMultiIndex(t *testing.T) {
+	m := testModule(t, "plan-computed-multi-index")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(testTerraformPlanComputedMultiIndexStr)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestContext2Plan_count(t *testing.T) {
 	m := testModule(t, "plan-count")
 	p := testProvider("aws")

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -587,7 +587,7 @@ func (i *Interpolater) computeResourceMultiVariable(
 		}
 
 		if multiAttr == unknownVariable {
-			return &ast.Variable{Type: ast.TypeString, Value: ""}, nil
+			return &unknownVariable, nil
 		}
 
 		values = append(values, multiAttr)

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -943,6 +943,24 @@ STATE:
 <no state>
 `
 
+const testTerraformPlanComputedMultiIndexStr = `
+DIFF:
+
+CREATE: aws_instance.bar
+  foo:  "" => "<computed>"
+  type: "" => "aws_instance"
+CREATE: aws_instance.foo.0
+  ip.#: "" => "<computed>"
+  type: "" => "aws_instance"
+CREATE: aws_instance.foo.1
+  ip.#: "" => "<computed>"
+  type: "" => "aws_instance"
+
+STATE:
+
+<no state>
+`
+
 const testTerraformPlanCountStr = `
 DIFF:
 

--- a/terraform/test-fixtures/plan-computed-multi-index/main.tf
+++ b/terraform/test-fixtures/plan-computed-multi-index/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "foo" {
+    count = 2
+    compute = "ip.#"
+}
+
+resource "aws_instance" "bar" {
+    count = 1
+    foo = "${aws_instance.foo.*.ip[count.index]}"
+}


### PR DESCRIPTION
Fixes #8695

When a list count was computed in a multi-resource access
(foo.bar.*.list), we were returning the value as empty string. I don't
actually know the histocal reasoning for this but this can't be correct:
we must return unknown.

When changing this to unknown, the new tests passed and none of the old
tests failed. This leads me further to believe that the return empty
string is probably a holdover from long ago to just avoid crashes or
UUIDs in the plan output and not actually the correct behavior.