### PR TITLE
website: Fix broken markdown style on 'lists' section of variables page

### DIFF
--- a/website/source/intro/getting-started/variables.html.md
+++ b/website/source/intro/getting-started/variables.html.md
@@ -133,6 +133,7 @@ for the variable.
 ## Lists
 
 Lists are defined either explicitly or implicity
+
 ```
 # implicitly by using brackets [...]
 variable "cidrs" { default = [] }
@@ -142,6 +143,7 @@ variable "cidrs" { type = "list" }
 ```
 
 You can specify lists in a `terraform.tfvars` file:
+
 ```
 cidrs = [ "10.0.0.0/16", "10.1.0.0/16" ]
 ```


### PR DESCRIPTION
This PR fixes an issue #10943, 
**Broken code style on [Getting Started - Variables - Lists](https://www.terraform.io/intro/getting-started/variables.html#lists).**


Before:

<img width="865" alt="2016-12-29 12 23 48" src="https://cloud.githubusercontent.com/assets/2101743/21525246/5721852e-cd5f-11e6-97de-a76c894656ba.png">

After:
<img width="827" alt="2016-12-29 12 23 36" src="https://cloud.githubusercontent.com/assets/2101743/21525331/0174c496-cd60-11e6-86c5-f5ac425b4bf3.png">

