### PR TITLE
provisioner/exec: Add verify attribute

### DIFF
--- a/builtin/provisioners/remote-exec/resource_provisioner.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner.go
@@ -31,12 +31,48 @@ func (p *ResourceProvisioner) Apply(
 	}
 
 	// Collect the scripts
+	// This should happen first, so we catch any configuration errors before
+	// establishing a connection
 	scripts, err := p.collectScripts(c)
 	if err != nil {
 		return err
 	}
 	for _, s := range scripts {
 		defer s.Close()
+	}
+
+	// Collect verification scripts if needed
+	var verifyScripts []io.ReadCloser
+	_, verifyOk := c.Config["verify"]
+	if verifyOk {
+		verifyScripts, err = p.collectVerification(c)
+		if err != nil {
+			return err
+		}
+		for _, s := range verifyScripts {
+			defer s.Close()
+		}
+	}
+
+	// Wait and retry until we establish a connection
+	err = retryFunc(comm.Timeout(), func() error {
+		err := comm.Connect(o)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	defer comm.Disconnect()
+
+	// If verify is specified, verify that the exec scripts need to be ran
+	if verifyOk {
+		if err := p.runScripts(o, comm, verifyScripts); err == nil {
+			// No error, verification passed, log and return
+			log.Printf("[DEBUG] remote-exec provisioner verified successfully, skipping execution")
+			return nil
+		} else {
+			log.Printf("[DEBUG] remote-exec provisioner didn't verify successfully: %s", err)
+		}
 	}
 
 	// Copy and execute each script
@@ -53,6 +89,8 @@ func (p *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string
 		switch name {
 		case "scripts", "script", "inline":
 			num++
+		case "verify":
+			continue
 		default:
 			es = append(es, fmt.Errorf("Unknown configuration '%s'", name))
 		}
@@ -63,41 +101,13 @@ func (p *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string
 	return
 }
 
-// generateScript takes the configuration and creates a script to be executed
-// from the inline configs
-func (p *ResourceProvisioner) generateScript(c *terraform.ResourceConfig) (string, error) {
-	var lines []string
-	command, ok := c.Config["inline"]
-	if ok {
-		switch cmd := command.(type) {
-		case string:
-			lines = append(lines, cmd)
-		case []string:
-			lines = append(lines, cmd...)
-		case []interface{}:
-			for _, l := range cmd {
-				lStr, ok := l.(string)
-				if ok {
-					lines = append(lines, lStr)
-				} else {
-					return "", fmt.Errorf("Unsupported 'inline' type! Must be string, or list of strings.")
-				}
-			}
-		default:
-			return "", fmt.Errorf("Unsupported 'inline' type! Must be string, or list of strings.")
-		}
-	}
-	lines = append(lines, "")
-	return strings.Join(lines, "\n"), nil
-}
-
 // collectScripts is used to collect all the scripts we need
 // to execute in preparation for copying them.
 func (p *ResourceProvisioner) collectScripts(c *terraform.ResourceConfig) ([]io.ReadCloser, error) {
 	// Check if inline
 	_, ok := c.Config["inline"]
 	if ok {
-		script, err := p.generateScript(c)
+		script, err := joinLines(c, "inline")
 		if err != nil {
 			return nil, err
 		}
@@ -152,20 +162,22 @@ func (p *ResourceProvisioner) collectScripts(c *terraform.ResourceConfig) ([]io.
 	return fhs, nil
 }
 
+// collectVerification is used to collect all the scripts needed for
+// verification.
+func (p *ResourceProvisioner) collectVerification(c *terraform.ResourceConfig) ([]io.ReadCloser, error) {
+	script, err := joinLines(c, "verify")
+	if err != nil {
+		return nil, err
+	}
+	rc := ioutil.NopCloser(bytes.NewReader([]byte(script)))
+	return []io.ReadCloser{rc}, nil
+}
+
 // runScripts is used to copy and execute a set of scripts
 func (p *ResourceProvisioner) runScripts(
 	o terraform.UIOutput,
 	comm communicator.Communicator,
 	scripts []io.ReadCloser) error {
-	// Wait and retry until we establish the connection
-	err := retryFunc(comm.Timeout(), func() error {
-		err := comm.Connect(o)
-		return err
-	})
-	if err != nil {
-		return err
-	}
-	defer comm.Disconnect()
 
 	for _, script := range scripts {
 		var cmd *remote.Cmd
@@ -177,7 +189,7 @@ func (p *ResourceProvisioner) runScripts(
 		go p.copyOutput(o, errR, errDoneCh)
 
 		remotePath := comm.ScriptPath()
-		err = retryFunc(comm.Timeout(), func() error {
+		err := retryFunc(comm.Timeout(), func() error {
 			if err := comm.UploadScript(remotePath, script); err != nil {
 				return fmt.Errorf("Failed to upload script: %v", err)
 			}
@@ -248,4 +260,32 @@ func retryFunc(timeout time.Duration, f func() error) error {
 		case <-time.After(3 * time.Second):
 		}
 	}
+}
+
+// joinLines takes a config value, and regardless of the type,
+// returns a string of values with newline separators
+func joinLines(c *terraform.ResourceConfig, key string) (string, error) {
+	var lines []string
+	command, ok := c.Config[key]
+	if ok {
+		switch cmd := command.(type) {
+		case string:
+			lines = append(lines, cmd)
+		case []string:
+			lines = append(lines, cmd...)
+		case []interface{}:
+			for _, l := range cmd {
+				lStr, ok := l.(string)
+				if ok {
+					lines = append(lines, lStr)
+				} else {
+					return "", fmt.Errorf("Unsupported '%s' type! Must be string, or list of strings.", key)
+				}
+			}
+		default:
+			return "", fmt.Errorf("Unsupported '%s' type! Must be string, or list of strings.", key)
+		}
+	}
+	lines = append(lines, "")
+	return strings.Join(lines, "\n"), nil
 }

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -16,6 +16,7 @@ func TestResourceProvisioner_impl(t *testing.T) {
 func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"inline": "echo foo",
+		"verify": "echo foo",
 	})
 	p := new(ResourceProvisioner)
 	warn, errs := p.Validate(c)
@@ -47,7 +48,6 @@ exit 0
 `
 
 func TestResourceProvider_generateScript(t *testing.T) {
-	p := new(ResourceProvisioner)
 	conf := testConfig(t, map[string]interface{}{
 		"inline": []interface{}{
 			"cd /tmp",
@@ -55,7 +55,7 @@ func TestResourceProvider_generateScript(t *testing.T) {
 			"exit 0",
 		},
 	})
-	out, err := p.generateScript(conf)
+	out, err := joinLines(conf, "inline")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/website/source/docs/provisioners/local-exec.html.markdown
+++ b/website/source/docs/provisioners/local-exec.html.markdown
@@ -38,3 +38,7 @@ The following arguments are supported:
   It is evaluated in a shell, and can use environment variables or Terraform
   variables.
 
+* `verify` - (Optional) This is the command to verify if the above command
+needs to be executed or not. If the `verify` command exits with a `0` exit code
+the `command` command will not be executed. If the `verify` command fails, the
+`command` command will be ran.

--- a/website/source/docs/provisioners/remote-exec.html.markdown
+++ b/website/source/docs/provisioners/remote-exec.html.markdown
@@ -26,6 +26,9 @@ resource "aws_instance" "web" {
         "puppet apply",
         "consul join ${aws_instance.web.private_ip}"
         ]
+        verify = [
+        "test -e /etc/consul.d/config",
+        ]
     }
 }
 ```
@@ -44,6 +47,10 @@ The following arguments are supported:
 * `scripts` - This is a list of paths (relative or absolute) to local scripts
   that will be copied to the remote resource and then executed. They are executed
   in the order they are provided. This cannot be provided with `inline` or `script`.
+  
+* `verify` - This is a list of command strings. If this command list exits with
+  an exit code `0`, the execution commands specified by either `inline`, `script`,
+  or `scripts` will not be executed.
 
 ## Script Arguments
 


### PR DESCRIPTION
Adds the `verify` attribute for `local-exec` and `remote-exec`. Allows a user to cleanly define a `verify` step in order to cleanly skip a provisioner execution.
Fixes: #11231 