### PR TITLE
provider/aws: fix expectation messages that did not align with code

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -255,7 +255,7 @@ func TestCloudFrontStructure_expandDefaultCacheBehavior(t *testing.T) {
 		t.Fatalf("Expected TrustedSigners.Items to be %v, got %v", trustedSignersConf(), dcb.TrustedSigners.Items)
 	}
 	if *dcb.MaxTTL != 365000000 {
-		t.Fatalf("Expected MaxTTL to be 86400, got %v", *dcb.MaxTTL)
+		t.Fatalf("Expected MaxTTL to be 365000000, got %v", *dcb.MaxTTL)
 	}
 	if *dcb.SmoothStreaming != false {
 		t.Fatalf("Expected SmoothStreaming to be false, got %v", *dcb.SmoothStreaming)
@@ -417,7 +417,7 @@ func TestCloudFrontStructure_expandTrustedSigners_empty(t *testing.T) {
 	data := []interface{}{}
 	ts := expandTrustedSigners(data)
 	if *ts.Quantity != 0 {
-		t.Fatalf("Expected Quantity to be 2, got %v", *ts.Quantity)
+		t.Fatalf("Expected Quantity to be 0, got %v", *ts.Quantity)
 	}
 	if *ts.Enabled != false {
 		t.Fatalf("Expected Enabled to be true, got %v", *ts.Enabled)
@@ -545,7 +545,7 @@ func TestCloudFrontStructure_expandAllowedMethods(t *testing.T) {
 	data := allowedMethodsConf()
 	am := expandAllowedMethods(data)
 	if *am.Quantity != 7 {
-		t.Fatalf("Expected Quantity to be 3, got %v", *am.Quantity)
+		t.Fatalf("Expected Quantity to be 7, got %v", *am.Quantity)
 	}
 	if reflect.DeepEqual(am.Items, expandStringList(data)) != true {
 		t.Fatalf("Expected Items to be %v, got %v", data, am.Items)


### PR DESCRIPTION
While working on #10985, I noticed that there were a few test failure messages that didn't match up with the assertions the code was actually performing. After some `sed` and `grep` tomfoolery, I'm pretty sure these three locations were the only places this kind of mismatch existed.