### PR TITLE
provider/aws: Add EBS Volume support for EMR Instance Groups

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -727,3 +727,19 @@ func validateAwsEcsPlacementStrategy(stratType, stratField string) error {
 	}
 	return nil
 }
+
+func validateAwsEmrEbsVolumeType(v interface{}, k string) (ws []string, errors []error) {
+	validTypes := map[string]struct{}{
+		"gp2":      {},
+		"io1":      {},
+		"standard": {},
+	}
+
+	value := v.(string)
+
+	if _, ok := validTypes[value]; !ok {
+		errors = append(errors, fmt.Errorf(
+			"%q must be one of ['gp2', 'io1', 'standard']", k))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1172,3 +1172,48 @@ func TestValidateEcsPlacementStrategy(t *testing.T) {
 
 	}
 }
+
+func TestValidateEmrEbsVolumeType(t *testing.T) {
+	cases := []struct {
+		VolType  string
+		ErrCount int
+	}{
+		{
+			VolType:  "gp2",
+			ErrCount: 0,
+		},
+		{
+			VolType:  "io1",
+			ErrCount: 0,
+		},
+		{
+			VolType:  "standard",
+			ErrCount: 0,
+		},
+		{
+			VolType:  "stand",
+			ErrCount: 1,
+		},
+		{
+			VolType:  "io",
+			ErrCount: 1,
+		},
+		{
+			VolType:  "gp1",
+			ErrCount: 1,
+		},
+		{
+			VolType:  "fast-disk",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateAwsEmrEbsVolumeType(tc.VolType, "volume")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %d errors, got %d: %s", tc.ErrCount, len(errors), errors)
+		}
+	}
+
+}


### PR DESCRIPTION
Adds EBS Volume support and tests for EMR Instnace Groups

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEMRInstanceGroup_ebsBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/25 10:14:58 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEMRInstanceGroup_ebsBasic -timeout 120m
=== RUN   TestAccAWSEMRInstanceGroup_ebsBasic
--- PASS: TestAccAWSEMRInstanceGroup_ebsBasic (675.14s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    675.171s
```

Partially fixes #11126 