### PR TITLE
Add support for importing openstack compute instance

### DIFF
--- a/builtin/providers/openstack/import_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_compute_instance_v2_test.go
@@ -1,0 +1,28 @@
+package openstack
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccComputeV2Instnace_importBasic(t *testing.T) {
+	resourceName := "openstack_compute_instance_v2.sg_1"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeV2InstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeV2Instance_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -32,6 +32,9 @@ func resourceComputeInstanceV2() *schema.Resource {
 		Read:   resourceComputeInstanceV2Read,
 		Update: resourceComputeInstanceV2Update,
 		Delete: resourceComputeInstanceV2Delete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"region": &schema.Schema{


### PR DESCRIPTION
Hey @jtopjian wanted to get your opinion on this before I send it upstream. 
Would you mind giving me some context as to why we didn't implement import for compute instances before ?
Thanks!