### PR TITLE
provider/postgresql: Quote connection string parameters

### DIFF
--- a/builtin/providers/postgresql/GNUmakefile
+++ b/builtin/providers/postgresql/GNUmakefile
@@ -4,7 +4,8 @@ PSQL?=/opt/local/lib/postgresql96/bin/psql
 PGDATA?=$(GOPATH)/src/github.com/hashicorp/terraform/builtin/providers/postgresql/data
 
 initdb::
-	/opt/local/lib/postgresql96/bin/initdb --no-locale -U postgres -D $(PGDATA)
+	echo "" > pwfile
+	/opt/local/lib/postgresql96/bin/initdb --no-locale -U postgres -A md5 --pwfile=pwfile -D $(PGDATA)
 
 startdb::
 	2>&1 \
@@ -18,6 +19,7 @@ startdb::
 
 cleandb::
 	rm -rf $(PGDATA)
+	rm -f pwfile
 
 freshdb:: cleandb initdb startdb
 

--- a/builtin/providers/postgresql/config.go
+++ b/builtin/providers/postgresql/config.go
@@ -31,7 +31,7 @@ type Client struct {
 func (c *Config) NewClient() (*Client, error) {
 	// NOTE: dbname must come before user otherwise dbname will be set to
 	// user.
-	const dsnFmt = "host=%s port=%d dbname=%s user=%s password=%s sslmode=%s fallback_application_name=%s connect_timeout=%d"
+	const dsnFmt = "host='%s' port='%d' dbname='%s' user='%s' password='%s' sslmode='%s' fallback_application_name='%s' connect_timeout='%d'"
 
 	logDSN := fmt.Sprintf(dsnFmt, c.Host, c.Port, c.Database, c.Username, "<redacted>", c.SSLMode, c.ApplicationName, c.ConnectTimeoutSec)
 	log.Printf("[INFO] PostgreSQL DSN: `%s`", logDSN)

--- a/builtin/providers/postgresql/provider.go
+++ b/builtin/providers/postgresql/provider.go
@@ -112,11 +112,10 @@ func tfAppName() string {
 	const VersionPrerelease = terraform.VersionPrerelease
 	var versionString bytes.Buffer
 
-	fmt.Fprintf(&versionString, "'Terraform v%s", terraform.Version)
+	fmt.Fprintf(&versionString, "Terraform v%s", terraform.Version)
 	if terraform.VersionPrerelease != "" {
 		fmt.Fprintf(&versionString, "-%s", terraform.VersionPrerelease)
 	}
-	fmt.Fprintf(&versionString, "'")
 
 	return versionString.String()
 }


### PR DESCRIPTION
Build upon what @idubinskiy correctly identified and properly escape DSN parameters when connecting to PostgreSQL.

CC @stack72 

Fixes: #10915