### PR TITLE
provider/aws: Route53 Record: Add Type validation

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -47,9 +47,10 @@ func resourceAwsRoute53Record() *schema.Resource {
 			},
 
 			"type": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateRoute53RecordType,
 			},
 
 			"zone_id": &schema.Schema{

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -648,3 +648,28 @@ func validateOnceADayWindowFormat(v interface{}, k string) (ws []string, errors 
 	}
 	return
 }
+
+func validateRoute53RecordType(v interface{}, k string) (ws []string, errors []error) {
+	// Valid Record types
+	// SOA, A, TXT, NS, CNAME, MX, NAPTR, PTR, SRV, SPF, AAAA
+	validTypes := map[string]struct{}{
+		"SOA":   {},
+		"A":     {},
+		"TXT":   {},
+		"NS":    {},
+		"CNAME": {},
+		"MX":    {},
+		"NAPTR": {},
+		"PTR":   {},
+		"SRV":   {},
+		"SPF":   {},
+		"AAAA":  {},
+	}
+
+	value := v.(string)
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of [SOA, A, TXT, NS, CNAME, MX, NAPTR, PTR, SRV, SPF, AAAA]", k))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1005,3 +1005,41 @@ func TestValidateOnceADayWindowFormat(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateRoute53RecordType(t *testing.T) {
+	validTypes := []string{
+		"AAAA",
+		"SOA",
+		"A",
+		"TXT",
+		"CNAME",
+		"MX",
+		"NAPTR",
+		"PTR",
+		"SPF",
+		"SRV",
+		"NS",
+	}
+
+	invalidTypes := []string{
+		"a",
+		"alias",
+		"SpF",
+		"Txt",
+		"AaAA",
+	}
+
+	for _, v := range validTypes {
+		_, errors := validateRoute53RecordType(v, "route53_record")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid Route53 record type: %v", v, errors)
+		}
+	}
+
+	for _, v := range invalidTypes {
+		_, errors := validateRoute53RecordType(v, "route53_record")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid Route53 record type", v)
+		}
+	}
+}


### PR DESCRIPTION
Adds validation for the `type` parameter of an `aws_route53_record` resource.

This will allow Terraform to catch any user errors of a `type` parameter during a `terraform plan` instead of during a `terraform apply`.

Fixes: #11114