### PR TITLE
provider/digitalocean: Fix failing acceptance test

### DIFF
--- a/builtin/providers/digitalocean/import_digitalocean_domain_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_domain_test.go
@@ -18,11 +18,11 @@ func TestAccDigitalOceanDomain_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanDomainConfig_basic, domainName),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/digitalocean/import_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_droplet_test.go
@@ -14,11 +14,11 @@ func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_basic,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/digitalocean/import_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_floating_ip_test.go
@@ -14,11 +14,11 @@ func TestAccDigitalOceanFloatingIP_importBasicRegion(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanFloatingIPConfig_region,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -35,11 +35,11 @@ func TestAccDigitalOceanFloatingIP_importBasicDroplet(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/digitalocean/import_digitalocean_ssh_key_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_ssh_key_test.go
@@ -14,11 +14,11 @@ func TestAccDigitalOceanSSHKey_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanSSHKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanSSHKeyConfig_basic,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/digitalocean/import_digitalocean_tag_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_tag_test.go
@@ -14,11 +14,11 @@ func TestAccDigitalOceanTag_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanTagDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanTagConfig_basic,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/digitalocean/import_digitalocean_volume_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_volume_test.go
@@ -18,11 +18,11 @@ func TestAccDigitalOceanVolume_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanVolumeDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeConfig_basic, volumeName),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/digitalocean/provider.go
+++ b/builtin/providers/digitalocean/provider.go
@@ -9,7 +9,7 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"token": &schema.Schema{
+			"token": {
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("DIGITALOCEAN_TOKEN", nil),

--- a/builtin/providers/digitalocean/resource_digitalocean_domain.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_domain.go
@@ -18,13 +18,13 @@ func resourceDigitalOceanDomain() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"ip_address": &schema.Schema{
+			"ip_address": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,

--- a/builtin/providers/digitalocean/resource_digitalocean_domain_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_domain_test.go
@@ -19,7 +19,7 @@ func TestAccDigitalOceanDomain_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanDomainConfig_basic, domainName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDomainExists("digitalocean_domain.foobar", &domain),

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -23,18 +23,18 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"image": &schema.Schema{
+			"image": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"region": &schema.Schema{
+			"region": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -44,7 +44,7 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				},
 			},
 
-			"size": &schema.Schema{
+			"size": {
 				Type:     schema.TypeString,
 				Required: true,
 				StateFunc: func(val interface{}) string {
@@ -53,43 +53,43 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				},
 			},
 
-			"disk": &schema.Schema{
+			"disk": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			"vcpus": &schema.Schema{
+			"vcpus": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
 
-			"resize_disk": &schema.Schema{
+			"resize_disk": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
 
-			"status": &schema.Schema{
+			"status": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"locked": &schema.Schema{
+			"locked": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"backups": &schema.Schema{
+			"backups": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
 
-			"ipv6": &schema.Schema{
+			"ipv6": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
 
-			"ipv6_address": &schema.Schema{
+			"ipv6_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 				StateFunc: func(val interface{}) string {
@@ -97,45 +97,45 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				},
 			},
 
-			"ipv6_address_private": &schema.Schema{
+			"ipv6_address_private": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"private_networking": &schema.Schema{
+			"private_networking": {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
 
-			"ipv4_address": &schema.Schema{
+			"ipv4_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"ipv4_address_private": &schema.Schema{
+			"ipv4_address_private": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"ssh_keys": &schema.Schema{
+			"ssh_keys": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"tags": &schema.Schema{
+			"tags": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
 
-			"user_data": &schema.Schema{
+			"user_data": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"volume_ids": &schema.Schema{
+			"volume_ids": {
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -19,7 +19,7 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -48,7 +48,7 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -56,7 +56,7 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_RenameAndResize,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -81,7 +81,7 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -89,7 +89,7 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -112,7 +112,7 @@ func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
@@ -120,7 +120,7 @@ func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_userdata_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
@@ -144,7 +144,7 @@ func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
@@ -152,7 +152,7 @@ func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_tag_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
@@ -178,7 +178,7 @@ func TestAccDigitalOceanDroplet_PrivateNetworkingIpv6(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip.go
@@ -21,19 +21,19 @@ func resourceDigitalOceanFloatingIp() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"ip_address": &schema.Schema{
+			"ip_address": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"region": &schema.Schema{
+			"region": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"droplet_id": &schema.Schema{
+			"droplet_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -17,7 +17,7 @@ func TestAccDigitalOceanFloatingIP_Region(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanFloatingIPConfig_region,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
@@ -37,7 +37,7 @@ func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),

--- a/builtin/providers/digitalocean/resource_digitalocean_record.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record.go
@@ -18,52 +18,52 @@ func resourceDigitalOceanRecord() *schema.Resource {
 		Delete: resourceDigitalOceanRecordDelete,
 
 		Schema: map[string]*schema.Schema{
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"domain": &schema.Schema{
+			"domain": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"port": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"priority": &schema.Schema{
+			"port": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
 
-			"weight": &schema.Schema{
+			"priority": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
 
-			"value": &schema.Schema{
+			"weight": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
 
-			"fqdn": &schema.Schema{
+			"value": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"fqdn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},

--- a/builtin/providers/digitalocean/resource_digitalocean_record_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record_test.go
@@ -43,7 +43,7 @@ func TestAccDigitalOceanRecord_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanRecordConfig_basic, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
@@ -71,7 +71,7 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanRecordConfig_basic, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanRecordExists("digitalocean_record.foobar", &record),
@@ -86,7 +86,7 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 						"digitalocean_record.foobar", "type", "A"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(
 					testAccCheckDigitalOceanRecordConfig_new_value, domain),
 				Check: resource.ComposeTestCheckFunc(
@@ -115,7 +115,7 @@ func TestAccDigitalOceanRecord_HostnameValue(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(
 					testAccCheckDigitalOceanRecordConfig_cname, domain),
 				Check: resource.ComposeTestCheckFunc(
@@ -144,7 +144,7 @@ func TestAccDigitalOceanRecord_ExternalHostnameValue(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(
 					testAccCheckDigitalOceanRecordConfig_external_cname, domain),
 				Check: resource.ComposeTestCheckFunc(

--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
@@ -19,7 +19,7 @@ func TestAccDigitalOceanSSHKey_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanSSHKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanSSHKeyConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSSHKeyExists("digitalocean_ssh_key.foobar", &key),

--- a/builtin/providers/digitalocean/resource_digitalocean_tag.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_tag.go
@@ -19,7 +19,7 @@ func resourceDigitalOceanTag() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},

--- a/builtin/providers/digitalocean/resource_digitalocean_tag_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_tag_test.go
@@ -17,7 +17,7 @@ func TestAccDigitalOceanTag_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanTagDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckDigitalOceanTagConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanTagExists("digitalocean_tag.foobar", &tag),

--- a/builtin/providers/digitalocean/resource_digitalocean_volume.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_volume.go
@@ -18,36 +18,36 @@ func resourceDigitalOceanVolume() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"region": &schema.Schema{
+			"region": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"droplet_ids": &schema.Schema{
+			"droplet_ids": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeInt},
 				Computed: true,
 			},
 
-			"size": &schema.Schema{
+			"size": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true, // Update-ability Coming Soon ™
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true, // Update-ability Coming Soon ™

--- a/builtin/providers/digitalocean/resource_digitalocean_volume_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_volume_test.go
@@ -22,7 +22,7 @@ func TestAccDigitalOceanVolume_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanVolumeDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDigitalOceanVolumeConfig_basic, name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
@@ -103,7 +103,7 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDigitalOceanVolumeDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(
 					testAccCheckDigitalOceanVolumeConfig_droplet,
 					testAccValidPublicKey, volume.Name,
@@ -113,7 +113,7 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					// the droplet should see an attached volume
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "volume_ids", volume.ID),
+						"digitalocean_droplet.foobar", "volume_ids.#", "1"),
 				),
 			},
 		},

--- a/builtin/providers/digitalocean/tags.go
+++ b/builtin/providers/digitalocean/tags.go
@@ -17,7 +17,7 @@ func setTags(conn *godo.Client, d *schema.ResourceData) error {
 	for _, tag := range remove {
 		_, err := conn.Tags.UntagResources(tag, &godo.UntagResourcesRequest{
 			Resources: []godo.Resource{
-				godo.Resource{
+				{
 					ID:   d.Id(),
 					Type: godo.DropletResourceType,
 				},
@@ -32,7 +32,7 @@ func setTags(conn *godo.Client, d *schema.ResourceData) error {
 	for _, tag := range create {
 		_, err := conn.Tags.TagResources(tag, &godo.TagResourcesRequest{
 			Resources: []godo.Resource{
-				godo.Resource{
+				{
 					ID:   d.Id(),
 					Type: godo.DropletResourceType,
 				},


### PR DESCRIPTION
Fixes failing acceptance test:
```
$ make testacc TEST=./builtin/providers/digitalocean TESTARGS='-run=TestAccDigitalOceanVolume_Droplet'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/20 11:38:26 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=TestAccDigitalOceanVolume_Droplet -timeout 120m
=== RUN   TestAccDigitalOceanVolume_Droplet
--- PASS: TestAccDigitalOceanVolume_Droplet (57.38s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/digitalocean   57.411s
```

Also removes all redundant type declarations in the digitalocean package.