### PR TITLE
provider/aws: Added aws_iam_login_profile custom password setting

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_user_login_profile_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_login_profile_test.go
@@ -169,7 +169,7 @@ func testDecryptPasswordAndTest(nProfile, nAccessKey, key string) resource.TestC
 				NewPassword: aws.String(generatePassword(20)),
 			})
 			if err != nil {
-				if awserr, ok := err.(awserr.Error); ok && awserr.Code() == "InvalidClientTokenId" {
+				if awserr, ok := err.(awserr.Error); ok && (awserr.Code() == "InvalidClientTokenId" || awserr.Code() == "EntityTemporarilyUnmodifiable") {
 					return resource.RetryableError(err)
 				}
 

--- a/website/source/docs/providers/aws/r/iam_user_login_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user_login_profile.html.markdown
@@ -12,7 +12,26 @@ Provides one-time creation of a IAM user login profile, and uses PGP to
 encrypt the password for safe transport to the user. PGP keys can be
 obtained from Keybase.
 
-## Example Usage
+## Example usage
+
+```
+resource "aws_iam_user" "u" {
+        name = "auser"
+        path = "/"
+        force_destroy = true
+}
+
+resource "aws_iam_user_login_profile" "u" {
+        user = "${aws_iam_user.u.name}"
+        password = "MyP@ssw0rd"
+}
+
+output "password" {
+        value = "${aws_iam_user_login_profile.u.password}"
+}
+```
+
+## PGP Key Example
 
 ```
 resource "aws_iam_user" "u" {
@@ -31,17 +50,20 @@ output "password" {
 }
 ```
 
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `user` - (Required) The IAM user's name.
-* `pgp_key` - (Required) Either a base-64 encoded PGP public key, or a
+* `password` - (Optional) The password you want to set. It not specified,
+  one will be generated.
+* `pgp_key` - (Optional) Either a base-64 encoded PGP public key, or a
   keybase username in the form `keybase:username`.
+* `password_length` - (Optional, default 20) The length of the generated
+  password. Used when the password is auto-generated.
 * `password_reset_required` - (Optional, default "true") Whether the
   user should be forced to reset the generated password on first login.
-* `password_length` - (Optional, default 20) The length of the generated
-  password.
 
 ## Attributes Reference
 
@@ -49,10 +71,10 @@ The following attributes are exported:
 
 * `key_fingerprint` - The fingerprint of the PGP key used to encrypt
   the password
-* `encrypted_password` - The encrypted password, base64 encoded.
+* `encrypted_password` - The encrypted password when using PGP **only**, base64 encoded.
 
 ~> **NOTE:** The encrypted password may be decrypted using the command line,
-   for example: `terraform output password | base64 --decode | keybase pgp decrypt`. 
+   for example: `terraform output password | base64 --decode | keybase pgp decrypt`.
 
 ## Import
 


### PR DESCRIPTION
#### Reasoning for this change
This is the continuation of https://github.com/hashicorp/terraform/pull/9605.

The previous PR introduced PGP-based keys, encrypting and decrypting using keybase.io.
As the login_profile password was generated, it was missing the ability to generate a custom password. 
This allows to set it, making this even more flexible.

#### Real Configuration
```hcl
 resource "aws_iam_user" "user" {
     name = "demo"
     path = "/"
     force_destroy = true
 }
 
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "user" {
     statement {
         effect = "Allow"
         actions = ["iam:GetAccountPasswordPolicy"]
         resources = ["*"]
     }
     statement {
         effect = "Allow"
         actions = ["iam:ChangePassword"]
         resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/&{aws:username}"]
     }
 }
 
 resource "aws_iam_user_policy" "user" {
     name = "AllowChangeOwnPassword"
     user = "${aws_iam_user.user.name}"
     policy = "${data.aws_iam_policy_document.user.json}"
 }
 
 resource "aws_iam_access_key" "user" {
     user = "${aws_iam_user.user.name}"
 }
 
 resource "aws_iam_user_login_profile" "user" {
     user = "${aws_iam_user.user.name}"
     password = "test"
 }
```

#### Use cases
Demos, trainings or handsons.

#### Acceptance tests
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSUserLoginProfile_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/14 21:58:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSUserLoginProfile_ -timeout 120m
=== RUN   TestAccAWSUserLoginProfile_basic
--- PASS: TestAccAWSUserLoginProfile_basic (22.11s)
=== RUN   TestAccAWSUserLoginProfile_keybase
--- PASS: TestAccAWSUserLoginProfile_keybase (20.71s)
=== RUN   TestAccAWSUserLoginProfile_keybaseDoesntExist
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (12.11s)
=== RUN   TestAccAWSUserLoginProfile_notAKey
--- PASS: TestAccAWSUserLoginProfile_notAKey (14.28s)
=== RUN   TestAccAWSUserLoginProfile_customPassword
--- PASS: TestAccAWSUserLoginProfile_customPassword (19.61s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	88.850s
```