### PR TITLE
Destroy Provisioners

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -136,6 +136,9 @@ type Provisioner struct {
 	Type      string
 	RawConfig *RawConfig
 	ConnInfo  *RawConfig
+
+	When      ProvisionerWhen
+	OnFailure ProvisionerOnFailure
 }
 
 // Copy returns a copy of this Provisioner
@@ -144,6 +147,8 @@ func (p *Provisioner) Copy() *Provisioner {
 		Type:      p.Type,
 		RawConfig: p.RawConfig.Copy(),
 		ConnInfo:  p.ConnInfo.Copy(),
+		When:      p.When,
+		OnFailure: p.OnFailure,
 	}
 }
 
@@ -553,7 +558,7 @@ func (c *Config) Validate() error {
 		// Validate DependsOn
 		errs = append(errs, c.validateDependsOn(n, r.DependsOn, resources, modules)...)
 
-		// Verify provisioners don't contain any splats
+		// Verify provisioners
 		for _, p := range r.Provisioners {
 			// This validation checks that there are now splat variables
 			// referencing ourself. This currently is not allowed.
@@ -584,6 +589,17 @@ func (c *Config) Validate() error {
 							"referencing itself", n))
 					break
 				}
+			}
+
+			// Check for invalid when/onFailure values, though this should be
+			// picked up by the loader we check here just in case.
+			if p.When == ProvisionerWhenInvalid {
+				errs = append(errs, fmt.Errorf(
+					"%s: provisioner 'when' value is invalid", n))
+			}
+			if p.OnFailure == ProvisionerOnFailureInvalid {
+				errs = append(errs, fmt.Errorf(
+					"%s: provisioner 'on_failure' value is invalid", n))
 			}
 		}
 

--- a/config/config_string.go
+++ b/config/config_string.go
@@ -214,7 +214,16 @@ func resourcesStr(rs []*Resource) string {
 		if len(r.Provisioners) > 0 {
 			result += fmt.Sprintf("  provisioners\n")
 			for _, p := range r.Provisioners {
-				result += fmt.Sprintf("    %s\n", p.Type)
+				when := ""
+				if p.When != ProvisionerWhenCreate {
+					when = fmt.Sprintf(" (%s)", p.When.String())
+				}
+
+				result += fmt.Sprintf("    %s%s\n", p.Type, when)
+
+				if p.OnFailure != ProvisionerOnFailureFail {
+					result += fmt.Sprintf("      on_failure = %s\n", p.OnFailure.String())
+				}
 
 				ks := make([]string, 0, len(p.RawConfig.Raw))
 				for k, _ := range p.RawConfig.Raw {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -168,6 +168,13 @@ func TestConfigValidate_table(t *testing.T) {
 			true,
 			"data sources cannot have",
 		},
+
+		{
+			"basic provisioners",
+			"validate-basic-provisioners",
+			false,
+			"",
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -629,6 +629,22 @@ func TestLoadFile_provisioners(t *testing.T) {
 	}
 }
 
+func TestLoadFile_provisionersDestroy(t *testing.T) {
+	c, err := LoadFile(filepath.Join(fixtureDir, "provisioners-destroy.tf"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if c == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	actual := resourcesStr(c.Resources)
+	if actual != strings.TrimSpace(provisionerDestroyResourcesStr) {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestLoadFile_unnamedOutput(t *testing.T) {
 	_, err := LoadFile(filepath.Join(fixtureDir, "output-unnamed.tf"))
 	if err == nil {
@@ -1124,6 +1140,17 @@ aws_instance.web (x1)
   vars
     resource: aws_security_group.firewall.foo
     user: var.foo
+`
+
+const provisionerDestroyResourcesStr = `
+aws_instance.web (x1)
+  provisioners
+    shell
+    shell (destroy)
+      path
+    shell (destroy)
+      on_failure = continue
+      path
 `
 
 const connectionResourcesStr = `

--- a/config/provisioner_enums.go
+++ b/config/provisioner_enums.go
@@ -1,0 +1,40 @@
+package config
+
+// ProvisionerWhen is an enum for valid values for when to run provisioners.
+type ProvisionerWhen int
+
+const (
+	ProvisionerWhenInvalid ProvisionerWhen = iota
+	ProvisionerWhenCreate
+	ProvisionerWhenDestroy
+)
+
+var provisionerWhenStrs = map[ProvisionerWhen]string{
+	ProvisionerWhenInvalid: "invalid",
+	ProvisionerWhenCreate:  "create",
+	ProvisionerWhenDestroy: "destroy",
+}
+
+func (v ProvisionerWhen) String() string {
+	return provisionerWhenStrs[v]
+}
+
+// ProvisionerOnFailure is an enum for valid values for on_failure options
+// for provisioners.
+type ProvisionerOnFailure int
+
+const (
+	ProvisionerOnFailureInvalid ProvisionerOnFailure = iota
+	ProvisionerOnFailureContinue
+	ProvisionerOnFailureFail
+)
+
+var provisionerOnFailureStrs = map[ProvisionerOnFailure]string{
+	ProvisionerOnFailureInvalid:  "invalid",
+	ProvisionerOnFailureContinue: "continue",
+	ProvisionerOnFailureFail:     "fail",
+}
+
+func (v ProvisionerOnFailure) String() string {
+	return provisionerOnFailureStrs[v]
+}

--- a/config/test-fixtures/provisioners-destroy.tf
+++ b/config/test-fixtures/provisioners-destroy.tf
@@ -1,0 +1,14 @@
+resource "aws_instance" "web" {
+    provisioner "shell" {}
+
+    provisioner "shell" {
+        path = "foo"
+        when = "destroy"
+    }
+
+    provisioner "shell" {
+        path = "foo"
+        when = "destroy"
+        on_failure = "continue"
+    }
+}

--- a/config/test-fixtures/validate-basic-provisioners/main.tf
+++ b/config/test-fixtures/validate-basic-provisioners/main.tf
@@ -1,0 +1,14 @@
+resource "aws_instance" "web" {
+    provisioner "shell" {}
+
+    provisioner "shell" {
+        path = "foo"
+        when = "destroy"
+    }
+
+    provisioner "shell" {
+        path = "foo"
+        when = "destroy"
+        on_failure = "continue"
+    }
+}

--- a/terraform/debug.go
+++ b/terraform/debug.go
@@ -413,7 +413,7 @@ func (*DebugHook) PreProvision(ii *InstanceInfo, s string) (HookAction, error) {
 	return HookActionContinue, nil
 }
 
-func (*DebugHook) PostProvision(ii *InstanceInfo, s string) (HookAction, error) {
+func (*DebugHook) PostProvision(ii *InstanceInfo, s string, err error) (HookAction, error) {
 	if dbug == nil {
 		return HookActionContinue, nil
 	}

--- a/terraform/debug_test.go
+++ b/terraform/debug_test.go
@@ -156,7 +156,7 @@ func TestDebugHook_nilArgs(t *testing.T) {
 	h.PostApply(nil, nil, nil)
 	h.PostDiff(nil, nil)
 	h.PostImportState(nil, nil)
-	h.PostProvision(nil, "")
+	h.PostProvision(nil, "", nil)
 	h.PostProvisionResource(nil, nil)
 	h.PostRefresh(nil, nil)
 	h.PostStateUpdate(nil)

--- a/terraform/eval_apply.go
+++ b/terraform/eval_apply.go
@@ -160,9 +160,13 @@ func (n *EvalApplyProvisioners) Eval(ctx EvalContext) (interface{}, error) {
 		return nil, nil
 	}
 
+	// taint tells us whether to enable tainting.
+	taint := n.When == config.ProvisionerWhenCreate
+
 	if n.Error != nil && *n.Error != nil {
-		// We're already errored creating, so mark as tainted and continue
-		state.Tainted = true
+		if taint {
+			state.Tainted = true
+		}
 
 		// We're already tainted, so just return out
 		return nil, nil
@@ -182,8 +186,9 @@ func (n *EvalApplyProvisioners) Eval(ctx EvalContext) (interface{}, error) {
 	// if we have one, otherwise we just output it.
 	err := n.apply(ctx, provs)
 	if err != nil {
-		// Provisioning failed, so mark the resource as tainted
-		state.Tainted = true
+		if taint {
+			state.Tainted = true
+		}
 
 		if n.Error != nil {
 			*n.Error = multierror.Append(*n.Error, err)

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -96,13 +96,8 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 		),
 
 		// Provisioner-related transformations
-		GraphTransformIf(
-			func() bool { return !b.Destroy },
-			GraphTransformMulti(
-				&MissingProvisionerTransformer{Provisioners: b.Provisioners},
-				&ProvisionerTransformer{},
-			),
-		),
+		&MissingProvisionerTransformer{Provisioners: b.Provisioners},
+		&ProvisionerTransformer{},
 
 		// Add root variables
 		&RootVariableTransformer{Module: b.Module},

--- a/terraform/graph_test.go
+++ b/terraform/graph_test.go
@@ -88,6 +88,32 @@ func TestGraphWalk_panicWrap(t *testing.T) {
 	}
 }
 
+// testGraphContains is an assertion helper that tests that a node is
+// contained in the graph.
+func testGraphContains(t *testing.T, g *Graph, name string) {
+	for _, v := range g.Vertices() {
+		if dag.VertexName(v) == name {
+			return
+		}
+	}
+
+	t.Fatalf(
+		"Expected %q in:\n\n%s",
+		name, g.String())
+}
+
+// testGraphnotContains is an assertion helper that tests that a node is
+// NOT contained in the graph.
+func testGraphNotContains(t *testing.T, g *Graph, name string) {
+	for _, v := range g.Vertices() {
+		if dag.VertexName(v) == name {
+			t.Fatalf(
+				"Expected %q to NOT be in:\n\n%s",
+				name, g.String())
+		}
+	}
+}
+
 // testGraphHappensBefore is an assertion helper that tests that node
 // A (dag.VertexName value) happens before node B.
 func testGraphHappensBefore(t *testing.T, g *Graph, A, B string) {

--- a/terraform/hook.go
+++ b/terraform/hook.go
@@ -42,7 +42,7 @@ type Hook interface {
 	PreProvisionResource(*InstanceInfo, *InstanceState) (HookAction, error)
 	PostProvisionResource(*InstanceInfo, *InstanceState) (HookAction, error)
 	PreProvision(*InstanceInfo, string) (HookAction, error)
-	PostProvision(*InstanceInfo, string) (HookAction, error)
+	PostProvision(*InstanceInfo, string, error) (HookAction, error)
 	ProvisionOutput(*InstanceInfo, string, string)
 
 	// PreRefresh and PostRefresh are called before and after a single
@@ -92,7 +92,7 @@ func (*NilHook) PreProvision(*InstanceInfo, string) (HookAction, error) {
 	return HookActionContinue, nil
 }
 
-func (*NilHook) PostProvision(*InstanceInfo, string) (HookAction, error) {
+func (*NilHook) PostProvision(*InstanceInfo, string, error) (HookAction, error) {
 	return HookActionContinue, nil
 }
 

--- a/terraform/hook_mock.go
+++ b/terraform/hook_mock.go
@@ -55,6 +55,7 @@ type MockHook struct {
 	PostProvisionCalled        bool
 	PostProvisionInfo          *InstanceInfo
 	PostProvisionProvisionerId string
+	PostProvisionErrorArg      error
 	PostProvisionReturn        HookAction
 	PostProvisionError         error
 
@@ -170,13 +171,14 @@ func (h *MockHook) PreProvision(n *InstanceInfo, provId string) (HookAction, err
 	return h.PreProvisionReturn, h.PreProvisionError
 }
 
-func (h *MockHook) PostProvision(n *InstanceInfo, provId string) (HookAction, error) {
+func (h *MockHook) PostProvision(n *InstanceInfo, provId string, err error) (HookAction, error) {
 	h.Lock()
 	defer h.Unlock()
 
 	h.PostProvisionCalled = true
 	h.PostProvisionInfo = n
 	h.PostProvisionProvisionerId = provId
+	h.PostProvisionErrorArg = err
 	return h.PostProvisionReturn, h.PostProvisionError
 }
 

--- a/terraform/hook_stop.go
+++ b/terraform/hook_stop.go
@@ -38,7 +38,7 @@ func (h *stopHook) PreProvision(*InstanceInfo, string) (HookAction, error) {
 	return h.hook()
 }
 
-func (h *stopHook) PostProvision(*InstanceInfo, string) (HookAction, error) {
+func (h *stopHook) PostProvision(*InstanceInfo, string, error) (HookAction, error) {
 	return h.hook()
 }
 

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -321,6 +321,7 @@ func (n *NodeApplyableResource) evalTreeManagedResource(
 				InterpResource: resource,
 				CreateNew:      &createNew,
 				Error:          &err,
+				When:           config.ProvisionerWhenCreate,
 			},
 			&EvalIf{
 				If: func(ctx EvalContext) (bool, error) {

--- a/terraform/node_resource_apply.go
+++ b/terraform/node_resource_apply.go
@@ -298,6 +298,12 @@ func (n *NodeApplyableResource) evalTreeManagedResource(
 				Name:   stateId,
 				Output: &state,
 			},
+			// Call pre-apply hook
+			&EvalApplyPre{
+				Info:  info,
+				State: &state,
+				Diff:  &diffApply,
+			},
 			&EvalApply{
 				Info:      info,
 				State:     &state,

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -172,6 +172,13 @@ func (n *NodeDestroyResource) EvalTree() EvalNode {
 					State: &state,
 				},
 
+				// Call pre-apply hook
+				&EvalApplyPre{
+					Info:  info,
+					State: &state,
+					Diff:  &diffApply,
+				},
+
 				// Run destroy provisioners if not tainted
 				&EvalIf{
 					If: func(ctx EvalContext) (bool, error) {

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -107,6 +107,17 @@ func (n *NodeDestroyResource) EvalTree() EvalNode {
 		uniqueExtra: "destroy",
 	}
 
+	// Build the resource for eval
+	addr := n.Addr
+	resource := &Resource{
+		Name:       addr.Name,
+		Type:       addr.Type,
+		CountIndex: addr.Index,
+	}
+	if resource.CountIndex < 0 {
+		resource.CountIndex = 0
+	}
+
 	// Get our state
 	rs := n.ResourceState
 	if rs == nil {
@@ -160,6 +171,27 @@ func (n *NodeDestroyResource) EvalTree() EvalNode {
 				&EvalRequireState{
 					State: &state,
 				},
+
+				// Run destroy provisioners if not tainted
+				&EvalIf{
+					If: func(ctx EvalContext) (bool, error) {
+						if state != nil && state.Tainted {
+							return false, nil
+						}
+
+						return true, nil
+					},
+
+					Then: &EvalApplyProvisioners{
+						Info:           info,
+						State:          &state,
+						Resource:       n.Config,
+						InterpResource: resource,
+						Error:          &err,
+						When:           config.ProvisionerWhenDestroy,
+					},
+				},
+
 				// Make sure we handle data sources properly.
 				&EvalIf{
 					If: func(ctx EvalContext) (bool, error) {

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -192,6 +192,20 @@ func (n *NodeDestroyResource) EvalTree() EvalNode {
 					},
 				},
 
+				// If we have a provisioning error, then we just call
+				// the post-apply hook now.
+				&EvalIf{
+					If: func(ctx EvalContext) (bool, error) {
+						return err != nil, nil
+					},
+
+					Then: &EvalApplyPost{
+						Info:  info,
+						State: &state,
+						Error: &err,
+					},
+				},
+
 				// Make sure we handle data sources properly.
 				&EvalIf{
 					If: func(ctx EvalContext) (bool, error) {

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -179,6 +179,10 @@ func (h *HookRecordApplyOrder) PreApply(
 	info *InstanceInfo,
 	s *InstanceState,
 	d *InstanceDiff) (HookAction, error) {
+	if d.Empty() {
+		return HookActionContinue, nil
+	}
+
 	if h.Active {
 		h.l.Lock()
 		defer h.l.Unlock()

--- a/terraform/test-fixtures/apply-provisioner-destroy-continue/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-continue/main.tf
@@ -1,0 +1,15 @@
+resource "aws_instance" "foo" {
+    foo = "bar"
+
+    provisioner "shell" {
+        foo  = "one"
+        when = "destroy"
+        on_failure = "continue"
+    }
+
+    provisioner "shell" {
+        foo  = "two"
+        when = "destroy"
+        on_failure = "continue"
+    }
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy-fail/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-fail/main.tf
@@ -1,0 +1,14 @@
+resource "aws_instance" "foo" {
+    foo = "bar"
+
+    provisioner "shell" {
+        foo  = "one"
+        when = "destroy"
+        on_failure = "continue"
+    }
+
+    provisioner "shell" {
+        foo  = "two"
+        when = "destroy"
+    }
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy/main.tf
@@ -1,0 +1,12 @@
+resource "aws_instance" "foo" {
+    foo = "bar"
+
+    provisioner "shell" {
+        foo = "create"
+    }
+
+    provisioner "shell" {
+        foo  = "destroy"
+        when = "destroy"
+    }
+}

--- a/terraform/test-fixtures/apply-provisioner-fail-continue/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-fail-continue/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "foo" {
+    foo = "bar"
+
+    provisioner "shell" {
+        on_failure = "continue"
+    }
+}

--- a/terraform/test-fixtures/graph-builder-apply-provisioner/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-provisioner/main.tf
@@ -1,0 +1,3 @@
+resource "null_resource" "foo" {
+    provisioner "local" {}
+}

--- a/terraform/transform_deposed.go
+++ b/terraform/transform_deposed.go
@@ -127,6 +127,12 @@ func (n *graphNodeDeposedResource) EvalTree() EvalNode {
 					State:  &state,
 					Output: &diff,
 				},
+				// Call pre-apply hook
+				&EvalApplyPre{
+					Info:  info,
+					State: &state,
+					Diff:  &diff,
+				},
 				&EvalApply{
 					Info:     info,
 					State:    &state,

--- a/terraform/transform_orphan.go
+++ b/terraform/transform_orphan.go
@@ -321,6 +321,11 @@ func (n *graphNodeOrphanResource) managedResourceEvalNodes(info *InstanceInfo) [
 					Name:   n.ResourceKey.String(),
 					Output: &state,
 				},
+				&EvalApplyPre{
+					Info:  info,
+					State: &state,
+					Diff:  &diff,
+				},
 				&EvalApply{
 					Info:     info,
 					State:    &state,

--- a/terraform/transform_resource.go
+++ b/terraform/transform_resource.go
@@ -500,6 +500,11 @@ func (n *graphNodeExpandedResource) managedResourceEvalNodes(resource *Resource,
 					Name:   n.stateId(),
 					Output: &state,
 				},
+				&EvalApplyPre{
+					Info:  info,
+					State: &state,
+					Diff:  &diffApply,
+				},
 				&EvalApply{
 					Info:      info,
 					State:     &state,

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -295,6 +295,9 @@ where `PROVISIONER` is:
 provisioner NAME {
 	CONFIG ...
 
+	[when = "create"|"destroy"]
+	[on_failure = "continue"|"fail"]
+
 	[CONNECTION]
 }
 ```

--- a/website/source/docs/provisioners/index.html.markdown
+++ b/website/source/docs/provisioners/index.html.markdown
@@ -3,15 +3,104 @@ layout: "docs"
 page_title: "Provisioners"
 sidebar_current: "docs-provisioners"
 description: |-
-  When a resource is initially created, provisioners can be executed to initialize that resource. This can be used to add resources to an inventory management system, run a configuration management tool, bootstrap the resource into a cluster, etc.
+  Provisioners are used to execute scripts on a local or remote machine as part of resource creation or destruction.
 ---
 
 # Provisioners
 
-When a resource is initially created, provisioners can be executed to
-initialize that resource. This can be used to add resources to an inventory
-management system, run a configuration management tool, bootstrap the
-resource into a cluster, etc.
+Provisioners are used to execute scripts on a local or remote machine
+as part of resource creation or destruction. Provisioners can be used to
+bootstrap a resource, cleanup before destroy, run configuration management, etc.
 
-Use the navigation to the left to read about the available provisioners.
+Provisioners are added directly to any resource:
 
+```
+resource "aws_instance" "web" {
+    # ...
+
+    provisioner "local-exec" {
+        command = "echo ${self.private_ip_address} > file.txt"
+    }
+}
+```
+
+For provisioners other than local execution, you must specify
+[connection settings](/docs/provisioners/connection.html) so Terraform knows
+how to communicate with the resource.
+
+## Creation-Time Provisioners
+
+Provisioners by default run when the resource they are defined within is
+created. Creation-time provisioners are only run during _creation_, not
+during updating or any other lifecycle. They are meant as a means to perform
+bootstrapping of a system.
+
+If a creation-time provisioner fails, the resource is marked as **tainted**.
+A tainted resource will be planned for destruction and recreation upon the
+next `terraform apply`. Terraform does this because a failed provisioner
+can leave a resource in a semi-configured state. Because Terraform cannot
+reason about what the provisioner does, the only way to ensure proper creation
+of a resource is to recreate it. This is tainting.
+
+You can change this behavior by setting the `on_failure` attribute,
+which is covered in detail below.
+
+## Destroy-Time Provisioners
+
+If `when = "destroy"` is specified, the provisioner will run when the
+resource it is defined within is _destroyed_.
+
+Destroy provisioners are run before the resource is destroyed. If they
+fail, Terraform will error and rerun the provisioners again on the next
+`terraform apply`. Due to this behavior, care should be taken for destroy
+provisioners to be safe to run multiple times.
+
+## Multiple Provisioners
+
+Multiple provisioners can be specified within a resource. Multiple provisioners
+are executed in the order they're defined in the configuration file.
+
+You may also mix and match creation and destruction provisioners. Only
+the provisioners that are valid for a given operation will be run. Those
+valid provisioners will be run in the order they're defined in the configuration
+file.
+
+Example of multiple provisioners:
+
+```
+resource "aws_instance" "web" {
+    # ...
+
+    provisioner "local-exec" {
+        command = "echo first"
+    }
+
+    provisioner "local-exec" {
+        command = "echo second"
+    }
+}
+```
+
+## Failure Behavior
+
+By default, provisioners that fail will also cause the Terraform apply
+itself to error. The `on_failure` setting can be used to change this. The
+allowed values are:
+
+  * `"continue"` - Ignore the error and continue with creation or destruction.
+
+  * `"fail"` - Error (the default behavior). If this is a creation provisioner,
+    taint the resource.
+
+Example:
+
+```
+resource "aws_instance" "web" {
+    # ...
+
+    provisioner "local-exec" {
+        command = "echo ${self.private_ip_address} > file.txt"
+        on_failure = "continue"
+    }
+}
+```

--- a/website/source/intro/getting-started/provision.html.md
+++ b/website/source/intro/getting-started/provision.html.md
@@ -100,6 +100,20 @@ If you create an execution plan with a tainted resource, however, the
 plan will clearly state that the resource will be destroyed because
 it is tainted.
 
+## Destroy Provisioners
+
+Provisioners can also be defined that run only during a destroy
+operation. These are useful for performing system cleanup, extracting
+data, etc.
+
+For many resources, using built-in cleanup mechanisms is recommended
+if possible (such as init scripts), but provisioners can be used if
+necessary.
+
+The getting started guide won't show any destroy provisioner examples.
+If you need to use destroy provisioners, please
+[see the provisioner documentation](/docs/provisioners).
+
 ## Next
 
 Provisioning is important for being able to bootstrap instances.


### PR DESCRIPTION
Fixes #386 

I'm going to go light on the details in this PR description since there is a really good discussion and RFC in #386. You can also view the website changes in this PR to see how it works!

Highlights:

  * Provisioners that run during destruction
  * Option `on_failure` to determine behavior when a provisioner fails (works for both create and destroy provisioners)