### PR TITLE
provider/postgresql: Fix failing acceptance test

### DIFF
--- a/builtin/providers/postgresql/resource_postgresql_role_test.go
+++ b/builtin/providers/postgresql/resource_postgresql_role_test.go
@@ -28,7 +28,7 @@ func TestAccPostgresqlRole_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "bypass_row_level_security", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "connection_limit", "-1"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "encrypted_password", "true"),
-					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "password", ""),
+					resource.TestCheckNoResourceAttr("postgresql_role.role_with_defaults", "password"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "valid_until", "infinity"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_drop_role", "false"),
 					resource.TestCheckResourceAttr("postgresql_role.role_with_defaults", "skip_reassign_owned", "false"),


### PR DESCRIPTION
```
$ make testacc TEST=./builtin/providers/postgresql
```
```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/24 09:18:10 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/postgresql -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccPostgresqlDatabase_Basic
--- PASS: TestAccPostgresqlDatabase_Basic (3.87s)
=== RUN   TestAccPostgresqlDatabase_DefaultOwner
--- PASS: TestAccPostgresqlDatabase_DefaultOwner (3.42s)
=== RUN   TestAccPostgresqlExtension_Basic
--- PASS: TestAccPostgresqlExtension_Basic (0.12s)
=== RUN   TestAccPostgresqlExtension_SchemaRename
--- PASS: TestAccPostgresqlExtension_SchemaRename (0.38s)
=== RUN   TestAccPostgresqlRole_Basic
--- PASS: TestAccPostgresqlRole_Basic (0.65s)
=== RUN   TestAccPostgresqlRole_Update
--- PASS: TestAccPostgresqlRole_Update (0.23s)
=== RUN   TestAccPostgresqlSchema_Basic
--- PASS: TestAccPostgresqlSchema_Basic (0.49s)
=== RUN   TestAccPostgresqlSchema_AddPolicy
--- PASS: TestAccPostgresqlSchema_AddPolicy (2.15s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/postgresql	11.313s
```

Related to #11218