### PR TITLE
provider/aws: (#10587) Changing volumes in ECS task definition should force new revision

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -70,11 +70,13 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 						"name": {
 							Type:     schema.TypeString,
 							Required: true,
+							ForceNew: true,
 						},
 
 						"host_path": {
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 					},
 				},


### PR DESCRIPTION
fix for: https://github.com/hashicorp/terraform/issues/10587

ECS task definition doesn't support updates so changes in volumes configuration should also tiger recreating resource.