### PR TITLE
provider/aws: Fixed the data source ami enforcing non-nil values

### DIFF
--- a/builtin/providers/aws/data_source_aws_ami.go
+++ b/builtin/providers/aws/data_source_aws_ami.go
@@ -193,7 +193,11 @@ func dataSourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 		params.Filters = buildAwsDataSourceFilters(filters.(*schema.Set))
 	}
 	if ownersOk {
-		params.Owners = expandStringList(owners.([]interface{}))
+		o := expandStringList(owners.([]interface{}))
+
+		if len(o) > 0 {
+			params.Owners = o
+		}
 	}
 
 	resp, err := conn.DescribeImages(params)

--- a/builtin/providers/aws/data_source_aws_ami_test.go
+++ b/builtin/providers/aws/data_source_aws_ami_test.go
@@ -14,7 +14,7 @@ func TestAccAWSAmiDataSource_natInstance(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAwsAmiDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAmiDataSourceID("data.aws_ami.nat_ami"),
@@ -57,7 +57,7 @@ func TestAccAWSAmiDataSource_windowsInstance(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAwsAmiDataSourceWindowsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAmiDataSourceID("data.aws_ami.windows_ami"),
@@ -95,7 +95,7 @@ func TestAccAWSAmiDataSource_instanceStore(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAwsAmiDataSourceInstanceStoreConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAmiDataSourceID("data.aws_ami.instance_store_ami"),
@@ -129,8 +129,24 @@ func TestAccAWSAmiDataSource_owners(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAwsAmiDataSourceOwnersConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAmiDataSourceID("data.aws_ami.amazon_ami"),
+				),
+			},
+		},
+	})
+}
+
+// Acceptance test for: https://github.com/hashicorp/terraform/issues/10758
+func TestAccAWSAmiDataSource_ownersEmpty(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsAmiDataSourceEmptyOwnersConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAmiDataSourceID("data.aws_ami.amazon_ami"),
 				),
@@ -144,7 +160,7 @@ func TestAccAWSAmiDataSource_localNameFilter(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAwsAmiDataSourceNameRegexConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAmiDataSourceID("data.aws_ami.name_regex_filtered_ami"),
@@ -310,6 +326,13 @@ const testAccCheckAwsAmiDataSourceOwnersConfig = `
 data "aws_ami" "amazon_ami" {
 	most_recent = true
 	owners = ["amazon"]
+}
+`
+
+const testAccCheckAwsAmiDataSourceEmptyOwnersConfig = `
+data "aws_ami" "amazon_ami" {
+	most_recent = true
+	owners = [""]
 }
 `
 

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -695,7 +695,10 @@ func flattenElastiCacheParameters(list []*elasticache.Parameter) []map[string]in
 func expandStringList(configured []interface{}) []*string {
 	vs := make([]*string, 0, len(configured))
 	for _, v := range configured {
-		vs = append(vs, aws.String(v.(string)))
+		val, ok := v.(string)
+		if ok && val != "" {
+			vs = append(vs, aws.String(v.(string)))
+		}
 	}
 	return vs
 }

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -447,7 +447,27 @@ func TestExpandStringList(t *testing.T) {
 			stringList,
 			expected)
 	}
+}
 
+func TestExpandStringListEmptyItems(t *testing.T) {
+	initialList := []string{"foo", "bar", "", "baz"}
+	l := make([]interface{}, len(initialList))
+	for i, v := range initialList {
+		l[i] = v
+	}
+	stringList := expandStringList(l)
+	expected := []*string{
+		aws.String("foo"),
+		aws.String("bar"),
+		aws.String("baz"),
+	}
+
+	if !reflect.DeepEqual(stringList, expected) {
+		t.Fatalf(
+			"Got:\n\n%#v\n\nExpected:\n\n%#v\n",
+			stringList,
+			expected)
+	}
 }
 
 func TestExpandParameters(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/10758

#### Acceptance tests
```hcl
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAmiDataSource_owners'     
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/15 19:02:49 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAmiDataSource_owners -timeout 120m
=== RUN   TestAccAWSAmiDataSource_owners
--- PASS: TestAccAWSAmiDataSource_owners (42.25s)
=== RUN   TestAccAWSAmiDataSource_ownersEmpty
--- PASS: TestAccAWSAmiDataSource_ownersEmpty (136.98s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	179.490s
```