### PR TITLE
provider/aws: Validate window time format

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -120,9 +120,10 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"backup_window": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateOnceADayWindowFormat,
 			},
 
 			"iops": {
@@ -147,6 +148,7 @@ func resourceAwsDbInstance() *schema.Resource {
 					}
 					return ""
 				},
+				ValidateFunc: validateOnceAWeekWindowFormat,
 			},
 
 			"multi_az": {

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -77,9 +77,10 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 			Set:      schema.HashString,
 		},
 		"snapshot_window": &schema.Schema{
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
+			Type:         schema.TypeString,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validateOnceADayWindowFormat,
 		},
 		"snapshot_name": &schema.Schema{
 			Type:     schema.TypeString,
@@ -96,6 +97,7 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 				// to lowercase
 				return strings.ToLower(val.(string))
 			},
+			ValidateFunc: validateOnceAWeekWindowFormat,
 		},
 		"port": &schema.Schema{
 			Type:     schema.TypeInt,

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -160,9 +160,10 @@ func resourceAwsRDSCluster() *schema.Resource {
 			},
 
 			"preferred_backup_window": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validateOnceADayWindowFormat,
 			},
 
 			"preferred_maintenance_window": {
@@ -175,6 +176,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 					}
 					return strings.ToLower(val.(string))
 				},
+				ValidateFunc: validateOnceAWeekWindowFormat,
 			},
 
 			"backup_retention_period": {

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -101,6 +101,7 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 					}
 					return strings.ToLower(val.(string))
 				},
+				ValidateFunc: validateOnceAWeekWindowFormat,
 			},
 
 			"cluster_parameter_group_name": {

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -624,3 +624,27 @@ func validateSecurityRuleType(v interface{}, k string) (ws []string, errors []er
 	}
 	return
 }
+
+func validateOnceAWeekWindowFormat(v interface{}, k string) (ws []string, errors []error) {
+	// valid time format is "ddd:hh24:mi"
+	validTimeFormat := "(sun|mon|tue|wed|thu|fri|sat):([0-1][0-9]|2[0-3]):([0-5][0-9])"
+
+	value := strings.ToLower(v.(string))
+	if !regexp.MustCompile(validTimeFormat + "-" + validTimeFormat).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must satisfy the format of \"ddd:hh24:mi-ddd:hh24:mi\".", k))
+	}
+	return
+}
+
+func validateOnceADayWindowFormat(v interface{}, k string) (ws []string, errors []error) {
+	// valid time format is "hh24:mi"
+	validTimeFormat := "([0-1][0-9]|2[0-3]):([0-5][0-9])"
+
+	value := v.(string)
+	if !regexp.MustCompile(validTimeFormat + "-" + validTimeFormat).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q must satisfy the format of \"hh24:mi-hh24:mi\".", k))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -923,3 +923,85 @@ func TestValidateSecurityRuleType(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateOnceAWeekWindowFormat(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			// once a day window format
+			Value:    "04:00-05:00",
+			ErrCount: 1,
+		},
+		{
+			// invalid day of week
+			Value:    "san:04:00-san:05:00",
+			ErrCount: 1,
+		},
+		{
+			// invalid hour
+			Value:    "sun:24:00-san:25:00",
+			ErrCount: 1,
+		},
+		{
+			// invalid min
+			Value:    "sun:04:00-sun:04:60",
+			ErrCount: 1,
+		},
+		{
+			// valid format
+			Value:    "sun:04:00-sun:05:00",
+			ErrCount: 0,
+		},
+		{
+			// "Sun" can also be used
+			Value:    "Sun:04:00-Sun:05:00",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateOnceAWeekWindowFormat(tc.Value, "maintenance_window")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %d validation errors, But got %d errors for \"%s\"", tc.ErrCount, len(errors), tc.Value)
+		}
+	}
+}
+
+func TestValidateOnceADayWindowFormat(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			// once a week window format
+			Value:    "sun:04:00-sun:05:00",
+			ErrCount: 1,
+		},
+		{
+			// invalid hour
+			Value:    "24:00-25:00",
+			ErrCount: 1,
+		},
+		{
+			// invalid min
+			Value:    "04:00-04:60",
+			ErrCount: 1,
+		},
+		{
+			// valid format
+			Value:    "04:00-05:00",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateOnceADayWindowFormat(tc.Value, "backup_window")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %d validation errors, But got %d errors for \"%s\"", tc.ErrCount, len(errors), tc.Value)
+		}
+	}
+}


### PR DESCRIPTION
## Why
If using invalid format for window attributes (for example: maintenance window, backup window, snapshot window, etc), error occurred when `terraform apply`.

```
aws_elasticache_cluster.bar: Creating...
  apply_immediately:      "" => "<computed>"
  availability_zone:      "" => "<computed>"
  az_mode:                "" => "<computed>"
  cache_nodes.#:          "" => "<computed>"
  cluster_address:        "" => "<computed>"
  cluster_id:             "" => "cluster-example"
  configuration_endpoint: "" => "<computed>"
  engine:                 "" => "memcached"
  engine_version:         "" => "<computed>"
  maintenance_window:     "" => "22:00-23:00"
  node_type:              "" => "cache.t2.micro"
  num_cache_nodes:        "" => "1"
  parameter_group_name:   "" => "default.memcached1.4"
  port:                   "" => "11211"
  replication_group_id:   "" => "<computed>"
  security_group_ids.#:   "" => "<computed>"
  security_group_names.#: "" => "<computed>"
  snapshot_window:        "" => "<computed>"
  subnet_group_name:      "" => "<computed>"
Error applying plan:

1 error(s) occurred:

* aws_elasticache_cluster.bar: Error creating Elasticache: InvalidParameterValue: Invalid maintenance window format. Should be specified as a range ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). Example: Sun:23:15-Mon:03:15
        status code: 400, request id: ****

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

Such a problem should be notified when `terraform plan`.

## Proposal
Add `ValidateFunc` to window attributes. Perhaps, `aws_db_instance`, `aws_elasticache_cluster`, `aws_rds_cluster`, `aws_redshift_cluster` have these attributes.

## Environment
Check behavior in following environment:
```
$ bin/terraform -v
Terraform v0.8.3-dev (4fd10356221a6880c62c86d0d2465f692b8b61bf+CHANGES)
```