### PR TITLE
provider/aws: Add support for policy to AWS provider assume_role

### DIFF
--- a/builtin/providers/aws/auth_helpers.go
+++ b/builtin/providers/aws/auth_helpers.go
@@ -146,8 +146,8 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 
 	// Otherwise we need to construct and STS client with the main credentials, and verify
 	// that we can assume the defined role.
-	log.Printf("[INFO] Attempting to AssumeRole %s (SessionName: %q, ExternalId: %q)",
-		c.AssumeRoleARN, c.AssumeRoleSessionName, c.AssumeRoleExternalID)
+	log.Printf("[INFO] Attempting to AssumeRole %s (SessionName: %q, ExternalId: %q, Policy: %q)",
+		c.AssumeRoleARN, c.AssumeRoleSessionName, c.AssumeRoleExternalID, c.AssumeRolePolicy)
 
 	creds := awsCredentials.NewChainCredentials(providers)
 	cp, err := creds.Get()
@@ -181,6 +181,9 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 	}
 	if c.AssumeRoleExternalID != "" {
 		assumeRoleProvider.ExternalID = aws.String(c.AssumeRoleExternalID)
+	}
+	if c.AssumeRolePolicy != "" {
+		assumeRoleProvider.Policy = aws.String(c.AssumeRolePolicy)
 	}
 
 	providers = []awsCredentials.Provider{assumeRoleProvider}

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -79,6 +79,7 @@ type Config struct {
 	AssumeRoleARN         string
 	AssumeRoleExternalID  string
 	AssumeRoleSessionName string
+	AssumeRolePolicy      string
 
 	AllowedAccountIds   []interface{}
 	ForbiddenAccountIds []interface{}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -471,6 +471,10 @@ func init() {
 
 		"assume_role_external_id": "The external ID to use when assuming the role. If omitted," +
 			" no external ID is passed to the AssumeRole call.",
+
+		"assume_role_policy": "The permissions applied when assuming a role. You cannot use," +
+			" this policy to grant further permissions that are in excess to those of the, " +
+			" role that is being assumed.",
 	}
 }
 
@@ -499,8 +503,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		config.AssumeRoleARN = assumeRole["role_arn"].(string)
 		config.AssumeRoleSessionName = assumeRole["session_name"].(string)
 		config.AssumeRoleExternalID = assumeRole["external_id"].(string)
-		log.Printf("[INFO] assume_role configuration set: (ARN: %q, SessionID: %q, ExternalID: %q)",
-			config.AssumeRoleARN, config.AssumeRoleSessionName, config.AssumeRoleExternalID)
+
+		if v := assumeRole["policy"].(string); v != "" {
+			config.AssumeRolePolicy = v
+		}
+
+		log.Printf("[INFO] assume_role configuration set: (ARN: %q, SessionID: %q, ExternalID: %q, Policy: %q)",
+			config.AssumeRoleARN, config.AssumeRoleSessionName, config.AssumeRoleExternalID, config.AssumeRolePolicy)
 	} else {
 		log.Printf("[INFO] No assume_role block read from configuration")
 	}
@@ -553,6 +562,12 @@ func assumeRoleSchema() *schema.Schema {
 					Optional:    true,
 					Description: descriptions["assume_role_external_id"],
 				},
+
+				"policy": {
+					Type:        schema.TypeString,
+					Optional:    true,
+					Description: descriptions["assume_role_policy"],
+				},
 			},
 		},
 		Set: assumeRoleToHash,
@@ -565,6 +580,7 @@ func assumeRoleToHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", m["role_arn"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["session_name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["external_id"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["policy"].(string)))
 	return hashcode.String(buf.String())
 }
 

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -231,6 +231,11 @@ The nested `assume_role` block supports the following:
 * `external_id` - (Optional) The external ID to use when making the
   AssumeRole call.
 
+* `policy` - (Optional) A more restrictive policy to apply to the temporary credentials. 
+This gives you a way to further restrict the permissions for the resulting temporary
+security credentials. You cannot use the passed policy to grant permissions that are
+in excess of those allowed by the access policy of the role that is being assumed.
+
 Nested `endpoints` block supports the following:
 
 * `iam` - (Optional) Use this to override the default endpoint


### PR DESCRIPTION
Fixes: #11461

This will allow the user to pass a policy to further restrict the use
of AssumeRole. It is important to note that it will NOT allow an
expansion of access rights