### PR TITLE
provider/rundeck: Set Computed on rundeck_job preserve_options_order

### DIFF
--- a/builtin/providers/rundeck/resource_job.go
+++ b/builtin/providers/rundeck/resource_job.go
@@ -80,6 +80,7 @@ func resourceRundeckJob() *schema.Resource {
 			"preserve_options_order": &schema.Schema{
 				Type:     schema.TypeBool,
 				Optional: true,
+				Computed: true,
 			},
 
 			"command_ordering_strategy": &schema.Schema{


### PR DESCRIPTION
Before the change, this was the test result:

```
% make testacc TEST=./builtin/providers/rundeck                                                                               2 ↵
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/13 11:14:11 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/rundeck -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccJob_basic
--- FAIL: TestAccJob_basic (6.51s)
	testing.go:265: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: rundeck_job.test
		  preserve_options_order: "true" => "false"

		STATE:

		rundeck_job.test:
		  ID = 1da079e6-31f1-4c77-9cbb-c77c0a16fea5
		  allow_concurrent_executions = true
		  command.# = 1
		  command.0.inline_script =
		  command.0.job.# = 0
		  command.0.node_step_plugin.# = 0
		  command.0.script_file =
		  command.0.script_file_args =
		  command.0.shell_command = echo Hello World
		  command.0.step_plugin.# = 0
		  command_ordering_strategy = node-first
		  continue_on_error = false
		  description = A basic job
		  group_name =
		  log_level = INFO
		  max_thread_count = 1
		  name = basic-job
		  node_filter_exclude_precedence = false
		  node_filter_query = example
		  option.# = 1
		  option.0.allow_multiple_values = false
		  option.0.default_value = bar
		  option.0.description =
		  option.0.exposed_to_scripts = false
		  option.0.multi_value_delimiter =
		  option.0.name = foo
		  option.0.obscure_input = false
		  option.0.require_predefined_choice = false
		  option.0.required = false
		  option.0.validation_regex =
		  option.0.value_choices.# = 0
		  option.0.value_choices_url =
		  preserve_options_order = true
		  project_name = terraform-acc-test-job
		  rank_attribute =
		  rank_order = ascending

		  Dependencies:
		    rundeck_project.test
		rundeck_project.test:
		  ID = terraform-acc-test-job
		  default_node_executor_plugin = jsch-ssh
		  default_node_file_copier_plugin = jsch-scp
		  description = parent project for job acceptance tests
		  extra_config.% = 0
		  name = terraform-acc-test-job
		  resource_model_source.# = 1
		  resource_model_source.0.config.% = 2
		  resource_model_source.0.config.file = /tmp/terraform-acc-tests.xml
		  resource_model_source.0.config.format = resourcexml
		  resource_model_source.0.type = file
		  ssh_authentication_type = privateKey
		  ssh_key_file_path =
		  ssh_key_storage_path =
		  ui_url = http://192.168.50.2:4440/api/18/project/terraform-acc-test-job
=== RUN   TestAccPrivateKey_basic
--- PASS: TestAccPrivateKey_basic (7.90s)
=== RUN   TestAccProject_basic
--- PASS: TestAccProject_basic (2.21s)
=== RUN   TestAccPublicKey_basic
--- PASS: TestAccPublicKey_basic (2.43s)
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/rundeck	19.067s
make: *** [testacc] Error 1
```

After the change:

```
% make testacc TEST=./builtin/providers/rundeck                                                                               2 ↵
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/13 11:35:46 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/rundeck -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccJob_basic
--- PASS: TestAccJob_basic (1.46s)
=== RUN   TestAccPrivateKey_basic
--- PASS: TestAccPrivateKey_basic (0.26s)
=== RUN   TestAccProject_basic
--- PASS: TestAccProject_basic (0.65s)
=== RUN   TestAccPublicKey_basic
--- PASS: TestAccPublicKey_basic (0.59s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/rundeck	2.975s
```