### PR TITLE
Add support for BinaryMediaTypes and ContentHandling to AWS API Gateway

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -82,6 +82,12 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 				Deprecated:    "Use field request_parameters instead",
 			},
 
+			"content_handling": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateApiGatewayIntegrationContentHandling,
+			},
+
 			"passthrough_behavior": &schema.Schema{
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -131,6 +137,11 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		credentials = aws.String(val.(string))
 	}
 
+	var contentHandling *string
+	if val, ok := d.GetOk("content_handling"); ok {
+		contentHandling = aws.String(val.(string))
+	}
+
 	_, err := conn.PutIntegration(&apigateway.PutIntegrationInput{
 		HttpMethod: aws.String(d.Get("http_method").(string)),
 		ResourceId: aws.String(d.Get("resource_id").(string)),
@@ -144,6 +155,7 @@ func resourceAwsApiGatewayIntegrationCreate(d *schema.ResourceData, meta interfa
 		CacheNamespace:      nil,
 		CacheKeyParameters:  nil,
 		PassthroughBehavior: passthroughBehavior,
+		ContentHandling:     contentHandling,
 	})
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Integration: %s", err)
@@ -185,6 +197,7 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 	d.Set("request_parameters", aws.StringValueMap(integration.RequestParameters))
 	d.Set("request_parameters_in_json", aws.StringValueMap(integration.RequestParameters))
 	d.Set("passthrough_behavior", integration.PassthroughBehavior)
+	d.Set("content_handling", integration.ContentHandling)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
@@ -36,6 +36,8 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 						"aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_integration.test", "content_handling", ""),
 				),
 			},
 
@@ -52,6 +54,8 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 						"aws_api_gateway_integration.test", "uri", ""),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_integration.test", "passthrough_behavior", "NEVER"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_BINARY"),
 				),
 			},
 		},
@@ -65,6 +69,9 @@ func testAccCheckAWSAPIGatewayMockIntegrationAttributes(conf *apigateway.Integra
 		}
 		if *conf.RequestParameters["integration.request.header.X-Authorization"] != "'updated'" {
 			return fmt.Errorf("wrong updated RequestParameters for header.X-Authorization")
+		}
+		if *conf.ContentHandling != "CONVERT_TO_BINARY" {
+			return fmt.Errorf("wrong ContentHandling: %q", *conf.ContentHandling)
 		}
 		return nil
 	}
@@ -232,6 +239,7 @@ resource "aws_api_gateway_integration" "test" {
 
   type = "MOCK"
   passthrough_behavior = "NEVER"
+  content_handling = "CONVERT_TO_BINARY"
 
 }
 `

--- a/builtin/providers/aws/resource_aws_api_gateway_rest_api_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_rest_api_test.go
@@ -29,6 +29,8 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 						"aws_api_gateway_rest_api.test", "description", ""),
 					resource.TestCheckResourceAttrSet(
 						"aws_api_gateway_rest_api.test", "created_date"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_rest_api.test", "binary_media_types", ""),
 				),
 			},
 
@@ -44,6 +46,10 @@ func TestAccAWSAPIGatewayRestApi_basic(t *testing.T) {
 						"aws_api_gateway_rest_api.test", "description", "test"),
 					resource.TestCheckResourceAttrSet(
 						"aws_api_gateway_rest_api.test", "created_date"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_rest_api.test", "binary_media_types.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_rest_api.test", "binary_media_types.0", "application/octet-stream"),
 				),
 			},
 		},
@@ -135,5 +141,6 @@ const testAccAWSAPIGatewayRestAPIUpdateConfig = `
 resource "aws_api_gateway_rest_api" "test" {
   name = "test"
   description = "test"
+  binary_media_types = ["application/octet-stream"]
 }
 `

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -541,6 +541,22 @@ func validateApiGatewayIntegrationType(v interface{}, k string) (ws []string, er
 	return
 }
 
+func validateApiGatewayIntegrationContentHandling(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	validTypes := map[string]bool{
+		"CONVERT_TO_BINARY": true,
+		"CONVERT_TO_TEXT":   true,
+	}
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q contains an invalid integration type %q. Valid types are either %q or %q.",
+			k, value, "CONVERT_TO_BINARY", "CONVERT_TO_TEXT"))
+	}
+	return
+}
+
 func validateSQSQueueName(v interface{}, k string) (errors []error) {
 	value := v.(string)
 	if len(value) > 80 {


### PR DESCRIPTION
I've added support for `BinaryMediaTypes` in AWS API Gateway RestApi to allow for handling binary payloads (e.g., JPG images).

I also added `ContentHandling` to AWS API Gateway Integration to enable conversion from binary or text -> Base64. This is important for passing content from API Gateway to Lambda since Lambda can only handle Base64.

This implements enhancement issue: #10696

### Relevant APIs docs:

API Gateway RestApi
https://docs.aws.amazon.com/apigateway/api-reference/resource/rest-api/

API Gateway Integration
https://docs.aws.amazon.com/apigateway/api-reference/resource/integration/

### Tests

I didn't run all the AWS provider Acceptance Tests, but I did run the relevant unit tests to these changes (which passed):

```
make testacc TEST=./builtin/providers/aws TESTARGS="-run TestAccAWSAPIGatewayRestApi_basic" AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
```

and

```
make testacc TEST=./builtin/providers/aws TESTARGS="-run TestAccAWSAPIGatewayIntegration_basic" AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...
```