### PR TITLE
clarify text: existing -> user-supplied

### DIFF
--- a/website/source/docs/providers/aws/r/key_pair.html.markdown
+++ b/website/source/docs/providers/aws/r/key_pair.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an [EC2 key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) resource. A key pair is used to control login access to EC2 instances. 
 
-Currently this resource only supports importing an existing key pair, not creating a new key pair.
+Currently this resource only supports importing a user-supplied key pair, not the creation of a new key pair.
 
 When importing an existing key pair the public key material may be in any format supported by AWS. Supported formats (per the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws)) are:
 


### PR DESCRIPTION
I think this clarifies the text.
The source of the public key material is not existing (which could be interpreted through the lens that existing resources are eligible for `terraform import`).