### PR TITLE
provider/aws: Add import to route53 record

### DIFF
--- a/builtin/providers/aws/import_aws_route53_record_test.go
+++ b/builtin/providers/aws/import_aws_route53_record_test.go
@@ -1,0 +1,28 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAwsRoute53Record_importBasic(t *testing.T) {
+	resourceName := "aws_route53_record.default"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoute53RecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoute53RecordConfig,
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"weight"},
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -27,7 +27,9 @@ func resourceAwsRoute53Record() *schema.Resource {
 		Read:   resourceAwsRoute53RecordRead,
 		Update: resourceAwsRoute53RecordUpdate,
 		Delete: resourceAwsRoute53RecordDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		SchemaVersion: 2,
 		MigrateState:  resourceAwsRoute53RecordMigrateState,
 		Schema: map[string]*schema.Schema{

--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -133,3 +133,12 @@ Weighted routing policies support the following:
 ## Attributes Reference
 
 * `fqdn` - [FQDN](https://en.wikipedia.org/wiki/Fully_qualified_domain_name) built using the zone domain and `name`
+
+
+## Import
+
+Route53 Records can be imported using ID of the record, e.g.
+
+```
+$ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS
+```


### PR DESCRIPTION
Allows the user to run:

```
terraform import aws_route53_record.record_name <record_id>
```

Fixes: #10941