### PR TITLE
provider/aws: Fix panic caused by main route table lookup

### DIFF
--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -197,7 +197,10 @@ func dataSourceAssociationsRead(ec2Assocations []*ec2.RouteTableAssociation) []m
 		m := make(map[string]interface{})
 		m["route_table_id"] = *a.RouteTableId
 		m["route_table_association_id"] = *a.RouteTableAssociationId
-		m["subnet_id"] = *a.SubnetId
+		// GH[11134]
+		if a.SubnetId != nil {
+			m["subnet_id"] = *a.SubnetId
+		}
 		m["main"] = *a.Main
 		associations = append(associations, m)
 	}

--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -25,6 +25,21 @@ func TestAccDataSourceAwsRouteTable(t *testing.T) {
 	})
 }
 
+func TestAccDataSourceAwsRouteTable_main(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsRouteTableMainRoute,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsRouteTableCheckMain("data.aws_route_table.by_filter"),
+				),
+			},
+		},
+	})
+}
+
 func testAccDataSourceAwsRouteTableCheck(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
@@ -68,10 +83,36 @@ func testAccDataSourceAwsRouteTableCheck(name string) resource.TestCheckFunc {
 		}
 		if attr["associations.0.subnet_id"] != subnetRs.Primary.Attributes["id"] {
 			return fmt.Errorf(
-				"subnet_id  is %v; want %s",
+				"subnet_id is %v; want %s",
 				attr["associations.0.subnet_id"],
 				subnetRs.Primary.Attributes["id"],
 			)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsRouteTableCheckMain(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		attr := rs.Primary.Attributes
+
+		// Verify attributes are set
+		if _, ok := attr["id"]; !ok {
+			return fmt.Errorf("id not set for main route table")
+		}
+		if _, ok := attr["vpc_id"]; !ok {
+			return fmt.Errorf("vpc_id not set for main route table")
+		}
+		// Verify it's actually the main route table that's returned
+		if attr["associations.0.main"] != "true" {
+			return fmt.Errorf("main route table not found")
 		}
 
 		return nil
@@ -129,4 +170,18 @@ data "aws_route_table" "by_subnet" {
   depends_on = ["aws_route_table_association.a"]
 }
 
+`
+
+// Uses us-east-2, as region only has a single main route table
+const testAccDataSourceAwsRouteTableMainRoute = `
+provider "aws" {
+  region = "us-east-2"
+}
+
+data "aws_route_table" "by_filter" {
+  filter {
+    name = "association.main"
+    values = ["true"]
+  }
+}
 `


### PR DESCRIPTION
A VPC's main route table has an implicit subnet association, not an explicit subnet association. This caused a Terraform panic when using the `data_source_aws_route_table` resource to query the main route table for a VPC.

This fixes the Terraform panic, and allows the data lookup to complete successfully. Also added an acceptance test to verify the bugfix.

Fixes: #11134