### PR TITLE
provider/aws: allow destroy of LB stickiness policy with missing LB

### DIFF
--- a/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
+++ b/builtin/providers/aws/resource_aws_lb_cookie_stickiness_policy.go
@@ -103,9 +103,10 @@ func resourceAwsLBCookieStickinessPolicyRead(d *schema.ResourceData, meta interf
 
 	getResp, err := elbconn.DescribeLoadBalancerPolicies(request)
 	if err != nil {
-		if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "PolicyNotFound" {
-			// The policy is gone.
-			d.SetId("")
+		if ec2err, ok := err.(awserr.Error); ok {
+			if ec2err.Code() == "PolicyNotFound" || ec2err.Code() == "LoadBalancerNotFound" {
+				d.SetId("")
+			}
 			return nil
 		}
 		return fmt.Errorf("Error retrieving policy: %s", err)


### PR DESCRIPTION
Previously an attempt to destroy a LB stickiness policy with a missing load balancer would
result in an error like this:

```
* aws_lb_cookie_stickiness_policy.foo: Error removing LBCookieStickinessPolicy: LoadBalancerNotFound: There is no ACTIVE Load Balancer named 'tf-test-lb-tqatd'
    status code: 400, request id: 28af1167-e4a4-11e6-8ddd-57ba410cbbb6
```

This checks for a missing load balancer on the policy read and allows
the destroy.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLBCookieStickinessPolicy_missingLB'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/27 07:21:11 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLBCookieStickinessPolicy_missingLB -timeout 120m
=== RUN   TestAccAWSLBCookieStickinessPolicy_missingLB
--- PASS: TestAccAWSLBCookieStickinessPolicy_missingLB (28.90s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    28.929s
```