### PR TITLE
provider/aws: Fix issue with ECS Placement Strat. and type casing

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -357,7 +357,7 @@ func flattenPlacementStrategy(pss []*ecs.PlacementStrategy) []map[string]interfa
 	for _, ps := range pss {
 		c := make(map[string]interface{})
 		c["type"] = *ps.Type
-		c["field"] = *ps.Field
+		c["field"] = strings.ToLower(*ps.Field)
 		results = append(results, c)
 	}
 	return results

--- a/builtin/providers/aws/resource_aws_ecs_service_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_service_test.go
@@ -445,7 +445,7 @@ resource "aws_ecs_service" "mongo" {
   desired_count = 1
   placement_strategy {
 	type = "binpack"
-	field = "MEMORY"
+	field = "memory"
   }
 }
 `


### PR DESCRIPTION
The API asks you to send lower case values, but returns uppercase ones.
Here we lowercase the returned API values.

There is no migration here because the field in question is nested in a
set, so the hash will change regardless. Anyone using this feature now
has it broken anyway.