### PR TITLE
Update `parameter_group_name`

### DIFF
--- a/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticache_replication_group.html.markdown
@@ -19,7 +19,7 @@ resource "aws_elasticache_replication_group" "bar" {
   node_type                     = "cache.m1.small"
   number_cache_clusters         = 2
   port                          = 6379
-  parameter_group_name          = "default.redis2.8"
+  parameter_group_name          = "default.redis3.2"
   availability_zones            = ["us-west-2a", "us-west-2b"]
   automatic_failover_enabled    = true
 }


### PR DESCRIPTION
```
1 error(s) occurred:

* aws_elasticache_replication_group.cache: Error creating Elasticache Replication Group: InvalidParameterCombination: Expected a parameter group of family redis3.2 but found one of family redis2.8
	status code: 400, request id: 9e6563a4-dd91-11e6-bc8b-ed011a44f429
```