### PR TITLE
provider/aws: Add `most_recent` to the `ebs_snapshot` data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_ebs_snapshot_test.go
+++ b/builtin/providers/aws/data_source_aws_ebs_snapshot_test.go
@@ -69,6 +69,7 @@ resource "aws_ebs_snapshot" "snapshot" {
 }
 
 data "aws_ebs_snapshot" "snapshot" {
+    most_recent = true
     snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
 }
 `
@@ -88,6 +89,7 @@ resource "aws_ebs_snapshot" "snapshot" {
 }
 
 data "aws_ebs_snapshot" "snapshot" {
+    most_recent = true
     snapshot_ids = ["${aws_ebs_snapshot.snapshot.id}"]
     filter {
 	name = "volume-size"

--- a/website/source/docs/providers/aws/d/ebs_snapshot.html.markdown
+++ b/website/source/docs/providers/aws/d/ebs_snapshot.html.markdown
@@ -14,6 +14,7 @@ Use this data source to get information about an EBS Snapshot for use when provi
 
 ```
 data "aws_ebs_snapshot" "ebs_volume" {
+    most_recent = true
     owners = ["self"]
     filter {
         name = "volume-size"
@@ -29,6 +30,8 @@ data "aws_ebs_snapshot" "ebs_volume" {
 ## Argument Reference
 
 The following arguments are supported:
+
+* `most_recent` - (Optional) If more than one result is returned, use the most recent snapshot.
 
 * `owners` - (Optional) Returns the snapshots owned by the specified owner id. Multiple owners can be specified.
 


### PR DESCRIPTION
Implements the `most_recent` argument to the `ebs_snapshot` data source.

This has been implemented based on how the `most_recent` argument was implemented for the `ebs_volume` data source.

Implements #10814 