### PR TITLE
Add CLI output example to Usage of Modules Docs

### DIFF
--- a/website/source/docs/modules/usage.html.markdown
+++ b/website/source/docs/modules/usage.html.markdown
@@ -97,6 +97,12 @@ This purposely is very similar to accessing resource attributes. Instead of mapp
 
 Just like resources, this will create a dependency from the `aws_instance.client` resource to the module, so the module will be built first.
 
+To use module outputs via command line you have to specify the module name before the variable, for example:
+
+```
+terraform output -module=consul server_availability_zone
+```
+
 ## Plans and Graphs
 
 Commands such as the [plan command](/docs/commands/plan.html) and [graph command](/docs/commands/graph.html) will expand modules by default. You can use the `-module-depth` parameter to limit the graph.


### PR DESCRIPTION
Adding a CLI Example to grab output variables from a module.

**Reasoning for docs update**: It can be confusing for how to grab the output variables for a module from the CLI tool, so I added an example to show using the -module flag. It was confusing and a bit of a time sink for me so I figured it would be useful to show.

**Relevant Terraform version**: This could go into the docs now, we are using 0.7 and used this syntax.
