### PR TITLE
provider/aws: Fix panic from AZs Data Source Test

### DIFF
--- a/builtin/providers/aws/data_source_aws_availability_zones.go
+++ b/builtin/providers/aws/data_source_aws_availability_zones.go
@@ -16,12 +16,12 @@ func dataSourceAwsAvailabilityZones() *schema.Resource {
 		Read: dataSourceAwsAvailabilityZonesRead,
 
 		Schema: map[string]*schema.Schema{
-			"names": &schema.Schema{
+			"names": {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"state": &schema.Schema{
+			"state": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ValidateFunc: validateStateType,
@@ -40,7 +40,7 @@ func dataSourceAwsAvailabilityZonesRead(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("state"); ok {
 		request.Filters = []*ec2.Filter{
-			&ec2.Filter{
+			{
 				Name:   aws.String("state"),
 				Values: []*string{aws.String(v.(string))},
 			},

--- a/builtin/providers/aws/data_source_aws_availability_zones_test.go
+++ b/builtin/providers/aws/data_source_aws_availability_zones_test.go
@@ -16,13 +16,22 @@ func TestAccAWSAvailabilityZones_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckAwsAvailabilityZonesConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAvailabilityZonesMeta("data.aws_availability_zones.availability_zones"),
 				),
 			},
-			resource.TestStep{
+		},
+	})
+}
+
+func TestAccAWSAvailabilityZones_stateFilter(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
 				Config: testAccCheckAwsAvailabilityZonesStateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsAvailabilityZoneState("data.aws_availability_zones.state_filter"),


### PR DESCRIPTION
The `aws_availability_zones` data source test was panicking. This fixes both tests

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAvailabilityZones'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/01/31 15:47:39 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAvailabilityZones -timeout 120m
=== RUN   TestAccAWSAvailabilityZones_basic
--- PASS: TestAccAWSAvailabilityZones_basic (12.56s)
=== RUN   TestAccAWSAvailabilityZones_stateFilter
--- PASS: TestAccAWSAvailabilityZones_stateFilter (13.59s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    26.187s
```