### PR TITLE
provider/aws: Remove MaxFrameRate default on Elastictranscoder Preset

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_transcoder_preset.go
+++ b/builtin/providers/aws/resource_aws_elastic_transcoder_preset.go
@@ -212,7 +212,6 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 						},
 						"max_frame_rate": &schema.Schema{
 							Type:     schema.TypeString,
-							Default:  "30",
 							Optional: true,
 							ForceNew: true,
 						},


### PR DESCRIPTION
Fixes #9847 by just removing the default and have the default be set by the AWS API instead.
This resolves the ability to set a fixed frame rate.