### PR TITLE
Shorten ID in example

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -14,7 +14,7 @@ Provides an ElastiCache Replication Group resource.
 
 ```
 resource "aws_elasticache_replication_group" "bar" {
-  replication_group_id          = "tf-replication-group-1"
+  replication_group_id          = "tf-rep-group-1"
   replication_group_description = "test description"
   node_type                     = "cache.m1.small"
   number_cache_clusters         = 2


### PR DESCRIPTION
Example code fails a validation:

```
Errors:

  * aws_elasticache_replication_group.cache: "replication_group_id" must contain from 1 to 20 alphanumeric characters or hyphens
```