### PR TITLE
provider/openstack: LoadBalancer Security Groups

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2_test.go
@@ -5,9 +5,12 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/lbaas_v2/loadbalancers"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/security/groups"
+	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 )
 
 func TestAccLBV2LoadBalancer_basic(t *testing.T) {
@@ -19,19 +22,75 @@ func TestAccLBV2LoadBalancer_basic(t *testing.T) {
 		CheckDestroy: testAccCheckLBV2LoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: TestAccLBV2LoadBalancerConfig_basic,
+				Config: testAccLBV2LoadBalancerConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLBV2LoadBalancerExists("openstack_lb_loadbalancer_v2.loadbalancer_1", &lb),
 				),
 			},
 			resource.TestStep{
-				Config: TestAccLBV2LoadBalancerConfig_update,
+				Config: testAccLBV2LoadBalancerConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"openstack_lb_loadbalancer_v2.loadbalancer_1", "name", "loadbalancer_1_updated"),
 					resource.TestMatchResourceAttr(
 						"openstack_lb_loadbalancer_v2.loadbalancer_1", "vip_port_id",
 						regexp.MustCompile("^[a-f0-9-]+")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLBV2LoadBalancer_secGroup(t *testing.T) {
+	var lb loadbalancers.LoadBalancer
+	var sg_1, sg_2 groups.SecGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLBV2LoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccLBV2LoadBalancer_secGroup,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2LoadBalancerExists(
+						"openstack_lb_loadbalancer_v2.loadbalancer_1", &lb),
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_1", &sg_1),
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_1", &sg_2),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_loadbalancer_v2.loadbalancer_1", "security_group_ids.#", "1"),
+					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg_1),
+				),
+			},
+			resource.TestStep{
+				Config: testAccLBV2LoadBalancer_secGroup_update1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2LoadBalancerExists(
+						"openstack_lb_loadbalancer_v2.loadbalancer_1", &lb),
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_2", &sg_1),
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_2", &sg_2),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_loadbalancer_v2.loadbalancer_1", "security_group_ids.#", "2"),
+					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg_1),
+					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg_2),
+				),
+			},
+			resource.TestStep{
+				Config: testAccLBV2LoadBalancer_secGroup_update2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckLBV2LoadBalancerExists(
+						"openstack_lb_loadbalancer_v2.loadbalancer_1", &lb),
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_2", &sg_1),
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_2", &sg_2),
+					resource.TestCheckResourceAttr(
+						"openstack_lb_loadbalancer_v2.loadbalancer_1", "security_group_ids.#", "1"),
+					testAccCheckLBV2LoadBalancerHasSecGroup(&lb, &sg_2),
 				),
 			},
 		},
@@ -59,7 +118,8 @@ func testAccCheckLBV2LoadBalancerDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckLBV2LoadBalancerExists(n string, lb *loadbalancers.LoadBalancer) resource.TestCheckFunc {
+func testAccCheckLBV2LoadBalancerExists(
+	n string, lb *loadbalancers.LoadBalancer) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -91,7 +151,31 @@ func testAccCheckLBV2LoadBalancerExists(n string, lb *loadbalancers.LoadBalancer
 	}
 }
 
-const TestAccLBV2LoadBalancerConfig_basic = `
+func testAccCheckLBV2LoadBalancerHasSecGroup(
+	lb *loadbalancers.LoadBalancer, sg *groups.SecGroup) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		config := testAccProvider.Meta().(*Config)
+		networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
+		if err != nil {
+			return fmt.Errorf("Error creating OpenStack networking client: %s", err)
+		}
+
+		port, err := ports.Get(networkingClient, lb.VipPortID).Extract()
+		if err != nil {
+			return err
+		}
+
+		for _, p := range port.SecurityGroups {
+			if p == sg.ID {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("LoadBalancer does not have the security group")
+	}
+}
+
+const testAccLBV2LoadBalancerConfig_basic = `
 resource "openstack_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
@@ -110,7 +194,7 @@ resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
 }
 `
 
-const TestAccLBV2LoadBalancerConfig_update = `
+const testAccLBV2LoadBalancerConfig_update = `
 resource "openstack_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
@@ -127,5 +211,100 @@ resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
   name = "loadbalancer_1_updated"
   admin_state_up = "true"
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+}
+`
+
+const testAccLBV2LoadBalancer_secGroup = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "secgroup_1"
+  description = "secgroup_1"
+}
+
+resource "openstack_networking_secgroup_v2" "secgroup_2" {
+  name = "secgroup_2"
+  description = "secgroup_2"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  cidr = "192.168.199.0/24"
+}
+
+resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
+    name = "loadbalancer_1"
+    vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    security_group_ids = [
+      "${openstack_networking_secgroup_v2.secgroup_1.id}"
+    ]
+}
+`
+
+const testAccLBV2LoadBalancer_secGroup_update1 = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "secgroup_1"
+  description = "secgroup_1"
+}
+
+resource "openstack_networking_secgroup_v2" "secgroup_2" {
+  name = "secgroup_2"
+  description = "secgroup_2"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  cidr = "192.168.199.0/24"
+}
+
+resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
+    name = "loadbalancer_1"
+    vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    security_group_ids = [
+      "${openstack_networking_secgroup_v2.secgroup_1.id}",
+      "${openstack_networking_secgroup_v2.secgroup_2.id}"
+    ]
+}
+`
+
+const testAccLBV2LoadBalancer_secGroup_update2 = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "secgroup_1"
+  description = "secgroup_1"
+}
+
+resource "openstack_networking_secgroup_v2" "secgroup_2" {
+  name = "secgroup_2"
+  description = "secgroup_2"
+}
+
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+  cidr = "192.168.199.0/24"
+}
+
+resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
+    name = "loadbalancer_1"
+    vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
+    security_group_ids = [
+      "${openstack_networking_secgroup_v2.secgroup_2.id}"
+    ]
+    depends_on = ["openstack_networking_secgroup_v2.secgroup_1"]
 }
 `

--- a/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
@@ -53,6 +53,10 @@ The following arguments are supported:
 * `provider` - (Optional) The name of the provider. Changing this creates a new
     loadbalancer.
 
+* `security_group_ids` - (Optional) A list of security group IDs to apply to the
+    loadbalancer. The security groups must be specified by ID and not name (as
+    opposed to how they are configured with the Compute Instance).
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -66,4 +70,5 @@ The following attributes are exported:
 * `admin_state_up` - See Argument Reference above.
 * `flavor` - See Argument Reference above.
 * `provider` - See Argument Reference above.
+* `security_group_ids` - See Argument Reference above.
 * `vip_port_id` - The Port ID of the Load Balancer IP.


### PR DESCRIPTION
This commit adds the ability to specify security groups on a loadbalancer
resource.

Fixes #11066 