### PR TITLE
provider/aws: implement CloudFront Lambda Function Associations

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -228,11 +228,6 @@ func defaultCacheBehaviorHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
-	if d, ok := m["lambda_function_association"]; ok {
-		for _, e := range d.(*schema.Set).List() {
-			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(e.(map[string]interface{}))))
-		}
-	}
 	return hashcode.String(buf.String())
 }
 
@@ -365,11 +360,6 @@ func cacheBehaviorHash(v interface{}) int {
 	if d, ok := m["path_pattern"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", d))
 	}
-	if d, ok := m["lambda_function_association"]; ok {
-		for _, e := range d.(*schema.Set).List() {
-			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(e.(map[string]interface{}))))
-		}
-	}
 	return hashcode.String(buf.String())
 }
 
@@ -400,11 +390,11 @@ func expandLambdaFunctionAssociations(v interface{}) *cloudfront.LambdaFunctionA
 		}
 	}
 
-	s := v.(*schema.Set)
+	s := v.([]interface{})
 	var lfa cloudfront.LambdaFunctionAssociations
-	lfa.Quantity = aws.Int64(int64(s.Len()))
-	lfa.Items = make([]*cloudfront.LambdaFunctionAssociation, s.Len())
-	for i, lf := range s.List() {
+	lfa.Quantity = aws.Int64(int64(len(s)))
+	lfa.Items = make([]*cloudfront.LambdaFunctionAssociation, len(s))
+	for i, lf := range s {
 		lfa.Items[i] = expandLambdaFunctionAssociation(lf.(map[string]interface{}))
 	}
 	return &lfa
@@ -421,12 +411,12 @@ func expandLambdaFunctionAssociation(lf map[string]interface{}) *cloudfront.Lamb
 	return &lfa
 }
 
-func flattenLambdaFunctionAssociations(lfa *cloudfront.LambdaFunctionAssociations) *schema.Set {
+func flattenLambdaFunctionAssociations(lfa *cloudfront.LambdaFunctionAssociations) []interface{} {
 	s := make([]interface{}, len(lfa.Items))
 	for i, v := range lfa.Items {
 		s[i] = flattenLambdaFunctionAssociation(v)
 	}
-	return schema.NewSet(lambdaFunctionAssociationHash, s)
+	return s
 }
 
 func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation) map[string]interface{} {
@@ -436,14 +426,6 @@ func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation)
 		m["lambda_arn"] = *lfa.LambdaFunctionARN
 	}
 	return m
-}
-
-func lambdaFunctionAssociationHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["event_type"].(string)))
-	buf.WriteString(fmt.Sprintf("%s", m["lambda_arn"].(string)))
-	return hashcode.String(buf.String())
 }
 
 func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues {

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -441,7 +441,8 @@ func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation)
 func lambdaFunctionAssociationHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(m["event_type"].(string))
+	buf.WriteString(fmt.Sprintf("%s-", m["event_type"].(string)))
+	buf.WriteString(fmt.Sprintf("%s", m["lambda_arn"].(string)))
 	return hashcode.String(buf.String())
 }
 

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -462,8 +462,11 @@ func TestCloudFrontStructure_expandLambdaFunctionAssociations(t *testing.T) {
 	if len(lfa.Items) != 2 {
 		t.Fatalf("Expected Items to be len 2, got %v", len(lfa.Items))
 	}
-	if et := "origin-response"; *lfa.Items[0].EventType != et {
-		t.Fatalf("Expected first Item's EventType to be len %q, got %q", et, *lfa.Items[0].EventType)
+	if et := "viewer-request"; *lfa.Items[0].EventType != et {
+		t.Fatalf("Expected first Item's EventType to be %q, got %q", et, *lfa.Items[0].EventType)
+	}
+	if et := "origin-response"; *lfa.Items[1].EventType != et {
+		t.Fatalf("Expected second Item's EventType to be %q, got %q", et, *lfa.Items[1].EventType)
 	}
 }
 

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -46,7 +46,7 @@ func trustedSignersConf() []interface{} {
 	return []interface{}{"1234567890EX", "1234567891EX"}
 }
 
-func lambdaFunctionAssociationsConf() *schema.Set {
+func lambdaFunctionAssociationsConf() []interface{} {
 	s := []interface{}{
 		map[string]interface{}{
 			"event_type": "viewer-request",
@@ -57,7 +57,7 @@ func lambdaFunctionAssociationsConf() *schema.Set {
 			"lambda_arn": "arn:aws:lambda:us-east-1:999999999:function2:alias",
 		},
 	}
-	return schema.NewSet(lambdaFunctionAssociationHash, s)
+	return s
 }
 
 func forwardedValuesConf() map[string]interface{} {
@@ -359,9 +359,8 @@ func TestCloudFrontStructure_flattenCacheBehavior(t *testing.T) {
 	if out["target_origin_id"] != "myS3Origin" {
 		t.Fatalf("Expected out[target_origin_id] to be myS3Origin, got %v", out["target_origin_id"])
 	}
-	diff = out["lambda_function_association"].(*schema.Set).Difference(in["lambda_function_association"].(*schema.Set))
-	if diff.Len() > 0 {
-		t.Fatalf("Expected out[lambda_function_association] to be %v, got %v, diff: %v", out["lambda_function_association"], in["lambda_function_association"], diff)
+	if reflect.DeepEqual(out["lambda_function_associations"], in["lambda_function_associations"]) != true {
+		t.Fatalf("Expected out[lambda_function_associations] to be %v, got %v", in["lambda_function_associations"], out["lambda_function_associations"])
 	}
 	diff = out["forwarded_values"].(*schema.Set).Difference(in["forwarded_values"].(*schema.Set))
 	if len(diff.List()) > 0 {
@@ -475,13 +474,13 @@ func TestCloudFrontStructure_flattenlambdaFunctionAssociations(t *testing.T) {
 	lfa := expandLambdaFunctionAssociations(in)
 	out := flattenLambdaFunctionAssociations(lfa)
 
-	if out.Difference(in).Len() != 0 {
+	if reflect.DeepEqual(in, out) != true {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
 
 func TestCloudFrontStructure_expandlambdaFunctionAssociations_empty(t *testing.T) {
-	data := schema.NewSet(lambdaFunctionAssociationHash, []interface{}{})
+	data := []interface{}{}
 	lfa := expandLambdaFunctionAssociations(data)
 	if *lfa.Quantity != 0 {
 		t.Fatalf("Expected Quantity to be 0, got %v", *lfa.Quantity)

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -102,6 +102,24 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 								},
 							},
 						},
+						"lambda_function_association": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Set:      lambdaFunctionAssociationHash,
+							MaxItems: 4,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"event_type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"lambda_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
 						"max_ttl": {
 							Type:     schema.TypeInt,
 							Required: true,
@@ -228,6 +246,24 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Type:     schema.TypeList,
 										Optional: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"lambda_function_association": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Set:      lambdaFunctionAssociationHash,
+							MaxItems: 4,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"event_type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"lambda_arn": {
+										Type:     schema.TypeString,
+										Required: true,
 									},
 								},
 							},

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -105,7 +105,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"lambda_function_association": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Set:      lambdaFunctionAssociationHash,
 							MaxItems: 4,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -253,7 +252,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"lambda_function_association": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Set:      lambdaFunctionAssociationHash,
 							MaxItems: 4,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -103,7 +103,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"lambda_function_association": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 4,
 							Elem: &schema.Resource{
@@ -250,7 +250,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"lambda_function_association": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 4,
 							Elem: &schema.Resource{


### PR DESCRIPTION
Implements [Lambda Function Associations](http://docs.aws.amazon.com/AmazonCloudFront/latest/APIReference/API_LambdaFunctionAssociations.html) for CloudFront cache behaviors.

Within a `cache_behavior` or `default_cache_behavior` block:

```
lambda_function_association {
  event_type = "viewer-request"
  lambda_arn = "arn:aws:lambda:us-east-1:${data.aws_caller_identity.current.account_id}:some-function:$LATEST"
}
```

should fix #10938 

My first contribution to Terraform. How'd I do?