### PR TITLE
Update cloudwatch_metric_alarm.html.markdown

### DIFF
--- a/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_metric_alarm" "bat" {
     period = "120"
     statistic = "Average"
     threshold = "80"
-    dimensions {
+    dimensions = {
         AutoScalingGroupName = "${aws_autoscaling_group.bar.name}"
     }
     alarm_description = "This metric monitor ec2 cpu utilization"


### PR DESCRIPTION
Added the missing `=` in the "Example in Conjunction with Scaling Policies" script