### PR TITLE
provider/aws: Fix S3BucketPolicy Acceptance Tests

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_policy_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_policy_test.go
@@ -16,7 +16,7 @@ func TestAccAWSS3BucketPolicy_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	expectedPolicyText := fmt.Sprintf(
-		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:*","Resource":["arn:aws:s3:::%s","arn:aws:s3:::%s/*"]}]}`,
+		`{"Version":"2012-10-17","Statement":[{"Sid": "", "Effect":"Allow","Principal":"*","Action":"s3:*","Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
 		name, name)
 
 	resource.Test(t, resource.TestCase{
@@ -39,11 +39,11 @@ func TestAccAWSS3BucketPolicy_policyUpdate(t *testing.T) {
 	name := fmt.Sprintf("tf-test-bucket-%d", acctest.RandInt())
 
 	expectedPolicyText1 := fmt.Sprintf(
-		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":"s3:*","Resource":["arn:aws:s3:::%s","arn:aws:s3:::%s/*"]}]}`,
+		`{"Version":"2012-10-17","Statement":[{"Sid": "", "Effect":"Allow","Principal":"*","Action":"s3:*","Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
 		name, name)
 
 	expectedPolicyText2 := fmt.Sprintf(
-		`{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"*"},"Action":["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"], "Resource":["arn:aws:s3:::%s","arn:aws:s3:::%s/*"]}]}`,
+		`{"Version":"2012-10-17","Statement":[{"Sid": "", "Effect":"Allow","Principal":"*","Action":["s3:DeleteBucket", "s3:ListBucket", "s3:ListBucketVersions"], "Resource":["arn:aws:s3:::%s/*","arn:aws:s3:::%s"]}]}`,
 		name, name)
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Fixes AwsS3BucketPolicy Acceptance Tests to match policy document changes from upstream.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3BucketPolicy'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/20 11:55:23 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3BucketPolicy -timeout 120m
=== RUN   TestAccAWSS3BucketPolicy_basic
--- PASS: TestAccAWSS3BucketPolicy_basic (33.64s)
=== RUN   TestAccAWSS3BucketPolicy_policyUpdate
--- PASS: TestAccAWSS3BucketPolicy_policyUpdate (61.91s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    95.591s
```