### PR TITLE
terraform: add module vars after providers to see references

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -657,6 +657,29 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_moduleProviderVar(t *testing.T) {
+	m := testModule(t, "plan-module-provider-var")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(testTerraformPlanModuleProviderVarStr)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestContext2Plan_moduleVar(t *testing.T) {
 	m := testModule(t, "plan-module-var")
 	p := testProvider("aws")

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -92,6 +92,13 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		// Add root variables
 		&RootVariableTransformer{Module: b.Module},
 
+		// Create all the providers
+		&MissingProviderTransformer{Providers: b.Providers, Concrete: concreteProvider},
+		&ProviderTransformer{},
+		&DisableProviderTransformer{},
+		&ParentProviderTransformer{},
+		&AttachProviderConfigTransformer{Module: b.Module},
+
 		// Add module variables
 		&ModuleVariableTransformer{Module: b.Module},
 
@@ -101,17 +108,6 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 		// Target
 		&TargetsTransformer{Targets: b.Targets},
-
-		// Create all the providers
-		&MissingProviderTransformer{Providers: b.Providers, Concrete: concreteProvider},
-		&ProviderTransformer{},
-		&DisableProviderTransformer{},
-		&ParentProviderTransformer{},
-		&AttachProviderConfigTransformer{Module: b.Module},
-
-		// Connect references again to connect the providers, module variables,
-		// etc. This is idempotent.
-		&ReferenceTransformer{},
 
 		// Single root
 		&RootTransformer{},

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1381,6 +1381,19 @@ module.child:
     ID = baz
 `
 
+const testTerraformPlanModuleProviderVarStr = `
+DIFF:
+
+module.child:
+  CREATE: aws_instance.test
+    type:  "" => "aws_instance"
+    value: "" => "hello"
+
+STATE:
+
+<no state>
+`
+
 const testTerraformPlanModuleVarStr = `
 DIFF:
 

--- a/terraform/test-fixtures/plan-module-provider-var/child/main.tf
+++ b/terraform/test-fixtures/plan-module-provider-var/child/main.tf
@@ -1,0 +1,9 @@
+variable "foo" {}
+
+provider "aws" {
+    value = "${var.foo}"
+}
+
+resource "aws_instance" "test" {
+    value = "hello"
+}

--- a/terraform/test-fixtures/plan-module-provider-var/main.tf
+++ b/terraform/test-fixtures/plan-module-provider-var/main.tf
@@ -1,0 +1,6 @@
+variable "foo" { default = "bar" }
+
+module "child" {
+    source = "./child"
+    foo    = "${var.foo}"
+}

--- a/terraform/transform_module_variable.go
+++ b/terraform/transform_module_variable.go
@@ -11,7 +11,7 @@ import (
 // ModuleVariableTransformer is a GraphTransformer that adds all the variables
 // in the configuration to the graph.
 //
-// This only adds variables that are referenced by other thigns in the graph.
+// This only adds variables that are referenced by other things in the graph.
 // If a module variable is not referenced, it won't be added to the graph.
 type ModuleVariableTransformer struct {
 	Module *module.Tree


### PR DESCRIPTION
Fixes #10711

The `ModuleVariablesTransformer` only adds module variables in use. This
was missing module variables used by providers since we ran the provider
too late. This moves the transformer and adds a test for this.