### PR TITLE
provider/aws: Fix the normalization of AWS policy statements

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1857,10 +1857,10 @@
 			"revision": "f233a8bac88d1f2dc282a98186f5a3363b806181"
 		},
 		{
-			"checksumSHA1": "zyyyjWKu9gGLFy00k8utV7pncvg=",
+			"checksumSHA1": "rixrz9zVpq9gss5jHqc/nGNpSw0=",
 			"path": "github.com/jen20/awspolicyequivalence",
-			"revision": "ebe5485f2c1822e7bee8b5008e14d9481a14a3a3",
-			"revisionTime": "2016-09-29T21:48:42Z"
+			"revision": "ed4c14ea400d756059e9312e409477a9ebf448f4",
+			"revisionTime": "2017-01-03T19:23:32Z"
 		},
 		{
 			"checksumSHA1": "tRK0n/cIjBCYjnumPiP9cCS2CnA=",


### PR DESCRIPTION
Fixes: #10784

When AWS was passed an AWS policy with a single statement, it normalized
it to a slice of statement. This was causing issues for Terraform when
it was trying to reapply changes