### PR TITLE
provider/pagerduty: pagerduty_escalation_policy data source

### DIFF
--- a/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy.go
@@ -13,10 +13,6 @@ func dataSourcePagerDutyEscalationPolicy() *schema.Resource {
 		Read: dataSourcePagerDutyEscalationPolicyRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,

--- a/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy.go
@@ -1,0 +1,61 @@
+package pagerduty
+
+import (
+	"fmt"
+	"log"
+
+	pagerduty "github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourcePagerDutyEscalationPolicy() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePagerDutyEscalationPolicyRead,
+
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourcePagerDutyEscalationPolicyRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty escalation policy")
+
+	searchName := d.Get("name").(string)
+
+	o := &pagerduty.ListEscalationPoliciesOptions{
+		Query: searchName,
+	}
+
+	resp, err := client.ListEscalationPolicies(*o)
+	if err != nil {
+		return err
+	}
+
+	var found *pagerduty.EscalationPolicy
+
+	for _, policy := range resp.EscalationPolicies {
+		if policy.Name == searchName {
+			found = &policy
+			break
+		}
+	}
+
+	if found == nil {
+		return fmt.Errorf("Unable to locate any escalation policy with the name: %s", searchName)
+	}
+
+	d.SetId(found.ID)
+	d.Set("name", found.Name)
+
+	return nil
+}

--- a/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy_test.go
@@ -1,0 +1,78 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourcePagerDutyEscalationPolicy_Basic(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourcePagerDutyEscalationPolicyConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyEscalationPolicy("pagerduty_escalation_policy.test", "data.pagerduty_escalation_policy.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyEscalationPolicy(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		srcR := s.RootModule().Resources[src]
+		srcA := srcR.Primary.Attributes
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get a escalation policy ID from PagerDuty")
+		}
+
+		testAtts := []string{"id", "name"}
+
+		for _, att := range testAtts {
+			if a[att] != srcA[att] {
+				return fmt.Errorf("Expected the escalation policy %s to be: %s, but got: %s", att, srcA[att], a[att])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyEscalationPolicyConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "pagerduty_user" "test" {
+  name  = "TF User %[1]s"
+  email = "tf.%[1]s@example.com"
+}
+
+resource "pagerduty_escalation_policy" "test" {
+  name        = "TF Escalation Policy %[1]v"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = "${data.pagerduty_user.test.id}"
+    }
+  }
+}
+
+data "pagerduty_escalation_policy" "by_name" {
+  name = "${pagerduty_escalation_policy.test.name}"
+}
+`, rName)
+}

--- a/builtin/providers/pagerduty/provider.go
+++ b/builtin/providers/pagerduty/provider.go
@@ -19,9 +19,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"pagerduty_user":     dataSourcePagerDutyUser(),
-			"pagerduty_schedule": dataSourcePagerDutySchedule(),
-			"pagerduty_vendor":   dataSourcePagerDutyVendor(),
+			"pagerduty_user":              dataSourcePagerDutyUser(),
+			"pagerduty_schedule":          dataSourcePagerDutySchedule(),
+			"pagerduty_escalation_policy": dataSourcePagerDutyEscalationPolicy(),
+			"pagerduty_vendor":            dataSourcePagerDutyVendor(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/source/docs/providers/pagerduty/d/escalation_policy.html.markdown
+++ b/website/source/docs/providers/pagerduty/d/escalation_policy.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_escalation_policy"
+sidebar_current: "docs-pagerduty-datasource-escalation-policy"
+description: |-
+  Provides information about a Escalation Policy.
+
+  This data source can be helpful when an escalation policy is handled outside Terraform but still want to reference it in other resources.
+---
+
+# pagerduty\_escalation_policy
+
+Use this data source to get information about a specific [escalation policy][1] that you can use for other PagerDuty resources.
+
+## Example Usage
+
+```
+data "pagerduty_escalation_policy" "test" {
+  name = "Engineering Escalation Policy"
+}
+
+resource "pagerduty_service" "test" {
+  name                    = "My Web App"
+  auto_resolve_timeout    = 14400
+  acknowledgement_timeout = 600
+  escalation_policy       = "${data.pagerduty_escalation_policy.test.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name to use to find an escalation policy in the PagerDuty API.  
+
+## Attributes Reference
+* `name` - The short name of the found escalation policy.
+
+[1]: https://v2.developer.pagerduty.com/v2/page/api-reference#!/Escalation_Policies/get_escalation_policies

--- a/website/source/layouts/pagerduty.erb
+++ b/website/source/layouts/pagerduty.erb
@@ -22,6 +22,9 @@
                 <li<%= sidebar_current("docs-pagerduty-datasource-vendor") %>>
                     <a href="/docs/providers/pagerduty/d/vendor.html">pagerduty_vendor</a>
                 </li>
+                <li<%= sidebar_current("docs-pagerduty-datasource-escalation-policy") %>>
+                    <a href="/docs/providers/pagerduty/d/escalation_policy.html">pagerduty_escalation_policy</a>
+                </li>
             </ul>
         </li>
 


### PR DESCRIPTION
This PR adds a new data source `pagerduty_escalation_policy`

This along with https://github.com/hashicorp/terraform/pull/11614 should hopefully cover the use case where people don't have schedules and/or escalation policies managed by Terraform but still want to reference them in other resources.

Example usage:
```hcl
data "pagerduty_escalation_policy" "test" {
  name = "Engineering Escalation Policy"
}

resource "pagerduty_service" "test" {
  name                    = "My Web App"
  auto_resolve_timeout    = 14400
  acknowledgement_timeout = 600
  escalation_policy       = "${data.pagerduty_escalation_policy.test.id}"
}
```