### PR TITLE
Use vault api.DefaultConfig()

### DIFF
--- a/builtin/providers/vault/provider.go
+++ b/builtin/providers/vault/provider.go
@@ -107,7 +107,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		clientAuthKey = clientAuth["key_file"].(string)
 	}
 
-	config.ConfigureTLS(&api.TLSConfig{
+	err := config.ConfigureTLS(&api.TLSConfig{
 		CACert:   d.Get("ca_cert_file").(string),
 		CAPath:   d.Get("ca_cert_dir").(string),
 		Insecure: d.Get("skip_tls_verify").(bool),
@@ -115,6 +115,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ClientCert: clientAuthCert,
 		ClientKey:  clientAuthKey,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure TLS for Vault API: %s", err)
+	}
 
 	client, err := api.NewClient(config)
 	if err != nil {

--- a/builtin/providers/vault/provider.go
+++ b/builtin/providers/vault/provider.go
@@ -91,9 +91,8 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	config := &api.Config{
-		Address: d.Get("address").(string),
-	}
+	config := api.DefaultConfig()
+	config.Address = d.Get("address").(string)
 
 	clientAuthI := d.Get("client_auth").([]interface{})
 	if len(clientAuthI) > 1 {


### PR DESCRIPTION
Closes #11364

The Vault API creates an HTTP client and lightly configures TLS it in `api.DefaultConfig()`, which the Terraform backend does not do.  As a result, the terraform acceptance tests work because they are run against a dev server without TLS enabled, but it does not work on a real server.