### PR TITLE
provider/aws: Added API GW documentation regarding request/response templates

### DIFF
--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -36,6 +36,15 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
   http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
   type = "MOCK"
+
+  # Transforms the incoming XML request to JSON
+  request_templates {
+    "application/xml" = <<EOF
+{
+   "body" : $input.json('$')
+}
+EOF
+  }
 }
 ```
 

--- a/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration_response.html.markdown
@@ -53,6 +53,17 @@ resource "aws_api_gateway_integration_response" "MyDemoIntegrationResponse" {
   resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
   http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
   status_code = "${aws_api_gateway_method_response.200.status_code}"
+
+  # Transforms the backend JSON response to XML
+  response_templates {
+    "application/xml" = <<EOF
+#set($inputRoot = $input.path('$'))
+<?xml version="1.0" encoding="UTF-8"?>
+<message>
+    $inputRoot.body
+</message>
+EOF
+  }
 }
 ```
 


### PR DESCRIPTION
#### Reasoning for this change
This adds examples about how using request/response templates to manage content transformations using API Gateway.

#### Use cases
Any Content-Negotiation transformations or proxyfications:
* XML to JSON
* JSON to XML
* Obfuscating the real API required parameters
* etc.