### PR TITLE
provider/google: Fix master_instance_name to prevent slave rebuilds

### DIFF
--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -70,6 +71,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 						"crash_safe_replication": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"database_flags": &schema.Schema{
 							Type:     schema.TypeList,
@@ -564,7 +566,7 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 				_backupConfiguration["enabled"] = settings.BackupConfiguration.Enabled
 			}
 
-			if vp, okp := _backupConfiguration["start_time"]; okp && vp != nil {
+			if vp, okp := _backupConfiguration["start_time"]; okp && len(vp.(string)) > 0 {
 				_backupConfiguration["start_time"] = settings.BackupConfiguration.StartTime
 			}
 
@@ -758,7 +760,7 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("ip_address", _ipAddresses)
 
 	if v, ok := d.GetOk("master_instance_name"); ok && v != nil {
-		d.Set("master_instance_name", instance.MasterInstanceName)
+		d.Set("master_instance_name", strings.TrimPrefix(instance.MasterInstanceName, project+":"))
 	}
 
 	d.Set("self_link", instance.SelfLink)

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -10,6 +10,7 @@ package google
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -80,6 +81,34 @@ func TestAccGoogleSqlDatabaseInstance_settings_basic(t *testing.T) {
 						"google_sql_database_instance.instance", &instance),
 					testAccCheckGoogleSqlDatabaseInstanceEquals(
 						"google_sql_database_instance.instance", &instance),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGoogleSqlDatabaseInstance_slave(t *testing.T) {
+	var instance sqladmin.DatabaseInstance
+	masterID := acctest.RandInt()
+	slaveID := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_slave, masterID, slaveID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleSqlDatabaseInstanceExists(
+						"google_sql_database_instance.instance_master", &instance),
+					testAccCheckGoogleSqlDatabaseInstanceEquals(
+						"google_sql_database_instance.instance_master", &instance),
+					testAccCheckGoogleSqlDatabaseInstanceExists(
+						"google_sql_database_instance.instance_slave", &instance),
+					testAccCheckGoogleSqlDatabaseInstanceEquals(
+						"google_sql_database_instance.instance_slave", &instance),
 				),
 			},
 		},
@@ -199,7 +228,7 @@ func testAccCheckGoogleSqlDatabaseInstanceEquals(n string,
 			return fmt.Errorf("Error settings.tier mismatch, (%s, %s)", server, local)
 		}
 
-		server = instance.MasterInstanceName
+		server = strings.TrimPrefix(instance.MasterInstanceName, instance.Project+":")
 		local = attributes["master_instance_name"]
 		if server != local && len(server) > 0 && len(local) > 0 {
 			return fmt.Errorf("Error master_instance_name mismatch, (%s, %s)", server, local)
@@ -470,6 +499,33 @@ resource "google_sql_database_instance" "instance" {
 		username = "username"
 		ssl_cipher = "ALL"
 		verify_server_certificate = false
+	}
+}
+`
+
+var testGoogleSqlDatabaseInstance_slave = `
+resource "google_sql_database_instance" "instance_master" {
+	name = "tf-lw-%d"
+	region = "us-central1"
+
+	settings {
+		tier = "db-f1-micro"
+
+		backup_configuration {
+			enabled = true
+			binary_log_enabled = true
+		}
+	}
+}
+
+resource "google_sql_database_instance" "instance_slave" {
+	name = "tf-lw-%d"
+	region = "us-central1"
+
+	master_instance_name = "${google_sql_database_instance.instance_master.name}"
+
+	settings {
+		tier = "db-f1-micro"
 	}
 }
 `


### PR DESCRIPTION
The v1beta4 API returns the `master_instance_name` for a Second Generation Replica prefixed with the `project` which is not what Terraform is expecting, nor is it required. With the `project` prefixed Terraform plans to recreate the slave on every subsequent apply. The read method has been adjusted to strip the `project` prefix so slaves can persist.

Two minor fixes are included that were uncovered in the acceptance test. `crash_safe_replication` is only relevant for First Generation instances so I have not specified it. With the slave the API returns `true` even if we haven't set the value. Terraform will attempt to set it to `false` on the next apply which appears to be a no-op in Google as the next plan will show `true`. I have changed this to a `Computed` value as it is a boolean.

Not specifying the optional `start_time` for `backup_configuration` causes subsequent plans to attempt to adjust the Google default to an empty value. As this is a string I have changed the read to return no value if we haven't set the value.