### PR TITLE
terraform: TargetsTransformer should preserve module variables

### DIFF
--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -89,6 +89,12 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Attach the state
 		&AttachStateTransformer{State: b.State},
 
+		// Add root variables
+		&RootVariableTransformer{Module: b.Module},
+
+		// Add module variables
+		&ModuleVariableTransformer{Module: b.Module},
+
 		// Connect so that the references are ready for targeting. We'll
 		// have to connect again later for providers and so on.
 		&ReferenceTransformer{},
@@ -102,12 +108,6 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&DisableProviderTransformer{},
 		&ParentProviderTransformer{},
 		&AttachProviderConfigTransformer{Module: b.Module},
-
-		// Add root variables
-		&RootVariableTransformer{Module: b.Module},
-
-		// Add module variables
-		&ModuleVariableTransformer{Module: b.Module},
 
 		// Connect references again to connect the providers, module variables,
 		// etc. This is idempotent.

--- a/terraform/node_module_variable.go
+++ b/terraform/node_module_variable.go
@@ -37,6 +37,13 @@ func (n *NodeApplyableModuleVariable) Path() []string {
 	return rootModulePath
 }
 
+// RemovableIfNotTargeted
+func (n *NodeApplyableModuleVariable) RemoveIfNotTargeted() bool {
+	// We need to add this so that this node will be removed if
+	// it isn't targeted or a dependency of a target.
+	return true
+}
+
 // GraphNodeReferenceGlobal
 func (n *NodeApplyableModuleVariable) ReferenceGlobal() bool {
 	// We have to create fully qualified references because we cross

--- a/terraform/test-fixtures/plan-targeted-cross-module/A/main.tf
+++ b/terraform/test-fixtures/plan-targeted-cross-module/A/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "foo" {
+    foo = "bar"
+}
+
+output "value" { value = "${aws_instance.foo.id}" }

--- a/terraform/test-fixtures/plan-targeted-cross-module/B/main.tf
+++ b/terraform/test-fixtures/plan-targeted-cross-module/B/main.tf
@@ -1,0 +1,5 @@
+variable "input" {}
+
+resource "aws_instance" "bar" {
+    foo = "${var.input}"
+}

--- a/terraform/test-fixtures/plan-targeted-cross-module/main.tf
+++ b/terraform/test-fixtures/plan-targeted-cross-module/main.tf
@@ -1,0 +1,8 @@
+module "A" {
+    source = "./A"
+}
+
+module "B" {
+    source = "./B"
+    input  = "${module.A.value}"
+}


### PR DESCRIPTION
Fixes #10680

This moves TargetsTransformer to run after the transforms that add
module variables is run. This makes targeting work across modules (test
added).

This is a bug that only exists in the new graph, but was caught by a
shadow error in #10680. Tests were added to protect against regressions.

@jbardin: This is important to get into 0.8 since it would be a regression from 0.7.