### PR TITLE
Read vault token from ~/.vault-token if none supplied

### DIFF
--- a/builtin/providers/vault/provider.go
+++ b/builtin/providers/vault/provider.go
@@ -129,7 +129,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		// Use the vault CLI's token, if present.
 		homePath, err := homedir.Dir()
 		if err != nil {
-			return nil, fmt.Errorf("No vault token found: %s", err)
+			return nil, fmt.Errorf("Can't find home directory when looking for ~/.vault-token: %s", err)
 		}
 		tokenBytes, err := ioutil.ReadFile(homePath + "/.vault-token")
 		if err != nil {

--- a/website/source/docs/providers/vault/index.html.markdown
+++ b/website/source/docs/providers/vault/index.html.markdown
@@ -84,6 +84,8 @@ variables in order to keep credential information out of the configuration.
 
 * `token` - (Required) Vault token that will be used by Terraform to
   authenticate. May be set via the `VAULT_TOKEN` environment variable.
+  If none is otherwise supplied, Terraform will attempt to read it from
+  `~/.vault-token` (where the vault command stores its current token).
   Terraform will issue itself a new token that is a child of the one given,
   with a short TTL to limit the exposure of any requested secrets.
 


### PR DESCRIPTION
This closes #11365 (a feature request).