### PR TITLE
provider/aws: Improved the SNS topic subscription protocols validation

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic_subscription.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription.go
@@ -30,22 +30,10 @@ func resourceAwsSnsTopicSubscription() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"protocol": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: false,
-				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
-					value := v.(string)
-					forbidden := []string{"email", "sms"}
-					for _, f := range forbidden {
-						if strings.Contains(value, f) {
-							errors = append(
-								errors,
-								fmt.Errorf("Unsupported protocol (%s) for SNS Topic", value),
-							)
-						}
-					}
-					return
-				},
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     false,
+				ValidateFunc: validateSNSSubscriptionProtocol,
 			},
 			"endpoint": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -571,5 +572,19 @@ func validateSQSFifoQueueName(v interface{}, k string) (errors []error) {
 		errors = append(errors, fmt.Errorf("FIFO queue name should ends with \".fifo\": %v", value))
 	}
 
+	return
+}
+
+func validateSNSSubscriptionProtocol(v interface{}, k string) (ws []string, errors []error) {
+	value := strings.ToLower(v.(string))
+	forbidden := []string{"email", "sms"}
+	for _, f := range forbidden {
+		if strings.Contains(value, f) {
+			errors = append(
+				errors,
+				fmt.Errorf("Unsupported protocol (%s) for SNS Topic", value),
+			)
+		}
+	}
 	return
 }

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -865,3 +865,33 @@ func TestValidateSQSFifoQueueName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateSNSSubscriptionProtocol(t *testing.T) {
+	validProtocols := []string{
+		"lambda",
+		"sqs",
+		"sqs",
+		"application",
+		"http",
+		"https",
+	}
+	for _, v := range validProtocols {
+		if _, errors := validateSNSSubscriptionProtocol(v, "protocol"); len(errors) > 0 {
+			t.Fatalf("%q should be a valid SNS Subscription protocol: %v", v, errors)
+		}
+	}
+
+	invalidProtocols := []string{
+		"Email",
+		"email",
+		"Email-JSON",
+		"email-json",
+		"SMS",
+		"sms",
+	}
+	for _, v := range invalidProtocols {
+		if _, errors := validateSNSSubscriptionProtocol(v, "protocol"); len(errors) == 0 {
+			t.Fatalf("%q should be an invalid SNS Subscription protocol: %v", v, errors)
+		}
+	}
+}


### PR DESCRIPTION
#### Reasonning for this change
Partially fixes https://github.com/hashicorp/terraform/issues/10697

#### Acceptance tests
```bash
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSNSTopicSubscription_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/13 17:53:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSNSTopicSubscription_basic -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_basic
--- PASS: TestAccAWSSNSTopicSubscription_basic (22.24s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	22.278s
```