### PR TITLE
Basic authentication for HTTP remote state backend

### DIFF
--- a/website/source/docs/state/remote/http.html.md
+++ b/website/source/docs/state/remote/http.html.md
@@ -36,5 +36,7 @@ data "terraform_remote_state" "foo" {
 The following configuration options are supported:
 
  * `address` - (Required) The address of the REST endpoint
+ * `username` - (Optional) The username for HTTP basic authentication
+ * `password` - (Optional) The password for HTTP basic authentication
  * `skip_cert_verification` - (Optional) Whether to skip TLS verification.
    Defaults to `false`.


### PR DESCRIPTION
A simple fix to make the HTTP remote state backend pass muster for production use.