### PR TITLE
Provider AWS: Add Placement Strategy to aws_ecs_service resource

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_service_test.go
@@ -257,6 +257,30 @@ func TestAccAWSEcsService_withAlb(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsServiceWithPlacementStrategy(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcsService,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_strategy.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSEcsServiceWithPlacementStrategy,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_strategy.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEcsServiceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ecsconn
 
@@ -357,6 +381,38 @@ resource "aws_ecs_service" "mongo" {
   cluster = "${aws_ecs_cluster.default.id}"
   task_definition = "${aws_ecs_task_definition.mongo.arn}"
   desired_count = 2
+}
+`
+
+var testAccAWSEcsServiceWithPlacementStrategy = `
+resource "aws_ecs_cluster" "default" {
+	name = "terraformecstest1"
+}
+
+resource "aws_ecs_task_definition" "mongo" {
+  family = "mongodb"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "mongo" {
+  name = "mongodb"
+  cluster = "${aws_ecs_cluster.default.id}"
+  task_definition = "${aws_ecs_task_definition.mongo.arn}"
+  desired_count = 1
+  placement_strategy {
+	type = "binpack"
+	field = "MEMORY"
+  }
 }
 `
 

--- a/website/source/docs/providers/aws/r/ecs_service.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_service.html.markdown
@@ -25,6 +25,11 @@ resource "aws_ecs_service" "mongo" {
   iam_role = "${aws_iam_role.foo.arn}"
   depends_on = ["aws_iam_role_policy.foo"]
 
+  placement_strategy {
+    type = "binpack"
+    field = "CPU"
+  }
+
   load_balancer {
     elb_name = "${aws_elb.foo.name}"
     container_name = "mongo"
@@ -44,6 +49,10 @@ The following arguments are supported:
 * `iam_role` - (Optional) The ARN of IAM role that allows your Amazon ECS container agent to make calls to your load balancer on your behalf. This parameter is only required if you are using a load balancer with your service.
 * `deployment_maximum_percent` - (Optional) The upper limit (as a percentage of the service's desiredCount) of the number of running tasks that can be running in a service during a deployment.
 * `deployment_minimum_healthy_percent` - (Optional) The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
+* `placement_strategy` - (Optional) Service level strategy rules that are taken
+into consideration during task placement. The maximum number of
+`placement_strategy` blocks is `5`. See [the related docs](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html) for
+details on attributes.
 * `load_balancer` - (Optional) A load balancer block. Load balancers documented below.
 
 -> **Note:** As a result of an AWS limitation, a single `load_balancer` can be attached to the ECS service at most. See [related docs](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-load-balancing.html#load-balancing-concepts).


### PR DESCRIPTION
Add `placement_strategy` on ECS Service Creation (modification or removal require recreation) to complement feature support for `placement_constraints` recently added to Task Definitions (from which much of this PR is derived).