### PR TITLE
provider/aws allow ALB target group stickiness to be enabled

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group.go
@@ -75,6 +75,11 @@ func resourceAwsAlbTargetGroup() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  true,
+						},
 						"type": {
 							Type:         schema.TypeString,
 							Required:     true,
@@ -251,6 +256,8 @@ func resourceAwsAlbTargetGroupRead(d *schema.ResourceData, meta interface{}) err
 	stickinessMap := map[string]interface{}{}
 	for _, attr := range attrResp.Attributes {
 		switch *attr.Key {
+		case "stickiness.enabled":
+			stickinessMap["enabled"] = *attr.Value
 		case "stickiness.type":
 			stickinessMap["type"] = *attr.Value
 		case "stickiness.lb_cookie.duration_seconds":
@@ -324,7 +331,7 @@ func resourceAwsAlbTargetGroupUpdate(d *schema.ResourceData, meta interface{}) e
 			attrs = append(attrs,
 				&elbv2.TargetGroupAttribute{
 					Key:   aws.String("stickiness.enabled"),
-					Value: aws.String("true"),
+					Value: aws.String(strconv.FormatBool(stickiness["enabled"].(bool))),
 				},
 				&elbv2.TargetGroupAttribute{
 					Key:   aws.String("stickiness.type"),

--- a/builtin/providers/aws/resource_aws_alb_target_group_test.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_test.go
@@ -65,6 +65,7 @@ func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "true"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
@@ -269,6 +270,91 @@ func TestAccAWSALBTargetGroup_updateHealthCheck(t *testing.T) {
 					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_updateSticknessEnabled(t *testing.T) {
+	var conf elbv2.TargetGroup
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, false, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, true, true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "true"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.path", "/health2"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.interval", "30"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.port", "8082"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.protocol", "HTTPS"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.timeout", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "4"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200"),
+				),
+			},
+			{
+				Config: testAccAWSALBTargetGroupConfig_stickiness(targetGroupName, true, false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "arn"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "name", targetGroupName),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "port", "443"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "protocol", "HTTPS"),
+					resource.TestCheckResourceAttrSet("aws_alb_target_group.test", "vpc_id"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "deregistration_delay", "200"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.#", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.enabled", "false"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.type", "lb_cookie"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "stickiness.0.cookie_duration", "10000"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.#", "1"),
@@ -584,4 +670,46 @@ resource "aws_vpc" "test" {
     TestName = "TestAccAWSALBTargetGroup_basic"
   }
 }`, targetGroupName)
+}
+
+func testAccAWSALBTargetGroupConfig_stickiness(targetGroupName string, addStickinessBlock bool, enabled bool) string {
+	var stickinessBlock string
+
+	if addStickinessBlock {
+		stickinessBlock = fmt.Sprintf(`stickiness {
+	    enabled = "%t"
+	    type = "lb_cookie"
+	    cookie_duration = 10000
+	  }`, enabled)
+	}
+
+	return fmt.Sprintf(`resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  %s
+
+  health_check {
+    path = "/health2"
+    interval = 30
+    port = 8082
+    protocol = "HTTPS"
+    timeout = 4
+    healthy_threshold = 4
+    unhealthy_threshold = 4
+    matcher = "200"
+  }
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALBTargetGroup_stickiness"
+  }
+}`, targetGroupName, stickinessBlock)
 }

--- a/website/source/docs/providers/aws/r/alb_target_group.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_target_group.html.markdown
@@ -44,6 +44,7 @@ Stickiness Blocks (`stickiness`) support the following:
 
 * `type` - (Required) The type of sticky sessions. The only current possible value is `lb_cookie`.
 * `cookie_duration` - (Optional) The time period, in seconds, during which requests from a client should be routed to the same target. After this time period expires, the load balancer-generated cookie is considered stale. The range is 1 second to 1 week (604800 seconds). The default value is 1 day (86400 seconds).
+* `enabled` - (Optional) Boolean to enable / disable `stickiness`. Default is `true`
 
 Health Check Blocks (`health_check`) support the following:
 


### PR DESCRIPTION
Allow disabling sticky sessions when stickiness block is given. I put load balancers in a standard module and want the ability to only enable this when necessary.