### PR TITLE
command: terraform show -format=json

### DIFF
--- a/command/format_plan.go
+++ b/command/format_plan.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -228,4 +229,22 @@ func formatPlanModuleSingle(
 		"    %d resource(s)",
 		len(m.Resources)))
 	buf.WriteString(opts.Color.Color("[reset]\n"))
+}
+
+func FormatPlanJSON(plan *terraform.Plan) string {
+	err := plan.State.PrepareForWrite()
+	if err != nil {
+		// should never happen
+		panic(err)
+	}
+
+	dst := bytes.NewBuffer(make([]byte, 0, 64))
+	enc := json.NewEncoder(dst)
+	enc.SetIndent("", "  ")
+	err = enc.Encode(plan)
+	if err != nil {
+		// should never happen
+		panic(err)
+	}
+	return dst.String()
 }

--- a/command/format_state.go
+++ b/command/format_state.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -149,4 +150,16 @@ func formatStateModuleSingle(
 
 	// Now just write how many resources are in here.
 	buf.WriteString(fmt.Sprintf("  %d resource(s)\n", len(m.Resources)))
+}
+
+func FormatStateJSON(state *terraform.State) string {
+	dst := bytes.NewBuffer(make([]byte, 0, 64))
+	enc := json.NewEncoder(dst)
+	enc.SetIndent("", "  ")
+	err := enc.Encode(state)
+	if err != nil {
+		// should never happen
+		panic(err)
+	}
+	return dst.String()
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,15 +26,15 @@ type Config struct {
 	// Dir is the path to the directory where this configuration was
 	// loaded from. If it is blank, this configuration wasn't loaded from
 	// any meaningful directory.
-	Dir string
+	Dir string `json:"source_dir"`
 
-	Terraform       *Terraform
-	Atlas           *AtlasConfig
-	Modules         []*Module
-	ProviderConfigs []*ProviderConfig
-	Resources       []*Resource
-	Variables       []*Variable
-	Outputs         []*Output
+	Terraform       *Terraform        `json:"terraform"`
+	Atlas           *AtlasConfig      `json:"atlas"`
+	Modules         []*Module         `json:"modules"`
+	ProviderConfigs []*ProviderConfig `json:"provider_configs"`
+	Resources       []*Resource       `json:"resources"`
+	Variables       []*Variable       `json:"variables"`
+	Outputs         []*Output         `json:"outputs"`
 
 	// The fields below can be filled in by loaders for validation
 	// purposes.
@@ -44,14 +44,15 @@ type Config struct {
 // Terraform is the Terraform meta-configuration that can be present
 // in configuration files for configuring Terraform itself.
 type Terraform struct {
-	RequiredVersion string `hcl:"required_version"` // Required Terraform version (constraint)
+	// Required Terraform version (constraint)
+	RequiredVersion string `hcl:"required_version" json:"required_version"`
 }
 
 // AtlasConfig is the configuration for building in HashiCorp's Atlas.
 type AtlasConfig struct {
-	Name    string
-	Include []string
-	Exclude []string
+	Name    string   `json:"name"`
+	Include []string `json:"include"`
+	Exclude []string `json:"exclude"`
 }
 
 // Module is a module used within a configuration.
@@ -59,9 +60,9 @@ type AtlasConfig struct {
 // This does not represent a module itself, this represents a module
 // call-site within an existing configuration.
 type Module struct {
-	Name      string
-	Source    string
-	RawConfig *RawConfig
+	Name      string     `json:"name"`
+	Source    string     `json:"source"`
+	RawConfig *RawConfig `json:"config"`
 }
 
 // ProviderConfig is the configuration for a resource provider.
@@ -69,9 +70,9 @@ type Module struct {
 // For example, Terraform needs to set the AWS access keys for the AWS
 // resource provider.
 type ProviderConfig struct {
-	Name      string
-	Alias     string
-	RawConfig *RawConfig
+	Name      string     `json:"name"`
+	Alias     string     `json:"alias,omitempty"`
+	RawConfig *RawConfig `json:"config"`
 }
 
 // A resource represents a single Terraform resource in the configuration.
@@ -79,15 +80,18 @@ type ProviderConfig struct {
 // usual "create, read, update, delete" operations, depending on
 // the given Mode.
 type Resource struct {
-	Mode         ResourceMode // which operations the resource supports
-	Name         string
-	Type         string
-	RawCount     *RawConfig
-	RawConfig    *RawConfig
-	Provisioners []*Provisioner
-	Provider     string
-	DependsOn    []string
-	Lifecycle    ResourceLifecycle
+
+	// which operations the resource supports
+	Mode ResourceMode `json:"mode"`
+
+	Name         string            `json:"name"`
+	Type         string            `json:"type"`
+	RawCount     *RawConfig        `json:"meta_config"`
+	RawConfig    *RawConfig        `json:"config"`
+	Provisioners []*Provisioner    `json:"provisioners,omitempty"`
+	Provider     string            `json:"provider_name,omitempty"`
+	DependsOn    []string          `json:"depends_on,omitempty"`
+	Lifecycle    ResourceLifecycle `json:"lifecycle"`
 }
 
 // Copy returns a copy of this Resource. Helpful for avoiding shared
@@ -115,9 +119,9 @@ func (r *Resource) Copy() *Resource {
 // ResourceLifecycle is used to store the lifecycle tuning parameters
 // to allow customized behavior
 type ResourceLifecycle struct {
-	CreateBeforeDestroy bool     `mapstructure:"create_before_destroy"`
-	PreventDestroy      bool     `mapstructure:"prevent_destroy"`
-	IgnoreChanges       []string `mapstructure:"ignore_changes"`
+	CreateBeforeDestroy bool     `mapstructure:"create_before_destroy" json:"create_before_destroy"`
+	PreventDestroy      bool     `mapstructure:"prevent_destroy" json:"prevent_destroy"`
+	IgnoreChanges       []string `mapstructure:"ignore_changes" json:"ignore_changes"`
 }
 
 // Copy returns a copy of this ResourceLifecycle
@@ -133,9 +137,9 @@ func (r *ResourceLifecycle) Copy() *ResourceLifecycle {
 
 // Provisioner is a configured provisioner step on a resource.
 type Provisioner struct {
-	Type      string
-	RawConfig *RawConfig
-	ConnInfo  *RawConfig
+	Type      string     `json:"type"`
+	RawConfig *RawConfig `json:"config"`
+	ConnInfo  *RawConfig `json:"conn_info,omitempty"`
 }
 
 // Copy returns a copy of this Provisioner
@@ -149,10 +153,10 @@ func (p *Provisioner) Copy() *Provisioner {
 
 // Variable is a variable defined within the configuration.
 type Variable struct {
-	Name         string
-	DeclaredType string `mapstructure:"type"`
-	Default      interface{}
-	Description  string
+	Name         string      `json:"name"`
+	DeclaredType string      `json:"type" mapstructure:"type"`
+	Default      interface{} `json:"default,omitempty"`
+	Description  string      `json:"description,omitempty"`
 }
 
 // Output is an output defined within the configuration. An output is
@@ -160,11 +164,11 @@ type Variable struct {
 // output marked Sensitive will be output in a masked form following
 // application, but will still be available in state.
 type Output struct {
-	Name        string
-	DependsOn   []string
-	Description string
-	Sensitive   bool
-	RawConfig   *RawConfig
+	Name        string     `json:"name"`
+	DependsOn   []string   `json:"depends_on,omitempty"`
+	Description string     `json:"description,omitempty"`
+	Sensitive   bool       `json:"sensitive"`
+	RawConfig   *RawConfig `json:"config"`
 }
 
 // VariableType is the type of value a variable is holding, and returned

--- a/config/module/tree_json.go
+++ b/config/module/tree_json.go
@@ -1,0 +1,51 @@
+package module
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/hashicorp/terraform/config"
+)
+
+func (t *Tree) UnmarshalJSON(bs []byte) error {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// Decode the gob data
+	var data treeJSON
+	dec := json.NewDecoder(bytes.NewReader(bs))
+	if err := dec.Decode(&data); err != nil {
+		return err
+	}
+
+	// Set the fields
+	t.name = data.Name
+	t.config = data.Config
+	t.children = data.Children
+	t.path = data.Path
+
+	return nil
+}
+
+func (t *Tree) MarshalJSON() ([]byte, error) {
+	data := &treeJSON{
+		Config:   t.config,
+		Children: t.children,
+		Name:     t.name,
+		Path:     t.path,
+	}
+
+	return json.Marshal(data)
+}
+
+// treeJSON is used as a structure to JSON encode a tree.
+//
+// This structure is private so it can't be referenced but the fields are
+// public, allowing us to properly encode this. When we decode this, we are
+// able to turn it into a Tree.
+type treeJSON struct {
+	Config   *config.Config   `json:"config"`
+	Children map[string]*Tree `json:"children"`
+	Name     string           `json:"name"`
+	Path     []string         `json:"path"`
+}

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"bytes"
 	"encoding/gob"
+	"encoding/json"
 	"sync"
 
 	"github.com/hashicorp/hil"
@@ -27,10 +28,10 @@ const UnknownVariableValue = "74D93920-ED26-11E3-AC10-0800200C9A66"
 // RawConfig supports a query-like interface to request
 // information from deep within the structure.
 type RawConfig struct {
-	Key            string
-	Raw            map[string]interface{}
-	Interpolations []ast.Node
-	Variables      map[string]InterpolatedVariable
+	Key            string                          `json:"key"`
+	Raw            map[string]interface{}          `json:"raw"`
+	Interpolations []ast.Node                      `json:"interpolations,omitempty"`
+	Variables      map[string]InterpolatedVariable `json:"variables,omitempty"`
 
 	lock        sync.Mutex
 	config      map[string]interface{}
@@ -322,4 +323,14 @@ func langEvalConfig(vs map[string]ast.Variable) *hil.EvalConfig {
 			FuncMap: funcMap,
 		},
 	}
+}
+
+// MarshalJSON produces a JSON serialization of just the raw configuration
+// values, under the assumption that the remainder can be derived from it.
+//
+// The output here is intended by consumption of tools outside of Terraform
+// rather than by Terraform itself, so there is no corresponding
+// UnmarshalJSON method.
+func (r *RawConfig) MarshalJSON() ([]byte, error) {
+	return json.Marshal(r.Raw)
 }

--- a/config/resource_mode.go
+++ b/config/resource_mode.go
@@ -7,3 +7,14 @@ const (
 	ManagedResourceMode ResourceMode = iota
 	DataResourceMode
 )
+
+func (m ResourceMode) MarshalJSON() ([]byte, error) {
+	switch m {
+	case ManagedResourceMode:
+		return []byte(`"managed"`), nil
+	case DataResourceMode:
+		return []byte(`"data"`), nil
+	default:
+		return []byte(`"invalid"`), nil
+	}
+}

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -21,11 +21,11 @@ func init() {
 // Plan represents a single Terraform execution plan, which contains
 // all the information necessary to make an infrastructure change.
 type Plan struct {
-	Diff    *Diff
-	Module  *module.Tree
-	State   *State
-	Vars    map[string]interface{}
-	Targets []string
+	Diff    *Diff                  `json:"diff"`
+	Module  *module.Tree           `json:"module"`
+	State   *State                 `json:"state"`
+	Vars    map[string]interface{} `json:"variables"`
+	Targets []string               `json:"targets,omitempty"`
 
 	once sync.Once
 }

--- a/website/source/docs/commands/show.html.markdown
+++ b/website/source/docs/commands/show.html.markdown
@@ -22,8 +22,27 @@ file. If no path is specified, the current state will be shown.
 
 The command-line flags are all optional. The list of available flags are:
 
+* `-format=name` - Produces output in an alternative format. Currently "json"
+  is the only supported alternative format. See below for more information
+  and caveats regarding the JSON output.
+
 * `-module-depth=n` - Specifies the depth of modules to show in the output.
   By default this is -1, which will expand all.
 
 * `-no-color` - Disables output with coloring
 
+## JSON Output
+
+As a convenience for intepreting Terraform data using external tools, Terraform
+can produce detailed plan and state information in JSON format.
+
+However, since Terraform is still quickly evolving we are unable to guarantee
+100% compatibility with the current JSON data structures in future versions,
+and so the current data structures are not documented in detail.
+
+Please use this feature sparingly and with care, and be ready to update any
+integrations when moving to newer versions of Terraform.
+
+~> **Warning** The JSON output is generally more detailed than the
+human-readable output, and in particular can include *sensitive information*.
+The JSON output must therefore be stored and transmitted with care.


### PR DESCRIPTION
This set of changes adds a `-format=json` option to the `terraform show` command to allow users to obtain machine-readable plan and state output.

There are (and have been) several other variants of adding some JSON output support to Terraform:

* In #4610 I tried to make JSON the primary format for plans, for consistency with states. However, this would've likely tempted people to try to hand-edit plan files, which is likely to cause Terraform to misbehave or crash.
* #3170 proposes to add JSON output to the `terraform plan` command itself. That would work, but is a little problematic because the `plan` command produces more output than just the plan, including the log of refreshing any existing resources and warnings about various things, and so it feels better (to me) to leave `terraform plan` as human-readable and provide a separate command for JSONifying plans.
* #2460 is a bit of a "meta-issue" aiming to get JSON support in a bunch of different places. JSON-readable logs of Terraform's ongoing behavior would be interesting, but is a lot of work to bite off.

So this change focuses on one primary use-case: I already made a plan using `terraform plan -out=...` and now I want to use some separate tool to analyze the plan.

```
$ terraform plan -out=tfplan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.


The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Your plan was also saved to the path below. Call the "apply" subcommand
with this plan file and Terraform will exactly execute this execution
plan.

Path: tfplan

(... etc, etc ...)

$ terraform show -format=json tfplan
{
   ...a big blob of JSON...
}
```

`terraform show` is used because it is focused on obtaining information without any other side-effects. This keeps the multi-format complexity from spreading all over the `command` module *and* should make a reasonable interface for producing a plan once and then safely rendering it in a number of different formats. (A maximum of two to start, but who knows...)

Since it is the `terraform show` command that is being extended here, it also supports JSON output of states. This is pretty redundant, since the state is already JSON-readable in exactly the same format in the local state file. It is thus included just for consistency and completeness for now, but could become more useful in future if, for example, we were to implement encryption of the local state file at rest (#9556), or if the local cache were to go away altogether as part of some forthcoming redesign of the remote state management workflow (#1964 or something like it).

This includes some of the work I did for #4610, though it required some tweaking to catch up with changes to Terraform's data structures in the mean time.

----

A big reason to be cautious about supporting something like this is that it creates a pretty big API surface area to maintain compatibility with. Terraform is still evolving very fast, so it's basically impossible to retain 100% compatibility with any machine-readable format. As a pragmatic compromise this change adds a JSON format for adventurous people to use, but specifically disclaims any defined behavior of it across Terraform versions and declines to document it in any way.

My thought was that for now this would remain a "buyer beware" sort of feature for adventurous early adopters, and then we'll get some experience with what people tend to do with it and then, at some later point, possibly commit to some level of compatibility for this format and produce some documentation on it.
