### PR TITLE
backend/local: validate module exists for plan

### DIFF
--- a/backend/local/backend_plan_test.go
+++ b/backend/local/backend_plan_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/backend"
@@ -33,6 +34,29 @@ func TestLocal_planBasic(t *testing.T) {
 
 	if !p.DiffCalled {
 		t.Fatal("diff should be called")
+	}
+}
+
+func TestLocal_planNoConfig(t *testing.T) {
+	b := TestLocal(t)
+	TestLocalProvider(t, b, "test")
+
+	op := testOperationPlan()
+	op.Module = nil
+	op.PlanRefresh = true
+
+	run, err := b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	<-run.Done()
+
+	err = run.Err
+	if err == nil {
+		t.Fatal("should error")
+	}
+	if !strings.Contains(err.Error(), "configuration") {
+		t.Fatalf("bad: %s", err)
 	}
 }
 
@@ -81,6 +105,48 @@ func TestLocal_planDestroy(t *testing.T) {
 	op.Destroy = true
 	op.PlanRefresh = true
 	op.Module = mod
+	op.PlanOutPath = planPath
+
+	run, err := b.Operation(context.Background(), op)
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	<-run.Done()
+	if run.Err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !p.RefreshCalled {
+		t.Fatal("refresh should be called")
+	}
+
+	if run.PlanEmpty {
+		t.Fatal("plan should not be empty")
+	}
+
+	plan := testReadPlan(t, planPath)
+	for _, m := range plan.Diff.Modules {
+		for _, r := range m.Resources {
+			if !r.Destroy {
+				t.Fatalf("bad: %#v", r)
+			}
+		}
+	}
+}
+
+func TestLocal_planDestroyNoConfig(t *testing.T) {
+	b := TestLocal(t)
+	p := TestLocalProvider(t, b, "test")
+	terraform.TestStateFile(t, b.StatePath, testPlanState())
+
+	outDir := testTempDir(t)
+	defer os.RemoveAll(outDir)
+	planPath := filepath.Join(outDir, "plan.tfplan")
+
+	op := testOperationPlan()
+	op.Destroy = true
+	op.PlanRefresh = true
+	op.Module = nil
 	op.PlanOutPath = planPath
 
 	run, err := b.Operation(context.Background(), op)


### PR DESCRIPTION
Fixes #11504

The local backend should error if `terraform plan` is called in a
directory with no Terraform config files (same behavior as 0.8.x).
**New behavior:** We now allow `terraform plan -destroy` with no
configuration files since that seems reasonable.