### PR TITLE
vSphere virtual machine don't ignore VM power on errors

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -2110,7 +2110,14 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 	}
 
 	if vm.hasBootableVmdk || vm.template != "" {
-		newVM.PowerOn(context.TODO())
+		t, err := newVM.PowerOn(context.TODO())
+		if err != nil {
+			return err
+		}
+		_, err = t.WaitForResult(context.TODO(), nil)
+		if err != nil {
+			return err
+		}
 		err = newVM.WaitForPowerState(context.TODO(), types.VirtualMachinePowerStatePoweredOn)
 		if err != nil {
 			return err


### PR DESCRIPTION
This prevents Terraform from hanging indefinitely while waiting for the VM to power on.