### PR TITLE
 Clarify location of the remote state file in Manta backend

### DIFF
--- a/website/source/docs/state/remote/manta.html.md
+++ b/website/source/docs/state/remote/manta.html.md
@@ -35,7 +35,7 @@ data "terraform_remote_state" "foo" {
 
 The following configuration options are supported:
 
- * `path` - (Required) The path where to store the state file
+ * `path` - (Required) The path relative to your private storage directory (`/$MANTA_USER/stor`) where the state file will be stored
  * `objectName` - (Optional) The name of the state file (defaults to `terraform.tfstate`)
 
 The following [Manta environment variables](https://apidocs.joyent.com/manta/#setting-up-your-environment) are supported:


### PR DESCRIPTION
The user's private object storage directory (`/$MANTA_USER/stor/`) will automatically be prepended to the supplied path. It's helpful to know that you can't use an absolute Manta path such as `/$MANTA_USER/stor/random/path` or `~~/stor/random/path`. 