### PR TITLE
provider/aws: Add DataSource to get a list of Autoscaling groups in a region

### DIFF
--- a/builtin/providers/aws/data_source_aws_autoscaling_groups.go
+++ b/builtin/providers/aws/data_source_aws_autoscaling_groups.go
@@ -1,0 +1,51 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"sort"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsAutoscalingGroups() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsAutoscalingGroupsRead,
+
+		Schema: map[string]*schema.Schema{
+			"names": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceAwsAutoscalingGroupsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).autoscalingconn
+
+	log.Printf("[DEBUG] Reading Autoscaling Groups.")
+	d.SetId(time.Now().UTC().String())
+
+	resp, err := conn.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	if err != nil {
+		return fmt.Errorf("Error fetching Autoscaling Groups: %s", err)
+	}
+
+	raw := make([]string, len(resp.AutoScalingGroups))
+	for i, v := range resp.AutoScalingGroups {
+		raw[i] = *v.AutoScalingGroupName
+	}
+
+	sort.Strings(raw)
+
+	if err := d.Set("names", raw); err != nil {
+		return fmt.Errorf("[WARN] Error setting Autoscaling Group Names: %s", err)
+	}
+
+	return nil
+
+}

--- a/builtin/providers/aws/data_source_aws_autoscaling_groups_test.go
+++ b/builtin/providers/aws/data_source_aws_autoscaling_groups_test.go
@@ -1,0 +1,207 @@
+package aws
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSAutoscalingGroups_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsAutoscalingGroupsConfig(acctest.RandInt(), acctest.RandInt(), acctest.RandInt()),
+			},
+			{
+				Config: testAccCheckAwsAutoscalingGroupsConfigWithDataSource(acctest.RandInt(), acctest.RandInt(), acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsAutoscalingGroups("data.aws_autoscaling_groups.group_list"),
+					resource.TestCheckResourceAttr("data.aws_autoscaling_groups.group_list", "names.#", "3"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsAutoscalingGroups(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find ASG resource: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("AZ resource ID not set.")
+		}
+
+		actual, err := testAccCheckAwsAutoscalingGroupsAvailable(rs.Primary.Attributes)
+		if err != nil {
+			return err
+		}
+
+		expected := actual
+		sort.Strings(expected)
+		if reflect.DeepEqual(expected, actual) != true {
+			return fmt.Errorf("ASG not sorted - expected %v, got %v", expected, actual)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAwsAutoscalingGroupsAvailable(attrs map[string]string) ([]string, error) {
+	v, ok := attrs["names.#"]
+	if !ok {
+		return nil, fmt.Errorf("Available ASG list is missing.")
+	}
+	qty, err := strconv.Atoi(v)
+	if err != nil {
+		return nil, err
+	}
+	if qty < 1 {
+		return nil, fmt.Errorf("No ASG found in region, this is probably a bug.")
+	}
+	zones := make([]string, qty)
+	for n := range zones {
+		zone, ok := attrs["names."+strconv.Itoa(n)]
+		if !ok {
+			return nil, fmt.Errorf("ASG list corrupt, this is definitely a bug.")
+		}
+		zones[n] = zone
+	}
+	return zones, nil
+}
+
+func testAccCheckAwsAutoscalingGroupsConfig(rInt1, rInt2, rInt3 int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+  image_id = "ami-21f78e11"
+  instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "bar" {
+  availability_zones = ["us-west-2a"]
+  name = "test-asg-%d"
+  max_size = 1
+  min_size = 0
+  health_check_type = "EC2"
+  desired_capacity = 0
+  force_delete = true
+
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key = "Foo"
+    value = "foo-bar"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group" "foo" {
+  availability_zones = ["us-west-2b"]
+  name = "test-asg-%d"
+  max_size = 1
+  min_size = 0
+  health_check_type = "EC2"
+  desired_capacity = 0
+  force_delete = true
+
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key = "Foo"
+    value = "foo-bar"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group" "barbaz" {
+  availability_zones = ["us-west-2c"]
+  name = "test-asg-%d"
+  max_size = 1
+  min_size = 0
+  health_check_type = "EC2"
+  desired_capacity = 0
+  force_delete = true
+
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key = "Foo"
+    value = "foo-bar"
+    propagate_at_launch = true
+  }
+}`, rInt1, rInt2, rInt3)
+}
+
+func testAccCheckAwsAutoscalingGroupsConfigWithDataSource(rInt1, rInt2, rInt3 int) string {
+	return fmt.Sprintf(`
+resource "aws_launch_configuration" "foobar" {
+  image_id = "ami-21f78e11"
+  instance_type = "t1.micro"
+}
+
+resource "aws_autoscaling_group" "bar" {
+  availability_zones = ["us-west-2a"]
+  name = "test-asg-%d"
+  max_size = 1
+  min_size = 0
+  health_check_type = "EC2"
+  desired_capacity = 0
+  force_delete = true
+
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key = "Foo"
+    value = "foo-bar"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group" "foo" {
+  availability_zones = ["us-west-2b"]
+  name = "test-asg-%d"
+  max_size = 1
+  min_size = 0
+  health_check_type = "EC2"
+  desired_capacity = 0
+  force_delete = true
+
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key = "Foo"
+    value = "foo-bar"
+    propagate_at_launch = true
+  }
+}
+
+resource "aws_autoscaling_group" "barbaz" {
+  availability_zones = ["us-west-2c"]
+  name = "test-asg-%d"
+  max_size = 1
+  min_size = 0
+  health_check_type = "EC2"
+  desired_capacity = 0
+  force_delete = true
+
+  launch_configuration = "${aws_launch_configuration.foobar.name}"
+
+  tag {
+    key = "Foo"
+    value = "foo-bar"
+    propagate_at_launch = true
+  }
+}
+
+data "aws_autoscaling_groups" "group_list" {}
+`, rInt1, rInt2, rInt3)
+}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -147,6 +147,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_alb":                      dataSourceAwsAlb(),
 			"aws_alb_listener":             dataSourceAwsAlbListener(),
 			"aws_ami":                      dataSourceAwsAmi(),
+			"aws_autoscaling_groups":       dataSourceAwsAutoscalingGroups(),
 			"aws_availability_zone":        dataSourceAwsAvailabilityZone(),
 			"aws_availability_zones":       dataSourceAwsAvailabilityZones(),
 			"aws_billing_service_account":  dataSourceAwsBillingServiceAccount(),

--- a/website/source/docs/providers/aws/d/autoscaling_groups.html.markdown
+++ b/website/source/docs/providers/aws/d/autoscaling_groups.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_autoscaling_groups"
+sidebar_current: "docs-aws-datasource-autoscaling-groups"
+description: |-
+    Provides a list of Autoscaling Groups within the specific availablity zone.
+---
+
+# aws\_autoscaling\_groups
+
+The Autoscaling Groups data source allows access to the list of AWS
+ASGs within the specific region. This will allow you to pass a list of AutoScaling groups to other resources.
+
+## Example Usage
+
+```
+# Declare the data source
+data "aws_autoscaling_groups" "groups" {}
+
+resource "aws_autoscaling_notification" "slack_notifications" {
+  group_names = ["${data.aws_autoscaling_groups.groups.names}"]
+  notifications  = [
+    "autoscaling:EC2_INSTANCE_LAUNCH",
+    "autoscaling:EC2_INSTANCE_TERMINATE",
+    "autoscaling:EC2_INSTANCE_LAUNCH_ERROR",
+    "autoscaling:EC2_INSTANCE_TERMINATE_ERROR"
+  ]
+  topic_arn = "TOPIC ARN"
+}
+```
+
+## Argument Reference
+
+The data source currently takes no arguments as it uses the current region that the provider works in.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `names` - A list of the Autoscaling Groups in the region.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -26,6 +26,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-alb-listener") %>>
                             <a href="/docs/providers/aws/d/alb_listener.html">aws_alb_listener</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-autoscaling-groups") %>>
+                            <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-availability-zone") %>>
                             <a href="/docs/providers/aws/d/availability_zone.html">aws_availability_zone</a>
                         </li>


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAutoscalingGroups_'
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/20 11:39:37 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAutoscalingGroups_basic -timeout 120m
=== RUN   TestAccAWSAutoscalingGroups_basic
--- PASS: TestAccAWSAutoscalingGroups_basic (121.29s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	121.335s
```