### PR TITLE
Fix StatusCake test timeout schema

### DIFF
--- a/builtin/providers/statuscake/resource_statuscaketest.go
+++ b/builtin/providers/statuscake/resource_statuscaketest.go
@@ -54,10 +54,13 @@ func resourceStatusCakeTest() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+
 			"timeout": &schema.Schema{
 				Type:     schema.TypeInt,
-				Computed: true,
+				Optional: true,
+				Default:  40,
 			},
+
 			"confirmations": &schema.Schema{
 				Type:     schema.TypeInt,
 				Optional: true,

--- a/builtin/providers/statuscake/resource_statuscaketest_test.go
+++ b/builtin/providers/statuscake/resource_statuscaketest_test.go
@@ -51,6 +51,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					testAccTestCheckAttributes("statuscake_test.google", &test),
 					resource.TestCheckResourceAttr("statuscake_test.google", "check_rate", "500"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "paused", "true"),
+					resource.TestCheckResourceAttr("statuscake_test.google", "timeout", "40"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "contact_id", "0"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "confirmations", "0"),
 				),
@@ -147,6 +148,7 @@ resource "statuscake_test" "google" {
 	website_url = "www.google.com"
 	test_type = "HTTP"
 	check_rate = 300
+	timeout = 10
 	contact_id = 12345
 	confirmations = 1
 }


### PR DESCRIPTION
Although `timeout` in StatusCake tests is [defined correctly in the documentation](https://www.terraform.io/docs/providers/statuscake/r/test.html#timeout) as an optional value, in the resource it is defined as a computed value - most probably a copy-paste error.

The default value of 40 is the one shown in the StatusCake Web UI when a test is created manually.
