### PR TITLE
provider/aws: Updating the aws_efs_mount_target dns_name

### DIFF
--- a/builtin/providers/aws/resource_aws_efs_mount_target.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target.go
@@ -200,13 +200,13 @@ func resourceAwsEfsMountTargetRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	// DNS name per http://docs.aws.amazon.com/efs/latest/ug/mounting-fs-mount-cmd-dns-name.html
-	az, err := getAzFromSubnetId(*mt.SubnetId, meta.(*AWSClient).ec2conn)
+	_, err = getAzFromSubnetId(*mt.SubnetId, meta.(*AWSClient).ec2conn)
 	if err != nil {
 		return fmt.Errorf("Failed getting Availability Zone from subnet ID (%s): %s", *mt.SubnetId, err)
 	}
 
 	region := meta.(*AWSClient).region
-	err = d.Set("dns_name", resourceAwsEfsMountTargetDnsName(az, *mt.FileSystemId, region))
+	err = d.Set("dns_name", resourceAwsEfsMountTargetDnsName(*mt.FileSystemId, region))
 	if err != nil {
 		return err
 	}
@@ -286,8 +286,8 @@ func resourceAwsEfsMountTargetDelete(d *schema.ResourceData, meta interface{}) e
 	return nil
 }
 
-func resourceAwsEfsMountTargetDnsName(az, fileSystemId, region string) string {
-	return fmt.Sprintf("%s.%s.efs.%s.amazonaws.com", az, fileSystemId, region)
+func resourceAwsEfsMountTargetDnsName(fileSystemId, region string) string {
+	return fmt.Sprintf("%s.efs.%s.amazonaws.com", fileSystemId, region)
 }
 
 func hasEmptyMountTargets(mto *efs.DescribeMountTargetsOutput) bool {

--- a/builtin/providers/aws/resource_aws_efs_mount_target_test.go
+++ b/builtin/providers/aws/resource_aws_efs_mount_target_test.go
@@ -34,7 +34,7 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_efs_mount_target.alpha",
 						"dns_name",
-						regexp.MustCompile("^us-west-2a.[^.]+.efs.us-west-2.amazonaws.com$"),
+						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
 				),
 			},
@@ -48,7 +48,7 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_efs_mount_target.alpha",
 						"dns_name",
-						regexp.MustCompile("^us-west-2a.[^.]+.efs.us-west-2.amazonaws.com$"),
+						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
 					testAccCheckEfsMountTarget(
 						"aws_efs_mount_target.beta",
@@ -57,7 +57,7 @@ func TestAccAWSEFSMountTarget_basic(t *testing.T) {
 					resource.TestMatchResourceAttr(
 						"aws_efs_mount_target.beta",
 						"dns_name",
-						regexp.MustCompile("^us-west-2b.[^.]+.efs.us-west-2.amazonaws.com$"),
+						regexp.MustCompile("^[^.]+.efs.us-west-2.amazonaws.com$"),
 					),
 				),
 			},
@@ -91,10 +91,9 @@ func TestAccAWSEFSMountTarget_disappears(t *testing.T) {
 }
 
 func TestResourceAWSEFSMountTarget_mountTargetDnsName(t *testing.T) {
-	actual := resourceAwsEfsMountTargetDnsName("non-existent-1c",
-		"fs-123456ab", "non-existent-1")
+	actual := resourceAwsEfsMountTargetDnsName("fs-123456ab", "non-existent-1")
 
-	expected := "non-existent-1c.fs-123456ab.efs.non-existent-1.amazonaws.com"
+	expected := "fs-123456ab.efs.non-existent-1.amazonaws.com"
 	if actual != expected {
 		t.Fatalf("Expected EFS mount target DNS name to be %s, got %s",
 			expected, actual)

--- a/website/source/docs/providers/aws/r/efs_mount_target.html.markdown
+++ b/website/source/docs/providers/aws/r/efs_mount_target.html.markdown
@@ -10,9 +10,6 @@ description: |-
 
 Provides an Elastic File System (EFS) mount target.
 
-~> **NOTE:** As per the current [documentation](https://docs.aws.amazon.com/efs/latest/ug/limits.html)
-the limit is 1 mount target per Availability Zone for a single EFS file system.
-
 ## Example Usage
 
 ```


### PR DESCRIPTION
Fixes:#10902

AWS introduced a change to the Mount Target DNS Name to remove the
availability_zone from it -
https://aws.amazon.com/about-aws/whats-new/2016/12/simplified-mounting-of-amazon-efs-file-systems/

This was because there used to be a limit of 1 mount target per AZ -
this has been raised.

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEFSMountTarget_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/04 10:45:35 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEFSMountTarget_ -timeout 120m
=== RUN   TestAccAWSEFSMountTarget_importBasic
--- PASS: TestAccAWSEFSMountTarget_importBasic (236.19s)
=== RUN   TestAccAWSEFSMountTarget_basic
--- PASS: TestAccAWSEFSMountTarget_basic (445.52s)
=== RUN   TestAccAWSEFSMountTarget_disappears
--- PASS: TestAccAWSEFSMountTarget_disappears (228.31s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	910.044s
```