### PR TITLE
provider/aws: Fix cloudwatch log subscription filter test

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -21,7 +21,7 @@ func TestAccAWSCloudwatchLogSubscriptionFilter_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudwatchLogSubscriptionFilterDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudwatchLogSubscriptionFilterConfig(rstring),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsCloudwatchLogSubscriptionFilterExists("aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter", &conf, rstring),
@@ -112,6 +112,7 @@ resource "aws_lambda_function" "test_lambdafunction" {
   filename      = "test-fixtures/lambdatest.zip"
   function_name = "example_lambda_name_%s"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
+  runtime       = "nodejs4.3"
   handler       = "exports.handler"
 }
 


### PR DESCRIPTION
Fixes `aws_cloudwatch_log_subscription_filter` acceptance tests that had been failing since mid December

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudwatchLogSubscriptionFilter_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/30 16:00:05 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudwatchLogSubscriptionFilter_basic -timeout 120m
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_basic
--- PASS: TestAccAWSCloudwatchLogSubscriptionFilter_basic (26.34s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	26.364s
```