### PR TITLE
provider/aws: Add Placement Constraints to ECS Task Definition

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -80,6 +80,27 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 				},
 				Set: resourceAwsEcsTaskDefinitionVolumeHash,
 			},
+
+			"placement_constraints": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				MaxItems: 10,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": &schema.Schema{
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+						},
+						"expression": &schema.Schema{
+							Type:     schema.TypeString,
+							ForceNew: true,
+							Required: true,
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -128,6 +149,19 @@ func resourceAwsEcsTaskDefinitionCreate(d *schema.ResourceData, meta interface{}
 		input.Volumes = volumes
 	}
 
+	constraints := d.Get("placement_constraints").(*schema.Set).List()
+	if len(constraints) > 0 {
+		var pc []*ecs.TaskDefinitionPlacementConstraint
+		for _, raw := range constraints {
+			p := raw.(map[string]interface{})
+			pc = append(pc, &ecs.TaskDefinitionPlacementConstraint{
+				Type:       aws.String(p["type"].(string)),
+				Expression: aws.String(p["expression"].(string)),
+			})
+		}
+		input.PlacementConstraints = pc
+	}
+
 	log.Printf("[DEBUG] Registering ECS task definition: %s", input)
 	out, err := conn.RegisterTaskDefinition(&input)
 	if err != nil {
@@ -167,8 +201,25 @@ func resourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}) 
 	d.Set("task_role_arn", taskDefinition.TaskRoleArn)
 	d.Set("network_mode", taskDefinition.NetworkMode)
 	d.Set("volumes", flattenEcsVolumes(taskDefinition.Volumes))
+	if err := d.Set("placement_constraints", flattenPlacementConstraints(taskDefinition.PlacementConstraints)); err != nil {
+		log.Printf("[ERR] Error setting placement_constraints for (%s): %s", d.Id(), err)
+	}
 
 	return nil
+}
+
+func flattenPlacementConstraints(pcs []*ecs.TaskDefinitionPlacementConstraint) []map[string]interface{} {
+	if len(pcs) == 0 {
+		return nil
+	}
+	results := make([]map[string]interface{}, 0)
+	for _, pc := range pcs {
+		c := make(map[string]interface{})
+		c["type"] = *pc.Type
+		c["expression"] = *pc.Expression
+		results = append(results, c)
+	}
+	return results
 }
 
 func resourceAwsEcsTaskDefinitionDelete(d *schema.ResourceData, meta interface{}) error {

--- a/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
@@ -21,6 +21,11 @@ resource "aws_ecs_task_definition" "service" {
     name = "service-storage"
     host_path = "/ecs/service-storage"
   }
+
+  placement_constraints {
+    type = "memberOf"
+    expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
+  }
 }
 ```
 
@@ -74,12 +79,24 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 * `task_role_arn` - (Optional) The ARN of IAM role that allows your Amazon ECS container task to make calls to other AWS services.
 * `network_mode` - (Optional) The Docker networking mode to use for the containers in the task. The valid values are `none`, `bridge`, and `host`.
 * `volume` - (Optional) A volume block. See below for details about what arguments are supported.
+* `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of 
+`placement_constraints` is `10`. Defined below.
 
 Volume block supports the following arguments:
 
 * `name` - (Required) The name of the volume. This name is referenced in the `sourceVolume`
 parameter of container definition in the `mountPoints` section.
 * `host_path` - (Optional) The path on the host container instance that is presented to the container. If not set, ECS will create a nonpersistent data volume that starts empty and is deleted after the task has finished.
+
+## placement_constraints 
+
+`placement_constraints` support the following:
+
+* `expression` -  Cluster Query Language expression to apply to the constraint.
+For more information, see [Cluster Query Language in the Amazon EC2 Container
+Service Developer
+Guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html).
+* `type` - The type of constraint. The only valid value at this time is `memberOf`
 
 ## Attributes Reference
 


### PR DESCRIPTION
Adds support for applying placement constraints to `aws_ecs_task_definition` resource. Refs #10968

- [Amazon EC2 Container Service: Task Placement Constraints](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#constraints)

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcsTaskDefinition_ -timeout 120m
=== RUN   TestAccAWSEcsTaskDefinition_basic
--- PASS: TestAccAWSEcsTaskDefinition_basic (20.61s)
=== RUN   TestAccAWSEcsTaskDefinition_withScratchVolume
--- PASS: TestAccAWSEcsTaskDefinition_withScratchVolume (12.22s)
=== RUN   TestAccAWSEcsTaskDefinition_withEcsService
--- PASS: TestAccAWSEcsTaskDefinition_withEcsService (143.42s)
=== RUN   TestAccAWSEcsTaskDefinition_withTaskRoleArn
--- PASS: TestAccAWSEcsTaskDefinition_withTaskRoleArn (13.27s)
=== RUN   TestAccAWSEcsTaskDefinition_withNetworkMode
--- PASS: TestAccAWSEcsTaskDefinition_withNetworkMode (13.38s)
=== RUN   TestAccAWSEcsTaskDefinition_constraint
--- PASS: TestAccAWSEcsTaskDefinition_constraint (12.10s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    215.027s
```