### PR TITLE
provider/aws: Find matching public zones even when passing in a vpc_id to aws_route53_zone data source 

### DIFF
--- a/builtin/providers/aws/data_source_aws_route53_zone.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone.go
@@ -104,6 +104,10 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 							break
 						}
 					}
+					// if we specified a vpc_id but private_zone is false and the name matches
+					if *hostedZone.Config.PrivateZone == false {
+						matchingVPC = true
+					}
 				} else {
 					matchingVPC = true
 				}


### PR DESCRIPTION
I'm hoping to use the `aws_route53_zone` data source more generically so that when I create a route53 record, whether in a public or a private zone, and just have it return the appropriate zone ID for me (currently hardcoding a lookup list of IDs from the pre-data source days).

A simple example would look something like this:

### modules/elb/main.tf:
```hcl
variable "environment" {}
variable "internal" {}
variable "subnets" {}
variable "vpc_id" {}
variable "dns_record" { default = "www" }
variable "dns_domain" {}

resource "aws_elb" "balancer" {
  name = "elb-${var.environment}"
  internal = "${var.internal}"
  subnets = [ "${split(",", var.subnets)}" ]

  listener {
    lb_port = "443"
    lb_protocol = "https"
    instance_port = "443"
    instance_protocol = "https"
  }
}

data "aws_route53_zone" "zone" {
  name = "${var.dns_domain}"
  vpc_id = "${var.vpc_id}"
  private_zone = "${var.internal}"
}

resource "aws_route53_record" "frontend" {
  name = "${var.dns_record}.${var.dns_domain}"
  zone_id = "${data.aws_route53_zone.zone.id}"
  type = "A"

  alias {
    name = "${aws_elb.balancer.dns_name}"
    zone_id = "${aws_elb.balancer.zone_id }"
    evaluate_target_health = "false"
  }
}
```

### dev/main.tf:
```hcl
module "elb" {
  source = "../modules/elb"
  environment = "dev"
  internal = "true"
  subnets = "subnet-123abc,subnet-124abc,subnet-125abc"
  vpc_id = "vpc-123abc"
  dns_domain = dev.example.com
}
```

### prod/main.tf:
```hcl
module "elb" {
  source = "../modules/elb"
  environment = "prod"
  internal = "false"
  subnets = "subnet-123abd,subnet-124abd,subnet-125abd"
  vpc_id = "vpc-123abd"
  dns_domain = example.com
}
```

In the above example the generic ELB module comes with a Route53 record that may or may not be in a public zone (in prod it is public, in dev it's not). With the current code on master running prod would still pass in a `vpc_id` parameter to the data source and so force it to look for private zones only and fail to match a private zone called `example.com` with there only being a `dev.example.com` private zone.

This pull request aims to fix that so if the `private_zone` parameter is set to false then it will search for public zones even if `vpc_id` is provided.
