### PR TITLE
provider/pagerduty: Allow timeouts to be disabled (pagerduty_service)

### DIFF
--- a/builtin/providers/pagerduty/resource_pagerduty_service.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service.go
@@ -117,6 +117,10 @@ func resourcePagerDutyServiceRead(d *schema.ResourceData, meta interface{}) erro
 	service, err := client.GetService(d.Id(), o)
 
 	if err != nil {
+		if isNotFound(err) {
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/builtin/providers/pagerduty/resource_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_test.go
@@ -38,9 +38,9 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "bar"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "auto_resolve_timeout", "3600"),
+						"pagerduty_service.foo", "auto_resolve_timeout", "0"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "acknowledgement_timeout", "3600"),
+						"pagerduty_service.foo", "acknowledgement_timeout", "0"),
 				),
 			},
 		},
@@ -149,10 +149,8 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-  name                    = "bar"
-  description             = "bar"
-  auto_resolve_timeout    = 3600
-  acknowledgement_timeout = 3600
-  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+  name              = "bar"
+  description       = "bar"
+  escalation_policy = "${pagerduty_escalation_policy.foo.id}"
 }
 `

--- a/vendor/github.com/PagerDuty/go-pagerduty/service.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/service.go
@@ -2,8 +2,9 @@ package pagerduty
 
 import (
 	"fmt"
-	"github.com/google/go-querystring/query"
 	"net/http"
+
+	"github.com/google/go-querystring/query"
 )
 
 // Integration is an endpoint (like Nagios, email, or an API call) that generates events, which are normalized and de-duplicated by PagerDuty to create incidents.
@@ -59,8 +60,8 @@ type Service struct {
 	APIObject
 	Name                   string               `json:"name,omitempty"`
 	Description            string               `json:"description,omitempty"`
-	AutoResolveTimeout     *uint                `json:"auto_resolve_timeout,omitempty"`
-	AcknowledgementTimeout *uint                `json:"acknowledgement_timeout,omitempty"`
+	AutoResolveTimeout     *uint                `json:"auto_resolve_timeout"`
+	AcknowledgementTimeout *uint                `json:"acknowledgement_timeout"`
 	CreateAt               string               `json:"created_at,omitempty"`
 	Status                 string               `json:"status,omitempty"`
 	LastIncidentTimestamp  string               `json:"last_incident_timestamp,omitempty"`

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -376,10 +376,10 @@
 			"revisionTime": "2016-11-03T18:56:17Z"
 		},
 		{
-			"checksumSHA1": "wzzdybMOEWsQ/crdkpTLneeob2U=",
+			"checksumSHA1": "trj+UY2oSzP0O1WJKz8auncslVs=",
 			"path": "github.com/PagerDuty/go-pagerduty",
-			"revision": "317bca1364fc322f4d6f8eeb276e931b6667b43b",
-			"revisionTime": "2016-12-20T22:05:08Z"
+			"revision": "fad777c9c72ec7c62aeec0194f01684d6a2efd0e",
+			"revisionTime": "2017-01-28T02:14:22Z"
 		},
 		{
 			"checksumSHA1": "ly9VLPE9GKo2U7mnbZyjb2LDQ3w=",

--- a/website/source/docs/providers/pagerduty/r/service.html.markdown
+++ b/website/source/docs/providers/pagerduty/r/service.html.markdown
@@ -49,8 +49,8 @@ The following arguments are supported:
   * `name` - (Required) The name of the service.
   * `description` - (Optional) A human-friendly description of the escalation policy.
     If not set, a placeholder of "Managed by Terraform" will be set.
-  * `auto_resolve_timeout` - (Optional) Time in seconds that an incident is automatically resolved if left open for that long.
-  * `acknowledgement_timeout` - (Optional) Time in seconds that an incident changes to the Triggered State after being Acknowledged.
+  * `auto_resolve_timeout` - (Optional) Time in seconds that an incident is automatically resolved if left open for that long. Disabled if not set.
+  * `acknowledgement_timeout` - (Optional) Time in seconds that an incident changes to the Triggered State after being Acknowledged. Disabled if not set.
   * `escalation_policy` - (Required) The escalation policy used by this service.
 
 ## Attributes Reference


### PR DESCRIPTION
This PR aims to solve the issue described in #9861 where 
auto_resolve_timeout & acknowledgement_timeout can't be disabled via Terraform.

Old behaviour:
If auto_resolve_timeout & acknowledgement_timeout wasn't set, 
API defaults would be used which is:
```
acknowledgement_timeout: 1800
auto_resolve_timeout:    14400
```

New behaviour:
The default for both auto_resolve_timeout & acknowledgement_timeout is now:
`0` which disables the timeouts. 

Please note though that this is a breaking change because the user would now have to explicitly pass the values for these two timeouts in order for them to be enabled.