### PR TITLE
provider/google-cloud: Add second generation disk specification options

### DIFF
--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -297,7 +297,7 @@ func testAccCheckGoogleSqlDatabaseInstanceEquals(n string,
 
 		server = strconv.FormatInt(instance.Settings.DataDiskSizeGb, 10)
 		local = attributes["settings.0.disk_size"]
-		if server != local && len(server) > 0 && len(local) > 0 {
+		if server != local && len(server) > 0 && len(local) > 0 && local != "0" {
 			return fmt.Errorf("Error settings.disk_size mismatch, (%s, %s)", server, local)
 		}
 

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -115,6 +115,29 @@ func TestAccGoogleSqlDatabaseInstance_slave(t *testing.T) {
 	})
 }
 
+func TestAccGoogleSqlDatabaseInstance_diskspecs(t *testing.T) {
+	var instance sqladmin.DatabaseInstance
+	masterID := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_diskspecs, masterID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleSqlDatabaseInstanceExists(
+						"google_sql_database_instance.instance", &instance),
+					testAccCheckGoogleSqlDatabaseInstanceEquals(
+						"google_sql_database_instance.instance", &instance),
+				),
+			},
+		},
+	})
+}
+
 func TestAccGoogleSqlDatabaseInstance_settings_upgrade(t *testing.T) {
 	var instance sqladmin.DatabaseInstance
 	databaseID := acctest.RandInt()
@@ -264,6 +287,24 @@ func testAccCheckGoogleSqlDatabaseInstanceEquals(n string,
 		local = attributes["settings.0.crash_safe_replication"]
 		if server != local && len(server) > 0 && len(local) > 0 {
 			return fmt.Errorf("Error settings.crash_safe_replication mismatch, (%s, %s)", server, local)
+		}
+
+		server = strconv.FormatBool(instance.Settings.StorageAutoResize)
+		local = attributes["settings.0.disk_autoresize"]
+		if server != local && len(server) > 0 && len(local) > 0 {
+			return fmt.Errorf("Error settings.disk_autoresize mismatch, (%s, %s)", server, local)
+		}
+
+		server = strconv.FormatInt(instance.Settings.DataDiskSizeGb, 10)
+		local = attributes["settings.0.disk_size"]
+		if server != local && len(server) > 0 && len(local) > 0 {
+			return fmt.Errorf("Error settings.disk_size mismatch, (%s, %s)", server, local)
+		}
+
+		server = instance.Settings.DataDiskType
+		local = attributes["settings.0.disk_type"]
+		if server != local && len(server) > 0 && len(local) > 0 {
+			return fmt.Errorf("Error settings.disk_type mismatch, (%s, %s)", server, local)
 		}
 
 		if instance.Settings.IpConfiguration != nil {
@@ -526,6 +567,20 @@ resource "google_sql_database_instance" "instance_slave" {
 
 	settings {
 		tier = "db-f1-micro"
+	}
+}
+`
+
+var testGoogleSqlDatabaseInstance_diskspecs = `
+resource "google_sql_database_instance" "instance" {
+	name = "tf-lw-%d"
+	region = "us-central1"
+
+	settings {
+		tier = "db-f1-micro"
+		disk_autoresize = true
+		disk_size = 15
+		disk_type = "PD_HDD"
 	}
 }
 `

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -73,6 +73,12 @@ The required `settings` block supports:
 * `crash_safe_replication` - (Optional) Specific to read instances, indicates
     when crash-safe replication flags are enabled.
 
+* `disk_autoresize` - (Optional, Second Generation, Default: `false`) Configuration to increase storage size automatically.
+
+* `disk_size` - (Optional, Second Generation, Default: `10`) The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased.
+
+* `disk_type` - (Optional, Second Generation, Default: `PD_SSD`) The type of data disk: PD_SSD or PD_HDD.
+
 * `pricing_plan` - (Optional) Pricing plan for this instance, can be one of
     `PER_USE` or `PACKAGE`.
 


### PR DESCRIPTION
This is an enhancement to the `google_sql_database_instance` resource to add three optional settings for use with Second Generation instances:

- `disk_autoresize`: Toggles automatic resizing of the underlying disk
- `disk_size`: Allows specification of the initial disk size and can be used to increase disk size
- `disk_type`: Allows you to choose between the two disk types currently offered.

With the documentation I have indicated that these are Second Generation options by specifying this along with the Optional flag and default value.

I found that someone has raised an issue requesting these: https://github.com/hashicorp/terraform/issues/8943