### PR TITLE
terraform: add Meta field to diffs

### DIFF
--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -364,6 +364,12 @@ type InstanceDiff struct {
 	Destroy        bool
 	DestroyDeposed bool
 	DestroyTainted bool
+
+	// Meta is a simple K/V map that is stored in a diff and persisted to
+	// plans but otherwise is completely ignored by Terraform core. It is
+	// mean to be used for additional data a resource may want to pass through.
+	// The value here must only contain Go primitives and collections.
+	Meta map[string]interface{}
 }
 
 func (d *InstanceDiff) Lock()   { d.mu.Lock() }

--- a/terraform/plan_test.go
+++ b/terraform/plan_test.go
@@ -31,6 +31,10 @@ func TestReadWritePlan(t *testing.T) {
 									RequiresNew: true,
 								},
 							},
+
+							Meta: map[string]interface{}{
+								"foo": []interface{}{1, 2, 3},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
This adds a Meta field (similar to InstanceState.Meta) to InstanceDiff.

This allows providers to store arbitrary k/v data as part of a diff and
have it persist through to the Apply. This will be used by helper/schema
for timeout storage being done by @catsby.

This should be perfectly forwards/backwards compatible without any
plan version change since it is purely additive to the struct.

The type here is `map[string]interface{}`. A couple notes:

  * **Not using `string`**: The Meta field of InstanceState is a string
    value. We've learned that forcing things to strings is bad. Let's
    just allow types.

  * **Primitives only**: Even though it is type `interface{}`, it must
    be able to cleanly pass the go-plugin RPC barrier as well as be
    encoded to a file as Gob. Given these constraints, the value must
    only comprise of primitive types and collections. No structs,
    functions, channels, etc.