### PR TITLE
provider/aws: Set aws_autoscaling_policy metric_aggregation_type to be Computed

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_policy.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_policy.go
@@ -54,6 +54,7 @@ func resourceAwsAutoscalingPolicy() *schema.Resource {
 			"metric_aggregation_type": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"min_adjustment_magnitude": &schema.Schema{
 				Type:     schema.TypeInt,


### PR DESCRIPTION
Fixes: #10887

In the Terraform documentation, we say the following:

```
metric_aggregation_type - (Optional) The aggregation type for the policy's metrics. Valid values are "Minimum", "Maximum", and "Average". Without a value, AWS will treat the aggregation type as "Average".
```

Therefore, because the parameter wasn't set as computed, we got a diff as follows:

```
~ aws_autoscaling_policy.scale
    metric_aggregation_type: "Average" => ""
```

With the change in place, we get the correct behaviour

```
% terraform plan
[WARN] /Users/stacko/Code/go/bin/terraform-provider-aws overrides an internal plugin for aws-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but
will not be persisted to local or remote state storage.

aws_launch_configuration.launch: Refreshing state... (ID: config)
aws_autoscaling_group.asg: Refreshing state... (ID: asg)
aws_autoscaling_policy.scale: Refreshing state... (ID: scale)

No changes. Infrastructure is up-to-date. This means that Terraform
could not detect any differences between your configuration and
the real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```