### PR TITLE
provider/azurerm: add caching support for virtual_machine data_disks

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -197,6 +197,12 @@ func resourceArmVirtualMachine() *schema.Resource {
 							Required: true,
 						},
 
+						"caching": {
+							Type:     schema.TypeString,
+							Optional: true,
+							Computed: true,
+						},
+
 						"disk_size_gb": {
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -864,6 +870,7 @@ func flattenAzureRmVirtualMachineDataDisk(disks *[]compute.DataDisk) interface{}
 		l["name"] = *disk.Name
 		l["vhd_uri"] = *disk.Vhd.URI
 		l["create_option"] = disk.CreateOption
+		l["caching"] = string(disk.Caching)
 		if disk.DiskSizeGB != nil {
 			l["disk_size_gb"] = *disk.DiskSizeGB
 		}
@@ -1195,6 +1202,10 @@ func expandAzureRmVirtualMachineDataDisk(d *schema.ResourceData) ([]compute.Data
 			},
 			Lun:          &lun,
 			CreateOption: compute.DiskCreateOptionTypes(createOption),
+		}
+
+		if v := config["caching"].(string); v != "" {
+			data_disk.Caching = compute.CachingTypes(v)
 		}
 
 		if v := config["disk_size_gb"]; v != nil {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -1019,6 +1019,7 @@ resource "azurerm_virtual_machine" "test" {
         vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/mydatadisk1.vhd"
     	disk_size_gb  = "1023"
     	create_option = "Empty"
+        caching       = "ReadWrite"
     	lun           = 0
     }
 

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -258,6 +258,7 @@ For more information on the different example configurations, please check out t
 * `vhd_uri` - (Required) Specifies the uri of the location in storage where the vhd for the virtual machine should be placed.
 * `create_option` - (Required) Specifies how the data disk should be created.
 * `disk_size_gb` - (Required) Specifies the size of the data disk in gigabytes.
+* `caching` - (Optional) Specifies the caching requirements.
 * `lun` - (Required) Specifies the logical unit number of the data disk.
 
 `os_profile` supports the following:


### PR DESCRIPTION
Ran some basic VM tests:

```
TestAccAzureRMVirtualMachine_basicLinuxMachine
TestAccAzureRMVirtualMachine_basicLinuxMachine_disappears
TestAccAzureRMVirtualMachine_importBasic
TestAccAzureRMVirtualMachine_withDataDisk
TestAccAzureRMVirtualMachine_updateMachineSize
TestAccAzureRMVirtualMachine_tags
TestAccAzureRMVirtualMachine_basicWindowsMachine
```