### PR TITLE
provider/postgres grant role when creating database

### DIFF
--- a/builtin/providers/postgresql/resource_postgresql_database.go
+++ b/builtin/providers/postgresql/resource_postgresql_database.go
@@ -125,7 +125,7 @@ func resourcePostgreSQLDatabaseCreate(d *schema.ResourceData, meta interface{}) 
 	//needed in order to set the owner of the db if the connection user is not a superuser
 	err = grantRoleMembership(conn, d.Get(dbOwnerAttr).(string), c.username)
 	if err != nil {
-		return err
+		return errwrap.Wrapf(fmt.Sprintf("Error granting role membership on  database %s: {{err}}", dbName), err)
 	}
 
 	// Handle each option individually and stream results into the query

--- a/builtin/providers/postgresql/resource_postgresql_database.go
+++ b/builtin/providers/postgresql/resource_postgresql_database.go
@@ -122,6 +122,12 @@ func resourcePostgreSQLDatabaseCreate(d *schema.ResourceData, meta interface{}) 
 	b := bytes.NewBufferString("CREATE DATABASE ")
 	fmt.Fprint(b, pq.QuoteIdentifier(dbName))
 
+	//needed in order to set the owner of the db if the connection user is not a superuser
+	err = grantRoleMembership(conn, d.Get(dbOwnerAttr).(string), c.username)
+	if err != nil {
+		return err
+	}
+
 	// Handle each option individually and stream results into the query
 	// buffer.
 
@@ -462,5 +468,20 @@ func doSetDBIsTemplate(conn *sql.DB, dbName string, isTemplate bool) error {
 		return errwrap.Wrapf("Error updating database IS_TEMPLATE: {{err}}", err)
 	}
 
+	return nil
+}
+
+func grantRoleMembership(conn *sql.DB, dbOwner string, connUsername string) error {
+	if dbOwner != "" && dbOwner != connUsername {
+		query := fmt.Sprintf("GRANT %s TO %s", pq.QuoteIdentifier(dbOwner), pq.QuoteIdentifier(connUsername))
+		_, err := conn.Query(query)
+		if err != nil {
+			// is already member or role
+			if strings.Contains(err.Error(), "duplicate key value violates unique constraint") {
+				return nil
+			}
+			return errwrap.Wrapf("Error granting membership: {{err}}", err)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
The code here is reintroduced from older commits. See:

https://github.com/hashicorp/terraform/commit/2e529146a5e92251081b3c75fba6ecabbac37c3d

and

https://github.com/hashicorp/terraform/commit/f3add9e7efbb3066a743d88a86cf8c8f61cc4c0a

(the part related to grantRoleMembership).

Without this code - creating a new database with a terraform generated role as the owner will not work. You will get the error:

```bash
Error applying plan:

1 error(s) occurred:

* postgresql_database.my-db: Error creating database database1: pq: must be member of role "my-role"
```
