### PR TITLE
providers/MySQL: Table Level Privilege Grant

### DIFF
--- a/builtin/providers/mysql/resource_grant.go
+++ b/builtin/providers/mysql/resource_grant.go
@@ -62,15 +62,7 @@ func resourceGrant() *schema.Resource {
 
 func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*providerConfiguration).Conn
-
-	// create a comma-delimited string of privileges
-	var privileges string
-	var privilegesList []string
-	vL := d.Get("privileges").(*schema.Set).List()
-	for _, v := range vL {
-		privilegesList = append(privilegesList, v.(string))
-	}
-	privileges = strings.Join(privilegesList, ",")
+	privileges := getPrivilegesString(d)
 
 	stmtSQL := fmt.Sprintf("GRANT %s on %s.%s TO '%s'@'%s'",
 		privileges,
@@ -89,8 +81,8 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	user := fmt.Sprintf("%s@%s:%s", d.Get("user").(string), d.Get("host").(string), d.Get("database"))
-	d.SetId(user)
+	identifier := fmt.Sprintf("%s@%s:%s.%s", d.Get("user").(string), d.Get("host").(string), d.Get("database"), d.Get("table"))
+	d.SetId(identifier)
 
 	return ReadGrant(d, meta)
 }
@@ -103,7 +95,24 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*providerConfiguration).Conn
 
-	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.%s FROM '%s'@'%s'",
+	// remove GRANT OPTION only if granted by this resource
+	if d.Get("grant").(bool) {
+		stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.%s FROM '%s'@'%s'",
+			d.Get("database").(string),
+			d.Get("table").(string),
+			d.Get("user").(string),
+			d.Get("host").(string))
+		log.Println("Executing statement:", stmtSQL)
+		_, _, err := conn.Query(stmtSQL)
+		if err != nil {
+			return err
+		}
+	}
+
+	// remove privileges only if granted by this resource
+	privileges := getPrivilegesString(d)
+	stmtSQL := fmt.Sprintf("REVOKE %s ON %s.%s FROM '%s'@'%s'",
+		privileges,
 		d.Get("database").(string),
 		d.Get("table").(string),
 		d.Get("user").(string),
@@ -115,17 +124,15 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	stmtSQL = fmt.Sprintf("REVOKE ALL ON %s.%s FROM '%s'@'%s'",
-		d.Get("database").(string),
-		d.Get("table").(string),
-		d.Get("user").(string),
-		d.Get("host").(string))
-
-	log.Println("Executing statement:", stmtSQL)
-	_, _, err = conn.Query(stmtSQL)
-	if err != nil {
-		return err
-	}
-
 	return nil
+}
+
+func getPrivilegesString(d *schema.ResourceData) string {
+	// create a comma-delimited string of privileges
+	var privilegesList []string
+	vL := d.Get("privileges").(*schema.Set).List()
+	for _, v := range vL {
+		privilegesList = append(privilegesList, v.(string))
+	}
+	return strings.Join(privilegesList, ",")
 }

--- a/builtin/providers/mysql/resource_grant.go
+++ b/builtin/providers/mysql/resource_grant.go
@@ -35,6 +35,13 @@ func resourceGrant() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"table": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Default:  "*",
+			},
+
 			"privileges": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
@@ -65,9 +72,10 @@ func CreateGrant(d *schema.ResourceData, meta interface{}) error {
 	}
 	privileges = strings.Join(privilegesList, ",")
 
-	stmtSQL := fmt.Sprintf("GRANT %s on %s.* TO '%s'@'%s'",
+	stmtSQL := fmt.Sprintf("GRANT %s on %s.%s TO '%s'@'%s'",
 		privileges,
 		d.Get("database").(string),
+		d.Get("table").(string),
 		d.Get("user").(string),
 		d.Get("host").(string))
 
@@ -95,8 +103,9 @@ func ReadGrant(d *schema.ResourceData, meta interface{}) error {
 func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*providerConfiguration).Conn
 
-	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.* FROM '%s'@'%s'",
+	stmtSQL := fmt.Sprintf("REVOKE GRANT OPTION ON %s.%s FROM '%s'@'%s'",
 		d.Get("database").(string),
+		d.Get("table").(string),
 		d.Get("user").(string),
 		d.Get("host").(string))
 
@@ -106,8 +115,9 @@ func DeleteGrant(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	stmtSQL = fmt.Sprintf("REVOKE ALL ON %s.* FROM '%s'@'%s'",
+	stmtSQL = fmt.Sprintf("REVOKE ALL ON %s.%s FROM '%s'@'%s'",
 		d.Get("database").(string),
+		d.Get("table").(string),
 		d.Get("user").(string),
 		d.Get("host").(string))
 

--- a/builtin/providers/mysql/resource_grant_test.go
+++ b/builtin/providers/mysql/resource_grant_test.go
@@ -112,8 +112,8 @@ func testAccGrantCheckDestroy(s *terraform.State) error {
 const testAccGrantConfig_basic = `
 resource "mysql_user" "test" {
         user = "jdoe"
-				host = "example.com"
-				password = "password"
+		host = "example.com"
+		password = "password"
 }
 
 resource "mysql_grant" "test" {

--- a/website/source/docs/providers/mysql/r/grant.html.markdown
+++ b/website/source/docs/providers/mysql/r/grant.html.markdown
@@ -24,6 +24,7 @@ resource "mysql_grant" "jdoe" {
     user = "${mysql_user.jdoe.user}"
     host = "${mysql_user.jdoe.host}"
     database = "app"
+    table = "users"
     privileges = ["SELECT", "UPDATE"]
 }
 ```
@@ -36,8 +37,9 @@ The following arguments are supported:
 
 * `host` - (Optional) The source host of the user. Defaults to "localhost".
 
-* `database` - (Required) The database to grant privileges on. At this time,
-  privileges are given to all tables on the database (`mydb.*`).
+* `database` - (Required) The database to grant privileges on.
+
+* `table` - (Optional) The table to grant privileges on. Defaults to "*"(grant to all tables).
 
 * `privileges` - (Required) A list of privileges to grant to the user. Refer
   to a list of privileges (such as


### PR DESCRIPTION
Hi! This is an enhancement around mysql provider's privilege grant functionality.
Currently, privileges are given to all tables on the database. This change is to add a table attribute to the resource so that users can grant privilege on the table level.

Previous resource definition, privileges are granted to the entire database:
```
resource "mysql_grant" "jdoe" {
    user = "${mysql_user.jdoe.user}"
    host = "${mysql_user.jdoe.host}"
    database = "app"
    privileges = ["SELECT", "UPDATE"]
}
```

Enhanced resource definition, privileges can be granted to a specific table:
```
resource "mysql_grant" "jdoe" {
    user = "${mysql_user.jdoe.user}"
    host = "${mysql_user.jdoe.host}"
    database = "app"
    table = "users" // new attribute added in this PR
    privileges = ["SELECT", "UPDATE"]
}
```

Enhanced resource definition, privileges can still be grant to the entire database by not specifying a table attribute:
```
resource "mysql_grant" "jdoe" {
    user = "${mysql_user.jdoe.user}"
    host = "${mysql_user.jdoe.host}"
    database = "app"
    privileges = ["SELECT", "UPDATE"]
}
```

0. updated code
1. updated tests
2. updated website document