### PR TITLE
Example aws-elb fix

### DIFF
--- a/examples/aws-elb/main.tf
+++ b/examples/aws-elb/main.tf
@@ -25,13 +25,6 @@ resource "aws_security_group" "default" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # outbound internet access
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 # Our elb security group to access
@@ -48,13 +41,6 @@ resource "aws_security_group" "elb" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  # outbound internet access
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }
 
 resource "aws_elb" "web" {
@@ -62,7 +48,7 @@ resource "aws_elb" "web" {
 
   # The same availability zone as our instance
   availability_zones = ["${aws_instance.web.availability_zone}"]
-  security_groups    = ["${aws_security_group.elb.id}"]
+  source_security_group    = "${aws_security_group.elb.name}"
 
   listener {
     instance_port     = 80
@@ -96,7 +82,7 @@ resource "aws_lb_cookie_stickiness_policy" "default" {
 }
 
 resource "aws_instance" "web" {
-  instance_type = "t2.micro"
+  instance_type = "t1.micro"
 
   # Lookup the correct AMI based on the region
   # we specified

--- a/examples/aws-elb/main.tf
+++ b/examples/aws-elb/main.tf
@@ -6,7 +6,7 @@ provider "aws" {
 # Our default security group to access
 # the instances over SSH and HTTP
 resource "aws_security_group" "default" {
-  name        = "instance_sg"
+  name_prefix        = "instance_sg"
   description = "Used in the terraform"
 
   # SSH access from anywhere
@@ -30,7 +30,7 @@ resource "aws_security_group" "default" {
 # Our elb security group to access
 # the ELB over HTTP
 resource "aws_security_group" "elb" {
-  name        = "elb_sg"
+  name_prefix        = "elb_sg"
   description = "Used in the terraform"
 
   # HTTP access from anywhere

--- a/examples/aws-elb/variables.tf
+++ b/examples/aws-elb/variables.tf
@@ -10,7 +10,7 @@ variable "aws_region" {
 # ubuntu-trusty-14.04 (x64)
 variable "aws_amis" {
   default = {
-    "us-east-1" = "ami-5f709f34"
-    "us-west-2" = "ami-7f675e4f"
+    "us-east-1" = "ami-73709f18"
+    "us-west-2" = "ami-0f675e3f"
   }
 }


### PR DESCRIPTION
While testing the aws-elb example ran into the following error when performing a terraform apply:
```

Error applying plan:

2 error(s) occurred:

* aws_security_group.default: Error authorizing security group egress rules: InvalidParameterValue: Only Amazon VPC security groups may be used with this operation.
	status code: 400, request id: 061c2299-8be5-4620-9c24-226a0f1c32ba
* aws_security_group.elb: Error authorizing security group egress rules: InvalidParameterValue: Only Amazon VPC security groups may be used with this operation.
	status code: 400, request id: 4a7225f1-95f9-4696-b55e-54e9487a50d6

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

This initial error led to a few other errors which should be resolved in this version.

Most of the changes involved leveraging arguments that are supported by EC2 Classic because the current master references VPC options. Because of the changes to make this work completely outside of a VPC there was a need to change the instance type to a t1.micro as the t2.micro was VPC only. To facilitate this change the variables.tf file was updated to use the appropriate AMI type.

Tested against 0.8.4 to validate that this had not been resolved in a newer release.