### PR TITLE
fix wrong usage of hashicorp/errwrap

### DIFF
--- a/builtin/providers/aws/auth_helpers.go
+++ b/builtin/providers/aws/auth_helpers.go
@@ -30,7 +30,7 @@ func GetAccountInfo(iamconn *iam.IAM, stsconn *sts.STS, authProviderName string)
 		setOptionalEndpoint(cfg)
 		sess, err := session.NewSession(cfg)
 		if err != nil {
-			return "", "", errwrap.Wrapf("Error creating AWS session: %s", err)
+			return "", "", errwrap.Wrapf("Error creating AWS session: {{err}}", err)
 		}
 
 		metadataClient := ec2metadata.New(sess)

--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -218,7 +218,7 @@ func flattenCloudWatchTags(d *schema.ResourceData, conn *cloudwatchlogs.CloudWat
 		LogGroupName: aws.String(d.Get("name").(string)),
 	})
 	if err != nil {
-		return nil, errwrap.Wrapf("Error Getting CloudWatch Logs Tag List: %s", err)
+		return nil, errwrap.Wrapf("Error Getting CloudWatch Logs Tag List: {{err}}", err)
 	}
 	if tagsOutput != nil {
 		output := make(map[string]interface{}, len(tagsOutput.Tags))

--- a/builtin/providers/aws/resource_aws_cloudwatch_log_stream.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_stream.go
@@ -48,7 +48,7 @@ func resourceAwsCloudWatchLogStreamCreate(d *schema.ResourceData, meta interface
 		LogStreamName: aws.String(d.Get("name").(string)),
 	})
 	if err != nil {
-		return errwrap.Wrapf("Creating CloudWatch Log Stream failed: %s", err)
+		return errwrap.Wrapf("Creating CloudWatch Log Stream failed: {{err}}", err)
 	}
 
 	d.SetId(d.Get("name").(string))
@@ -86,7 +86,7 @@ func resourceAwsCloudWatchLogStreamDelete(d *schema.ResourceData, meta interface
 	}
 	_, err := conn.DeleteLogStream(params)
 	if err != nil {
-		return errwrap.Wrapf("Error deleting CloudWatch Log Stream: %s", err)
+		return errwrap.Wrapf("Error deleting CloudWatch Log Stream: {{err}}", err)
 	}
 
 	return nil

--- a/builtin/providers/postgresql/provider.go
+++ b/builtin/providers/postgresql/provider.go
@@ -102,7 +102,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	client, err := config.NewClient()
 	if err != nil {
-		return nil, errwrap.Wrapf("Error initializing PostgreSQL client: %s", err)
+		return nil, errwrap.Wrapf("Error initializing PostgreSQL client: {{err}}", err)
 	}
 
 	return client, nil


### PR DESCRIPTION
According to https://github.com/hashicorp/errwrap
'{{err}}' has to be used instead of '%s'

Without this patch, error output from terraform is missing important information:
* aws_cloudwatch_log_group.logs: Error Getting CloudWatch Logs Tag List: %s

With this patch, I get the important information. E.g.:
* aws_cloudwatch_log_group.logs: Error Getting CloudWatch Logs Tag List: AccessDeniedException: User: arn:aws:sts::XYZ:assumed-role/AAA-BBB-CCC/terraform-assuming-role-assume-role-ReadOnly is not authorized to perform: logs:ListTagsLogGroup on resource: arn:aws:logs:us-east-1:XYZ:log-group:logs:log-stream: