### PR TITLE
provider/openstack: Volume Attachment Updates

### DIFF
--- a/website/source/docs/providers/openstack/r/compute_volume_attach_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_volume_attach_v2.html.markdown
@@ -43,6 +43,13 @@ The following arguments are supported:
 
 * `volume_id` - (Required) The ID of the Volume to attach to an Instance.
 
+* `device` - (Optional) The device of the volume attachment (ex: `/dev/vdc`).
+  _NOTE_: Being able to specify a device is dependent upon the hypervisor in
+  use. There is a chance that the device specified in Terraform will not be
+  the same device the hypervisor chose. If this happens, Terraform will wish
+  to update the device upon subsequent applying which will cause the volume
+  to be detached and reattached indefinitely. Please use with caution.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -50,10 +57,9 @@ The following attributes are exported:
 * `region` - See Argument Reference above.
 * `instance_id` - See Argument Reference above.
 * `volume_id` - See Argument Reference above.
-* `device` - The device of the volume attachment (ex: `/dev/vdc`).
-  _NOTE_: This is the device reported by the Compute API and the real device
-  might actually differ depending on the hypervisor being used. This should
-  not be used as an authoritative piece of information.
+* `device` - See Argument Reference above. _NOTE_: The correctness of this
+  information is dependent upon the hypervisor in use. In some cases, this
+  should not be used as an authoritative piece of information.
 
 ## Import
 


### PR DESCRIPTION
This commit adds a StateRefresh func for volume attachments. Mostly
this is to add a buffer of time between the request and the return
of the attachment to give time for the volume to become attached,
however, in some cases the refresh function could work as specified.

Docs have also been updated to reflect that a device could be specified,
but to use with caution.