### PR TITLE
Rancher imports broken

### DIFF
--- a/builtin/providers/rancher/resource_rancher_registration_token.go
+++ b/builtin/providers/rancher/resource_rancher_registration_token.go
@@ -16,7 +16,7 @@ func resourceRancherRegistrationToken() *schema.Resource {
 		Read:   resourceRancherRegistrationTokenRead,
 		Delete: resourceRancherRegistrationTokenDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceRancherRegistrationTokenImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -196,6 +196,16 @@ func resourceRancherRegistrationTokenDelete(d *schema.ResourceData, meta interfa
 
 	d.SetId("")
 	return nil
+}
+
+func resourceRancherRegistrationTokenImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*Config)
+	regT, err := client.RegistrationToken.ById(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	d.Set("environment_id", regT.AccountId)
+	return []*schema.ResourceData{d}, nil
 }
 
 // RegistrationTokenStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch

--- a/builtin/providers/rancher/resource_rancher_registry.go
+++ b/builtin/providers/rancher/resource_rancher_registry.go
@@ -17,7 +17,7 @@ func resourceRancherRegistry() *schema.Resource {
 		Update: resourceRancherRegistryUpdate,
 		Delete: resourceRancherRegistryDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceRancherRegistryImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -202,6 +202,16 @@ func resourceRancherRegistryDelete(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId("")
 	return nil
+}
+
+func resourceRancherRegistryImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*Config)
+	reg, err := client.Registry.ById(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	d.Set("environment_id", reg.AccountId)
+	return []*schema.ResourceData{d}, nil
 }
 
 // RegistryStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch

--- a/builtin/providers/rancher/resource_rancher_registry_credential.go
+++ b/builtin/providers/rancher/resource_rancher_registry_credential.go
@@ -17,7 +17,7 @@ func resourceRancherRegistryCredential() *schema.Resource {
 		Update: resourceRancherRegistryCredentialUpdate,
 		Delete: resourceRancherRegistryCredentialDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceRancherRegistryCredentialImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -224,6 +224,16 @@ func resourceRancherRegistryCredentialDelete(d *schema.ResourceData, meta interf
 
 	d.SetId("")
 	return nil
+}
+
+func resourceRancherRegistryCredentialImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*Config)
+	regC, err := client.RegistryCredential.ById(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	d.Set("environment_id", regC.AccountId)
+	return []*schema.ResourceData{d}, nil
 }
 
 // RegistryCredentialStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch

--- a/builtin/providers/rancher/resource_rancher_stack.go
+++ b/builtin/providers/rancher/resource_rancher_stack.go
@@ -19,7 +19,7 @@ func resourceRancherStack() *schema.Resource {
 		Update: resourceRancherStackUpdate,
 		Delete: resourceRancherStackDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceRancherStackImport,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -327,6 +327,16 @@ func resourceRancherStackDelete(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId("")
 	return nil
+}
+
+func resourceRancherStackImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*Config)
+	stack, err := client.Environment.ById(d.Id())
+	if err != nil {
+		return []*schema.ResourceData{}, err
+	}
+	d.Set("environment_id", stack.AccountId)
+	return []*schema.ResourceData{d}, nil
 }
 
 // StackStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch


### PR DESCRIPTION
fa656429373d4bdfe3894d1f5fd85ff2bc225e4d breaks all imports, because  `environment_id` is not specified in imported resources.

I see two ways to fix that:

* either use a global client when `environment_id` is not set
* or import the `environment_id` from `account_id` on import, so it is set. This is probably the cleanest option.

/cc @johnrengelman 