### PR TITLE
deps: Update github.com/hashicorp/atlas-go

### DIFF
--- a/vendor/github.com/hashicorp/atlas-go/v1/build_config.go
+++ b/vendor/github.com/hashicorp/atlas-go/v1/build_config.go
@@ -13,6 +13,13 @@ type bcWrapper struct {
 	BuildConfig *BuildConfig `json:"build_configuration"`
 }
 
+// Atlas expects a list of key/value vars
+type BuildVar struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+type BuildVars []BuildVar
+
 // BuildConfig represents a Packer build configuration.
 type BuildConfig struct {
 	// User is the namespace under which the build config lives
@@ -126,7 +133,7 @@ func (c *Client) CreateBuildConfig(user, name string) (*BuildConfig, error) {
 //
 // Actual API: "Create Build Config Version"
 func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[string]interface{},
-	data io.Reader, size int64) error {
+	vars BuildVars, data io.Reader, size int64) error {
 
 	log.Printf("[INFO] uploading build configuration version %s (%d bytes), with metadata %q",
 		v.Slug(), size, metadata)
@@ -137,6 +144,7 @@ func (c *Client) UploadBuildConfigVersion(v *BuildConfigVersion, metadata map[st
 	var bodyData bcCreateWrapper
 	bodyData.Version.Builds = v.Builds
 	bodyData.Version.Metadata = metadata
+	bodyData.Version.Vars = vars
 	body, err := json.Marshal(bodyData)
 	if err != nil {
 		return err
@@ -179,5 +187,6 @@ type bcCreateWrapper struct {
 	Version struct {
 		Metadata map[string]interface{} `json:"metadata,omitempty"`
 		Builds   []BuildConfigBuild     `json:"builds"`
+		Vars     BuildVars              `json:"packer_vars,omitempty"`
 	} `json:"version"`
 }

--- a/vendor/github.com/hashicorp/atlas-go/v1/client.go
+++ b/vendor/github.com/hashicorp/atlas-go/v1/client.go
@@ -34,6 +34,11 @@ const (
 	// load trusted certs from a directory
 	atlasCAPathEnvVar = "ATLAS_CAPATH"
 
+	// atlasTLSNoVerifyEnvVar disables TLS verification, similar to curl -k
+	// This defaults to false (verify) and will change to true (skip
+	// verification) with any non-empty value
+	atlasTLSNoVerifyEnvVar = "ATLAS_TLS_NOVERIFY"
+
 	// atlasTokenHeader is the header key used for authenticating with Atlas
 	atlasTokenHeader = "X-Atlas-Token"
 )
@@ -130,6 +135,9 @@ func NewClient(urlString string) (*Client, error) {
 func (c *Client) init() error {
 	c.HTTPClient = cleanhttp.DefaultClient()
 	tlsConfig := &tls.Config{}
+	if os.Getenv(atlasTLSNoVerifyEnvVar) != "" {
+		tlsConfig.InsecureSkipVerify = true
+	}
 	err := rootcerts.ConfigureTLS(tlsConfig, &rootcerts.Config{
 		CAFile: os.Getenv(atlasCAFileEnvVar),
 		CAPath: os.Getenv(atlasCAPathEnvVar),

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1586,15 +1586,15 @@
 			"checksumSHA1": "FUiF2WLrih0JdHsUTMMDz3DRokw=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/archive",
-			"revision": "8e45a6c8b2de014db767a42c3ee777f101e11624",
-			"revisionTime": "2016-08-24T17:34:10Z"
+			"revision": "1792bd8de119ba49b17fd8d3c3c1f488ec613e62",
+			"revisionTime": "2016-11-07T20:49:10Z"
 		},
 		{
-			"checksumSHA1": "yylO3hSRKd0T4mveT9ho2OSARwU=",
+			"checksumSHA1": "lrfddRS4/LDKnF0sAbyZ59eUSjo=",
 			"comment": "20141209094003-92-g95fa852",
 			"path": "github.com/hashicorp/atlas-go/v1",
-			"revision": "9be9a611a15ba2f857a99b332fd966896867299a",
-			"revisionTime": "2016-07-26T16:33:11Z"
+			"revision": "1792bd8de119ba49b17fd8d3c3c1f488ec613e62",
+			"revisionTime": "2016-11-07T20:49:10Z"
 		},
 		{
 			"checksumSHA1": "ZY6NCrR80zUmtOtPtKffbmFxRWw=",


### PR DESCRIPTION
Update in order that Terraform communicating with Atlas obeys the `ATLAS_TLS_NOVERIFY` environment variable.