### PR TITLE
provider/aws: Fix RouteTable data source test

### DIFF
--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -189,5 +189,9 @@ data "aws_route_table" "by_filter" {
     name = "association.main"
     values = ["true"]
   }
+  filter {
+    name = "vpc-id"
+    values = ["vpc-6bd70802"]
+  }
 }
 `


### PR DESCRIPTION
Fixes the `TestAccDataSourceAwsRouteTable_main` acceptance test.

```
=== RUN   TestAccDataSourceAwsRouteTable_main
--- PASS: TestAccDataSourceAwsRouteTable_main (11.19s)
```