### PR TITLE
provider/google: Use node_version during google_container_cluster creation

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -278,6 +278,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		InitialNodeCount: int64(d.Get("initial_node_count").(int)),
 	}
 
+	if v, ok := d.GetOk("node_version"); ok {
+		cluster.InitialClusterVersion = v.(string)
+	}
+
 	if v, ok := d.GetOk("cluster_ipv4_cidr"); ok {
 		cluster.ClusterIpv4Cidr = v.(string)
 	}

--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -26,6 +26,23 @@ func TestAccContainerCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withVersion(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerCluster_withVersion,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerClusterExists(
+						"google_container_cluster.with_version"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withNodeConfig(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -131,6 +148,19 @@ resource "google_container_cluster" "primary" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
 	initial_node_count = 3
+
+	master_auth {
+		username = "mr.yoda"
+		password = "adoy.rm"
+	}
+}`, acctest.RandString(10))
+
+var testAccContainerCluster_withVersion = fmt.Sprintf(`
+resource "google_container_cluster" "with_version" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	node_version = "1.4.7"
+	initial_node_count = 1
 
 	master_auth {
 		username = "mr.yoda"


### PR DESCRIPTION
It appears that the `node_version` was never hooked into the `google_container_cluster` creation step. This step maps the `node_version` field to the proper API field so that a specific version can be requested at cluster provision time.

```
$ make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccContainerCluster_withVersion'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/17 22:24:48 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccContainerCluster_withVersion -timeout 120m
=== RUN   TestAccContainerCluster_withVersion
--- PASS: TestAccContainerCluster_withVersion (389.43s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	389.444s
```