### PR TITLE
provider/pagerduty: Allow 'team_responder' role for pagerduty_user resource

### DIFF
--- a/builtin/providers/pagerduty/resource_pagerduty_user.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_user.go
@@ -39,6 +39,7 @@ func resourcePagerDutyUser() *schema.Resource {
 					"limited_user",
 					"owner",
 					"read_only_user",
+          "team_responder",
 					"user",
 				}),
 			},

--- a/builtin/providers/pagerduty/resource_pagerduty_user.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_user.go
@@ -39,7 +39,7 @@ func resourcePagerDutyUser() *schema.Resource {
 					"limited_user",
 					"owner",
 					"read_only_user",
-          "team_responder",
+					"team_responder",
 					"user",
 				}),
 			},

--- a/builtin/providers/pagerduty/resource_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_user_test.go
@@ -44,7 +44,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "color", "red"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "role", "user"),
+						"pagerduty_user.foo", "role", "team_responder"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "job_title", "bar"),
 					resource.TestCheckResourceAttr(

--- a/builtin/providers/pagerduty/resource_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_user_test.go
@@ -161,7 +161,7 @@ resource "pagerduty_user" "foo" {
   name        = "bar"
   email       = "bar@foo.com"
   color       = "red"
-  role        = "user"
+  role        = "team_responder"
   job_title   = "bar"
   description = "bar"
 }

--- a/website/source/docs/providers/pagerduty/r/user.html.markdown
+++ b/website/source/docs/providers/pagerduty/r/user.html.markdown
@@ -33,7 +33,7 @@ The following arguments are supported:
   * `name` - (Required) The name of the user.
   * `email` - (Required) The user's email address.
   * `color` - (Optional) The schedule color for the user.
-  * `role` - (Optional) The user role. Account must have the `read_only_users` ability to set a user as a `read_only_user`. Can be `admin`, `limited_user`, `owner`, `read_only_user` or `user`
+  * `role` - (Optional) The user role. Account must have the `read_only_users` ability to set a user as a `read_only_user`. Can be `admin`, `limited_user`, `owner`, `read_only_user`, `team_responder` or `user`
   * `job_title` - (Optional) The user's title.
   * `teams` - (Optional) A list of teams the user should belong to.
   * `description` - (Optional) A human-friendly description of the user.


### PR DESCRIPTION
The PagerDuty API documentation is incomplete in that the User API also allows a value of `role = "team_responder"` in addition to the documented roles.

Their support page has more information about this user role: https://support.pagerduty.com/hc/en-us/articles/202830040-User-Roles-in-Your-Account-

This PR expands the list of allowed roles and updates the documentation accordingly.

I have run this locally against our team PD account with no problems.