### PR TITLE
Fix contradiction in terms with provider documentation (#10815)

### DIFF
--- a/builtin/providers/scaleway/provider.go
+++ b/builtin/providers/scaleway/provider.go
@@ -14,13 +14,21 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SCALEWAY_ACCESS_KEY", nil),
+				Deprecated:  "Use `token` instead.",
+				Description: "The API key for Scaleway API operations.",
+			},
+
+			"token": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SCALEWAY_TOKEN", nil),
 				Description: "The API key for Scaleway API operations.",
 			},
 			"organization": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("SCALEWAY_ORGANIZATION", nil),
-				Description: "The Organization ID for Scaleway API operations.",
+				Description: "The Organization ID (a.k.a. 'access key') for Scaleway API operations.",
 			},
 			"region": &schema.Schema{
 				Type:        schema.TypeString,
@@ -51,9 +59,18 @@ func Provider() terraform.ResourceProvider {
 var scalewayMutexKV = mutexkv.NewMutexKV()
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	apiKey := ""
+	if v, ok := d.Get("token").(string); ok {
+		apiKey = v
+	} else {
+		if v, ok := d.Get("access_key").(string); ok {
+			apiKey = v
+		}
+	}
+
 	config := Config{
 		Organization: d.Get("organization").(string),
-		APIKey:       d.Get("access_key").(string),
+		APIKey:       apiKey,
 		Region:       d.Get("region").(string),
 	}
 

--- a/builtin/providers/scaleway/provider_test.go
+++ b/builtin/providers/scaleway/provider_test.go
@@ -32,7 +32,7 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("SCALEWAY_ORGANIZATION"); v == "" {
 		t.Fatal("SCALEWAY_ORGANIZATION must be set for acceptance tests")
 	}
-	if v := os.Getenv("SCALEWAY_ACCESS_KEY"); v == "" {
-		t.Fatal("SCALEWAY_ACCESS_KEY must be set for acceptance tests")
+	if v := os.Getenv("SCALEWAY_TOKEN"); v == "" {
+		t.Fatal("SCALEWAY_TOKEN must be set for acceptance tests")
 	}
 }

--- a/website/source/docs/providers/scaleway/index.html.markdown
+++ b/website/source/docs/providers/scaleway/index.html.markdown
@@ -85,13 +85,13 @@ you can leave them out:
 ```
 provider "scaleway" {
   organization = ""
-  access_key = ""
+  token = ""
   region = "par1"
 }
 ```
 
 ...and instead set these environment variables:
 
-- **SCALEWAY_ORGANIZATION**: Your Scaleway organization `access key`
-- **SCALEWAY_ACCESS_KEY**: Your API access `token`
+- **SCALEWAY_ORGANIZATION**: Your Scaleway `organization` access key
+- **SCALEWAY_TOKEN**: Your API access `token`
 - **SCALEWAY_REGION**: The Scaleway region

--- a/website/source/docs/providers/scaleway/index.html.markdown
+++ b/website/source/docs/providers/scaleway/index.html.markdown
@@ -3,7 +3,7 @@ layout: "scaleway"
 page_title: "Provider: Scaleway"
 sidebar_current: "docs-scaleway-index"
 description: |-
-  The Scaleway provider is used to interact with Scaleway ARM cloud provider.
+  The Scaleway provider is used to interact with Scaleway bare metal & VPS provider.
 ---
 
 # Scaleway Provider

--- a/website/source/docs/providers/scaleway/r/ip.html.markdown
+++ b/website/source/docs/providers/scaleway/r/ip.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # scaleway\_ip
 
-Provides IPs for ARM servers. This allows IPs to be created, updated and deleted.
+Provides IPs for servers. This allows IPs to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#ips).
 
 ## Example Usage
@@ -22,7 +22,7 @@ resource "scaleway_ip" "test_ip" {
 
 The following arguments are supported:
 
-* `server` - (Optional) ID of ARM server to associate IP with
+* `server` - (Optional) ID of server to associate IP with
 
 Field `server` is editable.
 

--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # scaleway\_server
 
-Provides ARM servers. This allows servers to be created, updated and deleted.
+Provides servers. This allows servers to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#servers).
 
 ## Example Usage
@@ -30,9 +30,9 @@ resource "scaleway_server" "test" {
 
 The following arguments are supported:
 
-* `name` - (Required) name of ARM server
-* `image` - (Required) base image of ARM server
-* `type` - (Required) type of ARM server
+* `name` - (Required) name of server
+* `image` - (Required) base image of server
+* `type` - (Required) type of server
 * `bootscript` - (Optional) server bootscript
 * `tags` - (Optional) list of tags for server
 * `enable_ipv6` - (Optional) enable ipv6

--- a/website/source/docs/providers/scaleway/r/volume.html.markdown
+++ b/website/source/docs/providers/scaleway/r/volume.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # scaleway\_volume
 
-Provides ARM volumes. This allows volumes to be created, updated and deleted.
+Provides volumes. This allows volumes to be created, updated and deleted.
 For additional details please refer to [API documentation](https://developer.scaleway.com/#volumes).
 
 ## Example Usage


### PR DESCRIPTION
This PR fixes a contradiction in the API access terminology used by Scaleway and Terraform; each previously using `access_key` for different parameters. Discussion in #10815.

I've also included a removal of 'ARM' from the documentation (e.g. 'ARM server') to reflect the fact that Scaleway now also provides x86 servers.