### PR TITLE
terraform: destroy resources in dependent providers first

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -2843,6 +2843,109 @@ func TestContext2Apply_multiProviderDestroy(t *testing.T) {
 	checkStateString(t, state, `<no state>`)
 }
 
+// This is like the multiProviderDestroy test except it tests that
+// dependent resources within a child module that inherit provider
+// configuration are still destroyed first.
+func TestContext2Apply_multiProviderDestroyChild(t *testing.T) {
+	m := testModule(t, "apply-multi-provider-destroy-child")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+
+	p2 := testProvider("do")
+	p2.ApplyFn = testApplyFn
+	p2.DiffFn = testDiffFn
+
+	var state *State
+
+	// First, create the instances
+	{
+		ctx := testContext2(t, &ContextOpts{
+			Module: m,
+			Providers: map[string]ResourceProviderFactory{
+				"aws":   testProviderFuncFixed(p),
+				"vault": testProviderFuncFixed(p2),
+			},
+		})
+
+		if _, err := ctx.Plan(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		s, err := ctx.Apply()
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		state = s
+	}
+
+	// Destroy them
+	{
+		// Verify that aws_instance.bar is destroyed first
+		var checked bool
+		var called int32
+		var lock sync.Mutex
+		applyFn := func(
+			info *InstanceInfo,
+			is *InstanceState,
+			id *InstanceDiff) (*InstanceState, error) {
+			lock.Lock()
+			defer lock.Unlock()
+
+			if info.HumanId() == "module.child.aws_instance.bar" {
+				checked = true
+
+				// Sleep to allow parallel execution
+				time.Sleep(50 * time.Millisecond)
+
+				// Verify that called is 0 (dep not called)
+				if atomic.LoadInt32(&called) != 0 {
+					return nil, fmt.Errorf("nothing else should be called")
+				}
+			}
+
+			atomic.AddInt32(&called, 1)
+			return testApplyFn(info, is, id)
+		}
+
+		// Set the apply functions
+		p.ApplyFn = applyFn
+		p2.ApplyFn = applyFn
+
+		ctx := testContext2(t, &ContextOpts{
+			Destroy: true,
+			State:   state,
+			Module:  m,
+			Providers: map[string]ResourceProviderFactory{
+				"aws":   testProviderFuncFixed(p),
+				"vault": testProviderFuncFixed(p2),
+			},
+		})
+
+		if _, err := ctx.Plan(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		s, err := ctx.Apply()
+		if err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		if !checked {
+			t.Fatal("should be checked")
+		}
+
+		state = s
+	}
+
+	checkStateString(t, state, `
+<no state>
+module.child:
+  <no state>
+`)
+}
+
 func TestContext2Apply_multiVar(t *testing.T) {
 	m := testModule(t, "apply-multi-var")
 	p := testProvider("aws")

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -81,19 +81,19 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		// Attach the state
 		&AttachStateTransformer{State: b.State},
 
-		// Destruction ordering
-		&DestroyEdgeTransformer{Module: b.Module, State: b.State},
-		GraphTransformIf(
-			func() bool { return !b.Destroy },
-			&CBDEdgeTransformer{Module: b.Module, State: b.State},
-		),
-
 		// Create all the providers
 		&MissingProviderTransformer{Providers: b.Providers, Concrete: concreteProvider},
 		&ProviderTransformer{},
 		&DisableProviderTransformer{},
 		&ParentProviderTransformer{},
 		&AttachProviderConfigTransformer{Module: b.Module},
+
+		// Destruction ordering
+		&DestroyEdgeTransformer{Module: b.Module, State: b.State},
+		GraphTransformIf(
+			func() bool { return !b.Destroy },
+			&CBDEdgeTransformer{Module: b.Module, State: b.State},
+		),
 
 		// Provisioner-related transformations
 		GraphTransformIf(

--- a/terraform/test-fixtures/apply-multi-provider-destroy-child/child/main.tf
+++ b/terraform/test-fixtures/apply-multi-provider-destroy-child/child/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "bar" {
+    foo = "bar"
+}

--- a/terraform/test-fixtures/apply-multi-provider-destroy-child/main.tf
+++ b/terraform/test-fixtures/apply-multi-provider-destroy-child/main.tf
@@ -1,0 +1,9 @@
+resource "vault_instance" "foo" {}
+
+provider "aws" {
+  addr = "${vault_instance.foo.id}"
+}
+
+module "child" {
+  source = "./child"
+}

--- a/terraform/test-fixtures/apply-multi-provider-destroy/main.tf
+++ b/terraform/test-fixtures/apply-multi-provider-destroy/main.tf
@@ -1,0 +1,9 @@
+resource "vault_instance" "foo" {}
+
+provider "aws" {
+  addr = "${vault_instance.foo.id}"
+}
+
+resource "aws_instance" "bar" {
+    foo = "bar"
+}

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -127,6 +127,8 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 		// Add providers since they can affect destroy order as well
 		&MissingProviderTransformer{AllowAny: true, Concrete: providerFn},
 		&ProviderTransformer{},
+		&DisableProviderTransformer{},
+		&ParentProviderTransformer{},
 		&AttachProviderConfigTransformer{Module: t.Module},
 
 		&ReferenceTransformer{},

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -114,6 +114,10 @@ type MissingProviderTransformer struct {
 	// Providers is the list of providers we support.
 	Providers []string
 
+	// AllowAny will not check that a provider is supported before adding
+	// it to the graph.
+	AllowAny bool
+
 	// Concrete, if set, overrides how the providers are made.
 	Concrete ConcreteProviderNodeFunc
 }
@@ -170,10 +174,12 @@ func (t *MissingProviderTransformer) Transform(g *Graph) error {
 				ptype = p[:idx]
 			}
 
-			if _, ok := supported[ptype]; !ok {
-				// If we don't support the provider type, skip it.
-				// Validation later will catch this as an error.
-				continue
+			if !t.AllowAny {
+				if _, ok := supported[ptype]; !ok {
+					// If we don't support the provider type, skip it.
+					// Validation later will catch this as an error.
+					continue
+				}
 			}
 
 			// Add the missing provider node to the graph


### PR DESCRIPTION
Fixes #4645

This is something that never worked (even in legacy graphs), but as we
push forward towards encouraging multi-provider usage especially with
things like the Vault data source, I want to make sure we have this
right for 0.8.

When you have a config like this:

```
resource "foo_type" "name" {}
provider "bar" { attr = "${foo_type.name.value}" }
resource "bar_type" "name" {}
```

Then the destruction ordering MUST be:

  1. `bar_type`
  2. `foo_type`

Since configuring the client for `bar_type` requires accessing data from
`foo_type`. Prior to this PR, these two would be done in parallel. This
properly pushes forward the dependency.

**THIS PR:**

  - ✅  Resources of dependent providers are destroyed first
  - ✅  Resources of dependent providers _in child modules_ are destroyed first

There are likely more edge cases but I think I got the most common ones.