### PR TITLE
vagrant provision fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,7 +53,7 @@ export PATH="$SRCROOT/bin:$SRCPATH/bin:\$PATH"
 EOF
 chmod 755 /etc/profile.d/gopath.sh
 
-cat >>/home/vagrant/.bashrc <<EOF
+grep -q -F 'cd /opt/gopath/src/github.com/hashicorp/terraform' /home/vagrant/.bashrc || cat >>/home/vagrant/.bashrc <<EOF
 
 ## After login, change to terraform directory
 cd /opt/gopath/src/github.com/hashicorp/terraform

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,11 +46,12 @@ mkdir -p "$SRCPATH"
 chown -R vagrant:vagrant "$SRCPATH" 2>/dev/null || true
 # ^^ silencing errors here because we expect this to fail for the shared folder
 
-install -m0755 /dev/stdin /etc/profile.d/gopath.sh <<EOF
+cat >/etc/profile.d/gopath.sh <<EOF
 export GOPATH="$SRCPATH"
 export GOROOT="$SRCROOT"
 export PATH="$SRCROOT/bin:$SRCPATH/bin:\$PATH"
 EOF
+chmod 755 /etc/profile.d/gopath.sh
 
 cat >>/home/vagrant/.bashrc <<EOF
 


### PR DESCRIPTION
The ```vagrant up``` command as described in [BUILDING.md](https://github.com/hashicorp/terraform/blob/master/BUILDING.md) is not completing successfully:

```
dylan@ubuntu-trusty:~/src/oe/go/src/github.com/hashicorp/terraform$ git checkout master
Switched to branch 'master'
Your branch is up-to-date with 'origin/master'.
dylan@ubuntu-trusty:~/src/oe/go/src/github.com/hashicorp/terraform$ vagrant destroy -f
==> default: The container hasn't been created yet.
dylan@ubuntu-trusty:~/src/oe/go/src/github.com/hashicorp/terraform$ vagrant up
Bringing machine 'default' up with 'docker' provider...
==> default: Pulling image 'tknerr/baseimage-ubuntu:16.04'...
==> default: Creating the container...
    default:   Name: terraform_default_1483389326
    default:  Image: tknerr/baseimage-ubuntu:16.04
    default: Volume: /home/dylan/src/oe/go/src/github.com/hashicorp/terraform:/opt/gopath/src/github.com/hashicorp/terraform
    default:   Port: 127.0.0.1:2222:22
    default:  
    default: Container created: e452edf68adf692f
==> default: Starting container...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 172.17.0.2:22
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: 
    default: Vagrant insecure key detected. Vagrant will automatically replace
    default: this with a newly generated keypair for better security.
    default: 
    default: Inserting generated public key within guest...
    default: Removing insecure key from the guest if it's present...
    default: Key inserted! Disconnecting and reconnecting using new SSH key...
==> default: Machine booted and ready!
==> default: Running provisioner: prepare-shell (shell)...
    default: Running: inline script
==> default: Running provisioner: initial-setup (shell)...
    default: Running: inline script
==> default: Upgrading packages ...
==> default: debconf: delaying package configuration, since apt-utils is not installed
==> default: Installing prerequisites ...
==> default: debconf: delaying package configuration, since apt-utils is not installed
==> default: Downloading go (1.7.4) ...
==> default: Setting up go (1.7.4) ...
==> default: install: cannot stat '/dev/stdin': Stale file handle
dylan@ubuntu-trusty:~/src/oe/go/src/github.com/hashicorp/terraform$ vagrant ssh
vagrant@terraform:/opt/gopath/src/github.com/hashicorp/terraform$ go
-bash: go: command not found
vagrant@terraform:/opt/gopath/src/github.com/hashicorp/terraform$ make test
==> Checking that code complies with gofmt requirements...
/opt/gopath/src/github.com/hashicorp/terraform/scripts/gofmtcheck.sh: line 5: gofmt: command not found
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
==> Installing errcheck...
/opt/gopath/src/github.com/hashicorp/terraform/scripts/errcheck.sh: line 9: go: command not found
/opt/gopath/src/github.com/hashicorp/terraform/scripts/errcheck.sh: line 16: errcheck: command not found
/bin/sh: 2: go: not found
Makefile:88: recipe for target 'generate' failed
make: *** [generate] Error 127
vagrant@terraform:/opt/gopath/src/github.com/hashicorp/terraform$ 
```

The ```==> default: install: cannot stat '/dev/stdin': Stale file handle``` error seems to be caused by the ```install``` command added here:

https://github.com/hashicorp/terraform/commit/9c3c5c1e319ed1fbda12d210dd88870941d02e1b#diff-23b6f443c01ea2efcb4f36eedfea9089R41

I removed the ```install``` and moved back to using ```cat```, which allows the ```vagrant up``` to finish successfully.

I believe this was also seen to be an issue here:

https://github.com/hashicorp/terraform/issues/9763

I also added a check so that the line to ```cd``` into the ```terraform``` directory won't be added everytime ```vagrant provision``` is run.