### PR TITLE
provider/azurerm: avoid registering providers already registered, add option to disable

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -144,15 +144,6 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error creating Riviera client: %s", err)
 	}
-
-	// validate that the credentials are correct using Riviera. Note that this must be
-	// done _before_ using the Microsoft SDK, because Riviera handles errors. Using a
-	// namespace registration instead of a simple OAuth token refresh guarantees that
-	// service delegation is correct. This has the effect of registering Microsoft.Compute
-	// which is neccessary anyway.
-	if err := registerProviderWithSubscription("Microsoft.Compute", rivieraClient); err != nil {
-		return nil, err
-	}
 	client.rivieraClient = rivieraClient
 
 	oauthConfig, err := azure.PublicCloud.OAuthConfigForTenant(c.TenantID)

--- a/website/source/docs/providers/azurerm/index.html.markdown
+++ b/website/source/docs/providers/azurerm/index.html.markdown
@@ -76,6 +76,12 @@ The following arguments are supported:
 * `tenant_id` - (Optional) The tenant ID to use. It can also be sourced from the
   `ARM_TENANT_ID` environment variable.
 
+* `skip_provider_registration` - (Optional) Prevents the provier from registering
+  the ARM provider namespaces, this can be used if you don't wish to give the Active
+  Directory Application permission to register resource providers. It can also be
+  sourced from the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable, defaults
+  to `false`.
+
 ## Creating Credentials
 
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details).


### PR DESCRIPTION
Fixes #10931.
Fixes #8824.

The provider now consults the Providers API to detect which providers are already
registered and uses this call to test the credentials

A new option `skip_provider_registration` / `ARM_SKIP_PROVIDER_REGISTRATION` is
now available to opt out of provider registration entirely.

The error message from the call used to test credentials has also been changed, this will give us better errors once Azure/go-autorest#101 makes it's way into the SDK. Example of current errors:

```bash
# Bad Client ID
* Unable to list provider registration status, it is possible that this is due to invalid credentials or the service principal does not have permission to use the Resource Manager API, Azure error: autorest#WithErrorUnlessStatusCode: POST https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/token?api-version=1.0 failed with 400 Bad Request: StatusCode=400

# Bad Client Secret
* Unable to list provider registration status, it is possible that this is due to invalid credentials or the service principal does not have permission to use the Resource Manager API, Azure error: autorest#WithErrorUnlessStatusCode: POST https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/token?api-version=1.0 failed with 401 Unauthorized: StatusCode=401

# Bad Subscription ID
* Unable to list provider registration status, it is possible that this is due to invalid credentials or the service principal does not have permission to use the Resource Manager API, Azure error: resources.ProvidersClient#List: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="SubscriptionNotFound" Message="The subscription '00000000-0000-0000-0000-000000000000' could not be found."

# Bad Tenant ID
* Unable to list provider registration status, it is possible that this is due to invalid credentials or the service principal does not have permission to use the Resource Manager API, Azure error: autorest#WithErrorUnlessStatusCode: POST https://login.microsoftonline.com/00000000-0000-0000-0000-000000000000/oauth2/token?api-version=1.0 failed with 400 Bad Request: StatusCode=400
```