### PR TITLE
website: Correct unrelated contents on env vars in variables page

### DIFF
--- a/website/source/intro/getting-started/variables.html.md
+++ b/website/source/intro/getting-started/variables.html.md
@@ -93,12 +93,6 @@ specify a file. These files are the same syntax as Terraform
 configuration files. And like Terraform configuration files, these files
 can also be JSON.
 
-#### From environment variables
-
-Terraform will read environment variables in the form of `TF_VAR_name`
-to find the value for a variable. For example, the `TF_VAR_access_key`
-variable can be set to set the `access_key` variable.
-
 We don't recommend saving usernames and password to version control, But you
 can create a local secret variables file and use `-var-file` to load it.
 
@@ -110,6 +104,13 @@ $ terraform plan \
   -var-file="secret.tfvars" \
   -var-file="production.tfvars"
 ```
+
+#### From environment variables
+
+Terraform will read environment variables in the form of `TF_VAR_name`
+to find the value for a variable. For example, the `TF_VAR_access_key`
+variable can be set to set the `access_key` variable.
+
 -> **Note**: Environment variables can only populate string-type variables. 
 List and map type variables must be populated via one of the other mechanisms.
 


### PR DESCRIPTION
### Expected Behavior

Paragraph about loading variables from a file should go `From a file` section, not `Envirionment Variables` section. Please see below screenshot (highlighted), and please compare with screenshot in Actual Behavior section.

<img width="844" alt="2016-12-29 4 42 15" src="https://cloud.githubusercontent.com/assets/2101743/21530055/5734efca-cd81-11e6-81ed-0c7fd374a43c.png">


### Actual Behavior

Some paragraph about loading variables from a file should go `From a file` section are exists on `Envirionment Variables` section.


<img width="832" alt="2016-12-29 4 39 37" src="https://cloud.githubusercontent.com/assets/2101743/21530007/0067494a-cd81-11e6-9007-baeb0df7e7ea.png">


Please see details on issue #10949.
