### PR TITLE
core: allow non-computed data source values in "count"

### DIFF
--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -575,7 +575,7 @@ func TestPlan_validate(t *testing.T) {
 	}
 
 	actual := ui.ErrorWriter.String()
-	if !strings.Contains(actual, "can't reference") {
+	if !strings.Contains(actual, "cannot be computed") {
 		t.Fatalf("bad: %s", actual)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -505,23 +505,17 @@ func (c *Config) Validate() error {
 					"%s: resource count can't reference count variable: %s",
 					n,
 					v.FullKey()))
-			case *ModuleVariable:
-				errs = append(errs, fmt.Errorf(
-					"%s: resource count can't reference module variable: %s",
-					n,
-					v.FullKey()))
-			case *ResourceVariable:
-				errs = append(errs, fmt.Errorf(
-					"%s: resource count can't reference resource variable: %s",
-					n,
-					v.FullKey()))
 			case *SimpleVariable:
 				errs = append(errs, fmt.Errorf(
 					"%s: resource count can't reference variable: %s",
 					n,
 					v.FullKey()))
+
+			// Good
+			case *ModuleVariable:
+			case *ResourceVariable:
 			case *UserVariable:
-				// Good
+
 			default:
 				panic(fmt.Sprintf("Unknown type in count var in %s: %T", n, v))
 			}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -254,29 +254,8 @@ func TestConfigValidate_countCountVar(t *testing.T) {
 	}
 }
 
-func TestConfigValidate_countModuleVar(t *testing.T) {
-	c := testConfig(t, "validate-count-module-var")
-	if err := c.Validate(); err == nil {
-		t.Fatal("should not be valid")
-	}
-}
-
 func TestConfigValidate_countNotInt(t *testing.T) {
 	c := testConfig(t, "validate-count-not-int")
-	if err := c.Validate(); err == nil {
-		t.Fatal("should not be valid")
-	}
-}
-
-func TestConfigValidate_countResourceVar(t *testing.T) {
-	c := testConfig(t, "validate-count-resource-var")
-	if err := c.Validate(); err == nil {
-		t.Fatal("should not be valid")
-	}
-}
-
-func TestConfigValidate_countResourceVarMulti(t *testing.T) {
-	c := testConfig(t, "validate-count-resource-var-multi")
 	if err := c.Validate(); err == nil {
 		t.Fatal("should not be valid")
 	}

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -1477,6 +1477,40 @@ func TestContext2Plan_countComputedModule(t *testing.T) {
 	}
 }
 
+func TestContext2Plan_countModuleStatic(t *testing.T) {
+	m := testModule(t, "plan-count-module-static")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(`
+DIFF:
+
+module.child:
+  CREATE: aws_instance.foo.0
+  CREATE: aws_instance.foo.1
+  CREATE: aws_instance.foo.2
+
+STATE:
+
+<no state>
+`)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestContext2Plan_countIndex(t *testing.T) {
 	m := testModule(t, "plan-count-index")
 	p := testProvider("aws")

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -1511,6 +1511,40 @@ STATE:
 	}
 }
 
+func TestContext2Plan_countModuleStaticGrandchild(t *testing.T) {
+	m := testModule(t, "plan-count-module-static-grandchild")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(`
+DIFF:
+
+module.child.child:
+  CREATE: aws_instance.foo.0
+  CREATE: aws_instance.foo.1
+  CREATE: aws_instance.foo.2
+
+STATE:
+
+<no state>
+`)
+	if actual != expected {
+		t.Fatalf("bad:\n%s", actual)
+	}
+}
+
 func TestContext2Plan_countIndex(t *testing.T) {
 	m := testModule(t, "plan-count-index")
 	p := testProvider("aws")

--- a/terraform/context_validate_test.go
+++ b/terraform/context_validate_test.go
@@ -115,6 +115,28 @@ func TestContext2Validate_computedVar(t *testing.T) {
 	}
 }
 
+// Test that validate allows through computed counts. We do this and allow
+// them to fail during "plan" since we can't know if the computed values
+// can be realized during a plan.
+func TestContext2Validate_countComputed(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "validate-count-computed")
+	c := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	w, e := c.Validate()
+	if len(w) > 0 {
+		t.Fatalf("bad: %#v", w)
+	}
+	if len(e) > 0 {
+		t.Fatalf("bad: %s", e)
+	}
+}
+
 func TestContext2Validate_countNegative(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "validate-count-negative")

--- a/terraform/eval_sequence.go
+++ b/terraform/eval_sequence.go
@@ -7,6 +7,10 @@ type EvalSequence struct {
 
 func (n *EvalSequence) Eval(ctx EvalContext) (interface{}, error) {
 	for _, n := range n.Nodes {
+		if n == nil {
+			continue
+		}
+
 		if _, err := EvalRaw(n, ctx); err != nil {
 			return nil, err
 		}

--- a/terraform/eval_validate.go
+++ b/terraform/eval_validate.go
@@ -42,6 +42,7 @@ func (n *EvalValidateCount) Eval(ctx EvalContext) (interface{}, error) {
 		c[n.Resource.RawCount.Key] = "1"
 		count = 1
 	}
+	err = nil
 
 	if count < 0 {
 		errs = append(errs, fmt.Errorf(

--- a/terraform/node_resource_abstract_count.go
+++ b/terraform/node_resource_abstract_count.go
@@ -14,6 +14,14 @@ type NodeAbstractCountResource struct {
 
 // GraphNodeEvalable
 func (n *NodeAbstractCountResource) EvalTree() EvalNode {
+	// We only check if the count is computed if we're not validating.
+	// If we're validating we allow computed counts since they just turn
+	// into more computed values.
+	var evalCountCheckComputed EvalNode
+	if !n.Validate {
+		evalCountCheckComputed = &EvalCountCheckComputed{Resource: n.Config}
+	}
+
 	return &EvalSequence{
 		Nodes: []EvalNode{
 			// The EvalTree for a plannable resource primarily involves
@@ -24,7 +32,8 @@ func (n *NodeAbstractCountResource) EvalTree() EvalNode {
 			// into the proper number of instances.
 			&EvalInterpolate{Config: n.Config.RawCount},
 
-			&EvalCountCheckComputed{Resource: n.Config},
+			// Check if the count is computed
+			evalCountCheckComputed,
 
 			// If validation is enabled, perform the validation
 			&EvalIf{

--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -26,9 +26,13 @@ func (n *NodeValidatableResource) DynamicExpand(ctx EvalContext) (*Graph, error)
 	defer lock.RUnlock()
 
 	// Expand the resource count which must be available by now from EvalTree
-	count, err := n.Config.Count()
-	if err != nil {
-		return nil, err
+	count := 1
+	if n.Config.RawCount.Value() != unknownValue() {
+		var err error
+		count, err = n.Config.Count()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// The concrete resource factory we'll use

--- a/terraform/test-fixtures/plan-count-module-static-grandchild/child/child/main.tf
+++ b/terraform/test-fixtures/plan-count-module-static-grandchild/child/child/main.tf
@@ -1,0 +1,5 @@
+variable "value" {}
+
+resource "aws_instance" "foo" {
+    count = "${var.value}"
+}

--- a/terraform/test-fixtures/plan-count-module-static-grandchild/child/main.tf
+++ b/terraform/test-fixtures/plan-count-module-static-grandchild/child/main.tf
@@ -1,0 +1,6 @@
+variable "value" {}
+
+module "child" {
+    source = "./child"
+    value = "${var.value}"
+}

--- a/terraform/test-fixtures/plan-count-module-static-grandchild/main.tf
+++ b/terraform/test-fixtures/plan-count-module-static-grandchild/main.tf
@@ -1,0 +1,6 @@
+variable "foo" { default = "3" }
+
+module "child" {
+    source = "./child"
+    value = "${var.foo}"
+}

--- a/terraform/test-fixtures/plan-count-module-static/child/main.tf
+++ b/terraform/test-fixtures/plan-count-module-static/child/main.tf
@@ -1,0 +1,5 @@
+variable "value" {}
+
+resource "aws_instance" "foo" {
+    count = "${var.value}"
+}

--- a/terraform/test-fixtures/plan-count-module-static/main.tf
+++ b/terraform/test-fixtures/plan-count-module-static/main.tf
@@ -1,0 +1,6 @@
+variable "foo" { default = "3" }
+
+module "child" {
+    source = "./child"
+    value = "${var.foo}"
+}

--- a/terraform/test-fixtures/validate-count-computed/main.tf
+++ b/terraform/test-fixtures/validate-count-computed/main.tf
@@ -1,0 +1,7 @@
+data "aws_data_source" "foo" {
+    compute = "value"
+}
+
+resource "aws_instance" "bar" {
+    count = "${data.aws_data_source.foo.value}"
+}


### PR DESCRIPTION
Based on #10418, but simpler due to new graphs (more LOC change due to tests).

This disables the computed value check for `count` during the validation
pass. This enables partial support for #3888 or #1497: as long as the
value is non-computed during the plan, complex values will work in
counts.

**Notably, this allows data source values to be present in counts!**

The "count" value can be disabled during validation safely because we
can treat it as if any field that uses `count.index` is computed for
validation. We then validate a single instance (as if `count = 1`) just
to make sure all required fields are set.

This still won't allow "computed" data source values: data sources that
themselves depend on the value of some computed resource (non-data source).

As promised, this loosens the strict requirement of computed count values.
I'm still trying to make this even better for 0.9...