### PR TITLE
provider/heroku: Fix failing acceptance test

### DIFF
--- a/builtin/providers/heroku/resource_heroku_app_test.go
+++ b/builtin/providers/heroku/resource_heroku_app_test.go
@@ -100,8 +100,8 @@ func TestAccHerokuApp_NukeVars(t *testing.T) {
 					testAccCheckHerokuAppAttributesNoVars(&app, appName),
 					resource.TestCheckResourceAttr(
 						"heroku_app.foobar", "name", appName),
-					resource.TestCheckResourceAttr(
-						"heroku_app.foobar", "config_vars.0.FOO", ""),
+					resource.TestCheckNoResourceAttr(
+						"heroku_app.foobar", "config_vars.0.FOO"),
 				),
 			},
 		},


### PR DESCRIPTION
```
$ make testacc TEST=./builtin/providers/heroku TESTARGS='-run=TestAccHerokuApp_NukeVars'
```
```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/24 08:48:22 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/heroku -v -run=TestAccHerokuApp_NukeVars -timeout 120m
=== RUN   TestAccHerokuApp_NukeVars
--- PASS: TestAccHerokuApp_NukeVars (5.23s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/heroku	5.240s
```

Related to https://github.com/hashicorp/terraform/pull/11218