### PR TITLE
provider/aws: New Resource aws_codedeploy_deployment_config

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -219,6 +219,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_autoscaling_lifecycle_hook":               resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":                  resourceAwsCloudWatchMetricAlarm(),
 			"aws_codedeploy_app":                           resourceAwsCodeDeployApp(),
+			"aws_codedeploy_deployment_config":		resourceAwsCodeDeployDeploymentConfig(),
 			"aws_codedeploy_deployment_group":              resourceAwsCodeDeployDeploymentGroup(),
 			"aws_codecommit_repository":                    resourceAwsCodeCommitRepository(),
 			"aws_codecommit_trigger":                       resourceAwsCodeCommitTrigger(),

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -219,7 +219,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_autoscaling_lifecycle_hook":               resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":                  resourceAwsCloudWatchMetricAlarm(),
 			"aws_codedeploy_app":                           resourceAwsCodeDeployApp(),
-			"aws_codedeploy_deployment_config":		resourceAwsCodeDeployDeploymentConfig(),
+			"aws_codedeploy_deployment_config":             resourceAwsCodeDeployDeploymentConfig(),
 			"aws_codedeploy_deployment_group":              resourceAwsCodeDeployDeploymentGroup(),
 			"aws_codecommit_repository":                    resourceAwsCodeCommitRepository(),
 			"aws_codecommit_trigger":                       resourceAwsCodeCommitTrigger(),

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_config.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_config.go
@@ -1,0 +1,134 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+)
+
+func resourceAwsCodeDeployDeploymentConfig() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCodeDeployDeploymentConfigCreate,
+		Read:   resourceAwsCodeDeployDeploymentConfigRead,
+		Delete: resourceAwsCodeDeployDeploymentConfigDelete,
+
+		Schema: map[string]*schema.Schema{
+			"deployment_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"minimum_healthy_hosts": {
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"type": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+
+						"value": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsCodeDeployDeploymentConfigCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	input := &codedeploy.CreateDeploymentConfigInput{
+		DeploymentConfigName: aws.String(d.Get("deployment_group_name").(string)),
+		MinimumHealthyHosts: expandAwsCodeDeployConfigMinimumHealthHosts(d),
+	}
+
+	resp, err := conn.CreateDeploymentConfig(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*resp.DeploymentConfigId)
+
+	return resourceAwsCodeDeployDeploymentConfigRead(d, meta)
+}
+
+
+func resourceAwsCodeDeployDeploymentConfigRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	input := &codedeploy.GetDeploymentConfigInput{
+		DeploymentConfigName: aws.String(d.Get("deployment_group_name").(string)),
+	}
+
+	resp, err := conn.GetDeploymentConfig(input)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if "DeploymentConfigDoesNotExistException" == awsErr.Code() {
+				log.Printf("[DEBUG] CodeDeploy Deployment Config (%s) not found", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+
+	if resp.DeploymentConfigInfo == nil {
+		return fmt.Errorf("[ERROR] Cannot find DeploymentConfig %q", d.Id())
+	}
+
+	if err := d.Set("storage_data_disk", flattenAwsCodeDeployConfigMinimumHealthHosts(resp.DeploymentConfigInfo.MinimumHealthyHosts)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting CodeDeploy DeploymentConfig MinimumHealthyHosts error: %#v", err)
+	}
+	d.Set("deployment_group_name", resp.DeploymentConfigInfo.DeploymentConfigName)
+
+	return nil
+}
+
+func resourceAwsCodeDeployDeploymentConfigDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).codedeployconn
+
+	input := &codedeploy.DeleteDeploymentConfigInput{
+		DeploymentConfigName: aws.String(d.Id()),
+	}
+
+	_, err := conn.DeleteDeploymentConfig(input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandAwsCodeDeployConfigMinimumHealthHosts(d *schema.ResourceData) *codedeploy.MinimumHealthyHosts {
+	hosts := d.Get("minimum_healthy_hosts").([]interface{})
+	host := hosts[0].(map[string]interface{})
+
+	minimumHealthyHost := codedeploy.MinimumHealthyHosts{
+		Type: aws.String(host["type"].(string)),
+		Value: aws.Int64(int64(host["value"].(int))),
+	}
+
+
+	return &minimumHealthyHost
+}
+
+func flattenAwsCodeDeployConfigMinimumHealthHosts(hosts *codedeploy.MinimumHealthyHosts) []interface{} {
+	result := make(map[string]interface{})
+
+	result["type"] = *hosts.Type
+	result["key"] = *hosts.Value
+
+	return []interface{}{result}
+}

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_config_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_config_test.go
@@ -1,0 +1,168 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/codedeploy"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCodeDeployDeploymentConfig_basic(t *testing.T) {
+	var config codedeploy.DeploymentConfigInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentConfigDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeDeployDeploymentConfigFleet(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.type", "FLEET_PERCENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.value", "75"),
+				),
+			},
+			{
+				Config: testAccAWSCodeDeployDeploymentConfigHostCount(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.type", "HOST_COUNT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.value", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestValidateAWSCodeDeployMinimumHealthyHostsType(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "FLEET_PERCENT",
+			ErrCount: 0,
+		},
+		{
+			Value:    "HOST_COUNT",
+			ErrCount: 0,
+		},
+		{
+			Value:    "host_count",
+			ErrCount: 1,
+		},
+		{
+			Value:    "hostcount",
+			ErrCount: 1,
+		},
+		{
+			Value:    "FleetPercent",
+			ErrCount: 1,
+		},
+		{
+			Value:    "Foo",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateMinimumHealtyHostsType(tc.Value, "minimum_healthy_hosts_type")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Minimum Healthy Hosts validation failed for type %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func testAccCheckAWSCodeDeployDeploymentConfigDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).codedeployconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_codedeploy_deployment_config" {
+			continue
+		}
+
+		resp, err := conn.GetDeploymentConfig(&codedeploy.GetDeploymentConfigInput{
+			DeploymentConfigName: aws.String(rs.Primary.ID),
+		})
+
+		if ae, ok := err.(awserr.Error); ok && ae.Code() == "DeploymentConfigDoesNotExistException" {
+			continue
+		}
+
+		if err == nil {
+			if resp.DeploymentConfigInfo != nil {
+				return fmt.Errorf("CodeDeploy deployment config still exists:\n%#v", *resp.DeploymentConfigInfo.DeploymentConfigName)
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccCheckAWSCodeDeployDeploymentConfigExists(name string, config *codedeploy.DeploymentConfigInfo) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).codedeployconn
+
+		resp, err := conn.GetDeploymentConfig(&codedeploy.GetDeploymentConfigInput{
+			DeploymentConfigName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		*config = *resp.DeploymentConfigInfo
+
+		return nil
+	}
+}
+
+func testAccAWSCodeDeployDeploymentConfigFleet(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codedeploy_deployment_config" "foo" {
+	deployment_group_name = "test-deployment-config-%s"
+	minimum_healthy_hosts {
+		type = "FLEET_PERCENT"
+		value = 75
+	}
+}`, rName)
+}
+
+func testAccAWSCodeDeployDeploymentConfigHostCount(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_codedeploy_deployment_config" "foo" {
+	deployment_group_name = "test-deployment-config-%s"
+	minimum_healthy_hosts {
+		type = "HOST_COUNT"
+		value = 1
+	}
+}`, rName)
+}

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_config_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_config_test.go
@@ -2,22 +2,17 @@ package aws
 
 import (
 	"fmt"
-	"reflect"
-	"regexp"
-	"sort"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/codedeploy"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
-	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSCodeDeployDeploymentConfig_basic(t *testing.T) {
+func TestAccAWSCodeDeployDeploymentConfig_fleetPercent(t *testing.T) {
 	var config codedeploy.DeploymentConfigInfo
 
 	rName := acctest.RandString(5)
@@ -32,19 +27,33 @@ func TestAccAWSCodeDeployDeploymentConfig_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.type", "FLEET_PERCENT"),
+						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.type", "FLEET_PERCENT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.value", "75"),
+						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.value", "75"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentConfig_hostCount(t *testing.T) {
+	var config codedeploy.DeploymentConfigInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentConfigDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCodeDeployDeploymentConfigHostCount(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentConfigExists("aws_codedeploy_deployment_config.foo", &config),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.type", "HOST_COUNT"),
+						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.type", "HOST_COUNT"),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_config.foo", "minimum_host_count.0.value", "1"),
+						"aws_codedeploy_deployment_config.foo", "minimum_healthy_hosts.0.value", "1"),
 				),
 			},
 		},
@@ -148,7 +157,7 @@ func testAccCheckAWSCodeDeployDeploymentConfigExists(name string, config *codede
 func testAccAWSCodeDeployDeploymentConfigFleet(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_config" "foo" {
-	deployment_group_name = "test-deployment-config-%s"
+	deployment_config_name = "test-deployment-config-%s"
 	minimum_healthy_hosts {
 		type = "FLEET_PERCENT"
 		value = 75
@@ -159,7 +168,7 @@ resource "aws_codedeploy_deployment_config" "foo" {
 func testAccAWSCodeDeployDeploymentConfigHostCount(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_codedeploy_deployment_config" "foo" {
-	deployment_group_name = "test-deployment-config-%s"
+	deployment_config_name = "test-deployment-config-%s"
 	minimum_healthy_hosts {
 		type = "HOST_COUNT"
 		value = 1

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_config.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_config.html.markdown
@@ -1,0 +1,75 @@
+---
+layout: "aws"
+page_title: "AWS: aws_codedeploy_deployment_config"
+sidebar_current: "docs-aws-resource-codedeploy-deployment-config"
+description: |-
+  Provides a CodeDeploy deployment config.
+---
+
+# aws\_codedeploy\_deployment\_config
+
+Provides a CodeDeploy deployment config for an application
+
+## Example Usage
+
+```
+
+resource "aws_codedeploy_deployment_config" "foo" {
+    deployment_config_name = "test-deployment-config"
+    minimum_healthy_hosts {
+        type = "HOST_COUNT"
+        value = "2"
+    }
+}
+
+resource "aws_codedeploy_deployment_group" "foo" {
+    app_name = "${aws_codedeploy_app.foo_app.name}"
+    deployment_group_name = "bar"
+    service_role_arn = "${aws_iam_role.foo_role.arn}"
+    deployment_config_name = "${aws_codedeploy_deployment_config.foo.id}"
+
+    ec2_tag_filter {
+        key = "filterkey"
+        type = "KEY_AND_VALUE"
+        value = "filtervalue"
+    }
+
+    trigger_configuration {
+        trigger_events = ["DeploymentFailure"]
+        trigger_name = "foo-trigger"
+        trigger_target_arn = "foo-topic-arn"
+    }
+
+    auto_rollback_configuration {
+      enabled = true
+      events = ["DEPLOYMENT_FAILURE"]
+    }
+
+    alarm_configuration {
+      alarms = ["my-alarm-name"]
+      enabled = true
+    }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `deployment_config_name` - (Required) The name of the deployment config.
+* `minimum_healthy_hosts` - (Optional) A minimum_healthy_hosts block. Minimum Healthy Hosts are documented below.
+
+A `minimum_healthy_hosts` block support the following:
+
+* `type` - (Required) The type can either be `FLEET_PERCENT` or `HOST_COUNT`.
+* `value` - (Required) The value when the type is `FLEET_PERCENT` represents the minimum number of healthy instances as
+a percentage of the total number of instances in the deployment. If you specify FLEET_PERCENT, at the start of the
+deployment, AWS CodeDeploy converts the percentage to the equivalent number of instance and rounds up fractional instances.
+When the type is `HOST_COUNT`, the value represents the minimum number of healthy instances as an absolute value.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The deployment group's config name.
+* `deployment_config_id` - The AWS Assigned deployment config id

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_config.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_config.html.markdown
@@ -18,7 +18,7 @@ resource "aws_codedeploy_deployment_config" "foo" {
     deployment_config_name = "test-deployment-config"
     minimum_healthy_hosts {
         type = "HOST_COUNT"
-        value = "2"
+        value = 2
     }
 }
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -249,6 +249,10 @@
                             <a href="/docs/providers/aws/r/codedeploy_app.html">aws_codedeploy_app</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-codedeploy-deployment-config") %>>
+                            <a href="/docs/providers/aws/r/codedeploy_deployment_config.html">aws_codedeploy_deployment_config</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-codedeploy-deployment-group") %>>
                             <a href="/docs/providers/aws/r/codedeploy_deployment_group.html">aws_codedeploy_deployment_group</a>
                         </li>


### PR DESCRIPTION
Fixes #10889 

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCodeDeployDeploymentConfig_'                       2 ↵ ✹ ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/05 20:49:34 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCodeDeployDeploymentConfig_ -timeout 120m
=== RUN   TestAccAWSCodeDeployDeploymentConfig_fleetPercent
--- PASS: TestAccAWSCodeDeployDeploymentConfig_fleetPercent (21.17s)
=== RUN   TestAccAWSCodeDeployDeploymentConfig_hostCount
--- PASS: TestAccAWSCodeDeployDeploymentConfig_hostCount (19.32s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	40.508s
```