### PR TITLE
provider/azurerm: fix update protocol for lb_probe

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -54,7 +54,6 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 			"request_path": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Computed: true,
 			},
 
 			"interval_in_seconds": {


### PR DESCRIPTION
Fixes #11098

request_path had Computed enabled which prevented updating it to an empty value

```
TF_ACC=1 go test ./builtin/providers/azurerm -v -run TestAccAzureRMLoadBalancerProbe -timeout 120m
=== RUN   TestAccAzureRMLoadBalancerProbe_basic
--- PASS: TestAccAzureRMLoadBalancerProbe_basic (119.63s)
=== RUN   TestAccAzureRMLoadBalancerProbe_removal
--- PASS: TestAccAzureRMLoadBalancerProbe_removal (122.50s)
=== RUN   TestAccAzureRMLoadBalancerProbe_update
--- PASS: TestAccAzureRMLoadBalancerProbe_update (129.98s)
=== RUN   TestAccAzureRMLoadBalancerProbe_duplicate
--- PASS: TestAccAzureRMLoadBalancerProbe_duplicate (115.22s)
=== RUN   TestAccAzureRMLoadBalancerProbe_updateProtocol
--- PASS: TestAccAzureRMLoadBalancerProbe_updateProtocol (127.25s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	614.657s
```