### PR TITLE
provisioner/exec: Add verify attribute

### DIFF
--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -65,6 +65,64 @@ func TestResourceProvider_Validate_missing(t *testing.T) {
 	}
 }
 
+func TestResourceProvider_Verify(t *testing.T) {
+	// Setup the file, containing 'foo'
+	defer os.Remove("test_out")
+	c := testConfig(t, map[string]interface{}{
+		"command": "echo bar > test_out",
+		"verify":  "grep -q bar test_out",
+	})
+
+	output := new(terraform.MockUIOutput)
+	p := new(ResourceProvisioner)
+	if err := p.Apply(output, nil, c); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	// Check the file
+	raw, err := ioutil.ReadFile("test_out")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	actual := strings.TrimSpace(string(raw))
+	expected := "bar"
+	if actual != expected {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
+// Not actually a failure, just forces execution
+func TestResourceProvider_VerifyFail(t *testing.T) {
+	// Setup the file, containing 'bar'
+	defer os.Remove("test_out")
+	c := testConfig(t, map[string]interface{}{
+		"command": "echo bar > test_out",
+		"verify":  "grep -q foo test_out",
+	})
+
+	output := new(terraform.MockUIOutput)
+	p := new(ResourceProvisioner)
+	if err := p.Apply(output, nil, c); err == nil {
+		t.Fatalf("should have failed")
+		if !strings.Contains(err.Error(), "verifying") {
+			t.Fatalf("should have failed at verifying: %v", err)
+		}
+	}
+
+	// Check the file
+	raw, err := ioutil.ReadFile("test_out")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	actual := strings.TrimSpace(string(raw))
+	expected := "bar"
+	if actual != expected {
+		t.Fatalf("bad: %#v", actual)
+	}
+}
+
 func testConfig(
 	t *testing.T,
 	c map[string]interface{}) *terraform.ResourceConfig {

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -16,6 +16,7 @@ func TestResourceProvisioner_impl(t *testing.T) {
 func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"inline": "echo foo",
+		"verify": "echo foo",
 	})
 	p := new(ResourceProvisioner)
 	warn, errs := p.Validate(c)
@@ -47,7 +48,6 @@ exit 0
 `
 
 func TestResourceProvider_generateScript(t *testing.T) {
-	p := new(ResourceProvisioner)
 	conf := testConfig(t, map[string]interface{}{
 		"inline": []interface{}{
 			"cd /tmp",
@@ -55,7 +55,7 @@ func TestResourceProvider_generateScript(t *testing.T) {
 			"exit 0",
 		},
 	})
-	out, err := p.generateScript(conf)
+	out, err := joinLines(conf, "inline")
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}

--- a/website/source/docs/provisioners/local-exec.html.markdown
+++ b/website/source/docs/provisioners/local-exec.html.markdown
@@ -25,6 +25,7 @@ resource "aws_instance" "web" {
     ...
     provisioner "local-exec" {
         command = "echo ${aws_instance.web.private_ip} >> private_ips.txt"
+        verify  = "grep -q ${aws_instance.web.private_ip} private_ips.txt"
     }
 }
 ```
@@ -38,3 +39,5 @@ The following arguments are supported:
   It is evaluated in a shell, and can use environment variables or Terraform
   variables.
 
+* `verify` - (Optional) This is the command to verify if the above command
+executed successfully or not. 

--- a/website/source/docs/provisioners/remote-exec.html.markdown
+++ b/website/source/docs/provisioners/remote-exec.html.markdown
@@ -26,6 +26,9 @@ resource "aws_instance" "web" {
         "puppet apply",
         "consul join ${aws_instance.web.private_ip}"
         ]
+        verify = [
+        "consul members",
+        ]
     }
 }
 ```
@@ -44,6 +47,10 @@ The following arguments are supported:
 * `scripts` - This is a list of paths (relative or absolute) to local scripts
   that will be copied to the remote resource and then executed. They are executed
   in the order they are provided. This cannot be provided with `inline` or `script`.
+  
+* `verify` - This is a list of command strings. Used to verify that the execution
+ scripts (Either: `inline`, `script`, or `scripts`) executed correctly.
+
 
 ## Script Arguments
 


### PR DESCRIPTION
Adds the `verify` attribute for `local-exec` and `remote-exec`. Allows a user to specify a specific verification script, in order to verify that the provisioning script actually performed the actions that it needed to.

Fixes: #11231 