### PR TITLE
provider/aws: implement CloudFront Lambda Function Associations (supersedes #10985)

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -269,7 +269,7 @@ func expandCacheBehavior(m map[string]interface{}) *cloudfront.CacheBehavior {
 	}
 
 	if v, ok := m["lambda_function_association"]; ok {
-		cb.LambdaFunctionAssociations = expandLambdaFunctionAssociations(v)
+		cb.LambdaFunctionAssociations = expandLambdaFunctionAssociations(v.(*schema.Set).List())
 	}
 
 	if v, ok := m["smooth_streaming"]; ok {

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -228,11 +228,6 @@ func defaultCacheBehaviorHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
-	if d, ok := m["lambda_function_association"]; ok {
-		for _, e := range d.(*schema.Set).List() {
-			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(e.(map[string]interface{}))))
-		}
-	}
 	return hashcode.String(buf.String())
 }
 
@@ -365,11 +360,6 @@ func cacheBehaviorHash(v interface{}) int {
 	if d, ok := m["path_pattern"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", d))
 	}
-	if d, ok := m["lambda_function_association"]; ok {
-		for _, e := range d.(*schema.Set).List() {
-			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(e.(map[string]interface{}))))
-		}
-	}
 	return hashcode.String(buf.String())
 }
 
@@ -400,11 +390,11 @@ func expandLambdaFunctionAssociations(v interface{}) *cloudfront.LambdaFunctionA
 		}
 	}
 
-	s := v.(*schema.Set)
+	s := v.([]interface{})
 	var lfa cloudfront.LambdaFunctionAssociations
-	lfa.Quantity = aws.Int64(int64(s.Len()))
-	lfa.Items = make([]*cloudfront.LambdaFunctionAssociation, s.Len())
-	for i, lf := range s.List() {
+	lfa.Quantity = aws.Int64(int64(len(s)))
+	lfa.Items = make([]*cloudfront.LambdaFunctionAssociation, len(s))
+	for i, lf := range s {
 		lfa.Items[i] = expandLambdaFunctionAssociation(lf.(map[string]interface{}))
 	}
 	return &lfa
@@ -421,12 +411,12 @@ func expandLambdaFunctionAssociation(lf map[string]interface{}) *cloudfront.Lamb
 	return &lfa
 }
 
-func flattenLambdaFunctionAssociations(lfa *cloudfront.LambdaFunctionAssociations) *schema.Set {
+func flattenLambdaFunctionAssociations(lfa *cloudfront.LambdaFunctionAssociations) []interface{} {
 	s := make([]interface{}, len(lfa.Items))
 	for i, v := range lfa.Items {
 		s[i] = flattenLambdaFunctionAssociation(v)
 	}
-	return schema.NewSet(lambdaFunctionAssociationHash, s)
+	return s
 }
 
 func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation) map[string]interface{} {
@@ -436,14 +426,6 @@ func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation)
 		m["lambda_arn"] = *lfa.LambdaFunctionARN
 	}
 	return m
-}
-
-func lambdaFunctionAssociationHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["event_type"].(string)))
-	buf.WriteString(fmt.Sprintf("%s", m["lambda_arn"].(string)))
-	return hashcode.String(buf.String())
 }
 
 func expandForwardedValues(m map[string]interface{}) *cloudfront.ForwardedValues {

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -228,6 +228,12 @@ func defaultCacheBehaviorHash(v interface{}) int {
 			buf.WriteString(fmt.Sprintf("%s-", e.(string)))
 		}
 	}
+	if d, ok := m["lambda_function_association"]; ok {
+		s := d.(*schema.Set)
+		for _, lfa := range s.List() {
+			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(lfa.(map[string]interface{}))))
+		}
+	}
 	return hashcode.String(buf.String())
 }
 
@@ -360,6 +366,12 @@ func cacheBehaviorHash(v interface{}) int {
 	if d, ok := m["path_pattern"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", d))
 	}
+	if d, ok := m["lambda_function_association"]; ok {
+		s := d.(*schema.Set)
+		for _, lfa := range s.List() {
+			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(lfa.(map[string]interface{}))))
+		}
+	}
 	return hashcode.String(buf.String())
 }
 
@@ -381,6 +393,14 @@ func flattenTrustedSigners(ts *cloudfront.TrustedSigners) []interface{} {
 		return flattenStringList(ts.Items)
 	}
 	return []interface{}{}
+}
+
+func lambdaFunctionAssociationHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["event_type"].(string)))
+	buf.WriteString(fmt.Sprintf("%s", m["lambda_arn"].(string)))
+	return hashcode.String(buf.String())
 }
 
 func expandLambdaFunctionAssociations(v interface{}) *cloudfront.LambdaFunctionAssociations {

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -229,8 +229,14 @@ func defaultCacheBehaviorHash(v interface{}) int {
 		}
 	}
 	if d, ok := m["lambda_function_association"]; ok {
-		s := d.(*schema.Set)
-		for _, lfa := range s.List() {
+		var associations []interface{}
+		switch d.(type) {
+		case *schema.Set:
+			associations = d.(*schema.Set).List()
+		default:
+			associations = d.([]interface{})
+		}
+		for _, lfa := range associations {
 			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(lfa.(map[string]interface{}))))
 		}
 	}
@@ -367,8 +373,14 @@ func cacheBehaviorHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", d))
 	}
 	if d, ok := m["lambda_function_association"]; ok {
-		s := d.(*schema.Set)
-		for _, lfa := range s.List() {
+		var associations []interface{}
+		switch d.(type) {
+		case *schema.Set:
+			associations = d.(*schema.Set).List()
+		default:
+			associations = d.([]interface{})
+		}
+		for _, lfa := range associations {
 			buf.WriteString(fmt.Sprintf("%d-", lambdaFunctionAssociationHash(lfa.(map[string]interface{}))))
 		}
 	}

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -441,7 +441,8 @@ func flattenLambdaFunctionAssociation(lfa *cloudfront.LambdaFunctionAssociation)
 func lambdaFunctionAssociationHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(m["event_type"].(string))
+	buf.WriteString(fmt.Sprintf("%s-", m["event_type"].(string)))
+	buf.WriteString(fmt.Sprintf("%s", m["lambda_arn"].(string)))
 	return hashcode.String(buf.String())
 }
 

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -56,7 +56,7 @@ func lambdaSetHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 	if v, ok := m["lambda_arn"]; ok {
-		buf.WriteString(fmt.Sprintf("%d-", v.(string)))
+		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
 	return hashcode.String(buf.String())
 }

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -1,14 +1,11 @@
 package aws
 
 import (
-	"bytes"
-	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudfront"
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -49,18 +46,6 @@ func trustedSignersConf() []interface{} {
 	return []interface{}{"1234567890EX", "1234567891EX"}
 }
 
-func lambdaSetHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	if v, ok := m["event_type"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-	}
-	if v, ok := m["lambda_arn"]; ok {
-		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
-	}
-	return hashcode.String(buf.String())
-}
-
 func lambdaFunctionAssociationsConf() *schema.Set {
 	x := []interface{}{
 		map[string]interface{}{
@@ -73,9 +58,7 @@ func lambdaFunctionAssociationsConf() *schema.Set {
 		},
 	}
 
-	s := schema.NewSet(lambdaSetHash, x)
-
-	return s
+	return schema.NewSet(lambdaFunctionAssociationHash, x)
 }
 
 func forwardedValuesConf() map[string]interface{} {
@@ -270,6 +253,9 @@ func viewerCertificateConfSetACM() map[string]interface{} {
 func TestCloudFrontStructure_expandDefaultCacheBehavior(t *testing.T) {
 	data := defaultCacheBehaviorConf()
 	dcb := expandDefaultCacheBehavior(data)
+	if dcb == nil {
+		t.Fatalf("ExpandDefaultCacheBehavior returned nil")
+	}
 	if *dcb.Compress != true {
 		t.Fatalf("Expected Compress to be true, got %v", *dcb.Compress)
 	}

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -462,8 +462,11 @@ func TestCloudFrontStructure_expandLambdaFunctionAssociations(t *testing.T) {
 	if len(lfa.Items) != 2 {
 		t.Fatalf("Expected Items to be len 2, got %v", len(lfa.Items))
 	}
-	if et := "origin-response"; *lfa.Items[0].EventType != et {
-		t.Fatalf("Expected first Item's EventType to be len %q, got %q", et, *lfa.Items[0].EventType)
+	if et := "viewer-request"; *lfa.Items[0].EventType != et {
+		t.Fatalf("Expected first Item's EventType to be %q, got %q", et, *lfa.Items[0].EventType)
+	}
+	if et := "origin-response"; *lfa.Items[1].EventType != et {
+		t.Fatalf("Expected second Item's EventType to be %q, got %q", et, *lfa.Items[1].EventType)
 	}
 }
 

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -46,7 +46,7 @@ func trustedSignersConf() []interface{} {
 	return []interface{}{"1234567890EX", "1234567891EX"}
 }
 
-func lambdaFunctionAssociationsConf() *schema.Set {
+func lambdaFunctionAssociationsConf() []interface{} {
 	s := []interface{}{
 		map[string]interface{}{
 			"event_type": "viewer-request",
@@ -57,7 +57,7 @@ func lambdaFunctionAssociationsConf() *schema.Set {
 			"lambda_arn": "arn:aws:lambda:us-east-1:999999999:function2:alias",
 		},
 	}
-	return schema.NewSet(lambdaFunctionAssociationHash, s)
+	return s
 }
 
 func forwardedValuesConf() map[string]interface{} {
@@ -359,9 +359,8 @@ func TestCloudFrontStructure_flattenCacheBehavior(t *testing.T) {
 	if out["target_origin_id"] != "myS3Origin" {
 		t.Fatalf("Expected out[target_origin_id] to be myS3Origin, got %v", out["target_origin_id"])
 	}
-	diff = out["lambda_function_association"].(*schema.Set).Difference(in["lambda_function_association"].(*schema.Set))
-	if diff.Len() > 0 {
-		t.Fatalf("Expected out[lambda_function_association] to be %v, got %v, diff: %v", out["lambda_function_association"], in["lambda_function_association"], diff)
+	if reflect.DeepEqual(out["lambda_function_associations"], in["lambda_function_associations"]) != true {
+		t.Fatalf("Expected out[lambda_function_associations] to be %v, got %v", in["lambda_function_associations"], out["lambda_function_associations"])
 	}
 	diff = out["forwarded_values"].(*schema.Set).Difference(in["forwarded_values"].(*schema.Set))
 	if len(diff.List()) > 0 {
@@ -475,13 +474,13 @@ func TestCloudFrontStructure_flattenlambdaFunctionAssociations(t *testing.T) {
 	lfa := expandLambdaFunctionAssociations(in)
 	out := flattenLambdaFunctionAssociations(lfa)
 
-	if out.Difference(in).Len() != 0 {
+	if reflect.DeepEqual(in, out) != true {
 		t.Fatalf("Expected out to be %v, got %v", in, out)
 	}
 }
 
 func TestCloudFrontStructure_expandlambdaFunctionAssociations_empty(t *testing.T) {
-	data := schema.NewSet(lambdaFunctionAssociationHash, []interface{}{})
+	data := []interface{}{}
 	lfa := expandLambdaFunctionAssociations(data)
 	if *lfa.Quantity != 0 {
 		t.Fatalf("Expected Quantity to be 0, got %v", *lfa.Quantity)

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -102,6 +102,24 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 								},
 							},
 						},
+						"lambda_function_association": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Set:      lambdaFunctionAssociationHash,
+							MaxItems: 4,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"event_type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"lambda_arn": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
 						"max_ttl": {
 							Type:     schema.TypeInt,
 							Required: true,
@@ -228,6 +246,24 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 										Type:     schema.TypeList,
 										Optional: true,
 										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"lambda_function_association": {
+							Type:     schema.TypeSet,
+							Optional: true,
+							Set:      lambdaFunctionAssociationHash,
+							MaxItems: 4,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"event_type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"lambda_arn": {
+										Type:     schema.TypeString,
+										Required: true,
 									},
 								},
 							},

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -103,7 +103,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"lambda_function_association": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							MaxItems: 4,
 							Elem: &schema.Resource{
@@ -250,7 +250,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"lambda_function_association": {
-							Type:     schema.TypeList,
+							Type:     schema.TypeSet,
 							Optional: true,
 							MaxItems: 4,
 							Elem: &schema.Resource{

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -105,7 +105,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"lambda_function_association": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Set:      lambdaFunctionAssociationHash,
 							MaxItems: 4,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
@@ -253,7 +252,6 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 						"lambda_function_association": {
 							Type:     schema.TypeSet,
 							Optional: true,
-							Set:      lambdaFunctionAssociationHash,
 							MaxItems: 4,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -118,6 +118,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									},
 								},
 							},
+							Set: lambdaFunctionAssociationHash,
 						},
 						"max_ttl": {
 							Type:     schema.TypeInt,
@@ -265,6 +266,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									},
 								},
 							},
+							Set: lambdaFunctionAssociationHash,
 						},
 						"max_ttl": {
 							Type:     schema.TypeInt,

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -103,7 +103,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"lambda_function_association": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 4,
 							Elem: &schema.Resource{
@@ -250,7 +250,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 							},
 						},
 						"lambda_function_association": {
-							Type:     schema.TypeSet,
+							Type:     schema.TypeList,
 							Optional: true,
 							MaxItems: 4,
 							Elem: &schema.Resource{

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -111,11 +111,9 @@ of several sub-resources - these resources are laid out below.
   * `comment` (Optional) - Any comments you want to include about the
     distribution.
 
-  * `custom_error_response` (Optional) - One or more [custom error
-    response](#custom-error-response-arguments) elements (multiples allowed).
+  * `custom_error_response` (Optional) - One or more [custom error response](#custom-error-response-arguments) elements (multiples allowed).
 
-  * `default_cache_behavior` (Required) - The [default cache
-    behavior](#default-cache-behavior-arguments) for this distribution (maximum
+  * `default_cache_behavior` (Required) - The [default cache behavior](#default-cache-behavior-arguments) for this distribution (maximum
     one).
 
   * `default_root_object` (Optional) - The object that you want CloudFront to
@@ -173,9 +171,12 @@ of several sub-resources - these resources are laid out below.
     object is in a CloudFront cache before CloudFront forwards another request
     in the absence of an `Cache-Control max-age` or `Expires` header.
 
-  * `forwarded_values` (Required) - The [forwarded values
-    configuration](#forwarded-values-arguments) that specifies how CloudFront
+  * `forwarded_values` (Required) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
     handles query strings, cookies and headers (maximum one).
+
+  * `lambda_function_association` (Optional) - A complext config that triggers a lambda function with
+  specific actions. Defined below, maximum 4. **Lambda@Edge is in technical
+  Preview, and must be enabled on your AWS account to be used**
 
   * `max_ttl` (Required) - The maximum amount of time (in seconds) that an
     object is in a CloudFront cache before CloudFront forwards another request
@@ -222,6 +223,19 @@ of several sub-resources - these resources are laid out below.
     `true` for `query_string`, all query strings are forwarded, however only the
     query string keys listed in this argument are cached. When omitted with a
     value of `true` for `query_string`, all query string keys are cached.
+    
+##### Lambda Function Association
+
+Lambda@Edge allows you to associate an AWS Lambda Function with a predefined
+event. You can associate a single function per event type. See [What is
+Lambda@Edge](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/what-is-lambda-at-edge.html) 
+for more information
+
+  * `event_type` (Required) - The specific event to trigger this functionon.
+  Valid values: `viewwer-request`, `origin-request`, `viewer-response`,
+  `origin-response`
+
+  * `lambda_function_arn` (Required) - ARN of the Lambda function.
 
 ##### Cookies Arguments
 

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -232,7 +232,7 @@ Lambda@Edge](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/w
 for more information
 
   * `event_type` (Required) - The specific event to trigger this function.
-  Valid values: `viewwer-request`, `origin-request`, `viewer-response`,
+  Valid values: `viewer-request`, `origin-request`, `viewer-response`,
   `origin-response`
 
   * `lambda_function_arn` (Required) - ARN of the Lambda function.

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -174,7 +174,7 @@ of several sub-resources - these resources are laid out below.
   * `forwarded_values` (Required) - The [forwarded values configuration](#forwarded-values-arguments) that specifies how CloudFront
     handles query strings, cookies and headers (maximum one).
 
-  * `lambda_function_association` (Optional) - A complext config that triggers a lambda function with
+  * `lambda_function_association` (Optional) - A config block that triggers a lambda function with
   specific actions. Defined below, maximum 4. **Lambda@Edge is in technical
   Preview, and must be enabled on your AWS account to be used**
 
@@ -231,7 +231,7 @@ event. You can associate a single function per event type. See [What is
 Lambda@Edge](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/what-is-lambda-at-edge.html) 
 for more information
 
-  * `event_type` (Required) - The specific event to trigger this functionon.
+  * `event_type` (Required) - The specific event to trigger this function.
   Valid values: `viewwer-request`, `origin-request`, `viewer-response`,
   `origin-response`
 


### PR DESCRIPTION
Continue the work done in #10985 with just a few tweaks to restore the `TypeSet` in `lambda_function_association`.

Should also fix #11295 