### PR TITLE
provider/docker: Fix regression, 'cert_path' stop working

### DIFF
--- a/builtin/providers/docker/config.go
+++ b/builtin/providers/docker/config.go
@@ -24,6 +24,10 @@ func (c *Config) NewClient() (*dc.Client, error) {
 			return nil, fmt.Errorf("ca_material, cert_material, and key_material must be specified")
 		}
 
+		if c.CertPath != "" {
+			return nil, fmt.Errorf("cert_path must not be specified")
+		}
+
 		return dc.NewTLSClientFromBytes(c.Host, []byte(c.Cert), []byte(c.Key), []byte(c.Ca))
 	}
 

--- a/builtin/providers/docker/provider.go
+++ b/builtin/providers/docker/provider.go
@@ -18,25 +18,22 @@ func Provider() terraform.ResourceProvider {
 			},
 
 			"ca_material": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("DOCKER_CA_MATERIAL", ""),
-				ConflictsWith: []string{"cert_path"},
-				Description:   "PEM-encoded content of Docker host CA certificate",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("DOCKER_CA_MATERIAL", ""),
+				Description: "PEM-encoded content of Docker host CA certificate",
 			},
 			"cert_material": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("DOCKER_CERT_MATERIAL", ""),
-				ConflictsWith: []string{"cert_path"},
-				Description:   "PEM-encoded content of Docker client certificate",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("DOCKER_CERT_MATERIAL", ""),
+				Description: "PEM-encoded content of Docker client certificate",
 			},
 			"key_material": &schema.Schema{
-				Type:          schema.TypeString,
-				Optional:      true,
-				DefaultFunc:   schema.EnvDefaultFunc("DOCKER_KEY_MATERIAL", ""),
-				ConflictsWith: []string{"cert_path"},
-				Description:   "PEM-encoded content of Docker client private key",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("DOCKER_KEY_MATERIAL", ""),
+				Description: "PEM-encoded content of Docker client private key",
 			},
 
 			"cert_path": &schema.Schema{


### PR DESCRIPTION
Fix #10754. My patch in #10151 broke original TLS authentication approach.

By some reason `DefaultFunc` and `ConflictsWith` in schema do not work together.
This code worked correctly
```
"ca_material": &schema.Schema{
  Type:          schema.TypeString,
  Optional:      true,
  Default: "",
  ConflictsWith: []string{"cert_path"},
},
```

but this fails
```
"ca_material": &schema.Schema{
  Type:          schema.TypeString,
  Optional:      true,
  DefaultFunc:   schema.EnvDefaultFunc("DOCKER_CA_MATERIAL", ""),
  ConflictsWith: []string{"cert_path"},
},
```

Now I've just hardcoded the validations.

I could write an integration test, but it's quite hard to setup such environment - we'll need launching multiple hosts. If you have any examples or just ideas, please share.