### PR TITLE
[WIP] Add allow_unverified_tls option to powerdns provider.

### DIFF
--- a/builtin/providers/powerdns/client.go
+++ b/builtin/providers/powerdns/client.go
@@ -21,11 +21,14 @@ type Client struct {
 }
 
 // NewClient returns a new PowerDNS client
-func NewClient(serverUrl string, apiKey string) (*Client, error) {
+func NewClient(serverUrl string, apiKey string, allowUnverifiedTLS bool) (*Client, error) {
 	client := Client{
 		ServerUrl: serverUrl,
 		ApiKey:    apiKey,
 		Http:      cleanhttp.DefaultClient(),
+	}
+	if allowUnverifiedTLS {
+		client.Http = cleanhttp.NoTLSVerifyClient()
 	}
 	var err error
 	client.ApiVersion, err = client.detectApiVersion()

--- a/builtin/providers/powerdns/config.go
+++ b/builtin/providers/powerdns/config.go
@@ -8,11 +8,12 @@ import (
 type Config struct {
 	ServerUrl string
 	ApiKey    string
+	AllowUnverifiedTLS bool
 }
 
 // Client returns a new client for accessing PowerDNS
 func (c *Config) Client() (*Client, error) {
-	client, err := NewClient(c.ServerUrl, c.ApiKey)
+	client, err := NewClient(c.ServerUrl, c.ApiKey, c.AllowUnverifiedTLS)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up PowerDNS client: %s", err)

--- a/builtin/providers/powerdns/provider.go
+++ b/builtin/providers/powerdns/provider.go
@@ -20,6 +20,12 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("PDNS_SERVER_URL", nil),
 				Description: "Location of PowerDNS server",
 			},
+			"allow_unverified_tls": {
+				Type:		schema.TypeBool,
+				Optional:	true,
+				Default:	false,
+				Description: "Allow unverified TLS, default: false",
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -34,6 +40,7 @@ func providerConfigure(data *schema.ResourceData) (interface{}, error) {
 	config := Config{
 		ApiKey:    data.Get("api_key").(string),
 		ServerUrl: data.Get("server_url").(string),
+		AllowUnverifiedTLS: data.Get("allow_unverified_tls").(bool),
 	}
 
 	return config.Client()


### PR DESCRIPTION
Add the option to communicate with a powerdns provider without verifying the TLS certificate.

Reasoning/Background: MacOSX has two areas where certificates are searched to find the signer of a presented certificate.  Unfortunately Go currently only searches one of these areas, the one which happens to be read-only to users and admins alike.  As such CA certificates installed, say for your company, cannot be used to verify a presented PowerDNS certificate.

To enable this use until Go supports searching both of the MacOSX stores I crafted this patch.  To prevent TLS verification 'accidentally' being turned off no environmental variable to accepted to change its value and the feature defaults to off.

This pull request depends on a corresponding PR in go-cleanhttp here:
https://github.com/hashicorp/go-cleanhttp/pull/7

Please let me know if there is anything I can do to help get this PR merged or if you have any concerns.  Thank you!