### PR TITLE
provider/aws: Wait until ALB is actually provisioned

### DIFF
--- a/builtin/providers/aws/data_source_aws_alb_listener_test.go
+++ b/builtin/providers/aws/data_source_aws_alb_listener_test.go
@@ -74,7 +74,7 @@ func testAccDataSourceAWSALBListenerConfigBasic(albName, targetGroupName string)
 
 resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
@@ -219,6 +219,14 @@ resource "aws_vpc" "alb_test" {
   tags {
     TestName = "TestAccAWSALB_basic"
   }
+}
+
+resource "aws_internet_gateway" "gw" {
+    vpc_id = "${aws_vpc.alb_test.id}"
+
+    tags {
+        TestName = "TestAccAWSALB_basic"
+    }
 }
 
 resource "aws_subnet" "alb_test" {

--- a/builtin/providers/aws/data_source_aws_alb_test.go
+++ b/builtin/providers/aws/data_source_aws_alb_test.go
@@ -19,7 +19,7 @@ func TestAccDataSourceAWSALB_basic(t *testing.T) {
 				Config: testAccDataSourceAWSALBConfigBasic(albName),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "name", albName),
-					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "internal", "false"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "internal", "true"),
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "subnets.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_arn", "tags.%", "1"),
@@ -31,7 +31,7 @@ func TestAccDataSourceAWSALB_basic(t *testing.T) {
 					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_arn", "dns_name"),
 					resource.TestCheckResourceAttrSet("data.aws_alb.alb_test_with_arn", "arn"),
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "name", albName),
-					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "internal", "false"),
+					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "internal", "true"),
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "subnets.#", "2"),
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("data.aws_alb.alb_test_with_name", "tags.%", "1"),
@@ -51,7 +51,7 @@ func TestAccDataSourceAWSALB_basic(t *testing.T) {
 func testAccDataSourceAWSALBConfigBasic(albName string) string {
 	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 

--- a/builtin/providers/aws/resource_aws_alb_listener_rule_test.go
+++ b/builtin/providers/aws/resource_aws_alb_listener_rule_test.go
@@ -133,7 +133,7 @@ resource "aws_alb_listener" "front_end" {
 
 resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 

--- a/builtin/providers/aws/resource_aws_alb_listener_test.go
+++ b/builtin/providers/aws/resource_aws_alb_listener_test.go
@@ -148,7 +148,7 @@ func testAccAWSALBListenerConfig_basic(albName, targetGroupName string) string {
 
 resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
@@ -289,6 +289,14 @@ resource "aws_vpc" "alb_test" {
   tags {
     TestName = "TestAccAWSALB_basic"
   }
+}
+
+resource "aws_internet_gateway" "gw" {
+    vpc_id = "${aws_vpc.alb_test.id}"
+
+    tags {
+        TestName = "TestAccAWSALB_basic"
+    }
 }
 
 resource "aws_subnet" "alb_test" {

--- a/builtin/providers/aws/resource_aws_alb_test.go
+++ b/builtin/providers/aws/resource_aws_alb_test.go
@@ -60,7 +60,7 @@ func TestAccAWSALB_basic(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "name", albName),
-					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "false"),
+					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "true"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "subnets.#", "2"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "tags.%", "1"),
@@ -197,7 +197,7 @@ func TestAccAWSALB_noSecurityGroup(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "name", albName),
-					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "false"),
+					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "true"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "subnets.#", "2"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "tags.%", "1"),
@@ -229,7 +229,7 @@ func TestAccAWSALB_accesslogs(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "name", albName),
-					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "false"),
+					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "true"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "subnets.#", "2"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "tags.%", "1"),
@@ -247,7 +247,7 @@ func TestAccAWSALB_accesslogs(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "name", albName),
-					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "false"),
+					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "true"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "subnets.#", "2"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "tags.%", "1"),
@@ -269,7 +269,7 @@ func TestAccAWSALB_accesslogs(t *testing.T) {
 				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "name", albName),
-					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "false"),
+					resource.TestCheckResourceAttr("aws_alb.alb_test", "internal", "true"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "subnets.#", "2"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "security_groups.#", "1"),
 					resource.TestCheckResourceAttr("aws_alb.alb_test", "tags.%", "1"),
@@ -362,7 +362,7 @@ func testAccCheckAWSALBDestroy(s *terraform.State) error {
 func testAccAWSALBConfig_basic(albName string) string {
 	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
@@ -429,7 +429,7 @@ resource "aws_security_group" "alb_test" {
 func testAccAWSALBConfig_generatedName() string {
 	return fmt.Sprintf(`
 resource "aws_alb" "alb_test" {
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
@@ -453,6 +453,14 @@ resource "aws_vpc" "alb_test" {
 
   tags {
     TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  tags {
+    Name = "TestAccAWSALB_basic"
   }
 }
 
@@ -497,7 +505,7 @@ func testAccAWSALBConfig_namePrefix() string {
 	return fmt.Sprintf(`
 resource "aws_alb" "alb_test" {
   name_prefix     = "tf-lb"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
@@ -563,7 +571,7 @@ resource "aws_security_group" "alb_test" {
 func testAccAWSALBConfig_updatedTags(albName string) string {
 	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
@@ -631,7 +639,7 @@ resource "aws_security_group" "alb_test" {
 func testAccAWSALBConfig_accessLogs(enabled bool, albName, bucketName string) string {
 	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
@@ -742,7 +750,7 @@ resource "aws_security_group" "alb_test" {
 func testAccAWSALBConfig_nosg(albName string) string {
 	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 
   idle_timeout = 30
@@ -784,7 +792,7 @@ resource "aws_subnet" "alb_test" {
 func testAccAWSALBConfig_updateSecurityGroups(albName string) string {
 	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
   name            = "%s"
-  internal        = false
+  internal        = true
   security_groups = ["${aws_security_group.alb_test.id}", "${aws_security_group.alb_test_2.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]
 


### PR DESCRIPTION
This is to bring ALBs in line with conventions we apply to most (hopefully all) other resources - which is that Terraform should always hand over resource only when it's actually ready.

### Public ALBs need IGW

We had a bunch of tests creating basically useless ALBs - until now unnoticed - specifically public ALBs in VPCs w/out IGW - hence no internet access. The ALB state from API reflects this issue in a way that the ALB remains stuck in `provisioning` state if it has no IGW and is set to public.

This is why these tests started to timeout - so I decided to either add IGW or make ALBs private to rectify that and test both cases.

I have also opened AWS support ticket in regards to confusing behaviour - I'd expect the ALB to reach `failed` state rather than stuck in `provisioning`.

### Test plan

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSALB'
```
```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/21 22:01:00 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSALB -timeout 120m
=== RUN   TestAccDataSourceAWSALBListener_basic
--- PASS: TestAccDataSourceAWSALBListener_basic (230.98s)
=== RUN   TestAccDataSourceAWSALBListener_https
--- PASS: TestAccDataSourceAWSALBListener_https (267.07s)
=== RUN   TestAccDataSourceAWSALB_basic
--- PASS: TestAccDataSourceAWSALB_basic (233.23s)
=== RUN   TestAccAWSALBListenerRule_basic
--- PASS: TestAccAWSALBListenerRule_basic (214.98s)
=== RUN   TestAccAWSALBListener_basic
--- PASS: TestAccAWSALBListener_basic (221.04s)
=== RUN   TestAccAWSALBListener_https
--- PASS: TestAccAWSALBListener_https (232.37s)
=== RUN   TestAccAWSALBTargetGroupAttachment_basic
--- PASS: TestAccAWSALBTargetGroupAttachment_basic (138.31s)
=== RUN   TestAccAWSALBTargetGroup_basic
--- PASS: TestAccAWSALBTargetGroup_basic (50.28s)
=== RUN   TestAccAWSALBTargetGroup_changeNameForceNew
--- PASS: TestAccAWSALBTargetGroup_changeNameForceNew (81.47s)
=== RUN   TestAccAWSALBTargetGroup_changeProtocolForceNew
--- PASS: TestAccAWSALBTargetGroup_changeProtocolForceNew (90.64s)
=== RUN   TestAccAWSALBTargetGroup_changePortForceNew
--- PASS: TestAccAWSALBTargetGroup_changePortForceNew (80.78s)
=== RUN   TestAccAWSALBTargetGroup_changeVpcForceNew
--- PASS: TestAccAWSALBTargetGroup_changeVpcForceNew (75.31s)
=== RUN   TestAccAWSALBTargetGroup_tags
--- PASS: TestAccAWSALBTargetGroup_tags (79.58s)
=== RUN   TestAccAWSALBTargetGroup_updateHealthCheck
--- PASS: TestAccAWSALBTargetGroup_updateHealthCheck (83.79s)
=== RUN   TestAccAWSALBTargetGroup_updateSticknessEnabled
--- PASS: TestAccAWSALBTargetGroup_updateSticknessEnabled (124.40s)
=== RUN   TestAccAWSALB_basic
--- PASS: TestAccAWSALB_basic (242.37s)
=== RUN   TestAccAWSALB_generatedName
--- PASS: TestAccAWSALB_generatedName (237.67s)
=== RUN   TestAccAWSALB_namePrefix
--- PASS: TestAccAWSALB_namePrefix (227.96s)
=== RUN   TestAccAWSALB_tags
--- PASS: TestAccAWSALB_tags (254.12s)
=== RUN   TestAccAWSALB_updatedSecurityGroups
--- PASS: TestAccAWSALB_updatedSecurityGroups (274.04s)
=== RUN   TestAccAWSALB_noSecurityGroup
--- PASS: TestAccAWSALB_noSecurityGroup (244.23s)
=== RUN   TestAccAWSALB_accesslogs
--- PASS: TestAccAWSALB_accesslogs (303.34s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	3988.009s
```

### Breaking change (?)

Creation of ALBs in some cases will (rightly) begin to time out for user as explained above, but the ALB remains in the state, hence I'd not treat that as BC. We just bring the error closer to the user.