### PR TITLE
provider/opsgenie: Documentation Fix

### DIFF
--- a/website/source/docs/providers/azurerm/r/eventhub_consumer_group.html.markdown
+++ b/website/source/docs/providers/azurerm/r/eventhub_consumer_group.html.markdown
@@ -40,12 +40,12 @@ resource "azurerm_eventhub" "test" {
 }
 
 resource "azurerm_eventhub_consumer_group" "test" {
-    name = "acceptanceTestEventHubConsumerGroup"
-    namespace_name = "${azurerm_eventhub_namespace.test.name}"
-    eventhub_name = "${azurerm_eventhub.test.name}"
+    name                = "acceptanceTestEventHubConsumerGroup"
+    namespace_name      = "${azurerm_eventhub_namespace.test.name}"
+    eventhub_name       = "${azurerm_eventhub.test.name}"
     resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "${azurerm_resource_group.test.location}"
-    user_metadata = "some-meta-data"
+    location            = "${azurerm_resource_group.test.location}"
+    user_metadata       = "some-meta-data"
 }
 ```
 

--- a/website/source/docs/providers/opsgenie/d/user.html.markdown
+++ b/website/source/docs/providers/opsgenie/d/user.html.markdown
@@ -13,12 +13,17 @@ Use this data source to get information about a specific user within OpsGenie.
 ## Example Usage
 
 ```
-data "opsgenie_user" "me" {
+data "opsgenie_user" "cookie_monster" {
   username = "me@cookie-monster.com"
 }
 
 resource "opsgenie_team" "test" {
-  TODO: example
+  name = "cookieeaters"
+
+  member {
+    username = "${data.opsgenie_user.cookie_monster.username}"
+    role     = "${data.opsgenie_user.cookie_monster.role}"
+  }
 }
 ```
 


### PR DESCRIPTION
- Fixing a missing TODO within the OpsGenie Documentation
- Making the AzureRM EventHub Consumer Group Examples more readable
