### PR TITLE
Mention how to use git modules over SSH

### DIFF
--- a/website/source/docs/modules/sources.html.markdown
+++ b/website/source/docs/modules/sources.html.markdown
@@ -57,6 +57,14 @@ module "consul" {
 }
 ```
 
+These will fetch the modules using HTTPS.  If you want to use SSH instead:
+
+```
+module "consul" {
+	source = "git@github.com:hashicorp/example.git//subdir"
+}
+```
+
 **Note:** The double-slash, `//`, is important. It is what tells Terraform that that is the separator for a subdirectory, and not part of the repository itself.
 
 GitHub source URLs require that Git is installed on your system and that you have access to the repository.


### PR DESCRIPTION
How this came about:

The only mention of using private modules is from a CI server.  This suggests using a username and password.  This doesn't work for me, since I (and everyone in our org) have 2FA enabled, so instead of a username and password, we would need a username and a personal auth token.

However, GitHub will not let us generate a personal auth token that can access private content.  So that is a dead end.  And this is not for a CI type environment.

Digging into the code of `go-getter`, I found out that strings prefixed with "git@github.com:" will be translated into SSH URLs.  This works for us.
