### PR TITLE
provider/aws: Fix Cloudwatch Log acceptance tests

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group_test.go
@@ -254,5 +254,5 @@ resource "aws_cloudwatch_log_group" "charlie" {
     name = "foo-bar-%d"
     retention_in_days = 3653
 }
-`, rInt, rInt, rInt)
+`, rInt, rInt+1, rInt+2)
 }


### PR DESCRIPTION
Fixes `aws_cloudwatch_log_group` and `aws_cloudwatch_log_metric_filter` acceptance tests

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudWatchLogMetricFilter_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/31 12:01:05 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudWatchLogMetricFilter_basic -timeout 120m
=== RUN   TestAccAWSCloudWatchLogMetricFilter_basic
--- PASS: TestAccAWSCloudWatchLogMetricFilter_basic (27.36s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    27.390s
```

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudWatchLogGroup_multiple'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/31 12:03:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudWatchLogGroup_multiple -timeout 120m
=== RUN   TestAccAWSCloudWatchLogGroup_multiple
--- PASS: TestAccAWSCloudWatchLogGroup_multiple (16.39s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    16.422s
```