### PR TITLE
vet: Fix vet errors in providers

### DIFF
--- a/builtin/providers/google/resource_google_project_iam_policy.go
+++ b/builtin/providers/google/resource_google_project_iam_policy.go
@@ -257,7 +257,7 @@ func setProjectIamPolicy(policy *cloudresourcemanager.Policy, config *Config, pi
 		&cloudresourcemanager.SetIamPolicyRequest{Policy: policy}).Do()
 
 	if err != nil {
-		return fmt.Errorf("Error applying IAM policy for project %q. Policy is %+s, error is %s", pid, policy, err)
+		return fmt.Errorf("Error applying IAM policy for project %q. Policy is %#v, error is %s", pid, policy, err)
 	}
 	return nil
 }

--- a/builtin/providers/profitbricks/resource_profitbricks_nic.go
+++ b/builtin/providers/profitbricks/resource_profitbricks_nic.go
@@ -101,7 +101,7 @@ func resourceProfitBricksNicRead(d *schema.ResourceData, meta interface{}) error
 	if nic.StatusCode > 299 {
 		return fmt.Errorf("Error occured while fetching a nic ID %s %s", d.Id(), nic.Response)
 	}
-	log.Printf("[INFO] LAN ON NIC: %s", nic.Properties.Lan)
+	log.Printf("[INFO] LAN ON NIC: %q", nic.Properties.Lan)
 	d.Set("dhcp", nic.Properties.Dhcp)
 	d.Set("lan", nic.Properties.Lan)
 	d.Set("name", nic.Properties.Name)

--- a/builtin/providers/profitbricks/resource_profitbricks_server.go
+++ b/builtin/providers/profitbricks/resource_profitbricks_server.go
@@ -372,7 +372,7 @@ func resourceProfitBricksServerCreate(d *schema.ResourceData, meta interface{}) 
 					}
 
 					request.Entities.Nics.Items[0].Entities = &profitbricks.NicEntities{
-						&profitbricks.FirewallRules{
+						Firewallrules: &profitbricks.FirewallRules{
 							Items: []profitbricks.FirewallRule{
 								firewall,
 							},


### PR DESCRIPTION
Working on a separate issue, noticed there were vet issues with a couple providers.

```
$ make vet
go vet .
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/google/resource_google_project_iam_policy.go:260: arg policy for printf verb %s of wrong type: *github.com/hashicorp/terraform/vendor/google.golang.org/api/cloudresourcemanager/v1.Policy
exit status 1
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/profitbricks/resource_profitbricks_nic.go:104: arg nic.Properties.Lan for printf verb %s of wrong type: int
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/profitbricks/resource_profitbricks_server.go:374: github.com/hashicorp/terraform/vendor/github.com/profitbricks/profitbricks-sdk-go.NicEntities composite literal uses unkeyed fields
exit status 1

Vet found suspicious constructs. Please check the reported constructs
and fix them if necessary before submitting the code for review.
make: *** [vet] Error 1
```