### PR TITLE
provider/aws: Allow disabled access_log in ELB

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -360,26 +360,28 @@ func expandElastiCacheParameters(configured []interface{}) ([]*elasticache.Param
 func flattenAccessLog(l *elb.AccessLog) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
 
-	if l != nil && *l.Enabled {
-		r := make(map[string]interface{})
-		if l.S3BucketName != nil {
-			r["bucket"] = *l.S3BucketName
-		}
-
-		if l.S3BucketPrefix != nil {
-			r["bucket_prefix"] = *l.S3BucketPrefix
-		}
-
-		if l.EmitInterval != nil {
-			r["interval"] = *l.EmitInterval
-		}
-
-		if l.Enabled != nil {
-			r["enabled"] = *l.Enabled
-		}
-
-		result = append(result, r)
+	if l == nil {
+		return nil
 	}
+
+	r := make(map[string]interface{})
+	if l.S3BucketName != nil {
+		r["bucket"] = *l.S3BucketName
+	}
+
+	if l.S3BucketPrefix != nil {
+		r["bucket_prefix"] = *l.S3BucketPrefix
+	}
+
+	if l.EmitInterval != nil {
+		r["interval"] = *l.EmitInterval
+	}
+
+	if l.Enabled != nil {
+		r["enabled"] = *l.Enabled
+	}
+
+	result = append(result, r)
 
 	return result
 }


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/10138

The AWS API does not let you "delete" `access_logs` from an ELB. Currently we simply mark the access logs as `disabled` and move on, however that prevented users from creating and tracking ELBs with disabled access logs... disabled `access_logs` were not being persisted to state. 

Here we persist `access_logs` blocks to state if they are found in the configuration, or if they are _not_ in the configuration and the API reports an enabled `access_logs` configuration. 

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSELB_ -timeout 120m
=== RUN   TestAccAWSELB_importBasic
--- PASS: TestAccAWSELB_importBasic (18.28s)
=== RUN   TestAccAWSELB_basic
--- PASS: TestAccAWSELB_basic (21.69s)
=== RUN   TestAccAWSELB_fullCharacterRange
--- PASS: TestAccAWSELB_fullCharacterRange (17.47s)
=== RUN   TestAccAWSELB_AccessLogs_enabled
--- PASS: TestAccAWSELB_AccessLogs_enabled (51.73s)
~~> === RUN   TestAccAWSELB_AccessLogs_disabled          <~~
~~> --- PASS: TestAccAWSELB_AccessLogs_disabled (51.06s) <~~
=== RUN   TestAccAWSELB_generatedName
--- PASS: TestAccAWSELB_generatedName (18.09s)
=== RUN   TestAccAWSELB_availabilityZones
--- PASS: TestAccAWSELB_availabilityZones (33.63s)
=== RUN   TestAccAWSELB_tags
--- PASS: TestAccAWSELB_tags (28.92s)
=== RUN   TestAccAWSELB_iam_server_cert
--- PASS: TestAccAWSELB_iam_server_cert (32.72s)
=== RUN   TestAccAWSELB_swap_subnets
--- PASS: TestAccAWSELB_swap_subnets (63.05s)
=== RUN   TestAccAWSELB_InstanceAttaching
--- PASS: TestAccAWSELB_InstanceAttaching (117.06s)
=== RUN   TestAccAWSELB_HealthCheck
--- PASS: TestAccAWSELB_HealthCheck (18.14s)
=== RUN   TestAccAWSELB_Timeout
--- PASS: TestAccAWSELB_Timeout (19.47s)
=== RUN   TestAccAWSELB_ConnectionDraining
--- PASS: TestAccAWSELB_ConnectionDraining (16.50s)
=== RUN   TestAccAWSELB_SecurityGroups
--- PASS: TestAccAWSELB_SecurityGroups (37.99s)
```