### PR TITLE
Document ECS scratch volumes

### DIFF
--- a/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
@@ -79,7 +79,7 @@ Volume block supports the following arguments:
 
 * `name` - (Required) The name of the volume. This name is referenced in the `sourceVolume`
 parameter of container definition in the `mountPoints` section.
-* `host_path` - (Required) The path on the host container instance that is presented to the container.
+* `host_path` - (Optional) The path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Update docs to say that volumes can be created without host_path, which will create an nonpersistent volume, as described in [Using Data Volumes in Tasks](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_data_volumes.html).

This feature was implemented in #3810 but did not appear in the docs.

@radeksimko 