### PR TITLE
provider/aws: Improved the API Gateway Integration documentation

### DIFF
--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -39,22 +39,91 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
 }
 ```
 
+## Lambda integration
+
+```
+# Variables
+variable "myregion" {}
+variable "accountId" {}
+
+# API Gateway
+resource "aws_api_gateway_rest_api" "api" {
+  name = "myapi"
+}
+
+resource "aws_api_gateway_method" "method" {
+  rest_api_id   = "${aws_api_gateway_rest_api.api.id}"
+  resource_id   = "${aws_api_gateway_rest_api.api.root_resource_id}"
+  http_method   = "GET"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "integration" {
+  rest_api_id             = "${aws_api_gateway_rest_api.api.id}"
+  resource_id             = "${aws_api_gateway_rest_api.api.root_resource_id}"
+  http_method             = "${aws_api_gateway_method.method.http_method}"
+  integration_http_method = "POST"
+  type                    = "AWS"
+  uri                     = "arn:aws:apigateway:${var.myregion}:lambda:path/2015-03-31/functions/${aws_lambda_function.lambda.arn}/invocations"
+}
+
+# Lambda
+resource "aws_lambda_permission" "apigw_lambda" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.lambda.arn}"
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.method.http_method}/"
+}
+
+resource "aws_lambda_function" "lambda" {
+  filename         = "lambda.zip"
+  function_name    = "mylambda"
+  role             = "${aws_iam_role.role.arn}"
+  handler          = "lambda.lambda_handler"
+  runtime          = "python2.7"
+  source_code_hash = "${base64sha256(file("lambda.zip"))}"
+}
+
+# IAM
+resource "aws_iam_role" "role" {
+  name               = "myrole"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+POLICY
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `rest_api_id` - (Required) The ID of the associated REST API
-* `resource_id` - (Required) The API resource ID
+* `rest_api_id` - (Required) The ID of the associated REST API.
+* `resource_id` - (Required) The API resource ID.
 * `http_method` - (Required) The HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`, `ANY`)
+  when calling the associated resource.
+* `integration_http_method` - (Optional) The integration HTTP method
+  (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`) specifying how API Gateway will interact with the back end.
+  **Required** if `type` is `AWS`, `AWS_PROXY`, `HTTP` or `HTTP_PROXY`.
+  Not all methods are compatible with all `AWS` integrations.
+  e.g. Lambda function [can only be invoked](https://github.com/awslabs/aws-apigateway-importer/issues/9#issuecomment-129651005) via `POST`.
 * `type` - (Required) The integration input's type (HTTP, MOCK, AWS, AWS_PROXY, HTTP_PROXY)
 * `uri` - (Optional) The input's URI (HTTP, AWS). **Required** if `type` is `HTTP` or `AWS`.
   For HTTP integrations, the URI must be a fully formed, encoded HTTP(S) URL according to the RFC-3986 specification . For AWS integrations, the URI should be of the form `arn:aws:apigateway:{region}:{subdomain.service|service}:{path|action}/{service_api}`. `region`, `subdomain` and `service` are used to determine the right endpoint.
   e.g. `arn:aws:apigateway:eu-west-1:lambda:path/2015-03-31/functions/arn:aws:lambda:eu-west-1:012345678901:function:my-func/invocations`
 * `credentials` - (Optional) The credentials required for the integration. For `AWS` integrations, 2 options are available. To specify an IAM Role for Amazon API Gateway to assume, use the role's ARN. To require that the caller's identity be passed through from the request, specify the string `arn:aws:iam::\*:user/\*`.
-* `integration_http_method` - (Optional) The integration HTTP method
-  (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTION`). **Required** if `type` is `AWS` or `HTTP`.
-  Not all methods are compatible with all `AWS` integrations.
-  e.g. Lambda function [can only be invoked](https://github.com/awslabs/aws-apigateway-importer/issues/9#issuecomment-129651005) via `POST`.
 * `request_templates` - (Optional) A map of the integration's request templates.
 * `request_parameters` - (Optional) A map of request query string parameters and headers that should be passed to the backend responder.
   For example: `request_parameters = { "integration.request.header.X-Some-Other-Header" = "method.request.header.X-Some-Header" }`


### PR DESCRIPTION
### Modifications
* Moved the `integration_http_method` closer to the `http_method` entry, in order to better correlate them
* Added `AWS_PROXY` and `HTTP_PROXY` to the list of `integration_http_method`s
* Added a functional Lambda Integration, exposing the way to build the `aws_lambda_permission` source_arn and the `aws_api_gateway_integration` uri

### Related issues
* https://github.com/hashicorp/terraform/issues/10501
* https://github.com/hashicorp/terraform/issues/10494

