### PR TITLE
Add Akamai provider focused on Akamai GTM functionality

### DIFF
--- a/builtin/bins/provider-akamai/main.go
+++ b/builtin/bins/provider-akamai/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/akamai"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: akamai.Provider,
+	})
+}

--- a/builtin/providers/akamai/config.go
+++ b/builtin/providers/akamai/config.go
@@ -1,0 +1,35 @@
+package akamai
+
+import (
+	"log"
+
+	"github.com/Comcast/go-edgegrid/edgegrid"
+)
+
+// Config is the configuration required to instantiate
+// Akamai API clients
+type Config struct {
+	AccessToken  string
+	ClientToken  string
+	ClientSecret string
+	APIHost      string
+}
+
+// Clients contains Akamai GTM and PAPI clients for
+// accessing the Akamai API.
+type Clients struct {
+	GTM  *edgegrid.GTMClient
+	PAPI *edgegrid.PAPIClient
+}
+
+// Client returns a new AkamaiClients for accessing Akamai.
+func (c *Config) Client() (*Clients, error) {
+	clients := &Clients{
+		edgegrid.GTMClientWithCreds(c.AccessToken, c.ClientToken, c.ClientSecret, c.APIHost),
+		edgegrid.PAPIClientWithCreds(c.AccessToken, c.ClientToken, c.ClientSecret, c.APIHost),
+	}
+
+	log.Printf("[INFO] Akamai GTM and PAPI API Clients configured for use")
+
+	return clients, nil
+}

--- a/builtin/providers/akamai/provider.go
+++ b/builtin/providers/akamai/provider.go
@@ -33,7 +33,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 
-		ResourcesMap: map[string]*schema.Resource{},
+		ResourcesMap: map[string]*schema.Resource{
+			"akamai_gtm_domain": resourceAkamaiGTMDomain(),
+		},
 
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/akamai/provider.go
+++ b/builtin/providers/akamai/provider.go
@@ -1,0 +1,68 @@
+package akamai
+
+import (
+	"os"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Provider returns a schema.Provider for Akamai.
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"host": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("AKAMAI_EDGEGRID_HOST"),
+			},
+			"access_token": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("AKAMAI_EDGEGRID_ACCESS_TOKEN"),
+			},
+			"client_token": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("AKAMAI_EDGEGRID_CLIENT_TOKEN"),
+			},
+			"client_secret": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("AKAMAI_EDGEGRID_CLIENT_SECRET"),
+			},
+		},
+
+		ResourcesMap: map[string]*schema.Resource{},
+
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func envDefaultFunc(k string) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		if v := os.Getenv(k); v != "" {
+			return v, nil
+		}
+
+		return nil, nil
+	}
+}
+
+func envDefaultFuncAllowMissing(k string) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		v := os.Getenv(k)
+		return v, nil
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := Config{
+		AccessToken:  d.Get("access_token").(string),
+		ClientToken:  d.Get("client_token").(string),
+		ClientSecret: d.Get("client_secret").(string),
+		APIHost:      d.Get("host").(string),
+	}
+
+	return config.Client()
+}

--- a/builtin/providers/akamai/provider.go
+++ b/builtin/providers/akamai/provider.go
@@ -34,7 +34,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"akamai_gtm_domain": resourceAkamaiGTMDomain(),
+			"akamai_gtm_domain":      resourceAkamaiGTMDomain(),
+			"akamai_gtm_property":    resourceAkamaiGTMProperty(),
+			"akamai_gtm_data_center": resourceAkamaiGTMDataCenter(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/akamai/provider_test.go
+++ b/builtin/providers/akamai/provider_test.go
@@ -1,0 +1,40 @@
+package akamai
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"akamai": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("AKAMAI_EDGEGRID_HOST"); v == "" {
+		t.Fatal("AKAMAI_EDGEGRID_HOST must be set for acceptance tests")
+	}
+	if v := os.Getenv("AKAMAI_EDGEGRID_ACCESS_TOKEN"); v == "" {
+		t.Fatal("AKAMAI_EDGEGRID_ACCESS_TOKEN must be set for acceptance tests")
+	}
+	if v := os.Getenv("AKAMAI_EDGEGRID_CLIENT_TOKEN"); v == "" {
+		t.Fatal("AKAMAI_EDGEGRID_CLIENT_TOKEN must be set for acceptance tests")
+	}
+	if v := os.Getenv("AKAMAI_EDGEGRID_CLIENT_SECRET"); v == "" {
+		t.Fatal("AKAMAI_EDGEGRID_CLIENT_SECRET must be set for acceptance tests")
+	}
+}

--- a/builtin/providers/akamai/resource_gtm_data_center.go
+++ b/builtin/providers/akamai/resource_gtm_data_center.go
@@ -100,11 +100,11 @@ func resourceGTMDatacenterUpdate(d *schema.ResourceData, meta interface{}) error
 	log.Printf("[INFO] Updating GTM Datacenter: %s", d.Id())
 
 	updateBody := dc(d)
-	dcId, err := strconv.Atoi(d.Id())
+	dcID, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return err
 	}
-	updateBody.DataCenterID = dcId
+	updateBody.DataCenterID = dcID
 
 	_, err = meta.(*Clients).GTM.DataCenterUpdate(d.Get("domain").(string), updateBody)
 	if err != nil {
@@ -116,11 +116,11 @@ func resourceGTMDatacenterUpdate(d *schema.ResourceData, meta interface{}) error
 
 func resourceGTMDatacenterDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Datacenter: %s", d.Id())
-	dcId, err := strconv.Atoi(d.Id())
+	dcID, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return err
 	}
-	err = meta.(*Clients).GTM.DataCenterDelete(d.Get("domain").(string), dcId)
+	err = meta.(*Clients).GTM.DataCenterDelete(d.Get("domain").(string), dcID)
 	if err != nil {
 		return err
 	}
@@ -134,7 +134,7 @@ func dc(d *schema.ResourceData) *edgegrid.DataCenter {
 		Nickname:             d.Get("name").(string),
 		City:                 d.Get("city").(string),
 		Country:              d.Get("country").(string),
-		StateOrProvince:      d.Get("state").(string),
+		StateOrProvince:      d.Get("state_or_province").(string),
 		Continent:            d.Get("continent").(string),
 		Latitude:             d.Get("latitude").(float64),
 		Longitude:            d.Get("longitude").(float64),

--- a/builtin/providers/akamai/resource_gtm_data_center.go
+++ b/builtin/providers/akamai/resource_gtm_data_center.go
@@ -10,10 +10,10 @@ import (
 
 func resourceAkamaiGTMDataCenter() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGTMDatacenterCreate,
-		Read:   resourceGTMDatacenterRead,
-		Update: resourceGTMDatacenterUpdate,
-		Delete: resourceGTMDatacenterDelete,
+		Create: resourceGTMDataCenterCreate,
+		Read:   resourceGTMDataCenterRead,
+		Update: resourceGTMDataCenterUpdate,
+		Delete: resourceGTMDataCenterDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -64,7 +64,7 @@ func resourceAkamaiGTMDataCenter() *schema.Resource {
 	}
 }
 
-func resourceGTMDatacenterCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceGTMDataCenterCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating GTM Datacenter d: %+v", d)
 
 	created, err := meta.(*Clients).GTM.DataCenterCreate(d.Get("domain").(string), dc(d))
@@ -80,7 +80,7 @@ func resourceGTMDatacenterCreate(d *schema.ResourceData, meta interface{}) error
 	return resourceGTMDatacenterRead(d, meta)
 }
 
-func resourceGTMDatacenterRead(d *schema.ResourceData, meta interface{}) error {
+func resourceGTMDataCenterRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Reading GTM Datacenter: %s", d.Id())
 	dcId, err := strconv.Atoi(d.Id())
 	if err != nil {
@@ -96,7 +96,7 @@ func resourceGTMDatacenterRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceGTMDatacenterUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceGTMDataCenterUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Updating GTM Datacenter: %s", d.Id())
 
 	updateBody := dc(d)
@@ -111,10 +111,10 @@ func resourceGTMDatacenterUpdate(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
-	return resourceGTMDatacenterRead(d, meta)
+	return resourceGTMDataCenterRead(d, meta)
 }
 
-func resourceGTMDatacenterDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceGTMDataCenterDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Datacenter: %s", d.Id())
 	dcID, err := strconv.Atoi(d.Id())
 	if err != nil {

--- a/builtin/providers/akamai/resource_gtm_data_center.go
+++ b/builtin/providers/akamai/resource_gtm_data_center.go
@@ -38,7 +38,7 @@ func resourceAkamaiGTMDataCenter() *schema.Resource {
 			},
 			"country": &schema.Schema{
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"continent": &schema.Schema{
 				Type:     schema.TypeString,
@@ -46,11 +46,11 @@ func resourceAkamaiGTMDataCenter() *schema.Resource {
 			},
 			"latitude": &schema.Schema{
 				Type:     schema.TypeFloat,
-				Required: true,
+				Optional: true,
 			},
 			"longitude": &schema.Schema{
 				Type:     schema.TypeFloat,
-				Required: true,
+				Optional: true,
 			},
 			"virtual": &schema.Schema{
 				Type:     schema.TypeBool,
@@ -65,28 +65,28 @@ func resourceAkamaiGTMDataCenter() *schema.Resource {
 }
 
 func resourceGTMDataCenterCreate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] Creating GTM Datacenter d: %+v", d)
+	log.Printf("[INFO] Creating GTM Data Center: %+v", d)
 
 	created, err := meta.(*Clients).GTM.DataCenterCreate(d.Get("domain").(string), dc(d))
 	if err != nil {
-		log.Printf("resourceDatacenterCreate: %v", err)
+		log.Printf("resourceDataCenterCreate: %v", err)
 		return err
 	}
 
-	log.Printf("[INFO] Created GTM Datacenter named: %s, with ID of: %d", created.DataCenter.Nickname, created.DataCenter.DataCenterID)
+	log.Printf("[INFO] Created GTM Data Center named: %s, with ID of: %d", created.DataCenter.Nickname, created.DataCenter.DataCenterID)
 
 	d.SetId(strconv.Itoa(created.DataCenter.DataCenterID))
 
-	return resourceGTMDatacenterRead(d, meta)
+	return resourceGTMDataCenterRead(d, meta)
 }
 
 func resourceGTMDataCenterRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] Reading GTM Datacenter: %s", d.Id())
-	dcId, err := strconv.Atoi(d.Id())
+	log.Printf("[INFO] Reading GTM Data Center: %s", d.Id())
+	dcID, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return err
 	}
-	read, err := meta.(*Clients).GTM.DataCenter(d.Get("domain").(string), dcId)
+	read, err := meta.(*Clients).GTM.DataCenter(d.Get("domain").(string), dcID)
 	if err != nil {
 		return err
 	}
@@ -97,7 +97,7 @@ func resourceGTMDataCenterRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGTMDataCenterUpdate(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] Updating GTM Datacenter: %s", d.Id())
+	log.Printf("[INFO] Updating GTM Data Center: %s", d.Id())
 
 	updateBody := dc(d)
 	dcID, err := strconv.Atoi(d.Id())
@@ -115,7 +115,7 @@ func resourceGTMDataCenterUpdate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceGTMDataCenterDelete(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] Deleting Datacenter: %s", d.Id())
+	log.Printf("[INFO] Deleting Data Center: %s", d.Id())
 	dcID, err := strconv.Atoi(d.Id())
 	if err != nil {
 		return err

--- a/builtin/providers/akamai/resource_gtm_data_center.go
+++ b/builtin/providers/akamai/resource_gtm_data_center.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func resourceAkamaiGtmDatacenter() *schema.Resource {
+func resourceAkamaiGTMDataCenter() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGTMDatacenterCreate,
 		Read:   resourceGTMDatacenterRead,
@@ -32,7 +32,7 @@ func resourceAkamaiGtmDatacenter() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"state": &schema.Schema{
+			"state_or_province": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/builtin/providers/akamai/resource_gtm_data_center_test.go
+++ b/builtin/providers/akamai/resource_gtm_data_center_test.go
@@ -37,15 +37,15 @@ func testAccAkamaiGTMDataCenterDestroy(s *terraform.State) error {
 		if rs.Type != "akamai_gtm_data_center" {
 			continue
 		}
-		dcId, err := strconv.Atoi(rs.Primary.ID)
+		dcID, err := strconv.Atoi(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
 		// Try to find the data center
-		_, err = client.DataCenter("terraform-test.akadns.net", dcId)
+		_, err = client.DataCenter("terraform-test.akadns.net", dcID)
 
 		if err == nil {
-			fmt.Errorf("Data center still exists")
+			return fmt.Errorf("Data center still exists")
 		}
 	}
 
@@ -56,7 +56,6 @@ func testAccCheckAkamaiGTMDataCenterExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("n is %s", n)
 			return fmt.Errorf("Not found %s", rs)
 		}
 
@@ -65,17 +64,17 @@ func testAccCheckAkamaiGTMDataCenterExists(n string) resource.TestCheckFunc {
 		}
 
 		client := testAccProvider.Meta().(*Clients).GTM
-		dcId, err := strconv.Atoi(rs.Primary.ID)
+		dcID, err := strconv.Atoi(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		readDc, err := client.DataCenter("terraform-test.akadns.net", dcId)
+		readDC, err := client.DataCenter("terraform-test.akadns.net", dcID)
 
 		if err != nil {
 			return err
 		}
 
-		if strconv.Itoa(readDc.DataCenterID) != rs.Primary.ID {
+		if strconv.Itoa(readDC.DataCenterID) != rs.Primary.ID {
 			return fmt.Errorf("Record not found")
 		}
 

--- a/builtin/providers/akamai/resource_gtm_data_center_test.go
+++ b/builtin/providers/akamai/resource_gtm_data_center_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAkamaiGtmDatacenterBasic(t *testing.T) {
+func TestAccAkamaiGTMDataCenterBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/akamai/resource_gtm_data_center_test.go
+++ b/builtin/providers/akamai/resource_gtm_data_center_test.go
@@ -13,46 +13,46 @@ func TestAccAkamaiGtmDatacenterBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccAkamaiGtmDatacenterDestroy,
+		CheckDestroy: testAccAkamaiGTMDataCenterDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckAkamaiGTMDatacenterConfigBasic,
+				Config: testAccCheckAkamaiGTMDataCenterConfigBasic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAkamaiGTMDatacenterExists("akamai_gtm_datacenter.test_dc"),
-					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "name", "test_dc"),
-					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "domain", "terraform-test.akadns.net"),
-					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "city", "Downpatrick"),
-					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "country", "GB"),
-					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "continent", "EU"),
+					testAccCheckAkamaiGTMDataCenterExists("akamai_gtm_data_center.test_dc"),
+					resource.TestCheckResourceAttr("akamai_gtm_data_center.test_dc", "name", "test_dc"),
+					resource.TestCheckResourceAttr("akamai_gtm_data_center.test_dc", "domain", "terraform-test.akadns.net"),
+					resource.TestCheckResourceAttr("akamai_gtm_data_center.test_dc", "city", "Downpatrick"),
+					resource.TestCheckResourceAttr("akamai_gtm_data_center.test_dc", "country", "GB"),
+					resource.TestCheckResourceAttr("akamai_gtm_data_center.test_dc", "continent", "EU"),
 				),
 			},
 		},
 	})
 }
 
-func testAccAkamaiGtmDatacenterDestroy(s *terraform.State) error {
+func testAccAkamaiGTMDataCenterDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*Clients).GTM
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "akamai_gtm_datacenter" {
+		if rs.Type != "akamai_gtm_data_center" {
 			continue
 		}
 		dcId, err := strconv.Atoi(rs.Primary.ID)
 		if err != nil {
 			return err
 		}
-		// Try to find the datacenter
+		// Try to find the data center
 		_, err = client.DataCenter("terraform-test.akadns.net", dcId)
 
 		if err == nil {
-			fmt.Errorf("Datacenter still exists")
+			fmt.Errorf("Data center still exists")
 		}
 	}
 
 	return nil
 }
 
-func testAccCheckAkamaiGTMDatacenterExists(n string) resource.TestCheckFunc {
+func testAccCheckAkamaiGTMDataCenterExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -83,8 +83,8 @@ func testAccCheckAkamaiGTMDatacenterExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckAkamaiGTMDatacenterConfigBasic = `
-resource "akamai_gtm_datacenter" "test_dc" {
+const testAccCheckAkamaiGTMDataCenterConfigBasic = `
+resource "akamai_gtm_data_center" "test_dc" {
   name =  "test_dc"
 	domain = "terraform-test.akadns.net"
 	city = "Downpatrick"

--- a/builtin/providers/akamai/resource_gtm_datacenter.go
+++ b/builtin/providers/akamai/resource_gtm_datacenter.go
@@ -1,0 +1,144 @@
+package akamai
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/Comcast/go-edgegrid/edgegrid"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAkamaiGtmDatacenter() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGTMDatacenterCreate,
+		Read:   resourceGTMDatacenterRead,
+		Update: resourceGTMDatacenterUpdate,
+		Delete: resourceGTMDatacenterDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"id": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"domain": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"city": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"state": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"country": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"continent": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"latitude": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Required: true,
+			},
+			"longitude": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Required: true,
+			},
+			"virtual": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"cloud_server_targeting": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceGTMDatacenterCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Creating GTM Datacenter d: %+v", d)
+
+	created, err := meta.(*Clients).GTM.DataCenterCreate(d.Get("domain").(string), dc(d))
+	if err != nil {
+		log.Printf("resourceDatacenterCreate: %v", err)
+		return err
+	}
+
+	log.Printf("[INFO] Created GTM Datacenter named: %s, with ID of: %d", created.DataCenter.Nickname, created.DataCenter.DataCenterID)
+
+	d.SetId(strconv.Itoa(created.DataCenter.DataCenterID))
+
+	return resourceGTMDatacenterRead(d, meta)
+}
+
+func resourceGTMDatacenterRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Reading GTM Datacenter: %s", d.Id())
+	dcId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+	read, err := meta.(*Clients).GTM.DataCenter(d.Get("domain").(string), dcId)
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", read.Nickname)
+
+	return nil
+}
+
+func resourceGTMDatacenterUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating GTM Datacenter: %s", d.Id())
+
+	updateBody := dc(d)
+	dcId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+	updateBody.DataCenterID = dcId
+
+	_, err = meta.(*Clients).GTM.DataCenterUpdate(d.Get("domain").(string), updateBody)
+	if err != nil {
+		return err
+	}
+
+	return resourceGTMDatacenterRead(d, meta)
+}
+
+func resourceGTMDatacenterDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Deleting Datacenter: %s", d.Id())
+	dcId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+	err = meta.(*Clients).GTM.DataCenterDelete(d.Get("domain").(string), dcId)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return err
+}
+
+func dc(d *schema.ResourceData) *edgegrid.DataCenter {
+	return &edgegrid.DataCenter{
+		Nickname:             d.Get("name").(string),
+		City:                 d.Get("city").(string),
+		Country:              d.Get("country").(string),
+		StateOrProvince:      d.Get("state").(string),
+		Continent:            d.Get("continent").(string),
+		Latitude:             d.Get("latitude").(float64),
+		Longitude:            d.Get("longitude").(float64),
+		Virtual:              d.Get("virtual").(bool),
+		CloudServerTargeting: d.Get("cloud_server_targeting").(bool),
+	}
+}

--- a/builtin/providers/akamai/resource_gtm_datacenter_test.go
+++ b/builtin/providers/akamai/resource_gtm_datacenter_test.go
@@ -1,0 +1,96 @@
+package akamai
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAkamaiGtmDatacenterBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAkamaiGtmDatacenterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAkamaiGTMDatacenterConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMDatacenterExists("akamai_gtm_datacenter.test_dc"),
+					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "name", "test_dc"),
+					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "domain", "terraform-test.akadns.net"),
+					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "city", "Downpatrick"),
+					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "country", "GB"),
+					resource.TestCheckResourceAttr("akamai_gtm_datacenter.test_dc", "continent", "EU"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAkamaiGtmDatacenterDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Clients).GTM
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_gtm_datacenter" {
+			continue
+		}
+		dcId, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		// Try to find the datacenter
+		_, err = client.DataCenter("terraform-test.akadns.net", dcId)
+
+		if err == nil {
+			fmt.Errorf("Datacenter still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAkamaiGTMDatacenterExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("n is %s", n)
+			return fmt.Errorf("Not found %s", rs)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*Clients).GTM
+		dcId, err := strconv.Atoi(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+		readDc, err := client.DataCenter("terraform-test.akadns.net", dcId)
+
+		if err != nil {
+			return err
+		}
+
+		if strconv.Itoa(readDc.DataCenterID) != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckAkamaiGTMDatacenterConfigBasic = `
+resource "akamai_gtm_datacenter" "test_dc" {
+  name =  "test_dc"
+	domain = "terraform-test.akadns.net"
+	city = "Downpatrick"
+	country = "GB"
+	continent = "EU"
+	latitude = 54.367
+	longitude = -5.582
+	virtual = false
+}`

--- a/builtin/providers/akamai/resource_gtm_domain.go
+++ b/builtin/providers/akamai/resource_gtm_domain.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func resourceAkamaiGtmDomain() *schema.Resource {
+func resourceAkamaiGTMDomain() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGTMDomainCreate,
 		Read:   resourceGTMDomainRead,

--- a/builtin/providers/akamai/resource_gtm_domain.go
+++ b/builtin/providers/akamai/resource_gtm_domain.go
@@ -66,9 +66,12 @@ func resourceGTMDomainUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 // NOTE: this 403s due to Akamai's permissions policy
-// DomainDelete has been removed from edgegrid.Client
 func resourceGTMDomainDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting domain: %s", d.Id())
+	err := meta.(*Clients).GTM.DomainDelete(d.Get("name").(string))
+	if err != nil {
+		return err
+	}
 
 	d.SetId("")
 

--- a/builtin/providers/akamai/resource_gtm_domain.go
+++ b/builtin/providers/akamai/resource_gtm_domain.go
@@ -1,0 +1,76 @@
+package akamai
+
+import (
+	"log"
+
+	"github.com/Comcast/go-edgegrid/edgegrid"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAkamaiGtmDomain() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGTMDomainCreate,
+		Read:   resourceGTMDomainRead,
+		Update: resourceGTMDomainUpdate,
+		Delete: resourceGTMDomainDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceGTMDomainCreate(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating GTM domain: %s", name)
+	created, err := meta.(*Clients).GTM.DomainCreate(name, d.Get("type").(string))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(created.Domain.Name)
+
+	return resourceGTMDomainRead(d, meta)
+}
+
+func resourceGTMDomainRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Reading GTM domain: %s", d.Id())
+	domain, err := meta.(*Clients).GTM.Domain(d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", domain.Name)
+
+	return nil
+}
+
+func resourceGTMDomainUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating GTM domain: %s", d.Id())
+	_, err := meta.(*Clients).GTM.DomainUpdate(&edgegrid.Domain{
+		Name: d.Get("name").(string),
+		Type: d.Get("type").(string),
+	})
+	if err != nil {
+		return err
+	}
+
+	return resourceGTMDomainRead(d, meta)
+}
+
+// NOTE: this 403s due to Akamai's permissions policy
+// DomainDelete has been removed from edgegrid.Client
+func resourceGTMDomainDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Deleting domain: %s", d.Id())
+
+	d.SetId("")
+
+	return nil
+}

--- a/builtin/providers/akamai/resource_gtm_domain_test.go
+++ b/builtin/providers/akamai/resource_gtm_domain_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAkamaiGtmDomainBasic(t *testing.T) {
+func TestAccAkamaiGTMDomainBasic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/akamai/resource_gtm_domain_test.go
+++ b/builtin/providers/akamai/resource_gtm_domain_test.go
@@ -1,0 +1,65 @@
+package akamai
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAkamaiGtmDomainBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAkamaiGTMDomainDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAkamaiGtmDomainConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMDomainExists("akamai_gtm_domain.test_domain"),
+					resource.TestCheckResourceAttr("akamai_gtm_domain.test_domain", "name", "terraform-test.akadns.net"),
+					resource.TestCheckResourceAttr("akamai_gtm_domain.test_domain", "type", "weighted"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAkamaiGTMDomainDestroy(s *terraform.State) error {
+	// TODO
+	return nil
+}
+
+func testAccCheckAkamaiGTMDomainExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", rs)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*Clients).GTM
+
+		readDomain, err := client.Domain(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if readDomain.Name != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckAkamaiGtmDomainConfigBasic = `
+resource "akamai_gtm_domain" "test_domain" {
+	name = "terraform-test.akadns.net"
+	type = "weighted"
+}`

--- a/builtin/providers/akamai/resource_gtm_property.go
+++ b/builtin/providers/akamai/resource_gtm_property.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func resourceAkamaiGtmProperty() *schema.Resource {
+func resourceAkamaiGTMProperty() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceGTMPropertyCreate,
 		Read:   resourceGTMPropertyRead,
@@ -174,7 +174,7 @@ func resourceAkamaiGtmProperty() *schema.Resource {
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"datacenter_id": &schema.Schema{
+						"data_center_id": &schema.Schema{
 							Type:     schema.TypeInt,
 							Required: true,
 						},
@@ -239,7 +239,7 @@ func resourceGTMPropertyRead(d *schema.ResourceData, meta interface{}) error {
 func resourceGTMPropertyUpdate(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	log.Printf("[INFO] Updating GTM property: %s", name)
-	updated, err := meta.(*AkamaiClients).GTM.PropertyCreate(d.Get("domain").(string), property(d))
+	updated, err := meta.(*Clients).GTM.PropertyCreate(d.Get("domain").(string), property(d))
 	if err != nil {
 		return err
 	}
@@ -254,7 +254,7 @@ func resourceGTMPropertyUpdate(d *schema.ResourceData, meta interface{}) error {
 	return resourceGTMPropertyRead(d, meta)
 }
 
-func resourceGtmPropertyDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceGTMPropertyDelete(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 	log.Printf("[INFO] Deleting property: %s", name)
 	_, err := meta.(*Clients).GTM.PropertyDelete(d.Get("domain").(string), name)
@@ -298,7 +298,7 @@ func trafficTargets(d *schema.ResourceData) []edgegrid.TrafficTarget {
 			Weight:       d.Get(prefix + ".weight").(float64),
 			Enabled:      d.Get(prefix + ".enabled").(bool),
 			Servers:      stringSetToStringSlice(d.Get(prefix + ".servers").(*schema.Set)),
-			DataCenterID: d.Get(prefix + ".datacenter_id").(int),
+			DataCenterID: d.Get(prefix + ".data_center_id").(int),
 		})
 	}
 

--- a/builtin/providers/akamai/resource_gtm_property.go
+++ b/builtin/providers/akamai/resource_gtm_property.go
@@ -1,0 +1,343 @@
+package akamai
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/Comcast/go-edgegrid/edgegrid"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAkamaiGtmProperty() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGTMPropertyCreate,
+		Read:   resourceGTMPropertyRead,
+		Update: resourceGTMPropertyUpdate,
+		Delete: resourceGTMPropertyDelete,
+
+		Schema: map[string]*schema.Schema{
+			"balance_by_download_score": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"domain": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"cname": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"dynamic_ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"failover_delay": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"failback_delay": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+			"handout_mode": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"health_max": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"health_multiplier": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"health_threshold": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"load_imbalance_percentage": &schema.Schema{
+				Type:     schema.TypeFloat,
+				Optional: true,
+			},
+			"ipv6": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"score_aggregation_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"static_ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"stickiness_bonus_percentage": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"stickiness_bonus_constant": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"use_computed_targets": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"liveness_test": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"http_error_3xx": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"http_error_4xx": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"http_error_5xx": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"test_interval": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"test_object": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"test_object_port": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"test_object_protocol": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"test_object_username": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"test_object_password": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"test_timeout": &schema.Schema{
+							Type:     schema.TypeFloat,
+							Optional: true,
+						},
+						"disable_nonstandard_port_warning": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+						},
+						"request_string": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"response_string": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ssl_client_private_key": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ssl_certificate": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"host_header": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"traffic_target": &schema.Schema{
+				Type:     schema.TypeList,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"datacenter_id": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"enabled": &schema.Schema{
+							Type:     schema.TypeBool,
+							Required: true,
+						},
+						"weight": &schema.Schema{
+							Type:     schema.TypeFloat,
+							Required: true,
+						},
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"servers": &schema.Schema{
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set: func(v interface{}) int {
+								return hashcode.String(v.(string))
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceGTMPropertyCreate(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	property := property(d)
+	log.Printf("[INFO] Creating GTM property: %s", name)
+	created, err := meta.(*Clients).GTM.PropertyCreate(d.Get("domain").(string), property)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(created.Property.Name)
+
+	err = resourceGTMWaitUntilDeployed(d, meta)
+	if err != nil {
+		return err
+	}
+
+	return resourceGTMPropertyRead(d, meta)
+}
+
+func resourceGTMPropertyRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Reading GTM property: %s", d.Id())
+	prop, err := meta.(*Clients).GTM.Property(d.Get("domain").(string), d.Get("name").(string))
+	if err != nil {
+		return err
+	}
+
+	d.Set("name", prop.Name)
+
+	return nil
+}
+
+func resourceGTMPropertyUpdate(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Updating GTM property: %s", name)
+	updated, err := meta.(*AkamaiClients).GTM.PropertyCreate(d.Get("domain").(string), property(d))
+	if err != nil {
+		return err
+	}
+
+	d.SetId(updated.Property.Name)
+
+	err = resourceGTMWaitUntilDeployed(d, meta)
+	if err != nil {
+		return err
+	}
+
+	return resourceGTMPropertyRead(d, meta)
+}
+
+func resourceGtmPropertyDelete(d *schema.ResourceData, meta interface{}) error {
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Deleting property: %s", name)
+	_, err := meta.(*Clients).GTM.PropertyDelete(d.Get("domain").(string), name)
+	if err != nil {
+		return nil
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func property(d *schema.ResourceData) *edgegrid.Property {
+	return &edgegrid.Property{
+		Cname:                     d.Get("cname").(string),
+		Name:                      d.Get("name").(string),
+		Type:                      d.Get("type").(string),
+		Ipv6:                      d.Get("ipv6").(bool),
+		DynamicTTL:                d.Get("dynamic_ttl").(int),
+		StaticTTL:                 d.Get("static_ttl").(int),
+		HandoutMode:               d.Get("handout_mode").(string),
+		FailbackDelay:             d.Get("failback_delay").(int),
+		FailoverDelay:             d.Get("failover_delay").(int),
+		ScoreAggregationType:      d.Get("score_aggregation_type").(string),
+		LoadImbalancePercentage:   d.Get("load_imbalance_percentage").(float64),
+		StickinessBonusPercentage: d.Get("stickiness_bonus_percentage").(int),
+		TrafficTargets:            trafficTargets(d),
+		LivenessTests:             livenessTests(d),
+	}
+}
+
+func trafficTargets(d *schema.ResourceData) []edgegrid.TrafficTarget {
+	targets := []edgegrid.TrafficTarget{}
+	targetsCount := d.Get("traffic_target.#").(int)
+
+	for i := 0; i < targetsCount; i++ {
+		prefix := fmt.Sprintf("traffic_target.%d", i)
+
+		targets = append(targets, edgegrid.TrafficTarget{
+			Name:         d.Get(prefix + ".name").(string),
+			Weight:       d.Get(prefix + ".weight").(float64),
+			Enabled:      d.Get(prefix + ".enabled").(bool),
+			Servers:      stringSetToStringSlice(d.Get(prefix + ".servers").(*schema.Set)),
+			DataCenterID: d.Get(prefix + ".datacenter_id").(int),
+		})
+	}
+
+	return targets
+}
+
+func livenessTests(d *schema.ResourceData) []edgegrid.LivenessTest {
+	tests := []edgegrid.LivenessTest{}
+	testsCount := d.Get("liveness_test.#").(int)
+
+	for i := 0; i < testsCount; i++ {
+		prefix := fmt.Sprintf("liveness_test.%d", i)
+
+		tests = append(tests, edgegrid.LivenessTest{
+			Name:                          d.Get(prefix + ".name").(string),
+			TestInterval:                  int64(d.Get(prefix + ".test_interval").(int)),
+			HTTPError3xx:                  d.Get(prefix + ".http_error_3xx").(bool),
+			HTTPError4xx:                  d.Get(prefix + ".http_error_4xx").(bool),
+			HTTPError5xx:                  d.Get(prefix + ".http_error_5xx").(bool),
+			TestObjectPort:                int64(d.Get(prefix + ".test_object_port").(int)),
+			TestTimeout:                   d.Get(prefix + ".test_timeout").(float64),
+			TestObject:                    d.Get(prefix + ".test_object").(string),
+			TestObjectProtocol:            d.Get(prefix + ".test_object_protocol").(string),
+			DisableNonstandardPortWarning: d.Get(prefix + ".disable_nonstandard_port_warning").(bool),
+		})
+	}
+
+	return tests
+}
+
+func getServers(prefix string, d *schema.ResourceData) []string {
+	servers := []string{}
+	serversPrefix := d.Get(prefix + ".servers")
+	serversCount := d.Get(fmt.Sprintf("%d.#", serversPrefix)).(int)
+
+	for i := 0; i < serversCount; i++ {
+		serverPrefix := fmt.Sprintf("%d.%s", serversPrefix, i)
+		servers = append(servers, d.Get(serverPrefix).(string))
+	}
+
+	return servers
+}

--- a/builtin/providers/akamai/resource_gtm_property.go
+++ b/builtin/providers/akamai/resource_gtm_property.go
@@ -335,7 +335,7 @@ func getServers(prefix string, d *schema.ResourceData) []string {
 	serversCount := d.Get(fmt.Sprintf("%d.#", serversPrefix)).(int)
 
 	for i := 0; i < serversCount; i++ {
-		serverPrefix := fmt.Sprintf("%d.%s", serversPrefix, i)
+		serverPrefix := fmt.Sprintf("%d.%s", serversPrefix, string(i))
 		servers = append(servers, d.Get(serverPrefix).(string))
 	}
 

--- a/builtin/providers/akamai/resource_gtm_property_test.go
+++ b/builtin/providers/akamai/resource_gtm_property_test.go
@@ -39,7 +39,7 @@ func testAccAkamaiGTMPropertyDestroy(s *terraform.State) error {
 		// Try to find the property
 		_, err := client.Property("terraform-test.akadns.net", name)
 		if err == nil {
-			fmt.Errorf("Property still exists")
+			return fmt.Errorf("Property still exists")
 		}
 	}
 

--- a/builtin/providers/akamai/resource_gtm_property_test.go
+++ b/builtin/providers/akamai/resource_gtm_property_test.go
@@ -79,7 +79,7 @@ resource "akamai_gtm_domain" "property_test_domain" {
 	type = "basic"
 }
 
-resource "akamai_gtm_datacenter" "property_test_dc1" {
+resource "akamai_gtm_data_center" "property_test_dc1" {
 	name = "property_test_dc1"
 	domain = "${akamai_gtm_domain.property_test_domain.name}"
 	country = "GB"
@@ -92,7 +92,7 @@ resource "akamai_gtm_datacenter" "property_test_dc1" {
 	]
 }
 
-resource "akamai_gtm_datacenter" "property_test_dc2" {
+resource "akamai_gtm_data_center" "property_test_dc2" {
 	name = "property_test_dc2"
 	domain = "${akamai_gtm_domain.property_test_domain.name}"
 	country = "IS"
@@ -101,7 +101,7 @@ resource "akamai_gtm_datacenter" "property_test_dc2" {
 	longitude = -23.776
 	latitude = 64.808
 	depends_on = [
-		"akamai_gtm_datacenter.property_test_dc1"
+		"akamai_gtm_data_center.property_test_dc1"
 	]
 }
 
@@ -139,9 +139,9 @@ resource "akamai_gtm_property" "test_property" {
   }
 	trafficTarget {
 		enabled = true
-		dataCenterId = "${akamai_gtm_datacenter.property_test_dc1.id}"
+		data_center_id = "${akamai_gtm_data_center.property_test_dc1.id}"
 		weight = 50.0
-		name = "${akamai_gtm_datacenter.property_test_dc1.name}"
+		name = "${akamai_gtm_data_center.property_test_dc1.name}"
 		servers = [
 			"1.2.3.4",
 			"1.2.3.5"
@@ -149,9 +149,9 @@ resource "akamai_gtm_property" "test_property" {
 	}
 	trafficTarget {
 		enabled = true
-		dataCenterId = "${akamai_gtm_datacenter.property_test_dc2.id}"
+		data_center_id = "${akamai_gtm_data_center.property_test_dc2.id}"
 		weight = 50.0
-		name = "${akamai_gtm_datacenter.property_test_dc2.name}"
+		name = "${akamai_gtm_data_center.property_test_dc2.name}"
 		servers = [
 			"1.2.3.6",
 			"1.2.3.7"

--- a/builtin/providers/akamai/resource_gtm_property_test.go
+++ b/builtin/providers/akamai/resource_gtm_property_test.go
@@ -1,0 +1,161 @@
+package akamai
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAkamaiGTMPropertyBasic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAkamaiGTMPropertyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAkamaiGTMPropertyConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAkamaiGTMPropertyExists("akamai_gtm_property.test_property"),
+					resource.TestCheckResourceAttr("akamai_gtm_property.test_property", "domain", "terraform-test.akadns.net"),
+					resource.TestCheckResourceAttr("akamai_gtm_property.test_property", "name", "test_property"),
+					resource.TestCheckResourceAttr("akamai_gtm_property.test_property", "cname", "example.com"),
+				),
+			},
+		},
+	})
+}
+
+func testAccAkamaiGTMPropertyDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*Clients).GTM
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "akamai_gtm_property" {
+			continue
+		}
+		name := rs.Primary.ID
+
+		// Try to find the property
+		_, err := client.Property("terraform-test.akadns.net", name)
+		if err == nil {
+			fmt.Errorf("Property still exists")
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAkamaiGTMPropertyExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", rs)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*Clients).GTM
+
+		readProp, err := client.Property("terraform-test.akadns.net", rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if readProp.Name != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckAkamaiGTMPropertyConfigBasic = `
+resource "akamai_gtm_domain" "property_test_domain" {
+	name = "terraform-test.akadns.net"
+	type = "basic"
+}
+
+resource "akamai_gtm_datacenter" "property_test_dc1" {
+	name = "property_test_dc1"
+	domain = "${akamai_gtm_domain.property_test_domain.name}"
+	country = "GB"
+	continent = "EU"
+	city = "Downpatrick"
+	longitude = -5.582
+	latitude = 54.367
+	depends_on = [
+		"akamai_gtm_domain.property_test_domain"
+	]
+}
+
+resource "akamai_gtm_datacenter" "property_test_dc2" {
+	name = "property_test_dc2"
+	domain = "${akamai_gtm_domain.property_test_domain.name}"
+	country = "IS"
+	continent = "EU"
+	city = "Snæfellsjökull"
+	longitude = -23.776
+	latitude = 64.808
+	depends_on = [
+		"akamai_gtm_datacenter.property_test_dc1"
+	]
+}
+
+resource "akamai_gtm_property" "test_property" {
+	cname = "example.com"
+	domain = "${akamai_gtm_domain.property_test_domain.name}"
+	type = "weighted-round-robin"
+	name = "test_property"
+	balanceByDownloadScore = false
+	dynamicTTL = 300
+	failoverDelay = 0
+	failbackDelay = 0
+	handoutMode = "normal"
+	healthThreshold = 0
+	healthMax = 0
+	healthMultiplier = 0
+	loadImbalancePercentage = 10
+	ipv6 = false
+	scoreAggregationType = "mean"
+	staticTTL = 600
+	stickinessBonusPercentage = 50
+	stickinessBonusConstant = 0
+	useComputedTargets = false
+  livenessTest {
+    name = "terraform-provider-akamai automated acceptance tests"
+    testObject = "/status"
+    testObjectProtocol = "HTTP"
+    testInterval = 60
+    disableNonstandardPortWarning = false
+    httpError4xx = true
+    httpError3xx = true
+    httpError5xx = true
+    testObjectPort = 80
+    testTimeout = 25
+  }
+	trafficTarget {
+		enabled = true
+		dataCenterId = "${akamai_gtm_datacenter.property_test_dc1.id}"
+		weight = 50.0
+		name = "${akamai_gtm_datacenter.property_test_dc1.name}"
+		servers = [
+			"1.2.3.4",
+			"1.2.3.5"
+		]
+	}
+	trafficTarget {
+		enabled = true
+		dataCenterId = "${akamai_gtm_datacenter.property_test_dc2.id}"
+		weight = 50.0
+		name = "${akamai_gtm_datacenter.property_test_dc2.name}"
+		servers = [
+			"1.2.3.6",
+			"1.2.3.7"
+		]
+	}
+}
+`

--- a/builtin/providers/akamai/resource_gtm_property_test.go
+++ b/builtin/providers/akamai/resource_gtm_property_test.go
@@ -110,34 +110,34 @@ resource "akamai_gtm_property" "test_property" {
 	domain = "${akamai_gtm_domain.property_test_domain.name}"
 	type = "weighted-round-robin"
 	name = "test_property"
-	balanceByDownloadScore = false
-	dynamicTTL = 300
-	failoverDelay = 0
-	failbackDelay = 0
-	handoutMode = "normal"
-	healthThreshold = 0
-	healthMax = 0
-	healthMultiplier = 0
-	loadImbalancePercentage = 10
+	balance_by_download_score = false
+	dynamic_ttl = 300
+	failover_delay = 0
+	failback_delay = 0
+	handout_mode = "normal"
+	health_threshold = 0
+	health_max = 0
+	health_multiplier = 0
+	load_imbalance_percentage = 10
 	ipv6 = false
-	scoreAggregationType = "mean"
-	staticTTL = 600
-	stickinessBonusPercentage = 50
-	stickinessBonusConstant = 0
-	useComputedTargets = false
-  livenessTest {
+	score_aggregation_type = "mean"
+	static_ttl = 600
+	stickiness_bonus_percentage = 50
+	stickiness_bonus_constant = 0
+	use_computed_targets = false
+  liveness_test {
     name = "terraform-provider-akamai automated acceptance tests"
-    testObject = "/status"
-    testObjectProtocol = "HTTP"
-    testInterval = 60
-    disableNonstandardPortWarning = false
-    httpError4xx = true
-    httpError3xx = true
-    httpError5xx = true
-    testObjectPort = 80
-    testTimeout = 25
+    test_object = "/status"
+    test_object_protocol = "HTTP"
+    test_interval = 60
+    disable_nonstandard_port_warning = false
+    http_error_4xx = true
+    http_error_3xx = true
+    http_error_5xx = true
+    test_object_port = 80
+    test_timeout = 25
   }
-	trafficTarget {
+	traffic_target {
 		enabled = true
 		data_center_id = "${akamai_gtm_data_center.property_test_dc1.id}"
 		weight = 50.0
@@ -147,7 +147,7 @@ resource "akamai_gtm_property" "test_property" {
 			"1.2.3.5"
 		]
 	}
-	trafficTarget {
+	traffic_target {
 		enabled = true
 		data_center_id = "${akamai_gtm_data_center.property_test_dc2.id}"
 		weight = 50.0

--- a/builtin/providers/akamai/util.go
+++ b/builtin/providers/akamai/util.go
@@ -1,0 +1,55 @@
+package akamai
+
+import (
+	"errors"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceGTMWaitUntilDeployed(d *schema.ResourceData, meta interface{}) error {
+	stateConf := &resource.StateChangeConf{
+		Pending:    []string{"PENDING"},
+		Target:     []string{"COMPLETE"},
+		Refresh:    resourceGTMStateRefreshFunc(d, meta),
+		Timeout:    30 * time.Minute,
+		Delay:      1 * time.Minute,
+		MinTimeout: 15 * time.Second,
+	}
+	_, err := stateConf.WaitForState()
+
+	return err
+}
+
+func resourceGTMStateRefreshFunc(d *schema.ResourceData, meta interface{}) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		log.Printf("[INFO] waiting for %v COMPLETE propagation status", d.Get("domain"))
+		status, err := meta.(*Clients).GTM.DomainStatus(d.Get("domain").(string))
+		if err != nil {
+			log.Printf("[ERROR] %#v", err)
+			return nil, "", err
+		}
+		if status.PropagationStatus == "DENIED" {
+			err = errors.New(status.Message)
+			log.Printf("[ERROR] propagation status DENIED: %#v", err)
+			return status, status.PropagationStatus, err
+		}
+
+		return status, status.PropagationStatus, nil
+	}
+}
+
+func stringSetToStringSlice(stringSet *schema.Set) []string {
+	ret := []string{}
+	if stringSet == nil {
+		return ret
+	}
+
+	for _, envVal := range stringSet.List() {
+		ret = append(ret, envVal.(string))
+	}
+
+	return ret
+}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -6,6 +6,7 @@
 package command
 
 import (
+	akamaiprovider "github.com/hashicorp/terraform/builtin/providers/akamai"
 	archiveprovider "github.com/hashicorp/terraform/builtin/providers/archive"
 	atlasprovider "github.com/hashicorp/terraform/builtin/providers/atlas"
 	awsprovider "github.com/hashicorp/terraform/builtin/providers/aws"
@@ -69,6 +70,7 @@ import (
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
+	"akamai":       akamaiprovider.Provider,
 	"archive":      archiveprovider.Provider,
 	"atlas":        atlasprovider.Provider,
 	"aws":          awsprovider.Provider,

--- a/vendor/github.com/Comcast/go-edgegrid/LICENSE
+++ b/vendor/github.com/Comcast/go-edgegrid/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2016 Comcast Cable Communications Management, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/github.com/Comcast/go-edgegrid/NOTICE
+++ b/vendor/github.com/Comcast/go-edgegrid/NOTICE
@@ -1,0 +1,5 @@
+go-edgegrid
+
+Copyright 2015-2016 Comcast Cable Communications Management, LLC
+
+This product includes software developed at Comcast (http://www.comcast.com/).

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/auth.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/auth.go
@@ -1,0 +1,166 @@
+package edgegrid
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/satori/go.uuid"
+)
+
+// AuthParams is used to house various request details such that
+// the AuthParams can be passed to Auth to sign using the
+// Akamai {OPEN} EdgeGrid Authentication scheme.
+type AuthParams struct {
+	req           *http.Request
+	clientToken   string
+	accessToken   string
+	clientSecret  string
+	timestamp     string
+	nonce         string
+	headersToSign []string
+}
+
+// NewAuthParams returns an AuthParams generated from req, accessToken,
+// clientToken, and clientSecret.
+func NewAuthParams(req *http.Request, accessToken, clientToken, clientSecret string) AuthParams {
+	return AuthParams{
+		req,
+		clientToken,
+		accessToken,
+		clientSecret,
+		time.Now().UTC().Format("20060102T15:04:05+0000"),
+		uuid.NewV4().String(),
+		[]string{},
+	}
+}
+
+// Auth takes prm and returns a string that can be
+// used as the `Authorization` header in making Akamai API requests.
+//
+// The string returned by Auth conforms to the
+// Akamai {OPEN} EdgeGrid Authentication scheme.
+// https://developer.akamai.com/introduction/Client_Auth.html
+func Auth(prm AuthParams) string {
+	var auth bytes.Buffer
+	orderedKeys := []string{"client_token", "access_token", "timestamp", "nonce"}
+	timestamp := prm.timestamp
+
+	m := map[string]string{
+		orderedKeys[0]: prm.clientToken,
+		orderedKeys[1]: prm.accessToken,
+		orderedKeys[2]: timestamp,
+		orderedKeys[3]: prm.nonce,
+	}
+
+	auth.WriteString("EG1-HMAC-SHA256 ")
+
+	for _, each := range orderedKeys {
+		auth.WriteString(concat([]string{
+			each,
+			"=",
+			m[each],
+			";",
+		}))
+	}
+
+	auth.WriteString(signRequest(prm.req, timestamp, prm.clientSecret, auth.String(), prm.headersToSign))
+
+	return auth.String()
+}
+
+func signRequest(request *http.Request, timestamp, clientSecret, authHeader string, headersToSign []string) string {
+	dataToSign := makeDataToSign(request, authHeader, headersToSign)
+	signingKey := makeSigningKey(timestamp, clientSecret)
+
+	return concat([]string{
+		"signature=",
+		base64HmacSha256(dataToSign, signingKey),
+	})
+}
+
+func base64Sha256(str string) string {
+	h := sha256.New()
+
+	h.Write([]byte(str))
+
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func base64HmacSha256(message, secret string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+
+	h.Write([]byte(message))
+
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func makeDataToSign(request *http.Request, authHeader string, headersToSign []string) string {
+	var data bytes.Buffer
+	values := []string{
+		request.Method,
+		request.URL.Scheme,
+		request.Host,
+		urlPathWithQuery(request),
+		canonicalizeHeaders(request, headersToSign),
+		makeContentHash(request),
+		authHeader,
+	}
+
+	data.WriteString(strings.Join(values, "\t"))
+
+	return data.String()
+}
+
+func canonicalizeHeaders(request *http.Request, headersToSign []string) string {
+	var canonicalized bytes.Buffer
+
+	for key, values := range request.Header {
+		if stringInSlice(key, headersToSign) {
+			canonicalized.WriteString(concat([]string{
+				strings.ToLower(key),
+				":",
+				strings.Join(strings.Fields(values[0]), " "),
+				"\t",
+			}))
+		}
+	}
+
+	return canonicalized.String()
+}
+
+func makeContentHash(req *http.Request) string {
+	if req.Method == "POST" {
+		buf, err := ioutil.ReadAll(req.Body)
+		rdr := reader{bytes.NewBuffer(buf)}
+
+		if err != nil {
+			panic(err)
+		}
+
+		req.Body = rdr
+
+		return base64Sha256(string(buf))
+	}
+
+	return ""
+}
+
+func makeSigningKey(timestamp, clientSecret string) string {
+	return base64HmacSha256(timestamp, clientSecret)
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if strings.ToLower(b) == strings.ToLower(a) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/client.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/client.go
@@ -1,0 +1,80 @@
+package edgegrid
+
+import (
+	"net/http"
+	"os"
+)
+
+// Client is an interface for an Akamai API client.
+type Client interface {
+	GetCredentials() *AuthCredentials
+	GetHTTPClient() *http.Client
+}
+
+// AuthCredentials houses various Akamai-client-specific
+// data necessary to authenticate the Akamai API.
+type AuthCredentials struct {
+	AccessToken  string
+	ClientToken  string
+	ClientSecret string
+	APIHost      string
+}
+
+// GTMClientWithCreds takes an accessToken, a clientToken, a clientSecret,
+// and an apiHost string and returns a GTMClient.
+func GTMClientWithCreds(accessToken, clientToken, clientSecret, apiHost string) *GTMClient {
+	return &GTMClient{
+		&AuthCredentials{accessToken, clientToken, clientSecret, apiHost},
+		&http.Client{},
+	}
+}
+
+// NewGTMClient returns a GTMClient using the
+// AKAMAI_EDGEGRID_ACCESS_TOKEN, AKAMAI_EDGEGRID_CLIENT_TOKEN,
+// AKAMAI_EDGEGRID_CLIENT_SECRET, and AKAMAI_EDGEGRID_HOST environment
+// variables.
+func NewGTMClient() *GTMClient {
+	return &GTMClient{
+		NewCredentials(),
+		&http.Client{},
+	}
+}
+
+// NewPAPIClient returns a PAPIClient using the
+// AKAMAI_EDGEGRID_ACCESS_TOKEN, AKAMAI_EDGEGRID_CLIENT_TOKEN,
+// AKAMAI_EDGEGRID_CLIENT_SECRET, and AKAMAI_EDGEGRID_HOST environment
+// variables.
+func NewPAPIClient() *PAPIClient {
+	return &PAPIClient{
+		NewCredentials(),
+		&http.Client{},
+	}
+}
+
+// PAPIClientWithCreds takes an accessToken, a clientToken, a clientSecret,
+// and an apiHost and returns a PAPIClient.
+func PAPIClientWithCreds(accessToken, clientToken, clientSecret, apiHost string) *PAPIClient {
+	return &PAPIClient{
+		&AuthCredentials{accessToken, clientToken, clientSecret, apiHost},
+		&http.Client{},
+	}
+}
+
+// NewCredentials returns an AuthCredentials
+// using the AKAMAI_EDGEGRID_ACCESS_TOKEN, AKAMAI_EDGEGRID_CLIENT_TOKEN,
+// AKAMAI_EDGEGRID_CLIENT_SECRET, and AKAMAI_EDGEGRID_HOST environment
+// variables.
+func NewCredentials() *AuthCredentials {
+	return &AuthCredentials{
+		os.Getenv("AKAMAI_EDGEGRID_ACCESS_TOKEN"),
+		os.Getenv("AKAMAI_EDGEGRID_CLIENT_TOKEN"),
+		os.Getenv("AKAMAI_EDGEGRID_CLIENT_SECRET"),
+		os.Getenv("AKAMAI_EDGEGRID_HOST"),
+	}
+}
+
+// LogRequests returns true if the AK_LOG environment variable is set;
+// false if it is not.
+func LogRequests() bool {
+	return os.Getenv("AK_LOG") != ""
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_client.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_client.go
@@ -1,0 +1,20 @@
+package edgegrid
+
+import "net/http"
+
+// GTMClient is an Akamai GTM API client.
+// https://developer.akamai.com/api/luna/config-gtm/overview.html
+type GTMClient struct {
+	Credentials *AuthCredentials
+	HTTPClient  *http.Client
+}
+
+// GetCredentials takes a GTMClient and returns its Credentials.
+func (c GTMClient) GetCredentials() *AuthCredentials {
+	return c.Credentials
+}
+
+// GetHTTPClient takes a GTMClient and returns its HTTPClient.
+func (c GTMClient) GetHTTPClient() *http.Client {
+	return c.HTTPClient
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_client_api.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_client_api.go
@@ -1,0 +1,212 @@
+package edgegrid
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sort"
+)
+
+// Domains returns the Akamai GTM DomainSummary for each domain the GTMClient
+// is authorized to view and modify
+func (c *GTMClient) Domains() ([]DomainSummary, error) {
+	domains := &Domains{}
+	err := resourceRequest(c, "GET", domainsEndpoint(c.GetCredentials()), nil, domains)
+	if err != nil {
+		return []DomainSummary{}, err
+	}
+	return domains.Domains, err
+}
+
+// Domain takes an Akamai GTM domain name and returns a Domain.
+func (c *GTMClient) Domain(name string) (*Domain, error) {
+	domain := &Domain{}
+	err := resourceRequest(c, "GET", domainEndpoint(c.GetCredentials(), name), nil, domain)
+	return domain, err
+}
+
+// DomainStatus takes an Akamai GTM domain name and returns its ResourceStatus.
+func (c *GTMClient) DomainStatus(name string) (*ResourceStatus, error) {
+	status := &ResourceStatus{}
+	err := resourceRequest(c, "GET", domainStatusEndpoint(c.GetCredentials(), name), nil, status)
+	return status, err
+}
+
+// DomainCreate issues a request to create a domain with the provided name and type.
+// The result is returned as a DomainResponse.
+func (c *GTMClient) DomainCreate(name string, domainType string) (*DomainResponse, error) {
+	payload := map[string]string{
+		"name": name,
+		"type": domainType,
+	}
+
+	jsonRequest, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	var createdDomain = &DomainResponse{}
+	err = resourceRequest(c, "PUT", domainEndpoint(c.GetCredentials(), name), jsonRequest, createdDomain)
+	return createdDomain, err
+}
+
+// DomainUpdate takes a domain and issues a request to update it accordingly.
+// The result is returned as a DomainResponse.
+func (c *GTMClient) DomainUpdate(domain *Domain) (*DomainResponse, error) {
+	jsonRequest, err := json.Marshal(domain)
+	if err != nil {
+		return nil, err
+	}
+	var updatedDomain = &DomainResponse{}
+	err = resourceRequest(c, "PUT", domainEndpoint(c.GetCredentials(), domain.Name), jsonRequest, updatedDomain)
+	return updatedDomain, err
+}
+
+// DomainDelete takes a domain and issues a request to delete it.
+func (c *GTMClient) DomainDelete(name string) error {
+	resp, err := doClientReq(c, "DELETE", domainEndpoint(c.GetCredentials(), name), nil)
+
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("HTTP status not OK")
+	}
+	return err
+}
+
+// DataCenters takes an Akamai GTM domain name and returns a []DataCenter
+// representing the datacenters associated with the domain.
+func (c *GTMClient) DataCenters(domain string) ([]DataCenter, error) {
+	dcs := &DataCenters{}
+	err := resourceRequest(c, "GET", dcsEndpoint(c.GetCredentials(), domain), nil, dcs)
+	if err != nil {
+		return []DataCenter{}, err
+	}
+	return dcs.Items, err
+}
+
+// DataCenterCreate takes an Akamai GTM domain name and a dc and
+// issues a request to create the DataCenter via the Akamai GTM API.
+// The result is returned as a DataCenterResponse.
+func (c *GTMClient) DataCenterCreate(domain string, dc *DataCenter) (*DataCenterResponse, error) {
+	jsonRequest, err := json.Marshal(dc)
+	if err != nil {
+		return nil, err
+	}
+	var resource = &DataCenterResponse{}
+	err = resourceRequest(c, "POST", dcsEndpoint(c.GetCredentials(), domain), jsonRequest, resource)
+	return resource, err
+}
+
+// DataCenter takes an Akamai GTM domain name and a datacenter id and
+// returns the DataCenter for the given ID.
+func (c *GTMClient) DataCenter(domain string, id int) (*DataCenter, error) {
+	dc := &DataCenter{}
+	err := resourceRequest(c, "GET", dcEndpoint(c.GetCredentials(), domain, id), nil, dc)
+	return dc, err
+}
+
+// DataCenterUpdate takes an Akamai GTM domain name and a dc and issues a request
+// to update the DataCenter details accordingly via the Akamai GTM API.
+// The result is returned as a DataCenterResponse.
+func (c *GTMClient) DataCenterUpdate(domain string, dc *DataCenter) (*DataCenterResponse, error) {
+	jsonRequest, err := json.Marshal(dc)
+	if err != nil {
+		return nil, err
+	}
+	var resource = &DataCenterResponse{}
+	err = resourceRequest(c, "PUT", dcEndpoint(c.GetCredentials(), domain, dc.DataCenterID), jsonRequest, resource)
+	return resource, err
+}
+
+// DataCenterByName takes an Akamai GTM domain name and a datacenter name
+// and returns the matching DataCenter.
+func (c *GTMClient) DataCenterByName(domain string, name string) (*DataCenter, error) {
+	dcs, err := c.DataCenters(domain)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, each := range dcs {
+		if each.Nickname == name {
+			return &each, nil
+		}
+	}
+	return &DataCenter{}, fmt.Errorf("DataCenter named: %s not found in domain: %s", name, domain)
+}
+
+// DataCenterDelete takes an Akamai GTM domain name and a datacenter id and
+// issues a request to delete the matching datacenter via the Akamai GTM API.
+func (c *GTMClient) DataCenterDelete(domain string, id int) error {
+	resp, err := doClientReq(c, "DELETE", dcEndpoint(c.GetCredentials(), domain, id), nil)
+
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return errors.New("HTTP status not OK")
+	}
+	return err
+}
+
+// Properties takes an Akamai GTM domain name and returns the Akamai GTM properties
+// associated with the domain.
+func (c *GTMClient) Properties(domain string) (*Properties, error) {
+	props := &Properties{}
+	err := resourceRequest(c, "GET", propertiesEndpoint(c.GetCredentials(), domain), nil, props)
+	return props, err
+}
+
+// PropertiesSorted sorted takes an Akamai GTM domain name and returns the Akamai GTM
+// properties associated with the domain name, sorted by their names.
+func (c *GTMClient) PropertiesSorted(domain string) (*Properties, error) {
+	props, err := c.Properties(domain)
+	sort.Sort(props)
+	return props, err
+}
+
+// Property takes an Akamai GTM domain name and a property name
+// and returns the matching Akamai GTM property.
+func (c *GTMClient) Property(domain, property string) (*Property, error) {
+	prop := &Property{}
+	err := resourceRequest(c, "GET", propertyEndpoint(c.GetCredentials(), domain, property), nil, prop)
+	return prop, err
+}
+
+// PropertyCreate takes an Akamai GTM domain name and a property and issues a request
+// to create the Property via the Akamai GTM API.
+// The result is returned as a PropertyResponse.
+func (c *GTMClient) PropertyCreate(domain string, property *Property) (*PropertyResponse, error) {
+	jsonRequest, err := json.Marshal(property)
+	if err != nil {
+		return nil, err
+	}
+
+	resource := &PropertyResponse{}
+	err = resourceRequest(c, "PUT", propertyEndpoint(c.GetCredentials(), domain, property.Name), jsonRequest, resource)
+	return resource, err
+}
+
+// PropertyUpdate takes an Akamai GTM domain name and a property and issues a request
+// to update the property accordingly via the Akamai GTM API.
+// The result is returned as a PropertyResponse.
+func (c *GTMClient) PropertyUpdate(domain string, property *Property) (*PropertyResponse, error) {
+	return c.PropertyCreate(domain, property)
+}
+
+// PropertyDelete takes an Akamai GTM domain name and a property name and issues a request
+// to delete the matching Akamai GTM property via the Akamai GTM API.
+// It returns true if the action was successful and false if it was not successful.
+func (c *GTMClient) PropertyDelete(domain string, property string) (bool, error) {
+	url := propertyEndpoint(c.GetCredentials(), domain, property)
+	resp, err := doClientReq(c, "DELETE", url, nil)
+
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return false, errors.New("HTTP status not OK")
+	}
+	return true, nil
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_endpoints.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_endpoints.go
@@ -1,0 +1,64 @@
+package edgegrid
+
+import (
+	"fmt"
+)
+
+const gtmPath = "/config-gtm/v1/"
+
+func gtmBase(c *AuthCredentials) string {
+	return concat([]string{
+		c.APIHost,
+		gtmPath,
+	})
+}
+
+func domainsEndpoint(c *AuthCredentials) string {
+	return concat([]string{
+		gtmBase(c),
+		"domains",
+	})
+}
+
+func domainEndpoint(c *AuthCredentials, domain string) string {
+	return concat([]string{
+		domainsEndpoint(c),
+		"/",
+		domain,
+	})
+}
+
+func domainStatusEndpoint(c *AuthCredentials, domain string) string {
+	return concat([]string{
+		domainsEndpoint(c),
+		"/",
+		domain,
+		"/status/current",
+	})
+}
+
+func dcEndpoint(c *AuthCredentials, domain string, id int) string {
+	return fmt.Sprintf("%s/%d", dcsEndpoint(c, domain), id)
+}
+
+func dcsEndpoint(c *AuthCredentials, domain string) string {
+	return concat([]string{
+		domainEndpoint(c, domain),
+		"/datacenters",
+	})
+}
+
+func propertiesEndpoint(c *AuthCredentials, domain string) string {
+	return concat([]string{
+		domainEndpoint(c, domain),
+		"/properties",
+	})
+}
+
+func propertyEndpoint(c *AuthCredentials, domain, property string) string {
+	return concat([]string{
+		propertiesEndpoint(c, domain),
+		"/",
+		property,
+	})
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_resources.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/gtm_resources.go
@@ -1,0 +1,221 @@
+package edgegrid
+
+import (
+	"strings"
+)
+
+// Domains is a representation of the Akamai GTM
+// domains response available at:
+// http://apibase.com/config-gtm/v1/domains
+type Domains struct {
+	Domains []DomainSummary `json:"items"`
+}
+
+// DomainSummary is a representation of the Akamai GTM
+// domain summary associated with each domain returned by
+// the domains response at:
+// http://apibase.com/config-gtm/v1/domains
+type DomainSummary struct {
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	LastModified string `json:"lastModified"`
+}
+
+// DomainResponse is a representation of the Akamai GTM
+// response from a domain CREATEs and UPDATEs at:
+// http://apibase.com/config-gtm/v1/domains/domain
+type DomainResponse struct {
+	Domain *Domain         `json:"resource"`
+	Status *ResourceStatus `json:"status"`
+}
+
+// Domain is a representation of an Akamai GTM domain.
+type Domain struct {
+	Name                 string          `json:"name"`
+	Status               *ResourceStatus `json:"status,omitempty"`
+	Type                 string          `json:"type"`
+	LastModified         string          `json:"lastModified,omitempty"`
+	LastModifiedBy       string          `json:"lastModifiedBy,omitempty"`
+	ModificationComments string          `json:"modificationComments,omitempty"`
+	CIDRMaps             []interface{}   `json:"cidrMaps,omitempty"`
+	Datacenters          []DataCenter    `json:"datacenters,omitempty"`
+	Properties           []Property      `json:"properties,omitempty"`
+	Links                []Link          `json:"links,omitempty"`
+	GeographicMaps       []interface{}   `json:"geographicMaps,omitempty"`
+	Resources            []interface{}   `json:"resources,omitempty"`
+}
+
+// ResourceStatus is a representation of an Akamai GTM status for
+// a given resource, such as a domain.
+type ResourceStatus struct {
+	Message               string `json:"message"`
+	ChangeID              string `json:"changeId"`
+	PropagationStatus     string `json:"propagationStatus"`
+	PropagationStatusDate string `json:"propagationStatusDate"`
+	PassingValidation     bool   `json:"passingValidation"`
+	Links                 []Link `json:"links"`
+}
+
+// DataCenters is a representation of an Akamai GTM datacenters
+// response returned from:
+// http://apibase.com/config-gtm/v1/domains/domain/datacenters
+type DataCenters struct {
+	Items []DataCenter `json:"items"`
+}
+
+// DataCenterResponse is a representation of an Akamai GTM datacenter
+// response returned from datacenter CREATEs and UPDATEs at:
+// http://apibase.com/config-gtm/v1/domains/domain/datacenters/4
+type DataCenterResponse struct {
+	DataCenter *DataCenter     `json:"resource"`
+	Status     *ResourceStatus `json:"status"`
+}
+
+// DataCenter represents an Akamai GTM datacenter.
+type DataCenter struct {
+	City                 string             `json:"city"`
+	CloneOf              int                `json:"cloneOf,omitempty"`
+	CloudServerTargeting bool               `json:"cloudServerTargeting"`
+	Continent            string             `json:"continent"`
+	Country              string             `json:"country"`
+	DataCenterID         int                `json:"datacenterId,omitempty"`
+	DefaultLoadObject    *DefaultLoadObject `json:"defaultLoadObject,omitempty"`
+	Latitude             float64            `json:"latitude"`
+	Links                []Link             `json:"links,omitempty"`
+	Longitude            float64            `json:"longitude"`
+	Nickname             string             `json:"nickname"`
+	StateOrProvince      string             `json:"stateOrProvince"`
+	Virtual              bool               `json:"virtual"`
+}
+
+// Link represents the link objects embedded in Akamai GTM API
+// response JSON.
+type Link struct {
+	Href string `json:"href"`
+	Rel  string `json:"rel"`
+}
+
+// DefaultLoadObject represents the default load object associated
+// with an Akamai GTM datacenter.
+type DefaultLoadObject struct {
+	LoadObject     interface{} `json:"loadObject"`
+	LoadObjectPort int64       `json:"loadObjectPort"`
+	LoadServers    interface{} `json:"loadServers"`
+}
+
+// LoadObject represents the load object associated with an Akamai
+// GTM datacenter.
+type LoadObject struct {
+	LoadObject           string `json:"loadObject"`
+	LoadObjectPort       string `json:"loadObjectPort"`
+	LoadServers          string `json:"loadServers"`
+	Continent            string `json:"continent"`
+	CloudServerTargeting bool   `json:"cloudServerTargeting"`
+}
+
+// PropertyResponse represents the Akamai GTM response returned
+// by Akamai GTM API CREATEs and DELETEs against:
+// http://apibase.com/config-gtm/v1/domains/domain/properties/property
+type PropertyResponse struct {
+	Property *Property       `json:"resource"`
+	Status   *ResourceStatus `json:"status"`
+}
+
+// Properties represents the properties returned from:
+// http://apibase.com/config-gtm/v1/domains/domain/properties/property
+type Properties struct {
+	Properties []Property `json:"items"`
+}
+
+func (props Properties) Len() int {
+	return len(props.Properties)
+}
+
+func (props Properties) Less(i, j int) bool {
+	return props.Properties[i].Name < props.Properties[j].Name
+}
+
+func (props Properties) Swap(i, j int) {
+	props.Properties[i], props.Properties[j] = props.Properties[j], props.Properties[i]
+}
+
+// Property represents an Akamai GTM property.
+type Property struct {
+	BackupCname               string          `json:"backupCName,omitempty"`
+	BackupIP                  string          `json:"backupIp,omitempty"`
+	BalanceByDownloadScore    bool            `json:"balanceByDownloadScore,omitempty"`
+	Cname                     string          `json:"cname,omitempty"`
+	Comments                  string          `json:"comments,omitempty"`
+	DynamicTTL                int             `json:"dynamicTTL,omitempty"`
+	FailbackDelay             int             `json:"failbackDelay"`
+	FailoverDelay             int             `json:"failoverDelay"`
+	HandoutMode               string          `json:"handoutMode,omitempty"`
+	HealthMax                 float64         `json:"healthMax,omitempty"`
+	HealthMultiplier          float64         `json:"healthMultiplier,omitempty"`
+	HealthThreshold           float64         `json:"healthThreshold,omitempty"`
+	Ipv6                      bool            `json:"ipv6,omitempty"`
+	LastModified              string          `json:"lastModified,omitempty"`
+	Links                     []Link          `json:"links,omitempty"`
+	LivenessTests             []LivenessTest  `json:"livenessTests,omitempty"`
+	LoadImbalancePercentage   float64         `json:"loadImbalancePercentage,omitempty"`
+	MapName                   interface{}     `json:"mapName,omitempty"`
+	MaxUnreachablePenalty     interface{}     `json:"maxUnreachablePenalty,omitempty"`
+	MxRecords                 []interface{}   `json:"mxRecords,omitempty"`
+	Name                      string          `json:"name"`
+	ScoreAggregationType      string          `json:"scoreAggregationType"`
+	StaticTTL                 interface{}     `json:"staticTTL,omitempty"`
+	StickinessBonusConstant   interface{}     `json:"stickinessBonusConstant,omitempty"`
+	StickinessBonusPercentage interface{}     `json:"stickinessBonusPercentage,omitempty"`
+	TrafficTargets            []TrafficTarget `json:"trafficTargets"`
+	Type                      string          `json:"type"`
+	UnreachableThreshold      interface{}     `json:"unreachableThreshold,omitempty"`
+	UseComputedTargets        bool            `json:"useComputedTargets,omitempty"`
+}
+
+// LivenessTest represents a liveness test associated with an Akamai
+// GTM property.
+type LivenessTest struct {
+	Name                          string  `json:"name"`
+	HTTPError3xx                  bool    `json:"httpError3xx,omitempty"`
+	HTTPError4xx                  bool    `json:"httpError4xx,omitempty"`
+	HTTPError5xx                  bool    `json:"httpError5xx,omitempty"`
+	TestInterval                  int64   `json:"testInterval,omitempty"`
+	TestObject                    string  `json:"testObject,omitempty"`
+	TestObjectPort                int64   `json:"testObjectPort,omitempty"`
+	TestObjectProtocol            string  `json:"testObjectProtocol,omitempty"`
+	TestObjectUsername            string  `json:"testObjectUsername,omitempty"`
+	TestObjectPassword            string  `json:"testObjectPassword,omitempty"`
+	TestTimeout                   float64 `json:"testTimeout,omitempty"`
+	DisableNonstandardPortWarning bool    `json:"disableNonstandardPortWarning,omitempty"`
+	RequestString                 string  `json:"requestString,omitempty"`
+	ResponseString                string  `json:"responseString,omitempty"`
+	SSLClientPrivateKey           string  `json:"sslClientPrivateKey,omitempty"`
+	SSLCertificate                string  `json:"sslClientCertificate,omitempty"`
+	HostHeader                    string  `json:"hostHeader,omitempty"`
+}
+
+// TrafficTarget represents a traffic target associated with an Akamai
+// GTM property.
+type TrafficTarget struct {
+	DataCenterID int         `json:"datacenterId"`
+	Enabled      bool        `json:"enabled"`
+	HandoutCname interface{} `json:"handoutCName"`
+	Name         interface{} `json:"name"`
+	Servers      []string    `json:"servers"`
+	Weight       float64     `json:"weight"`
+}
+
+// AkamaiError represents a non-successful HTTP response from the
+// Akamai API.
+type AkamaiError struct {
+	Type         string `json:"type"`
+	Title        string `json:"title"`
+	Detail       string `json:"detail"`
+	RequestBody  string `json:"-"`
+	ResponseBody string `json:"-"`
+}
+
+func (a AkamaiError) Error() string {
+	components := []string{a.Title, a.Detail, a.RequestBody, a.ResponseBody}
+	return strings.Join(components, "\n")
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_client.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_client.go
@@ -1,0 +1,20 @@
+package edgegrid
+
+import "net/http"
+
+// PAPIClient is an Akamai PAPI API client.
+// https://developer.akamai.com/api/luna/papi/overview.html
+type PAPIClient struct {
+	Credentials *AuthCredentials
+	HTTPClient  *http.Client
+}
+
+// GetCredentials takes a PAPIClient and returns its credentials.
+func (c PAPIClient) GetCredentials() *AuthCredentials {
+	return c.Credentials
+}
+
+// GetHTTPClient takes a PAPIClient and returns its HTTPClient.
+func (c PAPIClient) GetHTTPClient() *http.Client {
+	return c.HTTPClient
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_client_api.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_client_api.go
@@ -1,0 +1,163 @@
+package edgegrid
+
+import "io/ioutil"
+
+// Groups returns a []GroupSummary representing the groups associated with the PAPIClient.
+func (c *PAPIClient) Groups() ([]GroupSummary, error) {
+	groups := &Groups{}
+	err := resourceRequest(c, "GET", papiGroupsEndpoint(c.GetCredentials()), nil, groups)
+	if err != nil {
+		return []GroupSummary{}, err
+	}
+	return groups.Groups.Items, err
+}
+
+// Products takes a contractID returns the associated ProductSummary for each product
+// associated with the contractID.
+func (c *PAPIClient) Products(contractID string) ([]ProductSummary, error) {
+	prods := &Products{}
+	err := resourceRequest(c, "GET", papiProductsEndpoint(c.GetCredentials(), contractID), nil, prods)
+	if err != nil {
+		return []ProductSummary{}, err
+	}
+	return prods.Products.Items, err
+}
+
+// CpCodes takes a contractID and a groupID and returns the
+// associated []CpCodeSummary representing the CP code summaries associated
+// with the contractId and groupId.
+func (c *PAPIClient) CpCodes(contractID, groupID string) ([]CpCodeSummary, error) {
+	cps := &CpCodes{}
+	err := resourceRequest(c, "GET", papiCpCodesEndpoint(c.GetCredentials(), contractID, groupID), nil, cps)
+	if err != nil {
+		return []CpCodeSummary{}, err
+	}
+	return cps.CpCodes.Items, err
+}
+
+// CpCode takes a cpCodeID, a contractID, and a groupID
+// and returns the associated CpCodeSummary.
+func (c *PAPIClient) CpCode(cpCodeID, contractID, groupID string) (*CpCodeSummary, error) {
+	cps := &CpCodes{}
+	err := resourceRequest(c, "GET", papiCpCodeEndpoint(c.GetCredentials(), cpCodeID, contractID, groupID), nil, cps)
+	if err != nil {
+		return &CpCodeSummary{}, err
+	}
+	return &cps.CpCodes.Items[0], err
+}
+
+// Hostnames takes a contractID and a groupID and returns the
+// associated []HostnameSummary representing each HostnameSummary
+// for the hostnames associated with the contractID and groupID.
+func (c *PAPIClient) Hostnames(contractID, groupID string) ([]HostnameSummary, error) {
+	hostnames := &Hostnames{}
+	err := resourceRequest(c, "GET", papiHostnamesEndpoint(c.GetCredentials(), contractID, groupID), nil, hostnames)
+	if err != nil {
+		return []HostnameSummary{}, err
+	}
+	return hostnames.Hostnames.Items, err
+}
+
+// Hostname takes a hostID, a contractID, and a groupID and returns
+// the associated HostnameSummary.
+func (c *PAPIClient) Hostname(hostID, contractID, groupID string) (HostnameSummary, error) {
+	hostnames := &Hostnames{}
+	err := resourceRequest(c, "GET", papiHostnameEndpoint(c.GetCredentials(), hostID, contractID, groupID), nil, hostnames)
+	if err != nil {
+		return HostnameSummary{}, err
+	}
+	return hostnames.Hostnames.Items[0], err
+}
+
+// Properties takes a contractID and a groupID and returns the associated
+// []PapiPropertySummary for each property associated with the contractID and the groupID.
+func (c *PAPIClient) Properties(contractID, groupID string) ([]PapiPropertySummary, error) {
+	props := &PapiProperties{}
+	err := resourceRequest(c, "GET", papiPropertiesEndpoint(c.GetCredentials(), contractID, groupID), nil, props)
+	if err != nil {
+		return []PapiPropertySummary{}, err
+	}
+	return props.Properties.Items, err
+}
+
+// Property takes a propertyID, a contractID, and a groupID and returns
+// the PapiPropertySummary for the associated property.
+func (c *PAPIClient) Property(propID, contractID, groupID string) (PapiPropertySummary, error) {
+	props := &PapiProperties{}
+	err := resourceRequest(c, "GET", papiPropertyEndpoint(c.GetCredentials(), propID, contractID, groupID), nil, props)
+	if err != nil {
+		return PapiPropertySummary{}, err
+	}
+	return props.Properties.Items[0], err
+}
+
+// PropertyVersions takes a propertyID, a contractID, and a groupID and
+// returns the associated PapiPropertyVersionSummary for each property version.
+func (c *PAPIClient) PropertyVersions(propID, contractID, groupID string) ([]PapiPropertyVersionSummary, error) {
+	versions := &PapiPropertyVersions{}
+	err := resourceRequest(c, "GET", papiPropertyVersionsEndpoint(c.GetCredentials(), propID, contractID, groupID), nil, versions)
+	if err != nil {
+		return []PapiPropertyVersionSummary{}, err
+	}
+	return versions.Versions.Items, err
+}
+
+// PropertyVersion takes a version, a propertyID, a contractID, and a groupID
+// and returns the associated PapiPropertyVersionSummary.
+func (c *PAPIClient) PropertyVersion(version, propID, contractID, groupID string) (PapiPropertyVersionSummary, error) {
+	versions := &PapiPropertyVersions{}
+	err := resourceRequest(c, "GET", papiPropertyVersionEndpoint(c.GetCredentials(), version, propID, contractID, groupID), nil, versions)
+	if err != nil {
+		return PapiPropertyVersionSummary{}, err
+	}
+	return versions.Versions.Items[0], err
+}
+
+// PropertyVersionXML takes a version, a propertyID, a contractID, and a groupID
+// and returns the the associated property version XML string.
+func (c *PAPIClient) PropertyVersionXML(version, propID, contractID, groupID string) (string, error) {
+	xml, err := getXML(c, papiPropertyVersionEndpoint(c.GetCredentials(), version, propID, contractID, groupID))
+	if err != nil {
+		return "", err
+	}
+
+	body, err := ioutil.ReadAll(xml.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+// PropertyLatestVersion takes a propertyID, a contractID, and a groupID and returns
+// the PapiPropertyVersionSummary for the most recent property version.
+func (c *PAPIClient) PropertyLatestVersion(propID, contractID, groupID string) (PapiPropertyVersionSummary, error) {
+	versions := &PapiPropertyVersions{}
+	err := resourceRequest(c, "GET", papiPropertyLatestVersionEndpoint(c.GetCredentials(), propID, contractID, groupID), nil, versions)
+	if err != nil {
+		return PapiPropertyVersionSummary{}, err
+	}
+	return versions.Versions.Items[0], err
+}
+
+// PropertyRules takes a propertyID string, a version, and a groupID and returns a
+// the PapiPropertyRuleSummary for the associated property.
+func (c *PAPIClient) PropertyRules(propID, version, contractID, groupID string) (PapiPropertyRuleSummary, error) {
+	rules := &PapiPropertyRules{}
+	err := resourceRequest(c, "GET", papiPropertyRulesEndpoint(c.GetCredentials(), propID, version, contractID, groupID), nil, rules)
+	if err != nil {
+		return PapiPropertyRuleSummary{}, err
+	}
+	return rules.Rules, err
+}
+
+// Activations takes a propertyID, a contractID, and a groupID and returns
+// the associated []PapiActivation representing the property activations.
+func (c *PAPIClient) Activations(propID, contractID, groupID string) ([]PapiActivation, error) {
+	acts := &PapiActivations{}
+	err := resourceRequest(c, "GET", papiActivationsEndpoint(c.GetCredentials(), propID, contractID, groupID), nil, acts)
+	if err != nil {
+		return []PapiActivation{}, err
+	}
+	return acts.Activations.Items, err
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_endpoints.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_endpoints.go
@@ -1,0 +1,149 @@
+package edgegrid
+
+const papiPath = "/papi/v0/"
+
+func papiBase(c *AuthCredentials) string {
+	return concat([]string{
+		c.APIHost,
+		papiPath,
+	})
+}
+
+func papiGroupsEndpoint(c *AuthCredentials) string {
+	return concat([]string{
+		papiBase(c),
+		"groups/",
+	})
+}
+
+func papiProductsEndpoint(c *AuthCredentials, contractID string) string {
+	return concat([]string{
+		papiBase(c),
+		"products?contractId=",
+		contractID,
+	})
+}
+
+func papiCpCodesEndpoint(c *AuthCredentials, contractID, groupID string) string {
+	return concat([]string{
+		papiBase(c),
+		"cpcodes/",
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiCpCodeEndpoint(c *AuthCredentials, cpCodeID, contractID, groupID string) string {
+	return concat([]string{
+		papiBase(c),
+		"cpcodes/",
+		cpCodeID,
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiQuery(contractID, groupID string) string {
+	return concat([]string{
+		"?contractId=",
+		contractID,
+		"&groupId=",
+		groupID,
+	})
+}
+
+func papiHostnamesEndpoint(c *AuthCredentials, contractID, groupID string) string {
+	return concat([]string{
+		papiBase(c),
+		"edgehostnames",
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiHostnameEndpoint(c *AuthCredentials, hostID, contractID, groupID string) string {
+	return concat([]string{
+		papiBase(c),
+		"edgehostnames/",
+		hostID,
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiPropertiesBase(c *AuthCredentials) string {
+	return concat([]string{
+		papiBase(c),
+		"properties/",
+	})
+}
+
+func papiPropertiesEndpoint(c *AuthCredentials, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertiesBase(c),
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiPropertyBase(c *AuthCredentials, propID string) string {
+	return concat([]string{
+		papiPropertiesBase(c),
+		propID,
+	})
+}
+
+func papiPropertyEndpoint(c *AuthCredentials, propID, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyBase(c, propID),
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiPropertyVersionsBase(c *AuthCredentials, propID, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyBase(c, propID),
+		"/versions",
+	})
+}
+
+func papiPropertyVersionsEndpoint(c *AuthCredentials, propID, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyVersionsBase(c, propID, contractID, groupID),
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiPropertyVersionBase(c *AuthCredentials, version, propID, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyVersionsBase(c, propID, contractID, groupID),
+		"/",
+		version,
+	})
+}
+
+func papiPropertyVersionEndpoint(c *AuthCredentials, version, propID, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyVersionBase(c, version, propID, contractID, groupID),
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiPropertyLatestVersionEndpoint(c *AuthCredentials, propID, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyVersionsBase(c, propID, contractID, groupID),
+		"/latest",
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiPropertyRulesEndpoint(c *AuthCredentials, propID, version, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyVersionBase(c, version, propID, contractID, groupID),
+		"/rules/",
+		papiQuery(contractID, groupID),
+	})
+}
+
+func papiActivationsEndpoint(c *AuthCredentials, propID, contractID, groupID string) string {
+	return concat([]string{
+		papiPropertyBase(c, propID),
+		"/activations",
+		papiQuery(contractID, groupID),
+	})
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_resources.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/papi_resources.go
@@ -1,0 +1,176 @@
+package edgegrid
+
+// Groups is a representation of the Akamai PAPI
+// Groups response available at:
+// http://apibase.com/papi/v0/groups/
+type Groups struct {
+	Groups struct {
+		Items []GroupSummary `json:"items"`
+	} `json:"groups"`
+}
+
+// GroupSummary is a representation of the Akamai PAPI
+// group summary associated with each group returned by
+// the groups response at:
+// http://apibase.com/papi/v0/groups/
+type GroupSummary struct {
+	GroupID       string   `json:"groupId"`
+	Name          string   `json:"groupName"`
+	ContractIDs   []string `json:"contractIds"`
+	ParentGroupID string   `json:"parentGroupId"`
+}
+
+// Products is a representation of the Akamai PAPI
+// products response available at:
+// http://apibase.com/papi/v0/products?contractId=someId
+type Products struct {
+	Products struct {
+		Items []ProductSummary `json:"items"`
+	} `json:"products"`
+}
+
+// ProductSummary is a representation of the Akamai PAPI
+// product summary associated with each product returned
+// by the products response at:
+// http://apibase.com/papi/v0/products?contractId=someId
+type ProductSummary struct {
+	ProductID string `json:"productId"`
+	Name      string `json:"productName"`
+}
+
+// CpCodes is a representation of the Akamai PAPI
+// CP codes associated with the CP codes response available at:
+// http://apibase.com/papi/v0/cpcodes/?contractId=contractId&groupId=groupId
+type CpCodes struct {
+	CpCodes struct {
+		Items []CpCodeSummary `json:"items"`
+	} `json:"cpcodes"`
+}
+
+// CpCodeSummary is a representation of the Akamai PAPI
+// CP code summary associated with each CP code returned
+// by the CP codes response at:
+// http://apibase.com/papi/v0/cpcodes/?contractId=contractId&groupId=groupId
+type CpCodeSummary struct {
+	CPCodeID    string   `json:"cpcodeId"`
+	Name        string   `json:"cpcodeName"`
+	ProductIDs  []string `json:"productIds"`
+	CreatedDate string   `json:"createdDate"`
+}
+
+// Hostnames is a representation of the Akamai PAPI
+// hostnames response available at:
+// http://apibase.com/papi/v0/edgehostnames?contractId=contractId&groupId=groupId
+type Hostnames struct {
+	Hostnames struct {
+		Items []HostnameSummary `json:"items"`
+	} `json:"edgehostnames"`
+}
+
+// HostnameSummary is a representation of the Akamai PAPI
+// hostname summary associated with each hostname returned
+// by the hostnames response at:
+// http://apibase.com/papi/v0/edgehostnames?contractId=contractId&groupId=groupId
+type HostnameSummary struct {
+	EdgeHostnameID     string `json:"edgeHostnameId"`
+	DomainPrefix       string `json:"domainPrefix"`
+	DomainSuffix       string `json:"domainSuffix"`
+	IPVersionBehavior  string `json:"ipVersionBehavior"`
+	Secure             bool   `json:"secure"`
+	EdgeHostnameDomain string `json:"edgehostnameDomain"`
+}
+
+// PapiProperties is a representation of the Akamai PAPI
+// properties response available at:
+// http://apibase.com/papi/v0/properties/?contractId=contractId&groupId=groupId
+type PapiProperties struct {
+	Properties struct {
+		Items []PapiPropertySummary `json:"items"`
+	} `json:"properties"`
+}
+
+// PapiPropertySummary is a representation of the Akamai PAPI
+// property summary associated with each property returned by
+// the properties response at:
+// http://apibase.com/papi/v0/properties/?contractId=contractId&groupId=groupId
+type PapiPropertySummary struct {
+	AccountID         string `json:"accountId"`
+	ContractID        string `json:"contractId"`
+	GroupID           string `json:"groupId"`
+	PropertyID        string `json:"propertyId"`
+	Name              string `json:"propertyName"`
+	LatestVersion     int    `json:"latestVersion"`
+	StagingVersion    int    `json:"stagingVersion"`
+	ProductionVersion int    `json:"productionVersion"`
+	Note              string `json:"note"`
+}
+
+// PapiPropertyVersions is a representation of the Akamai PAPI
+// property versions response available at:
+// http://apibase.com/papi/v0/properties/propId/versions?contractId=contractId&groupId=groupId
+type PapiPropertyVersions struct {
+	Versions struct {
+		Items []PapiPropertyVersionSummary `json:"items"`
+	} `json:"versions"`
+}
+
+// PapiPropertyVersionSummary is a representation of the Akamai PAPI
+// property version summary associated with each property version at:
+// http://apibase.com/papi/v0/properties/propId/versions?contractId=contractId&groupId=groupId
+type PapiPropertyVersionSummary struct {
+	PropertyVersion  int    `json:"propertyVersion"`
+	UpdatedByUser    string `json:"updatedByUser"`
+	UpdatedDate      string `json:"updatedDate"`
+	ProductionStatus string `json:"productionStatus"`
+	StagingStatus    string `json:"stagingStatus"`
+	Etag             string `json:"etag"`
+	ProductID        string `json:"productId"`
+	Note             string `json:"note"`
+}
+
+// PapiPropertyRules is a representation of the Akamai PAPI
+// property rules response at:
+// http://apibase.com/papi/v0/properties/propId/versions/version/rules/?contractId=contractId&groupId=groupId
+type PapiPropertyRules struct {
+	Rules PapiPropertyRuleSummary `json:"rules"`
+}
+
+// PapiPropertyRuleSummary is a representation of the Akamai PAPI
+// rule summary associated with each property rule at:
+// http://apibase.com/papi/v0/properties/propId/versions/version/rules/?contractId=contractId&groupId=groupId
+type PapiPropertyRuleSummary struct {
+	Name      string                     `json:"name"`
+	UUID      string                     `json:"uuid"`
+	Behaviors []PapiPropertyRuleBehavior `json:"behaviors"`
+}
+
+// PapiPropertyRuleBehavior is a representation of the Akamai PAPI
+// property rule behavior associated with each property rule.
+type PapiPropertyRuleBehavior struct {
+	Name string `json:"name"`
+}
+
+// PapiActivations is a representation of the Akamai PAPI
+// activations response at:
+// http://apibase.com/papi/v0/properties/propId/activations?contractId=contractId&groupId=groupId
+type PapiActivations struct {
+	Activations struct {
+		Items []PapiActivation `json:"items"`
+	} `json:"activations"`
+}
+
+// PapiActivation is a representation of each Akamai PAPI
+// activation available at:
+// http://apibase.com/papi/v0/properties/propId/activations?contractId=contractId&groupId=groupId
+type PapiActivation struct {
+	ActivationID    string `json:"activationId"`
+	PropertyName    string `json:"propertyName"`
+	PropertyID      string `json:"propertyId"`
+	PropertyVersion int    `json:"propertyVersion"`
+	Network         string `json:"network"`
+	ActivationType  string `json:"activationType"`
+	Status          string `json:"status"`
+	SubmitDate      string `json:"submitDate"`
+	UpdateDate      string `json:"updateDate"`
+	Note            string `json:"note"`
+}

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/reader.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/reader.go
@@ -1,0 +1,9 @@
+package edgegrid
+
+import "bytes"
+
+type reader struct {
+	*bytes.Buffer
+}
+
+func (m reader) Close() error { return nil }

--- a/vendor/github.com/Comcast/go-edgegrid/edgegrid/util.go
+++ b/vendor/github.com/Comcast/go-edgegrid/edgegrid/util.go
@@ -1,0 +1,120 @@
+package edgegrid
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+func authenticate(c Client, req *http.Request) *http.Request {
+	auth := Auth(NewAuthParams(req, c.GetCredentials().AccessToken, c.GetCredentials().ClientToken, c.GetCredentials().ClientSecret))
+
+	req.Header.Add("Authorization", auth)
+
+	return req
+}
+
+func concat(arr []string) string {
+	var buff bytes.Buffer
+
+	for _, elem := range arr {
+		buff.WriteString(elem)
+	}
+
+	return buff.String()
+}
+
+func urlPathWithQuery(req *http.Request) string {
+	var query string
+
+	if req.URL.RawQuery != "" {
+		query = concat([]string{
+			"?",
+			req.URL.RawQuery,
+		})
+	} else {
+		query = ""
+	}
+
+	return concat([]string{
+		req.URL.Path,
+		query,
+	})
+}
+
+func resourceRequest(c Client, method string, url string, body []byte, responseStruct interface{}) error {
+	if LogRequests() {
+		fmt.Printf("Request url: \n\t%s\nrequest body: \n\t%s \n\n", url, string(body))
+	}
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	authReq := authenticate(c, req)
+	resp, err := c.GetHTTPClient().Do(authReq)
+
+	if err != nil {
+		return err
+	}
+
+	bodyContents, err := ioutil.ReadAll(resp.Body)
+	if LogRequests() {
+		fmt.Printf("Response status: \n\t%d\nresponse body: \n\t%s \n\n", resp.StatusCode, bodyContents)
+	}
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		akError := &AkamaiError{}
+		if err := json.Unmarshal(bodyContents, &akError); err != nil {
+			return err
+		}
+		akError.RequestBody = string(body)
+		akError.ResponseBody = string(bodyContents)
+		return akError
+	}
+	if err := json.Unmarshal(bodyContents, responseStruct); err != nil {
+		return err
+	}
+	return nil
+}
+
+func doClientReq(c Client, method string, url string, body []byte) (*http.Response, error) {
+	if LogRequests() {
+		fmt.Printf("Request url: \n\t%s\nrequest body: \n\t%s \n\n", url, string(body))
+	}
+	req, err := http.NewRequest(method, url, bytes.NewReader(body))
+
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Content-Type", "application/json")
+
+	authReq := authenticate(c, req)
+	resp, err := c.GetHTTPClient().Do(authReq)
+
+	return resp, err
+}
+
+func getXML(c Client, url string) (*http.Response, error) {
+	if LogRequests() {
+		fmt.Printf("Request url: \n\t%s\n", url)
+	}
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("Accept", "text/xml")
+	authReq := authenticate(c, req)
+	resp, err := c.GetHTTPClient().Do(authReq)
+
+	return resp, err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -306,6 +306,12 @@
 			"revision": "edd0930276e7f1a5f2cf3e7835b5dc42a3217669"
 		},
 		{
+			"checksumSHA1": "0JgIa0ijMOz7SyIb1jnhuOfHpYE=",
+			"path": "github.com/Comcast/go-edgegrid/edgegrid",
+			"revision": "e03bc9d8e9ed7b1ba67735ac32464c9f77005d58",
+			"revisionTime": "2016-11-15T02:41:37Z"
+		},
+		{
 			"checksumSHA1": "jZHdtVQsg/9NeRqbxwy63OSbLl8=",
 			"path": "github.com/DreamItGetIT/statuscake",
 			"revision": "9bfac395790f4d221cb5088c5c411f0ba8ba5f23",

--- a/website/source/docs/providers/akamai/index.html.markdown
+++ b/website/source/docs/providers/akamai/index.html.markdown
@@ -1,0 +1,101 @@
+---
+layout: "akamai"
+page_title: "Provider: Akamai"
+sidebar_current: "docs-akamai-index"
+description: |-
+  The Akamai provider is used to manage Akamai GTM configuration.
+---
+
+# Akamai Provider
+
+The Akamai provider is used to manage [Akamai GTM configuration](https://www.akamai.com/us/en/solutions/products/web-performance/global-traffic-management.jsp).
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```
+resource "akamai_gtm_domain" "some_domain" {
+    name = "some-domain.akadns.net"
+    type = "basic"
+}
+
+resource "akamai_gtm_datacenter" "dc1" {
+    name = "dc1"
+    domain = "${akamai_gtm_domain.some_domain.name}"
+    country = "GB"
+    continent = "EU"
+    city = "Downpatrick"
+    longitude = -5.582
+    latitude = 54.367
+    depends_on = [
+        "akamai_gtm_domain.some_domain"
+    ]
+}
+
+resource "akamai_gtm_datacenter" "dc2" {
+    name = "dc2"
+    domain = "${akamai_gtm_domain.some_domain.name}"
+    country = "IS"
+    continent = "EU"
+    city = "Snæfellsjökull"
+    longitude = -23.776
+    latitude = 64.808
+    depends_on = [
+        "akamai_gtm_datacenter.dc1"
+    ]
+}
+
+resource "akamai_gtm_property" "some_property" {
+  domain = "${akamai_gtm_domain.some_domain.name}"
+  type = "weighted-round-robin"
+  name = "some_property"
+  balance_by_download_score = false
+  dynamic_ttl = 300
+  failover_delay = 0
+  failback_delay = 0
+  handout_mode = "normal"
+  health_threshold = 0
+  health_max = 0
+  health_multiplier = 0
+  load_imbalance_percentage = 10
+  ipv6 = false
+  score_aggregation_type = "mean"
+  static_ttl = 600
+  stickiness_bonus_percentage = 50
+  stickiness_bonus_constant = 0
+  use_computed_targets = false
+  liveness_test {
+      name = "health check"
+      test_object = "/status"
+      test_object_protocol = "HTTP"
+      test_interval = 60
+      disable_nonstandard_port_warning = false
+      http_error_4xx = true
+      httpError3xx = true
+      httpError5xx = true
+      testObjectPort = 80
+      testTimeout = 25
+  }
+  trafficTarget {
+      enabled = true
+      datacenter_id = "${akamai_gtm_datacenter.dc1.id}"
+      weight = 50.0
+      name = "${akamai_gtm_datacenter.dc1.name}"
+      servers = [
+          "1.2.3.4",
+          "1.2.3.5"
+      ]
+  }
+  trafficTarget {
+      enabled = true
+      datacenter_id = "${akamai_gtm_datacenter.dc2.id}"
+      weight = 50.0
+      name = "${akamai_gtm_datacenter.dc2.name}"
+      servers = [
+          "1.2.3.6",
+          "1.2.3.7"
+      ]
+  }
+}
+```

--- a/website/source/docs/providers/akamai/index.html.markdown
+++ b/website/source/docs/providers/akamai/index.html.markdown
@@ -20,7 +20,7 @@ resource "akamai_gtm_domain" "some_domain" {
     type = "basic"
 }
 
-resource "akamai_gtm_datacenter" "dc1" {
+resource "akamai_gtm_data_center" "dc1" {
     name = "dc1"
     domain = "${akamai_gtm_domain.some_domain.name}"
     country = "GB"
@@ -33,7 +33,7 @@ resource "akamai_gtm_datacenter" "dc1" {
     ]
 }
 
-resource "akamai_gtm_datacenter" "dc2" {
+resource "akamai_gtm_data_center" "dc2" {
     name = "dc2"
     domain = "${akamai_gtm_domain.some_domain.name}"
     country = "IS"
@@ -42,7 +42,7 @@ resource "akamai_gtm_datacenter" "dc2" {
     longitude = -23.776
     latitude = 64.808
     depends_on = [
-        "akamai_gtm_datacenter.dc1"
+        "akamai_gtm_data_center.dc1"
     ]
 }
 
@@ -77,21 +77,21 @@ resource "akamai_gtm_property" "some_property" {
       testObjectPort = 80
       testTimeout = 25
   }
-  trafficTarget {
+  traffic_target {
       enabled = true
-      datacenter_id = "${akamai_gtm_datacenter.dc1.id}"
+      data_center_id = "${akamai_gtm_data_center.dc1.id}"
       weight = 50.0
-      name = "${akamai_gtm_datacenter.dc1.name}"
+      name = "${akamai_gtm_data_center.dc1.name}"
       servers = [
           "1.2.3.4",
           "1.2.3.5"
       ]
   }
-  trafficTarget {
+  traffic_target {
       enabled = true
-      datacenter_id = "${akamai_gtm_datacenter.dc2.id}"
+      data_center_id = "${akamai_gtm_data_center.dc2.id}"
       weight = 50.0
-      name = "${akamai_gtm_datacenter.dc2.name}"
+      name = "${akamai_gtm_data_center.dc2.name}"
       servers = [
           "1.2.3.6",
           "1.2.3.7"

--- a/website/source/docs/providers/akamai/index.html.markdown
+++ b/website/source/docs/providers/akamai/index.html.markdown
@@ -72,10 +72,10 @@ resource "akamai_gtm_property" "some_property" {
       test_interval = 60
       disable_nonstandard_port_warning = false
       http_error_4xx = true
-      httpError3xx = true
-      httpError5xx = true
-      testObjectPort = 80
-      testTimeout = 25
+      http_error_3xx = true
+      http_error_5xx = true
+      test_object_port = 80
+      test_timeout = 25
   }
   traffic_target {
       enabled = true

--- a/website/source/docs/providers/akamai/r/gtm_data_center.html.markdown
+++ b/website/source/docs/providers/akamai/r/gtm_data_center.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "akamai"
+page_title: "Akamai: akamai_gtm_data_center"
+sidebar_current: "docs-akamai-resource-gtm-data-center"
+description: |-
+  Provides access to a GTM data center managed by Akamai.
+---
+
+# akamai\_gtm\_data\_center
+
+Provides access to a GTM data center managed by Akamai.
+
+## Example Usage
+
+```
+resource "akamai_gtm_data_center" "some_dc" {
+    name = "some_dc"
+    domain = "some-domain.akadns.net"
+    country = "GB"
+    continent = "EU"
+    city = "Downpatrick"
+    longitude = -5.582
+    latitude = 54.367
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Specifies a name for the data center.
+
+* `domain` - (Required) Specifies the GTM domain with which to associate the data center.
+
+* `city` - (Optional) Specifies the name of the city where the data center is located.
+
+* `country` - (Optional) Specifies the two-letter ISO 3166 country code where the data center is located.
+
+* `state_or_province` - (Optional) Specifies the state or province where the data center is located.
+
+* `continent` - (Optional) Specifies the two-letter continent code where the data center is located. Valid values are `AF`, `AS`, `EU`, `NA`, `OC`, `OT`, or `SA`.
+
+* `latitude` - (Optional) Specifies the latitude where the data center is located.
+
+* `longitude` - (Optional) Specifies the longitude where the data center is located.
+
+* `virtual` - (Optional) Specifies to clients whether the data center is virtual or physical.

--- a/website/source/docs/providers/akamai/r/gtm_domain.html.markdown
+++ b/website/source/docs/providers/akamai/r/gtm_domain.html.markdown
@@ -26,13 +26,3 @@ The following arguments are supported:
 * `name` - (Required) Name of the GTM domain.
 
 * `type` - (Required) The type of GTM domain.
-
-## Attributes Reference
-
-The following attributes are exported:
-
-* `id` - The ID of the GTM domain.
-
-* `name` - The name of the GTM domain.
-
-* `type` - The GTM domain's type.

--- a/website/source/docs/providers/akamai/r/gtm_domain.html.markdown
+++ b/website/source/docs/providers/akamai/r/gtm_domain.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "akamai"
+page_title: "Akamai: akamai_gtm_domain"
+sidebar_current: "docs-akamai-resource-gtm-domain"
+description: |-
+  Provides access to a GTM domain managed by Akamai.
+---
+
+# akamai\_gtm\_domain
+
+Provides access to a GTM domain managed by Akamai.
+
+## Example Usage
+
+```
+resource "akamai_gtm_domain" "some_domain" {
+    name = "some-example.akadns.net"
+    type = "basic"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) Name of the GTM domain.
+
+* `type` - (Required) The type of GTM domain.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the GTM domain.
+
+* `name` - The name of the GTM domain.
+
+* `type` - The GTM domain's type.

--- a/website/source/docs/providers/akamai/r/gtm_property.html.markdown
+++ b/website/source/docs/providers/akamai/r/gtm_property.html.markdown
@@ -46,7 +46,7 @@ resource "akamai_gtm_property" "test_property" {
     }
     traffic_target {
         enabled = true
-        datacenter_id = "123"
+        data_center_id = "123"
         weight = 50.0
         name = "traffic_target1"
         servers = [
@@ -56,7 +56,7 @@ resource "akamai_gtm_property" "test_property" {
     }
     traffic_target {
         enabled = true
-        datacenter_id = "456"
+        data_center_id = "456"
         weight = 50.0
         name = "traffic_target2"
         servers = [
@@ -81,7 +81,7 @@ The following arguments are supported:
 
 * `traffic_target` - (Required) An option for where to direct traffic.
 
-* `handout_mode` - (Required) Relevant when more than one server IP exists in a given datacenter. Specifies the behavior of how IPs are returned when multiple IPs are alive and available. Valid values are `normal`, `persistent`, `one-ip`, `one-ip-hashed`, or `all-live-ips`.
+* `handout_mode` - (Required) Relevant when more than one server IP exists in a given data center. Specifies the behavior of how IPs are returned when multiple IPs are alive and available. Valid values are `normal`, `persistent`, `one-ip`, `one-ip-hashed`, or `all-live-ips`.
 
 * `balance_by_download_score` - (Optional) Enables download score based load balancing.
 
@@ -103,8 +103,8 @@ The following arguments are supported:
 
 * `static_ttl` - (Optional) Specifies the TTL for record types that do not change moment-to-moment.
 
-* `stickiness_bonus_percentage` - (Optional) Used with `stickiness_bonus_constant` to control datacenter affinity. Specifies that a user should not be switched unless the resulting improvement to their score exceeds a configured threshold.
+* `stickiness_bonus_percentage` - (Optional) Used with `stickiness_bonus_constant` to control data center affinity. Specifies that a user should not be switched unless the resulting improvement to their score exceeds a configured threshold.
 
-* `stickiness_bonus_constant` - (Optional) Used with `stickiness_bonus_percentage` to control datacenter affinity. Specifies that a user should not be switched unless the resulting improvement to their score exceeds a configured threshold.
+* `stickiness_bonus_constant` - (Optional) Used with `stickiness_bonus_percentage` to control data center affinity. Specifies that a user should not be switched unless the resulting improvement to their score exceeds a configured threshold.
 
 * `use_computed_targets` - (Optional) Specifies whether GTM should automatically compute target load.

--- a/website/source/docs/providers/akamai/r/gtm_property.html.markdown
+++ b/website/source/docs/providers/akamai/r/gtm_property.html.markdown
@@ -1,0 +1,110 @@
+---
+layout: "akamai"
+page_title: "Akamai: akamai_gtm_property"
+sidebar_current: "docs-akamai-resource-gtm-property"
+description: |-
+  Provides access to a GTM property managed by Akamai.
+---
+
+# akamai\_gtm\_property
+
+Provides access to a GTM property managed by Akamai.
+
+## Example Usage
+
+```
+resource "akamai_gtm_property" "test_property" {
+    domain = "some-domain.akadns.net"
+    type = "weighted-round-robin"
+    name = "test_property"
+    balance_by_download_score = false
+    dynamic_ttl = 300
+    failover_delay = 0
+    failback_delay = 0
+    handout_mode = "normal"
+    health_threshold = 0
+    health_max = 0
+    health_multiplier = 0
+    load_imbalance_percentage = 10
+    ipv6 = false
+    score_aggregation_type = "mean"
+    static_ttl = 600
+    stickiness_bonus_percentage = 50
+    stickiness_bonus_constant = 0
+    use_computed_targets = false
+    liveness_test {
+        name = "healthcheck"
+        test_object = "/status"
+        test_object_protocol = "HTTP"
+        test_interval = 60
+        disable_nonstandard_port_warning = false
+        http_error_4xx = true
+        http_error_3xx = true
+        http_error_5xx = true
+        test_object_port = 80
+        test_timeout = 25
+    }
+    traffic_target {
+        enabled = true
+        datacenter_id = "123"
+        weight = 50.0
+        name = "traffic_target1"
+        servers = [
+            "1.2.3.4",
+            "1.2.3.5"
+        ]
+    }
+    traffic_target {
+        enabled = true
+        datacenter_id = "456"
+        weight = 50.0
+        name = "traffic_target2"
+        servers = [
+            "1.2.3.6",
+            "1.2.3.7"
+        ]
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `domain` - (Required) The Akamai GTM domain with which to associate the GTM property.
+
+* `name` - (Required) A name for the Akamai GTM property. A property is a subdomain within a GTM domain. It is combined with the domain name and is used for load balancing.
+
+* `type` - (Required) Specifies the type of load balancing behavior for this property. Valid values are `failover`, `geographic`, `cidrmapping`, `weighted-round-robin`, `weighted-hashed`, `weighted-round-robin-load-feedback`, `qtr`, or `performance`.
+
+* `score_aggregation_type` - (Required) Specifies how GTM aggregates liveness test scores across different tests when multiple tests are configured. Valid valus are `mean`, `median`, `best`, or `worst`.
+
+* `traffic_target` - (Required) An option for where to direct traffic.
+
+* `handout_mode` - (Required) Relevant when more than one server IP exists in a given datacenter. Specifies the behavior of how IPs are returned when multiple IPs are alive and available. Valid values are `normal`, `persistent`, `one-ip`, `one-ip-hashed`, or `all-live-ips`.
+
+* `balance_by_download_score` - (Optional) Enables download score based load balancing.
+
+* `dynamic_ttl` - (Optional) The TTL for records that might change from moment to moment based on liveness and load balancing.
+
+* `failover_delay` - (Optional) Specifies the desired duration between liveness test failure and when GTM should consider the server down given persistant errors.
+
+* `failback_delay` - (Optional) Specifies the desired duration between liveness test recovery and when GTM should consider the server up given persistant liveness test success.
+
+* `health_threshold` - (Optional) Specifies a threshold value. A server with a score beyond the threshold will not receive traffic.
+
+* `health_max` - (Optional) Specifies an absolute limit beyond which all IPs are considered unhealthy if a `backup_cname` is provided.
+
+* `health_multiplier` - (Optional) Specifies a cutoff value that is computed from the median scores. Any server with a score beyond the cutoff value are considered unhealthy and won't receive traffice.
+
+* `load_imbalance_percentage` - (Optional) Controls the extent to which GTM allows imbalanced load.
+
+* `ipv6` - (Optional) Specifies whether the type of IP addresses handed out by the property are IPv6.
+
+* `static_ttl` - (Optional) Specifies the TTL for record types that do not change moment-to-moment.
+
+* `stickiness_bonus_percentage` - (Optional) Used with `stickiness_bonus_constant` to control datacenter affinity. Specifies that a user should not be switched unless the resulting improvement to their score exceeds a configured threshold.
+
+* `stickiness_bonus_constant` - (Optional) Used with `stickiness_bonus_percentage` to control datacenter affinity. Specifies that a user should not be switched unless the resulting improvement to their score exceeds a configured threshold.
+
+* `use_computed_targets` - (Optional) Specifies whether GTM should automatically compute target load.


### PR DESCRIPTION
This PR seeks to add support for an [Akamai GTM](https://developer.akamai.com/api/luna/config-gtm/overview.html) provider, as outlined in issue #5639.

Note that PR #9219 also seeks to add Akamai functionality, though it appears that PR is largely focused on [Akamai PAPI functionality](https://developer.akamai.com/api/luna/papi/overview.html) (vs GTM functionality) and has not been updated since October 4th. Also note that many of the issues @joshuaspence outlines in issue #5639 also pertain here:

* there is no API sandbox; acceptance tests require an active account
* it appears the GTM API does not support GTM domain deletion

Pending initial feedback, I can remove the `[WIP]` flag, as I _believe_ this is largely feature complete, aside from the above-cited issues.

Thanks!