### PR TITLE
provider/openstack: Remove Default Security Group Rules

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_secgroup_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_secgroup_v2_test.go
@@ -23,6 +23,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists(
 						"openstack_networking_secgroup_v2.secgroup_1", &security_group),
+					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 0),
 				),
 			},
 			resource.TestStep{
@@ -86,6 +87,18 @@ func testAccCheckNetworkingV2SecGroupExists(n string, security_group *groups.Sec
 		*security_group = *found
 
 		return nil
+	}
+}
+
+func testAccCheckNetworkingV2SecGroupRuleCount(
+	sg *groups.SecGroup, count int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(sg.Rules) == count {
+			return nil
+		}
+
+		return fmt.Errorf("Unexpected number of rules in group %s. Expected %d, got %d",
+			sg.ID, count, len(sg.Rules))
 	}
 }
 


### PR DESCRIPTION
This commit removes the default security group rules that are automatically
created when a security group is created. These rules are usually
permissive egress rules which makes it difficult to add more strict egress
security group rules.

Fixes #9799