### PR TITLE
documentation: Add warning for pathexpand interpolation function

### DIFF
--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -271,7 +271,8 @@ The supported built-in functions are:
   * `md5(string)` - Returns a (conventional) hexadecimal representation of the
     MD5 hash of the given string.
 
-  * `pathexpand(string)` - Returns a filepath string with `~` expanded to the home directory.
+  * `pathexpand(string)` - Returns a filepath string with `~` expanded to the home directory. Note:
+  This will create a plan diff between two different hosts, unless the filepaths are the same.
   
   * `replace(string, search, replace)` - Does a search and replace on the
       given string. All instances of `search` are replaced with the value

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -272,7 +272,7 @@ The supported built-in functions are:
     MD5 hash of the given string.
 
   * `pathexpand(string)` - Returns a filepath string with `~` expanded to the home directory. Note:
-  This will create a plan diff between two different hosts, unless the filepaths are the same.
+    This will create a plan diff between two different hosts, unless the filepaths are the same.
   
   * `replace(string, search, replace)` - Does a search and replace on the
       given string. All instances of `search` are replaced with the value


### PR DESCRIPTION
Note that the `pathexpand` interpolation function could cause an unwanted diff on two different hosts.

cc: @apparentlymart 