### PR TITLE
Add aws verification checks to opsworks acceptance tests

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_application_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,6 +13,7 @@ import (
 )
 
 func TestAccAWSOpsworksApplication(t *testing.T) {
+	var opsapp opsworks.App
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -20,6 +22,9 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksApplicationCreate,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksApplicationExists(
+						"aws_opsworks_application.tf-acc-app", &opsapp),
+					testAccCheckAWSOpsworksCreateAppAttributes(&opsapp),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "name", "tf-ops-acc-application",
 					),
@@ -55,6 +60,9 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksApplicationUpdate,
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksApplicationExists(
+						"aws_opsworks_application.tf-acc-app", &opsapp),
+					testAccCheckAWSOpsworksUpdateAppAttributes(&opsapp),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "name", "tf-ops-acc-application",
 					),
@@ -125,6 +133,148 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSOpsworksApplicationExists(
+	n string, opsapp *opsworks.App) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).opsworksconn
+
+		params := &opsworks.DescribeAppsInput{
+			AppIds: []*string{&rs.Primary.ID},
+		}
+		resp, err := conn.DescribeApps(params)
+
+		if err != nil {
+			return err
+		}
+
+		if v := len(resp.Apps); v != 1 {
+			return fmt.Errorf("Expected 1 response returned, got %d", v)
+		}
+
+		*opsapp = *resp.Apps[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAWSOpsworksCreateAppAttributes(
+	opsapp *opsworks.App) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *opsapp.EnableSsl {
+			return fmt.Errorf("Unexpected enable ssl: %s", *opsapp.EnableSsl)
+		}
+
+		if *opsapp.Attributes["DocumentRoot"] != "foo" {
+			return fmt.Errorf("Unnexpected document root: %s", *opsapp.Attributes["DocumentRoot"])
+		}
+
+		if *opsapp.Type != "other" {
+			return fmt.Errorf("Unnexpected type: %s", *opsapp.Type)
+		}
+
+		if *opsapp.AppSource.Type != "other" {
+			return fmt.Errorf("Unnexpected appsource type: %s", *opsapp.Type)
+		}
+
+		expectedEnv := []*opsworks.EnvironmentVariable{
+			&opsworks.EnvironmentVariable{
+				Key:    aws.String("key1"),
+				Value:  aws.String("value1"),
+				Secure: aws.Bool(false),
+			},
+		}
+
+		if !reflect.DeepEqual(expectedEnv, opsapp.Environment) {
+			return fmt.Errorf("Unnexpected environment: %s", opsapp.Environment)
+		}
+
+		if v := len(opsapp.Domains); v != 0 {
+			return fmt.Errorf("Expected 0 domains returned, got %d", v)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSOpsworksUpdateAppAttributes(
+	opsapp *opsworks.App) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *opsapp.Type != "rails" {
+			return fmt.Errorf("Unnexpected type: %s", *opsapp.Type)
+		}
+
+		if !*opsapp.EnableSsl {
+			return fmt.Errorf("Unexpected enable ssl: %s", *opsapp.EnableSsl)
+		}
+
+		if *opsapp.SslConfiguration.Certificate != "-----BEGIN CERTIFICATE-----\nMIIBkDCB+gIJALoScFD0sJq3MA0GCSqGSIb3DQEBBQUAMA0xCzAJBgNVBAYTAkRF\nMB4XDTE1MTIxOTIwMzU1MVoXDTE2MDExODIwMzU1MVowDTELMAkGA1UEBhMCREUw\ngZ8wDQYJKoZIhvcNAQEBBQADgY0AMIGJAoGBAKKQKbTTH/Julz16xY7ArYlzJYCP\nedTCx1bopuryCx/+d1gC94MtRdlPSpQl8mfc9iBdtXbJppp73Qh/DzLzO9Ns25xZ\n+kUQMhbIyLsaCBzuEGLgAaVdGpNvRBw++UoYtd0U7QczFAreTGLH8n8+FIzuI5Mc\n+MJ1TKbbt5gFfRSzAgMBAAEwDQYJKoZIhvcNAQEFBQADgYEALARo96wCDmaHKCaX\nS0IGLGnZCfiIUfCmBxOXBSJxDBwter95QHR0dMGxYIujee5n4vvavpVsqZnfMC3I\nOZWPlwiUJbNIpK+04Bg2vd5m/NMMrvi75RfmyeMtSfq/NrIX2Q3+nyWI7DLq7yZI\nV/YEvOqdAiy5NEWBztHx8HvB9G4=\n-----END CERTIFICATE-----" {
+			return fmt.Errorf("Unexpected ssl configuration certificate: %s", *opsapp.SslConfiguration.Certificate)
+		}
+
+		if *opsapp.SslConfiguration.PrivateKey != "-----BEGIN RSA PRIVATE KEY-----\nMIICXQIBAAKBgQCikCm00x/ybpc9esWOwK2JcyWAj3nUwsdW6Kbq8gsf/ndYAveD\nLUXZT0qUJfJn3PYgXbV2yaaae90Ifw8y8zvTbNucWfpFEDIWyMi7Gggc7hBi4AGl\nXRqTb0QcPvlKGLXdFO0HMxQK3kxix/J/PhSM7iOTHPjCdUym27eYBX0UswIDAQAB\nAoGBAIYcrvuqDboguI8U4TUjCkfSAgds1pLLWk79wu8jXkA329d1IyNKT0y3WIye\nPbyoEzmidZmZROQ/+ZsPz8c12Y0DrX73WSVzKNyJeP7XMk9HSzA1D9RX0U0S+5Kh\nFAMc2NEVVFIfQtVtoVmHdKDpnRYtOCHLW9rRpvqOOjd4mYk5AkEAzeiFr1mtlnsa\n67shMxzDaOTAFMchRz6G7aSovvCztxcB63ulFI/w9OTUMdTQ7ff7pet+lVihLc2W\nefIL0HvsjQJBAMocNTKaR/TnsV5GSk2kPAdR+zFP5sQy8sfMy0lEXTylc7zN4ajX\nMeHVoxp+GZgpfDcZ3ya808H1umyXh+xA1j8CQE9x9ZKQYT98RAjL7KVR5btk9w+N\nPTPF1j1+mHUDXfO4ds8qp6jlWKzEVXLcj7ghRADiebaZuaZ4eiSW1SQdjEkCQQC4\nwDhQ3X9RfEpCp3ZcqvjEqEg6t5N3XitYQPjDLN8eBRBbUsgpEy3iBuxl10eGNMX7\niIbYXlwkPYAArDPv3wT5AkAwp4vym+YKmDqh6gseKfRDuJqRiW9yD5A8VGr/w88k\n5rkuduVGP7tK3uIp00Its3aEyKF8mLGWYszVGeeLxAMH\n-----END RSA PRIVATE KEY-----" {
+			return fmt.Errorf("Unexpected ssl configuration private key: %s", *opsapp.SslConfiguration.PrivateKey)
+		}
+
+		expectedAttrs := map[string]*string{
+			"DocumentRoot":        aws.String("root"),
+			"RailsEnv":            aws.String("staging"),
+			"AutoBundleOnDeploy":  aws.String("true"),
+			"AwsFlowRubySettings": nil,
+		}
+
+		if !reflect.DeepEqual(expectedAttrs, opsapp.Attributes) {
+			return fmt.Errorf("Unnexpected Attributes: %s", opsapp.Attributes)
+		}
+
+		expectedAppSource := &opsworks.Source{
+			Type:     aws.String("git"),
+			Revision: aws.String("master"),
+			Url:      aws.String("https://github.com/aws/example.git"),
+		}
+
+		if !reflect.DeepEqual(expectedAppSource, opsapp.AppSource) {
+			return fmt.Errorf("Unnexpected appsource: %s", opsapp.AppSource)
+		}
+
+		expectedEnv := []*opsworks.EnvironmentVariable{
+			&opsworks.EnvironmentVariable{
+				Key:    aws.String("key2"),
+				Value:  aws.String("*****FILTERED*****"),
+				Secure: aws.Bool(true),
+			},
+			&opsworks.EnvironmentVariable{
+				Key:    aws.String("key1"),
+				Value:  aws.String("value1"),
+				Secure: aws.Bool(false),
+			},
+		}
+
+		if !reflect.DeepEqual(expectedEnv, opsapp.Environment) {
+			return fmt.Errorf("Unnexpected environment: %s", opsapp.Environment)
+		}
+
+		expectedDomains := []*string{
+			aws.String("example.com"),
+			aws.String("sub.example.com"),
+		}
+
+		if !reflect.DeepEqual(expectedDomains, opsapp.Domains) {
+			return fmt.Errorf("Unnexpected Daomins : %s", opsapp.Domains)
+		}
+
+		return nil
+	}
 }
 
 func testAccCheckAwsOpsworksApplicationDestroy(s *terraform.State) error {

--- a/builtin/providers/aws/resource_aws_opsworks_application_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application_test.go
@@ -184,7 +184,7 @@ func testAccCheckAWSOpsworksCreateAppAttributes(
 		}
 
 		if *opsapp.AppSource.Type != "other" {
-			return fmt.Errorf("Unnexpected appsource type: %s", *opsapp.Type)
+			return fmt.Errorf("Unnexpected appsource type: %s", *opsapp.AppSource.Type)
 		}
 
 		expectedEnv := []*opsworks.EnvironmentVariable{

--- a/builtin/providers/aws/resource_aws_opsworks_permission_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_permission_test.go
@@ -4,19 +4,28 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSOpsworksPermission(t *testing.T) {
 	sName := fmt.Sprintf("tf-ops-perm-%d", acctest.RandInt())
+	var opsperm opsworks.Permission
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksPermissionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "true", "true", "iam_only"),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksPermissionExists(
+						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckAWSOpsworksCreatePermissionAttributes(&opsperm, true, true, "iam_only"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "true",
 					),
@@ -31,6 +40,9 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "true", "false", "iam_only"),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksPermissionExists(
+						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckAWSOpsworksCreatePermissionAttributes(&opsperm, true, false, "iam_only"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "true",
 					),
@@ -45,6 +57,9 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "false", "false", "deny"),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksPermissionExists(
+						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckAWSOpsworksCreatePermissionAttributes(&opsperm, false, false, "deny"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "false",
 					),
@@ -59,6 +74,9 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "false", "false", "show"),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksPermissionExists(
+						"aws_opsworks_permission.tf-acc-perm", &opsperm),
+					testAccCheckAWSOpsworksCreatePermissionAttributes(&opsperm, false, false, "show"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_permission.tf-acc-perm", "allow_ssh", "false",
 					),
@@ -72,6 +90,87 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSOpsworksPermissionExists(
+	n string, opsperm *opsworks.Permission) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).opsworksconn
+
+		params := &opsworks.DescribePermissionsInput{
+			StackId:    aws.String(rs.Primary.Attributes["stack_id"]),
+			IamUserArn: aws.String(rs.Primary.Attributes["user_arn"]),
+		}
+		resp, err := conn.DescribePermissions(params)
+
+		if err != nil {
+			return err
+		}
+
+		if v := len(resp.Permissions); v != 1 {
+			return fmt.Errorf("Expected 1 response returned, got %d", v)
+		}
+
+		*opsperm = *resp.Permissions[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAWSOpsworksCreatePermissionAttributes(
+	opsperm *opsworks.Permission, allowSsh bool, allowSudo bool, level string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *opsperm.AllowSsh != allowSsh {
+			return fmt.Errorf("Unnexpected allowSsh: %s", *opsperm.AllowSsh)
+		}
+
+		if *opsperm.AllowSudo != allowSudo {
+			return fmt.Errorf("Unnexpected allowSudo: %s", *opsperm.AllowSudo)
+		}
+
+		if *opsperm.Level != level {
+			return fmt.Errorf("Unnexpected level: %s", *opsperm.Level)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAwsOpsworksPermissionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*AWSClient).opsworksconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_opsworks_permission" {
+			continue
+		}
+
+		req := &opsworks.DescribePermissionsInput{
+			IamUserArn: aws.String(rs.Primary.Attributes["user_arn"]),
+		}
+
+		resp, err := client.DescribePermissions(req)
+		if err == nil {
+			if len(resp.Permissions) > 0 {
+				return fmt.Errorf("OpsWorks Permissions still exist.")
+			}
+		}
+
+		if awserr, ok := err.(awserr.Error); ok {
+			if awserr.Code() != "ResourceNotFoundException" {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func testAccAwsOpsworksPermissionCreate(name, ssh, sudo, level string) string {

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -4,19 +4,28 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/opsworks"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 	sName := fmt.Sprintf("test-db-instance-%d", acctest.RandInt())
+	var opsdb opsworks.RdsDbInstance
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksRdsDbDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAwsOpsworksRdsDbInstance(sName, "foo", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksRdsDbExists(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckAWSOpsworksCreateRdsDbAttributes(&opsdb, "foo"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "foo",
 					),
@@ -25,6 +34,9 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksRdsDbInstance(sName, "bar", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksRdsDbExists(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckAWSOpsworksCreateRdsDbAttributes(&opsdb, "bar"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "bar",
 					),
@@ -33,6 +45,9 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksRdsDbInstance(sName, "bar", "foofoofoofoofoo"),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksRdsDbExists(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckAWSOpsworksCreateRdsDbAttributes(&opsdb, "bar"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "bar",
 					),
@@ -41,6 +56,9 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 			resource.TestStep{
 				Config: testAccAwsOpsworksRdsDbInstanceForceNew(sName),
 				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksRdsDbExists(
+						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", &opsdb),
+					testAccCheckAWSOpsworksCreateRdsDbAttributes(&opsdb, "foo"),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_rds_db_instance.tf-acc-opsworks-db", "db_user", "foo",
 					),
@@ -48,6 +66,84 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckAWSOpsworksRdsDbExists(
+	n string, opsdb *opsworks.RdsDbInstance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		if _, ok := rs.Primary.Attributes["stack_id"]; !ok {
+			return fmt.Errorf("Rds Db stack id is missing, should be set.")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).opsworksconn
+
+		params := &opsworks.DescribeRdsDbInstancesInput{
+			StackId: aws.String(rs.Primary.Attributes["stack_id"]),
+		}
+		resp, err := conn.DescribeRdsDbInstances(params)
+
+		if err != nil {
+			return err
+		}
+
+		if v := len(resp.RdsDbInstances); v != 1 {
+			return fmt.Errorf("Expected 1 response returned, got %d", v)
+		}
+
+		*opsdb = *resp.RdsDbInstances[0]
+
+		return nil
+	}
+}
+
+func testAccCheckAWSOpsworksCreateRdsDbAttributes(
+	opsdb *opsworks.RdsDbInstance, user string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *opsdb.DbUser != user {
+			return fmt.Errorf("Unnexpected user: %s", *opsdb.DbUser)
+		}
+		if *opsdb.Engine != "mysql" {
+			return fmt.Errorf("Unnexpected engine: %s", *opsdb.Engine)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAwsOpsworksRdsDbDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*AWSClient).opsworksconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_opsworks_rds_db_instance" {
+			continue
+		}
+
+		req := &opsworks.DescribeRdsDbInstancesInput{
+			StackId: aws.String(rs.Primary.Attributes["stack_id"]),
+		}
+
+		resp, err := client.DescribeRdsDbInstances(req)
+		if err == nil {
+			if len(resp.RdsDbInstances) > 0 {
+				return fmt.Errorf("OpsWorks Rds db instances  still exist.")
+			}
+		}
+
+		if awserr, ok := err.(awserr.Error); ok {
+			if awserr.Code() != "ResourceNotFoundException" {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 func testAccAwsOpsworksRdsDbInstance(name, userName, password string) string {


### PR DESCRIPTION
Fixes #6202 

All of the opsworks resource acceptance tests are now verifying with the opsworks api to ensure that the resources were properly created.

I ran the opsworks acceptance tests on my aws account that does not have access to EC2-classic. 
All of the tests passed except: `TestAccAWSOpsworksCustomLayer`, `TestAccAWSOpsworksStackNoVpc`, `TestAccAWSOpsworksUserProfile`. Also, as a baseline, I ran the tests off of master and the same 3 tests failed for me with the same output. 

Could someone with an EC2-classic account please verify that the tests pass for them?


Also, here is my full test output:

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworks -timeout 120m
=== RUN   TestAccAWSOpsworksCustomLayerImportBasic
--- PASS: TestAccAWSOpsworksCustomLayerImportBasic (36.33s)
=== RUN   TestAccAWSOpsworksStackImportBasic
--- PASS: TestAccAWSOpsworksStackImportBasic (29.82s)
=== RUN   TestAccAWSOpsworksApplication
--- PASS: TestAccAWSOpsworksApplication (51.01s)
=== RUN   TestAccAWSOpsworksCustomLayer
--- FAIL: TestAccAWSOpsworksCustomLayer (26.88s)
	testing.go:265: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		DESTROY/CREATE: aws_opsworks_custom_layer.tf-acc
		  auto_assign_elastic_ips:               "false" => "false"
		  auto_assign_public_ips:                "true" => "true"
		  auto_healing:                          "true" => "true"
		  custom_security_group_ids.#:           "2" => "2"
		  custom_security_group_ids.1009903242:  "sg-cc7c48b1" => "sg-cc7c48b1"
		  custom_security_group_ids.4144011415:  "sg-cf7c48b2" => "sg-cf7c48b2"
		  drain_elb_on_shutdown:                 "true" => "true"
		  ebs_volume.#:                          "1" => "1"
		  ebs_volume.3575749636.iops:            "0" => "0"
		  ebs_volume.3575749636.mount_point:     "/home" => "/home"
		  ebs_volume.3575749636.number_of_disks: "2" => "2"
		  ebs_volume.3575749636.raid_level:      "0" => "0"
		  ebs_volume.3575749636.size:            "100" => "100"
		  ebs_volume.3575749636.type:            "gp2" => "gp2"
		  install_updates_on_boot:               "true" => "true"
		  instance_shutdown_timeout:             "300" => "300"
		  name:                                  "tf-4459038228110306281" => "tf-4459038228110306281"
		  short_name:                            "tf-ops-acc-custom-layer" => "tf-ops-acc-custom-layer"
		  stack_id:                              "15ff7963-c9ad-40c4-ac11-f282504e6158" => "<computed>" (forces new resource)
		  system_packages.#:                     "2" => "2"
		  system_packages.1368285564:            "git" => "git"
		  system_packages.2937857443:            "golang" => "golang"
		  use_ebs_optimized_instances:           "false" => "false"
		DESTROY/CREATE: aws_opsworks_stack.tf-acc
		  agent_version:                 "3442-20161201055821" => "<computed>"
		  berkshelf_version:             "3.2.0" => "3.2.0"
		  configuration_manager_name:    "Chef" => "Chef"
		  configuration_manager_version: "11.10" => "11.10"
		  custom_cookbooks_source.#:     "0" => "<computed>"
		  custom_json:                   "{\"key\": \"value\"}" => "{\"key\": \"value\"}"
		  default_availability_zone:     "us-east-1a" => "us-east-1a"
		  default_instance_profile_arn:  "arn:aws:iam::513236018328:instance-profile/tf-4459038228110306281_opsworks_instance" => "arn:aws:iam::513236018328:instance-profile/tf-4459038228110306281_opsworks_instance"
		  default_os:                    "Amazon Linux 2014.09" => "Amazon Linux 2014.09"
		  default_root_device_type:      "ebs" => "ebs"
		  default_subnet_id:             "subnet-9b1274b1" => ""
		  hostname_theme:                "Layer_Dependent" => "Layer_Dependent"
		  manage_berkshelf:              "false" => "false"
		  name:                          "tf-4459038228110306281" => "tf-4459038228110306281"
		  region:                        "us-east-1" => "us-east-1"
		  service_role_arn:              "arn:aws:iam::513236018328:role/tf-4459038228110306281_opsworks_service" => "arn:aws:iam::513236018328:role/tf-4459038228110306281_opsworks_service"
		  use_custom_cookbooks:          "false" => "false"
		  use_opsworks_security_groups:  "false" => "false"
		  vpc_id:                        "vpc-3953a05e" => "" (forces new resource)

		STATE:

		aws_iam_instance_profile.opsworks_instance:
		  ID = tf-4459038228110306281_opsworks_instance
		  arn = arn:aws:iam::513236018328:instance-profile/tf-4459038228110306281_opsworks_instance
		  name = tf-4459038228110306281_opsworks_instance
		  path = /
		  roles.# = 1
		  roles.769378176 = tf-4459038228110306281_opsworks_instance

		  Dependencies:
		    aws_iam_role.opsworks_instance
		aws_iam_role.opsworks_instance:
		  ID = tf-4459038228110306281_opsworks_instance
		  arn = arn:aws:iam::513236018328:role/tf-4459038228110306281_opsworks_instance
		  assume_role_policy = {
		  "Version": "2008-10-17",
		  "Statement": [
		    {
		      "Sid": "",
		      "Effect": "Allow",
		      "Principal": {
		        "Service": "ec2.amazonaws.com"
		      },
		      "Action": "sts:AssumeRole"
		    }
		  ]
		}

		  create_date = 2016-12-17T23:57:57Z
		  name = tf-4459038228110306281_opsworks_instance
		  path = /
		  unique_id = AROAIN3S3TBMBAZZ4OM2I
		aws_iam_role.opsworks_service:
		  ID = tf-4459038228110306281_opsworks_service
		  arn = arn:aws:iam::513236018328:role/tf-4459038228110306281_opsworks_service
		  assume_role_policy = {
		  "Version": "2008-10-17",
		  "Statement": [
		    {
		      "Sid": "",
		      "Effect": "Allow",
		      "Principal": {
		        "Service": "opsworks.amazonaws.com"
		      },
		      "Action": "sts:AssumeRole"
		    }
		  ]
		}

		  create_date = 2016-12-17T23:57:57Z
		  name = tf-4459038228110306281_opsworks_service
		  path = /
		  unique_id = AROAJSN3KY3ZXRHSUJJLW
		aws_iam_role_policy.opsworks_service:
		  ID = tf-4459038228110306281_opsworks_service:tf-4459038228110306281_opsworks_service
		  name = tf-4459038228110306281_opsworks_service
		  policy = {
		  "Statement": [
		    {
		      "Action": [
		        "ec2:*",
		        "iam:PassRole",
		        "cloudwatch:GetMetricStatistics",
		        "elasticloadbalancing:*",
		        "rds:*"
		      ],
		      "Effect": "Allow",
		      "Resource": ["*"]
		    }
		  ]
		}

		  role = tf-4459038228110306281_opsworks_service

		  Dependencies:
		    aws_iam_role.opsworks_service
		aws_opsworks_custom_layer.tf-acc:
		  ID = c744054f-0c2d-4120-9426-2c8f50193d38
		  auto_assign_elastic_ips = false
		  auto_assign_public_ips = true
		  auto_healing = true
		  custom_configure_recipes.# = 0
		  custom_deploy_recipes.# = 0
		  custom_instance_profile_arn =
		  custom_json =
		  custom_security_group_ids.# = 2
		  custom_security_group_ids.1009903242 = sg-cc7c48b1
		  custom_security_group_ids.4144011415 = sg-cf7c48b2
		  custom_setup_recipes.# = 0
		  custom_shutdown_recipes.# = 0
		  custom_undeploy_recipes.# = 0
		  drain_elb_on_shutdown = true
		  ebs_volume.# = 1
		  ebs_volume.3575749636.iops = 0
		  ebs_volume.3575749636.mount_point = /home
		  ebs_volume.3575749636.number_of_disks = 2
		  ebs_volume.3575749636.raid_level = 0
		  ebs_volume.3575749636.size = 100
		  ebs_volume.3575749636.type = gp2
		  elastic_load_balancer =
		  install_updates_on_boot = true
		  instance_shutdown_timeout = 300
		  name = tf-4459038228110306281
		  short_name = tf-ops-acc-custom-layer
		  stack_id = 15ff7963-c9ad-40c4-ac11-f282504e6158
		  system_packages.# = 2
		  system_packages.1368285564 = git
		  system_packages.2937857443 = golang
		  use_ebs_optimized_instances = false

		  Dependencies:
		    aws_security_group.tf-ops-acc-layer1
		    aws_security_group.tf-ops-acc-layer2
		    aws_opsworks_stack.tf-acc
		aws_opsworks_stack.tf-acc:
		  ID = 15ff7963-c9ad-40c4-ac11-f282504e6158
		  agent_version = 3442-20161201055821
		  berkshelf_version = 3.2.0
		  color =
		  configuration_manager_name = Chef
		  configuration_manager_version = 11.10
		  custom_cookbooks_source.# = 0
		  custom_json = {"key": "value"}
		  default_availability_zone = us-east-1a
		  default_instance_profile_arn = arn:aws:iam::513236018328:instance-profile/tf-4459038228110306281_opsworks_instance
		  default_os = Amazon Linux 2014.09
		  default_root_device_type = ebs
		  default_ssh_key_name =
		  default_subnet_id = subnet-9b1274b1
		  hostname_theme = Layer_Dependent
		  manage_berkshelf = false
		  name = tf-4459038228110306281
		  region = us-east-1
		  service_role_arn = arn:aws:iam::513236018328:role/tf-4459038228110306281_opsworks_service
		  use_custom_cookbooks = false
		  use_opsworks_security_groups = false
		  vpc_id = vpc-3953a05e

		  Dependencies:
		    aws_iam_role.opsworks_service
		    aws_iam_instance_profile.opsworks_instance
		aws_security_group.tf-ops-acc-layer1:
		  ID = sg-cc7c48b1
		  description = Managed by Terraform
		  egress.# = 0
		  ingress.# = 1
		  ingress.490428346.cidr_blocks.# = 1
		  ingress.490428346.cidr_blocks.0 = 0.0.0.0/0
		  ingress.490428346.from_port = 8
		  ingress.490428346.protocol = icmp
		  ingress.490428346.security_groups.# = 0
		  ingress.490428346.self = false
		  ingress.490428346.to_port = -1
		  name = tf-4459038228110306281-layer1
		  owner_id = 513236018328
		  tags.% = 0
		  vpc_id = vpc-3953a05e
		aws_security_group.tf-ops-acc-layer2:
		  ID = sg-cf7c48b2
		  description = Managed by Terraform
		  egress.# = 0
		  ingress.# = 1
		  ingress.490428346.cidr_blocks.# = 1
		  ingress.490428346.cidr_blocks.0 = 0.0.0.0/0
		  ingress.490428346.from_port = 8
		  ingress.490428346.protocol = icmp
		  ingress.490428346.security_groups.# = 0
		  ingress.490428346.self = false
		  ingress.490428346.to_port = -1
		  name = tf-4459038228110306281-layer2
		  owner_id = 513236018328
		  tags.% = 0
		  vpc_id = vpc-3953a05e
=== RUN   TestAccAWSOpsworksInstance
--- PASS: TestAccAWSOpsworksInstance (58.94s)
=== RUN   TestAccAWSOpsworksPermission
--- PASS: TestAccAWSOpsworksPermission (84.78s)
=== RUN   TestAccAWSOpsworksRailsAppLayer
--- PASS: TestAccAWSOpsworksRailsAppLayer (55.41s)
=== RUN   TestAccAWSOpsworksRdsDbInstance
--- PASS: TestAccAWSOpsworksRdsDbInstance (872.23s)
=== RUN   TestAccAWSOpsworksStackNoVpc
--- FAIL: TestAccAWSOpsworksStackNoVpc (20.87s)
	testing.go:265: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		DESTROY/CREATE: aws_opsworks_stack.tf-acc
		  agent_version:                 "3442-20161201055821" => "<computed>"
		  berkshelf_version:             "3.2.0" => "3.2.0"
		  configuration_manager_name:    "Chef" => "Chef"
		  configuration_manager_version: "11.10" => "11.10"
		  custom_cookbooks_source.#:     "0" => "<computed>"
		  custom_json:                   "{\"key\": \"value\"}" => "{\"key\": \"value\"}"
		  default_availability_zone:     "us-east-1a" => "us-east-1a"
		  default_instance_profile_arn:  "arn:aws:iam::513236018328:instance-profile/tf-opsworks-acc-303983871870393620_opsworks_instance" => "arn:aws:iam::513236018328:instance-profile/tf-opsworks-acc-303983871870393620_opsworks_instance"
		  default_os:                    "Amazon Linux 2014.09" => "Amazon Linux 2014.09"
		  default_root_device_type:      "ebs" => "ebs"
		  default_subnet_id:             "subnet-9b1274b1" => ""
		  hostname_theme:                "Layer_Dependent" => "Layer_Dependent"
		  manage_berkshelf:              "false" => "false"
		  name:                          "tf-opsworks-acc-303983871870393620" => "tf-opsworks-acc-303983871870393620"
		  region:                        "us-east-1" => "us-east-1"
		  service_role_arn:              "arn:aws:iam::513236018328:role/tf-opsworks-acc-303983871870393620_opsworks_service" => "arn:aws:iam::513236018328:role/tf-opsworks-acc-303983871870393620_opsworks_service"
		  use_custom_cookbooks:          "false" => "false"
		  use_opsworks_security_groups:  "false" => "false"
		  vpc_id:                        "vpc-3953a05e" => "" (forces new resource)

		STATE:

		aws_iam_instance_profile.opsworks_instance:
		  ID = tf-opsworks-acc-303983871870393620_opsworks_instance
		  arn = arn:aws:iam::513236018328:instance-profile/tf-opsworks-acc-303983871870393620_opsworks_instance
		  name = tf-opsworks-acc-303983871870393620_opsworks_instance
		  path = /
		  roles.# = 1
		  roles.31956874 = tf-opsworks-acc-303983871870393620_opsworks_instance

		  Dependencies:
		    aws_iam_role.opsworks_instance
		aws_iam_role.opsworks_instance:
		  ID = tf-opsworks-acc-303983871870393620_opsworks_instance
		  arn = arn:aws:iam::513236018328:role/tf-opsworks-acc-303983871870393620_opsworks_instance
		  assume_role_policy = {
		  "Version": "2008-10-17",
		  "Statement": [
		    {
		      "Sid": "",
		      "Effect": "Allow",
		      "Principal": {
		        "Service": "ec2.amazonaws.com"
		      },
		      "Action": "sts:AssumeRole"
		    }
		  ]
		}

		  create_date = 2016-12-18T00:16:16Z
		  name = tf-opsworks-acc-303983871870393620_opsworks_instance
		  path = /
		  unique_id = AROAIX5W5K6B3F6CNDNNQ
		aws_iam_role.opsworks_service:
		  ID = tf-opsworks-acc-303983871870393620_opsworks_service
		  arn = arn:aws:iam::513236018328:role/tf-opsworks-acc-303983871870393620_opsworks_service
		  assume_role_policy = {
		  "Version": "2008-10-17",
		  "Statement": [
		    {
		      "Sid": "",
		      "Effect": "Allow",
		      "Principal": {
		        "Service": "opsworks.amazonaws.com"
		      },
		      "Action": "sts:AssumeRole"
		    }
		  ]
		}

		  create_date = 2016-12-18T00:16:16Z
		  name = tf-opsworks-acc-303983871870393620_opsworks_service
		  path = /
		  unique_id = AROAIVMPAIWFW5WX2EWR2
		aws_iam_role_policy.opsworks_service:
		  ID = tf-opsworks-acc-303983871870393620_opsworks_service:tf-opsworks-acc-303983871870393620_opsworks_service
		  name = tf-opsworks-acc-303983871870393620_opsworks_service
		  policy = {
		  "Statement": [
		    {
		      "Action": [
		        "ec2:*",
		        "iam:PassRole",
		        "cloudwatch:GetMetricStatistics",
		        "elasticloadbalancing:*",
		        "rds:*"
		      ],
		      "Effect": "Allow",
		      "Resource": ["*"]
		    }
		  ]
		}

		  role = tf-opsworks-acc-303983871870393620_opsworks_service

		  Dependencies:
		    aws_iam_role.opsworks_service
		aws_opsworks_stack.tf-acc:
		  ID = 6689371c-aaba-4692-85e3-dca919c65f10
		  agent_version = 3442-20161201055821
		  berkshelf_version = 3.2.0
		  color =
		  configuration_manager_name = Chef
		  configuration_manager_version = 11.10
		  custom_cookbooks_source.# = 0
		  custom_json = {"key": "value"}
		  default_availability_zone = us-east-1a
		  default_instance_profile_arn = arn:aws:iam::513236018328:instance-profile/tf-opsworks-acc-303983871870393620_opsworks_instance
		  default_os = Amazon Linux 2014.09
		  default_root_device_type = ebs
		  default_ssh_key_name =
		  default_subnet_id = subnet-9b1274b1
		  hostname_theme = Layer_Dependent
		  manage_berkshelf = false
		  name = tf-opsworks-acc-303983871870393620
		  region = us-east-1
		  service_role_arn = arn:aws:iam::513236018328:role/tf-opsworks-acc-303983871870393620_opsworks_service
		  use_custom_cookbooks = false
		  use_opsworks_security_groups = false
		  vpc_id = vpc-3953a05e

		  Dependencies:
		    aws_iam_role.opsworks_service
		    aws_iam_instance_profile.opsworks_instance
=== RUN   TestAccAWSOpsworksStackVpc
--- PASS: TestAccAWSOpsworksStackVpc (45.86s)
=== RUN   TestAccAWSOpsworksUserProfile
--- FAIL: TestAccAWSOpsworksUserProfile (21.77s)
	testing.go:265: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		DESTROY/CREATE: aws_opsworks_stack.tf-acc
		  agent_version:                 "3442-20161201055821" => "<computed>"
		  berkshelf_version:             "3.2.0" => "3.2.0"
		  configuration_manager_name:    "Chef" => "Chef"
		  configuration_manager_version: "11.10" => "11.10"
		  custom_cookbooks_source.#:     "0" => "<computed>"
		  custom_json:                   "{\"key\": \"value\"}" => "{\"key\": \"value\"}"
		  default_availability_zone:     "us-east-1a" => "us-east-1a"
		  default_instance_profile_arn:  "arn:aws:iam::513236018328:instance-profile/tf-ops-user-profile-6398585000273764235_opsworks_instance" => "arn:aws:iam::513236018328:instance-profile/tf-ops-user-profile-6398585000273764235_opsworks_instance"
		  default_os:                    "Amazon Linux 2014.09" => "Amazon Linux 2014.09"
		  default_root_device_type:      "ebs" => "ebs"
		  default_subnet_id:             "subnet-9b1274b1" => ""
		  hostname_theme:                "Layer_Dependent" => "Layer_Dependent"
		  manage_berkshelf:              "false" => "false"
		  name:                          "tf-ops-user-profile-6398585000273764235" => "tf-ops-user-profile-6398585000273764235"
		  region:                        "us-east-1" => "us-east-1"
		  service_role_arn:              "arn:aws:iam::513236018328:role/tf-ops-user-profile-6398585000273764235_opsworks_service" => "arn:aws:iam::513236018328:role/tf-ops-user-profile-6398585000273764235_opsworks_service"
		  use_custom_cookbooks:          "false" => "false"
		  use_opsworks_security_groups:  "false" => "false"
		  vpc_id:                        "vpc-3953a05e" => "" (forces new resource)

		STATE:

		aws_iam_instance_profile.opsworks_instance:
		  ID = tf-ops-user-profile-6398585000273764235_opsworks_instance
		  arn = arn:aws:iam::513236018328:instance-profile/tf-ops-user-profile-6398585000273764235_opsworks_instance
		  name = tf-ops-user-profile-6398585000273764235_opsworks_instance
		  path = /
		  roles.# = 1
		  roles.3999219534 = tf-ops-user-profile-6398585000273764235_opsworks_instance

		  Dependencies:
		    aws_iam_role.opsworks_instance
		aws_iam_role.opsworks_instance:
		  ID = tf-ops-user-profile-6398585000273764235_opsworks_instance
		  arn = arn:aws:iam::513236018328:role/tf-ops-user-profile-6398585000273764235_opsworks_instance
		  assume_role_policy = {
		  "Version": "2008-10-17",
		  "Statement": [
		    {
		      "Sid": "",
		      "Effect": "Allow",
		      "Principal": {
		        "Service": "ec2.amazonaws.com"
		      },
		      "Action": "sts:AssumeRole"
		    }
		  ]
		}

		  create_date = 2016-12-18T00:17:22Z
		  name = tf-ops-user-profile-6398585000273764235_opsworks_instance
		  path = /
		  unique_id = AROAJXF42SCDPOALUQ3SU
		aws_iam_role.opsworks_service:
		  ID = tf-ops-user-profile-6398585000273764235_opsworks_service
		  arn = arn:aws:iam::513236018328:role/tf-ops-user-profile-6398585000273764235_opsworks_service
		  assume_role_policy = {
		  "Version": "2008-10-17",
		  "Statement": [
		    {
		      "Sid": "",
		      "Effect": "Allow",
		      "Principal": {
		        "Service": "opsworks.amazonaws.com"
		      },
		      "Action": "sts:AssumeRole"
		    }
		  ]
		}

		  create_date = 2016-12-18T00:17:22Z
		  name = tf-ops-user-profile-6398585000273764235_opsworks_service
		  path = /
		  unique_id = AROAICD4UXQPYBHI65X3Y
		aws_iam_role_policy.opsworks_service:
		  ID = tf-ops-user-profile-6398585000273764235_opsworks_service:tf-ops-user-profile-6398585000273764235_opsworks_service
		  name = tf-ops-user-profile-6398585000273764235_opsworks_service
		  policy = {
		  "Statement": [
		    {
		      "Action": [
		        "ec2:*",
		        "iam:PassRole",
		        "cloudwatch:GetMetricStatistics",
		        "elasticloadbalancing:*",
		        "rds:*"
		      ],
		      "Effect": "Allow",
		      "Resource": ["*"]
		    }
		  ]
		}

		  role = tf-ops-user-profile-6398585000273764235_opsworks_service

		  Dependencies:
		    aws_iam_role.opsworks_service
		aws_iam_user.user:
		  ID = test-user-86087773605481067
		  arn = arn:aws:iam::513236018328:user/test-user-86087773605481067
		  force_destroy = false
		  name = test-user-86087773605481067
		  path = /
		  unique_id = AIDAJRX7S7PQBN63QFAZY
		aws_opsworks_stack.tf-acc:
		  ID = 4f6e1979-ba0f-4cef-a9c5-40bdb8eef4e4
		  agent_version = 3442-20161201055821
		  berkshelf_version = 3.2.0
		  color =
		  configuration_manager_name = Chef
		  configuration_manager_version = 11.10
		  custom_cookbooks_source.# = 0
		  custom_json = {"key": "value"}
		  default_availability_zone = us-east-1a
		  default_instance_profile_arn = arn:aws:iam::513236018328:instance-profile/tf-ops-user-profile-6398585000273764235_opsworks_instance
		  default_os = Amazon Linux 2014.09
		  default_root_device_type = ebs
		  default_ssh_key_name =
		  default_subnet_id = subnet-9b1274b1
		  hostname_theme = Layer_Dependent
		  manage_berkshelf = false
		  name = tf-ops-user-profile-6398585000273764235
		  region = us-east-1
		  service_role_arn = arn:aws:iam::513236018328:role/tf-ops-user-profile-6398585000273764235_opsworks_service
		  use_custom_cookbooks = false
		  use_opsworks_security_groups = false
		  vpc_id = vpc-3953a05e

		  Dependencies:
		    aws_iam_instance_profile.opsworks_instance
		    aws_iam_role.opsworks_service
		aws_opsworks_user_profile.user:
		  ID = arn:aws:iam::513236018328:user/test-user-86087773605481067
		  allow_self_management = false
		  ssh_public_key =
		  ssh_username = test-user-86087773605481067
		  user_arn = arn:aws:iam::513236018328:user/test-user-86087773605481067

		  Dependencies:
		    aws_iam_user.user
		    aws_iam_user.user
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/aws	1303.935s
```