### PR TITLE
Update error message when no outputs are defined

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -76,10 +76,13 @@ func (c *OutputCommand) Run(args []string) int {
 	}
 
 	if state.Empty() || len(mod.Outputs) == 0 {
-		c.Ui.Error(fmt.Sprintf(
-			"The state file has no outputs defined. Define an output\n" +
-				"in your configuration with the `output` directive and re-run\n" +
-				"`terraform refresh` for it to become available."))
+		c.Ui.Error(
+			"The state file either has no outputs defined, or all the defined\n" +
+				"outputs are empty. Please define an output in your configuration\n" +
+				"with the `output` keyword and run `terraform refresh` for it to\n" +
+				"become available. If you are using interpolation, please verify\n" +
+				"the interpolated value is not empty. You can use the \n" +
+				"`terraform console` command to assist.")
 		return 1
 	}
 

--- a/command/output.go
+++ b/command/output.go
@@ -79,7 +79,7 @@ func (c *OutputCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(
 			"The state file has no outputs defined. Define an output\n" +
 				"in your configuration with the `output` directive and re-run\n" +
-				"`terraform apply` for it to become available."))
+				"`terraform refresh` for it to become available."))
 		return 1
 	}
 


### PR DESCRIPTION
Terraform can't tell the difference between an empty output and an undefined output. This is often confusing for folks using interpolation. As much as it would be great to fix upstream, changing this error message to be a bit more helpful is a good stop-gap to avoid frustration.