### PR TITLE
provider/google: make local_traffic_selector computed now that we rea…

### DIFF
--- a/builtin/providers/google/resource_compute_vpn_tunnel.go
+++ b/builtin/providers/google/resource_compute_vpn_tunnel.go
@@ -68,6 +68,7 @@ func resourceComputeVpnTunnel() *schema.Resource {
 				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},


### PR DESCRIPTION
As part of the acceptance tests for #11020 the traffic selectors are now read back from the server. If local_traffic_selector is not provided during tunnel creation, Cloud VPN still returns it as "0.0.0.0/0". If the Computed attribute is not set, the tunnel will get recreated if the user does not set local_traffic_selector explicitly, until its value is set to that value.

Setting it as computed skips the recreation.