### PR TITLE
provider/openstack: More Import and Region Fixes

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_network_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_network_v2_test.go
@@ -2,7 +2,6 @@ package openstack
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -41,21 +40,17 @@ func TestAccNetworkingV2Network_basic(t *testing.T) {
 }
 
 func TestAccNetworkingV2Network_netstack(t *testing.T) {
-	region := os.Getenv(OS_REGION_NAME)
-
 	var network networks.Network
 	var subnet subnets.Subnet
 	var router routers.Router
 
 	var testAccNetworkingV2Network_netstack = fmt.Sprintf(`
 		resource "openstack_networking_network_v2" "foo" {
-			region = "%s"
 			name = "network_1"
 			admin_state_up = "true"
 		}
 
 		resource "openstack_networking_subnet_v2" "foo" {
-			region = "%s"
 			name = "subnet_1"
 			network_id = "${openstack_networking_network_v2.foo.id}"
 			cidr = "192.168.10.0/24"
@@ -63,15 +58,13 @@ func TestAccNetworkingV2Network_netstack(t *testing.T) {
 		}
 
 		resource "openstack_networking_router_v2" "foo" {
-			region = "%s"
 			name = "router_1"
 		}
 
 		resource "openstack_networking_router_interface_v2" "foo" {
-			region = "%s"
 			router_id = "${openstack_networking_router_v2.foo.id}"
 			subnet_id = "${openstack_networking_subnet_v2.foo.id}"
-		}`, region, region, region, region)
+		}`)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -92,8 +85,6 @@ func TestAccNetworkingV2Network_netstack(t *testing.T) {
 }
 
 func TestAccNetworkingV2Network_fullstack(t *testing.T) {
-	region := os.Getenv(OS_REGION_NAME)
-
 	var instance servers.Server
 	var network networks.Network
 	var port ports.Port
@@ -102,13 +93,11 @@ func TestAccNetworkingV2Network_fullstack(t *testing.T) {
 
 	var testAccNetworkingV2Network_fullstack = fmt.Sprintf(`
 		resource "openstack_networking_network_v2" "foo" {
-			region = "%s"
 			name = "network_1"
 			admin_state_up = "true"
 		}
 
 		resource "openstack_networking_subnet_v2" "foo" {
-			region = "%s"
 			name = "subnet_1"
 			network_id = "${openstack_networking_network_v2.foo.id}"
 			cidr = "192.168.199.0/24"
@@ -116,7 +105,6 @@ func TestAccNetworkingV2Network_fullstack(t *testing.T) {
 		}
 
 		resource "openstack_compute_secgroup_v2" "foo" {
-			region = "%s"
 			name = "secgroup_1"
 			description = "a security group"
 			rule {
@@ -128,7 +116,6 @@ func TestAccNetworkingV2Network_fullstack(t *testing.T) {
 		}
 
 		resource "openstack_networking_port_v2" "foo" {
-			region = "%s"
 			name = "port_1"
 			network_id = "${openstack_networking_network_v2.foo.id}"
 			admin_state_up = "true"
@@ -140,14 +127,13 @@ func TestAccNetworkingV2Network_fullstack(t *testing.T) {
 		}
 
 		resource "openstack_compute_instance_v2" "foo" {
-			region = "%s"
 			name = "terraform-test"
 			security_groups = ["${openstack_compute_secgroup_v2.foo.name}"]
 
 			network {
 				port = "${openstack_networking_port_v2.foo.id}"
 			}
-		}`, region, region, region, region, region)
+		}`)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_subnet_v2.go
@@ -54,6 +54,7 @@ func resourceNetworkingSubnetV2() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"start": &schema.Schema{


### PR DESCRIPTION
This has a few more import and region fixes from #10509

The most notable fix is changing the subnet allocation pool to computed so that automatically created allocation pools are correctly stored in state. The other fixes are just cleaning up acceptance tests (which I plan to do in greater detail at some point).

I came across these while running the full set of acceptance tests in preparation for the upcoming 0.8 release. All acceptance tests pass with this PR in place.