### PR TITLE
helper/variables: trim whitespace around the key in -var

### DIFF
--- a/helper/variables/flag.go
+++ b/helper/variables/flag.go
@@ -21,6 +21,9 @@ func (v *Flag) Set(raw string) error {
 	}
 
 	key, input := raw[0:idx], raw[idx+1:]
+
+	// Trim the whitespace on the key
+	key = strings.TrimSpace(key)
 	if key == "" {
 		return fmt.Errorf("No key to left '=' in arg: %s", raw)
 	}
@@ -29,9 +32,6 @@ func (v *Flag) Set(raw string) error {
 	if err != nil {
 		return err
 	}
-
-	// Trim the whitespace on the key
-	key = strings.TrimSpace(key)
 
 	*v = Merge(*v, map[string]interface{}{key: value})
 	return nil

--- a/helper/variables/flag.go
+++ b/helper/variables/flag.go
@@ -21,10 +21,17 @@ func (v *Flag) Set(raw string) error {
 	}
 
 	key, input := raw[0:idx], raw[idx+1:]
+	if key == "" {
+		return fmt.Errorf("No key to left '=' in arg: %s", raw)
+	}
+
 	value, err := ParseInput(input)
 	if err != nil {
 		return err
 	}
+
+	// Trim the whitespace on the key
+	key = strings.TrimSpace(key)
 
 	*v = Merge(*v, map[string]interface{}{key: value})
 	return nil

--- a/helper/variables/flag_test.go
+++ b/helper/variables/flag_test.go
@@ -26,6 +26,12 @@ func TestFlag(t *testing.T) {
 		},
 
 		{
+			" =value",
+			nil,
+			true,
+		},
+
+		{
 			"key=value",
 			map[string]interface{}{"key": "value"},
 			false,

--- a/helper/variables/flag_test.go
+++ b/helper/variables/flag_test.go
@@ -20,6 +20,12 @@ func TestFlag(t *testing.T) {
 		Error  bool
 	}{
 		{
+			"=value",
+			nil,
+			true,
+		},
+
+		{
 			"key=value",
 			map[string]interface{}{"key": "value"},
 			false,
@@ -40,6 +46,24 @@ func TestFlag(t *testing.T) {
 		{
 			"key=false",
 			map[string]interface{}{"key": "false"},
+			false,
+		},
+
+		{
+			"key =value",
+			map[string]interface{}{"key": "value"},
+			false,
+		},
+
+		{
+			"key = value",
+			map[string]interface{}{"key": " value"},
+			false,
+		},
+
+		{
+			`key = "value"`,
+			map[string]interface{}{"key": "value"},
 			false,
 		},
 


### PR DESCRIPTION
Fixes #10716

This trims whitespace around the key in the `-var` flag.

This is a regression from 0.7.x.

The value is whitespace sensitive unless double-quoted. This is the same
behavior as 0.7.x. I considered rejecting whitespace around the '='
completely but I don't want to introduce BC and the behavior actually
seems quite obvious to me.

Non-regression from 0.7.x but added in here trivially: verify the key is non-empty.