### PR TITLE
Recreate Rancher stack if it was removed

### DIFF
--- a/builtin/providers/rancher/resource_rancher_stack.go
+++ b/builtin/providers/rancher/resource_rancher_stack.go
@@ -132,6 +132,12 @@ func resourceRancherStackRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if stack.State == "removed" {
+		log.Printf("[INFO] Stack %s was removed on %v", d.Id(), stack.Removed)
+		d.SetId("")
+		return nil
+	}
+
 	config, err := client.Environment.ActionExportconfig(stack, &rancherClient.ComposeConfigInput{})
 	if err != nil {
 		return err


### PR DESCRIPTION
Currently, a stack that is manually removed on Rancher is never seen as removed by Terraform, and thus not recreated. This patch forces Terraform to recreate a removed stack.