### PR TITLE
provider/azurerm: support import for load balancer and sub resources

### DIFF
--- a/builtin/providers/azurerm/import_arm_loadbalancer_backend_address_pool_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_backend_address_pool_test.go
@@ -1,0 +1,35 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMLoadBalancerBackEndAddressPool_importBasic(t *testing.T) {
+	resourceName := "azurerm_lb_backend_address_pool.test"
+
+	ri := acctest.RandInt()
+	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// location is deprecated and was never actually used
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_nat_pool_test.go
@@ -1,0 +1,35 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMLoadBalancerNatPool_importBasic(t *testing.T) {
+	resourceName := "azurerm_lb_nat_pool.test"
+
+	ri := acctest.RandInt()
+	natPoolName := fmt.Sprintf("NatPool-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// location is deprecated and was never actually used
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_nat_rule_test.go
@@ -1,0 +1,35 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMLoadBalancerNatRule_importBasic(t *testing.T) {
+	resourceName := "azurerm_lb_nat_rule.test"
+
+	ri := acctest.RandInt()
+	natRuleName := fmt.Sprintf("NatRule-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// location is deprecated and was never actually used
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_probe_test.go
@@ -1,0 +1,35 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMLoadBalancerProbe_importBasic(t *testing.T) {
+	resourceName := "azurerm_lb_probe.test"
+
+	ri := acctest.RandInt()
+	probeName := fmt.Sprintf("probe-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// location is deprecated and was never actually used
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_rule_test.go
@@ -1,0 +1,35 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMLoadBalancerRule_importBasic(t *testing.T) {
+	resourceName := "azurerm_lb_rule.test"
+
+	ri := acctest.RandInt()
+	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				// location is deprecated and was never actually used
+				ImportStateVerifyIgnore: []string{"location"},
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_loadbalancer_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_test.go
@@ -1,0 +1,29 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMLoadBalancer_importBasic(t *testing.T) {
+	resourceName := "azurerm_lb.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMLoadBalancer_basic(acctest.RandInt()),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_loadbalancer.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer.go
@@ -18,6 +18,9 @@ func resourceArmLoadBalancer() *schema.Resource {
 		Read:   resourecArmLoadBalancerRead,
 		Update: resourceArmLoadBalancerCreate,
 		Delete: resourceArmLoadBalancerDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -147,6 +150,11 @@ func resourceArmLoadBalancerCreate(d *schema.ResourceData, meta interface{}) err
 }
 
 func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+
 	loadBalancer, exists, err := retrieveLoadBalancerById(d.Id(), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
@@ -156,6 +164,10 @@ func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
 		return nil
 	}
+
+	d.Set("name", loadBalancer.Name)
+	d.Set("location", loadBalancer.Location)
+	d.Set("resource_group_name", id.ResourceGroup)
 
 	if loadBalancer.LoadBalancerPropertiesFormat != nil && loadBalancer.LoadBalancerPropertiesFormat.FrontendIPConfigurations != nil {
 		d.Set("frontend_ip_configuration", flattenLoadBalancerFrontendIpConfiguration(loadBalancer.LoadBalancerPropertiesFormat.FrontendIPConfigurations))

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool.go
@@ -17,6 +17,9 @@ func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 		Create: resourceArmLoadBalancerBackendAddressPoolCreate,
 		Read:   resourceArmLoadBalancerBackendAddressPoolRead,
 		Delete: resourceArmLoadBalancerBackendAddressPoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: loadBalancerSubResourceStateImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -25,7 +28,14 @@ func resourceArmLoadBalancerBackendAddressPool() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": locationSchema(),
+			"location": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Optional:         true,
+				StateFunc:        azureRMNormalizeLocation,
+				DiffSuppressFunc: azureRMSuppressLocationDiff,
+				Deprecated:       "location is no longer used",
+			},
 
 			"resource_group_name": {
 				Type:     schema.TypeString,
@@ -130,42 +140,48 @@ func resourceArmLoadBalancerBackendAddressPoolCreate(d *schema.ResourceData, met
 }
 
 func resourceArmLoadBalancerBackendAddressPoolRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	name := id.Path["backendAddressPools"]
+
 	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", name)
 		return nil
 	}
 
-	config, _, exists := findLoadBalancerBackEndAddressPoolByName(loadBalancer, d.Get("name").(string))
+	config, _, exists := findLoadBalancerBackEndAddressPoolByName(loadBalancer, name)
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer Backend Address Pool %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer Backend Address Pool %q not found. Removing from state", name)
 		return nil
 	}
 
 	d.Set("name", config.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 
+	var backend_ip_configurations []string
 	if config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations != nil {
-		backend_ip_configurations := make([]string, 0, len(*config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations))
 		for _, backendConfig := range *config.BackendAddressPoolPropertiesFormat.BackendIPConfigurations {
 			backend_ip_configurations = append(backend_ip_configurations, *backendConfig.ID)
 		}
 
-		d.Set("backend_ip_configurations", backend_ip_configurations)
 	}
+	d.Set("backend_ip_configurations", backend_ip_configurations)
 
+	var load_balancing_rules []string
 	if config.BackendAddressPoolPropertiesFormat.LoadBalancingRules != nil {
-		load_balancing_rules := make([]string, 0, len(*config.BackendAddressPoolPropertiesFormat.LoadBalancingRules))
 		for _, rule := range *config.BackendAddressPoolPropertiesFormat.LoadBalancingRules {
 			load_balancing_rules = append(load_balancing_rules, *rule.ID)
 		}
-
-		d.Set("backend_ip_configurations", load_balancing_rules)
 	}
+	d.Set("load_balancing_rules", load_balancing_rules)
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool.go
@@ -18,6 +18,9 @@ func resourceArmLoadBalancerNatPool() *schema.Resource {
 		Read:   resourceArmLoadBalancerNatPoolRead,
 		Update: resourceArmLoadBalancerNatPoolCreate,
 		Delete: resourceArmLoadBalancerNatPoolDelete,
+		Importer: &schema.ResourceImporter{
+			State: loadBalancerSubResourceStateImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -26,7 +29,14 @@ func resourceArmLoadBalancerNatPool() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": locationSchema(),
+			"location": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Optional:         true,
+				StateFunc:        azureRMNormalizeLocation,
+				DiffSuppressFunc: azureRMSuppressLocationDiff,
+				Deprecated:       "location is no longer used",
+			},
 
 			"resource_group_name": {
 				Type:     schema.TypeString,
@@ -153,30 +163,43 @@ func resourceArmLoadBalancerNatPoolCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmLoadBalancerNatPoolRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	name := id.Path["inboundNatPools"]
+
 	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", name)
 		return nil
 	}
 
-	config, _, exists := findLoadBalancerNatPoolByName(loadBalancer, d.Get("name").(string))
+	config, _, exists := findLoadBalancerNatPoolByName(loadBalancer, name)
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer Nat Pool %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer Nat Pool %q not found. Removing from state", name)
 		return nil
 	}
 
 	d.Set("name", config.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("protocol", config.InboundNatPoolPropertiesFormat.Protocol)
 	d.Set("frontend_port_start", config.InboundNatPoolPropertiesFormat.FrontendPortRangeStart)
 	d.Set("frontend_port_end", config.InboundNatPoolPropertiesFormat.FrontendPortRangeEnd)
 	d.Set("backend_port", config.InboundNatPoolPropertiesFormat.BackendPort)
 
 	if config.InboundNatPoolPropertiesFormat.FrontendIPConfiguration != nil {
+		fipID, err := parseAzureResourceID(*config.InboundNatPoolPropertiesFormat.FrontendIPConfiguration.ID)
+		if err != nil {
+			return err
+		}
+
+		d.Set("frontend_ip_configuration_name", fipID.Path["frontendIPConfigurations"])
 		d.Set("frontend_ip_configuration_id", config.InboundNatPoolPropertiesFormat.FrontendIPConfiguration.ID)
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule.go
@@ -18,6 +18,9 @@ func resourceArmLoadBalancerNatRule() *schema.Resource {
 		Read:   resourceArmLoadBalancerNatRuleRead,
 		Update: resourceArmLoadBalancerNatRuleCreate,
 		Delete: resourceArmLoadBalancerNatRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: loadBalancerSubResourceStateImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -26,7 +29,14 @@ func resourceArmLoadBalancerNatRule() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": locationSchema(),
+			"location": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Optional:         true,
+				StateFunc:        azureRMNormalizeLocation,
+				DiffSuppressFunc: azureRMSuppressLocationDiff,
+				Deprecated:       "location is no longer used",
+			},
 
 			"resource_group_name": {
 				Type:     schema.TypeString,
@@ -153,29 +163,42 @@ func resourceArmLoadBalancerNatRuleCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmLoadBalancerNatRuleRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	name := id.Path["inboundNatRules"]
+
 	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", name)
 		return nil
 	}
 
-	config, _, exists := findLoadBalancerNatRuleByName(loadBalancer, d.Get("name").(string))
+	config, _, exists := findLoadBalancerNatRuleByName(loadBalancer, name)
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer Nat Rule %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer Nat Rule %q not found. Removing from state", name)
 		return nil
 	}
 
 	d.Set("name", config.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("protocol", config.InboundNatRulePropertiesFormat.Protocol)
 	d.Set("frontend_port", config.InboundNatRulePropertiesFormat.FrontendPort)
 	d.Set("backend_port", config.InboundNatRulePropertiesFormat.BackendPort)
 
 	if config.InboundNatRulePropertiesFormat.FrontendIPConfiguration != nil {
+		fipID, err := parseAzureResourceID(*config.InboundNatRulePropertiesFormat.FrontendIPConfiguration.ID)
+		if err != nil {
+			return err
+		}
+
+		d.Set("frontend_ip_configuration_name", fipID.Path["frontendIPConfigurations"])
 		d.Set("frontend_ip_configuration_id", config.InboundNatRulePropertiesFormat.FrontendIPConfiguration.ID)
 	}
 

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe.go
@@ -18,6 +18,9 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 		Read:   resourceArmLoadBalancerProbeRead,
 		Update: resourceArmLoadBalancerProbeCreate,
 		Delete: resourceArmLoadBalancerProbeDelete,
+		Importer: &schema.ResourceImporter{
+			State: loadBalancerSubResourceStateImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -26,7 +29,14 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": locationSchema(),
+			"location": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Optional:         true,
+				StateFunc:        azureRMNormalizeLocation,
+				DiffSuppressFunc: azureRMSuppressLocationDiff,
+				Deprecated:       "location is no longer used",
+			},
 
 			"resource_group_name": {
 				Type:     schema.TypeString,
@@ -68,7 +78,7 @@ func resourceArmLoadBalancerProbe() *schema.Resource {
 				Default:  2,
 			},
 
-			"load_balance_rules": {
+			"load_balancer_rules": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -158,29 +168,44 @@ func resourceArmLoadBalancerProbeCreate(d *schema.ResourceData, meta interface{}
 }
 
 func resourceArmLoadBalancerProbeRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	name := id.Path["probes"]
+
 	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", name)
 		return nil
 	}
 
-	config, _, exists := findLoadBalancerProbeByName(loadBalancer, d.Get("name").(string))
+	config, _, exists := findLoadBalancerProbeByName(loadBalancer, name)
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer Probe %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer Probe %q not found. Removing from state", name)
 		return nil
 	}
 
 	d.Set("name", config.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 	d.Set("protocol", config.ProbePropertiesFormat.Protocol)
 	d.Set("interval_in_seconds", config.ProbePropertiesFormat.IntervalInSeconds)
 	d.Set("number_of_probes", config.ProbePropertiesFormat.NumberOfProbes)
 	d.Set("port", config.ProbePropertiesFormat.Port)
 	d.Set("request_path", config.ProbePropertiesFormat.RequestPath)
+
+	var load_balancer_rules []string
+	if config.ProbePropertiesFormat.LoadBalancingRules != nil {
+		for _, ruleConfig := range *config.ProbePropertiesFormat.LoadBalancingRules {
+			load_balancer_rules = append(load_balancer_rules, *ruleConfig.ID)
+		}
+	}
+	d.Set("load_balancer_rules", load_balancer_rules)
 
 	return nil
 }

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule.go
@@ -19,6 +19,9 @@ func resourceArmLoadBalancerRule() *schema.Resource {
 		Read:   resourceArmLoadBalancerRuleRead,
 		Update: resourceArmLoadBalancerRuleCreate,
 		Delete: resourceArmLoadBalancerRuleDelete,
+		Importer: &schema.ResourceImporter{
+			State: loadBalancerSubResourceStateImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -28,7 +31,14 @@ func resourceArmLoadBalancerRule() *schema.Resource {
 				ValidateFunc: validateArmLoadBalancerRuleName,
 			},
 
-			"location": locationSchema(),
+			"location": {
+				Type:             schema.TypeString,
+				ForceNew:         true,
+				Optional:         true,
+				StateFunc:        azureRMNormalizeLocation,
+				DiffSuppressFunc: azureRMSuppressLocationDiff,
+				Deprecated:       "location is no longer used",
+			},
 
 			"resource_group_name": {
 				Type:     schema.TypeString,
@@ -180,24 +190,31 @@ func resourceArmLoadBalancerRuleCreate(d *schema.ResourceData, meta interface{})
 }
 
 func resourceArmLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) error {
+	id, err := parseAzureResourceID(d.Id())
+	if err != nil {
+		return err
+	}
+	name := id.Path["loadBalancingRules"]
+
 	loadBalancer, exists, err := retrieveLoadBalancerById(d.Get("loadbalancer_id").(string), meta)
 	if err != nil {
 		return errwrap.Wrapf("Error Getting LoadBalancer By ID {{err}}", err)
 	}
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer %q not found. Removing from state", name)
 		return nil
 	}
 
-	config, _, exists := findLoadBalancerRuleByName(loadBalancer, d.Get("name").(string))
+	config, _, exists := findLoadBalancerRuleByName(loadBalancer, name)
 	if !exists {
 		d.SetId("")
-		log.Printf("[INFO] LoadBalancer Rule %q not found. Removing from state", d.Get("name").(string))
+		log.Printf("[INFO] LoadBalancer Rule %q not found. Removing from state", name)
 		return nil
 	}
 
 	d.Set("name", config.Name)
+	d.Set("resource_group_name", id.ResourceGroup)
 
 	d.Set("protocol", config.LoadBalancingRulePropertiesFormat.Protocol)
 	d.Set("frontend_port", config.LoadBalancingRulePropertiesFormat.FrontendPort)
@@ -212,6 +229,12 @@ func resourceArmLoadBalancerRuleRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	if config.LoadBalancingRulePropertiesFormat.FrontendIPConfiguration != nil {
+		fipID, err := parseAzureResourceID(*config.LoadBalancingRulePropertiesFormat.FrontendIPConfiguration.ID)
+		if err != nil {
+			return err
+		}
+
+		d.Set("frontend_ip_configuration_name", fipID.Path["frontendIPConfigurations"])
 		d.Set("frontend_ip_configuration_id", config.LoadBalancingRulePropertiesFormat.FrontendIPConfiguration.ID)
 	}
 

--- a/website/source/docs/providers/azurerm/r/loadbalancer.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer.html.markdown
@@ -61,3 +61,11 @@ The following attributes are exported:
 
 * `id` - The LoadBalancer ID.
 
+## Import
+
+Load Balancers can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_lb.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1
+```
+

--- a/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
@@ -60,3 +60,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the LoadBalancer to which the resource is attached.
+
+## Import
+
+Load Balancer Backend Address Pools can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_lb_backend_address_pool.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/backendAddressPools/pool1
+```

--- a/website/source/docs/providers/azurerm/r/loadbalancer_nat_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_nat_pool.html.markdown
@@ -70,3 +70,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the LoadBalancer to which the resource is attached.
+
+## Import
+
+Load Balancer NAT Pools can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_lb_nat_pool.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatPools/pool1
+```

--- a/website/source/docs/providers/azurerm/r/loadbalancer_nat_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_nat_rule.html.markdown
@@ -68,3 +68,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the LoadBalancer to which the resource is attached.
+
+## Import
+
+Load Balancer NAT Rules can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_lb_nat_rule.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/inboundNatRules/rule1
+```

--- a/website/source/docs/providers/azurerm/r/loadbalancer_probe.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_probe.html.markdown
@@ -68,3 +68,11 @@ The following attributes are exported:
 
 * `id` - The ID of the LoadBalancer to which the resource is attached.
 
+## Import
+
+Load Balancer Probes can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_lb_probe.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/probes/probe1
+```
+

--- a/website/source/docs/providers/azurerm/r/loadbalancer_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_rule.html.markdown
@@ -73,3 +73,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the LoadBalancer to which the resource is attached.
+
+## Import
+
+Load Balancer Rules can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_lb_rule.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/loadBalancingRules/rule1
+```


### PR DESCRIPTION
* implemented ResourceImporter for sub resources which extracts the lb id
* deprecated location on each sub resource as it was unused

Ran all LB tests including new import tests:
```
TestAccAzureRMLoadBalancer_importBasic
TestAccAzureRMLoadBalancerNatPool_importBasic
TestAccAzureRMLoadBalancerNatPool_removal
TestAccAzureRMLoadBalancerBackEndAddressPool_basic
TestAccAzureRMLoadBalancerBackEndAddressPool_removal
TestAccAzureRMLoadBalancerNatRule_importBasic
TestAccAzureRMLoadBalancerNatPool_basic
TestAccAzureRMLoadBalancerProbe_importBasic
TestAccAzureRMLoadBalancerBackEndAddressPool_disappears
TestAccAzureRMLoadBalancerBackEndAddressPool_importBasic
TestAccAzureRMLoadBalancerRule_importBasic
TestAccAzureRMLoadBalancerBackEndAddressPool_reapply
TestAccAzureRMLoadBalancerNatPool_update
TestAccAzureRMLoadBalancerNatPool_disappears
TestAccAzureRMLoadBalancerNatRule_basic
TestAccAzureRMLoadBalancerProbe_removal
TestAccAzureRMLoadBalancerNatPool_reapply
TestAccAzureRMLoadBalancerProbe_update
TestAccAzureRMLoadBalancerNatRule_disappears
TestAccAzureRMLoadBalancerNatRule_removal
TestAccAzureRMLoadBalancerProbe_basic
TestAccAzureRMLoadBalancerNatRule_reapply
TestAccAzureRMLoadBalancerNatRule_update
TestAccAzureRMLoadBalancerProbe_updateProtocol
TestAccAzureRMLoadBalancer_basic
TestAccAzureRMLoadBalancer_tags
TestAccAzureRMLoadBalancerProbe_reapply
TestAccAzureRMLoadBalancerRule_removal
TestAccAzureRMLoadBalancerProbe_disappears
TestAccAzureRMLoadBalancerRule_basic
TestAccAzureRMLoadBalancerRule_inconsistentReads
TestAccAzureRMLoadBalancerRule_disappears
TestAccAzureRMLoadBalancerRule_update
TestAccAzureRMLoadBalancerRule_reapply
TestAccAzureRMLoadBalancer_frontEndConfig
```