### PR TITLE
Alphabetize sidebar list of providers by displayed name

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -190,12 +190,12 @@
 					<a href="/docs/providers/bitbucket/index.html">Bitbucket</a>
 					</li>
 
-					<li<%= sidebar_current("docs-providers-chef") %>>
-					<a href="/docs/providers/chef/index.html">Chef</a>
-					</li>
-
 					<li<%= sidebar_current("docs-providers-clc") %>>
 					<a href="/docs/providers/clc/index.html">CenturyLinkCloud</a>
+					</li>
+
+					<li<%= sidebar_current("docs-providers-chef") %>>
+					<a href="/docs/providers/chef/index.html">Chef</a>
 					</li>
 
 					<li<%= sidebar_current("docs-providers-cloudflare") %>>
@@ -242,12 +242,12 @@
 					<a href="/docs/providers/external/index.html">External</a>
 					</li>
 
-					<li<%= sidebar_current("docs-providers-github") %>>
-					<a href="/docs/providers/github/index.html">GitHub</a>
-					</li>
-
 					<li<%= sidebar_current("docs-providers-fastly") %>>
 					<a href="/docs/providers/fastly/index.html">Fastly</a>
+					</li>
+
+					<li<%= sidebar_current("docs-providers-github") %>>
+					<a href="/docs/providers/github/index.html">GitHub</a>
 					</li>
 
 					<li<%= sidebar_current("docs-providers-google") %>>
@@ -286,10 +286,6 @@
             <a href="/docs/providers/newrelic/index.html">New Relic</a>
           </li>
 
-					<li<%= sidebar_current("docs-providers-nomad") %>>
-					<a href="/docs/providers/nomad/index.html">Nomad</a>
-					</li>
-
 					<li<%= sidebar_current("docs-providers-azurerm") %>>
 					<a href="/docs/providers/azurerm/index.html">Microsoft Azure</a>
 					</li>
@@ -300,6 +296,10 @@
 
 					<li<%= sidebar_current("docs-providers-mysql") %>>
 					<a href="/docs/providers/mysql/index.html">MySQL</a>
+					</li>
+
+					<li<%= sidebar_current("docs-providers-nomad") %>>
+					<a href="/docs/providers/nomad/index.html">Nomad</a>
 					</li>
 
 					<li<%= sidebar_current("docs-providers-openstack") %>>
@@ -338,17 +338,17 @@
 					<a href="/docs/providers/rundeck/index.html">Rundeck</a>
 					</li>
 
-                    <li<%= sidebar_current("docs-providers-statuscake") %>>
-                        <a href="/docs/providers/statuscake/index.html">StatusCake</a>
-                    </li>
+          <li<%= sidebar_current("docs-providers-scaleway") %>>
+          <a href="/docs/providers/scaleway/index.html">Scaleway</a>
+          </li>
 
 					<li<%= sidebar_current("docs-providers-softlayer") %>>
 					<a href="/docs/providers/softlayer/index.html">SoftLayer</a>
 					</li>
 
-          <li<%= sidebar_current("docs-providers-scaleway") %>>
-          <a href="/docs/providers/scaleway/index.html">Scaleway</a>
-          </li>
+                    <li<%= sidebar_current("docs-providers-statuscake") %>>
+                        <a href="/docs/providers/statuscake/index.html">StatusCake</a>
+                    </li>
 
 					<li<%= sidebar_current("docs-providers-template") %>>
 					<a href="/docs/providers/template/index.html">Template</a>


### PR DESCRIPTION
The list of providers was not strictly alphabetized. I believe this fixes all out-of-order items.

I attempted to retain the indentation / whitespace for any given link (they are not all the same).