### PR TITLE
core: stoppable provisioners, helper/schema for provisioners

### DIFF
--- a/builtin/bins/provisioner-file/main.go
+++ b/builtin/bins/provisioner-file/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/file"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(file.ResourceProvisioner)
-		},
+		ProvisionerFunc: file.Provisioner,
 	})
 }

--- a/builtin/bins/provisioner-local-exec/main.go
+++ b/builtin/bins/provisioner-local-exec/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/local-exec"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(localexec.ResourceProvisioner)
-		},
+		ProvisionerFunc: localexec.Provisioner,
 	})
 }

--- a/builtin/bins/provisioner-remote-exec/main.go
+++ b/builtin/bins/provisioner-remote-exec/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(remoteexec.ResourceProvisioner)
-		},
+		ProvisionerFunc: remoteexec.Provisioner,
 	})
 }

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -132,6 +132,11 @@ type Provisioner struct {
 // ResourceProvisioner represents a generic chef provisioner
 type ResourceProvisioner struct{}
 
+func (r *ResourceProvisioner) Stop() error {
+	// Noop for now. TODO in the future.
+	return nil
+}
+
 // Apply executes the file provisioner
 func (r *ResourceProvisioner) Apply(
 	o terraform.UIOutput,

--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -40,11 +40,11 @@ func Provisioner() terraform.ResourceProvisioner {
 }
 
 func applyFn(ctx context.Context) error {
-	connData := ctx.Value(schema.ProvConnDataKey).(*schema.ResourceData)
+	connState := ctx.Value(schema.ProvRawStateKey).(*terraform.InstanceState)
 	data := ctx.Value(schema.ProvConfigDataKey).(*schema.ResourceData)
 
 	// Get a new communicator
-	comm, err := communicator.NewData(connData)
+	comm, err := communicator.New(connState)
 	if err != nil {
 		return err
 	}

--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -8,26 +9,48 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 )
 
-// ResourceProvisioner represents a file provisioner
-type ResourceProvisioner struct{}
+func Provisioner() terraform.ResourceProvisioner {
+	return &schema.Provisioner{
+		Schema: map[string]*schema.Schema{
+			"source": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"content"},
+			},
 
-// Apply executes the file provisioner
-func (p *ResourceProvisioner) Apply(
-	o terraform.UIOutput,
-	s *terraform.InstanceState,
-	c *terraform.ResourceConfig) error {
+			"content": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"source"},
+			},
+
+			"destination": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+
+		ApplyFunc: applyFn,
+	}
+}
+
+func applyFn(ctx context.Context) error {
+	connData := ctx.Value(schema.ProvConnDataKey).(*schema.ResourceData)
+	data := ctx.Value(schema.ProvConfigDataKey).(*schema.ResourceData)
+
 	// Get a new communicator
-	comm, err := communicator.New(s)
+	comm, err := communicator.NewData(connData)
 	if err != nil {
 		return err
 	}
 
 	// Get the source
-	src, deleteSource, err := p.getSrc(c)
+	src, deleteSource, err := getSrc(data)
 	if err != nil {
 		return err
 	}
@@ -36,57 +59,20 @@ func (p *ResourceProvisioner) Apply(
 	}
 
 	// Get destination
-	dRaw := c.Config["destination"]
-	dst, ok := dRaw.(string)
-	if !ok {
-		return fmt.Errorf("Unsupported 'destination' type! Must be string.")
-	}
-	return p.copyFiles(comm, src, dst)
-}
-
-// Validate checks if the required arguments are configured
-func (p *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string, es []error) {
-	numDst := 0
-	numSrc := 0
-	for name := range c.Raw {
-		switch name {
-		case "destination":
-			numDst++
-		case "source", "content":
-			numSrc++
-		default:
-			es = append(es, fmt.Errorf("Unknown configuration '%s'", name))
-		}
-	}
-	if numSrc != 1 || numDst != 1 {
-		es = append(es, fmt.Errorf("Must provide one  of 'content' or 'source' and 'destination' to file"))
-	}
-	return
+	dst := data.Get("destination").(string)
+	return copyFiles(comm, src, dst)
 }
 
 // getSrc returns the file to use as source
-func (p *ResourceProvisioner) getSrc(c *terraform.ResourceConfig) (string, bool, error) {
-	var src string
-
-	sRaw, ok := c.Config["source"]
-	if ok {
-		if src, ok = sRaw.(string); !ok {
-			return "", false, fmt.Errorf("Unsupported 'source' type! Must be string.")
-		}
-	}
-
-	content, ok := c.Config["content"]
-	if ok {
+func getSrc(data *schema.ResourceData) (string, bool, error) {
+	src := data.Get("source").(string)
+	if content, ok := data.GetOk("content"); ok {
 		file, err := ioutil.TempFile("", "tf-file-content")
 		if err != nil {
 			return "", true, err
 		}
 
-		contentStr, ok := content.(string)
-		if !ok {
-			return "", true, fmt.Errorf("Unsupported 'content' type! Must be string.")
-		}
-		if _, err = file.WriteString(contentStr); err != nil {
+		if _, err = file.WriteString(content.(string)); err != nil {
 			return "", true, err
 		}
 
@@ -98,7 +84,7 @@ func (p *ResourceProvisioner) getSrc(c *terraform.ResourceConfig) (string, bool,
 }
 
 // copyFiles is used to copy the files from a source to a destination
-func (p *ResourceProvisioner) copyFiles(comm communicator.Communicator, src, dst string) error {
+func copyFiles(comm communicator.Communicator, src, dst string) error {
 	// Wait and retry until we establish the connection
 	err := retryFunc(comm.Timeout(), func() error {
 		err := comm.Connect(nil)

--- a/builtin/provisioners/file/resource_provisioner_test.go
+++ b/builtin/provisioners/file/resource_provisioner_test.go
@@ -7,16 +7,12 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceProvisioner_impl(t *testing.T) {
-	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
-}
-
 func TestResourceProvider_Validate_good_source(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source":      "/tmp/foo",
 		"destination": "/tmp/bar",
 	})
-	p := new(ResourceProvisioner)
+	p := Provisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -31,7 +27,7 @@ func TestResourceProvider_Validate_good_content(t *testing.T) {
 		"content":     "value to copy",
 		"destination": "/tmp/bar",
 	})
-	p := new(ResourceProvisioner)
+	p := Provisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -45,7 +41,7 @@ func TestResourceProvider_Validate_bad_not_destination(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source": "nope",
 	})
-	p := new(ResourceProvisioner)
+	p := Provisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -61,7 +57,7 @@ func TestResourceProvider_Validate_bad_to_many_src(t *testing.T) {
 		"content":     "value to copy",
 		"destination": "/tmp/bar",
 	})
-	p := new(ResourceProvisioner)
+	p := Provisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)

--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -72,15 +72,14 @@ func applyFn(ctx context.Context) error {
 	err := cmd.Start()
 	if err == nil {
 		// Wait for the command to complete in a goroutine
-		doneCh := make(chan struct{})
+		doneCh := make(chan error, 1)
 		go func() {
-			defer close(doneCh)
-			err = cmd.Wait()
+			doneCh <- cmd.Wait()
 		}()
 
 		// Wait for the command to finish or for us to be interrupted
 		select {
-		case <-doneCh:
+		case err = <-doneCh:
 		case <-ctx.Done():
 			cmd.Process.Kill()
 			err = cmd.Wait()

--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -1,13 +1,14 @@
 package localexec
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os/exec"
 	"runtime"
 
 	"github.com/armon/circbuf"
-	"github.com/hashicorp/terraform/helper/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-linereader"
 )
@@ -19,21 +20,26 @@ const (
 	maxBufSize = 8 * 1024
 )
 
-type ResourceProvisioner struct{}
+func Provisioner() terraform.ResourceProvisioner {
+	return &schema.Provisioner{
+		Schema: map[string]*schema.Schema{
+			"command": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
 
-func (p *ResourceProvisioner) Apply(
-	o terraform.UIOutput,
-	s *terraform.InstanceState,
-	c *terraform.ResourceConfig) error {
-
-	// Get the command
-	commandRaw, ok := c.Config["command"]
-	if !ok {
-		return fmt.Errorf("local-exec provisioner missing 'command'")
+		ApplyFunc: applyFn,
 	}
-	command, ok := commandRaw.(string)
-	if !ok {
-		return fmt.Errorf("local-exec provisioner command must be a string")
+}
+
+func applyFn(ctx context.Context) error {
+	data := ctx.Value(schema.ProvConfigDataKey).(*schema.ResourceData)
+	o := ctx.Value(schema.ProvOutputKey).(terraform.UIOutput)
+
+	command := data.Get("command").(string)
+	if command == "" {
+		return fmt.Errorf("local-exec provisioner command must be a non-empty string")
 	}
 
 	// Execute the command using a shell
@@ -49,7 +55,7 @@ func (p *ResourceProvisioner) Apply(
 	// Setup the reader that will read the lines from the command
 	pr, pw := io.Pipe()
 	copyDoneCh := make(chan struct{})
-	go p.copyOutput(o, pr, copyDoneCh)
+	go copyOutput(o, pr, copyDoneCh)
 
 	// Setup the command
 	cmd := exec.Command(shell, flag, command)
@@ -78,15 +84,7 @@ func (p *ResourceProvisioner) Apply(
 	return nil
 }
 
-func (p *ResourceProvisioner) Validate(c *terraform.ResourceConfig) ([]string, []error) {
-	validator := config.Validator{
-		Required: []string{"command"},
-	}
-	return validator.Validate(c)
-}
-
-func (p *ResourceProvisioner) copyOutput(
-	o terraform.UIOutput, r io.Reader, doneCh chan<- struct{}) {
+func copyOutput(o terraform.UIOutput, r io.Reader, doneCh chan<- struct{}) {
 	defer close(doneCh)
 	lr := linereader.New(r)
 	for line := range lr.Ch {

--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -10,10 +10,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestResourceProvisioner_impl(t *testing.T) {
-	var _ terraform.ResourceProvisioner = new(ResourceProvisioner)
-}
-
 func TestResourceProvider_Apply(t *testing.T) {
 	defer os.Remove("test_out")
 	c := testConfig(t, map[string]interface{}{
@@ -21,7 +17,7 @@ func TestResourceProvider_Apply(t *testing.T) {
 	})
 
 	output := new(terraform.MockUIOutput)
-	p := new(ResourceProvisioner)
+	p := Provisioner()
 	if err := p.Apply(output, nil, c); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -43,7 +39,7 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"command": "echo foo",
 	})
-	p := new(ResourceProvisioner)
+	p := Provisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
@@ -55,7 +51,7 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 
 func TestResourceProvider_Validate_missing(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{})
-	p := new(ResourceProvisioner)
+	p := Provisioner()
 	warn, errs := p.Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)

--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -23,6 +23,7 @@ func Provisioner() terraform.ResourceProvisioner {
 			"inline": &schema.Schema{
 				Type:          schema.TypeList,
 				Elem:          &schema.Schema{Type: schema.TypeString},
+				PromoteSingle: true,
 				Optional:      true,
 				ConflictsWith: []string{"script", "scripts"},
 			},

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -65,13 +65,15 @@ import (
 	vaultprovider "github.com/hashicorp/terraform/builtin/providers/vault"
 	vcdprovider "github.com/hashicorp/terraform/builtin/providers/vcd"
 	vsphereprovider "github.com/hashicorp/terraform/builtin/providers/vsphere"
-	chefresourceprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef"
-	fileresourceprovisioner "github.com/hashicorp/terraform/builtin/provisioners/file"
-	localexecresourceprovisioner "github.com/hashicorp/terraform/builtin/provisioners/local-exec"
-	remoteexecresourceprovisioner "github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
+	fileprovisioner "github.com/hashicorp/terraform/builtin/provisioners/file"
+	localexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/local-exec"
+	remoteexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
 
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
+
+	// Legacy, will remove once it conforms with new structure
+	chefprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef"
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
@@ -137,8 +139,13 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 }
 
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{
-	"chef":        func() terraform.ResourceProvisioner { return new(chefresourceprovisioner.ResourceProvisioner) },
-	"file":        func() terraform.ResourceProvisioner { return new(fileresourceprovisioner.ResourceProvisioner) },
-	"local-exec":  func() terraform.ResourceProvisioner { return new(localexecresourceprovisioner.ResourceProvisioner) },
-	"remote-exec": func() terraform.ResourceProvisioner { return new(remoteexecresourceprovisioner.ResourceProvisioner) },
+	"file":        fileprovisioner.Provisioner,
+	"local-exec":  localexecprovisioner.Provisioner,
+	"remote-exec": remoteexecprovisioner.Provisioner,
+}
+
+func init() {
+	// Legacy provisioners that don't match our heuristics for auto-finding
+	// built-in provisioners.
+	InternalProvisioners["chef"] = func() terraform.ResourceProvisioner { return new(chefprovisioner.ResourceProvisioner) }
 }

--- a/communicator/communicator.go
+++ b/communicator/communicator.go
@@ -8,7 +8,6 @@ import (
 	"github.com/hashicorp/terraform/communicator/remote"
 	"github.com/hashicorp/terraform/communicator/ssh"
 	"github.com/hashicorp/terraform/communicator/winrm"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -51,19 +50,4 @@ func New(s *terraform.InstanceState) (Communicator, error) {
 	default:
 		return nil, fmt.Errorf("connection type '%s' not supported", connType)
 	}
-}
-
-// NewData creates a new Communicator from a ResourceData structure that
-// represents the connection information.
-func NewData(d *schema.ResourceData) (Communicator, error) {
-	// Turn the ResourceData into a legacy-style ConnInfo struct that
-	// is used to instantiate the communicator.
-	raw := d.State()
-	state := &terraform.InstanceState{
-		Ephemeral: terraform.EphemeralState{
-			ConnInfo: raw.Attributes,
-		},
-	}
-
-	return New(state)
 }

--- a/communicator/communicator.go
+++ b/communicator/communicator.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform/communicator/remote"
 	"github.com/hashicorp/terraform/communicator/ssh"
 	"github.com/hashicorp/terraform/communicator/winrm"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -50,4 +51,19 @@ func New(s *terraform.InstanceState) (Communicator, error) {
 	default:
 		return nil, fmt.Errorf("connection type '%s' not supported", connType)
 	}
+}
+
+// NewData creates a new Communicator from a ResourceData structure that
+// represents the connection information.
+func NewData(d *schema.ResourceData) (Communicator, error) {
+	// Turn the ResourceData into a legacy-style ConnInfo struct that
+	// is used to instantiate the communicator.
+	raw := d.State()
+	state := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: raw.Attributes,
+		},
+	}
+
+	return New(state)
 }

--- a/helper/schema/field_reader_config.go
+++ b/helper/schema/field_reader_config.go
@@ -79,10 +79,35 @@ func (r *ConfigFieldReader) readField(
 
 	k := strings.Join(address, ".")
 	schema := schemaList[len(schemaList)-1]
+
+	// If we're getting the single element of a promoted list, then
+	// check to see if we have a single element we need to promote.
+	if address[len(address)-1] == "0" && len(schemaList) > 1 {
+		lastSchema := schemaList[len(schemaList)-2]
+		if lastSchema.Type == TypeList && lastSchema.PromoteSingle {
+			k := strings.Join(address[:len(address)-1], ".")
+			result, err := r.readPrimitive(k, schema)
+			if err == nil {
+				return result, nil
+			}
+		}
+	}
+
 	switch schema.Type {
 	case TypeBool, TypeFloat, TypeInt, TypeString:
 		return r.readPrimitive(k, schema)
 	case TypeList:
+		// If we support promotion then we first check if we have a lone
+		// value that we must promote.
+		// a value that is alone.
+		if schema.PromoteSingle {
+			result, err := r.readPrimitive(k, schema.Elem.(*Schema))
+			if err == nil && result.Exists {
+				result.Value = []interface{}{result.Value}
+				return result, nil
+			}
+		}
+
 		return readListField(&nestedConfigFieldReader{r}, address, schema)
 	case TypeMap:
 		return r.readMap(k, schema)

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -130,8 +130,10 @@ func (p *Provisioner) Apply(
 		// easily build a ResourceData structure. We do this by simply treating
 		// the conn info as configuration input.
 		raw := make(map[string]interface{})
-		for k, v := range s.Ephemeral.ConnInfo {
-			raw[k] = v
+		if s != nil {
+			for k, v := range s.Ephemeral.ConnInfo {
+				raw[k] = v
+			}
 		}
 
 		c, err := config.NewRawConfig(raw)

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -1,0 +1,173 @@
+package schema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Provisioner represents a resource provisioner in Terraform and properly
+// implements all of the ResourceProvisioner API.
+//
+// This higher level structure makes it much easier to implement a new or
+// custom provisioner for Terraform.
+//
+// The function callbacks for this structure are all passed a context object.
+// This context object has a number of pre-defined values that can be accessed
+// via the global functions defined in context.go.
+type Provisioner struct {
+	// ConnSchema is the schema for the connection settings for this
+	// provisioner.
+	//
+	// The keys of this map are the configuration keys, and the value is
+	// the schema describing the value of the configuration.
+	//
+	// NOTE: The value of connection keys can only be strings for now.
+	ConnSchema map[string]*Schema
+
+	// Schema is the schema for the usage of this provisioner.
+	//
+	// The keys of this map are the configuration keys, and the value is
+	// the schema describing the value of the configuration.
+	Schema map[string]*Schema
+
+	// ApplyFunc is the function for executing the provisioner. This is required.
+	// It is given a context. See the Provisioner struct docs for more
+	// information.
+	ApplyFunc func(ctx context.Context) error
+
+	stopCtx       context.Context
+	stopCtxCancel context.CancelFunc
+	stopOnce      sync.Once
+}
+
+// These constants are the keys that can be used to access data in
+// the context parameters for Provisioners.
+const (
+	connDataInvalid int = iota
+
+	// This returns a *ResourceData for the connection information.
+	// Guaranteed to never be nil.
+	ProvConnDataKey
+
+	// This returns a *ResourceData for the config information.
+	// Guaranteed to never be nil.
+	ProvConfigDataKey
+
+	// This returns a terraform.UIOutput. Guaranteed to never be nil.
+	ProvOutputKey
+)
+
+// InternalValidate should be called to validate the structure
+// of the provisioner.
+//
+// This should be called in a unit test to verify before release that this
+// structure is properly configured for use.
+func (p *Provisioner) InternalValidate() error {
+	if p == nil {
+		return errors.New("provisioner is nil")
+	}
+
+	var validationErrors error
+	{
+		sm := schemaMap(p.ConnSchema)
+		if err := sm.InternalValidate(sm); err != nil {
+			validationErrors = multierror.Append(validationErrors, err)
+		}
+	}
+
+	{
+		sm := schemaMap(p.Schema)
+		if err := sm.InternalValidate(sm); err != nil {
+			validationErrors = multierror.Append(validationErrors, err)
+		}
+	}
+
+	if p.ApplyFunc == nil {
+		validationErrors = multierror.Append(validationErrors, fmt.Errorf(
+			"ApplyFunc must not be nil"))
+	}
+
+	return validationErrors
+}
+
+// StopContext returns a context that checks whether a provisioner is stopped.
+func (p *Provisioner) StopContext() context.Context {
+	p.stopOnce.Do(p.stopInit)
+	return p.stopCtx
+}
+
+func (p *Provisioner) stopInit() {
+	p.stopCtx, p.stopCtxCancel = context.WithCancel(context.Background())
+}
+
+// Stop implementation of terraform.ResourceProvisioner interface.
+func (p *Provisioner) Stop() error {
+	p.stopOnce.Do(p.stopInit)
+	p.stopCtxCancel()
+	return nil
+}
+
+func (p *Provisioner) Validate(c *terraform.ResourceConfig) ([]string, []error) {
+	return schemaMap(p.Schema).Validate(c)
+}
+
+// Apply implementation of terraform.ResourceProvisioner interface.
+func (p *Provisioner) Apply(
+	o terraform.UIOutput,
+	s *terraform.InstanceState,
+	c *terraform.ResourceConfig) error {
+	var connData, configData *ResourceData
+
+	{
+		// We first need to turn the connection information into a
+		// terraform.ResourceConfig so that we can use that type to more
+		// easily build a ResourceData structure. We do this by simply treating
+		// the conn info as configuration input.
+		raw := make(map[string]interface{})
+		for k, v := range s.Ephemeral.ConnInfo {
+			raw[k] = v
+		}
+
+		c, err := config.NewRawConfig(raw)
+		if err != nil {
+			return err
+		}
+
+		sm := schemaMap(p.ConnSchema)
+		diff, err := sm.Diff(nil, terraform.NewResourceConfig(c))
+		if err != nil {
+			return err
+		}
+		connData, err = sm.Data(nil, diff)
+		if err != nil {
+			return err
+		}
+	}
+
+	{
+		// Build the configuration data. Doing this requires making a "diff"
+		// even though that's never used. We use that just to get the correct types.
+		configMap := schemaMap(p.Schema)
+		diff, err := configMap.Diff(nil, c)
+		if err != nil {
+			return err
+		}
+		configData, err = configMap.Data(nil, diff)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Build the context and call the function
+	ctx := p.StopContext()
+	ctx = context.WithValue(ctx, ProvConnDataKey, connData)
+	ctx = context.WithValue(ctx, ProvConfigDataKey, configData)
+	ctx = context.WithValue(ctx, ProvOutputKey, o)
+	return p.ApplyFunc(ctx)
+}

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -61,6 +61,10 @@ const (
 
 	// This returns a terraform.UIOutput. Guaranteed to never be nil.
 	ProvOutputKey
+
+	// This returns the raw InstanceState passed to Apply. Guaranteed to
+	// be set, but may be nil.
+	ProvRawStateKey
 )
 
 // InternalValidate should be called to validate the structure
@@ -171,5 +175,6 @@ func (p *Provisioner) Apply(
 	ctx = context.WithValue(ctx, ProvConnDataKey, connData)
 	ctx = context.WithValue(ctx, ProvConfigDataKey, configData)
 	ctx = context.WithValue(ctx, ProvOutputKey, o)
+	ctx = context.WithValue(ctx, ProvRawStateKey, s)
 	return p.ApplyFunc(ctx)
 }

--- a/helper/schema/provisioner_test.go
+++ b/helper/schema/provisioner_test.go
@@ -137,6 +137,42 @@ func TestProvisionerApply(t *testing.T) {
 	}
 }
 
+func TestProvisionerApply_nilState(t *testing.T) {
+	p := &Provisioner{
+		ConnSchema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeString,
+				Optional: true,
+			},
+		},
+
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+
+		ApplyFunc: func(ctx context.Context) error {
+			return nil
+		},
+	}
+
+	conf := map[string]interface{}{
+		"foo": 42,
+	}
+
+	c, err := config.NewRawConfig(conf)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	err = p.Apply(nil, nil, terraform.NewResourceConfig(c))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestProvisionerStop(t *testing.T) {
 	var p Provisioner
 

--- a/helper/schema/provisioner_test.go
+++ b/helper/schema/provisioner_test.go
@@ -1,0 +1,241 @@
+package schema
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestProvisioner_impl(t *testing.T) {
+	var _ terraform.ResourceProvisioner = new(Provisioner)
+}
+
+func TestProvisionerValidate(t *testing.T) {
+	cases := []struct {
+		Name   string
+		P      *Provisioner
+		Config map[string]interface{}
+		Err    bool
+	}{
+		{
+			"Basic required field",
+			&Provisioner{
+				Schema: map[string]*Schema{
+					"foo": &Schema{
+						Required: true,
+						Type:     TypeString,
+					},
+				},
+			},
+			nil,
+			true,
+		},
+
+		{
+			"Basic required field set",
+			&Provisioner{
+				Schema: map[string]*Schema{
+					"foo": &Schema{
+						Required: true,
+						Type:     TypeString,
+					},
+				},
+			},
+			map[string]interface{}{
+				"foo": "bar",
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			c, err := config.NewRawConfig(tc.Config)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			_, es := tc.P.Validate(terraform.NewResourceConfig(c))
+			if len(es) > 0 != tc.Err {
+				t.Fatalf("%d: %#v", i, es)
+			}
+		})
+	}
+}
+
+func TestProvisionerApply(t *testing.T) {
+	cases := []struct {
+		Name   string
+		P      *Provisioner
+		Conn   map[string]string
+		Config map[string]interface{}
+		Err    bool
+	}{
+		{
+			"Basic config",
+			&Provisioner{
+				ConnSchema: map[string]*Schema{
+					"foo": &Schema{
+						Type:     TypeString,
+						Optional: true,
+					},
+				},
+
+				Schema: map[string]*Schema{
+					"foo": &Schema{
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+
+				ApplyFunc: func(ctx context.Context) error {
+					cd := ctx.Value(ProvConnDataKey).(*ResourceData)
+					d := ctx.Value(ProvConfigDataKey).(*ResourceData)
+					if d.Get("foo").(int) != 42 {
+						return fmt.Errorf("bad config data")
+					}
+					if cd.Get("foo").(string) != "bar" {
+						return fmt.Errorf("bad conn data")
+					}
+
+					return nil
+				},
+			},
+			map[string]string{
+				"foo": "bar",
+			},
+			map[string]interface{}{
+				"foo": 42,
+			},
+			false,
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			c, err := config.NewRawConfig(tc.Config)
+			if err != nil {
+				t.Fatalf("err: %s", err)
+			}
+
+			state := &terraform.InstanceState{
+				Ephemeral: terraform.EphemeralState{
+					ConnInfo: tc.Conn,
+				},
+			}
+
+			err = tc.P.Apply(
+				nil, state, terraform.NewResourceConfig(c))
+			if err != nil != tc.Err {
+				t.Fatalf("%d: %s", i, err)
+			}
+		})
+	}
+}
+
+func TestProvisionerStop(t *testing.T) {
+	var p Provisioner
+
+	// Verify stopch blocks
+	ch := p.StopContext().Done()
+	select {
+	case <-ch:
+		t.Fatal("should not be stopped")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// Stop it
+	if err := p.Stop(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	select {
+	case <-ch:
+	case <-time.After(10 * time.Millisecond):
+		t.Fatal("should be stopped")
+	}
+}
+
+func TestProvisionerStop_apply(t *testing.T) {
+	p := &Provisioner{
+		ConnSchema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeString,
+				Optional: true,
+			},
+		},
+
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+
+		ApplyFunc: func(ctx context.Context) error {
+			<-ctx.Done()
+			return nil
+		},
+	}
+
+	conn := map[string]string{
+		"foo": "bar",
+	}
+
+	conf := map[string]interface{}{
+		"foo": 42,
+	}
+
+	c, err := config.NewRawConfig(conf)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	state := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: conn,
+		},
+	}
+
+	// Run the apply in a goroutine
+	doneCh := make(chan struct{})
+	go func() {
+		p.Apply(nil, state, terraform.NewResourceConfig(c))
+		close(doneCh)
+	}()
+
+	// Should block
+	select {
+	case <-doneCh:
+		t.Fatal("should not be done")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// Stop!
+	p.Stop()
+
+	select {
+	case <-doneCh:
+	case <-time.After(10 * time.Millisecond):
+		t.Fatal("should be done")
+	}
+}
+
+func TestProvisionerStop_stopFirst(t *testing.T) {
+	var p Provisioner
+
+	// Stop it
+	if err := p.Stop(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	select {
+	case <-p.StopContext().Done():
+	case <-time.After(10 * time.Millisecond):
+		t.Fatal("should be stopped")
+	}
+}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -583,6 +583,72 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
+			Name: "List decode with promotion",
+			Schema: map[string]*Schema{
+				"ports": &Schema{
+					Type:          TypeList,
+					Required:      true,
+					Elem:          &Schema{Type: TypeInt},
+					PromoteSingle: true,
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"ports": "5",
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"ports.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"ports.0": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "5",
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
+			Name: "List decode with promotion with list",
+			Schema: map[string]*Schema{
+				"ports": &Schema{
+					Type:          TypeList,
+					Required:      true,
+					Elem:          &Schema{Type: TypeInt},
+					PromoteSingle: true,
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"ports": []interface{}{"5"},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"ports.#": &terraform.ResourceAttrDiff{
+						Old: "0",
+						New: "1",
+					},
+					"ports.0": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "5",
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeList,
@@ -3583,6 +3649,40 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Config: nil,
 
 			Err: true,
+		},
+
+		"List with promotion": {
+			Schema: map[string]*Schema{
+				"ingress": &Schema{
+					Type:          TypeList,
+					Elem:          &Schema{Type: TypeInt},
+					PromoteSingle: true,
+					Optional:      true,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"ingress": "5",
+			},
+
+			Err: false,
+		},
+
+		"List with promotion set as list": {
+			Schema: map[string]*Schema{
+				"ingress": &Schema{
+					Type:          TypeList,
+					Elem:          &Schema{Type: TypeInt},
+					PromoteSingle: true,
+					Optional:      true,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"ingress": []interface{}{"5"},
+			},
+
+			Err: false,
 		},
 
 		"Optional sub-resource": {

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -1,0 +1,30 @@
+package schema
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// TestResourceDataRaw creates a ResourceData from a raw configuration map.
+func TestResourceDataRaw(
+	t *testing.T, schema map[string]*Schema, raw map[string]interface{}) *ResourceData {
+	c, err := config.NewRawConfig(raw)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	sm := schemaMap(schema)
+	diff, err := sm.Diff(nil, terraform.NewResourceConfig(c))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	result, err := sm.Data(nil, diff)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	return result
+}

--- a/plugin/resource_provisioner.go
+++ b/plugin/resource_provisioner.go
@@ -77,6 +77,19 @@ func (p *ResourceProvisioner) Apply(
 	return err
 }
 
+func (p *ResourceProvisioner) Stop() error {
+	var resp ResourceProvisionerStopResponse
+	err := p.Client.Call("Plugin.Stop", new(interface{}), &resp)
+	if err != nil {
+		return err
+	}
+	if resp.Error != nil {
+		err = resp.Error
+	}
+
+	return err
+}
+
 func (p *ResourceProvisioner) Close() error {
 	return p.Client.Close()
 }
@@ -97,6 +110,10 @@ type ResourceProvisionerApplyArgs struct {
 }
 
 type ResourceProvisionerApplyResponse struct {
+	Error *plugin.BasicError
+}
+
+type ResourceProvisionerStopResponse struct {
 	Error *plugin.BasicError
 }
 
@@ -141,5 +158,16 @@ func (s *ResourceProvisionerServer) Validate(
 		Warnings: warns,
 		Errors:   berrs,
 	}
+	return nil
+}
+
+func (s *ResourceProvisionerServer) Stop(
+	_ interface{},
+	reply *ResourceProvisionerStopResponse) error {
+	err := s.Provisioner.Stop()
+	*reply = ResourceProvisionerStopResponse{
+		Error: plugin.NewBasicError(err),
+	}
+
 	return nil
 }

--- a/plugin/serve.go
+++ b/plugin/serve.go
@@ -19,7 +19,7 @@ var Handshake = plugin.HandshakeConfig{
 	// one or the other that makes it so that they can't safely communicate.
 	// This could be adding a new interface value, it could be how
 	// helper/schema computes diffs, etc.
-	ProtocolVersion: 2,
+	ProtocolVersion: 3,
 
 	// The magic cookie values should NEVER be changed.
 	MagicCookieKey:   "TF_PLUGIN_MAGIC_COOKIE",

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -91,7 +91,7 @@ func makeProviderMap(items []plugin) string {
 func makeProvisionerMap(items []plugin) string {
 	output := ""
 	for _, item := range items {
-		output += fmt.Sprintf("\t\"%s\": func() terraform.ResourceProvisioner { return new(%s.%s) },\n", item.PluginName, item.ImportName, item.TypeName)
+		output += fmt.Sprintf("\t\"%s\":   %s.%s,\n", item.PluginName, item.ImportName, item.TypeName)
 	}
 	return output
 }
@@ -254,8 +254,8 @@ func discoverProviders() ([]plugin, error) {
 
 func discoverProvisioners() ([]plugin, error) {
 	path := "./builtin/provisioners"
-	typeID := "ResourceProvisioner"
-	typeName := ""
+	typeID := "terraform.ResourceProvisioner"
+	typeName := "Provisioner"
 	return discoverTypesInPath(path, typeID, typeName)
 }
 

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -270,6 +270,9 @@ import (
 IMPORTS
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
+
+	// Legacy, will remove once it conforms with new structure
+	chefprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef"
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
@@ -278,6 +281,12 @@ PROVIDERS
 
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{
 PROVISIONERS
+}
+
+func init() {
+	// Legacy provisioners that don't match our heuristics for auto-finding
+	// built-in provisioners.
+	InternalProvisioners["chef"] = func() terraform.ResourceProvisioner { return new(chefprovisioner.ResourceProvisioner) }
 }
 
 `

--- a/scripts/generate-plugins_test.go
+++ b/scripts/generate-plugins_test.go
@@ -7,29 +7,29 @@ func TestMakeProvisionerMap(t *testing.T) {
 		{
 			Package:    "file",
 			PluginName: "file",
-			TypeName:   "ResourceProvisioner",
+			TypeName:   "Provisioner",
 			Path:       "builtin/provisioners/file",
-			ImportName: "fileresourceprovisioner",
+			ImportName: "fileprovisioner",
 		},
 		{
 			Package:    "localexec",
 			PluginName: "local-exec",
-			TypeName:   "ResourceProvisioner",
+			TypeName:   "Provisioner",
 			Path:       "builtin/provisioners/local-exec",
-			ImportName: "localexecresourceprovisioner",
+			ImportName: "localexecprovisioner",
 		},
 		{
 			Package:    "remoteexec",
 			PluginName: "remote-exec",
-			TypeName:   "ResourceProvisioner",
+			TypeName:   "Provisioner",
 			Path:       "builtin/provisioners/remote-exec",
-			ImportName: "remoteexecresourceprovisioner",
+			ImportName: "remoteexecprovisioner",
 		},
 	})
 
-	expected := `	"file": func() terraform.ResourceProvisioner { return new(fileresourceprovisioner.ResourceProvisioner) },
-	"local-exec": func() terraform.ResourceProvisioner { return new(localexecresourceprovisioner.ResourceProvisioner) },
-	"remote-exec": func() terraform.ResourceProvisioner { return new(remoteexecresourceprovisioner.ResourceProvisioner) },
+	expected := `	"file":   fileprovisioner.Provisioner,
+	"local-exec":   localexecprovisioner.Provisioner,
+	"remote-exec":   remoteexecprovisioner.Provisioner,
 `
 
 	if p != expected {
@@ -86,12 +86,9 @@ func TestDiscoverTypesProviders(t *testing.T) {
 }
 
 func TestDiscoverTypesProvisioners(t *testing.T) {
-	plugins, err := discoverTypesInPath("../builtin/provisioners", "ResourceProvisioner", "")
+	plugins, err := discoverTypesInPath("../builtin/provisioners", "terraform.ResourceProvisioner", "Provisioner")
 	if err != nil {
 		t.Fatalf(err.Error())
-	}
-	if !contains(plugins, "chef") {
-		t.Errorf("Expected to find chef provisioner")
 	}
 	if !contains(plugins, "remote-exec") {
 		t.Errorf("Expected to find remote-exec provisioner")

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -632,10 +632,14 @@ func (c *Context) Refresh() (*State, error) {
 //
 // Stop will block until the task completes.
 func (c *Context) Stop() {
+	log.Printf("[WARN] terraform: Stop called, initiating interrupt sequence")
+
 	c.l.Lock()
 
 	// If we're running, then stop
 	if c.runContextCancel != nil {
+		log.Printf("[WARN] terraform: run context exists, stopping")
+
 		// Tell the hook we want to stop
 		c.sh.Stop()
 
@@ -652,8 +656,11 @@ func (c *Context) Stop() {
 
 	// Wait if we have a context
 	if ctx != nil {
+		log.Printf("[WARN] terraform: stop waiting for context completion")
 		<-ctx.Done()
 	}
+
+	log.Printf("[WARN] terraform: stop complete")
 }
 
 // Validate validates the configuration and returns any warnings or errors.

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -636,6 +636,7 @@ func (c *Context) Stop() {
 	log.Printf("[WARN] terraform: Stop called, initiating interrupt sequence")
 
 	c.l.Lock()
+	defer c.l.Unlock()
 
 	// If we're running, then stop
 	if c.runContextCancel != nil {
@@ -652,7 +653,6 @@ func (c *Context) Stop() {
 	// Grab the condition var before we exit
 	if cond := c.runCond; cond != nil {
 		cond.Wait()
-		c.l.Unlock()
 	}
 
 	log.Printf("[WARN] terraform: stop complete")

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -907,13 +907,10 @@ func (c *Context) walk(
 }
 
 func (c *Context) watchStop(walker *ContextGraphWalker, doneCh <-chan struct{}) {
-	// Get the stop channel. runContext might be nil only during tests.
-	// If this is called during a proper run operation, this will never
-	// be nil.
-	var stopCh <-chan struct{}
-	if ctx := c.runContext; ctx != nil {
-		stopCh = ctx.Done()
-	}
+	// Get the stop channel. runContext will never be nil since this should
+	// only be called within the context of an operation started with
+	// acquireRun
+	stopCh := c.runContext.Done()
 
 	// Wait for a stop or completion
 	select {

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -811,7 +811,8 @@ func (c *Context) walk(
 
 	// Watch for a stop so we can call the provider Stop() API.
 	doneCh := make(chan struct{})
-	go c.watchStop(walker, doneCh)
+	stopCh := c.runContext.Done()
+	go c.watchStop(walker, doneCh, stopCh)
 
 	// Walk the real graph, this will block until it completes
 	realErr := graph.Walk(walker)
@@ -906,12 +907,7 @@ func (c *Context) walk(
 	return walker, realErr
 }
 
-func (c *Context) watchStop(walker *ContextGraphWalker, doneCh <-chan struct{}) {
-	// Get the stop channel. runContext will never be nil since this should
-	// only be called within the context of an operation started with
-	// acquireRun
-	stopCh := c.runContext.Done()
-
+func (c *Context) watchStop(walker *ContextGraphWalker, doneCh, stopCh <-chan struct{}) {
 	// Wait for a stop or completion
 	select {
 	case <-stopCh:

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1720,6 +1720,82 @@ func TestContext2Apply_cancel(t *testing.T) {
 	}
 }
 
+func TestContext2Apply_cancelBlock(t *testing.T) {
+	m := testModule(t, "apply-cancel-block")
+	p := testProvider("aws")
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	applyCh := make(chan struct{})
+	p.DiffFn = testDiffFn
+	p.ApplyFn = func(*InstanceInfo, *InstanceState, *InstanceDiff) (*InstanceState, error) {
+		close(applyCh)
+
+		for !ctx.sh.Stopped() {
+			// Wait for stop to be called
+		}
+
+		// Sleep
+		time.Sleep(100 * time.Millisecond)
+
+		return &InstanceState{
+			ID: "foo",
+		}, nil
+	}
+
+	if _, err := ctx.Plan(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	// Start the Apply in a goroutine
+	var applyErr error
+	stateCh := make(chan *State)
+	go func() {
+		state, err := ctx.Apply()
+		if err != nil {
+			applyErr = err
+		}
+
+		stateCh <- state
+	}()
+
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		<-applyCh
+		ctx.Stop()
+	}()
+
+	// Make sure that stop blocks
+	select {
+	case <-stopDone:
+		t.Fatal("stop should block")
+	case <-time.After(10 * time.Millisecond):
+	}
+
+	// Wait for stop
+	select {
+	case <-stopDone:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("stop should be done")
+	}
+
+	// Wait for apply to complete
+	state := <-stateCh
+	if applyErr != nil {
+		t.Fatalf("err: %s", applyErr)
+	}
+
+	checkStateString(t, state, `
+aws_instance.foo:
+  ID = foo
+	`)
+}
+
 func TestContext2Apply_cancelProvisioner(t *testing.T) {
 	m := testModule(t, "apply-cancel-provisioner")
 	p := testProvider("aws")

--- a/terraform/context_import.go
+++ b/terraform/context_import.go
@@ -40,8 +40,7 @@ type ImportTarget struct {
 // imported.
 func (c *Context) Import(opts *ImportOpts) (*State, error) {
 	// Hold a lock since we can modify our own state here
-	v := c.acquireRun("import")
-	defer c.releaseRun(v)
+	defer c.acquireRun("import")()
 
 	// Copy our own state
 	c.state = c.state.DeepCopy()

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -906,6 +906,7 @@ func TestContext2Validate_PlanGraphBuilder(t *testing.T) {
 		Targets:   c.targets,
 	}).Build(RootModulePath)
 
+	defer c.acquireRun("validate-test")()
 	walker, err := c.walk(graph, graph, walkValidate)
 	if err != nil {
 		t.Fatal(err)

--- a/terraform/eval_context.go
+++ b/terraform/eval_context.go
@@ -8,6 +8,10 @@ import (
 
 // EvalContext is the interface that is given to eval nodes to execute.
 type EvalContext interface {
+	// Stopped returns a channel that is closed when evaluation is stopped
+	// via Terraform.Context.Stop()
+	Stopped() <-chan struct{}
+
 	// Path is the current module path.
 	Path() []string
 

--- a/terraform/eval_context_mock.go
+++ b/terraform/eval_context_mock.go
@@ -9,6 +9,9 @@ import (
 // MockEvalContext is a mock version of EvalContext that can be used
 // for tests.
 type MockEvalContext struct {
+	StoppedCalled bool
+	StoppedValue  <-chan struct{}
+
 	HookCalled bool
 	HookHook   Hook
 	HookError  error
@@ -83,6 +86,11 @@ type MockEvalContext struct {
 	StateCalled bool
 	StateState  *State
 	StateLock   *sync.RWMutex
+}
+
+func (c *MockEvalContext) Stopped() <-chan struct{} {
+	c.StoppedCalled = true
+	return c.StoppedValue
 }
 
 func (c *MockEvalContext) Hook(fn func(Hook) (HookAction, error)) error {

--- a/terraform/graph_walk_context.go
+++ b/terraform/graph_walk_context.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"sync"
@@ -15,8 +16,9 @@ type ContextGraphWalker struct {
 	NullGraphWalker
 
 	// Configurable values
-	Context   *Context
-	Operation walkOperation
+	Context     *Context
+	Operation   walkOperation
+	StopContext context.Context
 
 	// Outputs, do not set these. Do not read these while the graph
 	// is being walked.
@@ -65,6 +67,7 @@ func (w *ContextGraphWalker) EnterPath(path []string) EvalContext {
 	w.interpolaterVarLock.Unlock()
 
 	ctx := &BuiltinEvalContext{
+		StopContext:         w.StopContext,
 		PathValue:           path,
 		Hooks:               w.Context.hooks,
 		InputValue:          w.Context.uiInput,

--- a/terraform/graphtype_string.go
+++ b/terraform/graphtype_string.go
@@ -4,9 +4,9 @@ package terraform
 
 import "fmt"
 
-const _GraphType_name = "GraphTypeInvalidGraphTypeLegacyGraphTypeRefreshGraphTypePlanGraphTypePlanDestroyGraphTypeApply"
+const _GraphType_name = "GraphTypeInvalidGraphTypeLegacyGraphTypeRefreshGraphTypePlanGraphTypePlanDestroyGraphTypeApplyGraphTypeInputGraphTypeValidate"
 
-var _GraphType_index = [...]uint8{0, 16, 31, 47, 60, 80, 94}
+var _GraphType_index = [...]uint8{0, 16, 31, 47, 60, 80, 94, 108, 125}
 
 func (i GraphType) String() string {
 	if i >= GraphType(len(_GraphType_index)-1) {

--- a/terraform/resource_provisioner.go
+++ b/terraform/resource_provisioner.go
@@ -21,6 +21,26 @@ type ResourceProvisioner interface {
 	// is provided since provisioners only run after a resource has been
 	// newly created.
 	Apply(UIOutput, *InstanceState, *ResourceConfig) error
+
+	// Stop is called when the provisioner should halt any in-flight actions.
+	//
+	// This can be used to make a nicer Ctrl-C experience for Terraform.
+	// Even if this isn't implemented to do anything (just returns nil),
+	// Terraform will still cleanly stop after the currently executing
+	// graph node is complete. However, this API can be used to make more
+	// efficient halts.
+	//
+	// Stop doesn't have to and shouldn't block waiting for in-flight actions
+	// to complete. It should take any action it wants and return immediately
+	// acknowledging it has received the stop request. Terraform core will
+	// automatically not make any further API calls to the provider soon
+	// after Stop is called (technically exactly once the currently executing
+	// graph nodes are complete).
+	//
+	// The error returned, if non-nil, is assumed to mean that signaling the
+	// stop somehow failed and that the user should expect potentially waiting
+	// a longer period of time.
+	Stop() error
 }
 
 // ResourceProvisionerCloser is an interface that provisioners that can close

--- a/terraform/shadow_context.go
+++ b/terraform/shadow_context.go
@@ -88,7 +88,8 @@ func newShadowContext(c *Context) (*Context, *Context, Shadow) {
 		// l - no copy
 		parallelSem:         c.parallelSem,
 		providerInputConfig: c.providerInputConfig,
-		runCh:               c.runCh,
+		runContext:          c.runContext,
+		runContextCancel:    c.runContextCancel,
 		shadowErr:           c.shadowErr,
 	}
 

--- a/terraform/shadow_resource_provisioner.go
+++ b/terraform/shadow_resource_provisioner.go
@@ -112,6 +112,10 @@ func (p *shadowResourceProvisionerReal) Apply(
 	return err
 }
 
+func (p *shadowResourceProvisionerReal) Stop() error {
+	return p.ResourceProvisioner.Stop()
+}
+
 // shadowResourceProvisionerShadow is the shadow resource provisioner. Function
 // calls never affect real resources. This is paired with the "real" side
 // which must be called properly to enable recording.
@@ -226,6 +230,13 @@ func (p *shadowResourceProvisionerShadow) Apply(
 	}
 
 	return result.ResultErr
+}
+
+func (p *shadowResourceProvisionerShadow) Stop() error {
+	// For the shadow, we always just return nil since a Stop indicates
+	// that we were interrupted and shadows are disabled during interrupts
+	// anyways.
+	return nil
 }
 
 // The structs for the various function calls are put below. These structs

--- a/terraform/test-fixtures/apply-cancel-block/main.tf
+++ b/terraform/test-fixtures/apply-cancel-block/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+    num = "2"
+}

--- a/terraform/test-fixtures/apply-cancel-provisioner/main.tf
+++ b/terraform/test-fixtures/apply-cancel-provisioner/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+    num = "2"
+
+    provisioner "shell" {
+        foo = "bar"
+    }
+}


### PR DESCRIPTION
⚠️  For **Terraform 0.9** (Do not merge until master is 0.9) ⚠️ 

**Fast provisioner cancellation!** 💃 

![asdf](https://cloud.githubusercontent.com/assets/1299/21511753/93b67712-cc59-11e6-9b9a-b2ff55df07c4.gif)

This PR includes two things:

  * Create a new Stop API for provisioners that is called when terraform's Stop API (triggered by things like interrupts) is called.

  * Introduce a `helper/schema` framework for provisioners. This makes it easy to consume the Stop API also introduced in this PR. 

This PR uses `context` heavily to make it easy to consume the cancellation, and helper/schema handles managing this context. Terraform's core stop mechanism was also changed to use `context`. 
