### PR TITLE
provider/azurerm: add support for tags to dns_zone

### DIFF
--- a/builtin/providers/azurerm/resource_arm_dns_zone_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_zone_test.go
@@ -29,6 +29,37 @@ func TestAccAzureRMDnsZone_basic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMDnsZone_withTags(t *testing.T) {
+	ri := acctest.RandInt()
+	preConfig := fmt.Sprintf(testAccAzureRMDnsZone_withTags, ri, ri)
+	postConfig := fmt.Sprintf(testAccAzureRMDnsZone_withTagsUupdate, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMDnsZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: preConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDnsZoneExists("azurerm_dns_zone.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_dns_zone.test", "tags.%", "2"),
+				),
+			},
+
+			resource.TestStep{
+				Config: postConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMDnsZoneExists("azurerm_dns_zone.test"),
+					resource.TestCheckResourceAttr(
+						"azurerm_dns_zone.test", "tags.%", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testCheckAzureRMDnsZoneExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Ensure we have enough information in state to look up in API
@@ -86,5 +117,34 @@ resource "azurerm_resource_group" "test" {
 resource "azurerm_dns_zone" "test" {
     name = "acctestzone%d.com"
     resource_group_name = "${azurerm_resource_group.test.name}"
+}
+`
+
+var testAccAzureRMDnsZone_withTags = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG_%d"
+    location = "West US"
+}
+resource "azurerm_dns_zone" "test" {
+    name = "acctestzone%d.com"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+	tags {
+		environment = "Production"
+		cost_center = "MSFT"
+    }
+}
+`
+
+var testAccAzureRMDnsZone_withTagsUupdate = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG_%d"
+    location = "West US"
+}
+resource "azurerm_dns_zone" "test" {
+    name = "acctestzone%d.com"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+	tags {
+		environment = "staging"
+    }
 }
 `


### PR DESCRIPTION
tags were documented, just not implemented

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMDnsZone_ -timeout 120m
=== RUN   TestAccAzureRMDnsZone_importBasic
--- PASS: TestAccAzureRMDnsZone_importBasic (89.04s)
=== RUN   TestAccAzureRMDnsZone_basic
--- PASS: TestAccAzureRMDnsZone_basic (92.91s)
=== RUN   TestAccAzureRMDnsZone_withTags
--- PASS: TestAccAzureRMDnsZone_withTags (105.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	287.912s
```