### PR TITLE
provider/aws: Fix acceptance tests for autoscaling schedule

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_schedule.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_schedule.go
@@ -20,48 +20,48 @@ func resourceAwsAutoscalingSchedule() *schema.Resource {
 		Delete: resourceAwsAutoscalingScheduleDelete,
 
 		Schema: map[string]*schema.Schema{
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"scheduled_action_name": &schema.Schema{
+			"scheduled_action_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"autoscaling_group_name": &schema.Schema{
+			"autoscaling_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"start_time": &schema.Schema{
+			"start_time": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validateASGScheduleTimestamp,
 			},
-			"end_time": &schema.Schema{
+			"end_time": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ValidateFunc: validateASGScheduleTimestamp,
 			},
-			"recurrence": &schema.Schema{
+			"recurrence": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"min_size": &schema.Schema{
+			"min_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
-			"max_size": &schema.Schema{
+			"max_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
 			},
-			"desired_capacity": &schema.Schema{
+			"desired_capacity": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,


### PR DESCRIPTION
Fixes acceptance tests for `aws_autoscaling_schedule` resource

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAutoscalingSchedule_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/30 14:40:34 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAutoscalingSchedule_basic -timeout 120m
=== RUN   TestAccAWSAutoscalingSchedule_basic
--- PASS: TestAccAWSAutoscalingSchedule_basic (170.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	170.406s
```

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAutoscalingSchedule_disappears'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/30 15:00:49 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAutoscalingSchedule_disappears -timeout 120m
=== RUN   TestAccAWSAutoscalingSchedule_disappears
--- PASS: TestAccAWSAutoscalingSchedule_disappears (179.23s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	179.253s
```