### PR TITLE
Prevent data sources from being aplied early

### DIFF
--- a/terraform/test-fixtures/apply-data-depends-on/main.tf
+++ b/terraform/test-fixtures/apply-data-depends-on/main.tf
@@ -1,0 +1,8 @@
+resource "null_resource" "write" {
+	foo = "attribute"
+}
+
+data "null_data_source" "read" {
+	foo = ""
+	depends_on = ["null_resource.write"]
+}

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -601,7 +601,15 @@ func (n *graphNodeExpandedResource) dataResourceEvalNodes(resource *Resource, in
 				// apply phases.)
 				&EvalIf{
 					If: func(ctx EvalContext) (bool, error) {
+
 						if config.ComputedKeys != nil && len(config.ComputedKeys) > 0 {
+							return true, EvalEarlyExitError{}
+						}
+
+						// If the config explicitly has a depends_on for this
+						// data source, assume the intention is to prevent
+						// refreshing ahead of that dependency.
+						if len(n.Resource.DependsOn) > 0 {
 							return true, EvalEarlyExitError{}
 						}
 


### PR DESCRIPTION
If a data source has explicit dependencies in `depends_on`, we can
assume the user has added those because of a dependency not tracked
directly in the config. If there are any entries in `depends_on`, don't
apply the data source early during Refresh.

Fixes #10603 