### PR TITLE
Drop alias from state file if missing from lambda.

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_alias.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias.go
@@ -82,6 +82,12 @@ func resourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) error 
 
 	aliasConfiguration, err := conn.GetAlias(params)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == resourceNotFoundException && strings.Contains(awsErr.Message(), "Cannot find alias arn") {
+				d.SetId("")
+				return nil
+			}
+		}
 		return err
 	}
 

--- a/builtin/providers/aws/resource_aws_lambda_alias.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias.go
@@ -85,7 +85,7 @@ func resourceAwsLambdaAliasRead(d *schema.ResourceData, meta interface{}) error 
 	aliasConfiguration, err := conn.GetAlias(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == resourceNotFoundException && strings.Contains(awsErr.Message(), "Cannot find alias arn") {
+			if awsErr.Code() == "ResourceNotFoundException" && strings.Contains(awsErr.Message(), "Cannot find alias arn") {
 				d.SetId("")
 				return nil
 			}

--- a/builtin/providers/aws/resource_aws_lambda_alias.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias.go
@@ -3,8 +3,10 @@ package aws
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/hashicorp/terraform/helper/schema"
 )


### PR DESCRIPTION
This commit fixes an issue where if you remove a AWS Lambda, the corresponding alias for that Lambda is also deleted.