### PR TITLE
provider/aws Add S3 bucket object tag support

### DIFF
--- a/builtin/providers/aws/data_source_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/data_source_aws_s3_bucket_object.go
@@ -99,6 +99,8 @@ func dataSourceAwsS3BucketObject() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": tagsSchemaComputed(),
 		},
 	}
 }
@@ -200,6 +202,16 @@ func dataSourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) e
 		log.Printf("[INFO] Ignoring body of S3 object %s with Content-Type %q",
 			uniqueId, contentType)
 	}
+
+	tagResp, err := conn.GetObjectTagging(
+		&s3.GetObjectTaggingInput{
+			Bucket: aws.String(bucket),
+			Key:    aws.String(key),
+		})
+	if err != nil {
+		return err
+	}
+	d.Set("tags", tagsToMapS3(tagResp.TagSet))
 
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/data_source_aws_s3_bucket_object_test.go
@@ -1,3 +1,4 @@
+// make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccDataSourceAWSS3BucketObject_'
 package aws
 
 import (
@@ -160,6 +161,7 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "expires", ""),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "website_redirect_location", ""),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "metadata.%", "0"),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "tags.%", "1"),
 				),
 			},
 		},
@@ -284,6 +286,9 @@ CONTENT
 	content_disposition = "attachment"
 	content_encoding = "gzip"
 	content_language = "en-GB"
+	tags {
+		Key1 = "Value 1"
+	}
 }
 `, randInt, randInt)
 

--- a/website/source/docs/providers/aws/d/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/d/s3_bucket_object.html.markdown
@@ -79,3 +79,4 @@ The following attributes are exported:
 * `storage_class` - [Storage class](http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html) information of the object. Available for all objects except for `Standard` storage class objects.
 * `version_id` - The latest version ID of the object returned.
 * `website_redirect_location` - If the bucket is configured as a website, redirects requests for this object to another object in the same bucket or to an external URL. Amazon S3 stores the value of this header in the object metadata.
+* `tags`  - A mapping of tags assigned to the object.

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -83,6 +83,7 @@ This attribute is not compatible with `kms_key_id`.
 This value is a fully qualified **ARN** of the KMS Key. If using `aws_kms_key`,
 use the exported `arn` attribute:  
       `kms_key_id = "${aws_kms_key.foo.arn}"`
+* `tags` - (Optional) A mapping of tags to assign to the object.
 
 Either `source` or `content` must be provided to specify the bucket content.
 These two arguments are mutually-exclusive.


### PR DESCRIPTION
Add support for AWS S3 [object tagging](http://docs.aws.amazon.com/AmazonS3/latest/dev/object-tagging.html).