### PR TITLE
provider/aws: Fix up AWS Lambda* tests

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_alias_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_alias_test.go
@@ -148,6 +148,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
   function_name = "example_lambda_name_create"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.example"
+  runtime       = "nodejs4.3"
 }
 
 resource "aws_lambda_alias" "lambda_alias_test" {

--- a/builtin/providers/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -231,6 +231,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
     function_name = "example_lambda_name_create"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {
@@ -315,6 +316,7 @@ resource "aws_lambda_function" "lambda_function_test_create" {
     function_name = "example_lambda_name_create"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_lambda_function" "lambda_function_test_update" {

--- a/builtin/providers/aws/resource_aws_lambda_permission_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission_test.go
@@ -460,6 +460,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "lambda_function_name_perm"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -495,6 +496,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "lambda_function_name_perm_raw_func_name"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -540,6 +542,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "lambda_function_name_perm_qualifier"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -583,6 +586,7 @@ resource "aws_lambda_function" "test_lambda" {
     function_name = "lambda_function_name_perm_multiperms"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.handler"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -635,6 +639,7 @@ resource "aws_lambda_function" "my-func" {
     function_name = "lambda_function_name_perm_s3"
     role = "${aws_iam_role.police.arn}"
     handler = "exports.handler"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_iam_role" "police" {
@@ -681,6 +686,7 @@ resource "aws_lambda_function" "my-func" {
     function_name = "lambda_function_name_perm_sns"
     role = "${aws_iam_role.police.arn}"
     handler = "exports.handler"
+    runtime = "nodejs4.3"
 }
 
 resource "aws_iam_role" "police" {


### PR DESCRIPTION
The tests are complaining of:

```
Errors: []string{"aws_lambda_function.test_lambda: \"runtime\": required field is not set"}
```