### PR TITLE
provider/pagerduty: pagerduty_addon resource

### DIFF
--- a/builtin/providers/pagerduty/provider.go
+++ b/builtin/providers/pagerduty/provider.go
@@ -26,6 +26,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"pagerduty_addon":               resourcePagerDutyAddon(),
 			"pagerduty_user":                resourcePagerDutyUser(),
 			"pagerduty_team":                resourcePagerDutyTeam(),
 			"pagerduty_service":             resourcePagerDutyService(),

--- a/builtin/providers/pagerduty/resource_pagerduty_addon.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_addon.go
@@ -1,0 +1,114 @@
+package pagerduty
+
+import (
+	"log"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourcePagerDutyAddon() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePagerDutyAddonCreate,
+		Read:   resourcePagerDutyAddonRead,
+		Update: resourcePagerDutyAddonUpdate,
+		Delete: resourcePagerDutyAddonDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourcePagerDutyAddonImport,
+		},
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"src": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func buildAddonStruct(d *schema.ResourceData) *pagerduty.Addon {
+	addon := pagerduty.Addon{
+		Name: d.Get("name").(string),
+		Src:  d.Get("src").(string),
+		APIObject: pagerduty.APIObject{
+			Type: "full_page_addon",
+		},
+	}
+
+	return &addon
+}
+
+func resourcePagerDutyAddonCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	addon := buildAddonStruct(d)
+
+	log.Printf("[INFO] Creating PagerDuty add-on %s", addon.Name)
+
+	addon, err := client.InstallAddon(*addon)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(addon.ID)
+
+	return resourcePagerDutyAddonRead(d, meta)
+}
+
+func resourcePagerDutyAddonRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Reading PagerDuty add-on %s", d.Id())
+
+	addon, err := client.GetAddon(d.Id())
+	if err != nil {
+		if isNotFound(err) {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.Set("name", addon.Name)
+	d.Set("src", addon.Src)
+
+	return nil
+}
+
+func resourcePagerDutyAddonUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	addon := buildAddonStruct(d)
+
+	log.Printf("[INFO] Updating PagerDuty add-on %s", d.Id())
+
+	if _, err := client.UpdateAddon(d.Id(), *addon); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resourcePagerDutyAddonDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*pagerduty.Client)
+
+	log.Printf("[INFO] Deleting PagerDuty add-on %s", d.Id())
+
+	if err := client.DeleteAddon(d.Id()); err != nil {
+		return err
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourcePagerDutyAddonImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	if err := resourcePagerDutyAddonRead(d, meta); err != nil {
+		return nil, err
+	}
+	return []*schema.ResourceData{d}, nil
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_addon_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_addon_test.go
@@ -1,0 +1,95 @@
+package pagerduty
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccPagerDutyAddon_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyAddonDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPagerDutyAddonConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyAddonExists("pagerduty_addon.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_addon.foo", "name", "Foo status page"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_addon.foo", "src", "https://intranet.foo.com/status"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckPagerDutyAddonConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyAddonExists("pagerduty_addon.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_addon.foo", "name", "Bar status page"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_addon.foo", "src", "https://intranet.bar.com/status"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckPagerDutyAddonDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*pagerduty.Client)
+	for _, r := range s.RootModule().Resources {
+		if r.Type != "pagerduty_addon" {
+			continue
+		}
+
+		if _, err := client.GetAddon(r.Primary.ID); err == nil {
+			return fmt.Errorf("Add-on still exists")
+		}
+
+	}
+	return nil
+}
+
+func testAccCheckPagerDutyAddonExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No add-on ID is set")
+		}
+
+		client := testAccProvider.Meta().(*pagerduty.Client)
+
+		found, err := client.GetAddon(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if found.ID != rs.Primary.ID {
+			return fmt.Errorf("Add-on not found: %v - %v", rs.Primary.ID, found)
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckPagerDutyAddonConfig = `
+resource "pagerduty_addon" "foo" {
+  name = "Foo status page"
+  src  = "https://intranet.foo.com/status"
+}
+`
+
+const testAccCheckPagerDutyAddonConfigUpdated = `
+resource "pagerduty_addon" "foo" {
+  name = "Bar status page"
+  src  = "https://intranet.bar.com/status"
+}
+`

--- a/website/source/docs/providers/pagerduty/r/addon.html.markdown
+++ b/website/source/docs/providers/pagerduty/r/addon.html.markdown
@@ -1,0 +1,41 @@
+---
+layout: "pagerduty"
+page_title: "PagerDuty: pagerduty_addon"
+sidebar_current: "docs-pagerduty-resource-addon"
+description: |-
+  Creates and manages an add-on in PagerDuty.
+---
+
+# pagerduty\_addon
+
+With [add-ons](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Add-ons/get_addons), third-party developers can write their own add-ons to PagerDuty's UI. Given a configuration containing a src parameter, that URL will be embedded in an iframe on a page that's available to users from a drop-down menu.
+
+## Example Usage
+
+```
+resource "pagerduty_addon" "example" {
+  name = "Internal Status Page"
+  src  = "https://intranet.example.com/status"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+  * `name` - (Required) The name of the add-on.
+  * `src` - (Required) The source URL to display in a frame in the PagerDuty UI. `HTTPS` is required.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+  * `id` - The ID of the add-on.
+
+## Import
+
+Add-ons can be imported using the `id`, e.g.
+
+```
+$ terraform import pagerduty_addon.example P3DH5M6
+```

--- a/website/source/layouts/pagerduty.erb
+++ b/website/source/layouts/pagerduty.erb
@@ -31,6 +31,9 @@
         <li<%= sidebar_current(/^docs-pagerduty-resource/) %>>
             <a href="#">Resources</a>
             <ul class="nav nav-visible">
+                <li<%= sidebar_current("docs-pagerduty-resource-addon") %>>
+                    <a href="/docs/providers/pagerduty/r/addon.html">pagerduty_addon</a>
+                </li>
                 <li<%= sidebar_current("docs-pagerduty-resource-user") %>>
                     <a href="/docs/providers/pagerduty/r/user.html">pagerduty_user</a>
                 </li>


### PR DESCRIPTION
This PR adds support for `add-ons` in PagerDuty. 

With add-ons, third-party developers can write their own add-ons to PagerDuty's UI. Given a configuration containing a src parameter, that URL will be embedded in an iframe on a page that's available to users from a drop-down menu.

Example usage:

```bash
resource "pagerduty_addon" "example" {
  name = "Internal Status Page"
  src  = "https://intranet.example.com/status"
}
```