### PR TITLE
core: Fix interpolation on schema.Sets

### DIFF
--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -838,6 +838,46 @@ func TestInterpolator_nestedMapsAndLists(t *testing.T) {
 		interfaceToVariableSwallowError(mapOfList))
 }
 
+func TestInterpolator_setAsList(t *testing.T) {
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_route53_zone.yada": &ResourceState{
+						Type:         "aws_route53_zone",
+						Dependencies: []string{},
+						Primary: &InstanceState{
+							ID: "null",
+							Attributes: map[string]string{
+								"list_from_set.#":          "2",
+								"list_from_set.1938594527": "foo",
+								"list_from_set.1996459178": "bar",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	i := &Interpolater{
+		Module:    testModule(t, "interpolate-multi-vars"),
+		StateLock: new(sync.RWMutex),
+		State:     state,
+	}
+
+	scope := &InterpolationScope{
+		Path: rootModulePath,
+	}
+
+	list := []interface{}{"foo", "bar"}
+
+	testInterpolate(t, i, scope, "aws_route53_zone.yada.list_from_set",
+		interfaceToVariableSwallowError(list))
+
+}
+
 func testInterpolate(
 	t *testing.T, i *Interpolater,
 	scope *InterpolationScope,


### PR DESCRIPTION
A change introduced in v0.8.2 simplified how interpolations on maps and
lists worked, moving this functionality to `flatmap.Expand`. However, it
seems that the new functionality did not take into account that lists
come from sets as well, where the "indexes", which are more like keys,
and being hashed, do not have a deterministic range bound to the length
of the list. This caused issues when interpolating sets where the
resulting list was almost always likely returned as a set of blank
strings.

This commit takes some of the old, pre-v0.8.2 functionality, and rolls
it into `flatmap.expandArray`. Rather than use a custom sort
implementation, we just derive all numeric indexes from the current
resource and build a sorted, de-duplicated (in the case of subkeys) list
that is then used with the actual length of the list to build the proper
interpolated set.

Fixes hashicorp/terraform#10977.