### PR TITLE
aws_key_pair: Ensure key_name attribute is set

### DIFF
--- a/builtin/providers/aws/resource_aws_key_pair.go
+++ b/builtin/providers/aws/resource_aws_key_pair.go
@@ -75,8 +75,10 @@ func resourceAwsKeyPairCreate(d *schema.ResourceData, meta interface{}) error {
 		keyName = v.(string)
 	} else if v, ok := d.GetOk("key_name_prefix"); ok {
 		keyName = resource.PrefixedUniqueId(v.(string))
+		d.Set("key_name", keyName)
 	} else {
 		keyName = resource.UniqueId()
+		d.Set("key_name", keyName)
 	}
 
 	publicKey := d.Get("public_key").(string)


### PR DESCRIPTION
Ensure that the `key_name` attribute is available to `aws_key_pair`
resource dependents, even when the attribute is not specifically
set (i.e., when `key_name_prefix` or automatic naming is performed).

Fixes #10983.