### PR TITLE
command/plan: add flag to display diffs only

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -108,6 +108,7 @@ type Operation struct {
 	// PlanOutBackend is the backend to store with the plan. This is the
 	// backend that will be used when applying the plan.
 	PlanId         string
+	PlanDiff       bool   // PlanDiff will only output differing attributes
 	PlanRefresh    bool   // PlanRefresh will do a refresh before a plan
 	PlanOutPath    string // PlanOutPath is the path to save the plan
 	PlanOutBackend *terraform.BackendState

--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -146,8 +146,10 @@ func (b *Local) opPlan(
 				path))
 		}
 
+		planDiff := op.PlanDiff
 		b.CLI.Output(format.Plan(&format.PlanOpts{
 			Plan:        plan,
+			PlanDiff:    planDiff,
 			Color:       b.Colorize(),
 			ModuleDepth: -1,
 		}))

--- a/command/plan.go
+++ b/command/plan.go
@@ -17,7 +17,7 @@ type PlanCommand struct {
 }
 
 func (c *PlanCommand) Run(args []string) int {
-	var destroy, refresh, detailed bool
+	var destroy, refresh, detailed, diff bool
 	var outPath string
 	var moduleDepth int
 
@@ -32,6 +32,7 @@ func (c *PlanCommand) Run(args []string) int {
 		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
+	cmdFlags.BoolVar(&diff, "diff", false, "diff")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
@@ -94,6 +95,7 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq.Destroy = destroy
 	opReq.Module = mod
 	opReq.Plan = plan
+	opReq.PlanDiff = diff
 	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
 	opReq.Type = backend.OperationTypePlan
@@ -151,6 +153,8 @@ Options:
                       0 - Succeeded, diff is empty (no changes)
                       1 - Errored
                       2 - Succeeded, there is a diff
+
+  -diff               Only output differing attributes.
 
   -input=true         Ask for input for variables if not directly set.
 

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -37,6 +37,8 @@ The command-line flags are all optional. The list of available flags are:
   * 1 = Error
   * 2 = Succeeded with non-empty diff (changes present)
 
+* `-diff` - Only output differing attributes.
+
 * `-input=true` - Ask for input for variables if not directly set.
 
 * `-lock=true` - Lock the state file when locking is supported.


### PR DESCRIPTION
Adds an optional new `-diff` flag to `terraform plan` to view only attributes which have changed. Useful when you're making a quick change and don't want to trawl through 100s of lines to pinpoint what's actually changing.

### Before
```
› terraform plan
[...]
~ aws_security_group.main
    ingress.#:                            "2" => "3"
    ingress.1969601585.cidr_blocks.#:     "0" => "1"
    ingress.1969601585.cidr_blocks.0:     "" => "0.0.0.0/0"
    ingress.1969601585.from_port:         "0" => "13714"
    ingress.1969601585.protocol:          "" => "udp"
    ingress.1969601585.security_groups.#: "0" => "0"
    ingress.1969601585.self:              "false" => "false"
    ingress.1969601585.to_port:           "0" => "13714"
    ingress.1971169986.cidr_blocks.#:     "1" => "1"
    ingress.1971169986.cidr_blocks.0:     "124.29.202.146/32" => "124.29.202.146/32"
    ingress.1971169986.from_port:         "443" => "443"
    ingress.1971169986.protocol:          "tcp" => "tcp"
    ingress.1971169986.security_groups.#: "0" => "0"
    ingress.1971169986.self:              "false" => "false"
    ingress.1971169986.to_port:           "443" => "443"
    ingress.3256548365.cidr_blocks.#:     "1" => "1"
    ingress.3256548365.cidr_blocks.0:     "124.29.202.146/32" => "124.29.202.146/32"
    ingress.3256548365.from_port:         "22" => "22"
    ingress.3256548365.protocol:          "tcp" => "tcp"
    ingress.3256548365.security_groups.#: "0" => "0"
    ingress.3256548365.self:              "false" => "false"
    ingress.3256548365.to_port:           "22" => "22"


Plan: 0 to add, 1 to change, 0 to destroy.
```

### After
```george • mac • /tmp/tmp.NGdGnpbrW0 • master
› terraform plan -diff
[...]
~ aws_security_group.main
    ingress.#:                            "2" => "3"
    ingress.1969601585.cidr_blocks.#:     "0" => "1"
    ingress.1969601585.cidr_blocks.0:     "" => "0.0.0.0/0"
    ingress.1969601585.from_port:         "0" => "13714"
    ingress.1969601585.protocol:          "" => "udp"
    ingress.1969601585.to_port:           "0" => "13714"


Plan: 0 to add, 1 to change, 0 to destroy.
```