### PR TITLE
build: Update travis for go1.8rc1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: go
 go:
 - 1.7.4
-- 1.8beta2
+- 1.8rc1
 install:
 # This script is used by the Travis build to install a cookie for
 # go.googlesource.com so rate limits are higher when using `go get` to fetch


### PR DESCRIPTION
Update travis to use go1.8rc1 for builds instead of go1.8beta2.