### PR TITLE
Add support for StatusCake confirmation servers

### DIFF
--- a/builtin/providers/statuscake/resource_statuscaketest.go
+++ b/builtin/providers/statuscake/resource_statuscaketest.go
@@ -57,6 +57,10 @@ func resourceStatusCakeTest() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"confirmations": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -65,13 +69,14 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*statuscake.Client)
 
 	newTest := &statuscake.Test{
-		WebsiteName: d.Get("website_name").(string),
-		WebsiteURL:  d.Get("website_url").(string),
-		CheckRate:   d.Get("check_rate").(int),
-		TestType:    d.Get("test_type").(string),
-		Paused:      d.Get("paused").(bool),
-		Timeout:     d.Get("timeout").(int),
-		ContactID:   d.Get("contact_id").(int),
+		WebsiteName:  d.Get("website_name").(string),
+		WebsiteURL:   d.Get("website_url").(string),
+		CheckRate:    d.Get("check_rate").(int),
+		TestType:     d.Get("test_type").(string),
+		Paused:       d.Get("paused").(bool),
+		Timeout:      d.Get("timeout").(int),
+		ContactID:    d.Get("contact_id").(int),
+		Confirmation: d.Get("confirmations").(int),
 	}
 
 	log.Printf("[DEBUG] Creating new StatusCake Test: %s", d.Get("website_name").(string))
@@ -134,6 +139,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("paused", testResp.Paused)
 	d.Set("timeout", testResp.Timeout)
 	d.Set("contact_id", testResp.ContactID)
+	d.Set("confirmations", testResp.Confirmation)
 
 	return nil
 }
@@ -166,6 +172,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("contact_id"); ok {
 		test.ContactID = v.(int)
+	}
+	if v, ok := d.GetOk("confirmations"); ok {
+		test.Confirmation = v.(int)
 	}
 	return test
 }

--- a/builtin/providers/statuscake/resource_statuscaketest_test.go
+++ b/builtin/providers/statuscake/resource_statuscaketest_test.go
@@ -52,6 +52,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuscake_test.google", "check_rate", "500"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "paused", "true"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "contact_id", "0"),
+					resource.TestCheckResourceAttr("statuscake_test.google", "confirmations", "0"),
 				),
 			},
 		},
@@ -116,6 +117,8 @@ func testAccTestCheckAttributes(rn string, test *statuscake.Test) resource.TestC
 				err = check(key, value, strconv.Itoa(test.Timeout))
 			case "contact_id":
 				err = check(key, value, strconv.Itoa(test.ContactID))
+			case "confirmations":
+				err = check(key, value, strconv.Itoa(test.Confirmation))
 			}
 
 			if err != nil {
@@ -145,6 +148,7 @@ resource "statuscake_test" "google" {
 	test_type = "HTTP"
 	check_rate = 300
 	contact_id = 12345
+	confirmations = 1
 }
 `
 

--- a/website/source/docs/providers/statuscake/r/test.html.markdown
+++ b/website/source/docs/providers/statuscake/r/test.html.markdown
@@ -26,12 +26,13 @@ resource "statuscake_test" "google" {
 The following arguments are supported:
 
 * `website_name` - (Required) This is the name of the test and the website to be monitored.
-* `website_url` - (Required) The URL of the website to be monitored
-* `check_rate` - (Optional) Test check rate in seconds. Defaults to 300
-* `test_type` - (Required) The type of Test. Either HTTP or TCP
+* `website_url` - (Required) The URL of the website to be monitored.
+* `check_rate` - (Optional) Test check rate in seconds. Defaults to 300.
+* `test_type` - (Required) The type of Test. Either HTTP or TCP.
 * `paused` - (Optional) Whether or not the test is paused. Defaults to false.
 * `timeout` - (Optional) The timeout of the test in seconds.
 * `contact_id` - (Optional) The ID of the contact group to associate with the test.
+* `confirmations` - (Optional) The number of confirmation servers to use in order to detect downtime. Defaults to 0.
 
 
 ## Attributes Reference


### PR DESCRIPTION
StatusCake supports confirmation servers which makes StatusCake tests check with additional servers before detecting, and possibly alerting on, downtime.

I've updated the documentation to describe the new agrument; this doesn't need to go out now but the docs site would need to be updated when/if this is merged and released.