### PR TITLE
provider/aws: data_source_aws_iam_server_certificate latest should be bool not string

### DIFF
--- a/builtin/providers/aws/data_source_aws_iam_server_certificate.go
+++ b/builtin/providers/aws/data_source_aws_iam_server_certificate.go
@@ -16,7 +16,7 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 		Read: dataSourceAwsIAMServerCertificateRead,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -32,7 +32,7 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 				},
 			},
 
-			"name_prefix": &schema.Schema{
+			"name_prefix": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -46,24 +46,24 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 				},
 			},
 
-			"latest": &schema.Schema{
-				Type:     schema.TypeString,
+			"latest": {
+				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 				Default:  false,
 			},
 
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"path": &schema.Schema{
+			"path": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"expiration_date": &schema.Schema{
+			"expiration_date": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/builtin/providers/aws/data_source_aws_iam_server_certificate_test.go
+++ b/builtin/providers/aws/data_source_aws_iam_server_certificate_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"testing"
 	"time"
@@ -55,9 +56,30 @@ func TestAccAWSDataSourceIAMServerCertificate_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMServerCertificateDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAwsDataIAMServerCertConfigMatchNamePrefix,
+				ExpectError: regexp.MustCompile(`Search for AWS IAM server certificate returned no results`),
+			},
+		},
+	})
+}
+
 var testAccAwsDataIAMServerCertConfig = fmt.Sprintf(`%s
 data "aws_iam_server_certificate" "test" {
   name = "${aws_iam_server_certificate.test_cert.name}"
   latest = true
 }
 `, testAccIAMServerCertConfig)
+
+var testAccAwsDataIAMServerCertConfigMatchNamePrefix = `
+data "aws_iam_server_certificate" "test" {
+  name_prefix = "MyCert"
+  latest = true
+}
+`


### PR DESCRIPTION
Fixes: #11010

Adds a test to show cover the use-case that the OP suggested caused the
panic

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDataSourceIAMServerCertificate_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/03 22:39:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDataSourceIAMServerCertificate_ -timeout 120m
=== RUN   TestAccAWSDataSourceIAMServerCertificate_basic
--- PASS: TestAccAWSDataSourceIAMServerCertificate_basic (19.48s)
=== RUN   TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix
--- PASS: TestAccAWSDataSourceIAMServerCertificate_matchNamePrefix (1.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	21.454s
```