### PR TITLE
provider/aws: Allow creating aws_codecommit repository outside of us-east-1

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -266,7 +266,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.cloudwatchconn = cloudwatch.New(sess)
 	client.cloudwatcheventsconn = cloudwatchevents.New(sess)
 	client.cloudwatchlogsconn = cloudwatchlogs.New(sess)
-	client.codecommitconn = codecommit.New(usEast1Sess)
+	client.codecommitconn = codecommit.New(sess)
 	client.codedeployconn = codedeploy.New(sess)
 	client.dsconn = directoryservice.New(sess)
 	client.dynamodbconn = dynamodb.New(dynamoSess)

--- a/builtin/providers/aws/resource_aws_codecommit_repository_test.go
+++ b/builtin/providers/aws/resource_aws_codecommit_repository_test.go
@@ -161,9 +161,6 @@ func testAccCheckCodeCommitRepositoryDestroy(s *terraform.State) error {
 
 func testAccCodeCommitRepository_basic(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
 resource "aws_codecommit_repository" "test" {
   repository_name = "test_repository_%d"
   description = "This is a test description"
@@ -173,9 +170,6 @@ resource "aws_codecommit_repository" "test" {
 
 func testAccCodeCommitRepository_withChanges(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
 resource "aws_codecommit_repository" "test" {
   repository_name = "test_repository_%d"
   description = "This is a test description - with changes"
@@ -185,9 +179,6 @@ resource "aws_codecommit_repository" "test" {
 
 func testAccCodeCommitRepository_with_default_branch(rInt int) string {
 	return fmt.Sprintf(`
-provider "aws" {
-  region = "us-east-1"
-}
 resource "aws_codecommit_repository" "test" {
   repository_name = "test_repository_%d"
   description = "This is a test description"


### PR DESCRIPTION
Fixes #11175

Because of a previous limitation that codecommit only ran in us-east-1,
we hard coded the session under which it should run. This has caused the
repository to be spun up in the wrong region regardless of what region
was passed to the provider

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCodeCommitRepository_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/12 16:09:52 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCodeCommitRepository_ -timeout 120m
=== RUN   TestAccAWSCodeCommitRepository_basic
--- PASS: TestAccAWSCodeCommitRepository_basic (23.28s)
=== RUN   TestAccAWSCodeCommitRepository_withChanges
--- PASS: TestAccAWSCodeCommitRepository_withChanges (33.71s)
=== RUN   TestAccAWSCodeCommitRepository_create_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_default_branch (22.70s)
=== RUN   TestAccAWSCodeCommitRepository_create_and_update_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_and_update_default_branch (32.72s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	112.437s
```