### PR TITLE
provider/aws: Fix panic in aws_rds_cluster missing parameter error message

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -350,11 +350,11 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 
 	} else {
 		if _, ok := d.GetOk("master_password"); !ok {
-			return fmt.Errorf(`provider.aws: aws_rds_cluster: %s: "master_password": required field is not set`, d.Get("name").(string))
+			return fmt.Errorf(`provider.aws: aws_rds_cluster: %s: "master_password": required field is not set`, d.Get("database_name").(string))
 		}
 
 		if _, ok := d.GetOk("master_username"); !ok {
-			return fmt.Errorf(`provider.aws: aws_rds_cluster: %s: "master_username": required field is not set`, d.Get("name").(string))
+			return fmt.Errorf(`provider.aws: aws_rds_cluster: %s: "master_username": required field is not set`, d.Get("database_name").(string))
 		}
 
 		createOpts := &rds.CreateDBClusterInput{

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -38,6 +38,22 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 	})
 }
 
+/// This is a regression test to make sure that we always cover the scenario as hightlighted in
+/// https://github.com/hashicorp/terraform/issues/11568
+func TestAccAWSRDSCluster_missingUserNameCausesError(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSClusterConfigWithoutUserNameAndPassword(acctest.RandInt()),
+				ExpectError: regexp.MustCompile(`required field is not set`),
+			},
+		},
+	})
+}
+
 func TestAccAWSRDSCluster_updateTags(t *testing.T) {
 	var v rds.DBCluster
 	ri := acctest.RandInt()
@@ -225,6 +241,15 @@ resource "aws_rds_cluster" "default" {
   tags {
     Environment = "production"
   }
+}`, n)
+}
+
+func testAccAWSClusterConfigWithoutUserNameAndPassword(n int) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster" "default" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  availability_zones = ["us-west-2a","us-west-2b","us-west-2c"]
+  database_name = "mydb"
 }`, n)
 }
 


### PR DESCRIPTION
Fixes: #11568

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSCluster_missingUserNameCausesError'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/01 12:11:14 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSCluster_missingUserNameCausesError -timeout 120m
=== RUN   TestAccAWSRDSCluster_missingUserNameCausesError
--- PASS: TestAccAWSRDSCluster_missingUserNameCausesError (3.22s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	3.243s
```

The error message for a required parameter being missing has a wrong parameter baked into it. Therefore, when the error message tried to fire, it was throwing a panic. Added a test to make sure that we know the condition still fires and with a correct message