### PR TITLE
provider/scaleway improve bootscript data source

### DIFF
--- a/builtin/providers/scaleway/data_source_scaleway_bootscript.go
+++ b/builtin/providers/scaleway/data_source_scaleway_bootscript.go
@@ -80,12 +80,16 @@ func dataSourceScalewayBootscriptRead(d *schema.ResourceData, meta interface{}) 
 
 	var isMatch func(api.ScalewayBootscript) bool
 
+	architecture := d.Get("architecture")
 	if name, ok := d.GetOk("name"); ok {
 		isMatch = func(s api.ScalewayBootscript) bool {
-			return s.Title == name.(string)
+			architectureMatch := true
+			if architecture != "" {
+				architectureMatch = architecture == s.Arch
+			}
+			return s.Title == name.(string) && architectureMatch
 		}
 	} else if nameFilter, ok := d.GetOk("name_filter"); ok {
-		architecture := d.Get("architecture")
 		exp, err := regexp.Compile(nameFilter.(string))
 		if err != nil {
 			return err

--- a/builtin/providers/scaleway/data_source_scaleway_bootscript_test.go
+++ b/builtin/providers/scaleway/data_source_scaleway_bootscript_test.go
@@ -20,7 +20,7 @@ func TestAccScalewayDataSourceBootscript_Basic(t *testing.T) {
 					testAccCheckBootscriptID("data.scaleway_bootscript.debug"),
 					resource.TestCheckResourceAttr("data.scaleway_bootscript.debug", "architecture", "x86_64"),
 					resource.TestCheckResourceAttr("data.scaleway_bootscript.debug", "public", "true"),
-					resource.TestMatchResourceAttr("data.scaleway_bootscript.debug", "kernel", regexp.MustCompile("4.8.3")),
+					resource.TestMatchResourceAttr("data.scaleway_bootscript.debug", "kernel", regexp.MustCompile("4.8.14")),
 				),
 			},
 		},
@@ -67,7 +67,7 @@ func testAccCheckBootscriptID(n string) resource.TestCheckFunc {
 
 const testAccCheckScalewayBootscriptConfig = `
 data "scaleway_bootscript" "debug" {
-  name = "x86_64 4.8.3 debug #1"
+  name = "x86_64 4.8.14 debug #2"
 }
 `
 

--- a/builtin/providers/scaleway/data_source_scaleway_bootscript_test.go
+++ b/builtin/providers/scaleway/data_source_scaleway_bootscript_test.go
@@ -2,30 +2,11 @@ package scaleway
 
 import (
 	"fmt"
-	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
-
-func TestAccScalewayDataSourceBootscript_Basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckScalewayBootscriptConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckBootscriptID("data.scaleway_bootscript.debug"),
-					resource.TestCheckResourceAttr("data.scaleway_bootscript.debug", "architecture", "x86_64"),
-					resource.TestCheckResourceAttr("data.scaleway_bootscript.debug", "public", "true"),
-					resource.TestMatchResourceAttr("data.scaleway_bootscript.debug", "kernel", regexp.MustCompile("4.8.14")),
-				),
-			},
-		},
-	})
-}
 
 func TestAccScalewayDataSourceBootscript_Filtered(t *testing.T) {
 	resource.Test(t, resource.TestCase{
@@ -64,12 +45,6 @@ func testAccCheckBootscriptID(n string) resource.TestCheckFunc {
 		return nil
 	}
 }
-
-const testAccCheckScalewayBootscriptConfig = `
-data "scaleway_bootscript" "debug" {
-  name = "x86_64 4.8.14 debug #2"
-}
-`
 
 const testAccCheckScalewayBootscriptFilterConfig = `
 data "scaleway_bootscript" "debug" {


### PR DESCRIPTION
this PR fixes the broken scaleway `bootscript` data source tests:

- it corrects a long standing error in the datasource: when `name` and `architecture` where present, `architecture` was not used for filtering the results. This behaviour however exists when a `name_filter` is present, so now the data source behaves the same in both cases.
- it improves the reliability of the tests by not hardcoding bootscript names.  these tend to change rather quickly and we don't want to update the test cases all the time because of some external change.

tests are green:

```
make testacc TEST=./builtin/providers/scaleway TESTARGS='-run=TestAccScalewayDataSourceBootscript'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/12 22:55:22 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScalewayDataSourceBootscript -timeout 120m
=== RUN   TestAccScalewayDataSourceBootscript_Basic
--- PASS: TestAccScalewayDataSourceBootscript_Basic (2.16s)
=== RUN   TestAccScalewayDataSourceBootscript_Filtered
--- PASS: TestAccScalewayDataSourceBootscript_Filtered (1.58s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/scaleway	3.763s
```

@stack72 PTAL