### PR TITLE
Increasing timeout for redshift cluster creation

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -416,7 +416,7 @@ func resourceAwsRedshiftClusterCreate(d *schema.ResourceData, meta interface{}) 
 		Pending:    []string{"creating", "backing-up", "modifying", "restoring"},
 		Target:     []string{"available"},
 		Refresh:    resourceAwsRedshiftClusterStateRefreshFunc(d, meta),
-		Timeout:    40 * time.Minute,
+		Timeout:    75 * time.Minute,
 		MinTimeout: 10 * time.Second,
 	}
 


### PR DESCRIPTION
This is in response to creating 25 node cluster, and taking longer than 40 min max.

```
aws_redshift_cluster.default: Still creating... (44m43s elapsed)
aws_redshift_cluster.default: Still creating... (44m53s elapsed)
Error applying plan:

1 error(s) occurred:

* aws_redshift_cluster.default: [WARN] Error waiting for Redshift Cluster state to be "available": timeout while waiting for state to become 'available' (last state: 'creating', timeout: 40m0s)

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```