### PR TITLE
Differentiate between lookup failure and value inequality.

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -581,7 +581,11 @@ func TestCheckResourceAttr(name, key, value string) TestCheckFunc {
 			return fmt.Errorf("No primary instance: %s", name)
 		}
 
-		if is.Attributes[key] != value {
+		if v, ok := is.Attributes[key]; !ok || v != value {
+			if !ok {
+				return fmt.Errorf("%s: Attribute '%s' not found", name, key)
+			}
+
 			return fmt.Errorf(
 				"%s: Attribute '%s' expected %#v, got %#v",
 				name,


### PR DESCRIPTION
Before this patch it was not possible to test for a key in a map where
the value is an empty string.  With this patch, however, it is now
possible to write a check like:

```
resource.TestCheckResourceAttr("res.name", "mymap.KeyWithEmptyValue", ""),
```

To test that `KeyWithEmptyValue` is a valid key in `mymap`.  After an offline convo re: this, I'm going to submit this as a PR for review.