### PR TITLE
provider/docker: Add network create --internal flag support

### DIFF
--- a/builtin/providers/docker/resource_docker_network.go
+++ b/builtin/providers/docker/resource_docker_network.go
@@ -42,6 +42,13 @@ func resourceDockerNetwork() *schema.Resource {
 				Computed: true,
 			},
 
+			"internal": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"ipam_driver": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/builtin/providers/docker/resource_docker_network_funcs.go
+++ b/builtin/providers/docker/resource_docker_network_funcs.go
@@ -55,7 +55,9 @@ func resourceDockerNetworkCreate(d *schema.ResourceData, meta interface{}) error
 	d.Set("scope", retNetwork.Scope)
 	d.Set("driver", retNetwork.Driver)
 	d.Set("options", retNetwork.Options)
-	d.Set("internal", retNetwork.Internal)
+
+	// The 'internal' property is not send back when create network
+	d.Set("internal", createOpts.Internal)
 
 	return nil
 }

--- a/builtin/providers/docker/resource_docker_network_funcs.go
+++ b/builtin/providers/docker/resource_docker_network_funcs.go
@@ -22,6 +22,9 @@ func resourceDockerNetworkCreate(d *schema.ResourceData, meta interface{}) error
 	if v, ok := d.GetOk("options"); ok {
 		createOpts.Options = v.(map[string]interface{})
 	}
+	if v, ok := d.GetOk("internal"); ok {
+		createOpts.Internal = v.(bool)
+	}
 
 	ipamOpts := dc.IPAMOptions{}
 	ipamOptsSet := false
@@ -52,6 +55,7 @@ func resourceDockerNetworkCreate(d *schema.ResourceData, meta interface{}) error
 	d.Set("scope", retNetwork.Scope)
 	d.Set("driver", retNetwork.Driver)
 	d.Set("options", retNetwork.Options)
+	d.Set("internal", retNetwork.Internal)
 
 	return nil
 }
@@ -74,6 +78,7 @@ func resourceDockerNetworkRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("scope", retNetwork.Scope)
 	d.Set("driver", retNetwork.Driver)
 	d.Set("options", retNetwork.Options)
+	d.Set("internal", retNetwork.Internal)
 
 	return nil
 }

--- a/builtin/providers/docker/resource_docker_network_test.go
+++ b/builtin/providers/docker/resource_docker_network_test.go
@@ -63,3 +63,37 @@ resource "docker_network" "foo" {
   name = "bar"
 }
 `
+
+func TestAccDockerNetwork_internal(t *testing.T) {
+	var n dc.Network
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDockerNetworkInternalConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccNetwork("docker_network.foobar", &n),
+					testAccNetworkInternal(&n, true),
+				),
+			},
+		},
+	})
+}
+
+func testAccNetworkInternal(network *dc.Network, internal bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if network.Internal != internal {
+			return fmt.Errorf("Bad value for attribute 'internal': %t", network.Internal)
+		}
+		return nil
+	}
+}
+
+const testAccDockerNetworkInternalConfig = `
+resource "docker_network" "foobar" {
+  name = "foobar"
+  internal = "true"
+}
+`

--- a/website/source/docs/providers/docker/r/network.html.markdown
+++ b/website/source/docs/providers/docker/r/network.html.markdown
@@ -34,6 +34,8 @@ The following arguments are supported:
   `bridge` driver.
 * `options` - (Optional, map of strings) Network specific options to be used by
   the drivers.
+* `internal` - (Optional, boolean) Restrict external access to the network.
+  Defaults to `false`.
 * `ipam_driver` - (Optional, string) Driver used by the custom IP scheme of the
   network.
 * `ipam_config` - (Optional, block) See [IPAM config](#ipam_config) below for


### PR DESCRIPTION
Add support for the `--internal` flag of the docker command `docker network create`