### PR TITLE
provider/openstack: Handle Volume Creation Errors

### DIFF
--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v1.go
@@ -130,9 +130,6 @@ func resourceBlockStorageVolumeV1Create(d *schema.ResourceData, meta interface{}
 	}
 	log.Printf("[INFO] Volume ID: %s", v.ID)
 
-	// Store the ID now
-	d.SetId(v.ID)
-
 	// Wait for the volume to become available.
 	log.Printf(
 		"[DEBUG] Waiting for volume (%s) to become available",
@@ -153,6 +150,9 @@ func resourceBlockStorageVolumeV1Create(d *schema.ResourceData, meta interface{}
 			"Error waiting for volume (%s) to become ready: %s",
 			v.ID, err)
 	}
+
+	// Store the ID now
+	d.SetId(v.ID)
 
 	return resourceBlockStorageVolumeV1Read(d, meta)
 }
@@ -312,6 +312,12 @@ func VolumeV1StateRefreshFunc(client *gophercloud.ServiceClient, volumeID string
 				return v, "deleted", nil
 			}
 			return nil, "", err
+		}
+
+		if v.Status == "error" {
+			return v, v.Status, fmt.Errorf("There was an error creating the volume. " +
+				"Please check with your cloud admin or check the Block Storage " +
+				"API logs to see why this error occurred.")
 		}
 
 		return v, v.Status, nil


### PR DESCRIPTION
This commit makes the openstack_blockstorage_volume resources better able
to handle volume creation errors upon resource creation. The cause of this
change is because there could be some storage backend error that happens
during storage provisioning that won't manifest in an "err" but will set
the volume's status to "error". We now check for a status of "error" and
propagate the error up the stack.

Fixes #10376