### PR TITLE
S3 Bucket Object Sever Side Encryption

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
@@ -90,10 +91,10 @@ func resourceAwsS3BucketObject() *schema.Resource {
 			},
 
 			"server_side_encryption": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ValidateFunc:  validateS3BucketObjectServerSideEncryption,
-				ConflictsWith: []string{"kms_key_id"},
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validateS3BucketObjectServerSideEncryption,
+				Computed:     true,
 			},
 
 			"kms_key_id": {
@@ -109,7 +110,7 @@ func resourceAwsS3BucketObject() *schema.Resource {
 				// See http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html
 				Optional:      true,
 				Computed:      true,
-				ConflictsWith: []string{"kms_key_id"},
+				ConflictsWith: []string{"kms_key_id", "server_side_encryption"},
 			},
 
 			"version_id": {
@@ -229,9 +230,20 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("content_language", resp.ContentLanguage)
 	d.Set("content_type", resp.ContentType)
 	d.Set("version_id", resp.VersionId)
-	if _, ok := d.GetOk("server_side_encryption"); ok {
-		d.Set("server_side_encryption", resp.ServerSideEncryption)
-	} else if _, ok := d.GetOk("kms_key_id"); ok {
+	d.Set("server_side_encryption", resp.ServerSideEncryption)
+
+	// retrieve S3 KMS Default Master Key
+	kmsconn := meta.(*AWSClient).kmsconn
+	kmsresp, err := kmsconn.DescribeKey(&kms.DescribeKeyInput{
+		KeyId: aws.String("alias/aws/s3"),
+	})
+	if err != nil {
+		return fmt.Errorf("Failed to describe default S3 KMS key (alias/aws/s3): %s", err)
+	}
+
+	// Only set non-default KMS key ID (one that doesn't match default)
+	if resp.SSEKMSKeyId != nil && *resp.SSEKMSKeyId != *kmsresp.KeyMetadata.Arn {
+		log.Printf("[DEBUG] S3 object is encrypted using a non-default KMS Key ID: %s", *resp.SSEKMSKeyId)
 		d.Set("kms_key_id", resp.SSEKMSKeyId)
 	}
 	d.Set("etag", strings.Trim(*resp.ETag, `"`))

--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -232,19 +232,21 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("version_id", resp.VersionId)
 	d.Set("server_side_encryption", resp.ServerSideEncryption)
 
-	// retrieve S3 KMS Default Master Key
-	kmsconn := meta.(*AWSClient).kmsconn
-	kmsresp, err := kmsconn.DescribeKey(&kms.DescribeKeyInput{
-		KeyId: aws.String("alias/aws/s3"),
-	})
-	if err != nil {
-		return fmt.Errorf("Failed to describe default S3 KMS key (alias/aws/s3): %s", err)
-	}
-
 	// Only set non-default KMS key ID (one that doesn't match default)
-	if resp.SSEKMSKeyId != nil && *resp.SSEKMSKeyId != *kmsresp.KeyMetadata.Arn {
-		log.Printf("[DEBUG] S3 object is encrypted using a non-default KMS Key ID: %s", *resp.SSEKMSKeyId)
-		d.Set("kms_key_id", resp.SSEKMSKeyId)
+	if resp.SSEKMSKeyId != nil {
+		// retrieve S3 KMS Default Master Key
+		kmsconn := meta.(*AWSClient).kmsconn
+		kmsresp, err := kmsconn.DescribeKey(&kms.DescribeKeyInput{
+			KeyId: aws.String("alias/aws/s3"),
+		})
+		if err != nil {
+			return fmt.Errorf("Failed to describe default S3 KMS key (alias/aws/s3): %s", err)
+		}
+
+		if *resp.SSEKMSKeyId != *kmsresp.KeyMetadata.Arn {
+			log.Printf("[DEBUG] S3 object is encrypted using a non-default KMS Key ID: %s", *resp.SSEKMSKeyId)
+			d.Set("kms_key_id", resp.SSEKMSKeyId)
+		}
 	}
 	d.Set("etag", strings.Trim(*resp.ETag, `"`))
 

--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -229,8 +229,11 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("content_language", resp.ContentLanguage)
 	d.Set("content_type", resp.ContentType)
 	d.Set("version_id", resp.VersionId)
-	d.Set("server_side_encryption", resp.ServerSideEncryption)
-	d.Set("kms_key_id", resp.SSEKMSKeyId)
+	if _, ok := d.GetOk("server_side_encryption"); ok {
+		d.Set("server_side_encryption", resp.ServerSideEncryption)
+	} else if _, ok := d.GetOk("kms_key_id"); ok {
+		d.Set("kms_key_id", resp.SSEKMSKeyId)
+	}
 	d.Set("etag", strings.Trim(*resp.ETag, `"`))
 
 	// The "STANDARD" (which is also the default) storage

--- a/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
@@ -267,6 +267,24 @@ func TestAccAWSS3BucketObject_kms(t *testing.T) {
 	})
 }
 
+func TestAccAWSS3BucketObject_sse(t *testing.T) {
+	rInt := acctest.RandInt()
+	var obj s3.GetObjectOutput
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSS3BucketObjectDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				PreConfig: func() {},
+				Config:    testAccAWSS3BucketObjectConfig_withSSE(rInt),
+				Check:     testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
+			},
+		},
+	})
+}
+
 func TestAccAWSS3BucketObject_acl(t *testing.T) {
 	rInt := acctest.RandInt()
 	var obj s3.GetObjectOutput
@@ -557,6 +575,21 @@ resource "aws_s3_bucket_object" "object" {
 	key = "test-key"
 	content = "stuff"
 	kms_key_id = "${aws_kms_key.kms_key_1.arn}"
+}
+`, randInt)
+}
+
+func testAccAWSS3BucketObjectConfig_withSSE(randInt int) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "object_bucket_2" {
+	bucket = "tf-object-test-bucket-%d"
+}
+
+resource "aws_s3_bucket_object" "object" {
+	bucket = "${aws_s3_bucket.object_bucket_2.bucket}"
+	key = "test-key"
+	content = "stuff"
+	server_side_encryption = "aws:kms"
 }
 `, randInt)
 }

--- a/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object_test.go
@@ -268,6 +268,18 @@ func TestAccAWSS3BucketObject_kms(t *testing.T) {
 }
 
 func TestAccAWSS3BucketObject_sse(t *testing.T) {
+	tmpFile, err := ioutil.TempFile("", "tf-acc-s3-obj-source-sse")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// first write some data to the tempfile just so it's not 0 bytes.
+	err = ioutil.WriteFile(tmpFile.Name(), []byte("{anything will do}"), 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	rInt := acctest.RandInt()
 	var obj s3.GetObjectOutput
 
@@ -278,8 +290,15 @@ func TestAccAWSS3BucketObject_sse(t *testing.T) {
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				PreConfig: func() {},
-				Config:    testAccAWSS3BucketObjectConfig_withSSE(rInt),
-				Check:     testAccCheckAWSS3BucketObjectExists("aws_s3_bucket_object.object", &obj),
+				Config:    testAccAWSS3BucketObjectConfig_withSSE(rInt, tmpFile.Name()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSS3BucketObjectExists(
+						"aws_s3_bucket_object.object",
+						&obj),
+					testAccCheckAWSS3BucketObjectSSE(
+						"aws_s3_bucket_object.object",
+						"aws:kms"),
+				),
 			},
 		},
 	})
@@ -485,6 +504,34 @@ func testAccCheckAWSS3BucketObjectStorageClass(n, expectedClass string) resource
 	}
 }
 
+func testAccCheckAWSS3BucketObjectSSE(n, expectedSSE string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[n]
+		s3conn := testAccProvider.Meta().(*AWSClient).s3conn
+
+		out, err := s3conn.HeadObject(&s3.HeadObjectInput{
+			Bucket: aws.String(rs.Primary.Attributes["bucket"]),
+			Key:    aws.String(rs.Primary.Attributes["key"]),
+		})
+
+		if err != nil {
+			return fmt.Errorf("HeadObject error: %v", err)
+		}
+
+		if out.ServerSideEncryption == nil {
+			return fmt.Errorf("Expected a non %v Server Side Encryption.", out.ServerSideEncryption)
+		}
+
+		sse := *out.ServerSideEncryption
+		if sse != expectedSSE {
+			return fmt.Errorf("Expected Server Side Encryption %v, got %v.",
+				expectedSSE, sse)
+		}
+
+		return nil
+	}
+}
+
 func testAccAWSS3BucketObjectConfigSource(randInt int, source string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "object_bucket" {
@@ -579,19 +626,19 @@ resource "aws_s3_bucket_object" "object" {
 `, randInt)
 }
 
-func testAccAWSS3BucketObjectConfig_withSSE(randInt int) string {
+func testAccAWSS3BucketObjectConfig_withSSE(randInt int, source string) string {
 	return fmt.Sprintf(`
-resource "aws_s3_bucket" "object_bucket_2" {
+resource "aws_s3_bucket" "object_bucket" {
 	bucket = "tf-object-test-bucket-%d"
 }
 
 resource "aws_s3_bucket_object" "object" {
-	bucket = "${aws_s3_bucket.object_bucket_2.bucket}"
+	bucket = "${aws_s3_bucket.object_bucket.bucket}"
 	key = "test-key"
-	content = "stuff"
+	source = "%s"
 	server_side_encryption = "aws:kms"
 }
-`, randInt)
+`, randInt, source)
 }
 
 func testAccAWSS3BucketObjectConfig_acl(randInt int, acl string) string {

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -44,6 +44,22 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 }
 ```
 
+### Server Side Encryption with S3 Default Master Key
+
+```
+resource "aws_s3_bucket" "examplebucket" {
+  bucket = "examplebuckettftest"
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_object" "examplebucket_object" {
+  key                    = "someobject"
+  bucket                 = "${aws_s3_bucket.examplebucket.bucket}"
+  source                 = "index.html"
+  server_side_encryption = "aws:kms"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -61,6 +77,8 @@ The following arguments are supported:
 * `storage_class` - (Optional) Specifies the desired [Storage Class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html)
 for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", or "`STANDARD_IA`". Defaults to "`STANDARD`".
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`.
+This attribute is not compatible with `kms_key_id`.
+* `server_side_encryption` - (Optional) Specifies server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".
 This attribute is not compatible with `kms_key_id`.
 * `kms_key_id` - (Optional) Specifies the AWS KMS Key ARN to use for object encryption.
 This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -79,7 +79,6 @@ for the object. Can be either "`STANDARD`", "`REDUCED_REDUNDANCY`", or "`STANDAR
 * `etag` - (Optional) Used to trigger updates. The only meaningful value is `${md5(file("path/to/file"))}`.
 This attribute is not compatible with `kms_key_id`.
 * `server_side_encryption` - (Optional) Specifies server-side encryption of the object in S3. Valid values are "`AES256`" and "`aws:kms`".
-This attribute is not compatible with `kms_key_id`.
 * `kms_key_id` - (Optional) Specifies the AWS KMS Key ARN to use for object encryption.
 This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
 use the exported `arn` attribute:  


### PR DESCRIPTION
This PR sees support for server side encryption added to s3 bucket object resources. This functionality is equivalent to

```
aws s3 cp --sse aws:kms source destination
```

which facilitates using S3 default master key for server side encryption.

 Associated acceptance testing and documentation has been included.