### PR TITLE
provider/openstack: Acceptance Test Cleanup: Provider & Block Storage

### DIFF
--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -9,8 +9,14 @@ import (
 )
 
 var (
-	OS_REGION_NAME = ""
-	OS_POOL_NAME   = ""
+	OS_EXTGW_ID    = os.Getenv("OS_EXTGW_ID")
+	OS_FLAVOR_ID   = os.Getenv("OS_FLAVOR_ID")
+	OS_FLAVOR_NAME = os.Getenv("OS_FLAVOR_NAME")
+	OS_IMAGE_ID    = os.Getenv("OS_IMAGE_ID")
+	OS_IMAGE_NAME  = os.Getenv("OS_IMAGE_NAME")
+	OS_NETWORK_ID  = os.Getenv("OS_NETWORK_ID")
+	OS_POOL_NAME   = os.Getenv("OS_POOL_NAME")
+	OS_REGION_NAME = os.Getenv("OS_REGION_NAME")
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -39,37 +45,23 @@ func testAccPreCheck(t *testing.T) {
 		t.Fatal("OS_AUTH_URL must be set for acceptance tests")
 	}
 
-	v = os.Getenv("OS_REGION_NAME")
-	if v != "" {
-		OS_REGION_NAME = v
-	}
-
-	v1 := os.Getenv("OS_IMAGE_ID")
-	v2 := os.Getenv("OS_IMAGE_NAME")
-
-	if v1 == "" || v2 == "" {
+	if OS_IMAGE_ID == "" || OS_IMAGE_NAME == "" {
 		t.Fatal("OS_IMAGE_ID and OS_IMAGE_NAME must be set for acceptance tests")
 	}
 
-	v = os.Getenv("OS_POOL_NAME")
-	if v == "" {
+	if OS_POOL_NAME == "" {
 		t.Fatal("OS_POOL_NAME must be set for acceptance tests")
 	}
-	OS_POOL_NAME = v
 
-	v1 = os.Getenv("OS_FLAVOR_ID")
-	v2 = os.Getenv("OS_FLAVOR_NAME")
-	if v1 == "" && v2 == "" {
+	if OS_FLAVOR_ID == "" && OS_FLAVOR_NAME == "" {
 		t.Fatal("OS_FLAVOR_ID or OS_FLAVOR_NAME must be set for acceptance tests")
 	}
 
-	v = os.Getenv("OS_NETWORK_ID")
-	if v == "" {
+	if OS_NETWORK_ID == "" {
 		t.Fatal("OS_NETWORK_ID must be set for acceptance tests")
 	}
 
-	v = os.Getenv("OS_EXTGW_ID")
-	if v == "" {
+	if OS_EXTGW_ID == "" {
 		t.Fatal("OS_EXTGW_ID must be set for acceptance tests")
 	}
 }

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_attach_v2_test.go
@@ -22,7 +22,7 @@ func TestAccBlockStorageVolumeAttachV2_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccBlockStorageVolumeAttachV2_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageVolumeAttachV2Exists(t, "openstack_blockstorage_volume_attach_v2.va_1", &va),
+					testAccCheckBlockStorageVolumeAttachV2Exists("openstack_blockstorage_volume_attach_v2.va_1", &va),
 				),
 			},
 		},
@@ -64,7 +64,7 @@ func testAccCheckBlockStorageVolumeAttachV2Destroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckBlockStorageVolumeAttachV2Exists(t *testing.T, n string, va *volumes.Attachment) resource.TestCheckFunc {
+func testAccCheckBlockStorageVolumeAttachV2Exists(n string, va *volumes.Attachment) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -107,20 +107,20 @@ func testAccCheckBlockStorageVolumeAttachV2Exists(t *testing.T, n string, va *vo
 	}
 }
 
-var testAccBlockStorageVolumeAttachV2_basic = `
-	resource "openstack_blockstorage_volume_v2" "volume_1" {
-		name = "volume_1"
-		size = 1
-	}
+const testAccBlockStorageVolumeAttachV2_basic = `
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  size = 1
+}
 
-	resource "openstack_compute_instance_v2" "instance_1" {
-		name = "instance_1"
-		security_groups = ["default"]
-	}
+resource "openstack_compute_instance_v2" "instance_1" {
+  name = "instance_1"
+  security_groups = ["default"]
+}
 
-	resource "openstack_blockstorage_volume_attach_v2" "va_1" {
-		instance_id = "${openstack_compute_instance_v2.instance_1.id}"
-		volume_id = "${openstack_blockstorage_volume_v2.volume_1.id}"
-		device = "auto"
-	}
+resource "openstack_blockstorage_volume_attach_v2" "va_1" {
+  instance_id = "${openstack_compute_instance_v2.instance_1.id}"
+  volume_id = "${openstack_blockstorage_volume_v2.volume_1.id}"
+  device = "auto"
+}
 `

--- a/builtin/providers/openstack/resource_openstack_blockstorage_volume_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_blockstorage_volume_v2_test.go
@@ -2,7 +2,6 @@ package openstack
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -23,33 +22,27 @@ func TestAccBlockStorageV2Volume_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccBlockStorageV2Volume_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists(t, "openstack_blockstorage_volume_v2.volume_1", &volume),
-					resource.TestCheckResourceAttr("openstack_blockstorage_volume_v2.volume_1", "name", "volume_1"),
+					testAccCheckBlockStorageV2VolumeExists("openstack_blockstorage_volume_v2.volume_1", &volume),
 					testAccCheckBlockStorageV2VolumeMetadata(&volume, "foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"openstack_blockstorage_volume_v2.volume_1", "name", "volume_1"),
 				),
 			},
 			resource.TestStep{
 				Config: testAccBlockStorageV2Volume_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists(t, "openstack_blockstorage_volume_v2.volume_1", &volume),
-					resource.TestCheckResourceAttr("openstack_blockstorage_volume_v2.volume_1", "name", "volume_1-updated"),
+					testAccCheckBlockStorageV2VolumeExists("openstack_blockstorage_volume_v2.volume_1", &volume),
 					testAccCheckBlockStorageV2VolumeMetadata(&volume, "foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"openstack_blockstorage_volume_v2.volume_1", "name", "volume_1-updated"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccBlockStorageV2Volume_bootable(t *testing.T) {
+func TestAccBlockStorageV2Volume_image(t *testing.T) {
 	var volume volumes.Volume
-
-	var testAccBlockStorageV2Volume_bootable = fmt.Sprintf(`
-		resource "openstack_blockstorage_volume_v2" "volume_1" {
-			name = "volume_1-bootable"
-			size = 5
-			image_id = "%s"
-		}`,
-		os.Getenv("OS_IMAGE_ID"))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,10 +50,11 @@ func TestAccBlockStorageV2Volume_bootable(t *testing.T) {
 		CheckDestroy: testAccCheckBlockStorageV2VolumeDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccBlockStorageV2Volume_bootable,
+				Config: testAccBlockStorageV2Volume_image,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV2VolumeExists(t, "openstack_blockstorage_volume_v2.volume_1", &volume),
-					resource.TestCheckResourceAttr("openstack_blockstorage_volume_v2.volume_1", "name", "volume_1-bootable"),
+					testAccCheckBlockStorageV2VolumeExists("openstack_blockstorage_volume_v2.volume_1", &volume),
+					resource.TestCheckResourceAttr(
+						"openstack_blockstorage_volume_v2.volume_1", "name", "volume_1"),
 				),
 			},
 		},
@@ -88,7 +82,7 @@ func testAccCheckBlockStorageV2VolumeDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckBlockStorageV2VolumeExists(t *testing.T, n string, volume *volumes.Volume) resource.TestCheckFunc {
+func testAccCheckBlockStorageV2VolumeExists(n string, volume *volumes.Volume) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -163,22 +157,32 @@ func testAccCheckBlockStorageV2VolumeMetadata(
 	}
 }
 
-var testAccBlockStorageV2Volume_basic = fmt.Sprintf(`
-	resource "openstack_blockstorage_volume_v2" "volume_1" {
-		name = "volume_1"
-		description = "first test volume"
-		metadata {
-			foo = "bar"
-		}
-		size = 1
-	}`)
+const testAccBlockStorageV2Volume_basic = `
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  description = "first test volume"
+  metadata {
+    foo = "bar"
+  }
+  size = 1
+}
+`
 
-var testAccBlockStorageV2Volume_update = fmt.Sprintf(`
-	resource "openstack_blockstorage_volume_v2" "volume_1" {
-		name = "volume_1-updated"
-		description = "first test volume"
-		metadata {
-			foo = "bar"
-		}
-		size = 1
-	}`)
+const testAccBlockStorageV2Volume_update = `
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1-updated"
+  description = "first test volume"
+  metadata {
+    foo = "bar"
+  }
+  size = 1
+}
+`
+
+var testAccBlockStorageV2Volume_image = fmt.Sprintf(`
+resource "openstack_blockstorage_volume_v2" "volume_1" {
+  name = "volume_1"
+  size = 5
+  image_id = "%s"
+}
+`, OS_IMAGE_ID)

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -74,7 +74,7 @@ func TestAccComputeV2Instance_volumeAttach(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeAttach,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.myvol", &volume),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume),
 				),
@@ -121,7 +121,7 @@ func TestAccComputeV2Instance_volumeAttachPostCreation(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeAttachPostCreationInstanceAndVolume,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.myvol", &volume),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume),
 				),
@@ -167,7 +167,7 @@ func TestAccComputeV2Instance_volumeDetachPostCreation(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeDetachPostCreationInstanceAndVolume,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.myvol", &volume),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume),
 				),
@@ -175,7 +175,7 @@ func TestAccComputeV2Instance_volumeDetachPostCreation(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeDetachPostCreationInstance,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.myvol", &volume),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.myvol", &volume),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumesDetached(&instance),
 				),
@@ -255,8 +255,8 @@ func TestAccComputeV2Instance_volumeDetachAdditionalVolumePostCreation(t *testin
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeDetachAdditionalVolumePostCreationInstanceAndVolume,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.root_volume", &volume_1),
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.additional_volume", &volume_2),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.root_volume", &volume_1),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.additional_volume", &volume_2),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume_1),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume_2),
@@ -265,8 +265,8 @@ func TestAccComputeV2Instance_volumeDetachAdditionalVolumePostCreation(t *testin
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeDetachPostCreationInstance,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.root_volume", &volume_1),
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.additional_volume", &volume_2),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.root_volume", &volume_1),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.additional_volume", &volume_2),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume_1),
 					testAccCheckComputeV2InstanceVolumeDetached(&instance, "openstack_blockstorage_volume_v1.additional_volume"),
@@ -332,8 +332,8 @@ func TestAccComputeV2Instance_volumeAttachInstanceDelete(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeAttachInstanceDelete_1,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.root_volume", &volume_1),
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.additional_volume", &volume_2),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.root_volume", &volume_1),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.additional_volume", &volume_2),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume_1),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance, &volume_2),
@@ -342,8 +342,8 @@ func TestAccComputeV2Instance_volumeAttachInstanceDelete(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeAttachInstanceDelete_2,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.root_volume", &volume_1),
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.additional_volume", &volume_2),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.root_volume", &volume_1),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.additional_volume", &volume_2),
 					testAccCheckComputeV2InstanceDoesNotExist(t, "openstack_compute_instance_v2.foo", &instance),
 					testAccCheckComputeV2InstanceVolumeDetached(&instance, "openstack_blockstorage_volume_v1.root_volume"),
 					testAccCheckComputeV2InstanceVolumeDetached(&instance, "openstack_blockstorage_volume_v1.additional_volume"),
@@ -408,7 +408,7 @@ func TestAccComputeV2Instance_volumeAttachToNewInstance(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeAttachToNewInstance_1,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.volume_1", &volume_1),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.volume_1", &volume_1),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.instance_1", &instance_1),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.instance_2", &instance_2),
 					testAccCheckComputeV2InstanceVolumeAttachment(&instance_1, &volume_1),
@@ -418,7 +418,7 @@ func TestAccComputeV2Instance_volumeAttachToNewInstance(t *testing.T) {
 			resource.TestStep{
 				Config: testAccComputeV2Instance_volumeAttachToNewInstance_2,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.volume_1", &volume_1),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.volume_1", &volume_1),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.instance_1", &instance_1),
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.instance_2", &instance_2),
 					testAccCheckComputeV2InstanceVolumeDetached(&instance_1, "openstack_blockstorage_volume_v1.volume_1"),
@@ -933,7 +933,7 @@ func TestAccComputeV2Instance_blockDeviceExistingVolume(t *testing.T) {
 				Config: testAccComputeV2Instance_blockDeviceExistingVolume,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists(t, "openstack_compute_instance_v2.instance_1", &instance_1),
-					testAccCheckBlockStorageV1VolumeExists(t, "openstack_blockstorage_volume_v1.volume_1", &volume_1),
+					testAccCheckBlockStorageV1VolumeExists("openstack_blockstorage_volume_v1.volume_1", &volume_1),
 				),
 			},
 		},


### PR DESCRIPTION
This is the first of a series of commits to clean up the OpenStack acceptance tests. Updates are an attempt to better align with the styles of other Terraform acceptance tests.

All PRs in this series have been confirmed to pass testing, so the only review required would be for style formatting.