### PR TITLE
provider/ns1/record: Fix "use_client_subnet".

### DIFF
--- a/builtin/providers/ns1/resource_record.go
+++ b/builtin/providers/ns1/resource_record.go
@@ -159,6 +159,9 @@ func recordToResourceData(d *schema.ResourceData, r *dns.Record) error {
 	// 	t := metaStructToDynamic(r.Meta)
 	// 	d.Set("meta", t)
 	// }
+	if r.UseClientSubnet != nil {
+		d.Set("use_client_subnet", *r.UseClientSubnet)
+	}
 	if len(r.Filters) > 0 {
 		filters := make([]map[string]interface{}, len(r.Filters))
 		for i, f := range r.Filters {
@@ -261,9 +264,9 @@ func resourceDataToRecord(r *dns.Record, d *schema.ResourceData) error {
 	// if v, ok := d.GetOk("meta"); ok {
 	// 	metaDynamicToStruct(r.Meta, v)
 	// }
-	useClientSubnetVal := d.Get("use_client_subnet").(bool)
-	if v := strconv.FormatBool(useClientSubnetVal); v != "" {
-		r.UseClientSubnet = &useClientSubnetVal
+	if v, ok := d.GetOk("use_client_subnet"); ok {
+		copy := v.(bool)
+		r.UseClientSubnet = &copy
 	}
 
 	if rawFilters := d.Get("filters").([]interface{}); len(rawFilters) > 0 {


### PR DESCRIPTION
The support for "use_client_subnet" was half finished.
- Field was defined in schema.
- ResourceData-to-struct code was present but incorrect.
- struct-to-ResourceData code was missing.

Made the change and verified with manual testing:
1. In NS1 UI, switched "Use Client Subnet" between checked and
   unchecked.
2. In Terraform config file, switched "use_client_subnet" field between
   "true", "false", and omitted.
3. The output of "terraform plan" was as expected in all six cases.

@pashap, @stack72 

BTW, if there are minor tweaks that need to be made before committing, it might be quicker to just make those changes yourself and then commit.  I don't care about retaining authorship here.