### PR TITLE
provider/postgres set default postgres connection limit

### DIFF
--- a/builtin/providers/postgresql/resource_postgresql_database.go
+++ b/builtin/providers/postgresql/resource_postgresql_database.go
@@ -86,7 +86,6 @@ func resourcePostgreSQLDatabase() *schema.Resource {
 			dbConnLimitAttr: {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Computed:     true,
 				Default:      -1,
 				Description:  "How many concurrent connections can be made to this database",
 				ValidateFunc: validateConnLimit,

--- a/builtin/providers/postgresql/resource_postgresql_database.go
+++ b/builtin/providers/postgresql/resource_postgresql_database.go
@@ -87,6 +87,7 @@ func resourcePostgreSQLDatabase() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true,
+				Default:      -1,
 				Description:  "How many concurrent connections can be made to this database",
 				ValidateFunc: validateConnLimit,
 			},

--- a/builtin/providers/postgresql/resource_postgresql_role.go
+++ b/builtin/providers/postgresql/resource_postgresql_role.go
@@ -78,7 +78,6 @@ func resourcePostgreSQLRole() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      -1,
-				Computed:     true,
 				Description:  "How many concurrent connections can be made with this role",
 				ValidateFunc: validateConnLimit,
 			},

--- a/builtin/providers/postgresql/resource_postgresql_role.go
+++ b/builtin/providers/postgresql/resource_postgresql_role.go
@@ -77,6 +77,7 @@ func resourcePostgreSQLRole() *schema.Resource {
 			roleConnLimitAttr: {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Default:      -1,
 				Computed:     true,
 				Description:  "How many concurrent connections can be made with this role",
 				ValidateFunc: validateConnLimit,


### PR DESCRIPTION
Hi, there seems to have been a regression for the postgres provider. When creating a new database or role, the connection limit is set to 0, making them unusable. The docs say that the default should be "-1".

This small change sets the default to -1, making the posgres provider act as it did previously.