### PR TITLE
provider/aws: fix the datasource aws_route_table, support for id argument

### DIFF
--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceAwsRouteTable(t *testing.T) {
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_tag"),
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_filter"),
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_subnet"),
+					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_id"),
 				),
 			},
 		},
@@ -129,4 +130,8 @@ data "aws_route_table" "by_subnet" {
   depends_on = ["aws_route_table_association.a"]
 }
 
+data "aws_route_table" "by_id" {
+  id = "${aws_route_table.test.id}"
+  depends_on = ["aws_route_table_association.a"]
+}
 `


### PR DESCRIPTION
This PR implements the `id` argument in the datasource `aws_route_table`.

But I hava an issue in the tests:
```
vagrant@terraform:/opt/gopath/src/github.com/hashicorp/terraform$ TF_ACC=true go test  -v github.com/hashicorp/terraform/builtin/providers/aws -run ^TestAccDataSourceAwsRouteTable$
=== RUN   TestAccDataSourceAwsRouteTable
--- FAIL: TestAccDataSourceAwsRouteTable (25.74s)
	testing.go:265: Step 0 error: After applying this step and refreshing, the plan was not empty:

		DIFF:

		UPDATE: data.aws_route_table.by_filter
		  associations.#:                    "" => "<computed>"
		  filter.#:                          "0" => "1"
		  filter.407483565.name:             "" => "association.route-table-association-id"
		  filter.407483565.values.#:         "0" => "1"
		  filter.407483565.values.187076141: "" => "rtbassoc-91d286f9"
		  routes.#:                          "" => "<computed>"
		  subnet_id:                         "" => "<computed>"
		  tags.%:                            "" => "<computed>"
		  vpc_id:                            "" => "<computed>"
		UPDATE: data.aws_route_table.by_id
		  associations.#: "" => "<computed>"
		  routes.#:       "" => "<computed>"
		  subnet_id:      "" => "<computed>"
		  tags.%:         "" => "<computed>"
		  vpc_id:         "" => "<computed>"
		UPDATE: data.aws_route_table.by_subnet
		  associations.#: "" => "<computed>"
		  routes.#:       "" => "<computed>"
		  subnet_id:      "" => "subnet-de3be8a4"
		  tags.%:         "" => "<computed>"
		  vpc_id:         "" => "<computed>"
		UPDATE: data.aws_route_table.by_tag
		  associations.#: "" => "<computed>"
		  routes.#:       "" => "<computed>"
		  subnet_id:      "" => "<computed>"
		  tags.%:         "0" => "1"
		  tags.Name:      "" => "terraform-testacc-routetable-data-source"
		  vpc_id:         "" => "<computed>"

		STATE:

		aws_route_table.test:
		  ID = rtb-c94bffa1
		  propagating_vgws.# = 0
		  route.# = 0
		  tags.% = 1
		  tags.Name = terraform-testacc-routetable-data-source
		  vpc_id = vpc-28965f40

		  Dependencies:
		    aws_vpc.test
		aws_route_table_association.a:
		  ID = rtbassoc-91d286f9
		  route_table_id = rtb-c94bffa1
		  subnet_id = subnet-de3be8a4

```

Can you explain me how to fix this please ?
Thanks