### PR TITLE
provider/aws: handle aws_lambda_function missing s3 key error

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -274,12 +274,8 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 		if err != nil {
 			log.Printf("[DEBUG] Error creating Lambda Function: %s", err)
 
-			if isAWSErr(err, "InvalidParameterValueException", "S3 Error Code: NoSuchKey") {
-				return resource.NonRetryableError(err)
-			}
-
 			if isAWSErr(err, "InvalidParameterValueException", "The role defined for the function cannot be assumed by Lambda") {
-				log.Printf("[ERROR] Received %q, retrying CreateFunction", err)
+				log.Printf("[DEBUG] Received %s, retrying CreateFunction", err)
 				return resource.RetryableError(err)
 			}
 

--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -272,14 +272,17 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 	err := resource.Retry(10*time.Minute, func() *resource.RetryError {
 		_, err := conn.CreateFunction(params)
 		if err != nil {
-			log.Printf("[ERROR] Received %q, retrying CreateFunction", err)
-			if awserr, ok := err.(awserr.Error); ok {
-				if awserr.Code() == "InvalidParameterValueException" {
-					log.Printf("[DEBUG] InvalidParameterValueException creating Lambda Function: %s", awserr)
-					return resource.RetryableError(awserr)
-				}
-			}
 			log.Printf("[DEBUG] Error creating Lambda Function: %s", err)
+
+			if isAWSErr(err, "InvalidParameterValueException", "S3 Error Code: NoSuchKey") {
+				return resource.NonRetryableError(err)
+			}
+
+			if isAWSErr(err, "InvalidParameterValueException", "The role defined for the function cannot be assumed by Lambda") {
+				log.Printf("[ERROR] Received %q, retrying CreateFunction", err)
+				return resource.RetryableError(err)
+			}
+
 			return resource.NonRetryableError(err)
 		}
 		return nil


### PR DESCRIPTION
This PR traps `S3 Error Code: NoSuchKey` as a non-retryable error when creating a new lambda function. Otherwise if the S3 key doesn't exist, then the function just loops for 10 minutes. I don't think this is the intended behavior.

The original code seemed to treat all `InvalidParameterValueException` as retryable, but the comment above it indicates that that was only for an IAM role propagation issue. So I've also added an explicit check for the IAM error.

I could also just remove the S3 check now that I have the explicit IAM check.

Side note, this came up because I was using `aws_s3_bucket_object` and _that_ check was showing the object existed. `aws_s3_bucket_object` seems to allow a leading `/` whereas `aws_lambda_function.s3_key` does not.

-- jonathan