### PR TITLE
provisioner/chef: Support named run-lists for Policyfiles

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -599,13 +599,12 @@ func (p *Provisioner) runChefClientFunc(
 		var cmd string
 
 		// Policyfiles do not support chef environments, so don't pass the `-E` flag.
-		if p.UsePolicyfile {
-			if p.NamedRunList == "" {
-				cmd = fmt.Sprintf("%s -j %q", chefCmd, fb)
-			} else {
-				cmd = fmt.Sprintf("%s -j %q -n %q", chefCmd, fb, p.NamedRunList)
-			}
-		} else {
+		switch {
+		case p.UsePolicyfile && p.NamedRunList == "":
+			cmd = fmt.Sprintf("%s -j %q", chefCmd, fb)
+		case p.UsePolicyfile && p.NamedRunList != "":
+			cmd = fmt.Sprintf("%s -j %q -n %q", chefCmd, fb, p.NamedRunList)
+		default:
 			cmd = fmt.Sprintf("%s -j %q -E %q", chefCmd, fb, p.Environment)
 		}
 

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -94,6 +94,7 @@ type Provisioner struct {
 	PolicyName            string   `mapstructure:"policy_name"`
 	HTTPProxy             string   `mapstructure:"http_proxy"`
 	HTTPSProxy            string   `mapstructure:"https_proxy"`
+	NamedRunList          string   `mapstructure:"named_run_list"`
 	NOProxy               []string `mapstructure:"no_proxy"`
 	NodeName              string   `mapstructure:"node_name"`
 	OhaiHints             []string `mapstructure:"ohai_hints"`
@@ -599,7 +600,11 @@ func (p *Provisioner) runChefClientFunc(
 
 		// Policyfiles do not support chef environments, so don't pass the `-E` flag.
 		if p.UsePolicyfile {
-			cmd = fmt.Sprintf("%s -j %q", chefCmd, fb)
+			if p.NamedRunList == "" {
+				cmd = fmt.Sprintf("%s -j %q", chefCmd, fb)
+			} else {
+				cmd = fmt.Sprintf("%s -j %q -n %q", chefCmd, fb, p.NamedRunList)
+			}
 		} else {
 			cmd = fmt.Sprintf("%s -j %q -E %q", chefCmd, fb, p.Environment)
 		}

--- a/website/source/docs/provisioners/chef.html.markdown
+++ b/website/source/docs/provisioners/chef.html.markdown
@@ -95,6 +95,10 @@ The following arguments are supported:
 
 * `https_proxy (string)` - (Optional) The proxy server for Chef Client HTTPS connections.
 
+* `named_run_list (string)` - (Optional) The name of an alternate run-list to invoke during the
+  initial Chef Client run. The run-list must already exist in the Policyfile that defines
+  `policy_name`. Only applies when `use_policyfile` is `true`.
+
 * `no_proxy (array)` - (Optional) A list of URLs that should bypass the proxy.
 
 * `node_name (string)` - (Required) The name of the node to register with the Chef Server.
@@ -113,9 +117,10 @@ The following arguments are supported:
 * `recreate_client (boolean)` - (Optional) If `true`, first delete any existing Chef Node and
   Client before registering the new Chef Client.
 
-* `run_list (array)` - (Required) A list with recipes that will be invoked during the initial
+* `run_list (array)` - (Optional) A list with recipes that will be invoked during the initial
   Chef Client run. The run-list will also be saved to the Chef Server after a successful
-  initial run.
+  initial run. Required if `use_policyfile` is `false`; ignored when `use_policyfile` is `true`
+  (see `named_run_list` to specify a run-list defined in a Policyfile).
 
 * `secret_key (string)` - (Optional) The contents of the secret key that is used
   by the Chef Client to decrypt data bags on the Chef Server. The key will be uploaded to the remote


### PR DESCRIPTION
Add an optional argument for overriding the Chef Client's initial
run with a named run-list specified by the Policyfile. This is useful
for bootstrapping a node with a one-time setup recipe that deviates
from a policy's normal run-list.