### PR TITLE
RDS cluster requires a minimum of 3 AZs

### DIFF
--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -63,7 +63,7 @@ string.
     made.
 * `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is created before the DB cluster is deleted. If true is specified, no DB snapshot is created. If false is specified, a DB snapshot is created before the DB cluster is deleted, using the value from `final_snapshot_identifier`. Default is true.
 * `availability_zones` - (Optional) A list of EC2 Availability Zones that
-  instances in the DB cluster can be created in
+  instances in the DB cluster can be created in. **NOTE:** If specified, a minimum of 3 AZs is needed, otherwise this resource will be forced recreation at every apply run regardless of template changes. See [Amazon RDS Aurora Cluster documentation for more information.](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Aurora.CreateInstance.html)
 * `backup_retention_period` - (Optional) The days to retain backups for. Default
 1
 * `preferred_backup_window` - (Optional) The daily time range during which automated backups are created if automated backups are enabled using the BackupRetentionPeriod parameter.

--- a/website/source/docs/providers/aws/r/s3_bucket_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_policy.html.markdown
@@ -24,7 +24,7 @@ data "aws_iam_policy_document" "b" {
 }
 
 resource "aws_s3_bucket_policy" "b" {
-  bucket = "${aws_s3_bucket.b.bucket}"
+  bucket = "${aws_s3_bucket.b.id}"
   policy = "${data.aws_iam_policy_document.b.json}"
 }
 ```


### PR DESCRIPTION
If less than 3 AZs are accidentally passed in, terraform will still create the RDS cluster, but will force recreation at subsequent runs regardless of template changed or not.

```
-/+ module.rds.aws_rds_cluster.default
    apply_immediately:               "" => "<computed>"
    availability_zones.#:            "3" => "2" (forces new resource)
    availability_zones.1305112097:   "us-east-1b" => "us-east-1b"
    availability_zones.3569565595:   "us-east-1a" => "us-east-1a"
    availability_zones.986537655:    "us-east-1c" => "" (forces new resource)
```