### PR TITLE
provider/pagerduty Add delete support to pagerduty_service_integration

### DIFF
--- a/builtin/providers/pagerduty/errors.go
+++ b/builtin/providers/pagerduty/errors.go
@@ -1,0 +1,11 @@
+package pagerduty
+
+import "strings"
+
+func isNotFound(err error) bool {
+	if strings.Contains(err.Error(), "Failed call API endpoint. HTTP response code: 404") {
+		return true
+	}
+
+	return false
+}

--- a/vendor/github.com/PagerDuty/go-pagerduty/incident.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/incident.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -39,6 +40,7 @@ type Incident struct {
 	EscalationPolicy     APIObject         `json:"escalation_policy,omitempty"`
 	Teams                []APIObject       `json:"teams,omitempty"`
 	Urgency              string            `json:"urgency,omitempty"`
+	Status               string            `json:"status,omitempty"`
 }
 
 // ListIncidentsResponse is the response structure when calling the ListIncident API endpoint.
@@ -144,4 +146,32 @@ func (c *Client) SnoozeIncident(id string, duration uint) error {
 	data["duration"] = duration
 	_, err := c.post("/incidents/"+id+"/snooze", data)
 	return err
+}
+
+// ListIncidentLogEntriesResponse is the response structure when calling the ListIncidentLogEntires API endpoint.
+type ListIncidentLogEntriesResponse struct {
+	APIListObject
+	LogEntires []LogEntry `json:"log_entries,omitempty"`
+}
+
+// ListIncidentLogEntriesOptions is the structure used when passing parameters to the ListIncidentLogEntires API endpoint.
+type ListIncidentLogEntriesOptions struct {
+	APIListObject
+	Includes   []string `url:"include,omitempty,brackets"`
+	IsOverview bool     `url:"is_overview,omitempty"`
+	TimeZone   string   `url:"time_zone,omitempty"`
+}
+
+// ListIncidentLogEntries lists existing log entires for the specified incident.
+func (c *Client) ListIncidentLogEntries(id string, o ListIncidentLogEntriesOptions) (*ListIncidentLogEntriesResponse, error) {
+	v, err := query.Values(o)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.get("/incidents/" + id + "/log_entries?" + v.Encode())
+	if err != nil {
+		return nil, err
+	}
+	var result ListIncidentLogEntriesResponse
+	return &result, c.decodeJSON(resp, &result)
 }

--- a/vendor/github.com/PagerDuty/go-pagerduty/log_entry.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/log_entry.go
@@ -2,6 +2,7 @@ package pagerduty
 
 import (
 	"fmt"
+
 	"github.com/google/go-querystring/query"
 )
 
@@ -13,16 +14,26 @@ type Channel struct {
 	Type string
 }
 
+// Context are to be included with the trigger such as links to graphs or images.
+type Context struct {
+	Alt  string
+	Href string
+	Src  string
+	Text string
+	Type string
+}
+
 // LogEntry is a list of all of the events that happened to an incident.
 type LogEntry struct {
 	APIObject
-	CreatedAt    string `json:"created_at"`
-	Agent        Agent
-	Channel      Channel
-	Incident     Incident
-	Teams        []Team
-	Contexts     []string
-	EventDetails map[string]string
+	CreatedAt              string `json:"created_at"`
+	Agent                  Agent
+	Channel                Channel
+	Incident               Incident
+	Teams                  []Team
+	Contexts               []Context
+	AcknowledgementTimeout int `json:"acknowledgement_timeout"`
+	EventDetails           map[string]string
 }
 
 // ListLogEntryResponse is the response data when calling the ListLogEntry API endpoint.

--- a/vendor/github.com/PagerDuty/go-pagerduty/service.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/service.go
@@ -165,7 +165,7 @@ func (c *Client) UpdateIntegration(serviceID string, i Integration) (*Integratio
 
 // DeleteIntegration deletes an existing integration.
 func (c *Client) DeleteIntegration(serviceID string, integrationID string) error {
-	_, err := c.delete("/services/" + serviceID + "/integrations" + integrationID)
+	_, err := c.delete("/services/" + serviceID + "/integrations/" + integrationID)
 	return err
 }
 

--- a/vendor/github.com/PagerDuty/go-pagerduty/webhook.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/webhook.go
@@ -16,7 +16,7 @@ type IncidentDetail struct {
 	AssignedToUser        *json.RawMessage `json:"assigned_to_user"`
 	AssignedTo            []string         `json:"assigned_to"`
 	TriggerSummaryData    *json.RawMessage `json:"trigger_summary_data"`
-	TriggerDeatilsHTMLUrl string           `json:"trigger_details_html_url"`
+	TriggerDetailsHTMLUrl string           `json:"trigger_details_html_url"`
 }
 
 // WebhookPayload is a single message array for a webhook.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -333,10 +333,10 @@
 			"revisionTime": "2016-11-03T18:56:17Z"
 		},
 		{
-			"checksumSHA1": "yAhUY67XCnf+0jpIsQ53lirk+GM=",
+			"checksumSHA1": "wzzdybMOEWsQ/crdkpTLneeob2U=",
 			"path": "github.com/PagerDuty/go-pagerduty",
-			"revision": "b98d93d395cd13b0438ad908b5f7c608f1f74c38",
-			"revisionTime": "2016-12-16T21:25:03Z"
+			"revision": "317bca1364fc322f4d6f8eeb276e931b6667b43b",
+			"revisionTime": "2016-12-20T22:05:08Z"
 		},
 		{
 			"path": "github.com/Unknwon/com",

--- a/website/source/docs/providers/pagerduty/r/service_integration.html.markdown
+++ b/website/source/docs/providers/pagerduty/r/service_integration.html.markdown
@@ -10,9 +10,6 @@ description: |-
 
 A [service integration](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/post_services_id_integrations) is an integration that belongs to a service.
 
-`Note`: A service integration `cannot` be deleted via Terraform nor the PagerDuty API so if you remove a service integration, be sure to remove it from the PagerDuty Web UI afterwards. However, if you delete the `service` attached to the `integration`, the integration will be removed.
-
-
 ## Example Usage
 
 ```


### PR DESCRIPTION
This PR adds `delete` support for `pagerduty_service_integration`. 
This was previously not possible and unfortunately not documented in the PagerDuty API reference.

Also added a `isNotFound` function that can be re-used across the different resources.