### PR TITLE
removes region param from google_compute_backend_service

### DIFF
--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -117,12 +117,6 @@ func resourceComputeBackendService() *schema.Resource {
 				Computed: true,
 			},
 
-			"region": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,

--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -117,6 +117,13 @@ func resourceComputeBackendService() *schema.Resource {
 				Computed: true,
 			},
 
+			"region": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				ForceNew:   true,
+				Deprecated: "This parameter has been removed as it was never used",
+			},
+
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -86,16 +86,12 @@ The following arguments are supported:
 * `protocol` - (Optional) The protocol for incoming requests. Defaults to
     `HTTP`.
 
-* `region` - (Optional) The Region in which the created address should reside.
-    If it is not provided, the provider region is used.
-
-* `session_affinity` - (Optional) How to distribute load. Options are `NONE` (no
-    affinity), `CLIENT_IP` (hash of the source/dest addresses / ports), and
-    `GENERATED_COOKIE` (distribute load using a generated session cookie).
+* `session_affinity` - (Optional) How to distribute load. Options are "NONE" (no
+    affinity), "CLIENT\_IP" (hash of the source/dest addresses / ports), and
+    "GENERATED\_COOKIE" (distribute load using a generated session cookie).
 
 * `timeout_sec` - (Optional) The number of secs to wait for a backend to respond
     to a request before considering the request failed. Defaults to `30`.
-
 
 **Backend** supports the following attributes:
 

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -86,9 +86,9 @@ The following arguments are supported:
 * `protocol` - (Optional) The protocol for incoming requests. Defaults to
     `HTTP`.
 
-* `session_affinity` - (Optional) How to distribute load. Options are "NONE" (no
-    affinity), "CLIENT\_IP" (hash of the source/dest addresses / ports), and
-    "GENERATED\_COOKIE" (distribute load using a generated session cookie).
+* `session_affinity` - (Optional) How to distribute load. Options are `NONE` (no
+    affinity), `CLIENT_IP` (hash of the source/dest addresses / ports), and
+    `GENERATED_COOKIE` (distribute load using a generated session cookie).
 
 * `timeout_sec` - (Optional) The number of secs to wait for a backend to respond
     to a request before considering the request failed. Defaults to `30`.


### PR DESCRIPTION
- this param was not being used in this service
- you need a regional_backend_service if you want to pass this
- docs also updated