### PR TITLE
providers/google: Add missing doc links

### DIFF
--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -66,6 +66,10 @@
 			<a href="/docs/providers/google/r/compute_global_forwarding_rule.html">google_compute_global_forwarding_rule</a>
 			</li>
 
+			<li<%= sidebar_current("docs-google-compute-health-check") %>>
+			<a href="/docs/providers/google/r/compute_health_check.html">google_compute_health_check</a>
+			</li>
+
 			<li<%= sidebar_current("docs-google-compute-http-health-check") %>>
 			<a href="/docs/providers/google/r/compute_http_health_check.html">google_compute_http_health_check</a>
 			</li>
@@ -100,6 +104,10 @@
 
 			<li<%= sidebar_current("docs-google-compute-project-metadata") %>>
 			<a href="/docs/providers/google/r/compute_project_metadata.html">google_compute_project_metadata</a>
+			</li>
+
+			<li<%= sidebar_current("docs-google-compute-region-backend-service") %>>
+			<a href="/docs/providers/google/r/compute_region_backend_service.html">google_compute_region_backend_service</a>
 			</li>
 
 			<li<%= sidebar_current("docs-google-compute-route") %>>


### PR DESCRIPTION
This accidentally got left out of #10453.
@evandbrown @paddyforan 