### PR TITLE
provider/aws: Remove hardcoded https from the ecr repository

### DIFF
--- a/builtin/providers/aws/resource_aws_ecr_repository.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository.go
@@ -100,7 +100,7 @@ func resourceAwsEcrRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 }
 
 func buildRepositoryUrl(repo *ecr.Repository, region string) string {
-	return fmt.Sprintf("https://%s.dkr.ecr.%s.amazonaws.com/%s", *repo.RegistryId, region, *repo.RepositoryName)
+	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s", *repo.RegistryId, region, *repo.RepositoryName)
 }
 
 func resourceAwsEcrRepositoryDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_ecr_repository_test.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_test.go
@@ -17,7 +17,7 @@ func TestAccAWSEcrRepository_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSEcrRepositoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSEcrRepository,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSEcrRepositoryExists("aws_ecr_repository.default"),

--- a/website/source/docs/providers/aws/r/ecr_repository.html.markdown
+++ b/website/source/docs/providers/aws/r/ecr_repository.html.markdown
@@ -35,7 +35,7 @@ The following attributes are exported:
 * `arn` - Full ARN of the repository.
 * `name` - The name of the repository.
 * `registry_id` - The registry ID where the repository was created.
-* `repository_url` - The URL of the repository (in the form `https://aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`
+* `repository_url` - The URL of the repository (in the form `/aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`
 
 
 ## Import

--- a/website/source/docs/providers/aws/r/ecr_repository.html.markdown
+++ b/website/source/docs/providers/aws/r/ecr_repository.html.markdown
@@ -35,7 +35,7 @@ The following attributes are exported:
 * `arn` - Full ARN of the repository.
 * `name` - The name of the repository.
 * `registry_id` - The registry ID where the repository was created.
-* `repository_url` - The URL of the repository (in the form `/aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`
+* `repository_url` - The URL of the repository (in the form `aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName`
 
 
 ## Import


### PR DESCRIPTION
When the ECR resource was created, we hardcoded the repository URL to
start with https://

This was a mistake as all interaction with the repository now must
include a replace function for the https:// to "" for this to be usable

We need to note this change in the backward incompatibilities

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcrRepository_'                                                      ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/20 14:37:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcrRepository_ -timeout 120m
=== RUN   TestAccAWSEcrRepository_importBasic
--- PASS: TestAccAWSEcrRepository_importBasic (20.46s)
=== RUN   TestAccAWSEcrRepository_basic
--- PASS: TestAccAWSEcrRepository_basic (18.77s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	39.251s
```