### PR TITLE
provider/aws: Add missing id argument for Route Table data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -18,7 +18,7 @@ func dataSourceAwsRouteTable() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
-			"rtb_id": {
+			"route_table_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -103,7 +103,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	req := &ec2.DescribeRouteTablesInput{}
 	vpcId, vpcIdOk := d.GetOk("vpc_id")
 	subnetId, subnetIdOk := d.GetOk("subnet_id")
-	rtbId, rtbOk := d.GetOk("rtb_id")
+	rtbId, rtbOk := d.GetOk("route_table_id")
 	tags, tagsOk := d.GetOk("tags")
 	filter, filterOk := d.GetOk("filter")
 

--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -108,7 +108,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	filter, filterOk := d.GetOk("filter")
 
 	if !vpcIdOk && !subnetIdOk && !tagsOk && !filterOk && !rtbOk {
-		return fmt.Errorf("One of rtb_id, vpc_id, subnet_id, filters, or tags must be assigned")
+		return fmt.Errorf("One of route_table_id, vpc_id, subnet_id, filters, or tags must be assigned")
 	}
 	req.Filters = buildEC2AttributeFilterList(
 		map[string]string{

--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -18,6 +18,11 @@ func dataSourceAwsRouteTable() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"rtb_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -98,14 +103,16 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	req := &ec2.DescribeRouteTablesInput{}
 	vpcId, vpcIdOk := d.GetOk("vpc_id")
 	subnetId, subnetIdOk := d.GetOk("subnet_id")
+	rtbId, rtbOk := d.GetOk("rtb_id")
 	tags, tagsOk := d.GetOk("tags")
 	filter, filterOk := d.GetOk("filter")
 
-	if !vpcIdOk && !subnetIdOk && !tagsOk && !filterOk {
-		return fmt.Errorf("One of vpc_id, subnet_id, filters, or tags must be assigned")
+	if !vpcIdOk && !subnetIdOk && !tagsOk && !filterOk && !rtbOk {
+		return fmt.Errorf("One of rtb_id, vpc_id, subnet_id, filters, or tags must be assigned")
 	}
 	req.Filters = buildEC2AttributeFilterList(
 		map[string]string{
+			"route-table-id":        rtbId.(string),
 			"vpc-id":                vpcId.(string),
 			"association.subnet-id": subnetId.(string),
 		},

--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -173,7 +173,7 @@ data "aws_route_table" "by_subnet" {
 }
 
 data "aws_route_table" "by_id" {
-  rtb_id = "${aws_route_table.test.id}"
+  route_table_id = "${aws_route_table.test.id}"
   depends_on = ["aws_route_table_association.a"]
 }
 `

--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -19,6 +19,7 @@ func TestAccDataSourceAwsRouteTable(t *testing.T) {
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_tag"),
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_filter"),
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_subnet"),
+					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_id"),
 				),
 			},
 		},
@@ -165,11 +166,16 @@ data "aws_route_table" "by_tag" {
   }
   depends_on = ["aws_route_table_association.a"]
 }
+
 data "aws_route_table" "by_subnet" {
   subnet_id = "${aws_subnet.test.id}"
   depends_on = ["aws_route_table_association.a"]
 }
 
+data "aws_route_table" "by_id" {
+  rtb_id = "${aws_route_table.test.id}"
+  depends_on = ["aws_route_table_association.a"]
+}
 `
 
 // Uses us-east-2, as region only has a single main route table

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -42,7 +42,7 @@ Route Table whose data will be exported as attributes.
 
 * `filter` - (Optional) Custom filter block as described below.
 
-* `id` - (Optional) The id of the specific Route Table to retrieve.
+* `rtb_id` - (Optional) The id of the specific Route Table to retrieve.
 
 * `tags` - (Optional) A mapping of tags, each pair of which must exactly match
   a pair on the desired Route Table.

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -42,7 +42,7 @@ Route Table whose data will be exported as attributes.
 
 * `filter` - (Optional) Custom filter block as described below.
 
-* `rtb_id` - (Optional) The id of the specific Route Table to retrieve.
+* `route_table_id` - (Optional) The id of the specific Route Table to retrieve.
 
 * `tags` - (Optional) A mapping of tags, each pair of which must exactly match
   a pair on the desired Route Table.


### PR DESCRIPTION
Documentation for the `aws_route_table` data source mentions that it supports a route table `id` as an argument, however it was missing from the actual provider code.

Adds in the missing provider code, adds a test, and updates the documentation to use `rtb_id` as the argument, instead of the more ambiguous `id`.