### PR TITLE
[WIP] providers/azurerm_vm - Only pass LicenseType if set in the terraform configuration.

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -488,14 +488,16 @@ func resourceArmVirtualMachineCreate(d *schema.ResourceData, meta interface{}) e
 
 	networkProfile := expandAzureRmVirtualMachineNetworkProfile(d)
 	vmSize := d.Get("vm_size").(string)
-	licenseType := d.Get("license_type").(string)
 	properties := compute.VirtualMachineProperties{
 		NetworkProfile: &networkProfile,
 		HardwareProfile: &compute.HardwareProfile{
 			VMSize: compute.VirtualMachineSizeTypes(vmSize),
 		},
 		StorageProfile: &storageProfile,
-		LicenseType:    &licenseType,
+	}
+	licenseType := d.Get("license_type").(string)
+	if licenseType != "" {
+		properties.LicenseType = &licenseType
 	}
 
 	if _, ok := d.GetOk("boot_diagnostics"); ok {


### PR DESCRIPTION
Only set the LicenseType property if the "license_type" string is not empty.