### PR TITLE
Correct 'aws_hosted_zone' -> 'aws_route53_zone' in data source documentation

### DIFF
--- a/website/source/docs/providers/aws/d/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/route53_zone.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_hosted_zone"
-sidebar_current: "docs-aws-datasource-hosted-zone"
+page_title: "AWS: aws_route53_zone"
+sidebar_current: "docs-aws-datasource-route53-zone"
 description: |-
-    Provides details about a specific Hosted Zone
+    Provides details about a specific Route 53 Hosted Zone
 ---
 
-# aws\_hosted\_zone
+# aws\_route53\_zone
 
-`aws_hosted_zone` provides details about a specific Hosted Zone.
+`aws_route53_zone` provides details about a specific Route 53 Hosted Zone.
 
 This data source allows to find a Hosted Zone ID given Hosted Zone name and certain search criteria. 
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -51,9 +51,6 @@
                         <li<%= sidebar_current("docs-aws-datasource-elb-service-account") %>>
                             <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-hosted-zone") %>>
-                          <a href="/docs/providers/aws/d/hosted_zone.html">aws_hosted_zone</a>
-                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-iam-policy-document") %>>
                             <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
                         </li>
@@ -74,6 +71,9 @@
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-route-table") %>>
                           <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-datasource-route53-zone") %>>
+                          <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-s3-bucket-object") %>>
                             <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>


### PR DESCRIPTION
Some places in the documentation still referred to the data source as `aws_hosted_zone` after it had been renamed to `aws_route53_zone`.
I also renamed the HTML file and the once place that linked to it.