### PR TITLE
providers/google: Add subnetwork_project field to enable cross-project networking in instance templates

### DIFF
--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -650,6 +650,7 @@ func flattenNetworkInterfaces(networkInterfaces []*compute.NetworkInterface) ([]
 			subnetworkUrl := strings.Split(networkInterface.Subnetwork, "/")
 			networkInterfaceMap["subnetwork"] = subnetworkUrl[len(subnetworkUrl)-1]
 			region = subnetworkUrl[len(subnetworkUrl)-3]
+			networkInterfaceMap["subnetwork_project"] = subnetworkUrl[len(subnetworkUrl)-5]
 		}
 
 		if networkInterface.AccessConfigs != nil {

--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -203,6 +203,12 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							ForceNew: true,
 						},
 
+						"subnetwork_project": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
 						"access_config": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
@@ -406,14 +412,16 @@ func buildNetworks(d *schema.ResourceData, meta interface{}) ([]*compute.Network
 	for i := 0; i < networksCount; i++ {
 		prefix := fmt.Sprintf("network_interface.%d", i)
 
-		var networkName, subnetworkName string
+		var networkName, subnetworkName, subnetworkProject string
 		if v, ok := d.GetOk(prefix + ".network"); ok {
 			networkName = v.(string)
 		}
 		if v, ok := d.GetOk(prefix + ".subnetwork"); ok {
 			subnetworkName = v.(string)
 		}
-
+		if v, ok := d.GetOk(prefix + ".subnetwork_project"); ok {
+			subnetworkProject = v.(string)
+		}
 		if networkName == "" && subnetworkName == "" {
 			return nil, fmt.Errorf("network or subnetwork must be provided")
 		}
@@ -435,8 +443,11 @@ func buildNetworks(d *schema.ResourceData, meta interface{}) ([]*compute.Network
 			if err != nil {
 				return nil, err
 			}
+			if subnetworkProject == "" {
+				subnetworkProject = project
+			}
 			subnetwork, err := config.clientCompute.Subnetworks.Get(
-				project, region, subnetworkName).Do()
+				subnetworkProject, region, subnetworkName).Do()
 			if err != nil {
 				return nil, fmt.Errorf(
 					"Error referencing subnetwork '%s' in region '%s': %s",

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 
@@ -549,6 +550,6 @@ resource "google_compute_instance_template" "foobar" {
 	network_interface{
 		network = "default"
 	}
-	
+
 	metadata_startup_script = "echo 'Hello'"
 }`, acctest.RandString(10))

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -119,7 +119,7 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")
-	
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -119,10 +119,7 @@ func TestAccComputeInstanceTemplate_subnet_custom(t *testing.T) {
 func TestAccComputeInstanceTemplate_subnet_xpn(t *testing.T) {
 	var instanceTemplate compute.InstanceTemplate
 	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")
-	if xpn_host == "" {
-		t.Fatal("GOOGLE_XPN_HOST_PROJECT must be set for TestAccComputeInstanceTemplate_subnet_xpn test")
-	}
-
+	
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,

--- a/website/source/docs/providers/google/r/compute_instance_template.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_template.html.markdown
@@ -138,7 +138,7 @@ The following arguments are supported:
 
 * `metadata_startup_script` - (Optional) An alternative to using the
     startup-script metadata key, mostly to match the compute_instance resource.
-    This replaces the startup-script metadata key on the created instance and 
+    This replaces the startup-script metadata key on the created instance and
     thus the two mechanisms are not allowed to be used simultaneously.
 
 * `network_interface` - (Required) Networks to attach to instances created from
@@ -207,6 +207,9 @@ The `network_interface` block supports:
 * `subnetwork` - (Optional) the name of the subnetwork to attach this interface
     to. The subnetwork must exist in the same `region` this instance will be
     created in. Either `network` or `subnetwork` must be provided.
+
+* `subnetwork_project` - (Optional) The project in which the subnetwork belongs.
+    If it is not provided, the provider project is used.
 
 * `access_config` - (Optional) Access configurations, i.e. IPs via which this
     instance can be accessed via the Internet. Omit to ensure that the instance


### PR DESCRIPTION
This change allows to use XPN feature with instance templates. It is an extension of #9662 

One thing which is currently missing is showing subnetwork project in terraform show.