### PR TITLE
Update documentation for roles attribute for iam_instance_profile

### DIFF
--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) The profile's name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the profile.
-* `roles` - (Required) A list of role names to include in the profile.
+* `roles` - (Required) A list of role names to include in the profile.  The current default is 1.  If you see an error message similar to `Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1`, then you must contact AWS support and ask for a limit increase.
 
 ## Attribute Reference
 


### PR DESCRIPTION
- When creating an `iam_instance_profile` you will receive an error if you have multiple roles defined but have not increased your AWS limit for the number of roles you can assign to an `iam_instance_profile`.
- See more on defaults: http://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-limits.html