### PR TITLE
State Locking initial implementations

### DIFF
--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -38,18 +38,18 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 	}
 
 	// Verify it exists where we expect it to
-	if _, err := os.Stat(DefaultStateFilename); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename) {
+		t.Fatalf("no state was written")
 	}
 
 	// Verify no backup since it was empty to start
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatal("expected error")
+	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup state should be empty")
 	}
 
 	// Verify no backend state was made
 	if !isEmptyState(filepath.Join(m.DataDir(), DefaultStateFilename)) {
-		t.Fatal("state created")
+		t.Fatal("backend state shoudl be empty")
 	}
 }
 
@@ -1063,8 +1063,8 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	}
 
 	// Verify a backup doesn't exist
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatalf("backup state should be empty")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -1847,13 +1847,13 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyBackend(t *testing.T) {
 	}
 
 	// Verify the default paths exist
-	if _, err := os.Stat(DefaultStateFilename); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename) {
+		t.Fatalf("default state was empty")
 	}
 
 	// Verify a backup doesn't exist
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backupstate should be empty")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -1945,13 +1945,13 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyLegacy(t *testing.T) {
 	}
 
 	// Verify the default paths exist
-	if _, err := os.Stat(DefaultStateFilename); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename) {
+		t.Fatalf("default state was empty")
 	}
 
 	// Verify a backup doesn't exist
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backupstate should be empty")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2182,8 +2182,8 @@ func TestMetaBackend_planLocal(t *testing.T) {
 	}
 
 	// Verify no local backup
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatalf("backup state should be empty")
 	}
 }
 

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -178,7 +178,7 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 
 	// Verify neither defaults exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	stateName := filepath.Join(m.DataDir(), DefaultStateFilename)
@@ -243,15 +243,15 @@ func TestMetaBackend_emptyLegacyRemote(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 	if _, err := os.Stat(statePath + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -312,12 +312,12 @@ func TestMetaBackend_configureNew(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -767,12 +767,12 @@ func TestMetaBackend_configureNewLegacyCopy(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -807,12 +807,12 @@ func TestMetaBackend_configuredUnchanged(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -851,12 +851,12 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Write some state
@@ -886,12 +886,12 @@ func TestMetaBackend_configuredChange(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -933,12 +933,12 @@ func TestMetaBackend_configuredChangeCopy(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -1148,7 +1148,7 @@ func TestMetaBackend_configuredUnchangedLegacy(t *testing.T) {
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured legacy
@@ -1199,12 +1199,12 @@ func TestMetaBackend_configuredUnchangedLegacy(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -1246,12 +1246,12 @@ func TestMetaBackend_configuredUnchangedLegacyCopy(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured legacy
@@ -1302,12 +1302,12 @@ func TestMetaBackend_configuredUnchangedLegacyCopy(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -1346,12 +1346,12 @@ func TestMetaBackend_configuredChangedLegacy(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured legacy
@@ -1402,12 +1402,12 @@ func TestMetaBackend_configuredChangedLegacy(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -1449,12 +1449,12 @@ func TestMetaBackend_configuredChangedLegacyCopyBackend(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured legacy
@@ -1505,12 +1505,12 @@ func TestMetaBackend_configuredChangedLegacyCopyBackend(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -1552,12 +1552,12 @@ func TestMetaBackend_configuredChangedLegacyCopyLegacy(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured legacy
@@ -1608,12 +1608,12 @@ func TestMetaBackend_configuredChangedLegacyCopyLegacy(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -1655,12 +1655,12 @@ func TestMetaBackend_configuredChangedLegacyCopyBoth(t *testing.T) {
 
 	// Verify the default paths don't exist
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured legacy
@@ -1711,12 +1711,12 @@ func TestMetaBackend_configuredChangedLegacyCopyBoth(t *testing.T) {
 
 	// Verify no local state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -2241,7 +2241,7 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 
 	// Verify a backup doesn't exists
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2408,7 +2408,7 @@ func TestMetaBackend_planLocalMismatchLineage(t *testing.T) {
 
 	// Verify a backup doesn't exists
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2460,7 +2460,7 @@ func TestMetaBackend_planLocalNewer(t *testing.T) {
 
 	// Verify a backup doesn't exists
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2563,12 +2563,12 @@ func TestMetaBackend_planBackendEmptyDir(t *testing.T) {
 
 	// Verify no default path
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -2624,12 +2624,12 @@ func TestMetaBackend_planBackendMatch(t *testing.T) {
 
 	// Verify the default path exists
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2665,12 +2665,12 @@ func TestMetaBackend_planBackendMatch(t *testing.T) {
 
 	// Verify no default path
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -2722,7 +2722,7 @@ func TestMetaBackend_planBackendMismatchLineage(t *testing.T) {
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2733,7 +2733,7 @@ func TestMetaBackend_planBackendMismatchLineage(t *testing.T) {
 
 	// Verify we have no default state
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 
@@ -2787,12 +2787,12 @@ func TestMetaBackend_planLegacy(t *testing.T) {
 
 	// Verify the default path
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2828,12 +2828,12 @@ func TestMetaBackend_planLegacy(t *testing.T) {
 
 	// Verify no default path
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 
 	// Verify no local backup
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+		t.Fatal("file should not exist")
 	}
 }
 

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -2520,14 +2520,14 @@ func TestMetaBackend_planBackendEmptyDir(t *testing.T) {
 		t.Fatalf("bad: %#v", state)
 	}
 
-	// Verify the default path
-	if isEmptyState(DefaultStateFilename) {
-		t.Fatal("state is empty")
+	// Verify the default path doesn't exist
+	if !isEmptyState(DefaultStateFilename) {
+		t.Fatal("state is not empty")
 	}
 
-	// Verify a backup exists
-	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
-		t.Fatal("backup is empty")
+	// Verify a backup doesn't exist
+	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is not empty")
 	}
 
 	// Verify we have no configured backend/legacy

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -49,7 +49,7 @@ func TestMetaBackend_emptyDir(t *testing.T) {
 
 	// Verify no backend state was made
 	if !isEmptyState(filepath.Join(m.DataDir(), DefaultStateFilename)) {
-		t.Fatal("backend state shoudl be empty")
+		t.Fatal("backend state should be empty")
 	}
 }
 
@@ -125,8 +125,8 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	}
 
 	// Verify a backup was made since we're modifying a pre-existing state
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup state should not be empty")
 	}
 }
 
@@ -195,8 +195,8 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	}
 
 	// Verify a backup was made since we're modifying a pre-existing state
-	if _, err := os.Stat(statePath + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(statePath + DefaultBackupExtension) {
+		t.Fatal("backup state should not be empty")
 	}
 }
 
@@ -311,13 +311,13 @@ func TestMetaBackend_configureNew(t *testing.T) {
 	}
 
 	// Verify the default paths don't exist
-	if !isEmptyState(DefaultStateFilename) {
-		t.Fatalf("state should not exist")
+	if _, err := os.Stat(DefaultStateFilename); err == nil {
+		t.Fatalf("err: %s", err)
 	}
 
 	// Verify a backup doesn't exist
-	if !isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
-		t.Fatalf("backup state should not exist")
+	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
+		t.Fatalf("err: %s", err)
 	}
 }
 
@@ -1100,8 +1100,8 @@ func TestMetaBackend_configuredUnsetCopy(t *testing.T) {
 	}
 
 	// Verify a backup since it wasn't empty to start
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 }
 
@@ -1903,8 +1903,8 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyBackend(t *testing.T) {
 	}
 
 	// Verify a local backup
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 }
 
@@ -2001,8 +2001,8 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyLegacy(t *testing.T) {
 	}
 
 	// Verify a local backup
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 }
 
@@ -2043,13 +2043,13 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyBoth(t *testing.T) {
 	}
 
 	// Verify the default paths exist
-	if _, err := os.Stat(DefaultStateFilename); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename) {
+		t.Fatal("state is empty")
 	}
 
 	// Verify a backup exists
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2099,8 +2099,8 @@ func TestMetaBackend_configuredUnsetWithLegacyCopyBoth(t *testing.T) {
 	}
 
 	// Verify a local backup
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 }
 
@@ -2276,8 +2276,8 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 	}
 
 	// Verify we have a backup
-	if _, err := os.Stat(statePath + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(statePath + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 }
 
@@ -2321,8 +2321,8 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	}
 
 	// Verify the default path
-	if _, err := os.Stat(DefaultStateFilename); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename) {
+		t.Fatal("state is empty")
 	}
 
 	// Verify a backup exists
@@ -2362,8 +2362,8 @@ func TestMetaBackend_planLocalMatch(t *testing.T) {
 	}
 
 	// Verify local backup
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err != nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 }
 
@@ -2521,13 +2521,13 @@ func TestMetaBackend_planBackendEmptyDir(t *testing.T) {
 	}
 
 	// Verify the default path
-	if _, err := os.Stat(DefaultStateFilename); err == nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename) {
+		t.Fatal("state is empty")
 	}
 
 	// Verify a backup exists
-	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
-		t.Fatalf("err: %s", err)
+	if isEmptyState(DefaultStateFilename + DefaultBackupExtension) {
+		t.Fatal("backup is empty")
 	}
 
 	// Verify we have no configured backend/legacy
@@ -2622,12 +2622,12 @@ func TestMetaBackend_planBackendMatch(t *testing.T) {
 		t.Fatalf("bad: %#v", state)
 	}
 
-	// Verify the default path
+	// Verify the default path exists
 	if _, err := os.Stat(DefaultStateFilename); err == nil {
 		t.Fatalf("err: %s", err)
 	}
 
-	// Verify a backup exists
+	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -2720,7 +2720,7 @@ func TestMetaBackend_planBackendMismatchLineage(t *testing.T) {
 		t.Fatalf("bad: %#v", actual)
 	}
 
-	// Verify a backup doesn't exists
+	// Verify a backup doesn't exist
 	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -59,6 +59,9 @@ func TestRefresh(t *testing.T) {
 	}
 }
 
+// TODO: State locking now creates the state file.
+//       Is there a good reason this shouldn't exist?
+/*
 func TestRefresh_badState(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -77,6 +80,7 @@ func TestRefresh_badState(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 }
+*/
 
 func TestRefresh_cwd(t *testing.T) {
 	cwd, err := os.Getwd()

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -59,9 +59,6 @@ func TestRefresh(t *testing.T) {
 	}
 }
 
-// TODO: State locking now creates the state file.
-//       Is there a good reason this shouldn't exist?
-/*
 func TestRefresh_badState(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)
@@ -80,7 +77,6 @@ func TestRefresh_badState(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 }
-*/
 
 func TestRefresh_cwd(t *testing.T) {
 	cwd, err := os.Getwd()

--- a/state/backup.go
+++ b/state/backup.go
@@ -43,6 +43,21 @@ func (s *BackupState) PersistState() error {
 	return s.Real.PersistState()
 }
 
+// all states get wrapped by BackupState, so it has to be a Locker
+func (s *BackupState) Lock(reason string) error {
+	if s, ok := s.Real.(Locker); ok {
+		return s.Lock(reason)
+	}
+	return nil
+}
+
+func (s *BackupState) Unlock() error {
+	if s, ok := s.Real.(Locker); ok {
+		return s.Unlock()
+	}
+	return nil
+}
+
 func (s *BackupState) backup() error {
 	state := s.Real.State()
 	if state == nil {

--- a/state/backup.go
+++ b/state/backup.go
@@ -1,8 +1,6 @@
 package state
 
-import (
-	"github.com/hashicorp/terraform/terraform"
-)
+import "github.com/hashicorp/terraform/terraform"
 
 // BackupState wraps a State that backs up the state on the first time that
 // a WriteState or PersistState is called.
@@ -68,9 +66,14 @@ func (s *BackupState) backup() error {
 		state = s.Real.State()
 	}
 
-	ls := &LocalState{Path: s.Path}
-	if err := ls.WriteState(state); err != nil {
-		return err
+	// LocalState.WriteState ensures that a file always exists for locking
+	// purposes, but we don't need a backup or lock if the state is empty, so
+	// skip this with a nil state.
+	if state != nil {
+		ls := &LocalState{Path: s.Path}
+		if err := ls.WriteState(state); err != nil {
+			return err
+		}
 	}
 
 	s.done = true

--- a/state/local.go
+++ b/state/local.go
@@ -16,7 +16,7 @@ type lockInfo struct {
 	// Path to the state file
 	Path string
 	// The time the lock was taken
-	Time time.Time
+	Created time.Time
 	// The time this lock expires
 	Expires time.Time
 	// The lock reason passed to State.Lock
@@ -26,7 +26,7 @@ type lockInfo struct {
 // return the lock info formatted in an error
 func (l *lockInfo) Err() error {
 	return fmt.Errorf("state file %q locked. created:%s, expires:%s, reason:%s",
-		l.Path, l.Time, l.Expires, l.Reason)
+		l.Path, l.Created, l.Expires, l.Reason)
 }
 
 // LocalState manages a state storage that is local to the filesystem.
@@ -227,8 +227,8 @@ func (s *LocalState) writeLockInfo(reason string) error {
 
 	lockInfo := &lockInfo{
 		Path:    s.Path,
-		Time:    time.Now(),
-		Expires: time.Now().Add(time.Hour),
+		Created: time.Now().UTC(),
+		Expires: time.Now().Add(time.Hour).UTC(),
 		Reason:  reason,
 	}
 

--- a/state/local.go
+++ b/state/local.go
@@ -1,11 +1,33 @@
 package state
 
 import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/hashicorp/terraform/terraform"
 )
+
+// lock metadata structure for local locks
+type lockInfo struct {
+	// Path to the state file
+	Path string
+	// The time the lock was taken
+	Time time.Time
+	// The time this lock expires
+	Expires time.Time
+	// The lock reason passed to State.Lock
+	Reason string
+}
+
+// return the lock info formatted in an error
+func (l *lockInfo) Err() error {
+	return fmt.Errorf("state file %q locked. created:%s, expires:%s, reason:%s",
+		l.Path, l.Time, l.Expires, l.Reason)
+}
 
 // LocalState manages a state storage that is local to the filesystem.
 type LocalState struct {
@@ -14,6 +36,10 @@ type LocalState struct {
 	// If PathOut already exists, it will be overwritten.
 	Path    string
 	PathOut string
+
+	// the file handles corresponding to Path and PathOut
+	stateFile    *os.File
+	stateFileOut *os.File
 
 	state     *terraform.State
 	readState *terraform.State
@@ -31,45 +57,105 @@ func (s *LocalState) State() *terraform.State {
 	return s.state.DeepCopy()
 }
 
-// WriteState for LocalState always persists the state as well.
-//
-// StateWriter impl.
-func (s *LocalState) WriteState(state *terraform.State) error {
-	s.state = state
-
-	path := s.PathOut
-	if path == "" {
-		path = s.Path
-	}
-
-	// If we don't have any state, we actually delete the file if it exists
-	if state == nil {
-		err := os.Remove(path)
-		if err != nil && os.IsNotExist(err) {
-			return nil
+// Lock implements a local filesystem state.Locker.
+func (s *LocalState) Lock(reason string) error {
+	if s.stateFileOut == nil {
+		if err := s.createStateFiles(); err != nil {
+			return err
 		}
-
-		return err
 	}
 
-	// Create all the directories
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return err
+	if err := s.lock(); err != nil {
+		if info, err := s.lockInfo(); err != nil {
+			return info.Err()
+		}
+		return fmt.Errorf("state file %q locked: %s", s.Path, err)
 	}
 
-	f, err := os.Create(path)
+	return s.writeLockInfo(reason)
+}
+
+func (s *LocalState) Unlock() error {
+	os.Remove(s.lockInfoPath())
+	return s.unlock()
+}
+
+// Open the state file, creating the directories and file as needed.
+func (s *LocalState) createStateFiles() error {
+	f, err := createFileAndDirs(s.Path)
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+
+	s.stateFile = f
+
+	if s.PathOut == "" {
+		s.PathOut = s.Path
+	}
+
+	if s.PathOut == s.Path {
+		s.stateFileOut = s.stateFile
+		return nil
+	}
+
+	f, err = createFileAndDirs(s.PathOut)
+	if err != nil {
+		return err
+	}
+	s.stateFileOut = f
+	return nil
+}
+
+func createFileAndDirs(path string) (*os.File, error) {
+	// Create all the directories
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return nil, err
+	}
+
+	return f, nil
+}
+
+// WriteState for LocalState always persists the state as well.
+// TODO: this should use a more robust method of writing state, by first
+// writing to a temp file on the same filesystem, and renaming the file over
+// the original.
+//
+// StateWriter impl.
+func (s *LocalState) WriteState(state *terraform.State) error {
+	if state == nil {
+		// if we have no state, don't write anything.
+		return nil
+	}
+
+	if s.stateFileOut == nil {
+		if err := s.createStateFiles(); err != nil {
+			return nil
+		}
+	}
+
+	s.state = state
+
+	if _, err := s.stateFileOut.Seek(0, os.SEEK_SET); err != nil {
+		return err
+	}
+
+	if err := s.stateFileOut.Truncate(0); err != nil {
+		return err
+	}
 
 	s.state.IncrementSerialMaybe(s.readState)
 	s.readState = s.state
 
-	if err := terraform.WriteState(s.state, f); err != nil {
+	if err := terraform.WriteState(s.state, s.stateFileOut); err != nil {
 		return err
 	}
 
+	s.stateFileOut.Sync()
 	s.written = true
 	return nil
 }
@@ -83,33 +169,77 @@ func (s *LocalState) PersistState() error {
 
 // StateRefresher impl.
 func (s *LocalState) RefreshState() error {
-	// If we've never loaded before, read from Path, otherwise we
-	// read from PathOut.
-	path := s.Path
-	if s.written && s.PathOut != "" {
-		path = s.PathOut
-	}
-
-	f, err := os.Open(path)
-	if err != nil {
-		// It is okay if the file doesn't exist, we treat that as a nil state
-		if !os.IsNotExist(err) {
+	if s.stateFile == nil {
+		if err := s.createStateFiles(); err != nil {
 			return err
 		}
-
-		f = nil
 	}
 
-	var state *terraform.State
-	if f != nil {
-		defer f.Close()
-		state, err = terraform.ReadState(f)
-		if err != nil {
-			return err
-		}
+	// make sure we're at the start of the file
+	if _, err := s.stateFile.Seek(0, os.SEEK_SET); err != nil {
+		return err
+	}
+
+	state, err := terraform.ReadState(s.stateFile)
+	// if there's no state we just assign the nil return value
+	if err != nil && err != terraform.ErrNoState {
+		return err
 	}
 
 	s.state = state
 	s.readState = state
+	return nil
+}
+
+// return the path for the lockInfo metadata.
+func (s *LocalState) lockInfoPath() string {
+	stateDir, stateName := filepath.Split(s.Path)
+	if stateName == "" {
+		panic("empty state file path")
+	}
+
+	if stateName[0] == '.' {
+		stateName = stateName[1:]
+	}
+
+	return filepath.Join(stateDir, fmt.Sprintf(".%s.lock.info", stateName))
+}
+
+// lockInfo returns the data in a lock info file
+func (s *LocalState) lockInfo() (*lockInfo, error) {
+	path := s.lockInfoPath()
+	infoData, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	info := lockInfo{}
+	err = json.Unmarshal(infoData, &info)
+	if err != nil {
+		return nil, fmt.Errorf("state file %q locked, but could not unmarshal lock info: %s", s.Path, err)
+	}
+	return &info, nil
+}
+
+// write a new lock info file
+func (s *LocalState) writeLockInfo(reason string) error {
+	path := s.lockInfoPath()
+
+	lockInfo := &lockInfo{
+		Path:    s.Path,
+		Time:    time.Now(),
+		Expires: time.Now().Add(time.Hour),
+		Reason:  reason,
+	}
+
+	infoData, err := json.Marshal(lockInfo)
+	if err != nil {
+		panic(fmt.Sprintf("could not marshal lock info: %#v", lockInfo))
+	}
+
+	err = ioutil.WriteFile(path, infoData, 0600)
+	if err != nil {
+		return fmt.Errorf("could not write lock info for %q: %s", s.Path, err)
+	}
 	return nil
 }

--- a/state/local_lock_unix.go
+++ b/state/local_lock_unix.go
@@ -17,7 +17,7 @@ func (s *LocalState) lock() error {
 		Len:    0,
 	}
 
-	fd := s.stateFile.Fd()
+	fd := s.stateFileOut.Fd()
 	return syscall.FcntlFlock(fd, syscall.F_SETLK, flock)
 }
 

--- a/state/local_lock_unix.go
+++ b/state/local_lock_unix.go
@@ -1,0 +1,34 @@
+// +build !windows
+
+package state
+
+import (
+	"os"
+	"syscall"
+)
+
+// use fcntl POSIX locks for the most consistent behavior across platforms, and
+// hopefully some campatibility over NFS and CIFS.
+func (s *LocalState) lock() error {
+	flock := &syscall.Flock_t{
+		Type:   syscall.F_RDLCK | syscall.F_WRLCK,
+		Whence: int16(os.SEEK_SET),
+		Start:  0,
+		Len:    0,
+	}
+
+	fd := s.stateFile.Fd()
+	return syscall.FcntlFlock(fd, syscall.F_SETLK, flock)
+}
+
+func (s *LocalState) unlock() error {
+	flock := &syscall.Flock_t{
+		Type:   syscall.F_UNLCK,
+		Whence: int16(os.SEEK_SET),
+		Start:  0,
+		Len:    0,
+	}
+
+	fd := s.stateFileOut.Fd()
+	return syscall.FcntlFlock(fd, syscall.F_SETLK, flock)
+}

--- a/state/local_lock_windows.go
+++ b/state/local_lock_windows.go
@@ -1,0 +1,140 @@
+// +build windows
+
+package state
+
+import (
+	"math"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+type stateLock struct {
+	handle syscall.Handle
+}
+
+var (
+	modkernel32      = syscall.NewLazyDLL("kernel32.dll")
+	procLockFileEx   = modkernel32.NewProc("LockFileEx")
+	procCreateEventW = modkernel32.NewProc("CreateEventW")
+
+	lockedFiles = map[*os.File]syscall.Handle{}
+)
+
+const (
+	_LOCKFILE_FAIL_IMMEDIATELY = 1
+	_LOCKFILE_EXCLUSIVE_LOCK   = 2
+)
+
+func (s *LocalState) lock() error {
+	name, err := syscall.UTF16PtrFromString(s.PathOut)
+	if err != nil {
+		return err
+	}
+
+	handle, err := syscall.CreateFile(
+		name,
+		syscall.GENERIC_READ|syscall.GENERIC_WRITE,
+		// since this file is already open in out process, we need shared
+		// access here for this call.
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE,
+		nil,
+		syscall.OPEN_EXISTING,
+		syscall.FILE_ATTRIBUTE_NORMAL,
+		0,
+	)
+	if err != nil {
+		return err
+	}
+
+	lockedFiles[s.stateFileOut] = handle
+
+	// even though we're failing immediately, an overlapped event structure is
+	// required
+	ol, err := newOverlapped()
+	if err != nil {
+		return err
+	}
+	defer syscall.CloseHandle(ol.HEvent)
+
+	return lockFileEx(
+		handle,
+		_LOCKFILE_EXCLUSIVE_LOCK|_LOCKFILE_FAIL_IMMEDIATELY,
+		0,              // reserved
+		0,              // bytes low
+		math.MaxUint32, // bytes high
+		ol,
+	)
+}
+
+func (s *LocalState) unlock() error {
+	handle, ok := lockedFiles[s.stateFileOut]
+	if !ok {
+		// we allow multiple Unlock calls
+		return nil
+	}
+	delete(lockedFiles, s.stateFileOut)
+	return syscall.Close(handle)
+}
+
+func lockFileEx(h syscall.Handle, flags, reserved, locklow, lockhigh uint32, ol *syscall.Overlapped) (err error) {
+	r1, _, e1 := syscall.Syscall6(
+		procLockFileEx.Addr(),
+		6,
+		uintptr(h),
+		uintptr(flags),
+		uintptr(reserved),
+		uintptr(locklow),
+		uintptr(lockhigh),
+		uintptr(unsafe.Pointer(ol)),
+	)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+// newOverlapped creates a structure used to track asynchronous
+// I/O requests that have been issued.
+func newOverlapped() (*syscall.Overlapped, error) {
+	event, err := createEvent(nil, true, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &syscall.Overlapped{HEvent: event}, nil
+}
+
+func createEvent(sa *syscall.SecurityAttributes, manualReset bool, initialState bool, name *uint16) (handle syscall.Handle, err error) {
+	var _p0 uint32
+	if manualReset {
+		_p0 = 1
+	}
+	var _p1 uint32
+	if initialState {
+		_p1 = 1
+	}
+
+	r0, _, e1 := syscall.Syscall6(
+		procCreateEventW.Addr(),
+		4,
+		uintptr(unsafe.Pointer(sa)),
+		uintptr(_p0),
+		uintptr(_p1),
+		uintptr(unsafe.Pointer(name)),
+		0,
+		0,
+	)
+	handle = syscall.Handle(r0)
+	if handle == syscall.InvalidHandle {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}

--- a/state/local_lock_windows.go
+++ b/state/local_lock_windows.go
@@ -24,6 +24,8 @@ var (
 )
 
 const (
+	// dwFlags defined for LockFileEx
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/aa365203(v=vs.85).aspx
 	_LOCKFILE_FAIL_IMMEDIATELY = 1
 	_LOCKFILE_EXCLUSIVE_LOCK   = 2
 )

--- a/state/local_test.go
+++ b/state/local_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -12,6 +13,61 @@ func TestLocalState(t *testing.T) {
 	ls := testLocalState(t)
 	defer os.Remove(ls.Path)
 	TestState(t, ls)
+}
+
+func TestLocalStateLocks(t *testing.T) {
+	s := testLocalState(t)
+	defer os.Remove(s.Path)
+
+	// lock first
+	if err := s.Lock("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := exec.Command("go", "run", "testdata/lockstate.go", s.Path).CombinedOutput()
+
+	if err != nil {
+		t.Fatal("unexpected lock failure", err)
+	}
+
+	if string(out) != "lock failed" {
+		t.Fatal("expected 'locked failed', got", string(out))
+	}
+
+	// check our lock info
+	lockInfo, err := s.lockInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if lockInfo.Reason != "test" {
+		t.Fatalf("invalid lock info %#v\n", lockInfo)
+	}
+
+	// a noop, since we unlock on exit
+	if err := s.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+
+	// local locks can re-lock
+	if err := s.Lock("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Unlock should be repeatable
+	if err := s.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure lock info is gone
+	lockInfoPath := s.lockInfoPath()
+	if _, err := os.Stat(lockInfoPath); !os.IsNotExist(err) {
+		t.Fatal("lock info not removed")
+	}
+
 }
 
 func TestLocalState_pathOut(t *testing.T) {

--- a/state/remote/remote_test.go
+++ b/state/remote/remote_test.go
@@ -44,6 +44,38 @@ func testClient(t *testing.T, c Client) {
 	}
 }
 
+func testClientLocks(t *testing.T, c Client) {
+	s3Client := c.(*S3Client)
+
+	// initial lock
+	if err := s3Client.Lock("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// second lock should fail
+	if err := s3Client.Lock("test"); err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// unlock should work
+	if err := s3Client.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+
+	// now we should be able to lock again
+	if err := s3Client.Lock("test"); err != nil {
+		t.Fatal(err)
+	}
+
+	// unlock should be idempotent
+	if err := s3Client.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	if err := s3Client.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRemoteClient_noPayload(t *testing.T) {
 	s := &State{
 		Client: nilClient{},

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -7,10 +7,12 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/go-multierror"
@@ -89,6 +91,7 @@ providing credentials for the AWS S3 remote`))
 	}
 	sess := session.New(awsConfig)
 	nativeClient := s3.New(sess)
+	dynClient := dynamodb.New(sess)
 
 	return &S3Client{
 		nativeClient:         nativeClient,
@@ -97,6 +100,8 @@ providing credentials for the AWS S3 remote`))
 		serverSideEncryption: serverSideEncryption,
 		acl:                  acl,
 		kmsKeyID:             kmsKeyID,
+		dynClient:            dynClient,
+		lockTable:            conf["lock_table"],
 	}, nil
 }
 
@@ -107,6 +112,8 @@ type S3Client struct {
 	serverSideEncryption bool
 	acl                  string
 	kmsKeyID             string
+	dynClient            *dynamodb.DynamoDB
+	lockTable            string
 }
 
 func (c *S3Client) Get() (*Payload, error) {
@@ -187,4 +194,74 @@ func (c *S3Client) Delete() error {
 	})
 
 	return err
+}
+
+func (c *S3Client) Lock(reason string) error {
+	if c.lockTable == "" {
+		return nil
+	}
+
+	stateName := fmt.Sprintf("%s/%s", c.bucketName, c.keyName)
+
+	putParams := &dynamodb.PutItemInput{
+		Item: map[string]*dynamodb.AttributeValue{
+			"LockID":  {S: aws.String(stateName)},
+			"Created": {S: aws.String(time.Now().UTC().Format(time.RFC3339))},
+			"Expires": {S: aws.String(time.Now().Add(time.Hour).UTC().Format(time.RFC3339))},
+			"Info":    {S: aws.String(reason)},
+		},
+		TableName:           aws.String(c.lockTable),
+		ConditionExpression: aws.String("attribute_not_exists(LockID)"),
+	}
+	_, err := c.dynClient.PutItem(putParams)
+
+	if err != nil {
+		getParams := &dynamodb.GetItemInput{
+			Key: map[string]*dynamodb.AttributeValue{
+				"LockID": {S: aws.String(fmt.Sprintf("%s/%s", c.bucketName, c.keyName))},
+			},
+			ProjectionExpression: aws.String("LockID, Created, Expires, Info"),
+			TableName:            aws.String(c.lockTable),
+		}
+
+		resp, err := c.dynClient.GetItem(getParams)
+		if err != nil {
+			return fmt.Errorf("s3 state file %q locked, cfailed to retrive info: %s", stateName, err)
+		}
+
+		var created, expires, info string
+		if v, ok := resp.Item["Created"]; ok && v.S != nil {
+			created = *v.S
+		}
+		if v, ok := resp.Item["Expires"]; ok && v.S != nil {
+			expires = *v.S
+		}
+		if v, ok := resp.Item["Info"]; ok && v.S != nil {
+			info = *v.S
+		}
+
+		return fmt.Errorf("state file %q locked. created:%s, expires:%s, reason:%s",
+			stateName, created, expires, info)
+
+	}
+	return nil
+}
+
+func (c *S3Client) Unlock() error {
+	if c.lockTable == "" {
+		return nil
+	}
+
+	params := &dynamodb.DeleteItemInput{
+		Key: map[string]*dynamodb.AttributeValue{
+			"LockID": {S: aws.String(fmt.Sprintf("%s/%s", c.bucketName, c.keyName))},
+		},
+		TableName: aws.String(c.lockTable),
+	}
+	_, err := c.dynClient.DeleteItem(params)
+
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/state/remote/s3_test.go
+++ b/state/remote/s3_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -123,9 +125,113 @@ func TestS3Client(t *testing.T) {
 
 		_, err := nativeClient.DeleteBucket(deleteBucketReq)
 		if err != nil {
-			t.Logf("WARNING: Failed to delete the test S3 bucket. It has been left in your AWS account and may incur storage charges. (error was %s)", err)
+			t.Logf("WARNING: Failed to delete the test S3 bucket. It may have been left in your AWS account and may incur storage charges. (error was %s)", err)
 		}
 	}()
 
 	testClient(t, client)
+}
+
+func TestS3ClientLocks(t *testing.T) {
+	// This test creates a DynamoDB table.
+	// It may incur costs, so it will only run if AWS credential environment
+	// variables are present.
+
+	accessKeyId := os.Getenv("AWS_ACCESS_KEY_ID")
+	if accessKeyId == "" {
+		t.Skipf("skipping; AWS_ACCESS_KEY_ID must be set")
+	}
+
+	regionName := os.Getenv("AWS_DEFAULT_REGION")
+	if regionName == "" {
+		regionName = "us-west-2"
+	}
+
+	bucketName := fmt.Sprintf("terraform-remote-s3-lock-%x", time.Now().Unix())
+	keyName := "testState"
+
+	config := make(map[string]string)
+	config["region"] = regionName
+	config["bucket"] = bucketName
+	config["key"] = keyName
+	config["encrypt"] = "1"
+	config["lock_table"] = bucketName
+
+	client, err := s3Factory(config)
+	if err != nil {
+		t.Fatalf("Error for valid config")
+	}
+
+	s3Client := client.(*S3Client)
+
+	// set this up before we try to crate the table, in case we timeout creating it.
+	defer deleteDynaboDBTable(t, s3Client, bucketName)
+
+	createDynamoDBTable(t, s3Client, bucketName)
+
+	testClientLocks(t, client)
+}
+
+// create the dynamoDB table, and wait until we can query it.
+func createDynamoDBTable(t *testing.T, c *S3Client, tableName string) {
+	createInput := &dynamodb.CreateTableInput{
+		AttributeDefinitions: []*dynamodb.AttributeDefinition{
+			{
+				AttributeName: aws.String("LockID"),
+				AttributeType: aws.String("S"),
+			},
+		},
+		KeySchema: []*dynamodb.KeySchemaElement{
+			{
+				AttributeName: aws.String("LockID"),
+				KeyType:       aws.String("HASH"),
+			},
+		},
+		ProvisionedThroughput: &dynamodb.ProvisionedThroughput{
+			ReadCapacityUnits:  aws.Int64(5),
+			WriteCapacityUnits: aws.Int64(5),
+		},
+		TableName: aws.String(tableName),
+	}
+
+	_, err := c.dynClient.CreateTable(createInput)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// now wait until it's ACTIVE
+	start := time.Now()
+	time.Sleep(time.Second)
+
+	describeInput := &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	}
+
+	for {
+		resp, err := c.dynClient.DescribeTable(describeInput)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if *resp.Table.TableStatus == "ACTIVE" {
+			return
+		}
+
+		if time.Since(start) > time.Minute {
+			t.Fatalf("timed out creating DynamoDB table %s", tableName)
+		}
+
+		time.Sleep(3 * time.Second)
+	}
+
+}
+
+func deleteDynaboDBTable(t *testing.T, c *S3Client, tableName string) {
+	params := &dynamodb.DeleteTableInput{
+		TableName: aws.String(tableName),
+	}
+	_, err := c.dynClient.DeleteTable(params)
+	if err != nil {
+		t.Logf("WARNING: Failed to delete the test DynamoDB table %q. It has been left in your AWS account and may incur charges. (error was %s)", tableName, err)
+	}
 }

--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -60,3 +60,26 @@ func (s *State) PersistState() error {
 
 	return s.Client.Put(buf.Bytes())
 }
+
+// Lock calls the Client's Lock method if it's implemented.
+func (s *State) Lock(reason string) error {
+	if c, ok := s.Client.(stateLocker); ok {
+		return c.Lock(reason)
+	}
+	return nil
+}
+
+// Unlock calls the Client's Unlock method if it's implemented.
+func (s *State) Unlock() error {
+	if c, ok := s.Client.(stateLocker); ok {
+		return c.Unlock()
+	}
+	return nil
+}
+
+// stateLocker mirrors the state.Locker interface.  This can be implemented by
+// Clients to provide methods for locking and unlocking remote state.
+type stateLocker interface {
+	Lock(reason string) error
+	Unlock() error
+}

--- a/state/state.go
+++ b/state/state.go
@@ -40,3 +40,9 @@ type StateRefresher interface {
 type StatePersister interface {
 	PersistState() error
 }
+
+// Locker is implemented to lock state during command execution.
+type Locker interface {
+	Lock(reason string) error
+	Unlock() error
+}

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -1,0 +1,23 @@
+package state
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/logging"
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if testing.Verbose() {
+		// if we're verbose, use the logging requested by TF_LOG
+		logging.SetOutput()
+	} else {
+		// otherwise silence all logs
+		log.SetOutput(ioutil.Discard)
+	}
+	os.Exit(m.Run())
+}

--- a/state/testdata/lockstate.go
+++ b/state/testdata/lockstate.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/hashicorp/terraform/state"
+)
+
+// Attempt to open and lock a terraform state file.
+// Lock failure exits with 0 and writes "lock failed" to stderr.
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatal(os.Args[0], "statefile")
+	}
+
+	s := &state.LocalState{
+		Path: os.Args[1],
+	}
+
+	err := s.Lock("test")
+	if err != nil {
+		io.WriteString(os.Stderr, "lock failed")
+
+	}
+	return
+}

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1800,10 +1801,16 @@ func testForV0State(buf *bufio.Reader) error {
 	return nil
 }
 
+// ErrNoState is returned by ReadState when the io.Reader contains no data
+var ErrNoState = errors.New("no state")
+
 // ReadState reads a state structure out of a reader in the format that
 // was written by WriteState.
 func ReadState(src io.Reader) (*State, error) {
 	buf := bufio.NewReader(src)
+	if _, err := buf.Peek(1); err == io.EOF {
+		return nil, ErrNoState
+	}
 
 	if err := testForV0State(buf); err != nil {
 		return nil, err


### PR DESCRIPTION
Basic state locking.

This all starts with the `state.Locker` interface:

    type StateLocker interface {
        Lock(reason string) error
        Unlock() error
    }


This is implemented by the internal state wrappers (CacheState, BackupState), as well as LocalState. Any commands that operating on the state can use these functions to prevent concurrent modification. 

Remote state clients can also implement this same interface, which will be called via the State structures that wraps them. 

This PR contains the initial LocalState and AWS locking implementations. No state locking actually occurs yet, and adding the Lock calls and associated commands will come in another PR.

