### PR TITLE
provider/ignition: Fix systemd unit errors

### DIFF
--- a/builtin/providers/ignition/resource_ignition_config_test.go
+++ b/builtin/providers/ignition/resource_ignition_config_test.go
@@ -83,7 +83,7 @@ func testIgnition(t *testing.T, input string, assert func(*types.Config) error) 
 	resource.Test(t, resource.TestCase{
 		Providers: testProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testTemplate, input),
 				Check:  check,
 			},

--- a/builtin/providers/ignition/resource_ignition_systemd_unit.go
+++ b/builtin/providers/ignition/resource_ignition_systemd_unit.go
@@ -12,39 +12,39 @@ func resourceSystemdUnit() *schema.Resource {
 		Exists: resourceSystemdUnitExists,
 		Read:   resourceSystemdUnitRead,
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"enable": &schema.Schema{
+			"enable": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 				ForceNew: true,
 			},
-			"mask": &schema.Schema{
+			"mask": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 			},
-			"content": &schema.Schema{
+			"content": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
-			"dropin": &schema.Schema{
+			"dropin": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Required: true,
 							ForceNew: true,
 						},
-						"content": &schema.Schema{
+						"content": {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
@@ -100,7 +100,7 @@ func buildSystemdUnit(d *schema.ResourceData, c *cache) (string, error) {
 	}
 
 	if err := validateUnitContent(d.Get("content").(string)); err != nil {
-		if err != errEmptyUnit || (err == errEmptyUnit && len(dropins) == 0) {
+		if err != errEmptyUnit {
 			return "", err
 		}
 	}


### PR DESCRIPTION
According to the coreos [documentation](https://coreos.com/ignition/docs/latest/configuration.html), systemd units only require the name attribute per each unit. This can also be validated with the CoreOS config validator. This change allows the `ignition_systemd_unit` resource to no longer fail if given an empty `content` and `dropin`.

Also adds a test to cover this use case.

Fixes: #11325 