### PR TITLE
docs/aws: Fix misdocumented placement_strategy block

### DIFF
--- a/website/source/docs/providers/aws/r/ecs_service.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_service.html.markdown
@@ -56,8 +56,7 @@ The following arguments are supported:
 * `deployment_minimum_healthy_percent` - (Optional) The lower limit (as a percentage of the service's desiredCount) of the number of running tasks that must remain running and healthy in a service during a deployment.
 * `placement_strategy` - (Optional) Service level strategy rules that are taken
 into consideration during task placement. The maximum number of
-`placement_strategy` blocks is `5`. See [the related docs](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html) for
-details on attributes.
+`placement_strategy` blocks is `5`. Defined below.
 * `load_balancer` - (Optional) A load balancer block. Load balancers documented below.
 * `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of
 `placement_constraints` is `10`. Defined below.
@@ -70,6 +69,16 @@ Load balancers support the following:
 * `target_group_arn` - (Required for ALB) The ARN of the ALB target group to associate with the service.
 * `container_name` - (Required) The name of the container to associate with the load balancer (as it appears in a container definition).
 * `container_port` - (Required) The port on the container to associate with the load balancer.
+
+## placement_strategy
+
+`placement_strategy` supports the following:
+
+* `type` - (Required) The type of placement strategy. Must be one of: `binpack`, `random`, or `spread`
+* `field` - (Optional) For the `spread` placement strategy, valid values are instanceId (or host,
+ which has the same effect), or any platform or custom attribute that is applied to a container instance.
+ For the `binpack` type, valid values are `memory` and `cpu`. For the `random` type, this attribute is not
+ needed. For more information, see [Placement Strategy](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PlacementStrategy.html).
 
 ## placement_constraints
 

--- a/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_task_definition.html.markdown
@@ -81,8 +81,6 @@ official [Developer Guide](https://docs.aws.amazon.com/AmazonECS/latest/develope
 * `volume` - (Optional) A volume block. See below for details about what arguments are supported.
 * `placement_constraints` - (Optional) rules that are taken into consideration during task placement. Maximum number of 
 `placement_constraints` is `10`. Defined below.
-* `placement_strategy` - (Optional) an algorithm for selecting instances for task placement or tasks for termination. Maximum
-number of `placement_strategy` blocks is `5`. Defined below.
 
 Volume block supports the following arguments:
 
@@ -100,17 +98,6 @@ for the `distinctInstance` type.
 For more information, see [Cluster Query Language in the Amazon EC2 Container
 Service Developer
 Guide](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/cluster-query-language.html).
-
-## placement_strategy
-
-`placement_strategy` supports the following:
-
-* `type` - (Required) The type of placement strategy. Must be one of: `binpack`, `random`, or `spread`
-* `field` - (Optional) For the `spread` placement strategy, valid values are instanceId (or host,
- which has the same effect), or any platform or custom attribute that is applied to a container instance.
- For the `binpack` type, valid values are `memory` and `cpu`. For the `random` type, this attribute is not
- needed. For more information, see [Placement Strategy](http://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_PlacementStrategy.html).
-
 
 
 ## Attributes Reference


### PR DESCRIPTION
Introduced in https://github.com/hashicorp/terraform/pull/11298

`placement_strategy` is ECS Service's attribute, not Task Definition's. 😉 