### PR TITLE
provisioners/chef: check IsComputed for JSON attributes

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -354,7 +354,7 @@ func (r *ResourceProvisioner) decodeConfig(c *terraform.ResourceConfig) (*Provis
 		p.UserKey = p.ValidationKey
 	}
 
-	if attrs, ok := c.Config["attributes_json"].(string); ok {
+	if attrs, ok := c.Config["attributes_json"].(string); ok && !c.IsComputed("attributes_json") {
 		var m map[string]interface{}
 		if err := json.Unmarshal([]byte(attrs), &m); err != nil {
 			return nil, fmt.Errorf("Error parsing attributes_json: %v", err)
@@ -362,7 +362,7 @@ func (r *ResourceProvisioner) decodeConfig(c *terraform.ResourceConfig) (*Provis
 		p.attributes = m
 	}
 
-	if vaults, ok := c.Config["vault_json"].(string); ok {
+	if vaults, ok := c.Config["vault_json"].(string); ok && !c.IsComputed("vault_json") {
 		var m map[string]interface{}
 		if err := json.Unmarshal([]byte(vaults), &m); err != nil {
 			return nil, fmt.Errorf("Error parsing vault_json: %v", err)

--- a/builtin/provisioners/chef/resource_provisioner_test.go
+++ b/builtin/provisioners/chef/resource_provisioner_test.go
@@ -47,6 +47,28 @@ func TestResourceProvider_Validate_bad(t *testing.T) {
 	}
 }
 
+// Test that the JSON attributes with an unknown value don't
+// validate.
+func TestResourceProvider_Validate_computedValues(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"environment":     "_default",
+		"node_name":       "nodename1",
+		"run_list":        []interface{}{"cookbook::recipe"},
+		"server_url":      "https://chef.local",
+		"user_name":       "bob",
+		"user_key":        "USER-KEY",
+		"attributes_json": config.UnknownVariableValue,
+	})
+	r := new(ResourceProvisioner)
+	warn, errs := r.Validate(c)
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("Errors: %v", errs)
+	}
+}
+
 func testConfig(t *testing.T, c map[string]interface{}) *terraform.ResourceConfig {
 	r, err := config.NewRawConfig(c)
 	if err != nil {


### PR DESCRIPTION
Fixes #10788

This checks `IsComputed` prior to attempting to use the JSON
configurations. Due to a change in 0.8, the prior check for simply map
existence would always succeed even with a computed value (as designed),
but we forgot to update provisioners to not do that.

There are other provisioners that also do this but to no ill effect
currently. I've only changed Chef since we know that is an issue.

This issue doesn't affect 0.9 due to helper/schema doing this
automatically for provisioners.