### PR TITLE
dag: string DotOpts through to vertex

### DIFF
--- a/dag/dot.go
+++ b/dag/dot.go
@@ -79,7 +79,7 @@ func (g *marshalGraph) Dot(opts *DotOpts) []byte {
 	return w.Bytes()
 }
 
-func (v *marshalVertex) dot(g *marshalGraph) []byte {
+func (v *marshalVertex) dot(g *marshalGraph, opts *DotOpts) []byte {
 	var buf bytes.Buffer
 	graphName := g.Name
 	if graphName == "" {
@@ -89,7 +89,7 @@ func (v *marshalVertex) dot(g *marshalGraph) []byte {
 	name := v.Name
 	attrs := v.Attrs
 	if v.graphNodeDotter != nil {
-		node := v.graphNodeDotter.DotNode(name, nil)
+		node := v.graphNodeDotter.DotNode(name, opts)
 		if node == nil {
 			return []byte{}
 		}
@@ -171,7 +171,7 @@ func (g *marshalGraph) writeBody(opts *DotOpts, w *indentWriter) {
 			continue
 		}
 
-		w.Write(v.dot(g))
+		w.Write(v.dot(g, opts))
 	}
 
 	var dotEdges []string

--- a/dag/dot_test.go
+++ b/dag/dot_test.go
@@ -1,0 +1,39 @@
+package dag
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestGraphDot_opts(t *testing.T) {
+	var v testDotVertex
+	var g Graph
+	g.Add(&v)
+
+	opts := &DotOpts{MaxDepth: 42}
+	actual := g.Dot(opts)
+	if len(actual) == 0 {
+		t.Fatal("should not be empty")
+	}
+
+	if !v.DotNodeCalled {
+		t.Fatal("should call DotNode")
+	}
+	if !reflect.DeepEqual(v.DotNodeOpts, opts) {
+		t.Fatalf("bad; %#v", v.DotNodeOpts)
+	}
+}
+
+type testDotVertex struct {
+	DotNodeCalled bool
+	DotNodeTitle  string
+	DotNodeOpts   *DotOpts
+	DotNodeReturn *DotNode
+}
+
+func (v *testDotVertex) DotNode(title string, opts *DotOpts) *DotNode {
+	v.DotNodeCalled = true
+	v.DotNodeTitle = title
+	v.DotNodeOpts = opts
+	return v.DotNodeReturn
+}


### PR DESCRIPTION
Fixes #11052

It appears that historically nodes did not expect DotOpts to ever be
nil. To avoid nil panics in general I'm in agreement with this behavior
so this modifies dag to always pass in a non-nil DotOpts. Tests
included.