### PR TITLE
provider/aws: Avoid dropping a security group from state on AWS consistency issues

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -273,7 +273,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 
 	}
 
-	return resourceAwsSecurityGroupUpdate(d, meta)
+	return resourceAwsSecurityGroupUpdateExisting(group, d, meta)
 }
 
 func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) error {
@@ -329,10 +329,12 @@ func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) er
 		d.SetId("")
 		return nil
 	}
-
 	group := sgRaw.(*ec2.SecurityGroup)
+	return resourceAwsSecurityGroupUpdateExisting(group, d, meta)
+}
 
-	err = resourceAwsSecurityGroupUpdateRules(d, "ingress", meta, group)
+func resourceAwsSecurityGroupUpdateExisting(group *ec2.SecurityGroup, d *schema.ResourceData, meta interface{}) error {
+	err := resourceAwsSecurityGroupUpdateRules(d, "ingress", meta, group)
 	if err != nil {
 		return err
 	}
@@ -345,6 +347,7 @@ func resourceAwsSecurityGroupUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	if !d.IsNewResource() {
+		conn := meta.(*AWSClient).ec2conn
 		if err := setTags(conn, d); err != nil {
 			return err
 		}


### PR DESCRIPTION
It appears, based on the report in #6991, that the EC2 API is being
inconsistent in reporting that a security group exists shortly after it
has been created; we've seen Terraform get past the "Waiting for
Security Group to exist" step but then apparently detect that it's gone
again once we get into the Update function.

If it happens in the Update function, as I suspect is the case for bug #6991, we will not drop it from the state.

Rework of #9719 based on @mitchellh feedback
