### PR TITLE
providers/vsphere: recreate virtual machine if template changes

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -372,6 +372,7 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 						"template": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							ForceNew: true,
 						},
 
 						"type": &schema.Schema{


### PR DESCRIPTION
Quite new to terraform and vsphere, but I've been having issues with updating templates not actually recreating the vm, so thought of looking into this.

This may be a possible solution but happy to hear any feedback anyone may have.