### PR TITLE
provider/aws: Allow bypassing region validation

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -92,6 +92,7 @@ type Config struct {
 	Insecure         bool
 
 	SkipCredsValidation     bool
+	SkipRegionValidation    bool
 	SkipRequestingAccountId bool
 	SkipMetadataApiCheck    bool
 	S3ForcePathStyle        bool
@@ -153,10 +154,14 @@ type AWSClient struct {
 func (c *Config) Client() (interface{}, error) {
 	// Get the auth and region. This can fail if keys/regions were not
 	// specified and we're attempting to use the environment.
-	log.Println("[INFO] Building AWS region structure")
-	err := c.ValidateRegion()
-	if err != nil {
-		return nil, err
+	if c.SkipRegionValidation {
+		log.Println("[INFO] Skipping region validation")
+	} else {
+		log.Println("[INFO] Building AWS region structure")
+		err := c.ValidateRegion()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var client AWSClient

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -120,6 +120,13 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["skip_credentials_validation"],
 			},
 
+			"skip_region_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["skip_region_validation"],
+			},
+
 			"skip_requesting_account_id": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -441,6 +448,9 @@ func init() {
 		"skip_credentials_validation": "Skip the credentials validation via STS API. " +
 			"Used for AWS API implementations that do not have STS available/implemented.",
 
+		"skip_region_validation": "Skip static validation of region name. " +
+			"Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).",
+
 		"skip_requesting_account_id": "Skip requesting the account ID. " +
 			"Used for AWS API implementations that do not have IAM/STS API and/or metadata API.",
 
@@ -475,6 +485,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		KinesisEndpoint:         d.Get("kinesis_endpoint").(string),
 		Insecure:                d.Get("insecure").(bool),
 		SkipCredsValidation:     d.Get("skip_credentials_validation").(bool),
+		SkipRegionValidation:    d.Get("skip_region_validation").(bool),
 		SkipRequestingAccountId: d.Get("skip_requesting_account_id").(bool),
 		SkipMetadataApiCheck:    d.Get("skip_metadata_api_check").(bool),
 		S3ForcePathStyle:        d.Get("s3_force_path_style").(bool),

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -188,6 +188,10 @@ The following arguments are supported in the `provider` block:
   validation via the STS API. Useful for AWS API implementations that do
   not have STS available or implemented.
 
+* `skip_region_validation` - (Optional) Skip validation of provided region name.
+  Useful for AWS-like implementations that use their own region names
+  or to bypass the validation for regions that aren't publicly available yet.
+
 * `skip_requesting_account_id` - (Optional) Skip requesting the account
   ID.  Useful for AWS API implementations that do not have the IAM, STS
   API, or metadata API.  When set to `true`, prevents you from managing


### PR DESCRIPTION
This was requested in a few places, e.g. https://github.com/hashicorp/terraform/issues/7183 and could take the pressure off the users (rushing to upgrade) & maintainers (rushing to cut release) when AWS announces new region.

btw. [Packer already has a similar option](https://www.packer.io/docs/builders/amazon-ebs.html#skip_region_validation).

It is important to say that there will be still certain data sources & resources which simply won't work as Terraform doesn't have the metadata for unknown regions, e.g.

 - `aws_s3_bucket` due to [zone ID](https://github.com/hashicorp/terraform/blob/2efe489d59ed2391aa128541eae5ddcb73976bd3/builtin/providers/aws/resource_aws_s3_bucket.go#L879-L883)
 - `aws_redshift_service_account`
 - `aws_elb_service_account`
 - `aws_elb_hosted_zone_id`

### Before

```hcl
provider "aws" {
  region = "eu-west-x"
}

resource "aws_vpc" "tada" {
  cidr_block = "10.0.0.0/16"
}
```
```
Error refreshing state: 1 error(s) occurred:

* Not a valid region: eu-west-x
```

### After

```hcl
provider "aws" {
  region = "eu-west-x"
  skip_region_validation = true
}

resource "aws_vpc" "tada" {
  cidr_block = "10.0.0.0/16"
}
```
Assuming the region doesn't _actually_ exist, the SDK will just keep retrying for ~5mins and eventually return error due to failed DNS lookup:
```
Error applying plan:

1 error(s) occurred:

* aws_vpc.tada: Error creating VPC: RequestError: send request failed
caused by: Post https://ec2.eu-west-x.amazonaws.com/: dial tcp: lookup ec2.eu-west-x.amazonaws.com on 10.0.0.1:53: no such host
```
^ that is also why most users using valid and publicly available regions want to avoid setting this new parameter.