### PR TITLE
provider/aws: Fix spot_instance_request bug

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -263,6 +263,9 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 				"host": *instance.PrivateIpAddress,
 			})
 		}
+		if err := readBlockDevices(d, instance, conn); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Discovered after #11619 was fixed, and while fixing acceptance tests for the `aws_spot_instance_request` resource.
Previously the `aws_spot_instance_request` resource wouldn't populate any of the block device attributes from the resulting instance's metadata. This fixes that issue, and also fixes the `aws_spot_instance_request` acceptance tests to be more equipped for running in parallel.

 ```
 make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSpotInstanceRequest_'
 ==> Checking that code complies with gofmt requirements...
 go generate $(go list ./... | grep -v /terraform/vendor/)
 2017/02/02 18:02:37 Generated command/internal_plugin_list.go
 TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSpotInstanceRequest_ -timeout 120m
 === RUN   TestAccAWSSpotInstanceRequest_basic
 --- PASS: TestAccAWSSpotInstanceRequest_basic (111.96s)
 === RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
 --- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (105.12s)
 === RUN   TestAccAWSSpotInstanceRequest_vpc
 --- PASS: TestAccAWSSpotInstanceRequest_vpc (115.81s)
 === RUN   TestAccAWSSpotInstanceRequest_SubnetAndSG
 --- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSG (130.46s)
 PASS
 ok      github.com/hashicorp/terraform/builtin/providers/aws    463.377s
 ```