### PR TITLE
Updated implementation of builtin PagerDuty provider.

### DIFF
--- a/builtin/providers/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_escalation_policy.go
@@ -30,6 +30,10 @@ func resourcePagerDutyEscalationPolicy() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"repeat_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 			"teams": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -94,6 +98,10 @@ func buildEscalationPolicyStruct(d *schema.ResourceData) *pagerduty.EscalationPo
 		escalationPolicy.Teams = expandTeams(attr.([]interface{}))
 	}
 
+	if attr, ok := d.GetOk("repeat_enabled"); ok {
+		escalationPolicy.RepeatEnabled = attr.(bool)
+	}
+
 	return &escalationPolicy
 }
 
@@ -132,6 +140,7 @@ func resourcePagerDutyEscalationPolicyRead(d *schema.ResourceData, meta interfac
 	d.Set("teams", escalationPolicy.Teams)
 	d.Set("description", escalationPolicy.Description)
 	d.Set("num_loops", escalationPolicy.NumLoops)
+	d.Set("repeat_enabled", escalationPolicy.RepeatEnabled)
 
 	if err := d.Set("rule", flattenEscalationRules(escalationPolicy.EscalationRules)); err != nil {
 		return err

--- a/builtin/providers/pagerduty/resource_pagerduty_schedule.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_schedule.go
@@ -95,6 +95,10 @@ func resourcePagerDutySchedule() *schema.Resource {
 										Type:     schema.TypeString,
 										Required: true,
 									},
+									"start_day_of_week": {
+										Type:     schema.TypeInt,
+										Optional: true,
+									},
 									"duration_seconds": {
 										Type:     schema.TypeInt,
 										Required: true,

--- a/builtin/providers/pagerduty/resource_pagerduty_service.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service.go
@@ -50,6 +50,119 @@ func resourcePagerDutyService() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"summary": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"incident_urgency_rule": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"urgency": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"during_support_hours": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"urgency": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+						"outside_support_hours": {
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"urgency": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			"support_hours": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"time_zone": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"days_of_week": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeInt},
+						},
+						"start_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"end_time": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"scheduled_actions": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"named_time": {
+							Type:     schema.TypeMap,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"name": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"to_urgency": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -86,6 +199,101 @@ func buildServiceStruct(d *schema.ResourceData) *pagerduty.Service {
 
 	service.EscalationPolicy = *escalationPolicy
 
+	iurMap := d.Get("incident_urgency_rule").(map[string]interface{})
+	iur := pagerduty.IncidentUrgencyRule{}
+	if val, ok := iurMap["during_support_hours"]; ok {
+		var duringSupportHours pagerduty.IncidentUrgencyType
+		m := val.(map[string]interface{})
+		if val, ok := m["type"]; ok {
+			duringSupportHours.Type = val.(string)
+		}
+		if val, ok := m["urgency"]; ok {
+			duringSupportHours.Urgency = val.(string)
+		}
+		iur.DuringSupportHours = &duringSupportHours
+	}
+	if val, ok := iurMap["outside_support_hours"]; ok {
+		var outsideSupportHours pagerduty.IncidentUrgencyType
+		m := val.(map[string]interface{})
+		if val, ok := m["type"]; ok {
+			outsideSupportHours.Type = val.(string)
+		}
+		if val, ok := m["urgency"]; ok {
+			outsideSupportHours.Urgency = val.(string)
+		}
+		iur.OutsideSupportHours = &outsideSupportHours
+	}
+	if val, ok := iurMap["type"]; ok {
+		iur.Type = val.(string)
+	}
+	if val, ok := iurMap["urgency"]; ok {
+		iur.Urgency = val.(string)
+	}
+	if iur.DuringSupportHours != nil ||
+		iur.OutsideSupportHours != nil ||
+		iur.Type != "" ||
+		iur.Urgency != "" {
+		service.IncidentUrgencyRule = &iur
+	}
+
+	if val, ok := d.GetOk("support_hours"); ok {
+		var supportHours pagerduty.SupportHours
+		m := val.(map[string]interface{})
+		if val, ok := m["type"]; ok {
+			supportHours.Type = val.(string)
+		}
+		if val, ok := m["time_zone"]; ok {
+			supportHours.Timezone = val.(string)
+		}
+		if val, ok := m["start_time"]; ok {
+			supportHours.StartTime = val.(string)
+		}
+		if val, ok := m["end_time"]; ok {
+			supportHours.EndTime = val.(string)
+		}
+		supportHours.DaysOfWeek = getUintArrayFromMap(m, "days_of_week")
+		if supportHours.Type != "" ||
+			supportHours.Timezone != "" ||
+			supportHours.StartTime != "" ||
+			supportHours.EndTime != "" ||
+			len(supportHours.DaysOfWeek) > 0 {
+			service.SupportHours = &supportHours
+		}
+	}
+
+	sa := d.Get("scheduled_actions")
+	if sa != nil {
+		var scheduledActions []pagerduty.ScheduledAction
+		for _, e := range sa.(*schema.Set).List() {
+			m := e.(map[string]interface{})
+			var actionType string
+			if val, ok := m["type"]; ok {
+				actionType = val.(string)
+			}
+			var at pagerduty.InlineModel
+			if val, ok := m["named_time"]; ok {
+				n := val.(map[string]interface{})
+				if val, ok := n["type"]; ok {
+					at.Type = val.(string)
+				}
+				if val, ok := n["name"]; ok {
+					at.Name = val.(string)
+				}
+			}
+			var toUrgency string
+			if val, ok := m["to_urgency"]; ok {
+				toUrgency = val.(string)
+			}
+			scheduledAction := pagerduty.ScheduledAction{
+				Type:      actionType,
+				At:        at,
+				ToUrgency: toUrgency,
+			}
+			scheduledActions = append(scheduledActions, scheduledAction)
+		}
+		service.ScheduledActions = scheduledActions
+	}
+
 	return &service
 }
 
@@ -120,6 +328,27 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 	}
 
+	var duringSupportHours map[string]interface{}
+	if service.IncidentUrgencyRule.DuringSupportHours != nil {
+		duringSupportHours = map[string]interface{}{
+			"type":    service.IncidentUrgencyRule.DuringSupportHours.Type,
+			"urgency": service.IncidentUrgencyRule.DuringSupportHours.Urgency,
+		}
+	}
+	var outsideSupportHours map[string]interface{}
+	if service.IncidentUrgencyRule.OutsideSupportHours != nil {
+		outsideSupportHours = map[string]interface{}{
+			"type":    service.IncidentUrgencyRule.OutsideSupportHours.Type,
+			"urgency": service.IncidentUrgencyRule.OutsideSupportHours.Urgency,
+		}
+	}
+	incidentUrgencyRule := map[string]interface{}{
+		"type":                  service.IncidentUrgencyRule.Type,
+		"urgency":               service.IncidentUrgencyRule.Urgency,
+		"during_support_hours":  duringSupportHours,
+		"outside_support_hours": outsideSupportHours,
+	}
+
 	d.Set("name", service.Name)
 	d.Set("status", service.Status)
 	d.Set("created_at", service.CreateAt)
@@ -128,22 +357,33 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("auto_resolve_timeout", service.AutoResolveTimeout)
 	d.Set("last_incident_timestamp", service.LastIncidentTimestamp)
 	d.Set("acknowledgement_timeout", service.AcknowledgementTimeout)
+	d.Set("incident_urgency_rule", incidentUrgencyRule)
+	d.Set("support_hours", service.SupportHours)
+	d.Set("scheduled_actions", service.ScheduledActions)
 
 	return nil
 }
 
 func resourcePagerDutyServiceUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*pagerduty.Client)
+	if d.HasChange("name") ||
+		d.HasChange("description") ||
+		d.HasChange("auto_resolve_timeout") ||
+		d.HasChange("escalation_policy_id") ||
+		d.HasChange("incident_urgency_rule") ||
+		d.HasChange("support_hours") ||
+		d.HasChange("scheduled_actions") {
 
-	service := buildServiceStruct(d)
+		client := meta.(*pagerduty.Client)
+		service := buildServiceStruct(d)
 
-	log.Printf("[INFO] Updating PagerDuty service %s", d.Id())
+		log.Printf("[INFO] Updating PagerDuty service %s", d.Id())
 
-	if _, err := client.UpdateService(*service); err != nil {
-		return err
+		if _, err := client.UpdateService(*service); err != nil {
+			return err
+		}
 	}
 
-	return nil
+	return resourcePagerDutyServiceRead(d, meta)
 }
 
 func resourcePagerDutyServiceDelete(d *schema.ResourceData, meta interface{}) error {
@@ -152,6 +392,10 @@ func resourcePagerDutyServiceDelete(d *schema.ResourceData, meta interface{}) er
 	log.Printf("[INFO] Deleting PagerDuty service %s", d.Id())
 
 	if err := client.DeleteService(d.Id()); err != nil {
+		if "HTTP Status Code: 404" == err.Error() {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/builtin/providers/pagerduty/structure.go
+++ b/builtin/providers/pagerduty/structure.go
@@ -95,6 +95,7 @@ func expandScheduleLayers(list []interface{}) []pagerduty.ScheduleLayer {
 				pagerduty.Restriction{
 					Type:            restriction["type"].(string),
 					StartTimeOfDay:  restriction["start_time_of_day"].(string),
+					StartDayOfWeek:  uint(restriction["start_day_of_week"].(int)),
 					DurationSeconds: uint(restriction["duration_seconds"].(int)),
 				},
 			)
@@ -149,6 +150,7 @@ func flattenScheduleLayers(list []pagerduty.ScheduleLayer) []map[string]interfac
 				restrictions = append(restrictions, map[string]interface{}{
 					"duration_seconds":  r.DurationSeconds,
 					"start_time_of_day": r.StartTimeOfDay,
+					"start_day_of_week": r.StartDayOfWeek,
 					"type":              r.Type,
 				})
 			}

--- a/builtin/providers/pagerduty/util.go
+++ b/builtin/providers/pagerduty/util.go
@@ -67,6 +67,7 @@ func getVendors(client *pagerduty.Client) ([]pagerduty.Vendor, error) {
 	return vendors, nil
 }
 
+// getUintArrayFromMap creates an array of uint from a map
 func getUintArrayFromMap(m map[string]interface{}, k string) []uint {
 	if val, ok := m[k]; ok {
 		arr := make([]uint, len(val.([]int)))

--- a/builtin/providers/pagerduty/util.go
+++ b/builtin/providers/pagerduty/util.go
@@ -66,3 +66,14 @@ func getVendors(client *pagerduty.Client) ([]pagerduty.Vendor, error) {
 
 	return vendors, nil
 }
+
+func getUintArrayFromMap(m map[string]interface{}, k string) []uint {
+	if val, ok := m[k]; ok {
+		arr := make([]uint, len(val.([]int)))
+		for i, a := range val.([]int) {
+			arr[i] = uint(a)
+		}
+		return arr
+	}
+	return make([]uint, 0)
+}

--- a/vendor/github.com/PagerDuty/go-pagerduty/schedule.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/schedule.go
@@ -10,6 +10,7 @@ import (
 type Restriction struct {
 	Type            string `json:"type,omitempty"`
 	StartTimeOfDay  string `json:"start_time_of_day,omitempty"`
+	StartDayOfWeek  uint   `json:"start_day_of_week,omitempty"`
 	DurationSeconds uint   `json:"duration_seconds,omitempty"`
 }
 


### PR DESCRIPTION
* Added repeat_enabled for resource_pagerduty_escalation_policy.
* Added start_day_of_week for resource_pagerduty_schedule.
** Added placeholder commit for start_day_of_week in go-pagerduty vendor file while awaiting PR approval from PagerDuty.
* Added summary, incident_urgency_rule, support_hours, and scheduled_actions to resource_pagerduty_service.