### PR TITLE
provider/aws: Save `iam_access_key` secret to state if no PGP key given (supersedes #10694)

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_access_key.go
+++ b/builtin/providers/aws/resource_aws_iam_access_key.go
@@ -72,6 +72,10 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 		)
 	}
 
+	if err := d.Set("secret", createResp.AccessKey.SecretAccessKey); err != nil {
+		return err
+	}
+
 	d.SetId(*createResp.AccessKey.AccessKeyId)
 
 	if createResp.AccessKey == nil || createResp.AccessKey.SecretAccessKey == nil {

--- a/builtin/providers/aws/resource_aws_iam_access_key.go
+++ b/builtin/providers/aws/resource_aws_iam_access_key.go
@@ -72,10 +72,6 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 		)
 	}
 
-	if err := d.Set("secret", createResp.AccessKey.SecretAccessKey); err != nil {
-		return err
-	}
-
 	d.SetId(*createResp.AccessKey.AccessKeyId)
 
 	if createResp.AccessKey == nil || createResp.AccessKey.SecretAccessKey == nil {
@@ -95,6 +91,10 @@ func resourceAwsIamAccessKeyCreate(d *schema.ResourceData, meta interface{}) err
 
 		d.Set("key_fingerprint", fingerprint)
 		d.Set("encrypted_secret", encrypted)
+	} else {
+		if err := d.Set("secret", createResp.AccessKey.SecretAccessKey); err != nil {
+			return err
+		}
 	}
 
 	d.Set("ses_smtp_password",

--- a/builtin/providers/aws/resource_aws_iam_access_key_test.go
+++ b/builtin/providers/aws/resource_aws_iam_access_key_test.go
@@ -29,6 +29,7 @@ func TestAccAWSAccessKey_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAccessKeyExists("aws_iam_access_key.a_key", &conf),
 					testAccCheckAWSAccessKeyAttributes(&conf),
+					resource.TestCheckResourceAttrSet("aws_iam_access_key.a_key", "secret"),
 				),
 			},
 		},


### PR DESCRIPTION
This pr builds of off #10694 and only saves the secret if no PGP is given. 