### PR TITLE
provider/docker: Add support for a list of pull_triggers within the docker_image resource.

### DIFF
--- a/builtin/providers/docker/resource_docker_image.go
+++ b/builtin/providers/docker/resource_docker_image.go
@@ -28,9 +28,19 @@ func resourceDockerImage() *schema.Resource {
 			},
 
 			"pull_trigger": &schema.Schema{
-				Type:     schema.TypeString,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"pull_triggers"},
+				Deprecated:    "Use field pull_triggers instead",
+			},
+
+			"pull_triggers": &schema.Schema{
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 		},
 	}

--- a/builtin/providers/docker/resource_docker_image_funcs.go
+++ b/builtin/providers/docker/resource_docker_image_funcs.go
@@ -188,15 +188,11 @@ func findImage(d *schema.ResourceData, client *dc.Client) (*dc.APIImages, error)
 		return nil, fmt.Errorf("Empty image name is not allowed")
 	}
 
-	foundImage := searchLocalImages(data, imageName)
-
-	if foundImage == nil {
-		if err := pullImage(&data, client, imageName); err != nil {
-			return nil, fmt.Errorf("Unable to pull image %s: %s", imageName, err)
-		}
+	if err := pullImage(&data, client, imageName); err != nil {
+		return nil, fmt.Errorf("Unable to pull image %s: %s", imageName, err)
 	}
 
-	foundImage = searchLocalImages(data, imageName)
+	foundImage := searchLocalImages(data, imageName)
 	if foundImage != nil {
 		return foundImage, nil
 	}

--- a/builtin/providers/docker/resource_docker_image_test.go
+++ b/builtin/providers/docker/resource_docker_image_test.go
@@ -89,6 +89,22 @@ func TestAccDockerImage_data(t *testing.T) {
 	})
 }
 
+func TestAccDockerImage_data_pull_trigger(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                  func() { testAccPreCheck(t) },
+		Providers:                 testAccProviders,
+		PreventPostDestroyRefresh: true,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerImageFromDataConfigWithPullTrigger,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr("docker_image.foobarbazoo", "latest", contentDigestRegexp),
+				),
+			},
+		},
+	})
+}
+
 func testAccDockerImageDestroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "docker_image" {
@@ -131,6 +147,16 @@ data "docker_registry_image" "foobarbaz" {
 }
 resource "docker_image" "foobarbaz" {
 	name = "${data.docker_registry_image.foobarbaz.name}"
-	pull_trigger = "${data.docker_registry_image.foobarbaz.sha256_digest}"
+	pull_triggers = ["${data.docker_registry_image.foobarbaz.sha256_digest}"]
+}
+`
+
+const testAccDockerImageFromDataConfigWithPullTrigger = `
+data "docker_registry_image" "foobarbazoo" {
+	name = "alpine:3.1"
+}
+resource "docker_image" "foobarbazoo" {
+	name = "${data.docker_registry_image.foobarbazoo.name}"
+	pull_trigger = "${data.docker_registry_image.foobarbazoo.sha256_digest}"
 }
 `

--- a/website/source/docs/providers/docker/d/registry_image.html.markdown
+++ b/website/source/docs/providers/docker/d/registry_image.html.markdown
@@ -23,7 +23,7 @@ data "docker_registry_image" "ubuntu" {
 
 resource "docker_image" "ubuntu" {
     name = "${data.docker_registry_image.ubuntu.name}"
-    pull_trigger = "${data.docker_registry_image.ubuntu.sha256_digest}"
+    pull_triggers = ["${data.docker_registry_image.ubuntu.sha256_digest}"]
 }
 ```
 

--- a/website/source/docs/providers/docker/r/image.html.markdown
+++ b/website/source/docs/providers/docker/r/image.html.markdown
@@ -14,7 +14,7 @@ Pulls a Docker image to a given Docker host from a Docker Registry.
 
 This resource will *not* pull new layers of the image automatically unless used in
 conjunction with [`docker_registry_image`](/docs/providers/docker/d/registry_image.html)
-data source to update the `pull_trigger` field.
+data source to update the `pull_triggers` field.
 
 ## Example Usage
 
@@ -36,7 +36,7 @@ data "docker_registry_image" "ubuntu" {
 
 resource "docker_image" "ubuntu" {
     name = "${data.docker_registry_image.ubuntu.name}"
-    pull_trigger = "${data.docker_registry_image.ubuntu.sha256_digest}"
+    pull_triggers = ["${data.docker_registry_image.ubuntu.sha256_digest}"]
 }
 ```
 
@@ -48,10 +48,12 @@ The following arguments are supported:
 * `keep_locally` - (Optional, boolean) If true, then the Docker image won't be
   deleted on destroy operation. If this is false, it will delete the image from
   the docker local storage on destroy operation.
-* `pull_trigger` - (Optional, string) Used to store the image digest from the
-  registry and will cause an image pull when changed. Needed when using
-  the `docker_registry_image` [data source](/docs/providers/docker/d/registry_image.html)
-  to trigger an update of the image.
+* `pull_triggers` - (Optional, list of strings) List of values which cause an
+  image pull when changed. This is used to store the image digest from the
+  registry when using the `docker_registry_image` [data source](/docs/providers/docker/d/registry_image.html)
+  to trigger an image update.
+* `pull_trigger` - **Deprecated**, use `pull_triggers` instead.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR is in response to an issue I opened earlier today: #10843 

Changes included are:
* Modify docker_image.pull_trigger (string) to now be a list of strings called docker_image.pull_triggers.
* Always pull images regardless of if they are found by searchLocalImages()
* Fixed acceptance test which used pull_trigger to now use the pull_triggers list.
* Updated relevant documentation

Why the PR?: When using the terraform provider to orchestrate a docker swarm cluster there are various times when you need to invoke a docker image pull outside of just the registry image sha256 changing. Take for example, adding a swarm node to the cluster. Once the new swarm node is up and accessible, an image pull must be triggered so that images are pulled onto the brand new node. To accommodate this I have changed pull_trigger into a list so that image pulls can be invoked by any number of things.

When testing this new functionality I found that images still were not being pulled onto the new host in the swarm. The reasoning behind this was because the provider was checking if an image was already found in the docker images list. When using docker swarm, 'docker images' will return an image if it is found in *any* node in the swarm, so in the case of a brand new swarm node, it will have no images and never be able to receive any images since the provider thinks the swarm already has the image. The best fix was to remove the check which sees if the image is already pulled and always attempt a pull operation. During this pull operation, nodes that already have the required docker image result in a no-op while nodes that need the image pull the image.

Example usage of pull_triggers attribute:
```hcl 
data "docker_registry_image" "elasticsearch" {
  name = "elasticsearch:latest"
}

resource "docker_image" "elasticsearch" {
  name = "${data.docker_registry_image.elasticsearch.name}"
  pull_triggers = ["${data.docker_registry_image.elasticsearch.sha256_digest}", "${var.swarm_cluster_size}"]
}
```

Thanks for taking a look, hopefully this is useful to others!