### PR TITLE
provider/aws: Removed deprecated parameter group from RDS Cluster

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -64,16 +64,6 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Computed: true,
 			},
 
-			// TODO: remove parameter_group_name
-			// See https://github.com/hashicorp/terraform/issues/7046
-			// Likely need migration to remove from state
-			"parameter_group_name": {
-				Type:       schema.TypeString,
-				Optional:   true,
-				Computed:   true,
-				Deprecated: "Use db_cluster_parameter_group_name instead. This attribute will be removed in a future version",
-			},
-
 			"db_cluster_parameter_group_name": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -326,10 +316,6 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			createOpts.DBSubnetGroupName = aws.String(attr.(string))
 		}
 
-		if attr, ok := d.GetOk("parameter_group_name"); ok {
-			createOpts.DBClusterParameterGroupName = aws.String(attr.(string))
-		}
-
 		if attr, ok := d.GetOk("db_cluster_parameter_group_name"); ok {
 			createOpts.DBClusterParameterGroupName = aws.String(attr.(string))
 		}
@@ -438,7 +424,6 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("cluster_identifier", dbc.DBClusterIdentifier)
 	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
-	d.Set("parameter_group_name", dbc.DBClusterParameterGroup)
 	d.Set("db_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
 	d.Set("endpoint", dbc.Endpoint)
 	d.Set("engine", dbc.Engine)
@@ -515,12 +500,6 @@ func resourceAwsRDSClusterUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("backup_retention_period") {
 		req.BackupRetentionPeriod = aws.Int64(int64(d.Get("backup_retention_period").(int)))
-		requestUpdate = true
-	}
-
-	if d.HasChange("parameter_group_name") {
-		d.SetPartial("parameter_group_name")
-		req.DBClusterParameterGroupName = aws.String(d.Get("parameter_group_name").(string))
 		requestUpdate = true
 	}
 


### PR DESCRIPTION
Removes the deprecated `parameter_group_name` attribute from `aws_rds_cluster`. This attribute was poorly named, and superseded by `db_cluster_parameter_group` in #7083 while being marked for removal later. Today is later!

There should be no backwards incompatible issues, as `db_parameter_group` was only available in release candidates (IIRC), and otherwise was marked as `deprecated` for all of v0.7.0 release.
