### PR TITLE
providers/google: Add support for encrypting a disk

### DIFF
--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -28,6 +28,17 @@ func resourceComputeDisk() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"disk_encryption_key_raw": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"disk_encryption_key_sha256": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"image": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -129,6 +140,11 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 		disk.SourceSnapshot = snapshotData.SelfLink
 	}
 
+	if v, ok := d.GetOk("disk_encryption_key_raw"); ok {
+		disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{}
+		disk.DiskEncryptionKey.RawKey = v.(string)
+	}
+
 	op, err := config.clientCompute.Disks.Insert(
 		project, d.Get("zone").(string), disk).Do()
 	if err != nil {
@@ -168,6 +184,9 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("self_link", disk.SelfLink)
+	if disk.DiskEncryptionKey != nil && disk.DiskEncryptionKey.Sha256 != "" {
+		d.Set("disk_encryption_key_sha256", disk.DiskEncryptionKey.Sha256)
+	}
 
 	return nil
 }

--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -29,9 +29,10 @@ func resourceComputeDisk() *schema.Resource {
 			},
 
 			"disk_encryption_key_raw": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				ForceNew:  true,
+				Sensitive: true,
 			},
 
 			"disk_encryption_key_sha256": &schema.Schema{

--- a/builtin/providers/google/resource_compute_disk_test.go
+++ b/builtin/providers/google/resource_compute_disk_test.go
@@ -30,6 +30,28 @@ func TestAccComputeDisk_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeDisk_encryption(t *testing.T) {
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var disk compute.Disk
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeDiskDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeDisk_encryption(diskName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeDiskExists(
+						"google_compute_disk.foobar", &disk),
+					testAccCheckEncryptionKey(
+						"google_compute_disk.foobar", &disk),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckComputeDiskDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -77,6 +99,26 @@ func testAccCheckComputeDiskExists(n string, disk *compute.Disk) resource.TestCh
 	}
 }
 
+func testAccCheckEncryptionKey(n string, disk *compute.Disk) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		attr := rs.Primary.Attributes["disk_encryption_key_sha256"]
+		if disk.DiskEncryptionKey == nil && attr != "" {
+			return fmt.Errorf("Disk %s has mismatched encryption key.\nTF State: %+v\nGCP State: <empty>", n, attr)
+		}
+
+		if attr != disk.DiskEncryptionKey.Sha256 {
+			return fmt.Errorf("Disk %s has mismatched encryption key.\nTF State: %+v.\nGCP State: %+v",
+				n, attr, disk.DiskEncryptionKey.Sha256)
+		}
+		return nil
+	}
+}
+
 func testAccComputeDisk_basic(diskName string) string {
 	return fmt.Sprintf(`
 resource "google_compute_disk" "foobar" {
@@ -85,5 +127,17 @@ resource "google_compute_disk" "foobar" {
 	size = 50
 	type = "pd-ssd"
 	zone = "us-central1-a"
+}`, diskName)
+}
+
+func testAccComputeDisk_encryption(diskName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "foobar" {
+	name = "%s"
+	image = "debian-8-jessie-v20160803"
+	size = 50
+	type = "pd-ssd"
+	zone = "us-central1-a"
+	disk_encryption_key_raw = "SGVsbG8gZnJvbSBHb29nbGUgQ2xvdWQgUGxhdGZvcm0="
 }`, diskName)
 }

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -77,9 +77,10 @@ func resourceComputeInstance() *schema.Resource {
 						},
 
 						"disk_encryption_key_raw": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							ForceNew:  true,
+							Sensitive: true,
 						},
 
 						"disk_encryption_key_sha256": &schema.Schema{
@@ -789,14 +790,13 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	disks := make([]map[string]interface{}, 0, 1)
 	for i, disk := range instance.Disks {
 		di := map[string]interface{}{
-			"disk":                    d.Get(fmt.Sprintf("disk.%d.disk", i)),
-			"image":                   d.Get(fmt.Sprintf("disk.%d.image", i)),
-			"type":                    d.Get(fmt.Sprintf("disk.%d.type", i)),
-			"scratch":                 d.Get(fmt.Sprintf("disk.%d.scratch", i)),
-			"auto_delete":             d.Get(fmt.Sprintf("disk.%d.auto_delete", i)),
-			"size":                    d.Get(fmt.Sprintf("disk.%d.size", i)),
-			"device_name":             d.Get(fmt.Sprintf("disk.%d.device_name", i)),
-			"disk_encryption_key_raw": d.Get(fmt.Sprintf("disk.%d.disk_encryption_key_raw", i)),
+			"disk":        d.Get(fmt.Sprintf("disk.%d.disk", i)),
+			"image":       d.Get(fmt.Sprintf("disk.%d.image", i)),
+			"type":        d.Get(fmt.Sprintf("disk.%d.type", i)),
+			"scratch":     d.Get(fmt.Sprintf("disk.%d.scratch", i)),
+			"auto_delete": d.Get(fmt.Sprintf("disk.%d.auto_delete", i)),
+			"size":        d.Get(fmt.Sprintf("disk.%d.size", i)),
+			"device_name": d.Get(fmt.Sprintf("disk.%d.device_name", i)),
 		}
 		if disk.DiskEncryptionKey != nil && disk.DiskEncryptionKey.Sha256 != "" {
 			di["disk_encryption_key_sha256"] = disk.DiskEncryptionKey.Sha256

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -75,6 +75,17 @@ func resourceComputeInstance() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
+
+						"disk_encryption_key_raw": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+
+						"disk_encryption_key_sha256": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
 					},
 				},
 			},
@@ -437,6 +448,11 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 			disk.DeviceName = v.(string)
 		}
 
+		if v, ok := d.GetOk(prefix + ".disk_encryption_key_raw"); ok {
+			disk.DiskEncryptionKey = &compute.CustomerEncryptionKey{}
+			disk.DiskEncryptionKey.RawKey = v.(string)
+		}
+
 		disks = append(disks, &disk)
 	}
 
@@ -769,6 +785,25 @@ func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error
 	if instance.Tags != nil {
 		d.Set("tags_fingerprint", instance.Tags.Fingerprint)
 	}
+
+	disks := make([]map[string]interface{}, 0, 1)
+	for i, disk := range instance.Disks {
+		di := map[string]interface{}{
+			"disk":                    d.Get(fmt.Sprintf("disk.%d.disk", i)),
+			"image":                   d.Get(fmt.Sprintf("disk.%d.image", i)),
+			"type":                    d.Get(fmt.Sprintf("disk.%d.type", i)),
+			"scratch":                 d.Get(fmt.Sprintf("disk.%d.scratch", i)),
+			"auto_delete":             d.Get(fmt.Sprintf("disk.%d.auto_delete", i)),
+			"size":                    d.Get(fmt.Sprintf("disk.%d.size", i)),
+			"device_name":             d.Get(fmt.Sprintf("disk.%d.device_name", i)),
+			"disk_encryption_key_raw": d.Get(fmt.Sprintf("disk.%d.disk_encryption_key_raw", i)),
+		}
+		if disk.DiskEncryptionKey != nil && disk.DiskEncryptionKey.Sha256 != "" {
+			di["disk_encryption_key_sha256"] = disk.DiskEncryptionKey.Sha256
+		}
+		disks = append(disks, di)
+	}
+	d.Set("disk", disks)
 
 	d.Set("self_link", instance.SelfLink)
 	d.SetId(instance.Name)

--- a/website/source/docs/providers/google/r/compute_disk.html.markdown
+++ b/website/source/docs/providers/google/r/compute_disk.html.markdown
@@ -32,6 +32,11 @@ The following arguments are supported:
 
 - - -
 
+* `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
+    encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    to encrypt this disk.
+
 * `image` - (Optional) The image from which to initialize this disk. Either the
     full URL, a contraction of the form "project/name", or just a name (in which
     case the current project is used).
@@ -50,5 +55,10 @@ The following arguments are supported:
 
 In addition to the arguments listed above, the following computed attributes are
 exported:
+
+* `disk_encryption_key_sha256` - The [RFC 4648 base64]
+    (https://tools.ietf.org/html/rfc4648#section-4) encoded SHA-256 hash of the
+    [customer-supplied encryption key](https://cloud.google.com/compute/docs/disks/customer-supplied-encryption)
+    that protects this resource.
 
 * `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -136,6 +136,11 @@ the type is "local-ssd", in which case scratch must be true).
 * `device_name` - (Optional) Name with which attached disk will be accessible
     under `/dev/disk/by-id/`
 
+* `disk_encryption_key_raw` - (Optional) A 256-bit [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption),
+    encoded in [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    to encrypt this disk.
+
 The `network_interface` block supports:
 
 * `network` - (Optional) The name or self_link of the network to attach this interface to.
@@ -204,3 +209,7 @@ exported:
 * `network_interface.0.address` - The internal ip address of the instance, either manually or dynamically assigned.
 
 * `network_interface.0.access_config.0.assigned_nat_ip` - If the instance has an access config, either the given external ip (in the `nat_ip` field) or the ephemeral (generated) ip (if you didn't provide one).
+
+* `disk.0.disk_encryption_key_sha256` - The [RFC 4648 base64](https://tools.ietf.org/html/rfc4648#section-4)
+    encoded SHA-256 hash of the [customer-supplied encryption key]
+    (https://cloud.google.com/compute/docs/disks/customer-supplied-encryption) that protects this resource.


### PR DESCRIPTION
This provides the ability to use raw customer-supplied encryption keys for disks created using the disk or instance resources.
https://cloud.google.com/compute/docs/disks/customer-supplied-encryption