### PR TITLE
provider/aws: Fix AWS RDS Cluster Parameter Group Tests

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -28,7 +28,7 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 				Config: testAccAWSDBClusterParameterGroupConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
-					testAccCheckAWSDBClusterParameterGroupAttributes(&v),
+					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
 					resource.TestCheckResourceAttr(
@@ -55,7 +55,7 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 				Config: testAccAWSDBClusterParameterGroupAddParametersConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
-					testAccCheckAWSDBClusterParameterGroupAttributes(&v),
+					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
 					resource.TestCheckResourceAttr(
@@ -126,7 +126,7 @@ func TestAccAWSDBClusterParameterGroupOnly(t *testing.T) {
 				Config: testAccAWSDBClusterParameterGroupOnlyConfig(parameterGroupName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.bar", &v),
-					testAccCheckAWSDBClusterParameterGroupAttributes(&v),
+					testAccCheckAWSDBClusterParameterGroupAttributes(&v, parameterGroupName),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster_parameter_group.bar", "name", parameterGroupName),
 					resource.TestCheckResourceAttr(
@@ -213,15 +213,15 @@ func testAccCheckAWSDBClusterParameterGroupDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckAWSDBClusterParameterGroupAttributes(v *rds.DBClusterParameterGroup) resource.TestCheckFunc {
+func testAccCheckAWSDBClusterParameterGroupAttributes(v *rds.DBClusterParameterGroup, name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		if *v.DBClusterParameterGroupName != "cluster-parameter-group-test-terraform" {
-			return fmt.Errorf("bad name: %#v", v.DBClusterParameterGroupName)
+		if *v.DBClusterParameterGroupName != name {
+			return fmt.Errorf("bad name: %#v expected: %v", *v.DBClusterParameterGroupName, name)
 		}
 
 		if *v.DBParameterGroupFamily != "aurora5.6" {
-			return fmt.Errorf("bad family: %#v", v.DBParameterGroupFamily)
+			return fmt.Errorf("bad family: %#v", *v.DBParameterGroupFamily)
 		}
 
 		return nil


### PR DESCRIPTION
Fixes `aws_rds_cluster_parameter_group` acceptance tests, which have been broken since aa8c2ac587e6214159dd16e692b54b83cf1d4ad2

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBClusterParameterGroupOnly'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/30 16:20:38 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBClusterParameterGroupOnly -timeout 120m
=== RUN   TestAccAWSDBClusterParameterGroupOnly
--- PASS: TestAccAWSDBClusterParameterGroupOnly (15.26s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	15.282s
```

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBClusterParameterGroup_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/30 16:22:48 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBClusterParameterGroup_basic -timeout 120m
=== RUN   TestAccAWSDBClusterParameterGroup_basic
--- PASS: TestAccAWSDBClusterParameterGroup_basic (29.48s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	29.510s
```