### PR TITLE
provider/aws require db option group name to be lower case

### DIFF
--- a/builtin/providers/aws/resource_aws_db_option_group.go
+++ b/builtin/providers/aws/resource_aws_db_option_group.go
@@ -354,6 +354,10 @@ func validateDbOptionGroupName(v interface{}, k string) (ws []string, errors []e
 		errors = append(errors, fmt.Errorf(
 			"only alphanumeric characters and hyphens allowed in %q", k))
 	}
+	if regexp.MustCompile(`[A-Z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase letters allowed in %q", k))
+	}
 	if regexp.MustCompile(`--`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot contain two consecutive hyphens", k))

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -174,6 +174,10 @@ func TestResourceAWSDBOptionGroupName_validation(t *testing.T) {
 			ErrCount: 1,
 		},
 		{
+			Value:    "tESTING123",
+			ErrCount: 1,
+		},
+		{
 			Value:    "testing--123",
 			ErrCount: 1,
 		},


### PR DESCRIPTION
AWS is automatically changing these names to lower case as described in #11040 
This is causing errors when terraform apply is re-run.

I don't believe this needs any documentation updates.

Closes #11040