### PR TITLE
provider/arukas: Fix broken build on windows

### DIFF
--- a/vendor/gopkg.in/alecthomas/kingpin.v2/guesswidth.go
+++ b/vendor/gopkg.in/alecthomas/kingpin.v2/guesswidth.go
@@ -1,0 +1,9 @@
+// +build appengine !linux,!freebsd,!darwin,!dragonfly,!netbsd,!openbsd
+
+package kingpin
+
+import "io"
+
+func guessWidth(w io.Writer) int {
+	return 80
+}


### PR DESCRIPTION
This fixes the problem that the build broke on Windows by merging #10862.  
