### PR TITLE
core: MergeDiff to delete nested entries in fields that became empty

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1678,15 +1678,14 @@ func (s *InstanceState) MergeDiff(d *InstanceDiff) *InstanceState {
 	}
 
 	for _, k := range deleted {
-		// Sanity check for invalid structures.
-		// If we removed the primary count key, there should have been no
+		// If we removed the primary count key, we also need to remove
 		// other keys left with this prefix.
 
 		// this must have a "#" or "%" which we need to remove
 		base := k[:len(k)-1]
 		for k, _ := range result.Attributes {
 			if strings.HasPrefix(k, base) {
-				panic(fmt.Sprintf("empty structure %q has entry %q", base, k))
+				delete(result.Attributes, k)
 			}
 		}
 	}

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -1452,6 +1452,76 @@ func TestInstanceState_MergeDiffRemoveCounts(t *testing.T) {
 	}
 }
 
+func TestInstanceState_MergeDiff_removeNestedFields(t *testing.T) {
+	is := &InstanceState{
+		ID: "f4e0a336-defe-4d89-9327-a6d4c74e2f0d",
+		Attributes: map[string]string{
+			"alarm_configuration.#":                           "1",
+			"alarm_configuration.0.alarms.#":                  "1",
+			"alarm_configuration.0.alarms.2356372769":         "foo",
+			"alarm_configuration.0.enabled":                   "true",
+			"alarm_configuration.0.ignore_poll_alarm_failure": "false",
+			"app_name":                      "foo-app-32345345345",
+			"auto_rollback_configuration.#": "0",
+			"autoscaling_groups.#":          "0",
+			"deployment_config_name":        "CodeDeployDefault.OneAtATime",
+			"deployment_group_name":         "foo-group-32345345345",
+			"ec2_tag_filter.#":              "0",
+			"id":                            "f4e0a336-defe-4d89-9327-a6d4c74e2f0d",
+			"on_premises_instance_tag_filter.#": "0",
+			"service_role_arn":                  "arn:aws:iam::123456789012:role/foo-role-32345345345",
+			"trigger_configuration.#":           "0",
+		},
+	}
+
+	diff := &InstanceDiff{
+		Attributes: map[string]*ResourceAttrDiff{
+			"alarm_configuration.#": &ResourceAttrDiff{
+				Old:         "1",
+				New:         "0",
+				NewComputed: false,
+				NewRemoved:  false,
+				RequiresNew: false,
+			},
+			"alarm_configuration.0.alarms.#": &ResourceAttrDiff{
+				Old:         "1",
+				New:         "0",
+				NewComputed: false,
+				NewRemoved:  false,
+				RequiresNew: false,
+			},
+			"alarm_configuration.0.alarms.2356372769": &ResourceAttrDiff{
+				Old:         "foo",
+				New:         "",
+				NewComputed: false,
+				NewRemoved:  true,
+				RequiresNew: false,
+			},
+			"alarm_configuration.0.enabled": &ResourceAttrDiff{
+				Old:         "true",
+				New:         "false",
+				NewComputed: false,
+				NewRemoved:  true,
+				RequiresNew: false,
+			},
+		},
+	}
+
+	is2 := is.MergeDiff(diff)
+
+	expected := map[string]string{
+		"app_name":               "foo-app-32345345345",
+		"deployment_config_name": "CodeDeployDefault.OneAtATime",
+		"deployment_group_name":  "foo-group-32345345345",
+		"id":               "f4e0a336-defe-4d89-9327-a6d4c74e2f0d",
+		"service_role_arn": "arn:aws:iam::123456789012:role/foo-role-32345345345",
+	}
+
+	if !reflect.DeepEqual(expected, is2.Attributes) {
+		t.Fatalf("expected: %#v\ngiven: %#v", expected, is2.Attributes)
+	}
+}
+
 func TestInstanceState_MergeDiff_nil(t *testing.T) {
 	var is *InstanceState
 


### PR DESCRIPTION
Related:
https://github.com/hashicorp/terraform/pull/11245

After merging #11245 a few acceptance tests started to panic.
I've verified that those panicking tests are testing genuine behaviour - something user would normally do too. The problem occurs when you have a resource w/ `TypeList` that has an existing state and you decide to remove that whole `TypeList` block in the config.

I don't know if the motivation behind the panic was the expectation that we'd always produce `InstanceDiff` where `TypeList` w/ `NewRemoved: true` also has all nested fields `NewRemoved: true` - that is currently _not_ the case. If that's expected, then this should be fixed elsewhere.

If it's supposed to be the responsibility of `MergeDiff` to figure this out then I think this is ok as is. 

I ran the full aws acceptance test suite and the panics all disappeared & new failures were just coming from flappy tests.