### PR TITLE
Correct error message for 'aws_caller_identity' acceptance test

### DIFF
--- a/builtin/providers/aws/data_source_aws_caller_identity_test.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity_test.go
@@ -36,7 +36,7 @@ func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 
 		expected := testAccProvider.Meta().(*AWSClient).accountid
 		if rs.Primary.Attributes["account_id"] != expected {
-			return fmt.Errorf("Incorrect Account ID: expected %q, got %q", expected, rs.Primary.ID)
+			return fmt.Errorf("Incorrect Account ID: expected %q, got %q", expected, rs.Primary.Attributes["account_id"])
 		}
 
 		return nil


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCallerIdentity_'
```