### PR TITLE
provider/digitalocean: Fix failing acceptance test

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -450,6 +450,7 @@ resource "digitalocean_droplet" "foobar" {
   size     = "1gb"
   image    = "centos-7-x64"
   region   = "nyc3"
+  user_data = "foobar"
   ssh_keys = ["${digitalocean_ssh_key.foobar.id}"]
   resize_disk = false
 }


### PR DESCRIPTION
The second step of the `TestAccDigitalOceanDroplet_ResizeWithOutDisk` acceptance test was regularly failing. Upon investigation it was found that the second step's Terraform configuration had omitted the `user_data` parameter, thus forcing Terraform to create a new droplet resource instead of updating the current resource.

```
-/+ digitalocean_droplet.foobar
    disk:                 "20" => "<computed>"
    image:                "centos-7-x64" => "centos-7-x64"
    ipv4_address:         "138.197.0.55" => "<computed>"
    ipv4_address_private: "" => "<computed>"
    ipv6_address:         "" => "<computed>"
    ipv6_address_private: "" => "<computed>"
    locked:               "false" => "<computed>"
    name:                 "foo" => "foo"
    region:               "nyc3" => "nyc3"
    resize_disk:          "true" => "false"
    size:                 "512mb" => "1gb"
    ssh_keys.#:           "1" => "1"
    ssh_keys.0:           "5770472" => "5770472"
    status:               "active" => "<computed>"
    user_data:            "foobar" => "" (forces new resource)
    vcpus:                "1" => "<computed>"
```

This fixes the acceptance test by adding the missing `user_data` parameter.