### PR TITLE
Rancher: reset Id for unknown resources

### DIFF
--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -94,6 +94,12 @@ func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
+	if env == nil {
+		log.Printf("[INFO] Environment %s not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	log.Printf("[INFO] Environment Name: %s", env.Name)
 
 	d.Set("description", env.Description)

--- a/builtin/providers/rancher/resource_rancher_registration_token.go
+++ b/builtin/providers/rancher/resource_rancher_registration_token.go
@@ -108,6 +108,12 @@ func resourceRancherRegistrationTokenRead(d *schema.ResourceData, meta interface
 		return err
 	}
 
+	if regT == nil {
+		log.Printf("[INFO] RegistrationToken %s not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	log.Printf("[INFO] RegistrationToken Name: %s", regT.Name)
 
 	d.Set("description", regT.Description)

--- a/builtin/providers/rancher/resource_rancher_registry.go
+++ b/builtin/providers/rancher/resource_rancher_registry.go
@@ -100,6 +100,12 @@ func resourceRancherRegistryRead(d *schema.ResourceData, meta interface{}) error
 		return err
 	}
 
+	if registry == nil {
+		log.Printf("[INFO] Registry %s not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	log.Printf("[INFO] Registry Name: %s", registry.Name)
 
 	d.Set("description", registry.Description)

--- a/builtin/providers/rancher/resource_rancher_registry_credential.go
+++ b/builtin/providers/rancher/resource_rancher_registry_credential.go
@@ -114,6 +114,12 @@ func resourceRancherRegistryCredentialRead(d *schema.ResourceData, meta interfac
 		return err
 	}
 
+	if registryCred == nil {
+		log.Printf("[INFO] RegistryCredential %s not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	log.Printf("[INFO] RegistryCredential Name: %s", registryCred.Name)
 
 	d.Set("description", registryCred.Description)

--- a/builtin/providers/rancher/resource_rancher_stack.go
+++ b/builtin/providers/rancher/resource_rancher_stack.go
@@ -132,6 +132,12 @@ func resourceRancherStackRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if stack == nil {
+		log.Printf("[INFO] Stack %s not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
 	if stack.State == "removed" {
 		log.Printf("[INFO] Stack %s was removed on %v", d.Id(), stack.Removed)
 		d.SetId("")


### PR DESCRIPTION
When switching from one Rancher server to another, we want Terraform to recreate Rancher resources. This currently leads to ugly `EOF` errors.    

This patch resets resource Ids when they can't be found in the Rancher API.
