### PR TITLE
provider/aws: Add support for content_handling to aws_api_gateway_integration_response

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration.go
@@ -17,7 +17,7 @@ func resourceAwsApiGatewayIntegration() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsApiGatewayIntegrationCreate,
 		Read:   resourceAwsApiGatewayIntegrationRead,
-		Update: resourceAwsApiGatewayIntegrationUpdate,
+		Update: resourceAwsApiGatewayIntegrationCreate,
 		Delete: resourceAwsApiGatewayIntegrationDelete,
 
 		Schema: map[string]*schema.Schema{
@@ -200,10 +200,6 @@ func resourceAwsApiGatewayIntegrationRead(d *schema.ResourceData, meta interface
 	d.Set("content_handling", integration.ContentHandling)
 
 	return nil
-}
-
-func resourceAwsApiGatewayIntegrationUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceAwsApiGatewayIntegrationCreate(d, meta)
 }
 
 func resourceAwsApiGatewayIntegrationDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_response.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_response.go
@@ -17,57 +17,63 @@ func resourceAwsApiGatewayIntegrationResponse() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsApiGatewayIntegrationResponseCreate,
 		Read:   resourceAwsApiGatewayIntegrationResponseRead,
-		Update: resourceAwsApiGatewayIntegrationResponseUpdate,
+		Update: resourceAwsApiGatewayIntegrationResponseCreate,
 		Delete: resourceAwsApiGatewayIntegrationResponseDelete,
 
 		Schema: map[string]*schema.Schema{
-			"rest_api_id": &schema.Schema{
+			"rest_api_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"resource_id": &schema.Schema{
+			"resource_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"http_method": &schema.Schema{
+			"http_method": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validateHTTPMethod,
 			},
 
-			"status_code": &schema.Schema{
+			"status_code": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"selection_pattern": &schema.Schema{
+			"selection_pattern": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"response_templates": &schema.Schema{
+			"response_templates": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Elem:     schema.TypeString,
 			},
 
-			"response_parameters": &schema.Schema{
+			"response_parameters": {
 				Type:          schema.TypeMap,
 				Elem:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"response_parameters_in_json"},
 			},
 
-			"response_parameters_in_json": &schema.Schema{
+			"response_parameters_in_json": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ConflictsWith: []string{"response_parameters"},
 				Deprecated:    "Use field response_parameters instead",
+			},
+
+			"content_handling": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateApiGatewayIntegrationContentHandling,
 			},
 		},
 	}
@@ -92,6 +98,10 @@ func resourceAwsApiGatewayIntegrationResponseCreate(d *schema.ResourceData, meta
 			return fmt.Errorf("Error unmarshaling response_parameters_in_json: %s", err)
 		}
 	}
+	var contentHandling *string
+	if val, ok := d.GetOk("content_handling"); ok {
+		contentHandling = aws.String(val.(string))
+	}
 
 	input := apigateway.PutIntegrationResponseInput{
 		HttpMethod:         aws.String(d.Get("http_method").(string)),
@@ -100,10 +110,12 @@ func resourceAwsApiGatewayIntegrationResponseCreate(d *schema.ResourceData, meta
 		StatusCode:         aws.String(d.Get("status_code").(string)),
 		ResponseTemplates:  aws.StringMap(templates),
 		ResponseParameters: aws.StringMap(parameters),
+		ContentHandling:    contentHandling,
 	}
 	if v, ok := d.GetOk("selection_pattern"); ok {
 		input.SelectionPattern = aws.String(v.(string))
 	}
+
 	_, err := conn.PutIntegrationResponse(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Integration Response: %s", err)
@@ -141,10 +153,6 @@ func resourceAwsApiGatewayIntegrationResponseRead(d *schema.ResourceData, meta i
 	d.Set("response_parameters", aws.StringValueMap(integrationResponse.ResponseParameters))
 	d.Set("response_parameters_in_json", aws.StringValueMap(integrationResponse.ResponseParameters))
 	return nil
-}
-
-func resourceAwsApiGatewayIntegrationResponseUpdate(d *schema.ResourceData, meta interface{}) error {
-	return resourceAwsApiGatewayIntegrationResponseCreate(d, meta)
 }
 
 func resourceAwsApiGatewayIntegrationResponseDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_api_gateway_integration_response_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_response_test.go
@@ -28,6 +28,8 @@ func TestAccAWSAPIGatewayIntegrationResponse_basic(t *testing.T) {
 						"aws_api_gateway_integration_response.test", "response_templates.application/json", ""),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_integration_response.test", "response_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_integration_response.test", "content_handling", ""),
 				),
 			},
 
@@ -40,6 +42,8 @@ func TestAccAWSAPIGatewayIntegrationResponse_basic(t *testing.T) {
 						"aws_api_gateway_integration_response.test", "response_templates.application/json", "$input.path('$')"),
 					resource.TestCheckResourceAttr(
 						"aws_api_gateway_integration_response.test", "response_templates.application/xml", ""),
+					resource.TestCheckResourceAttr(
+						"aws_api_gateway_integration_response.test", "content_handling", "CONVERT_TO_BINARY"),
 				),
 			},
 		},
@@ -281,6 +285,8 @@ resource "aws_api_gateway_integration_response" "test" {
     "application/json" = "$input.path('$')"
     "application/xml" = ""
   }
+
+  content_handling = "CONVERT_TO_BINARY"
 
 }
 `

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -72,3 +72,4 @@ The following arguments are supported:
 * `response_parameters` - (Optional) A map of response parameters that can be read from the backend response.
   For example: `response_parameters = { "method.response.header.X-Some-Header" = "integration.response.header.X-Some-Other-Header" }`,
 * `response_parameters_in_json` - **Deprecated**, use `response_parameters` instead.
+* `content_handling` - (Optional) Specifies how to handle request payload content type conversions. Supported values are `CONVERT_TO_BINARY` and `CONVERT_TO_TEXT`. If this property is not defined, the response payload will be passed through from the integration response to the method response without modification.


### PR DESCRIPTION
This continues the work carried out in #10696

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayIntegrationResponse_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/03 14:18:46 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccAWSAPIGatewayIntegrationResponse_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayIntegrationResponse_basic
--- PASS: TestAccAWSAPIGatewayIntegrationResponse_basic (57.33s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws57.352s
```