### PR TITLE
provider/azurerm: fix network_interface.ip_configuration hash for load balancers

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -324,10 +324,16 @@ func resourceArmNetworkInterfaceIpConfigurationHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", m["public_ip_address_id"].(string)))
 	}
 	if m["load_balancer_backend_address_pools_ids"] != nil {
-		buf.WriteString(fmt.Sprintf("%s-", m["load_balancer_backend_address_pools_ids"].(*schema.Set).GoString()))
+		ids := m["load_balancer_backend_address_pools_ids"].(*schema.Set).List()
+		for _, id := range ids {
+			buf.WriteString(fmt.Sprintf("%d-", schema.HashString(id.(string))))
+		}
 	}
 	if m["load_balancer_inbound_nat_rules_ids"] != nil {
-		buf.WriteString(fmt.Sprintf("%s-", m["load_balancer_inbound_nat_rules_ids"].(*schema.Set).GoString()))
+		ids := m["load_balancer_inbound_nat_rules_ids"].(*schema.Set).List()
+		for _, id := range ids {
+			buf.WriteString(fmt.Sprintf("%d-", schema.HashString(id.(string))))
+		}
 	}
 
 	return hashcode.String(buf.String())


### PR DESCRIPTION
The subsets for backend address pools and inbound nat rules weren't being hashed
properly as part of the ip_configuration hash which caused multiple
ip_configurations to be expanded and sent to the API with conflicting names

Fixes #9878
Fixes #10561

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMNetworkInterface -timeout 120m
=== RUN   TestAccAzureRMNetworkInterface_basic
--- PASS: TestAccAzureRMNetworkInterface_basic (160.24s)
=== RUN   TestAccAzureRMNetworkInterface_disappears
--- PASS: TestAccAzureRMNetworkInterface_disappears (157.00s)
=== RUN   TestAccAzureRMNetworkInterface_enableIPForwarding
--- PASS: TestAccAzureRMNetworkInterface_enableIPForwarding (156.86s)
=== RUN   TestAccAzureRMNetworkInterface_multipleLoadBalancers
--- PASS: TestAccAzureRMNetworkInterface_multipleLoadBalancers (185.87s)
=== RUN   TestAccAzureRMNetworkInterface_withTags
--- PASS: TestAccAzureRMNetworkInterface_withTags (1212.92s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	1872.960s
```