### PR TITLE
core: input graph uses new graph builders

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -219,15 +219,32 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 	case GraphTypeInput:
 		// The input graph is just a slightly modified plan graph
 		fallthrough
+	case GraphTypeValidate:
+		// The validate graph is just a slightly modified plan graph
+		fallthrough
 	case GraphTypePlan:
-		return (&PlanGraphBuilder{
+		// Create the plan graph builder
+		p := &PlanGraphBuilder{
 			Module:    c.module,
 			State:     c.state,
 			Providers: c.components.ResourceProviders(),
 			Targets:   c.targets,
 			Validate:  opts.Validate,
-			Input:     typ == GraphTypeInput,
-		}).Build(RootModulePath)
+		}
+
+		// Some special cases for other graph types shared with plan currently
+		var b GraphBuilder = p
+		switch typ {
+		case GraphTypeInput:
+			b = InputGraphBuilder(p)
+		case GraphTypeValidate:
+			// We need to set the provisioners so those can be validated
+			p.Provisioners = c.components.ResourceProvisioners()
+
+			b = ValidateGraphBuilder(p)
+		}
+
+		return b.Build(RootModulePath)
 
 	case GraphTypePlanDestroy:
 		return (&DestroyPlanGraphBuilder{
@@ -645,7 +662,7 @@ func (c *Context) Validate() ([]string, []error) {
 	// We also validate the graph generated here, but this graph doesn't
 	// necessarily match the graph that Plan will generate, so we'll validate the
 	// graph again later after Planning.
-	graph, err := c.Graph(GraphTypeLegacy, nil)
+	graph, err := c.Graph(GraphTypeValidate, nil)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -216,6 +216,9 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 			Validate:     opts.Validate,
 		}).Build(RootModulePath)
 
+	case GraphTypeInput:
+		// The input graph is just a slightly modified plan graph
+		fallthrough
 	case GraphTypePlan:
 		return (&PlanGraphBuilder{
 			Module:    c.module,
@@ -223,6 +226,7 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 			Providers: c.components.ResourceProviders(),
 			Targets:   c.targets,
 			Validate:  opts.Validate,
+			Input:     typ == GraphTypeInput,
 		}).Build(RootModulePath)
 
 	case GraphTypePlanDestroy:
@@ -402,7 +406,7 @@ func (c *Context) Input(mode InputMode) error {
 
 	if mode&InputModeProvider != 0 {
 		// Build the graph
-		graph, err := c.Graph(GraphTypeLegacy, nil)
+		graph, err := c.Graph(GraphTypeInput, nil)
 		if err != nil {
 			return err
 		}

--- a/terraform/context_graph_type.go
+++ b/terraform/context_graph_type.go
@@ -13,6 +13,7 @@ const (
 	GraphTypePlan
 	GraphTypePlanDestroy
 	GraphTypeApply
+	GraphTypeInput
 )
 
 // GraphTypeMap is a mapping of human-readable string to GraphType. This
@@ -20,6 +21,7 @@ const (
 // graph types.
 var GraphTypeMap = map[string]GraphType{
 	"apply":        GraphTypeApply,
+	"input":        GraphTypeInput,
 	"plan":         GraphTypePlan,
 	"plan-destroy": GraphTypePlanDestroy,
 	"legacy":       GraphTypeLegacy,

--- a/terraform/context_graph_type.go
+++ b/terraform/context_graph_type.go
@@ -14,6 +14,7 @@ const (
 	GraphTypePlanDestroy
 	GraphTypeApply
 	GraphTypeInput
+	GraphTypeValidate
 )
 
 // GraphTypeMap is a mapping of human-readable string to GraphType. This
@@ -25,4 +26,5 @@ var GraphTypeMap = map[string]GraphType{
 	"plan":         GraphTypePlan,
 	"plan-destroy": GraphTypePlanDestroy,
 	"legacy":       GraphTypeLegacy,
+	"validate":     GraphTypeValidate,
 }

--- a/terraform/graph_builder_input.go
+++ b/terraform/graph_builder_input.go
@@ -1,0 +1,27 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/dag"
+)
+
+// InputGraphBuilder creates the graph for the input operation.
+//
+// Unlike other graph builders, this is a function since it currently modifies
+// and is based on the PlanGraphBuilder. The PlanGraphBuilder passed in will be
+// modified and should not be used for any other operations.
+func InputGraphBuilder(p *PlanGraphBuilder) GraphBuilder {
+	// We're going to customize the concrete functions
+	p.CustomConcrete = true
+
+	// Set the provider to the normal provider. This will ask for input.
+	p.ConcreteProvider = func(a *NodeAbstractProvider) dag.Vertex {
+		return &NodeApplyableProvider{
+			NodeAbstractProvider: a,
+		}
+	}
+
+	// We purposely don't set any more concrete fields since the remainder
+	// should be no-ops.
+
+	return p
+}

--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -34,6 +34,14 @@ type PlanGraphBuilder struct {
 
 	// Validate will do structural validation of the graph.
 	Validate bool
+
+	// Input, if true, modifies this graph for inputs. There isn't a
+	// dedicated input graph because asking for input is identical to
+	// planning except for the operations done. You still need to know WHAT
+	// you're going to plan since you only need to ask for input for things
+	// that are necessary for planning. This requirement makes the graphs
+	// very similar.
+	Input bool
 }
 
 // See GraphBuilder
@@ -54,15 +62,18 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		}
 	}
 
-	concreteResource := func(a *NodeAbstractResource) dag.Vertex {
-		return &NodePlannableResource{
-			NodeAbstractResource: a,
+	var concreteResource, concreteResourceOrphan ConcreteResourceNodeFunc
+	if !b.Input {
+		concreteResource = func(a *NodeAbstractResource) dag.Vertex {
+			return &NodePlannableResource{
+				NodeAbstractResource: a,
+			}
 		}
-	}
 
-	concreteResourceOrphan := func(a *NodeAbstractResource) dag.Vertex {
-		return &NodePlannableResourceOrphan{
-			NodeAbstractResource: a,
+		concreteResourceOrphan = func(a *NodeAbstractResource) dag.Vertex {
+			return &NodePlannableResourceOrphan{
+				NodeAbstractResource: a,
+			}
 		}
 	}
 

--- a/terraform/graph_builder_validate.go
+++ b/terraform/graph_builder_validate.go
@@ -1,0 +1,34 @@
+package terraform
+
+import (
+	"github.com/hashicorp/terraform/dag"
+)
+
+// ValidateGraphBuilder creates the graph for the validate operation.
+//
+// ValidateGraphBuilder is based on the PlanGraphBuilder. We do this so that
+// we only have to validate what we'd normally plan anyways. The
+// PlanGraphBuilder given will be modified so it shouldn't be used for anything
+// else after calling this function.
+func ValidateGraphBuilder(p *PlanGraphBuilder) GraphBuilder {
+	// We're going to customize the concrete functions
+	p.CustomConcrete = true
+
+	// Set the provider to the normal provider. This will ask for input.
+	p.ConcreteProvider = func(a *NodeAbstractProvider) dag.Vertex {
+		return &NodeApplyableProvider{
+			NodeAbstractProvider: a,
+		}
+	}
+
+	p.ConcreteResource = func(a *NodeAbstractResource) dag.Vertex {
+		return &NodeValidatableResource{
+			NodeAbstractResource: a,
+		}
+	}
+
+	// We purposely don't set any other concrete types since they don't
+	// require validation.
+
+	return p
+}

--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -1,0 +1,66 @@
+package terraform
+
+// NodeValidatableResource represents a resource that is used for validation
+// only.
+type NodeValidatableResource struct {
+	*NodeAbstractResource
+}
+
+// GraphNodeEvalable
+func (n *NodeValidatableResource) EvalTree() EvalNode {
+	addr := n.NodeAbstractResource.Addr
+
+	// Build the resource for eval
+	resource := &Resource{
+		Name:       addr.Name,
+		Type:       addr.Type,
+		CountIndex: addr.Index,
+	}
+	if resource.CountIndex < 0 {
+		resource.CountIndex = 0
+	}
+
+	// Declare a bunch of variables that are used for state during
+	// evaluation. Most of this are written to by-address below.
+	var config *ResourceConfig
+	var provider ResourceProvider
+
+	seq := &EvalSequence{
+		Nodes: []EvalNode{
+			&EvalGetProvider{
+				Name:   n.ProvidedBy()[0],
+				Output: &provider,
+			},
+			&EvalInterpolate{
+				Config:   n.Config.RawConfig.Copy(),
+				Resource: resource,
+				Output:   &config,
+			},
+			&EvalValidateResource{
+				Provider:     &provider,
+				Config:       &config,
+				ResourceName: n.Config.Name,
+				ResourceType: n.Config.Type,
+				ResourceMode: n.Config.Mode,
+			},
+		},
+	}
+
+	// Validate all the provisioners
+	for _, p := range n.Config.Provisioners {
+		var provisioner ResourceProvisioner
+		seq.Nodes = append(seq.Nodes, &EvalGetProvisioner{
+			Name:   p.Type,
+			Output: &provisioner,
+		}, &EvalInterpolate{
+			Config:   p.RawConfig.Copy(),
+			Resource: resource,
+			Output:   &config,
+		}, &EvalValidateProvisioner{
+			Provisioner: &provisioner,
+			Config:      &config,
+		})
+	}
+
+	return seq
+}


### PR DESCRIPTION
This is similar to #11341 but for inputs.

There is no tangible benefit to this except to continue marching towards our goal of removing the legacy graph completely. Almost there! No tests added, removed, or changed. All existing tests pass.

This is the simplest so far in that it actually shares the graph with plan. The goal of the new graph builders was to create unique builders for each operation to simplify the graph. For input in particular, the graph is identical to the plan graph since in order to determine what we need input for we need to know what we're going to plan.

Therefore, input just shares the plan graph. Creating an entire new graph builder would be silly since it'd always have to be identical. While Refresh, Plan, Apply have unique ways to build their graphs, I believe Input and Validate likely won't since it is very similar to planning... but we'll see about Validate. 

The way the graph is built (using `GraphTypeInput`) gives us some play in the future if we choose to create a custom graph builder. 