### PR TITLE
Remove create_timeout backwards incompatibilities.

### DIFF
--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -301,7 +301,6 @@ func resourceComputeInstance() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  4,
-				ForceNew: true,
 			},
 		},
 	}

--- a/builtin/providers/google/resource_compute_instance_migrate.go
+++ b/builtin/providers/google/resource_compute_instance_migrate.go
@@ -32,6 +32,13 @@ func resourceComputeInstanceMigrateState(
 			return is, err
 		}
 		return is, nil
+	case 2:
+		log.Println("[INFO] Found Compute Instance State v2; migrating to v3")
+		is, err := migrateStateV2toV3(is)
+		if err != nil {
+			return is, err
+		}
+		return is, nil
 	default:
 		return is, fmt.Errorf("Unexpected schema version: %d", v)
 	}
@@ -135,6 +142,13 @@ func migrateStateV1toV2(is *terraform.InstanceState) (*terraform.InstanceState, 
 		}
 	}
 
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}
+
+func migrateStateV2toV3(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+	is.Attributes["create_timeout"] = "4"
 	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
 	return is, nil
 }

--- a/builtin/providers/google/resource_compute_instance_migrate_test.go
+++ b/builtin/providers/google/resource_compute_instance_migrate_test.go
@@ -48,6 +48,13 @@ func TestComputeInstanceMigrateState(t *testing.T) {
 				"service_account.0.scopes.3435931483": "https://www.googleapis.com/auth/datastore",
 			},
 		},
+		"add new create_timeout attribute": {
+			StateVersion: 2,
+			Attributes:   map[string]string{},
+			Expected: map[string]string{
+				"create_timeout": "4",
+			},
+		},
 	}
 
 	for tn, tc := range cases {


### PR DESCRIPTION
A new create_timeout attribute was added that had some backwards
incompatibilities, and as per discussion in #10823, it was determined we
could make upgrading to 0.8.x easier by fixing them, without really
losing any functionality.

Because create_timeout is not something stored or transmitted to the
API, it's not something we need a ForceNew on. Also, because an update
wouldn't result in an API call, we can add a state migration to avoid a
false positive diff that requires people to plan and apply but doesn't
actually make an API call.