### PR TITLE
provider/google: remote_traffic_selector for google_compute_vpn_tunnel

### DIFF
--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -199,6 +199,18 @@ func resourceComputeVpnTunnelRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error Reading VPN Tunnel %s: %s", name, err)
 	}
 
+	localTrafficSelectors := []string{}
+	for _, lts := range vpnTunnel.LocalTrafficSelector {
+		localTrafficSelectors = append(localTrafficSelectors, lts)
+	}
+	d.Set("local_traffic_selector", localTrafficSelectors)
+
+	remoteTrafficSelectors := []string{}
+	for _, rts := range vpnTunnel.RemoteTrafficSelector {
+		remoteTrafficSelectors = append(remoteTrafficSelectors, rts)
+	}
+	d.Set("remote_traffic_selector", remoteTrafficSelectors)
+
 	d.Set("detailed_status", vpnTunnel.DetailedStatus)
 	d.Set("self_link", vpnTunnel.SelfLink)
 

--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -72,6 +72,14 @@ func resourceComputeVpnTunnel() *schema.Resource {
 				Set:      schema.HashString,
 			},
 
+			"remote_traffic_selector": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -124,15 +132,24 @@ func resourceComputeVpnTunnelCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	var remoteTrafficSelectors []string
+	if v := d.Get("remote_traffic_selector").(*schema.Set); v.Len() > 0 {
+		remoteTrafficSelectors = make([]string, v.Len())
+		for i, v := range v.List() {
+			remoteTrafficSelectors[i] = v.(string)
+		}
+	}
+
 	vpnTunnelsService := compute.NewVpnTunnelsService(config.clientCompute)
 
 	vpnTunnel := &compute.VpnTunnel{
-		Name:                 name,
-		PeerIp:               peerIp,
-		SharedSecret:         sharedSecret,
-		TargetVpnGateway:     targetVpnGateway,
-		IkeVersion:           int64(ikeVersion),
-		LocalTrafficSelector: localTrafficSelectors,
+		Name:                  name,
+		PeerIp:                peerIp,
+		SharedSecret:          sharedSecret,
+		TargetVpnGateway:      targetVpnGateway,
+		IkeVersion:            int64(ikeVersion),
+		LocalTrafficSelector:  localTrafficSelectors,
+		RemoteTrafficSelector: remoteTrafficSelectors,
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
+++ b/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
@@ -15,17 +15,25 @@ Manages a VPN Tunnel to the GCE network. For more info, read the
 
 ```js
 resource "google_compute_network" "network1" {
-  name       = "network1"
-  ipv4_range = "10.120.0.0/16"
+  name = "network1"
+}
+
+resource "google_compute_subnetwork" "subnet1" {
+  name          = "subnet1"
+  network       = "${google_compute_network.network1.self_link}"
+  ip_cidr_range = "10.120.0.0/16"
+  region        = "us-central1"
 }
 
 resource "google_compute_vpn_gateway" "target_gateway" {
   name    = "vpn1"
   network = "${google_compute_network.network1.self_link}"
+  region  = "${google_compute_subnetwork.subnet1.region}"
 }
 
 resource "google_compute_address" "vpn_static_ip" {
   name   = "vpn-static-ip"
+  region = "${google_compute_subnetwork.subnet1.region}"
 }
 
 resource "google_compute_forwarding_rule" "fr_esp" {
@@ -57,6 +65,9 @@ resource "google_compute_vpn_tunnel" "tunnel1" {
   shared_secret = "a secret message"
 
   target_vpn_gateway = "${google_compute_vpn_gateway.target_gateway.self_link}"
+
+  local_traffic_selector = ["${google_compute_subnetwork.subnet1.ip_cidr_range}"]
+  remote_traffic_selector = ["172.16.0.0/12"]
 
   depends_on = [
     "google_compute_forwarding_rule.fr_esp",

--- a/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
+++ b/website/source/docs/providers/google/r/compute_vpn_tunnel.html.markdown
@@ -104,6 +104,11 @@ The following arguments are supported:
     custom subnetted network. Refer to Google documentation for more
     information.
 
+* `remote_traffic_selector` - (Optional) Specifies which CIDR ranges the VPN
+    tunnel can route to the remote side. Mandatory if the VPN gateway is attached to a
+    custom subnetted network. Refer to Google documentation for more
+    information.
+
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 


### PR DESCRIPTION
The google_compute_vpn_tunnel resource was missing support for the RemoteTrafficSelector parameter. As such, establishment of route based VPN tunnels fails due to the inability to negotiate a child SA. This should fix that.