### PR TITLE
config: validate invalid variable keys

### DIFF
--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -410,14 +410,12 @@ func loadVariablesHcl(list *ast.ObjectList) ([]*Variable, error) {
 				item.Pos(), NameRegexp)
 		}
 
-		/*
-			// TODO: catch extra fields
-			// Decode into raw map[string]interface{} so we know ALL fields
-			var config map[string]interface{}
-			if err := hcl.DecodeObject(&config, item.Val); err != nil {
-				return nil, err
-			}
-		*/
+		// Check for invalid keys
+		valid := []string{"type", "default", "description"}
+		if err := checkHCLKeys(item.Val, valid); err != nil {
+			return nil, multierror.Prefix(err, fmt.Sprintf(
+				"variable[%s]:", n))
+		}
 
 		// Decode into hclVariable to get typed values
 		var hclVar hclVariable

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -67,6 +67,13 @@ func TestLoadFile_lifecycleKeyCheck(t *testing.T) {
 	t.Logf("err: %s", err)
 }
 
+func TestLoadFile_varInvalidKey(t *testing.T) {
+	_, err := LoadFile(filepath.Join(fixtureDir, "var-invalid-key.tf"))
+	if err == nil {
+		t.Fatal("should have error")
+	}
+}
+
 func TestLoadFile_resourceArityMistake(t *testing.T) {
 	_, err := LoadFile(filepath.Join(fixtureDir, "resource-arity-mistake.tf"))
 	if err == nil {

--- a/config/test-fixtures/var-invalid-key.tf
+++ b/config/test-fixtures/var-invalid-key.tf
@@ -1,0 +1,3 @@
+variable "a" {
+  a = "b"
+}


### PR DESCRIPTION
Fixes #9416

A simple change to verify that only valid keys for `variable` blocks are
used.