### PR TITLE
provider/google: Pull a google_compute_backend resource out of the google_compute_backend_service resource.

### DIFF
--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -392,7 +392,15 @@ func resourceGoogleComputeBackendServiceBackendHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
+	if m["group"].(string) != "" {
+		buf.WriteString(fmt.Sprintf("%s-", m["group"].(string)))
+	}
+
+	if v, ok := m["groups"]; ok {
+		for _, group := range v.([]interface{}) {
+			buf.WriteString(fmt.Sprintf("%s-", group.(string)))
+		}
+	}
 
 	if v, ok := m["balancing_mode"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))

--- a/builtin/providers/google/resource_compute_region_backend_service.go
+++ b/builtin/providers/google/resource_compute_region_backend_service.go
@@ -196,7 +196,7 @@ func resourceComputeRegionBackendServiceRead(d *schema.ResourceData, meta interf
 	d.Set("fingerprint", service.Fingerprint)
 	d.Set("self_link", service.SelfLink)
 
-	d.Set("backend", flattenBackends(service.Backends))
+	d.Set("backend", service.Backends)
 	d.Set("health_checks", service.HealthChecks)
 
 	return nil

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -99,9 +99,12 @@ The following arguments are supported:
 
 **Backend** supports the following attributes:
 
-* `group` - (Required) The name or URI of a Compute Engine instance group
+* `group` - (Optional) The name or URI of a Compute Engine instance group
     (`google_compute_instance_group_manager.xyz.instance_group`) that can
     receive traffic.
+
+* `groups` - (Optional) A list of of Compute Engine instance group URIs or
+   names that will receive traffic.
 
 * `balancing_mode` - (Optional) Defines the strategy for balancing load.
     Defaults to `UTILIZATION`


### PR DESCRIPTION
This covers the case where you decide to use a `count` on creation of an `instance_group` and then the `google_compute_instance_group.foobar.*.self_link` syntax to grab the list of all instance groups

The `backend` now either excepts `group` or `groups`. When specifying `groups` it will take the values that you set for properties such as `balancing_mode` and share that across all of the instance groups.

Also, original implementation had `flatten_backend` as a function but it does not seem to be required so it was removed.

