### PR TITLE
provider/pagerduty: pagerduty_schedule data source

### DIFF
--- a/builtin/providers/pagerduty/data_source_pagerduty_schedule.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_schedule.go
@@ -13,10 +13,6 @@ func dataSourcePagerDutySchedule() *schema.Resource {
 		Read: dataSourcePagerDutyScheduleRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/builtin/providers/pagerduty/data_source_pagerduty_schedule.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_schedule.go
@@ -1,0 +1,61 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+
+	pagerduty "github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourcePagerDutySchedule() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyScheduleRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyScheduleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty schedule")
+
+	searchName := d.Get("name").(string)
+
+	o := &pagerduty.ListSchedulesOptions{
+		Query: searchName,
+	}
+
+	resp, err := client.ListSchedules(*o)
+	if err != nil {
+		return err
+	}
+
+	var found *pagerduty.Schedule
+
+	for _, schedule := range resp.Schedules {
+		if schedule.Name == searchName {
+			found = &schedule
+			break
+		}
+	}
+
+	if found == nil {
+		return fmt.Errorf("Unable to locate any schedule with the name: %s", searchName)
+	}
+
+	d.SetId(found.ID)
+	d.Set("name", found.Name)
+
+	return nil
+}

--- a/builtin/providers/pagerduty/data_source_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_schedule_test.go
@@ -1,0 +1,85 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourcePagerDutySchedule_Basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourcePagerDutyScheduleConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutySchedule("pagerduty_schedule.test", "data.pagerduty_schedule.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutySchedule(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get a schedule ID from PagerDuty")
+		}
+
+		testAtts := []string{"id", "name"}
+
+		for _, att := range testAtts {
+			if a[att] != srcA[att] {
+				return fmt.Errorf("Expected the schedule %s to be: %s, but got: %s", att, srcA[att], a[att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyScheduleConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "TF User %[1]s"
+  email = "tf.%[1]s@example.com"
+}
+
+resource "pagerduty_schedule" "test" {
+  name = "TF Schedule %[1]s"
+
+  time_zone = "America/New_York"
+
+  layer {
+    name                         = "foo"
+    start                        = "2015-11-06T20:00:00-05:00"
+    rotation_virtual_start       = "2015-11-06T20:00:00-05:00"
+    rotation_turn_length_seconds = 86400
+    users                        = ["${pagerduty_user.test.id}"]
+
+    restriction {
+      type              = "weekly_restriction"
+      start_time_of_day = "08:00:00"
+      start_day_of_week = 5
+      duration_seconds  = 32101
+    }
+  }
+}
+
+data "pagerduty_schedule" "by_name" {
+  name = "${pagerduty_schedule.test.name}"
+}
+`, rName)
+}

--- a/builtin/providers/pagerduty/provider.go
+++ b/builtin/providers/pagerduty/provider.go
@@ -19,8 +19,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"pagerduty_user":   dataSourcePagerDutyUser(),
-			"pagerduty_vendor": dataSourcePagerDutyVendor(),
+			"pagerduty_user":     dataSourcePagerDutyUser(),
+			"pagerduty_schedule": dataSourcePagerDutySchedule(),
+			"pagerduty_vendor":   dataSourcePagerDutyVendor(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/source/docs/providers/pagerduty/d/schedule.html.markdown
+++ b/website/source/docs/providers/pagerduty/d/schedule.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_schedule"
+sidebar_current: "docs-pagerduty-datasource-schedule"
+description: |-
+  Provides information about a Schedule.
+
+  This data source can be helpful when a schedule is handled outside Terraform but still want to reference it in other resources.
+---
+
+# pagerduty\_schedule
+
+Use this data source to get information about a specific [schedule][1] that you can use for other PagerDuty resources.
+
+## Example Usage
+
+```
+data "pagerduty_schedule" "test" {
+  name = "Daily Engineering Rotation"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name      = "Engineering Escalation Policy"
+  num_loops = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "schedule"
+      id   = "${data.pagerduty_schedule.test.id}"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name to use to find a schedule in the PagerDuty API.  
+
+## Attributes Reference
+* `name` - The short name of the found schedule.
+
+[1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Schedules/get_schedules

--- a/website/source/layouts/pagerduty.erb
+++ b/website/source/layouts/pagerduty.erb
@@ -16,6 +16,9 @@
                 <li<%= sidebar_current("docs-pagerduty-datasource-user") %>>
                     <a href="/docs/providers/pagerduty/d/user.html">pagerduty_user</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-schedule") %>>
+                    <a href="/docs/providers/pagerduty/d/schedule.html">pagerduty_schedule</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-datasource-vendor") %>>
                     <a href="/docs/providers/pagerduty/d/vendor.html">pagerduty_vendor</a>
                 </li>


### PR DESCRIPTION
This PR adds a new data source `pagerduty_schedule`

So far, the only thing we store is the actual ID of the resource, 
but can easily be extended to export more attributes in the future.

Example usage:
```hcl
data "pagerduty_schedule" "test" {
  name = "Daily Engineering Rotation"
}

resource "pagerduty_escalation_policy" "test" {
  name      = "Engineering Escalation Policy"
  num_loops = 2

  rule {
    escalation_delay_in_minutes = 10

    target {
      type = "schedule_reference"
      id   = "${data.pagerduty_schedule.test.id}"
    }
  }
}
```