### PR TITLE
provider/azurerm: make lb sub resources idempotent

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -100,11 +100,9 @@ func resourceArmLoadBalancerNatPoolCreate(d *schema.ResourceData, meta interface
 
 	existingNatPool, existingNatPoolIndex, exists := findLoadBalancerNatPoolByName(loadBalancer, d.Get("name").(string))
 	if exists {
-		if d.Id() == *existingNatPool.ID {
-			// this probe is being updated remove old copy from the slice
+		if d.Get("name").(string) == *existingNatPool.Name {
+			// this probe is being updated/reapplied remove old copy from the slice
 			natPools = append(natPools[:existingNatPoolIndex], natPools[existingNatPoolIndex+1:]...)
-		} else {
-			return fmt.Errorf("A NAT Pool with name %q already exists.", d.Get("name").(string))
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -100,11 +100,9 @@ func resourceArmLoadBalancerNatRuleCreate(d *schema.ResourceData, meta interface
 
 	existingNatRule, existingNatRuleIndex, exists := findLoadBalancerNatRuleByName(loadBalancer, d.Get("name").(string))
 	if exists {
-		if d.Id() == *existingNatRule.ID {
-			// this probe is being updated remove old copy from the slice
+		if d.Get("name").(string) == *existingNatRule.Name {
+			// this probe is being updated/reapplied remove old copy from the slice
 			natRules = append(natRules[:existingNatRuleIndex], natRules[existingNatRuleIndex+1:]...)
-		} else {
-			return fmt.Errorf("A NAT Rule with name %q already exists.", d.Get("name").(string))
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -105,11 +105,9 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 
 	existingProbe, existingProbeIndex, exists := findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
 	if exists {
-		if d.Id() == *existingProbe.ID {
-			// this probe is being updated remove old copy from the slice
+		if d.Get("name").(string) == *existingProbe.Name {
+			// this probe is being updated/reapplied remove old copy from the slice
 			probes = append(probes[:existingProbeIndex], probes[existingProbeIndex+1:]...)
-		} else {
-			return fmt.Errorf("A Probe with name %q already exists.", d.Get("name").(string))
 		}
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -127,11 +127,9 @@ func resourceArmLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{})
 
 	existingRule, existingRuleIndex, exists := findLoadBalancerRuleByName(loadBalancer, d.Get("name").(string))
 	if exists {
-		if d.Id() == *existingRule.ID {
-			// this rule is being updated remove old copy from the slice
+		if d.Get("name").(string) == *existingRule.Name {
+			// this rule is being updated/reapplied remove old copy from the slice
 			lbRules = append(lbRules[:existingRuleIndex], lbRules[existingRuleIndex+1:]...)
-		} else {
-			return fmt.Errorf("A LoadBalancer Rule with name %q already exists.", d.Get("name").(string))
 		}
 	}
 


### PR DESCRIPTION
If an error occurred which prevented the lb sub resources being written to state
then the next apply would fail as the resources would already exist in the API.

```
go test -c ./builtin/providers/azurerm -o ./builtin/providers/azurerm/test-azurerm
TestAccAzureRMLoadBalancerBackEndAddressPool_reapply
TestAccAzureRMLoadBalancerBackEndAddressPool_removal
TestAccAzureRMLoadBalancerNatPool_basic
TestAccAzureRMLoadBalancerBackEndAddressPool_basic
TestAccAzureRMLoadBalancerNatRule_basic
TestAccAzureRMLoadBalancerNatPool_reapply
TestAccAzureRMLoadBalancerNatPool_removal
TestAccAzureRMLoadBalancerNatPool_update
TestAccAzureRMLoadBalancerProbe_basic
TestAccAzureRMLoadBalancerNatRule_removal
TestAccAzureRMLoadBalancerNatRule_update
TestAccAzureRMLoadBalancerNatRule_reapply
TestAccAzureRMLoadBalancerProbe_removal
TestAccAzureRMLoadBalancerProbe_reapply
TestAccAzureRMLoadBalancerProbe_update
TestAccAzureRMLoadBalancerRule_basic
TestAccAzureRMLoadBalancerRule_inconsistentReads
TestAccAzureRMLoadBalancerRule_removal
TestAccAzureRMLoadBalancerProbe_updateProtocol
TestAccAzureRMLoadBalancer_basic
TestAccAzureRMLoadBalancerRule_update
TestAccAzureRMLoadBalancerRule_reapply
TestAccAzureRMLoadBalancer_frontEndConfig
TestAccAzureRMLoadBalancer_tags
```