### PR TITLE
provider/aws: More lambda test fixes

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -268,6 +268,8 @@ func TestAccAWSLambdaFunction_localUpdate(t *testing.T) {
 func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
+	rName := fmt.Sprintf("tf_test_iam_%d", acctest.RandInt())
+
 	path, zipFile, err := createTempFile("lambda_localUpdate")
 	if err != nil {
 		t.Fatal(err)
@@ -289,11 +291,11 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				PreConfig: func() {
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_local_name_only(path),
+				Config: genAWSLambdaFunctionConfig_local_name_only(path, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", "tf_acc_lambda_name_local", &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_local"),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, "tf_acc_lambda_name_local"),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", rName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, rName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "8DPiX+G1l2LQ8hjBkwRchQFf1TSCEvPrYGRKlM9UoyY="),
 				),
 			},
@@ -301,11 +303,11 @@ func TestAccAWSLambdaFunction_localUpdate_nameOnly(t *testing.T) {
 				PreConfig: func() {
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, updatedZipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_local_name_only(updatedPath),
+				Config: genAWSLambdaFunctionConfig_local_name_only(updatedPath, rName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", "tf_acc_lambda_name_local", &conf),
-					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_local"),
-					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, "tf_acc_lambda_name_local"),
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_local", rName, &conf),
+					testAccCheckAwsLambdaFunctionName(&conf, rName),
+					testAccCheckAwsLambdaFunctionArnHasSuffix(&conf, rName),
 					testAccCheckAwsLambdaSourceCodeHash(&conf, "0tdaP9H9hsk9c2CycSwOG/sa/x5JyAmSYunA/ce99Pg="),
 				),
 			},
@@ -369,6 +371,8 @@ func TestAccAWSLambdaFunction_s3Update(t *testing.T) {
 func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
+	rName := fmt.Sprintf("tf_iam_lambda_%d", acctest.RandInt())
+
 	path, zipFile, err := createTempFile("lambda_s3Update")
 	if err != nil {
 		t.Fatal(err)
@@ -389,7 +393,7 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 					// Upload 1st version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_s3_unversioned(bucketName, key, path),
+				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(rName, bucketName, key, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", "tf_acc_lambda_name_s3_unversioned", &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_s3_unversioned"),
@@ -402,7 +406,7 @@ func TestAccAWSLambdaFunction_s3Update_unversioned(t *testing.T) {
 					// Upload 2nd version
 					testAccCreateZipFromFiles(map[string]string{"test-fixtures/lambda_func_modified.js": "lambda.js"}, zipFile)
 				},
-				Config: genAWSLambdaFunctionConfig_s3_unversioned(bucketName, key2, path),
+				Config: testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(rName, bucketName, key2, path),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_s3", "tf_acc_lambda_name_s3_unversioned", &conf),
 					testAccCheckAwsLambdaFunctionName(&conf, "tf_acc_lambda_name_s3_unversioned"),
@@ -1027,14 +1031,14 @@ func genAWSLambdaFunctionConfig_local(filePath string) string {
 		filePath, filePath)
 }
 
-func genAWSLambdaFunctionConfig_local_name_only(filePath string) string {
-	return fmt.Sprintf(testAccAWSLambdaFunctionConfig_local_name_only_tpl,
-		filePath)
+func genAWSLambdaFunctionConfig_local_name_only(filePath, rName string) string {
+	return testAccAWSLambdaFunctionConfig_local_name_only_tpl(filePath, rName)
 }
 
-const testAccAWSLambdaFunctionConfig_local_name_only_tpl = `
+func testAccAWSLambdaFunctionConfig_local_name_only_tpl(filePath, rName string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda"
+    name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -1053,12 +1057,12 @@ EOF
 }
 resource "aws_lambda_function" "lambda_function_local" {
     filename = "%s"
-    function_name = "tf_acc_lambda_name_local"
+    function_name = "%s"
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs4.3"
+}`, rName, filePath, rName)
 }
-`
 
 const testAccAWSLambdaFunctionConfig_s3_tpl = `
 resource "aws_s3_bucket" "artifacts" {
@@ -1109,7 +1113,8 @@ func genAWSLambdaFunctionConfig_s3(bucket, key, path string) string {
 		bucket, key, path, path)
 }
 
-const testAccAWSLambdaFunctionConfig_s3_unversioned_tpl = `
+func testAccAWSLambdaFunctionConfig_s3_unversioned_tpl(rName, bucketName, key, path string) string {
+	return fmt.Sprintf(`
 resource "aws_s3_bucket" "artifacts" {
     bucket = "%s"
     acl = "private"
@@ -1146,10 +1151,5 @@ resource "aws_lambda_function" "lambda_function_s3" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs4.3"
-}
-`
-
-func genAWSLambdaFunctionConfig_s3_unversioned(bucket, key, path string) string {
-	return fmt.Sprintf(testAccAWSLambdaFunctionConfig_s3_unversioned_tpl,
-		bucket, key, path, path)
+}`, bucketName, key, path, path, rName)
 }

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -1127,7 +1127,7 @@ resource "aws_s3_bucket_object" "o" {
     etag = "${md5(file("%s"))}"
 }
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda"
+		name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/builtin/providers/aws/resource_aws_lambda_permission_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission_test.go
@@ -148,13 +148,15 @@ func TestAccAWSLambdaPermission_basic(t *testing.T) {
 	var statement LambdaPolicyStatement
 	endsWithFuncName := regexp.MustCompile(":function:lambda_function_name_perm$")
 
+	rName := fmt.Sprintf("tf_iam_%d", acctest.RandInt())
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSLambdaPermissionDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSLambdaPermissionConfig,
+				Config: testAccAWSLambdaPermissionConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckLambdaPermissionExists("aws_lambda_permission.allow_cloudwatch", &statement),
 					resource.TestCheckResourceAttr("aws_lambda_permission.allow_cloudwatch", "action", "lambda:InvokeFunction"),
@@ -459,7 +461,8 @@ func lambdaPermissionExists(rs *terraform.ResourceState, conn *lambda.Lambda) (*
 	return findLambdaPolicyStatementById(&policy, rs.Primary.ID)
 }
 
-var testAccAWSLambdaPermissionConfig = `
+func testAccAWSLambdaPermissionConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_lambda_permission" "allow_cloudwatch" {
     statement_id = "AllowExecutionFromCloudWatch"
     action = "lambda:InvokeFunction"
@@ -476,7 +479,7 @@ resource "aws_lambda_function" "test_lambda" {
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
-    name = "iam_for_lambda_perm"
+    name = "%s"
     assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -492,8 +495,8 @@ resource "aws_iam_role" "iam_for_lambda" {
   ]
 }
 EOF
+}`, rName)
 }
-`
 
 var testAccAWSLambdaPermissionConfig_withRawFunctionName = `
 resource "aws_lambda_permission" "with_raw_func_name" {


### PR DESCRIPTION
Had to do some randomizing and other fun things to get the lambda tests to play nice

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLambdaFunction -timeout 120m
=== RUN   TestAccAWSLambdaFunction_importLocalFile
--- PASS: TestAccAWSLambdaFunction_importLocalFile (28.49s)
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- PASS: TestAccAWSLambdaFunction_importLocalFile_VPC (28.24s)
=== RUN   TestAccAWSLambdaFunction_importS3
--- PASS: TestAccAWSLambdaFunction_importS3 (27.99s)
=== RUN   TestAccAWSLambdaFunction_basic
--- PASS: TestAccAWSLambdaFunction_basic (26.56s)
=== RUN   TestAccAWSLambdaFunction_expectFilenameAndS3Attributes
--- PASS: TestAccAWSLambdaFunction_expectFilenameAndS3Attributes (15.68s)
=== RUN   TestAccAWSLambdaFunction_envVariables
--- PASS: TestAccAWSLambdaFunction_envVariables (69.36s)
=== RUN   TestAccAWSLambdaFunction_encryptedEnvVariables
--- PASS: TestAccAWSLambdaFunction_encryptedEnvVariables (58.68s)
=== RUN   TestAccAWSLambdaFunction_versioned
--- PASS: TestAccAWSLambdaFunction_versioned (26.60s)
=== RUN   TestAccAWSLambdaFunction_VPC
--- PASS: TestAccAWSLambdaFunction_VPC (25.70s)
=== RUN   TestAccAWSLambdaFunction_s3
--- PASS: TestAccAWSLambdaFunction_s3 (30.47s)
=== RUN   TestAccAWSLambdaFunction_localUpdate
--- PASS: TestAccAWSLambdaFunction_localUpdate (31.81s)
=== RUN   TestAccAWSLambdaFunction_localUpdate_nameOnly
--- PASS: TestAccAWSLambdaFunction_localUpdate_nameOnly (30.62s)
=== RUN   TestAccAWSLambdaFunction_s3Update
--- PASS: TestAccAWSLambdaFunction_s3Update (58.24s)
=== RUN   TestAccAWSLambdaFunction_s3Update_unversioned
--- PASS: TestAccAWSLambdaFunction_s3Update_unversioned (42.38s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (24.03s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs (22.56s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_nodeJs43
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_nodeJs43 (25.68s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_python27
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_python27 (24.75s)
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_java8
--- PASS: TestAccAWSLambdaFunction_runtimeValidation_java8 (26.12s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    624.004s

```