### PR TITLE
provider/google: set additional_zones to computed and disallow the original zone from appearing in the list

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -444,7 +444,10 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("name", cluster.Name)
 	d.Set("zone", cluster.Zone)
-	d.Set("additional_zones", cluster.Locations)
+
+	if _, ok := d.GetOk("additional_zones"); ok {
+		d.Set("additional_zones", cluster.Locations)
+	}
 	d.Set("endpoint", cluster.Endpoint)
 
 	masterAuth := []map[string]interface{}{

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -442,15 +442,15 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", cluster.Name)
 	d.Set("zone", cluster.Zone)
 
+	locations := []string{}
 	if len(cluster.Locations) > 1 {
-		locations := []string{}
 		for _, location := range cluster.Locations {
 			if location != cluster.Zone {
 				locations = append(locations, location)
 			}
 		}
-		d.Set("additional_zones", locations)
 	}
+	d.Set("additional_zones", locations)
 
 	d.Set("endpoint", cluster.Endpoint)
 

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -95,6 +95,7 @@ func resourceContainerCluster() *schema.Resource {
 			"additional_zones": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
@@ -292,18 +293,14 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("additional_zones"); ok {
 		locationsList := v.([]interface{})
 		locations := []string{}
-		zoneInLocations := false
 		for _, v := range locationsList {
 			location := v.(string)
 			locations = append(locations, location)
 			if location == zoneName {
-				zoneInLocations = true
+				return fmt.Errorf("additional_zones should not contain the original 'zone'.")
 			}
 		}
-		if !zoneInLocations {
-			// zone must be in locations if specified separately
-			locations = append(locations, zoneName)
-		}
+		locations = append(locations, zoneName)
 		cluster.Locations = locations
 	}
 
@@ -445,9 +442,16 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", cluster.Name)
 	d.Set("zone", cluster.Zone)
 
-	if _, ok := d.GetOk("additional_zones"); ok {
-		d.Set("additional_zones", cluster.Locations)
+	if len(cluster.Locations) > 1 {
+		locations := []string{}
+		for _, location := range cluster.Locations {
+			if location != cluster.Zone {
+				locations = append(locations, location)
+			}
+		}
+		d.Set("additional_zones", locations)
 	}
+
 	d.Set("endpoint", cluster.Endpoint)
 
 	masterAuth := []map[string]interface{}{

--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -39,7 +39,7 @@ func TestAccContainerCluster_withAdditionalZones(t *testing.T) {
 					testAccCheckContainerClusterExists(
 						"google_container_cluster.with_additional_zones"),
 					testAccCheckContainerClusterAdditionalZonesExist(
-						"google_container_cluster.with_additional_zones"),
+						"google_container_cluster.with_additional_zones", 2),
 				),
 			},
 		},
@@ -163,23 +163,19 @@ func testAccCheckContainerClusterExists(n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccCheckContainerClusterAdditionalZonesExist(n string) resource.TestCheckFunc {
+func testAccCheckContainerClusterAdditionalZonesExist(n string, num int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
 
-		var (
-			additionalZonesSize int
-			err                 error
-		)
-
-		if additionalZonesSize, err = strconv.Atoi(rs.Primary.Attributes["additional_zones.#"]); err != nil {
+		additionalZonesSize, err := strconv.Atoi(rs.Primary.Attributes["additional_zones.#"])
+		if err != nil {
 			return err
 		}
-		if additionalZonesSize != 2 {
-			return fmt.Errorf("number of additional zones did not match 2")
+		if additionalZonesSize != num {
+			return fmt.Errorf("number of additional zones did not match %d, was %d", num, additionalZonesSize)
 		}
 
 		return nil


### PR DESCRIPTION
This fixes a bug introduced by #11018.

`cluster.Locations` will never be empty on read (because it will contain at least `cluster.Zone`), so even if `additional_zones` wasn't set in the config, it was getting set on read, causing a subsequent `terraform plan` to be non-empty.