### PR TITLE
provider/aws: Improve error message from ASG Hooks

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook.go
@@ -1,7 +1,6 @@
 package aws
 
 import (
-	"fmt"
 	"log"
 	"strings"
 	"time"
@@ -9,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
+	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -67,10 +67,10 @@ func resourceAwsAutoscalingLifecycleHookPutOp(conn *autoscaling.AutoScaling, par
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {
 				if strings.Contains(awsErr.Message(), "Unable to publish test message to notification target") {
-					return resource.RetryableError(fmt.Errorf("[DEBUG] Retrying AWS AutoScaling Lifecycle Hook: %s", params))
+					return resource.RetryableError(errwrap.Wrapf("[DEBUG] Retrying AWS AutoScaling Lifecycle Hook: {{err}}", awsErr))
 				}
 			}
-			return resource.NonRetryableError(fmt.Errorf("Error putting lifecycle hook: %s", err))
+			return resource.NonRetryableError(errwrap.Wrapf("Error putting lifecycle hook: {{err}}", err))
 		}
 		return nil
 	})
@@ -127,7 +127,7 @@ func resourceAwsAutoscalingLifecycleHookDelete(d *schema.ResourceData, meta inte
 		LifecycleHookName:    aws.String(d.Get("name").(string)),
 	}
 	if _, err := autoscalingconn.DeleteLifecycleHook(&params); err != nil {
-		return fmt.Errorf("Autoscaling Lifecycle Hook: %s ", err)
+		return errwrap.Wrapf("Autoscaling Lifecycle Hook: {{err}}", err)
 	}
 
 	d.SetId("")
@@ -178,7 +178,7 @@ func getAwsAutoscalingLifecycleHook(d *schema.ResourceData, meta interface{}) (*
 	log.Printf("[DEBUG] AutoScaling Lifecycle Hook Describe Params: %#v", params)
 	resp, err := autoscalingconn.DescribeLifecycleHooks(&params)
 	if err != nil {
-		return nil, fmt.Errorf("Error retrieving lifecycle hooks: %s", err)
+		return nil, errwrap.Wrapf("Error retrieving lifecycle hooks: {{err}}", err)
 	}
 
 	// find lifecycle hooks


### PR DESCRIPTION
This commit switches out the use of `fmt.Errorf` to `errwrap.Wrapf` in the `aws_autoscaling_lifecycle_hook` resource, and corrects a typo which causes the parameter object to be returned to a user rather than an underlying error.