### PR TITLE
Closes #11053. Use environment specific client for accessing resources.

### DIFF
--- a/builtin/providers/rancher/resource_rancher_registration_token.go
+++ b/builtin/providers/rancher/resource_rancher_registration_token.go
@@ -97,7 +97,11 @@ func resourceRancherRegistrationTokenCreate(d *schema.ResourceData, meta interfa
 
 func resourceRancherRegistrationTokenRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing RegistrationToken: %s", d.Id())
-	client := meta.(*Config)
+	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	if err != nil {
+		return err
+	}
+	// client := meta.(*Config)
 
 	regT, err := client.RegistrationToken.ById(d.Id())
 	if err != nil {

--- a/builtin/providers/rancher/resource_rancher_registry.go
+++ b/builtin/providers/rancher/resource_rancher_registry.go
@@ -90,7 +90,10 @@ func resourceRancherRegistryCreate(d *schema.ResourceData, meta interface{}) err
 
 func resourceRancherRegistryRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing Registry: %s", d.Id())
-	client := meta.(*Config)
+	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	if err != nil {
+		return err
+	}
 
 	registry, err := client.Registry.ById(d.Id())
 	if err != nil {

--- a/builtin/providers/rancher/resource_rancher_registry_credential.go
+++ b/builtin/providers/rancher/resource_rancher_registry_credential.go
@@ -104,7 +104,10 @@ func resourceRancherRegistryCredentialCreate(d *schema.ResourceData, meta interf
 
 func resourceRancherRegistryCredentialRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing RegistryCredential: %s", d.Id())
-	client := meta.(*Config)
+	client, err := meta.(*Config).RegistryClient(d.Get("registry_id").(string))
+	if err != nil {
+		return err
+	}
 
 	registryCred, err := client.RegistryCredential.ById(d.Id())
 	if err != nil {

--- a/builtin/providers/rancher/resource_rancher_stack.go
+++ b/builtin/providers/rancher/resource_rancher_stack.go
@@ -122,7 +122,10 @@ func resourceRancherStackCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceRancherStackRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing Stack: %s", d.Id())
-	client := meta.(*Config)
+	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	if err != nil {
+		return err
+	}
 
 	stack, err := client.Environment.ById(d.Id())
 	if err != nil {


### PR DESCRIPTION
When using access control, the Rancher global API may return 404 for
resources that exist and are accessible via the environment API.