### PR TITLE
provider/aws: Fix ECS Service Placement Constraints

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -202,10 +202,14 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 			if err := validateAwsEcsPlacementConstraint(t, e); err != nil {
 				return err
 			}
-			pc = append(pc, &ecs.PlacementConstraint{
-				Type:       aws.String(t),
-				Expression: aws.String(e),
-			})
+			constraint := &ecs.PlacementConstraint{
+				Type: aws.String(t),
+			}
+			if e != "" {
+				constraint.Expression = aws.String(e)
+			}
+
+			pc = append(pc, constraint)
 		}
 		input.PlacementConstraints = pc
 	}
@@ -336,7 +340,9 @@ func flattenServicePlacementConstraints(pcs []*ecs.PlacementConstraint) []map[st
 	for _, pc := range pcs {
 		c := make(map[string]interface{})
 		c["type"] = *pc.Type
-		c["expression"] = *pc.Expression
+		if pc.Expression != nil {
+			c["expression"] = *pc.Expression
+		}
 		results = append(results, c)
 	}
 	return results

--- a/builtin/providers/aws/resource_aws_ecs_service_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_service_test.go
@@ -298,6 +298,23 @@ func TestAccAWSEcsServiceWithPlacementConstraints(t *testing.T) {
 	})
 }
 
+func TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcsServiceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEcsServiceWithPlacementConstraintEmptyExpression,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcsServiceExists("aws_ecs_service.mongo"),
+					resource.TestCheckResourceAttr("aws_ecs_service.mongo", "placement_constraints.#", "1"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSEcsServiceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ecsconn
 
@@ -461,6 +478,37 @@ resource "aws_ecs_service" "mongo" {
   placement_constraints {
 	type = "memberOf"
 	expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
+  }
+}
+`
+
+var testAccAWSEcsServiceWithPlacementConstraintEmptyExpression = `
+resource "aws_ecs_cluster" "default" {
+	name = "terraformecstest212"
+}
+
+resource "aws_ecs_task_definition" "mongo" {
+  family = "mongodb"
+  container_definitions = <<DEFINITION
+[
+  {
+    "cpu": 128,
+    "essential": true,
+    "image": "mongo:latest",
+    "memory": 128,
+    "name": "mongodb"
+  }
+]
+DEFINITION
+}
+
+resource "aws_ecs_service" "mongo" {
+  name = "mongodb"
+  cluster = "${aws_ecs_cluster.default.id}"
+  task_definition = "${aws_ecs_task_definition.mongo.arn}"
+  desired_count = 1
+  placement_constraints {
+	  type = "distinctInstance"
   }
 }
 `


### PR DESCRIPTION
Introduced in #11298

Fixes placement constraints to correctly handle the `distictInstance` constraint. Added a test for such a case as well.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/27 11:10:50 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression -timeout 120m
=== RUN   TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression
--- PASS: TestAccAWSEcsServiceWithPlacementConstraints_emptyExpression (117.42s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    117.461s
```