### PR TITLE
provider/aws: Fixed the need of sending S3 Replication StorageClass when not set

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -1428,12 +1428,11 @@ func resourceAwsS3BucketReplicationConfigurationUpdate(s3conn *s3.S3, d *schema.
 			bd := dest[0].(map[string]interface{})
 			ruleDestination.Bucket = aws.String(bd["bucket"].(string))
 
-			if storageClass, ok := bd["storage_class"]; ok {
+			if storageClass, ok := bd["storage_class"]; ok && storageClass != "" {
 				ruleDestination.StorageClass = aws.String(storageClass.(string))
 			}
 		}
 		rcRule.Destination = ruleDestination
-
 		rules = append(rules, rcRule)
 	}
 


### PR DESCRIPTION
### Description
Fixes https://github.com/hashicorp/terraform/issues/10909

### Acceptance test
```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3Bucket_ReplicationWithoutStorageClass'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2016/12/24 11:43:54 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3Bucket_ReplicationWithoutStorageClass -timeout 120m
=== RUN   TestAccAWSS3Bucket_ReplicationWithoutStorageClass
--- PASS: TestAccAWSS3Bucket_ReplicationWithoutStorageClass (80.27s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	80.302s
```

Merry Christmas all!  😄 🎄 🎅 