### PR TITLE
Sort interpolated lists by index number

### DIFF
--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -210,10 +210,6 @@ func testDiffFn(
 	}
 
 	for k, v := range c.Raw {
-		if _, ok := v.(string); !ok {
-			continue
-		}
-
 		// Ignore __-prefixed keys since they're used for magic
 		if k[0] == '_' && k[1] == '_' {
 			continue

--- a/terraform/test-fixtures/plan-list-order/main.tf
+++ b/terraform/test-fixtures/plan-list-order/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "a" {
+	foo = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 20]
+}
+
+resource "aws_instance" "b" {
+	foo = "${aws_instance.a.foo}"
+}


### PR DESCRIPTION
Interpolated lists need to maintain the original list order