### PR TITLE
terraform: destroy edges should take into account module variables

### DIFF
--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -192,6 +192,46 @@ func TestApplyGraphBuilder_destroyCount(t *testing.T) {
 	}
 }
 
+func TestApplyGraphBuilder_moduleDestroy(t *testing.T) {
+	diff := &Diff{
+		Modules: []*ModuleDiff{
+			&ModuleDiff{
+				Path: []string{"root", "A"},
+				Resources: map[string]*InstanceDiff{
+					"null_resource.foo": &InstanceDiff{
+						Destroy: true,
+					},
+				},
+			},
+
+			&ModuleDiff{
+				Path: []string{"root", "B"},
+				Resources: map[string]*InstanceDiff{
+					"null_resource.foo": &InstanceDiff{
+						Destroy: true,
+					},
+				},
+			},
+		},
+	}
+
+	b := &ApplyGraphBuilder{
+		Module:    testModule(t, "graph-builder-apply-module-destroy"),
+		Diff:      diff,
+		Providers: []string{"null"},
+	}
+
+	g, err := b.Build(RootModulePath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	testGraphHappensBefore(
+		t, g,
+		"module.B.null_resource.foo (destroy)",
+		"module.A.null_resource.foo (destroy)")
+}
+
 const testApplyGraphBuilderStr = `
 aws_instance.create
   provider.aws

--- a/terraform/graph_test.go
+++ b/terraform/graph_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/hashicorp/terraform/dag"
 )
 
 func TestGraphAdd(t *testing.T) {
@@ -84,6 +86,42 @@ func TestGraphWalk_panicWrap(t *testing.T) {
 	if err == nil {
 		t.Fatal("should error")
 	}
+}
+
+// testGraphHappensBefore is an assertion helper that tests that node
+// A (dag.VertexName value) happens before node B.
+func testGraphHappensBefore(t *testing.T, g *Graph, A, B string) {
+	// Find the B vertex
+	var vertexB dag.Vertex
+	for _, v := range g.Vertices() {
+		if dag.VertexName(v) == B {
+			vertexB = v
+			break
+		}
+	}
+	if vertexB == nil {
+		t.Fatalf(
+			"Expected %q before %q. Couldn't find %q in:\n\n%s",
+			A, B, B, g.String())
+	}
+
+	// Look at ancestors
+	deps, err := g.Ancestors(vertexB)
+	if err != nil {
+		t.Fatalf("Error: %s in graph:\n\n%s", err, g.String())
+	}
+
+	// Make sure B is in there
+	for _, v := range deps.List() {
+		if dag.VertexName(v) == A {
+			// Success
+			return
+		}
+	}
+
+	t.Fatalf(
+		"Expected %q before %q in:\n\n%s",
+		A, B, g.String())
 }
 
 type testGraphSubPath struct {

--- a/terraform/test-fixtures/graph-builder-apply-module-destroy/A/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-module-destroy/A/main.tf
@@ -1,0 +1,7 @@
+variable "input" {}
+
+resource "null_resource" "foo" {
+    triggers { input = "${var.input}" }
+}
+
+output "output" { value = "${null_resource.foo.id}" }

--- a/terraform/test-fixtures/graph-builder-apply-module-destroy/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-module-destroy/main.tf
@@ -1,0 +1,11 @@
+variable "input" { default = "value" }
+
+module "A" {
+    source = "./A"
+    input  = "${var.input}"
+}
+
+module "B" {
+    source = "./A"
+    input  = "${module.A.output}"
+}

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -131,6 +131,12 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 		&ParentProviderTransformer{},
 		&AttachProviderConfigTransformer{Module: t.Module},
 
+		// Add all the variables. We can depend on resources through
+		// variables due to module parameters, and we need to properly
+		// determine that.
+		&RootVariableTransformer{Module: t.Module},
+		&ModuleVariableTransformer{Module: t.Module},
+
 		&ReferenceTransformer{},
 	}
 


### PR DESCRIPTION
Fixes #10729

Destruction ordering wasn't taking into account ordering implied through
variables across module boundaries.

This is because to build the destruction ordering we create a
non-destruction graph to determine the _creation_ ordering (to properly
flip edges). This creation graph we create wasn't including module
variables. This PR adds that transform to the graph.