### PR TITLE
provider/aws: Fix failing ecs acceptance test w/ ALB

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_service_test.go
@@ -915,6 +915,7 @@ resource "aws_alb_target_group" "test" {
 
 resource "aws_alb" "main" {
   name            = "tf-acc-test-test-alb-ecs"
+  internal        = true
   subnets         = ["${aws_subnet.main.*.id}"]
 }
 


### PR DESCRIPTION
Something I missed in https://github.com/hashicorp/terraform/pull/11333 because it was under ECS.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcsService_withAlb'
```
```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/23 22:20:22 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcsService_withAlb -timeout 120m
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (280.15s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	280.187s
```