### PR TITLE
Add support for name_prefix to google_compute_ssl_certificate

### DIFF
--- a/builtin/providers/google/resource_compute_ssl_certificate.go
+++ b/builtin/providers/google/resource_compute_ssl_certificate.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strconv"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/googleapi"
@@ -24,9 +25,36 @@ func resourceComputeSslCertificate() *schema.Resource {
 			},
 
 			"name": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					// https://cloud.google.com/compute/docs/reference/latest/sslCertificates#resource
+					value := v.(string)
+					if len(value) > 63 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 63 characters", k))
+					}
+					return
+				},
+			},
+
+			"name_prefix": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
+				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+					// https://cloud.google.com/compute/docs/reference/latest/sslCertificates#resource
+					// uuid is 26 characters, limit the prefix to 37.
+					value := v.(string)
+					if len(value) > 37 {
+						errors = append(errors, fmt.Errorf(
+							"%q cannot be longer than 37 characters, name is limited to 63", k))
+					}
+					return
+				},
 			},
 
 			"private_key": &schema.Schema{
@@ -68,9 +96,18 @@ func resourceComputeSslCertificateCreate(d *schema.ResourceData, meta interface{
 		return err
 	}
 
+	var certName string
+	if v, ok := d.GetOk("name"); ok {
+		certName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		certName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		certName = resource.UniqueId()
+	}
+
 	// Build the certificate parameter
 	cert := &compute.SslCertificate{
-		Name:        d.Get("name").(string),
+		Name:        certName,
 		Certificate: d.Get("certificate").(string),
 		PrivateKey:  d.Get("private_key").(string),
 	}

--- a/builtin/providers/google/resource_compute_ssl_certificate_test.go
+++ b/builtin/providers/google/resource_compute_ssl_certificate_test.go
@@ -26,6 +26,40 @@ func TestAccComputeSslCertificate_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeSslCertificate_no_name(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSslCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeSslCertificate_no_name,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSslCertificateExists(
+						"google_compute_ssl_certificate.foobar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeSslCertificate_name_prefix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeSslCertificateDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeSslCertificate_name_prefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeSslCertificateExists(
+						"google_compute_ssl_certificate.foobar"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeSslCertificateDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -75,6 +109,23 @@ var testAccComputeSslCertificate_basic = fmt.Sprintf(`
 resource "google_compute_ssl_certificate" "foobar" {
 	name = "sslcert-test-%s"
 	description = "very descriptive"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+`, acctest.RandString(10))
+
+var testAccComputeSslCertificate_no_name = fmt.Sprintf(`
+resource "google_compute_ssl_certificate" "foobar" {
+	description = "really descriptive"
+	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
+	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
+}
+`)
+
+var testAccComputeSslCertificate_name_prefix = fmt.Sprintf(`
+resource "google_compute_ssl_certificate" "foobar" {
+	name_prefix = "sslcert-test-%s-"
+	description = "extremely descriptive"
 	private_key = "${file("test-fixtures/ssl_cert/test.key")}"
 	certificate = "${file("test-fixtures/ssl_cert/test.crt")}"
 }

--- a/website/source/docs/providers/google/r/compute_ssl_certificate.html.markdown
+++ b/website/source/docs/providers/google/r/compute_ssl_certificate.html.markdown
@@ -18,7 +18,7 @@ For more information see
 
 ```js
 resource "google_compute_ssl_certificate" "default" {
-  name        = "my-certificate"
+  name_prefix = "my-certificate-"
   description = "a description"
   private_key = "${file("path/to/private.key")}"
   certificate = "${file("path/to/certificate.crt")}"
@@ -33,13 +33,16 @@ The following arguments are supported:
     may be at most 5 certs long, and must include at least one intermediate
     cert. Changing this forces a new resource to be created.
 
-* `name` - (Required) A unique name for the resource, required by GCE.
-    Changing this forces a new resource to be created.
-
 * `private_key` - (Required) Write only private key in PEM format.
     Changing this forces a new resource to be created.
 
 - - -
+
+* `name` - (Optional) A unique name for the SSL certificate. If you leave
+  this blank, Terraform will auto-generate a unique name.
+
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
 
 * `description` - (Optional) An optional description of this resource.
     Changing this forces a new resource to be created.


### PR DESCRIPTION
Fixes #10546.

Haven't made docs yet, but wanted to get code up for review. Adds name_prefix option, reusing code from https://github.com/hashicorp/terraform/blob/master/builtin/providers/google/resource_compute_instance_template.go.

(cc: @paddyforan)