### PR TITLE
core: New Refresh Graph

### DIFF
--- a/terraform/context_graph_type.go
+++ b/terraform/context_graph_type.go
@@ -10,6 +10,7 @@ type GraphType byte
 const (
 	GraphTypeInvalid GraphType = 0
 	GraphTypeLegacy  GraphType = iota
+	GraphTypeRefresh
 	GraphTypePlan
 	GraphTypePlanDestroy
 	GraphTypeApply
@@ -22,5 +23,6 @@ var GraphTypeMap = map[string]GraphType{
 	"apply":        GraphTypeApply,
 	"plan":         GraphTypePlan,
 	"plan-destroy": GraphTypePlanDestroy,
+	"refresh":      GraphTypeRefresh,
 	"legacy":       GraphTypeLegacy,
 }

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -520,7 +520,7 @@ func TestContext2Refresh_outputPartial(t *testing.T) {
 	}
 }
 
-func TestContext2Refresh_state(t *testing.T) {
+func TestContext2Refresh_stateBasic(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "refresh-basic")
 	state := &State{
@@ -529,6 +529,7 @@ func TestContext2Refresh_state(t *testing.T) {
 				Path: rootModulePath,
 				Resources: map[string]*ResourceState{
 					"aws_instance.web": &ResourceState{
+						Type: "aws_instance",
 						Primary: &InstanceState{
 							ID: "bar",
 						},
@@ -737,6 +738,21 @@ func TestContext2Refresh_unknownProvider(t *testing.T) {
 	ctx := testContext2(t, &ContextOpts{
 		Module:    m,
 		Providers: map[string]ResourceProviderFactory{},
+		State: &State{
+			Modules: []*ModuleState{
+				&ModuleState{
+					Path: rootModulePath,
+					Resources: map[string]*ResourceState{
+						"aws_instance.web": &ResourceState{
+							Type: "aws_instance",
+							Primary: &InstanceState{
+								ID: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
 	})
 
 	if _, err := ctx.Refresh(); err == nil {

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -56,7 +56,9 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 
 	concreteResource := func(a *NodeAbstractResource) dag.Vertex {
 		return &NodePlannableResource{
-			NodeAbstractResource: a,
+			NodeAbstractCountResource: &NodeAbstractCountResource{
+				NodeAbstractResource: a,
+			},
 		}
 	}
 

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -1,0 +1,121 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/config/module"
+	"github.com/hashicorp/terraform/dag"
+)
+
+// RefreshGraphBuilder implements GraphBuilder and is responsible for building
+// a graph for refreshing (updating the Terraform state).
+//
+// The primary difference between this graph and others:
+//
+//   * Based on the state since it represents the only resources that
+//     need to be refreshed.
+//
+//   * Ignores lifecycle options since no lifecycle events occur here. This
+//     simplifies the graph significantly since complex transforms such as
+//     create-before-destroy can be completely ignored.
+//
+type RefreshGraphBuilder struct {
+	// Module is the root module for the graph to build.
+	Module *module.Tree
+
+	// State is the current state
+	State *State
+
+	// Providers is the list of providers supported.
+	Providers []string
+
+	// Targets are resources to target
+	Targets []string
+
+	// DisableReduce, if true, will not reduce the graph. Great for testing.
+	DisableReduce bool
+
+	// Validate will do structural validation of the graph.
+	Validate bool
+}
+
+// See GraphBuilder
+func (b *RefreshGraphBuilder) Build(path []string) (*Graph, error) {
+	return (&BasicGraphBuilder{
+		Steps:    b.Steps(),
+		Validate: b.Validate,
+		Name:     "RefreshGraphBuilder",
+	}).Build(path)
+}
+
+// See GraphBuilder
+func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
+	// Custom factory for creating providers.
+	concreteProvider := func(a *NodeAbstractProvider) dag.Vertex {
+		return &NodeApplyableProvider{
+			NodeAbstractProvider: a,
+		}
+	}
+
+	concreteResource := func(a *NodeAbstractResource) dag.Vertex {
+		return &NodeRefreshableResource{
+			NodeAbstractResource: a,
+		}
+	}
+
+	steps := []GraphTransformer{
+		// Creates all the resources represented in the state
+		&StateTransformer{
+			Concrete: concreteResource,
+			State:    b.State,
+		},
+
+		// Creates all the data resources that aren't in the state
+		&ConfigTransformer{
+			Concrete:   concreteResource,
+			Module:     b.Module,
+			Unique:     true,
+			ModeFilter: true,
+			Mode:       config.DataResourceMode,
+		},
+
+		// Attach the state
+		&AttachStateTransformer{State: b.State},
+
+		// Attach the configuration to any resources
+		&AttachResourceConfigTransformer{Module: b.Module},
+
+		// Add root variables
+		&RootVariableTransformer{Module: b.Module},
+
+		// Create all the providers
+		&MissingProviderTransformer{Providers: b.Providers, Concrete: concreteProvider},
+		&ProviderTransformer{},
+		&DisableProviderTransformer{},
+		&ParentProviderTransformer{},
+		&AttachProviderConfigTransformer{Module: b.Module},
+
+		// Add the outputs
+		&OutputTransformer{Module: b.Module},
+
+		// Add module variables
+		&ModuleVariableTransformer{Module: b.Module},
+
+		// Connect so that the references are ready for targeting. We'll
+		// have to connect again later for providers and so on.
+		&ReferenceTransformer{},
+
+		// Target
+		&TargetsTransformer{Targets: b.Targets},
+
+		// Single root
+		&RootTransformer{},
+	}
+
+	if !b.DisableReduce {
+		// Perform the transitive reduction to make our graph a bit
+		// more sane if possible (it usually is possible).
+		steps = append(steps, &TransitiveReductionTransformer{})
+	}
+
+	return steps
+}

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -62,6 +62,14 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 		}
 	}
 
+	concreteDataResource := func(a *NodeAbstractResource) dag.Vertex {
+		return &NodeRefreshableDataResource{
+			NodeAbstractCountResource: &NodeAbstractCountResource{
+				NodeAbstractResource: a,
+			},
+		}
+	}
+
 	steps := []GraphTransformer{
 		// Creates all the resources represented in the state
 		&StateTransformer{
@@ -71,7 +79,7 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 
 		// Creates all the data resources that aren't in the state
 		&ConfigTransformer{
-			Concrete:   concreteResource,
+			Concrete:   concreteDataResource,
 			Module:     b.Module,
 			Unique:     true,
 			ModeFilter: true,

--- a/terraform/graphtype_string.go
+++ b/terraform/graphtype_string.go
@@ -4,9 +4,9 @@ package terraform
 
 import "fmt"
 
-const _GraphType_name = "GraphTypeInvalidGraphTypeLegacyGraphTypePlanGraphTypePlanDestroyGraphTypeApply"
+const _GraphType_name = "GraphTypeInvalidGraphTypeLegacyGraphTypeRefreshGraphTypePlanGraphTypePlanDestroyGraphTypeApply"
 
-var _GraphType_index = [...]uint8{0, 16, 31, 44, 64, 78}
+var _GraphType_index = [...]uint8{0, 16, 31, 47, 60, 80, 94}
 
 func (i GraphType) String() string {
 	if i >= GraphType(len(_GraphType_index)-1) {

--- a/terraform/node_data_refresh.go
+++ b/terraform/node_data_refresh.go
@@ -1,0 +1,209 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/dag"
+)
+
+// NodeRefreshableDataResource represents a resource that is "plannable":
+// it is ready to be planned in order to create a diff.
+type NodeRefreshableDataResource struct {
+	*NodeAbstractCountResource
+}
+
+// GraphNodeDynamicExpandable
+func (n *NodeRefreshableDataResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
+	// Grab the state which we read
+	state, lock := ctx.State()
+	lock.RLock()
+	defer lock.RUnlock()
+
+	// Expand the resource count which must be available by now from EvalTree
+	count, err := n.Config.Count()
+	if err != nil {
+		return nil, err
+	}
+
+	// The concrete resource factory we'll use
+	concreteResource := func(a *NodeAbstractResource) dag.Vertex {
+		// Add the config and state since we don't do that via transforms
+		a.Config = n.Config
+
+		return &NodeRefreshableDataResourceInstance{
+			NodeAbstractResource: a,
+		}
+	}
+
+	// Start creating the steps
+	steps := []GraphTransformer{
+		// Expand the count.
+		&ResourceCountTransformer{
+			Concrete: concreteResource,
+			Count:    count,
+			Addr:     n.ResourceAddr(),
+		},
+
+		// Attach the state
+		&AttachStateTransformer{State: state},
+
+		// Targeting
+		&TargetsTransformer{ParsedTargets: n.Targets},
+
+		// Connect references so ordering is correct
+		&ReferenceTransformer{},
+
+		// Make sure there is a single root
+		&RootTransformer{},
+	}
+
+	// Build the graph
+	b := &BasicGraphBuilder{
+		Steps:    steps,
+		Validate: true,
+		Name:     "NodeRefreshableDataResource",
+	}
+
+	return b.Build(ctx.Path())
+}
+
+// NodeRefreshableDataResourceInstance represents a _single_ resource instance
+// that is refreshable.
+type NodeRefreshableDataResourceInstance struct {
+	*NodeAbstractResource
+}
+
+// GraphNodeEvalable
+func (n *NodeRefreshableDataResourceInstance) EvalTree() EvalNode {
+	addr := n.NodeAbstractResource.Addr
+
+	// stateId is the ID to put into the state
+	stateId := addr.stateId()
+
+	// Build the instance info. More of this will be populated during eval
+	info := &InstanceInfo{
+		Id:   stateId,
+		Type: addr.Type,
+	}
+
+	// Get the state if we have it, if not we build it
+	rs := n.ResourceState
+	if rs == nil {
+		rs = &ResourceState{}
+	}
+
+	// If the config isn't empty we update the state
+	if n.Config != nil {
+		// Determine the dependencies for the state. We use some older
+		// code for this that we've used for a long time.
+		var stateDeps []string
+		{
+			oldN := &graphNodeExpandedResource{
+				Resource: n.Config,
+				Index:    addr.Index,
+			}
+			stateDeps = oldN.StateDependencies()
+		}
+
+		rs = &ResourceState{
+			Type:         n.Config.Type,
+			Provider:     n.Config.Provider,
+			Dependencies: stateDeps,
+		}
+	}
+
+	// Build the resource for eval
+	resource := &Resource{
+		Name:       addr.Name,
+		Type:       addr.Type,
+		CountIndex: addr.Index,
+	}
+	if resource.CountIndex < 0 {
+		resource.CountIndex = 0
+	}
+
+	// Declare a bunch of variables that are used for state during
+	// evaluation. Most of this are written to by-address below.
+	var config *ResourceConfig
+	var diff *InstanceDiff
+	var provider ResourceProvider
+	var state *InstanceState
+
+	return &EvalSequence{
+		Nodes: []EvalNode{
+			// Always destroy the existing state first, since we must
+			// make sure that values from a previous read will not
+			// get interpolated if we end up needing to defer our
+			// loading until apply time.
+			&EvalWriteState{
+				Name:         stateId,
+				ResourceType: rs.Type,
+				Provider:     rs.Provider,
+				Dependencies: rs.Dependencies,
+				State:        &state, // state is nil here
+			},
+
+			&EvalInterpolate{
+				Config:   n.Config.RawConfig.Copy(),
+				Resource: resource,
+				Output:   &config,
+			},
+
+			// The rest of this pass can proceed only if there are no
+			// computed values in our config.
+			// (If there are, we'll deal with this during the plan and
+			// apply phases.)
+			&EvalIf{
+				If: func(ctx EvalContext) (bool, error) {
+					if config.ComputedKeys != nil && len(config.ComputedKeys) > 0 {
+						return true, EvalEarlyExitError{}
+					}
+
+					// If the config explicitly has a depends_on for this
+					// data source, assume the intention is to prevent
+					// refreshing ahead of that dependency.
+					if len(n.Config.DependsOn) > 0 {
+						return true, EvalEarlyExitError{}
+					}
+
+					return true, nil
+				},
+
+				Then: EvalNoop{},
+			},
+
+			// The remainder of this pass is the same as running
+			// a "plan" pass immediately followed by an "apply" pass,
+			// populating the state early so it'll be available to
+			// provider configurations that need this data during
+			// refresh/plan.
+			&EvalGetProvider{
+				Name:   n.ProvidedBy()[0],
+				Output: &provider,
+			},
+
+			&EvalReadDataDiff{
+				Info:        info,
+				Config:      &config,
+				Provider:    &provider,
+				Output:      &diff,
+				OutputState: &state,
+			},
+
+			&EvalReadDataApply{
+				Info:     info,
+				Diff:     &diff,
+				Provider: &provider,
+				Output:   &state,
+			},
+
+			&EvalWriteState{
+				Name:         stateId,
+				ResourceType: rs.Type,
+				Provider:     rs.Provider,
+				Dependencies: rs.Dependencies,
+				State:        &state,
+			},
+
+			&EvalUpdateStateHook{},
+		},
+	}
+}

--- a/terraform/node_resource_abstract_count.go
+++ b/terraform/node_resource_abstract_count.go
@@ -1,0 +1,27 @@
+package terraform
+
+// NodeAbstractCountResource should be embedded instead of NodeAbstractResource
+// if the resource has a `count` value that needs to be expanded.
+//
+// The embedder should implement `DynamicExpand` to process the count.
+type NodeAbstractCountResource struct {
+	*NodeAbstractResource
+}
+
+// GraphNodeEvalable
+func (n *NodeAbstractCountResource) EvalTree() EvalNode {
+	return &EvalSequence{
+		Nodes: []EvalNode{
+			// The EvalTree for a plannable resource primarily involves
+			// interpolating the count since it can contain variables
+			// we only just received access to.
+			//
+			// With the interpolated count, we can then DynamicExpand
+			// into the proper number of instances.
+			&EvalInterpolate{Config: n.Config.RawCount},
+
+			&EvalCountCheckComputed{Resource: n.Config},
+			&EvalCountFixZeroOneBoundary{Resource: n.Config},
+		},
+	}
+}

--- a/terraform/node_resource_plan.go
+++ b/terraform/node_resource_plan.go
@@ -7,34 +7,7 @@ import (
 // NodePlannableResource represents a resource that is "plannable":
 // it is ready to be planned in order to create a diff.
 type NodePlannableResource struct {
-	*NodeAbstractResource
-
-	// Set by GraphNodeTargetable and used during DynamicExpand to
-	// forward targets downwards.
-	targets []ResourceAddress
-}
-
-// GraphNodeTargetable
-func (n *NodePlannableResource) SetTargets(targets []ResourceAddress) {
-	n.targets = targets
-}
-
-// GraphNodeEvalable
-func (n *NodePlannableResource) EvalTree() EvalNode {
-	return &EvalSequence{
-		Nodes: []EvalNode{
-			// The EvalTree for a plannable resource primarily involves
-			// interpolating the count since it can contain variables
-			// we only just received access to.
-			//
-			// With the interpolated count, we can then DynamicExpand
-			// into the proper number of instances.
-			&EvalInterpolate{Config: n.Config.RawCount},
-
-			&EvalCountCheckComputed{Resource: n.Config},
-			&EvalCountFixZeroOneBoundary{Resource: n.Config},
-		},
-	}
+	*NodeAbstractCountResource
 }
 
 // GraphNodeDynamicExpandable
@@ -91,7 +64,7 @@ func (n *NodePlannableResource) DynamicExpand(ctx EvalContext) (*Graph, error) {
 		&AttachStateTransformer{State: state},
 
 		// Targeting
-		&TargetsTransformer{ParsedTargets: n.targets},
+		&TargetsTransformer{ParsedTargets: n.Targets},
 
 		// Connect references so ordering is correct
 		&ReferenceTransformer{},

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -24,7 +24,11 @@ func (n *NodeRefreshableResource) EvalTree() EvalNode {
 	case config.ManagedResourceMode:
 		return n.evalTreeManagedResource()
 	case config.DataResourceMode:
-		return n.evalTreeDataResource()
+		dn := &NodeRefreshableDataResourceInstance{
+			NodeAbstractResource: n.NodeAbstractResource,
+		}
+
+		return dn.EvalTree()
 	default:
 		panic(fmt.Errorf("unsupported resource mode %s", mode))
 	}
@@ -81,142 +85,6 @@ func (n *NodeRefreshableResource) evalTreeManagedResource() EvalNode {
 				Dependencies: n.ResourceState.Dependencies,
 				State:        &state,
 			},
-		},
-	}
-}
-
-func (n *NodeRefreshableResource) evalTreeDataResource() EvalNode {
-	addr := n.NodeAbstractResource.Addr
-
-	// stateId is the ID to put into the state
-	stateId := addr.stateId()
-
-	// Build the instance info. More of this will be populated during eval
-	info := &InstanceInfo{
-		Id:   stateId,
-		Type: addr.Type,
-	}
-
-	// Get the state if we have it, if not we build it
-	rs := n.ResourceState
-	if rs == nil {
-		rs = &ResourceState{}
-	}
-
-	// If the config isn't empty we update the state
-	if n.Config != nil {
-		// Determine the dependencies for the state. We use some older
-		// code for this that we've used for a long time.
-		var stateDeps []string
-		{
-			oldN := &graphNodeExpandedResource{
-				Resource: n.Config,
-				Index:    addr.Index,
-			}
-			stateDeps = oldN.StateDependencies()
-		}
-
-		rs = &ResourceState{
-			Type:         n.Config.Type,
-			Provider:     n.Config.Provider,
-			Dependencies: stateDeps,
-		}
-	}
-
-	// Build the resource for eval
-	resource := &Resource{
-		Name:       addr.Name,
-		Type:       addr.Type,
-		CountIndex: addr.Index,
-	}
-	if resource.CountIndex < 0 {
-		resource.CountIndex = 0
-	}
-
-	// Declare a bunch of variables that are used for state during
-	// evaluation. Most of this are written to by-address below.
-	var config *ResourceConfig
-	var diff *InstanceDiff
-	var provider ResourceProvider
-	var state *InstanceState
-
-	return &EvalSequence{
-		Nodes: []EvalNode{
-			// Always destroy the existing state first, since we must
-			// make sure that values from a previous read will not
-			// get interpolated if we end up needing to defer our
-			// loading until apply time.
-			&EvalWriteState{
-				Name:         stateId,
-				ResourceType: rs.Type,
-				Provider:     rs.Provider,
-				Dependencies: rs.Dependencies,
-				State:        &state, // state is nil here
-			},
-
-			&EvalInterpolate{
-				Config:   n.Config.RawConfig.Copy(),
-				Resource: resource,
-				Output:   &config,
-			},
-
-			// The rest of this pass can proceed only if there are no
-			// computed values in our config.
-			// (If there are, we'll deal with this during the plan and
-			// apply phases.)
-			&EvalIf{
-				If: func(ctx EvalContext) (bool, error) {
-					if config.ComputedKeys != nil && len(config.ComputedKeys) > 0 {
-						return true, EvalEarlyExitError{}
-					}
-
-					// If the config explicitly has a depends_on for this
-					// data source, assume the intention is to prevent
-					// refreshing ahead of that dependency.
-					if len(n.Config.DependsOn) > 0 {
-						return true, EvalEarlyExitError{}
-					}
-
-					return true, nil
-				},
-
-				Then: EvalNoop{},
-			},
-
-			// The remainder of this pass is the same as running
-			// a "plan" pass immediately followed by an "apply" pass,
-			// populating the state early so it'll be available to
-			// provider configurations that need this data during
-			// refresh/plan.
-			&EvalGetProvider{
-				Name:   n.ProvidedBy()[0],
-				Output: &provider,
-			},
-
-			&EvalReadDataDiff{
-				Info:        info,
-				Config:      &config,
-				Provider:    &provider,
-				Output:      &diff,
-				OutputState: &state,
-			},
-
-			&EvalReadDataApply{
-				Info:     info,
-				Diff:     &diff,
-				Provider: &provider,
-				Output:   &state,
-			},
-
-			&EvalWriteState{
-				Name:         stateId,
-				ResourceType: rs.Type,
-				Provider:     rs.Provider,
-				Dependencies: rs.Dependencies,
-				State:        &state,
-			},
-
-			&EvalUpdateStateHook{},
 		},
 	}
 }

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -1,0 +1,222 @@
+package terraform
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/config"
+)
+
+// NodeRefreshableResource represents a resource that is "applyable":
+// it is ready to be applied and is represented by a diff.
+type NodeRefreshableResource struct {
+	*NodeAbstractResource
+}
+
+// GraphNodeDestroyer
+func (n *NodeRefreshableResource) DestroyAddr() *ResourceAddress {
+	return n.Addr
+}
+
+// GraphNodeEvalable
+func (n *NodeRefreshableResource) EvalTree() EvalNode {
+	// Eval info is different depending on what kind of resource this is
+	switch mode := n.Addr.Mode; mode {
+	case config.ManagedResourceMode:
+		return n.evalTreeManagedResource()
+	case config.DataResourceMode:
+		return n.evalTreeDataResource()
+	default:
+		panic(fmt.Errorf("unsupported resource mode %s", mode))
+	}
+}
+
+func (n *NodeRefreshableResource) evalTreeManagedResource() EvalNode {
+	addr := n.NodeAbstractResource.Addr
+
+	// stateId is the ID to put into the state
+	stateId := addr.stateId()
+
+	// Build the instance info. More of this will be populated during eval
+	info := &InstanceInfo{
+		Id:   stateId,
+		Type: addr.Type,
+	}
+
+	// Declare a bunch of variables that are used for state during
+	// evaluation. Most of this are written to by-address below.
+	var provider ResourceProvider
+	var state *InstanceState
+
+	// This happened during initial development. All known cases were
+	// fixed and tested but as a sanity check let's assert here.
+	if n.ResourceState == nil {
+		err := fmt.Errorf(
+			"No resource state attached for addr: %s\n\n"+
+				"This is a bug. Please report this to Terraform with your configuration\n"+
+				"and state attached. Please be careful to scrub any sensitive information.",
+			addr)
+		return &EvalReturnError{Error: &err}
+	}
+
+	return &EvalSequence{
+		Nodes: []EvalNode{
+			&EvalGetProvider{
+				Name:   n.ProvidedBy()[0],
+				Output: &provider,
+			},
+			&EvalReadState{
+				Name:   stateId,
+				Output: &state,
+			},
+			&EvalRefresh{
+				Info:     info,
+				Provider: &provider,
+				State:    &state,
+				Output:   &state,
+			},
+			&EvalWriteState{
+				Name:         stateId,
+				ResourceType: n.ResourceState.Type,
+				Provider:     n.ResourceState.Provider,
+				Dependencies: n.ResourceState.Dependencies,
+				State:        &state,
+			},
+		},
+	}
+}
+
+func (n *NodeRefreshableResource) evalTreeDataResource() EvalNode {
+	addr := n.NodeAbstractResource.Addr
+
+	// stateId is the ID to put into the state
+	stateId := addr.stateId()
+
+	// Build the instance info. More of this will be populated during eval
+	info := &InstanceInfo{
+		Id:   stateId,
+		Type: addr.Type,
+	}
+
+	// Get the state if we have it, if not we build it
+	rs := n.ResourceState
+	if rs == nil {
+		rs = &ResourceState{}
+	}
+
+	// If the config isn't empty we update the state
+	if n.Config != nil {
+		// Determine the dependencies for the state. We use some older
+		// code for this that we've used for a long time.
+		var stateDeps []string
+		{
+			oldN := &graphNodeExpandedResource{
+				Resource: n.Config,
+				Index:    addr.Index,
+			}
+			stateDeps = oldN.StateDependencies()
+		}
+
+		rs = &ResourceState{
+			Type:         n.Config.Type,
+			Provider:     n.Config.Provider,
+			Dependencies: stateDeps,
+		}
+	}
+
+	// Build the resource for eval
+	resource := &Resource{
+		Name:       addr.Name,
+		Type:       addr.Type,
+		CountIndex: addr.Index,
+	}
+	if resource.CountIndex < 0 {
+		resource.CountIndex = 0
+	}
+
+	// Declare a bunch of variables that are used for state during
+	// evaluation. Most of this are written to by-address below.
+	var config *ResourceConfig
+	var diff *InstanceDiff
+	var provider ResourceProvider
+	var state *InstanceState
+
+	return &EvalSequence{
+		Nodes: []EvalNode{
+			// Always destroy the existing state first, since we must
+			// make sure that values from a previous read will not
+			// get interpolated if we end up needing to defer our
+			// loading until apply time.
+			&EvalWriteState{
+				Name:         stateId,
+				ResourceType: rs.Type,
+				Provider:     rs.Provider,
+				Dependencies: rs.Dependencies,
+				State:        &state, // state is nil here
+			},
+
+			&EvalInterpolate{
+				Config:   n.Config.RawConfig.Copy(),
+				Resource: resource,
+				Output:   &config,
+			},
+
+			// The rest of this pass can proceed only if there are no
+			// computed values in our config.
+			// (If there are, we'll deal with this during the plan and
+			// apply phases.)
+			&EvalIf{
+				If: func(ctx EvalContext) (bool, error) {
+					if config.ComputedKeys != nil && len(config.ComputedKeys) > 0 {
+						return true, EvalEarlyExitError{}
+					}
+
+					// If the config explicitly has a depends_on for this
+					// data source, assume the intention is to prevent
+					// refreshing ahead of that dependency.
+					if len(n.Config.DependsOn) > 0 {
+						return true, EvalEarlyExitError{}
+					}
+
+					return true, nil
+				},
+
+				Then: EvalNoop{},
+			},
+
+			// The remainder of this pass is the same as running
+			// a "plan" pass immediately followed by an "apply" pass,
+			// populating the state early so it'll be available to
+			// provider configurations that need this data during
+			// refresh/plan.
+			&EvalGetProvider{
+				Name:   n.ProvidedBy()[0],
+				Output: &provider,
+			},
+
+			&EvalReadDataDiff{
+				Info:        info,
+				Config:      &config,
+				Provider:    &provider,
+				Output:      &diff,
+				OutputState: &state,
+			},
+
+			&EvalReadDataApply{
+				Info:     info,
+				Diff:     &diff,
+				Provider: &provider,
+				Output:   &state,
+			},
+
+			&EvalWriteState{
+				Name:         stateId,
+				ResourceType: rs.Type,
+				Provider:     rs.Provider,
+				Dependencies: rs.Dependencies,
+				State:        &state,
+			},
+
+			&EvalUpdateStateHook{},
+		},
+	}
+}

--- a/terraform/state_filter.go
+++ b/terraform/state_filter.go
@@ -85,15 +85,22 @@ func (f *StateFilter) filterSingle(a *ResourceAddress) []*StateFilterResult {
 	// the modules to find relevant resources.
 	for _, m := range modules {
 		for n, r := range m.Resources {
-			if f.relevant(a, r) {
-				// The name in the state contains valuable information. Parse.
-				key, err := ParseResourceStateKey(n)
-				if err != nil {
-					// If we get an error parsing, then just ignore it
-					// out of the state.
-					continue
-				}
+			// The name in the state contains valuable information. Parse.
+			key, err := ParseResourceStateKey(n)
+			if err != nil {
+				// If we get an error parsing, then just ignore it
+				// out of the state.
+				continue
+			}
 
+			// Older states and test fixtures often don't contain the
+			// type directly on the ResourceState. We add this so StateFilter
+			// is a bit more robust.
+			if r.Type == "" {
+				r.Type = key.Type
+			}
+
+			if f.relevant(a, r) {
 				if a.Name != "" && a.Name != key.Name {
 					// Name doesn't match
 					continue

--- a/terraform/state_filter_test.go
+++ b/terraform/state_filter_test.go
@@ -38,6 +38,15 @@ func TestStateFilterFilter(t *testing.T) {
 			},
 		},
 
+		"single resource from minimal state": {
+			"single-minimal-resource.tfstate",
+			[]string{"aws_instance.web"},
+			[]string{
+				"*terraform.ResourceState: aws_instance.web",
+				"*terraform.InstanceState: aws_instance.web",
+			},
+		},
+
 		"single resource with similar names": {
 			"small_test_instance.tfstate",
 			[]string{"test_instance.foo"},

--- a/terraform/test-fixtures/state-filter/single-minimal-resource.tfstate
+++ b/terraform/test-fixtures/state-filter/single-minimal-resource.tfstate
@@ -1,0 +1,18 @@
+{
+    "version": 1,
+    "serial": 12,
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "resources": {
+                "aws_instance.web": {
+                    "primary": {
+                        "id": "onprem"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/terraform/test-fixtures/transform-config-mode-data/main.tf
+++ b/terraform/test-fixtures/transform-config-mode-data/main.tf
@@ -1,0 +1,3 @@
+data "aws_ami" "foo" {}
+
+resource "aws_instance" "web" {}

--- a/terraform/transform_attach_state.go
+++ b/terraform/transform_attach_state.go
@@ -45,8 +45,10 @@ func (t *AttachStateTransformer) Transform(g *Graph) error {
 		}
 
 		// Attach the first resource state we get
+		log.Printf("SEARCH: %s", addr)
 		found := false
 		for _, result := range results {
+			log.Printf("WTF: %s %#v", addr, result)
 			if rs, ok := result.Value.(*ResourceState); ok {
 				log.Printf(
 					"[DEBUG] Attaching resource state to %q: %s",


### PR DESCRIPTION
This PR modifies the refresh graph to use a new custom graph builder. This work is just continuing the work I started and shipped for 0.8 but on the less complex and less dangerous graphs. See #9973 or #9388 as prior examples. 

The goal at this point now that plan/apply have shipped on new graphs is to complete the less dangerous graphs so we can ultimately fully remove the legacy graph building code. We still have to do refresh, validate, and input.

The changes here are minimal since refresh is simple. **What this PR changes/adds:**

  * New refresh graph, based on state as primary source of truth
  * `StateFilter` made more robust to handle cases where state may not have resource type. This was necessary for tests to pass without changes.
  * `ConfigTransformer` can filter the types of things added. This was necessary to add only data sources for refresh.

**This PR does not enable/use the shadow graph.** Refresh is not a scary operation (compared to plan/apply) and therefore we won't be using the shadow graph for this. We'll be shipping in default-on in 0.9 betas and let any bugs come through there.