### PR TITLE
provider/aws: New DataSource: aws_elb_hosted_zone_id

### DIFF
--- a/builtin/providers/aws/data_source_aws_elb_hosted_zone_id.go
+++ b/builtin/providers/aws/data_source_aws_elb_hosted_zone_id.go
@@ -1,0 +1,54 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+// See https://github.com/fog/fog-aws/pull/332/files
+// This list isn't exposed by AWS - it's been found through
+// trouble solving
+var elbHostedZoneIdPerRegionMap = map[string]string{
+	"ap-northeast-1": "Z14GRHDCWA56QT",
+	"ap-northeast-2": "ZWKZPGTI48KDX",
+	"ap-south-1":     "ZP97RAFLXTNZK",
+	"ap-southeast-1": "Z1LMS91P8CMLE5",
+	"ap-southeast-2": "Z1GM3OXH4ZPM65",
+	"ca-central-1":   "ZQSVJUPU6J1EY",
+	"eu-central-1":   "Z215JYRZR1TBD5",
+	"eu-west-1":      "Z32O12XQLNTSW2",
+	"eu-west-2":      "ZHURV8PSTC4K8",
+	"us-east-1":      "Z35SXDOTRQ7X7K",
+	"us-east-2":      "Z3AADJGX6KTTL2",
+	"us-west-1":      "Z368ELLRRE2KJ0",
+	"us-west-2":      "Z1H1FL5HABSF5",
+	"sa-east-1":      "Z2P70J7HTTTPLU",
+}
+
+func dataSourceAwsElbHostedZoneId() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsElbHostedZoneIdRead,
+
+		Schema: map[string]*schema.Schema{
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsElbHostedZoneIdRead(d *schema.ResourceData, meta interface{}) error {
+	region := meta.(*AWSClient).region
+	if v, ok := d.GetOk("region"); ok {
+		region = v.(string)
+	}
+
+	if zoneId, ok := elbHostedZoneIdPerRegionMap[region]; ok {
+		d.SetId(zoneId)
+		return nil
+	}
+
+	return fmt.Errorf("Unknown region (%q)", region)
+}

--- a/builtin/providers/aws/data_source_aws_elb_hosted_zone_id_test.go
+++ b/builtin/providers/aws/data_source_aws_elb_hosted_zone_id_test.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSElbHostedZoneId_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsElbHostedZoneIdConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_elb_hosted_zone_id.main", "id", "Z1H1FL5HABSF5"),
+				),
+			},
+			{
+				Config: testAccCheckAwsElbHostedZoneIdExplicitRegionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_elb_hosted_zone_id.regional", "id", "Z32O12XQLNTSW2"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAwsElbHostedZoneIdConfig = `
+data "aws_elb_hosted_zone_id" "main" { }
+`
+
+const testAccCheckAwsElbHostedZoneIdExplicitRegionConfig = `
+data "aws_elb_hosted_zone_id" "regional" {
+	region = "eu-west-1"
+}
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -156,6 +156,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ebs_volume":               dataSourceAwsEbsVolume(),
 			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),
 			"aws_eip":                      dataSourceAwsEip(),
+			"aws_elb_hosted_zone_id":       dataSourceAwsElbHostedZoneId(),
 			"aws_elb_service_account":      dataSourceAwsElbServiceAccount(),
 			"aws_iam_account_alias":        dataSourceAwsIamAccountAlias(),
 			"aws_iam_policy_document":      dataSourceAwsIamPolicyDocument(),

--- a/website/source/docs/providers/aws/d/elb_hosted_zone_id.html.markdown
+++ b/website/source/docs/providers/aws/d/elb_hosted_zone_id.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_elb_hosted_zone_id"
+sidebar_current: "docs-aws-datasource-elb-hosted-zone-id"
+description: |-
+  Get AWS Elastic Load Balancing Hosted Zone Id
+---
+
+# aws\_elb\_hosted\_zone\_id
+
+Use this data source to get the HostedZoneId of the [AWS Elastic Load Balancing Service Account](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy)
+in a given region for the purpose of using in an AWS Route53 Alias.
+
+## Example Usage
+
+```
+data "aws_elb_hosted_zone_id" "main" { }
+
+resource "aws_route53_record" "www" {
+  zone_id = "${aws_route53_zone.primary.zone_id}"
+  name = "example.com"
+  type = "A"
+
+  alias {
+    name = "${aws_elb.main.dns_name}"
+    zone_id = "${data.aws_elb_hosted_zone_id.main.id}"
+    evaluate_target_health = true
+  }
+}
+```
+
+## Argument Reference
+
+* `region` - (Optional) Name of the region whose AWS ELB HostedZoneId is desired.
+  Defaults to the region from the AWS provider configuration.
+
+
+## Attributes Reference
+
+* `id` - The ID of the AWS ELB HostedZoneId in the selected region.

--- a/website/source/docs/providers/aws/d/elb_hosted_zone_id.html.markdown
+++ b/website/source/docs/providers/aws/d/elb_hosted_zone_id.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws\_elb\_hosted\_zone\_id
 
-Use this data source to get the HostedZoneId of the [AWS Elastic Load Balancing Service Account](http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html#attach-bucket-policy)
+Use this data source to get the HostedZoneId of the AWS Elastic Load Balancing HostedZoneId
 in a given region for the purpose of using in an AWS Route53 Alias.
 
 ## Example Usage

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -47,6 +47,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-ecs-container-definition") %>>
                             <a href="/docs/providers/aws/d/ecs_container_definition.html">aws_ecs_container_definition</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-elb-hosted-zone-id") %>>
+                            <a href="/docs/providers/aws/d/elb_hosted_zone_id.html">aws_elb_hosted_zone_id</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-elb-service-account") %>>
                             <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
                         </li>


### PR DESCRIPTION
This datasource is a list of all of the ELB DualStack Hosted Zone IDs.
This will allow us to reference the correct hosted zone id when creating
route53 alias records

There are many bugs for this - this is just the beginning of fixing them

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElbHostedZoneId_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/04 13:04:32 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElbHostedZoneId_basic -timeout 120m
=== RUN   TestAccAWSElbHostedZoneId_basic
--- PASS: TestAccAWSElbHostedZoneId_basic (20.46s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	20.484s
```