### PR TITLE
Fixing terraform's issue #11131

### DIFF
--- a/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
+++ b/vendor/github.com/Azure/go-autorest/autorest/azure/environments.go
@@ -79,7 +79,7 @@ var (
 		PublishSettingsURL:        "https://manage.chinacloudapi.com/publishsettings/index",
 		ServiceManagementEndpoint: "https://management.core.chinacloudapi.cn/",
 		ResourceManagerEndpoint:   "https://management.chinacloudapi.cn/",
-		ActiveDirectoryEndpoint:   "https://login.chinacloudapi.cn/?api-version=1.0",
+		ActiveDirectoryEndpoint:   "https://login.chinacloudapi.cn/",
 		GalleryEndpoint:           "https://gallery.chinacloudapi.cn/",
 		KeyVaultEndpoint:          "https://vault.azure.cn/",
 		GraphEndpoint:             "https://graph.chinacloudapi.cn/",


### PR DESCRIPTION
is "?version-api" a leftover from some older server version deployed ?  it doesn't work for me in China - see https://github.com/hashicorp/terraform/issues/11131