### PR TITLE
provider/aws: update aws elb example to work in vpc

### DIFF
--- a/examples/aws-elb/README.md
+++ b/examples/aws-elb/README.md
@@ -4,6 +4,10 @@ The example launches a web server, installs nginx, creates an ELB for instance. 
 
 To run, configure your AWS provider as described in https://www.terraform.io/docs/providers/aws/index.html
 
+This example assumes you have created a Key Pair. Visit
+https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#KeyPairs:sort=keyName
+to create a key if you do not have one. 
+
 Run this example using:
 
     terraform apply -var 'key_name=YOUR_KEY_NAME'


### PR DESCRIPTION
Alternative to https://github.com/hashicorp/terraform/pull/11181 , bringing the `examples/aws-elb` example up to par and working in VPCs