### PR TITLE
Fix: Incorrect AWS Lambda Qualifier Regexp

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -251,7 +251,7 @@ func validateLambdaQualifier(v interface{}, k string) (ws []string, errors []err
 			"%q cannot be longer than 128 characters: %q", k, value))
 	}
 	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-	pattern := `^[a-zA-Z0-9$_]+$`
+	pattern := `^[a-zA-Z0-9$_-]+$`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q doesn't comply with restrictions (%q): %q",

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -111,6 +111,8 @@ func TestValidateLambdaQualifier(t *testing.T) {
 		"prod",
 		"PROD",
 		"MyTestEnv",
+		"contains-dashes",
+		"contains_underscores",
 		"$LATEST",
 	}
 	for _, v := range validNames {


### PR DESCRIPTION
Type of change:
===============
- Bug fix

What changed? ... and Why:
==========================
The regexp is currently set to:
`pattern := ^[a-zA-Z0-9$_]+$`

The AWS docs state that qualifer names must conform to the following
regexp:
`Pattern: (|[a-zA-Z0-9$_-]+)`

As you can see, the current regexp in Terraform is missing the `-` at
the end.

This addresses that.

How has it been tested?
=======================
Added a few test cases to the existing spec for `AwsLambdaQualifier`
validation.