### PR TITLE
provider/aws: Add support for setting MSSQL Timezone in aws_db_instance

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -313,6 +313,13 @@ func resourceAwsDbInstance() *schema.Resource {
 				ValidateFunc: validateArn,
 			},
 
+			"timezone": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -529,6 +536,10 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.CharacterSetName = aws.String(attr.(string))
 		}
 
+		if attr, ok := d.GetOk("timezone"); ok {
+			opts.Timezone = aws.String(attr.(string))
+		}
+
 		if attr, ok := d.GetOk("maintenance_window"); ok {
 			opts.PreferredMaintenanceWindow = aws.String(attr.(string))
 		}
@@ -678,6 +689,8 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if v.CharacterSetName != nil {
 		d.Set("character_set_name", v.CharacterSetName)
 	}
+
+	d.Set("timezone", v.Timezone)
 
 	if len(v.DBParameterGroups) > 0 {
 		d.Set("parameter_group_name", v.DBParameterGroups[0].DBParameterGroupName)

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -109,6 +109,8 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
 * `character_set_name` - (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed.
 [Oracle Character Sets Supported in Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Appendix.OracleCharacterSets.html)
 * `tags` - (Optional) A mapping of tags to assign to the resource.
+* `timezone` - (Optional) Time zone of the DB instance. `timezone` is currently only supported by Microsoft SQL Server. 
+The `timezone` can only be set on creation. See [MSSQL User Guide](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_SQLServer.html#SQLServer.Concepts.General.TimeZone) for more information
 
 ~> **NOTE:** Removing the `replicate_source_db` attribute from an existing RDS
 Replicate database managed by Terraform will promote the database to a fully


### PR DESCRIPTION
Adds support for setting the Timezone for MSSQL databases in the `aws_db_instance` resource. Fixes #8937 