### PR TITLE
provider/datadog: Add aggregator method to timeboard graph resource

### DIFF
--- a/builtin/providers/datadog/resource_datadog_timeboard.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard.go
@@ -31,6 +31,11 @@ func resourceDatadogTimeboard() *schema.Resource {
 					Optional: true,
 					Default:  "line",
 				},
+				"aggregator": {
+					Type:         schema.TypeString,
+					Optional:     true,
+					ValidateFunc: validateAggregatorMethod,
+				},
 				"style": &schema.Schema{
 					Type:     schema.TypeMap,
 					Optional: true,
@@ -307,8 +312,9 @@ func appendRequests(datadogGraph *datadog.Graph, terraformRequests *[]interface{
 	for _, t_ := range *terraformRequests {
 		t := t_.(map[string]interface{})
 		d := datadog.GraphDefinitionRequest{
-			Query: t["q"].(string),
-			Type:  t["type"].(string),
+			Query:      t["q"].(string),
+			Type:       t["type"].(string),
+			Aggregator: t["aggregator"].(string),
 		}
 		if stacked, ok := t["stacked"]; ok {
 			d.Stacked = stacked.(bool)
@@ -702,4 +708,19 @@ func resourceDatadogTimeboardExists(d *schema.ResourceData, meta interface{}) (b
 		return false, err
 	}
 	return true, nil
+}
+
+func validateAggregatorMethod(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validMethods := map[string]struct{}{
+		"average": {},
+		"max":     {},
+		"min":     {},
+		"sum":     {},
+	}
+	if _, ok := validMethods[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			`%q contains an invalid method %q. Valid methods are either "average", "max", "min", or "sum"`))
+	}
+	return
 }

--- a/builtin/providers/datadog/resource_datadog_timeboard.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard.go
@@ -720,7 +720,7 @@ func validateAggregatorMethod(v interface{}, k string) (ws []string, errors []er
 	}
 	if _, ok := validMethods[value]; !ok {
 		errors = append(errors, fmt.Errorf(
-			`%q contains an invalid method %q. Valid methods are either "average", "max", "min", or "sum"`))
+			`%q contains an invalid method %q. Valid methods are either "average", "max", "min", or "sum"`, k, value))
 	}
 	return
 }

--- a/website/source/docs/providers/datadog/r/timeboard.html.markdown
+++ b/website/source/docs/providers/datadog/r/timeboard.html.markdown
@@ -109,7 +109,8 @@ Nested `graph` `marker` blocks have the following structure:
 Nested `graph` `request` blocks have the following structure:
 
 * `q` - (Required) The query of the request. Pro tip: Use the JSON tab inside the Datadog UI to help build you query strings.
-* `stacked` - (Optional) Boolean value to determin if this is this a stacked area graph. Default: false (line chart).
+* `aggregator` - (Optional) The aggregation method used when the number of data points outnumbers the max that can be shown.
+* `stacked` - (Optional) Boolean value to determine if this is this a stacked area graph. Default: false (line chart).
 * `type` - (Optional) Choose how to draw the graph. For example: "lines", "bars" or "areas". Default: "lines".
 * `style` - (Optional) Nested block to customize the graph style.
 


### PR DESCRIPTION
Adds aggregator argument to the timeboard graph resource.

Ex:
```
request {
  q = "top(avg:docker.cpu.system{*} by {container_name}, 10, 'mean', 'desc')"
  aggregator = "sum"
}
```

```
$ make testacc TEST=./builtin/providers/datadog TESTARGS='-run=TestAccDatadogTimeboard_update'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/13 17:52:50 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/datadog -v -run=TestAccDatadogTimeboard_update -timeout 120m
=== RUN   TestAccDatadogTimeboard_update
--- PASS: TestAccDatadogTimeboard_update (82.60s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/datadog        82.619s
```

Fixes: #11168