### PR TITLE
docs/aws: Remove duplicate aws_route53_zone data source

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -20,11 +20,11 @@
                         <li<%= sidebar_current("docs-aws-datasource-alb") %>>
                             <a href="/docs/providers/aws/d/alb.html">aws_alb</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-ami") %>>
-                            <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
-                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-alb-listener") %>>
                             <a href="/docs/providers/aws/d/alb_listener.html">aws_alb_listener</a>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-datasource-ami") %>>
+                            <a href="/docs/providers/aws/d/ami.html">aws_ami</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-autoscaling-groups") %>>
                             <a href="/docs/providers/aws/d/autoscaling_groups.html">aws_autoscaling_groups</a>
@@ -77,11 +77,11 @@
                         <li<%= sidebar_current("docs-aws-datasource-region") %>>
                             <a href="/docs/providers/aws/d/region.html">aws_region</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-route-table") %>>
-                          <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
-                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-route53-zone") %>>
                           <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
+                        </li>
+                        <li<%= sidebar_current("docs-aws-datasource-route-table") %>>
+                          <a href="/docs/providers/aws/d/route_table.html">aws_route_table</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-s3-bucket-object") %>>
                             <a href="/docs/providers/aws/d/s3_bucket_object.html">aws_s3_bucket_object</a>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -56,9 +56,6 @@
                         <li<%= sidebar_current("docs-aws-datasource-elb-service-account") %>>
                             <a href="/docs/providers/aws/d/elb_service_account.html">aws_elb_service_account</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-route53-zone") %>>
-                          <a href="/docs/providers/aws/d/route53_zone.html">aws_route53_zone</a>
-                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-iam-account-alias") %>>
                             <a href="/docs/providers/aws/d/iam_account_alias.html">aws_iam_account_alias</a>
                         </li>


### PR DESCRIPTION
Introduced in https://github.com/hashicorp/terraform/pull/10803