### PR TITLE
provider/aws: aws_db_instance restored from snapshot had problem with subnet_group

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -941,7 +941,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 		req.DBPortNumber = aws.Int64(int64(d.Get("port").(int)))
 		requestUpdate = true
 	}
-	if d.HasChange("db_subnet_group_name") {
+	if d.HasChange("db_subnet_group_name") && !d.IsNewResource() {
 		d.SetPartial("db_subnet_group_name")
 		req.DBSubnetGroupName = aws.String(d.Get("db_subnet_group_name").(string))
 		requestUpdate = true


### PR DESCRIPTION
Fixes #11024

A change was introduced in 0.8.2 that allows db_instances to change
their db_subnet_group. Unfortunately, this caused an issue for
db_instances that were being restored from snapshot. The restore from
snapshot part of create calls the Update func whereas a normal create
calls the Read func

When calling the Update func, the db_instance was trying to go through a
db_subnet_group_name change and was failing for the following reason:

```
InvalidVPCNetworkStateFault: You cannot move DB instance _rds_instance_name_ to subnet group _subnet_group_name_. The specified DB subnet group and DB instance are in the same VPC. Choose a DB subnet group in different VPC than the specified DB instance and try again.
```