### PR TITLE
provider/aws: Improve IAM Group AccTests

### DIFF
--- a/builtin/providers/aws/import_aws_iam_group_test.go
+++ b/builtin/providers/aws/import_aws_iam_group_test.go
@@ -3,10 +3,12 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSIAMGroup_importBasic(t *testing.T) {
+	rInt := acctest.RandInt()
 	resourceName := "aws_iam_group.group"
 
 	resource.Test(t, resource.TestCase{
@@ -14,11 +16,11 @@ func TestAccAWSIAMGroup_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSGroupConfig,
+			{
+				Config: testAccAWSGroupConfig(rInt),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
Improve the iam_group acceptance tests. Previously, the iam_group would overlap when running our tests in parallel. This fixes that.