### PR TITLE
provider/aws: Import aws_alb_listener_rule fix

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_listener_rule.go
+++ b/builtin/providers/aws/resource_aws_alb_listener_rule.go
@@ -144,10 +144,15 @@ func resourceAwsAlbListenerRuleRead(d *schema.ResourceData, meta interface{}) er
 	rule := resp.Rules[0]
 
 	d.Set("arn", rule.RuleArn)
-	if priority, err := strconv.Atoi(*rule.Priority); err != nil {
-		return errwrap.Wrapf("Cannot convert rule priority %q to int: {{err}}", err)
+	// Rules are evaluated in priority order, from the lowest value to the highest value. The default rule has the lowest priority.
+	if *rule.Priority == "default" {
+		d.Set("priority", 99999)
 	} else {
-		d.Set("priority", priority)
+		if priority, err := strconv.Atoi(*rule.Priority); err != nil {
+			return errwrap.Wrapf("Cannot convert rule priority %q to int: {{err}}", err)
+		} else {
+			d.Set("priority", priority)
+		}
 	}
 
 	actions := make([]interface{}, len(rule.Actions))


### PR DESCRIPTION
Allows the user to import a default aws_alb_listener_rule. When creating the resource with TF, the AWS API requires that `priority` be an integer.
However, the `DescribeRules` API call returns a string for `priority`. This would work in every case except for the `default` listener rule, which sets the `priority` value to the string "default".

This fixes the previous error:
```
Error importing: 1 error(s) occurred:

* aws_alb_listener_rule.test: Cannot convert rule priority %q to int: strconv.ParseInt: parsing "default": invalid syntax
```

Fixes: #11464