### PR TITLE
Dept of second thoughts: remove authorization support ASAP.

### DIFF
--- a/builtin/providers/postgresql/resource_postgresql_schema_test.go
+++ b/builtin/providers/postgresql/resource_postgresql_schema_test.go
@@ -26,34 +26,6 @@ func TestAccPostgresqlSchema_Basic(t *testing.T) {
 
 					resource.TestCheckResourceAttr(
 						"postgresql_schema.test1", "name", "foo"),
-					// `postgres` is a calculated value
-					// based on the username used in the
-					// provider
-					resource.TestCheckResourceAttr(
-						"postgresql_schema.test1", "authorization", "postgres"),
-				),
-			},
-		},
-	})
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckPostgresqlSchemaDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccPostgresqlSchemaAuthConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckPostgresqlSchemaExists("postgresql_schema.test2", "foo2"),
-					resource.TestCheckResourceAttr(
-						"postgresql_role.myrole4", "name", "myrole4"),
-					resource.TestCheckResourceAttr(
-						"postgresql_role.myrole4", "login", "true"),
-
-					resource.TestCheckResourceAttr(
-						"postgresql_schema.test2", "name", "foo2"),
-					resource.TestCheckResourceAttr(
-						"postgresql_schema.test2", "authorization", "myrole4"),
 				),
 			},
 		},
@@ -139,17 +111,5 @@ resource "postgresql_role" "myrole3" {
 
 resource "postgresql_schema" "test1" {
   name = "foo"
-}
-`
-
-var testAccPostgresqlSchemaAuthConfig = `
-resource "postgresql_role" "myrole4" {
-  name = "myrole4"
-  login = true
-}
-
-resource "postgresql_schema" "test2" {
-  name = "foo2"
-  authorization = "${postgresql_role.myrole4.name}"
 }
 `

--- a/website/source/docs/providers/postgresql/r/postgresql_schema.html.markdown
+++ b/website/source/docs/providers/postgresql/r/postgresql_schema.html.markdown
@@ -17,7 +17,6 @@ PostgreSQL database.
 ```
 resource "postgresql_schema" "my_schema" {
   name = "my_schema"
-  authorization = "my_role"
 }
 ```
 
@@ -25,9 +24,6 @@ resource "postgresql_schema" "my_schema" {
 
 * `name` - (Required) The name of the schema. Must be unique in the PostgreSQL
   database instance where it is configured.
-
-* `authorization` - (Optional) The owner of the schema.  Defaults to the
-  username configured in the schema's provider.
 
 ## Import Example
 


### PR DESCRIPTION
When `postgresql_schema_policy` lands this attribute should be removed in
order to provide a single way of accomplishing setting permissions on
schema objects.  Removing ASAP to minimize any usage.