### PR TITLE
Add params zone_id to cloudstack ipaddress resource

### DIFF
--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
@@ -155,19 +155,9 @@ func verifyIPAddressParams(d *schema.ResourceData) error {
 	_, vpc := d.GetOk("vpc_id")
 	_, zone := d.GetOk("zone_id")
 
-	f := func(bs ...bool) int {
-		cnt := 0
-		for _, b := range bs {
-			if b {
-				cnt++
-			}
-		}
-		return cnt
-	}
-
-	if f(network, vpc, zone) >= 2 || (!network && !vpc && !zone) {
+	if (network && vpc) || (!network && !vpc && !zone) {
 		return fmt.Errorf(
-			"You must supply one value for either (so not more than two) the 'network_id' or 'vpc_id' or 'zone_id'  parameter")
+			"You must supply a value for either (so not both) the 'network_id' or 'vpc_id' parameter")
 	}
 
 	return nil

--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
@@ -153,9 +153,8 @@ func resourceCloudStackIPAddressDelete(d *schema.ResourceData, meta interface{})
 func verifyIPAddressParams(d *schema.ResourceData) error {
 	_, network := d.GetOk("network_id")
 	_, vpc := d.GetOk("vpc_id")
-	_, zone := d.GetOk("zone_id")
 
-	if (network && vpc) || (!network && !vpc && !zone) {
+	if (network && vpc) || (!network && !vpc) {
 		return fmt.Errorf(
 			"You must supply a value for either (so not both) the 'network_id' or 'vpc_id' parameter")
 	}

--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
@@ -28,6 +28,12 @@ func resourceCloudStackIPAddress() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"zone_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -61,6 +67,11 @@ func resourceCloudStackIPAddressCreate(d *schema.ResourceData, meta interface{})
 	if vpcid, ok := d.GetOk("vpc_id"); ok {
 		// Set the vpcid
 		p.SetVpcid(vpcid.(string))
+	}
+
+	if zoneid, ok := d.GetOk("zone_id"); ok {
+		// Set the vpcid
+		p.SetZoneid(zoneid.(string))
 	}
 
 	// If there is a project supplied, we retrieve and set the project id
@@ -109,6 +120,10 @@ func resourceCloudStackIPAddressRead(d *schema.ResourceData, meta interface{}) e
 		d.Set("vpc_id", ip.Vpcid)
 	}
 
+	if _, ok := d.GetOk("zone_id"); ok {
+		d.Set("zone_id", ip.Zoneid)
+	}
+
 	setValueOrID(d, "project", ip.Project, ip.Projectid)
 
 	return nil
@@ -138,8 +153,9 @@ func resourceCloudStackIPAddressDelete(d *schema.ResourceData, meta interface{})
 func verifyIPAddressParams(d *schema.ResourceData) error {
 	_, network := d.GetOk("network_id")
 	_, vpc := d.GetOk("vpc_id")
+	_, zone := d.GetOk("zone_id")
 
-	if (network && vpc) || (!network && !vpc) {
+	if (network && vpc) || (!network && !vpc && !zone) {
 		return fmt.Errorf(
 			"You must supply a value for either (so not both) the 'network_id' or 'vpc_id' parameter")
 	}

--- a/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
+++ b/builtin/providers/cloudstack/resource_cloudstack_ipaddress.go
@@ -155,9 +155,19 @@ func verifyIPAddressParams(d *schema.ResourceData) error {
 	_, vpc := d.GetOk("vpc_id")
 	_, zone := d.GetOk("zone_id")
 
-	if (network && vpc) || (!network && !vpc && !zone) {
+	f := func(bs ...bool) int {
+		cnt := 0
+		for _, b := range bs {
+			if b {
+				cnt++
+			}
+		}
+		return cnt
+	}
+
+	if f(network, vpc, zone) >= 2 || (!network && !vpc && !zone) {
 		return fmt.Errorf(
-			"You must supply a value for either (so not both) the 'network_id' or 'vpc_id' parameter")
+			"You must supply one value for either (so not more than two) the 'network_id' or 'vpc_id' or 'zone_id'  parameter")
 	}
 
 	return nil


### PR DESCRIPTION
Hi, I've add zone_id to cloudstack_ipaddress for CloudStack based provider IDCF. Their API only allows associate new IPAddress by zone_id.

Ref: http://docs.idcf.jp/cloud/api/address/#listpublicipaddresses