### PR TITLE
provider/aws: add aws_ecs_cluster datasource

### DIFF
--- a/builtin/providers/aws/data_source_aws_ecs_cluster.go
+++ b/builtin/providers/aws/data_source_aws_ecs_cluster.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsEcsCluster() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsEcsClusterRead,
+
+		Schema: map[string]*schema.Schema{
+			"cluster_name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"pending_tasks_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"running_tasks_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+
+			"registered_container_instances_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsEcsClusterRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecsconn
+
+	desc, err := conn.DescribeClusters(&ecs.DescribeClustersInput{})
+
+	if err != nil {
+		return err
+	}
+
+	var c *ecs.Cluster
+	for _, cluster := range desc.Clusters {
+		if aws.StringValue(cluster.ClusterName) == d.Get("cluster_name").(string) {
+			c = cluster
+			break
+		}
+	}
+
+	if c == nil {
+		return fmt.Errorf("cluster with name %q not found", d.Get("cluster_name").(string))
+	}
+
+	d.SetId(aws.StringValue(c.ClusterArn))
+	d.Set("status", c.Status)
+	d.Set("pending_tasks_count", c.PendingTasksCount)
+	d.Set("running_tasks_count", c.RunningTasksCount)
+	d.Set("registered_container_instances_count", c.RegisteredContainerInstancesCount)
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_ecs_cluster_test.go
+++ b/builtin/providers/aws/data_source_aws_ecs_cluster_test.go
@@ -1,0 +1,35 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSEcsDataSource_ecsCluster(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsEcsClusterDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "status", "ACTIVE"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "pending_tasks_count", "0"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "running_tasks_count", "0"),
+					resource.TestCheckResourceAttr("data.aws_ecs_cluster.default", "registered_container_instances_count", "0"),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAwsEcsClusterDataSourceConfig = `
+resource "aws_ecs_cluster" "default" {
+  name = "default"
+}
+
+data "aws_ecs_cluster" "default" {
+  cluster_name = "${aws_ecs_cluster.default.name}"
+}
+`

--- a/builtin/providers/aws/data_source_aws_ecs_cluster_test.go
+++ b/builtin/providers/aws/data_source_aws_ecs_cluster_test.go
@@ -2,10 +2,9 @@ package aws
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -58,4 +57,4 @@ resource "aws_ecs_service" "mongo" {
 data "aws_ecs_cluster" "default" {
   cluster_name = "${aws_ecs_cluster.default.name}"
 }
-`, rand.New(rand.NewSource(time.Now().UnixNano())).Int())
+`, acctest.RandInt())

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -163,6 +163,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_cloudformation_stack":     dataSourceAwsCloudFormationStack(),
 			"aws_ebs_snapshot":             dataSourceAwsEbsSnapshot(),
 			"aws_ebs_volume":               dataSourceAwsEbsVolume(),
+			"aws_ecs_cluster":              dataSourceAwsEcsCluster(),
 			"aws_ecs_container_definition": dataSourceAwsEcsContainerDefinition(),
 			"aws_eip":                      dataSourceAwsEip(),
 			"aws_elb_hosted_zone_id":       dataSourceAwsElbHostedZoneId(),


### PR DESCRIPTION
this pr adds support for the `aws_ecs_cluster` data source. 

since remote state is deprecated one needs a way to verify that a cluster exists & is accessible e.g. for scheduling tasks, etc.

tests are green:

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEcsDataSource_ecsCluster'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/31 23:36:41 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEcsDataSource_ecsCluster -timeout 120m
=== RUN   TestAccAWSEcsDataSource_ecsCluster
--- PASS: TestAccAWSEcsDataSource_ecsCluster (119.25s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    119.278s
```