### PR TITLE
Rancher stack upgrade fails

### DIFF
--- a/builtin/providers/rancher/resource_rancher_stack.go
+++ b/builtin/providers/rancher/resource_rancher_stack.go
@@ -245,7 +245,7 @@ func resourceRancherStackUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 
 			stateConf = &resource.StateChangeConf{
-				Pending:    []string{"active", "upgraded"},
+				Pending:    []string{"active", "upgraded", "finishing-upgrade"},
 				Target:     []string{"active"},
 				Refresh:    StackStateRefreshFunc(client, stack.Id),
 				Timeout:    10 * time.Minute,


### PR DESCRIPTION
Terraform 0.8.2 fails to upgrade Rancher stacks when it meets the `finishing-upgrade` state:

```
* rancher_stack.conplicity: Error waiting for stack (1e18) to be upgraded: unexpected state 'finishing-upgrade', wanted target 'active'. last error: %!s(<nil>)
```