### PR TITLE
provider/azurerm: check if lb sub resources exist when reading

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -140,31 +140,31 @@ func resourceArmLoadBalancerBackendAddressPoolRead(d *schema.ResourceData, meta 
 		return nil
 	}
 
-	configs := *loadBalancer.LoadBalancerPropertiesFormat.BackendAddressPools
-	for _, config := range configs {
-		if *config.Name == d.Get("name").(string) {
-			d.Set("name", config.Name)
+	config, _, exists := findLoadBalancerBackEndAddressPoolByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] LoadBalancer Backend Address Pool %q not found. Removing from state", d.Get("name").(string))
+		return nil
+	}
 
-			if config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations != nil {
-				backend_ip_configurations := make([]string, 0, len(*config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations))
-				for _, backendConfig := range *config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations {
-					backend_ip_configurations = append(backend_ip_configurations, *backendConfig.ID)
-				}
+	d.Set("name", config.Name)
 
-				d.Set("backend_ip_configurations", backend_ip_configurations)
-			}
-
-			if config.BackendAddressPoolPropertiesFormat.LoadBalancingRules != nil {
-				load_balancing_rules := make([]string, 0, len(*config.BackendAddressPoolPropertiesFormat.LoadBalancingRules))
-				for _, rule := range *config.BackendAddressPoolPropertiesFormat.LoadBalancingRules {
-					load_balancing_rules = append(load_balancing_rules, *rule.ID)
-				}
-
-				d.Set("backend_ip_configurations", load_balancing_rules)
-			}
-
-			break
+	if config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations != nil {
+		backend_ip_configurations := make([]string, 0, len(*config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations))
+		for _, backendConfig := range *config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations {
+			backend_ip_configurations = append(backend_ip_configurations, *backendConfig.ID)
 		}
+
+		d.Set("backend_ip_configurations", backend_ip_configurations)
+	}
+
+	if config.BackendAddressPoolPropertiesFormat.LoadBalancingRules != nil {
+		load_balancing_rules := make([]string, 0, len(*config.BackendAddressPoolPropertiesFormat.LoadBalancingRules))
+		for _, rule := range *config.BackendAddressPoolPropertiesFormat.LoadBalancingRules {
+			load_balancing_rules = append(load_balancing_rules, *rule.ID)
+		}
+
+		d.Set("backend_ip_configurations", load_balancing_rules)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -163,22 +163,21 @@ func resourceArmLoadBalancerNatPoolRead(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 
-	configs := *loadBalancer.LoadBalancerPropertiesFormat.InboundNatPools
-	for _, config := range configs {
-		if *config.Name == d.Get("name").(string) {
-			d.Set("name", config.Name)
+	config, _, exists := findLoadBalancerNatPoolByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] LoadBalancer Nat Pool %q not found. Removing from state", d.Get("name").(string))
+		return nil
+	}
 
-			d.Set("protocol", config.InboundNatPoolPropertiesFormat.Protocol)
-			d.Set("frontend_port_start", config.InboundNatPoolPropertiesFormat.FrontendPortRangeStart)
-			d.Set("frontend_port_end", config.InboundNatPoolPropertiesFormat.FrontendPortRangeEnd)
-			d.Set("backend_port", config.InboundNatPoolPropertiesFormat.BackendPort)
+	d.Set("name", config.Name)
+	d.Set("protocol", config.InboundNatPoolPropertiesFormat.Protocol)
+	d.Set("frontend_port_start", config.InboundNatPoolPropertiesFormat.FrontendPortRangeStart)
+	d.Set("frontend_port_end", config.InboundNatPoolPropertiesFormat.FrontendPortRangeEnd)
+	d.Set("backend_port", config.InboundNatPoolPropertiesFormat.BackendPort)
 
-			if config.InboundNatPoolPropertiesFormat.FrontendIPConfiguration != nil {
-				d.Set("frontend_ip_configuration_id", config.InboundNatPoolPropertiesFormat.FrontendIPConfiguration.ID)
-			}
-
-			break
-		}
+	if config.InboundNatPoolPropertiesFormat.FrontendIPConfiguration != nil {
+		d.Set("frontend_ip_configuration_id", config.InboundNatPoolPropertiesFormat.FrontendIPConfiguration.ID)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -163,25 +163,24 @@ func resourceArmLoadBalancerNatRuleRead(d *schema.ResourceData, meta interface{}
 		return nil
 	}
 
-	configs := *loadBalancer.LoadBalancerPropertiesFormat.InboundNatRules
-	for _, config := range configs {
-		if *config.Name == d.Get("name").(string) {
-			d.Set("name", config.Name)
+	config, _, exists := findLoadBalancerNatRuleByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] LoadBalancer Nat Rule %q not found. Removing from state", d.Get("name").(string))
+		return nil
+	}
 
-			d.Set("protocol", config.InboundNatRulePropertiesFormat.Protocol)
-			d.Set("frontend_port", config.InboundNatRulePropertiesFormat.FrontendPort)
-			d.Set("backend_port", config.InboundNatRulePropertiesFormat.BackendPort)
+	d.Set("name", config.Name)
+	d.Set("protocol", config.InboundNatRulePropertiesFormat.Protocol)
+	d.Set("frontend_port", config.InboundNatRulePropertiesFormat.FrontendPort)
+	d.Set("backend_port", config.InboundNatRulePropertiesFormat.BackendPort)
 
-			if config.InboundNatRulePropertiesFormat.FrontendIPConfiguration != nil {
-				d.Set("frontend_ip_configuration_id", config.InboundNatRulePropertiesFormat.FrontendIPConfiguration.ID)
-			}
+	if config.InboundNatRulePropertiesFormat.FrontendIPConfiguration != nil {
+		d.Set("frontend_ip_configuration_id", config.InboundNatRulePropertiesFormat.FrontendIPConfiguration.ID)
+	}
 
-			if config.InboundNatRulePropertiesFormat.BackendIPConfiguration != nil {
-				d.Set("backend_ip_configuration_id", config.InboundNatRulePropertiesFormat.BackendIPConfiguration.ID)
-			}
-
-			break
-		}
+	if config.InboundNatRulePropertiesFormat.BackendIPConfiguration != nil {
+		d.Set("backend_ip_configuration_id", config.InboundNatRulePropertiesFormat.BackendIPConfiguration.ID)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -168,20 +168,19 @@ func resourceArmLoadBalancerProbeRead(d *schema.ResourceData, meta interface{}) 
 		return nil
 	}
 
-	configs := *loadBalancer.LoadBalancerPropertiesFormat.Probes
-	for _, config := range configs {
-		if *config.Name == d.Get("name").(string) {
-			d.Set("name", config.Name)
-
-			d.Set("protocol", config.ProbePropertiesFormat.Protocol)
-			d.Set("interval_in_seconds", config.ProbePropertiesFormat.IntervalInSeconds)
-			d.Set("number_of_probes", config.ProbePropertiesFormat.NumberOfProbes)
-			d.Set("port", config.ProbePropertiesFormat.Port)
-			d.Set("request_path", config.ProbePropertiesFormat.RequestPath)
-
-			break
-		}
+	config, _, exists := findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] LoadBalancer Probe %q not found. Removing from state", d.Get("name").(string))
+		return nil
 	}
+
+	d.Set("name", config.Name)
+	d.Set("protocol", config.ProbePropertiesFormat.Protocol)
+	d.Set("interval_in_seconds", config.ProbePropertiesFormat.IntervalInSeconds)
+	d.Set("number_of_probes", config.ProbePropertiesFormat.NumberOfProbes)
+	d.Set("port", config.ProbePropertiesFormat.Port)
+	d.Set("request_path", config.ProbePropertiesFormat.RequestPath)
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -190,39 +190,41 @@ func resourceArmLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) e
 		return nil
 	}
 
-	configs := *loadBalancer.LoadBalancerPropertiesFormat.LoadBalancingRules
-	for _, config := range configs {
-		if *config.Name == d.Get("name").(string) {
-			d.Set("name", config.Name)
+	config, _, exists := findLoadBalancerRuleByName(loadBalancer, d.Get("name").(string))
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] LoadBalancer Rule %q not found. Removing from state", d.Get("name").(string))
+		return nil
+	}
 
-			d.Set("protocol", config.LoadBalancingRulePropertiesFormat.Protocol)
-			d.Set("frontend_port", config.LoadBalancingRulePropertiesFormat.FrontendPort)
-			d.Set("backend_port", config.LoadBalancingRulePropertiesFormat.BackendPort)
+	d.Set("name", config.Name)
 
-			if config.LoadBalancingRulePropertiesFormat.EnableFloatingIP != nil {
-				d.Set("enable_floating_ip", config.LoadBalancingRulePropertiesFormat.EnableFloatingIP)
-			}
+	d.Set("protocol", config.LoadBalancingRulePropertiesFormat.Protocol)
+	d.Set("frontend_port", config.LoadBalancingRulePropertiesFormat.FrontendPort)
+	d.Set("backend_port", config.LoadBalancingRulePropertiesFormat.BackendPort)
 
-			if config.LoadBalancingRulePropertiesFormat.IdleTimeoutInMinutes != nil {
-				d.Set("idle_timeout_in_minutes", config.LoadBalancingRulePropertiesFormat.IdleTimeoutInMinutes)
-			}
+	if config.LoadBalancingRulePropertiesFormat.EnableFloatingIP != nil {
+		d.Set("enable_floating_ip", config.LoadBalancingRulePropertiesFormat.EnableFloatingIP)
+	}
 
-			if config.LoadBalancingRulePropertiesFormat.FrontendIPConfiguration != nil {
-				d.Set("frontend_ip_configuration_id", config.LoadBalancingRulePropertiesFormat.FrontendIPConfiguration.ID)
-			}
+	if config.LoadBalancingRulePropertiesFormat.IdleTimeoutInMinutes != nil {
+		d.Set("idle_timeout_in_minutes", config.LoadBalancingRulePropertiesFormat.IdleTimeoutInMinutes)
+	}
 
-			if config.LoadBalancingRulePropertiesFormat.BackendAddressPool != nil {
-				d.Set("backend_address_pool_id", config.LoadBalancingRulePropertiesFormat.BackendAddressPool.ID)
-			}
+	if config.LoadBalancingRulePropertiesFormat.FrontendIPConfiguration != nil {
+		d.Set("frontend_ip_configuration_id", config.LoadBalancingRulePropertiesFormat.FrontendIPConfiguration.ID)
+	}
 
-			if config.LoadBalancingRulePropertiesFormat.Probe != nil {
-				d.Set("probe_id", config.LoadBalancingRulePropertiesFormat.Probe.ID)
-			}
+	if config.LoadBalancingRulePropertiesFormat.BackendAddressPool != nil {
+		d.Set("backend_address_pool_id", config.LoadBalancingRulePropertiesFormat.BackendAddressPool.ID)
+	}
 
-			if config.LoadBalancingRulePropertiesFormat.LoadDistribution != "" {
-				d.Set("load_distribution", config.LoadBalancingRulePropertiesFormat.LoadDistribution)
-			}
-		}
+	if config.LoadBalancingRulePropertiesFormat.Probe != nil {
+		d.Set("probe_id", config.LoadBalancingRulePropertiesFormat.Probe.ID)
+	}
+
+	if config.LoadBalancingRulePropertiesFormat.LoadDistribution != "" {
+		d.Set("load_distribution", config.LoadBalancingRulePropertiesFormat.LoadDistribution)
 	}
 
 	return nil


### PR DESCRIPTION
This fixes detection when a sub resource is deleted via the API or Portal

Fixes #11129

All Load Balancer tests passing:
```
TestAccAzureRMLoadBalancerBackEndAddressPool_removal
TestAccAzureRMLoadBalancerBackEndAddressPool_basic
TestAccAzureRMLoadBalancerBackEndAddressPool_disappears
TestAccAzureRMLoadBalancerNatPool_update
TestAccAzureRMLoadBalancerNatPool_removal
TestAccAzureRMLoadBalancerNatPool_basic
TestAccAzureRMLoadBalancerBackEndAddressPool_reapply
TestAccAzureRMLoadBalancerNatPool_reapply
TestAccAzureRMLoadBalancerNatRule_disappears
TestAccAzureRMLoadBalancerNatRule_basic
TestAccAzureRMLoadBalancerNatRule_reapply
TestAccAzureRMLoadBalancerNatPool_disappears
TestAccAzureRMLoadBalancerNatRule_removal
TestAccAzureRMLoadBalancerNatRule_update
TestAccAzureRMLoadBalancerProbe_removal
TestAccAzureRMLoadBalancerProbe_basic
TestAccAzureRMLoadBalancerProbe_update
TestAccAzureRMLoadBalancerProbe_disappears
TestAccAzureRMLoadBalancerRule_basic
TestAccAzureRMLoadBalancerProbe_reapply
TestAccAzureRMLoadBalancerProbe_updateProtocol
TestAccAzureRMLoadBalancerRule_removal
TestAccAzureRMLoadBalancerRule_inconsistentReads
TestAccAzureRMLoadBalancerRule_update
TestAccAzureRMLoadBalancer_basic
TestAccAzureRMLoadBalancer_tags
TestAccAzureRMLoadBalancerRule_disappears
TestAccAzureRMLoadBalancerRule_reapply
TestAccAzureRMLoadBalancer_frontEndConfig
```