### PR TITLE
Added forceNew on accessConfig in google_compute_instance_template

### DIFF
--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -212,6 +212,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 						"access_config": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
+							ForceNew: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"nat_ip": &schema.Schema{


### PR DESCRIPTION
This should force terraform to recreate the resource after updating it.

I don't know if I need to change tests or something...

This relates to #11547 