### PR TITLE
Inteprolate list of maps

### DIFF
--- a/builtin/providers/test/resource_test.go
+++ b/builtin/providers/test/resource_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -420,6 +421,65 @@ variable "maplist" {
 				`),
 				ExpectError: nil,
 				Check: func(s *terraform.State) error {
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func TestResource_dataSourceIndexMapList(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckResourceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: strings.TrimSpace(`
+resource "test_resource" "foo" {
+  required = "val"
+
+  required_map = {
+    x = "y"
+  }
+
+  list_of_map = [
+    {
+      a = "1"
+      b = "2"
+    },
+    {
+      c = "3"
+      d = "4"
+    },
+  ]
+}
+
+output "map_from_list" {
+  value = "${test_resource.foo.list_of_map[0]}"
+}
+
+output "value_from_map_from_list" {
+  value = "${lookup(test_resource.foo.list_of_map[1], "d")}"
+}
+				`),
+				ExpectError: nil,
+				Check: func(s *terraform.State) error {
+					root := s.ModuleByPath(terraform.RootModulePath)
+					mapOut := root.Outputs["map_from_list"].Value
+					expectedMapOut := map[string]interface{}{
+						"a": "1",
+						"b": "2",
+					}
+
+					valueOut := root.Outputs["value_from_map_from_list"].Value
+					expectedValueOut := "4"
+
+					if !reflect.DeepEqual(mapOut, expectedMapOut) {
+						t.Fatalf("Expected: %#v\nGot: %#v", expectedMapOut, mapOut)
+					}
+					if !reflect.DeepEqual(valueOut, expectedValueOut) {
+						t.Fatalf("Expected: %#v\nGot: %#v", valueOut, expectedValueOut)
+					}
 					return nil
 				},
 			},

--- a/flatmap/expand.go
+++ b/flatmap/expand.go
@@ -66,7 +66,10 @@ func expandMap(m map[string]string, prefix string) map[string]interface{} {
 			continue
 		}
 
-		// It contains a period, so it is a more complex structure
+		// skip the map count value
+		if key == "%" {
+			continue
+		}
 		result[key] = Expand(m, k[:len(prefix)+len(key)])
 	}
 

--- a/flatmap/expand_test.go
+++ b/flatmap/expand_test.go
@@ -69,6 +69,43 @@ func TestExpand(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			Map: map[string]string{
+				"list_of_map.#":   "2",
+				"list_of_map.0.%": "1",
+				"list_of_map.0.a": "1",
+				"list_of_map.1.%": "2",
+				"list_of_map.1.b": "2",
+				"list_of_map.1.c": "3",
+			},
+			Key: "list_of_map",
+			Output: []interface{}{
+				map[string]interface{}{
+					"a": "1",
+				},
+				map[string]interface{}{
+					"b": "2",
+					"c": "3",
+				},
+			},
+		},
+
+		{
+			Map: map[string]string{
+				"map_of_list.%":       "2",
+				"map_of_list.list2.#": "1",
+				"map_of_list.list2.0": "c",
+				"map_of_list.list1.#": "2",
+				"map_of_list.list1.0": "a",
+				"map_of_list.list1.1": "b",
+			},
+			Key: "map_of_list",
+			Output: map[string]interface{}{
+				"list1": []interface{}{"a", "b"},
+				"list2": []interface{}{"c"},
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Fix `flatmap.Expand` to work correctly with nested maps. This can then be used to unpack all nested values for the Interpolator, rather than parsing the keys and building the data structures in the Interpolator itself. 

Fixes #9693 
