### PR TITLE
aws_route53_record: Make unquoting slightly less hacky.

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -484,7 +484,7 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	err = d.Set("records", flattenResourceRecords(record.ResourceRecords))
+	err = d.Set("records", flattenResourceRecords(record.ResourceRecords, *record.Type))
 	if err != nil {
 		return fmt.Errorf("[DEBUG] Error setting records for: %s, error: %#v", d.Id(), err)
 	}

--- a/builtin/providers/aws/structure_test.go
+++ b/builtin/providers/aws/structure_test.go
@@ -819,23 +819,56 @@ func TestFlattenStepAdjustments(t *testing.T) {
 }
 
 func TestFlattenResourceRecords(t *testing.T) {
-	expanded := []*route53.ResourceRecord{
-		&route53.ResourceRecord{
-			Value: aws.String("127.0.0.1"),
-		},
-		&route53.ResourceRecord{
-			Value: aws.String("127.0.0.3"),
-		},
+	original := []string{
+		`127.0.0.1`,
+		`"abc def"`,
 	}
 
-	result := flattenResourceRecords(expanded)
+	dequoted := []string{
+		`127.0.0.1`,
+		`abc def`,
+	}
+
+	var wrapped []*route53.ResourceRecord = nil
+	for _, original := range original {
+		wrapped = append(wrapped, &route53.ResourceRecord{Value: aws.String(original)})
+	}
+
+	sub := func(recordType string, expected []string) {
+		t.Run(recordType, func(t *testing.T) {
+			checkFlattenResourceRecords(t, recordType, wrapped, expected)
+		})
+	}
+
+	// These record types should be dequoted.
+	sub("TXT", dequoted)
+	sub("SPF", dequoted)
+
+	// These record types should not be touched.
+	sub("CNAME", original)
+	sub("MX", original)
+}
+
+func checkFlattenResourceRecords(
+	t *testing.T,
+	recordType string,
+	expanded []*route53.ResourceRecord,
+	expected []string) {
+
+	result := flattenResourceRecords(expanded, recordType)
 
 	if result == nil {
 		t.Fatal("expected result to have value, but got nil")
 	}
 
-	if len(result) != 2 {
-		t.Fatal("expected result to have value, but got nil")
+	if len(result) != len(expected) {
+		t.Fatalf("expected %v, got %v", expected, result)
+	}
+
+	for i, e := range expected {
+		if result[i] != e {
+			t.Fatalf("expected %v, got %v", expected, result)
+		}
 	}
 }
 


### PR DESCRIPTION
Before, the code would remove up to the first two quotes.  Now it will
remove the first and last quote if they are both present.

There are still a bunch of problems with the way quoting is handled, but
I believe this change makes the situation slightly better.  In
particular, it helps with hashicorp/terraform#8423.