### PR TITLE
Read update_strategy before overwriting it.

### DIFF
--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -242,7 +242,11 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	d.Set("instance_group", manager.InstanceGroup)
 	d.Set("target_size", manager.TargetSize)
 	d.Set("self_link", manager.SelfLink)
-	d.Set("update_strategy", "RESTART") //this field doesn't match the manager api, set to default value
+	update_strategy, ok := d.GetOk("update_strategy")
+	if !ok {
+		update_strategy = "RESTART"
+	}
+	d.Set("update_strategy", update_strategy.(string))
 
 	return nil
 }


### PR DESCRIPTION
As brought up in #10174, our update_strategy property for instance group
managers in GCP would always be set to "RESTART" on read, even if the
user asked for them to be "NONE" in the config.

This adds a test to ensure that the user wishes were respected, which
fails until we check for update_strategy in the ResourceData before we
update it within the Read function. Because the update_strategy property
doesn't map to anything in the API, we never need to read it from
anywhere but the config, which means the ResourceData should be
considered authoritative by the time we get to the Read function.

The fix for this was provided by @JDiPierro in #10198 originally, but
was missing tests, so it got squashed into this.