### PR TITLE
provider/aws: Add 'aws_canonical_user_id' data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_canonical_user_id.go
+++ b/builtin/providers/aws/data_source_aws_canonical_user_id.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCanonicalUserId() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCanonicalUserIdRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"display_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCanonicalUserIdRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).s3conn
+
+	log.Printf("[DEBUG] Listing S3 buckets.")
+
+	req := &s3.ListBucketsInput{}
+	resp, err := conn.ListBuckets(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil || resp.Owner == nil {
+		return fmt.Errorf("no canonical user ID found")
+	}
+
+	d.SetId(aws.StringValue(resp.Owner.ID))
+	d.Set("id", resp.Owner.ID)
+	d.Set("display_name", resp.Owner.DisplayName)
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_canonical_user_id_test.go
+++ b/builtin/providers/aws/data_source_aws_canonical_user_id_test.go
@@ -1,0 +1,52 @@
+// make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccDataSourceAwsCanonicalUserId_'
+
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsCanonicalUserId_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsCanonicalUserIdConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsCanonicalUserIdCheckExists("data.aws_canonical_user_id.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsCanonicalUserIdCheckExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Can't find Canonical User ID resource: %s", name)
+		}
+
+		if rs.Primary.Attributes["id"] == "" {
+			return fmt.Errorf("Missing Canonical User ID")
+		}
+		if rs.Primary.Attributes["display_name"] == "" {
+			return fmt.Errorf("Missing Display Name")
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceAwsCanonicalUserIdConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+data "aws_canonical_user_id" "current" { }
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -152,6 +152,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_availability_zones":       dataSourceAwsAvailabilityZones(),
 			"aws_billing_service_account":  dataSourceAwsBillingServiceAccount(),
 			"aws_caller_identity":          dataSourceAwsCallerIdentity(),
+			"aws_canonical_user_id":        dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_stack":     dataSourceAwsCloudFormationStack(),
 			"aws_ebs_snapshot":             dataSourceAwsEbsSnapshot(),
 			"aws_ebs_volume":               dataSourceAwsEbsVolume(),

--- a/website/source/docs/providers/aws/d/canonical_user_id.html.markdown
+++ b/website/source/docs/providers/aws/d/canonical_user_id.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "aws"
+page_title: "AWS: aws_canonical_user_id"
+sidebar_current: "docs-aws-canonical-user-id"
+description: |-
+  Provides the canonical user ID for the AWS account associated with the provider
+  connection to AWS.
+---
+
+# aws\_canonical\_user\_id
+
+The Canonical User ID data source allows access to the [canonical user ID](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html)
+for the effective account in which Terraform is working.
+
+## Example Usage
+
+```
+data "aws_canonical_user_id" "current" { }
+
+output "canonical_user_id" {
+  value = "${data.aws_canonical_user_id.current.id}"
+}
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The canonical user ID associated with the AWS account.
+
+* `display_name` - The human-friendly name linked to the canonical user ID.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -38,6 +38,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-caller-identity") %>>
                           <a href="/docs/providers/aws/d/caller_identity.html">aws_caller_identity</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-canonical-user-id") %>>
+                            <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-cloudformation-stack") %>>
                             <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
                         </li>


### PR DESCRIPTION
Provides details about the [canonical user ID](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html) for the effective account in which Terraform is working.
Acceptance test:
```
 make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccDataSourceAwsCanonicalUserId_'
```