### PR TITLE
provider/google: set subnetwork_project to computed

### DIFF
--- a/builtin/providers/google/resource_compute_instance_template.go
+++ b/builtin/providers/google/resource_compute_instance_template.go
@@ -207,6 +207,7 @@ func resourceComputeInstanceTemplate() *schema.Resource {
 							Type:     schema.TypeString,
 							Optional: true,
 							ForceNew: true,
+							Computed: true,
 						},
 
 						"access_config": &schema.Schema{


### PR DESCRIPTION
Fixes #11492 

@paddyforan, any ideas of how to test this? I'm actually surprised the tests pass as they are since  testAccComputeInstanceTemplate_subnet_custom should have been hit by the bug (since it sets a subnetwork but not subnetwork_project).

FWIW, I wrote a quick sample config that reproduces the bug and confirmed it attempted to create a new resource using standard `terraform` and not when I rebuilt the google plugin, so I at least know this works.