### PR TITLE
Cleared up aws_key_pair requirements and purpose

### DIFF
--- a/website/source/docs/providers/aws/r/key_pair.html.markdown
+++ b/website/source/docs/providers/aws/r/key_pair.html.markdown
@@ -10,7 +10,7 @@ description: |-
 
 Provides an [EC2 key pair](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) resource. A key pair is used to control login access to EC2 instances. 
 
-Currently this resource only supports importing a user-supplied key pair, not the creation of a new key pair.
+Currently this resource requires an existing user-supplied key pair. This key pair's public key will be registered with AWS to allow logging-in to EC2 instances.
 
 When importing an existing key pair the public key material may be in any format supported by AWS. Supported formats (per the [AWS documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html#how-to-generate-your-own-key-and-import-it-to-aws)) are:
 


### PR DESCRIPTION
This makes it much more directly obvious what `aws_key_pair` does by saying the user *does* provide the key-pair of some kind and that all `aws_key_pair` does is register that public key with an optional name in AWS.