### PR TITLE
Remove obsolete reference from interpolation.html.md

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -60,8 +60,6 @@ The syntax is `TYPE.NAME.ATTRIBUTE`. For example,
 attribute set, you can access individual attributes with a zero-based
 index, such as `${aws_instance.web.0.id}`. You can also use the splat
 syntax to get a list of all the attributes: `${aws_instance.web.*.id}`.
-This is documented in more detail in the [resource configuration
-page](/docs/configuration/resources.html).
 
 #### Outputs from a module
 


### PR DESCRIPTION
The reference to the resources page is obsolete, the splat syntax is not described there (nor anywhere else, as far as I can see).