### PR TITLE
dag: new walker, supports walk-time updates

### DIFF
--- a/dag/dag.go
+++ b/dag/dag.go
@@ -167,7 +167,7 @@ func (g *AcyclicGraph) Walk(cb WalkFunc) error {
 	defer g.debug.BeginOperation(typeWalk, "").End("")
 
 	w := &walker{Callback: cb, Reverse: true}
-	w.Update(g.vertices, g.edges)
+	w.Update(&g.Graph)
 	return w.Wait()
 }
 

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -2,11 +2,8 @@ package dag
 
 import (
 	"fmt"
-	"log"
 	"sort"
 	"strings"
-	"sync"
-	"time"
 
 	"github.com/hashicorp/go-multierror"
 )
@@ -169,94 +166,9 @@ func (g *AcyclicGraph) Cycles() [][]Vertex {
 func (g *AcyclicGraph) Walk(cb WalkFunc) error {
 	defer g.debug.BeginOperation(typeWalk, "").End("")
 
-	// Cache the vertices since we use it multiple times
-	vertices := g.Vertices()
-
-	// Build the waitgroup that signals when we're done
-	var wg sync.WaitGroup
-	wg.Add(len(vertices))
-	doneCh := make(chan struct{})
-	go func() {
-		defer close(doneCh)
-		wg.Wait()
-	}()
-
-	// The map of channels to watch to wait for vertices to finish
-	vertMap := make(map[Vertex]chan struct{})
-	for _, v := range vertices {
-		vertMap[v] = make(chan struct{})
-	}
-
-	// The map of whether a vertex errored or not during the walk
-	var errLock sync.Mutex
-	var errs error
-	errMap := make(map[Vertex]bool)
-	for _, v := range vertices {
-		// Build our list of dependencies and the list of channels to
-		// wait on until we start executing for this vertex.
-		deps := AsVertexList(g.DownEdges(v))
-		depChs := make([]<-chan struct{}, len(deps))
-		for i, dep := range deps {
-			depChs[i] = vertMap[dep]
-		}
-
-		// Get our channel so that we can close it when we're done
-		ourCh := vertMap[v]
-
-		// Start the goroutine to wait for our dependencies
-		readyCh := make(chan bool)
-		go func(v Vertex, deps []Vertex, chs []<-chan struct{}, readyCh chan<- bool) {
-			// First wait for all the dependencies
-			for i, ch := range chs {
-			DepSatisfied:
-				for {
-					select {
-					case <-ch:
-						break DepSatisfied
-					case <-time.After(time.Second * 5):
-						log.Printf("[DEBUG] vertex %q, waiting for: %q",
-							VertexName(v), VertexName(deps[i]))
-					}
-				}
-				log.Printf("[DEBUG] vertex %q, got dep: %q",
-					VertexName(v), VertexName(deps[i]))
-			}
-
-			// Then, check the map to see if any of our dependencies failed
-			errLock.Lock()
-			defer errLock.Unlock()
-			for _, dep := range deps {
-				if errMap[dep] {
-					errMap[v] = true
-					readyCh <- false
-					return
-				}
-			}
-
-			readyCh <- true
-		}(v, deps, depChs, readyCh)
-
-		// Start the goroutine that executes
-		go func(v Vertex, doneCh chan<- struct{}, readyCh <-chan bool) {
-			defer close(doneCh)
-			defer wg.Done()
-
-			var err error
-			if ready := <-readyCh; ready {
-				err = cb(v)
-			}
-
-			errLock.Lock()
-			defer errLock.Unlock()
-			if err != nil {
-				errMap[v] = true
-				errs = multierror.Append(errs, err)
-			}
-		}(v, ourCh, readyCh)
-	}
-
-	<-doneCh
-	return errs
+	w := &walker{Callback: cb, Reverse: true}
+	w.Update(g.vertices, g.edges)
+	return w.Wait()
 }
 
 // simple convenience helper for converting a dag.Set to a []Vertex

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -167,7 +167,7 @@ func (g *AcyclicGraph) Walk(cb WalkFunc) error {
 	defer g.debug.BeginOperation(typeWalk, "").End("")
 
 	w := &Walker{Callback: cb, Reverse: true}
-	w.Update(&g.Graph)
+	w.Update(g)
 	return w.Wait()
 }
 

--- a/dag/dag.go
+++ b/dag/dag.go
@@ -166,7 +166,7 @@ func (g *AcyclicGraph) Cycles() [][]Vertex {
 func (g *AcyclicGraph) Walk(cb WalkFunc) error {
 	defer g.debug.BeginOperation(typeWalk, "").End("")
 
-	w := &walker{Callback: cb, Reverse: true}
+	w := &Walker{Callback: cb, Reverse: true}
 	w.Update(&g.Graph)
 	return w.Wait()
 }

--- a/dag/set.go
+++ b/dag/set.go
@@ -48,9 +48,31 @@ func (s *Set) Include(v interface{}) bool {
 // Intersection computes the set intersection with other.
 func (s *Set) Intersection(other *Set) *Set {
 	result := new(Set)
+	if s == nil {
+		return result
+	}
 	if other != nil {
 		for _, v := range s.m {
 			if other.Include(v) {
+				result.Add(v)
+			}
+		}
+	}
+
+	return result
+}
+
+// Difference returns a set with the elements that s has but
+// other doesn't.
+func (s *Set) Difference(other *Set) *Set {
+	result := new(Set)
+	if s != nil {
+		for k, v := range s.m {
+			var ok bool
+			if other != nil {
+				_, ok = other.m[k]
+			}
+			if !ok {
 				result.Add(v)
 			}
 		}

--- a/dag/set_test.go
+++ b/dag/set_test.go
@@ -1,0 +1,56 @@
+package dag
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSetDifference(t *testing.T) {
+	cases := []struct {
+		Name     string
+		A, B     []interface{}
+		Expected []interface{}
+	}{
+		{
+			"same",
+			[]interface{}{1, 2, 3},
+			[]interface{}{3, 1, 2},
+			[]interface{}{},
+		},
+
+		{
+			"A has extra elements",
+			[]interface{}{1, 2, 3},
+			[]interface{}{3, 2},
+			[]interface{}{1},
+		},
+
+		{
+			"B has extra elements",
+			[]interface{}{1, 2, 3},
+			[]interface{}{3, 2, 1, 4},
+			[]interface{}{},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
+			var one, two, expected Set
+			for _, v := range tc.A {
+				one.Add(v)
+			}
+			for _, v := range tc.B {
+				two.Add(v)
+			}
+			for _, v := range tc.Expected {
+				expected.Add(v)
+			}
+
+			actual := one.Difference(&two)
+			match := actual.Intersection(&expected)
+			if match.Len() != expected.Len() {
+				t.Fatalf("bad: %#v", actual.List())
+			}
+		})
+	}
+}

--- a/dag/walk.go
+++ b/dag/walk.go
@@ -98,7 +98,9 @@ func (w *walker) Wait() error {
 // and edges. It does not block until completion.
 //
 // Update can be called in parallel to Walk.
-func (w *walker) Update(v, e *Set) {
+func (w *walker) Update(g *Graph) {
+	v, e := g.vertices, g.edges
+
 	// Grab the change lock so no more updates happen but also so that
 	// no new vertices are executed during this time since we may be
 	// removing them.

--- a/dag/walk.go
+++ b/dag/walk.go
@@ -173,12 +173,8 @@ func (w *Walker) Update(g *Graph) {
 		info := &walkerVertex{
 			DoneCh:   make(chan struct{}),
 			CancelCh: make(chan struct{}),
-			DepsCh:   make(chan bool, 1),
 			deps:     make(map[Vertex]chan struct{}),
 		}
-
-		// Pass dependencies immediately assuming we have no edges
-		info.DepsCh <- true
 
 		// Add it to the map and kick off the walk
 		w.vertexMap[v] = info

--- a/dag/walk.go
+++ b/dag/walk.go
@@ -1,0 +1,267 @@
+package dag
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+// walker performs a graph walk
+type walker struct {
+	Callback WalkFunc
+
+	vertices  *Set
+	edges     *Set
+	vertexMap map[Vertex]*walkerVertex
+
+	wait       sync.WaitGroup
+	changeLock sync.Mutex
+
+	errMap  map[Vertex]error
+	errLock sync.Mutex
+}
+
+type walkerVertex struct {
+	sync.Mutex
+
+	DoneCh       chan struct{}
+	CancelCh     chan struct{}
+	DepsCh       chan struct{}
+	DepsUpdateCh chan chan struct{}
+
+	deps         map[Vertex]chan struct{}
+	depsCancelCh chan struct{}
+}
+
+// Wait waits for the completion of the walk and returns any errors (
+// in the form of a multierror) that occurred. Update should be called
+// to populate the walk with vertices and edges.
+func (w *walker) Wait() error {
+	// Wait for completion
+	w.wait.Wait()
+
+	// Grab the error lock
+	w.errLock.Lock()
+	defer w.errLock.Unlock()
+
+	// Build the error
+	var result error
+	for v, err := range w.errMap {
+		result = multierror.Append(result, fmt.Errorf(
+			"%s: %s", VertexName(v), err))
+	}
+
+	return result
+}
+
+// Update updates the currently executing walk with the given vertices
+// and edges. It does not block until completion.
+//
+// Update can be called in parallel to Walk.
+func (w *walker) Update(v, e *Set) {
+	// Grab the change lock so no more updates happen but also so that
+	// no new vertices are executed during this time since we may be
+	// removing them.
+	w.changeLock.Lock()
+	defer w.changeLock.Unlock()
+
+	// Initialize fields
+	if w.vertexMap == nil {
+		w.vertexMap = make(map[Vertex]*walkerVertex)
+	}
+
+	// Calculate all our sets
+	newEdges := e.Difference(w.edges)
+	newVerts := v.Difference(w.vertices)
+	oldVerts := w.vertices.Difference(v)
+
+	// Add the new vertices
+	for _, raw := range newVerts.List() {
+		v := raw.(Vertex)
+
+		// Add to the waitgroup so our walk is not done until everything finishes
+		w.wait.Add(1)
+
+		// Initialize the vertex info
+		info := &walkerVertex{
+			DoneCh:       make(chan struct{}),
+			CancelCh:     make(chan struct{}),
+			DepsCh:       make(chan struct{}),
+			DepsUpdateCh: make(chan chan struct{}, 5),
+			deps:         make(map[Vertex]chan struct{}),
+		}
+
+		// Close the deps channel immediately so it passes
+		close(info.DepsCh)
+
+		// Add it to the map and kick off the walk
+		w.vertexMap[v] = info
+	}
+
+	// Remove the old vertices
+	for _, raw := range oldVerts.List() {
+		v := raw.(Vertex)
+
+		// Get the vertex info so we can cancel it
+		info, ok := w.vertexMap[v]
+		if !ok {
+			// This vertex for some reason was never in our map. This
+			// shouldn't be possible.
+			continue
+		}
+
+		// Cancel the vertex
+		close(info.CancelCh)
+
+		// Delete it out of the map
+		delete(w.vertexMap, v)
+	}
+
+	// Add the new edges
+	var changedDeps Set
+	for _, raw := range newEdges.List() {
+		edge := raw.(Edge)
+
+		// waiter is the vertex that is "waiting" on this edge
+		waiter := edge.Target()
+
+		// dep is the dependency we're waiting on
+		dep := edge.Source()
+
+		// Get the info for the waiter
+		waiterInfo, ok := w.vertexMap[waiter]
+		if !ok {
+			// Vertex doesn't exist... shouldn't be possible but ignore.
+			continue
+		}
+
+		// Get the info for the dep
+		depInfo, ok := w.vertexMap[dep]
+		if !ok {
+			// Vertex doesn't exist... shouldn't be possible but ignore.
+			continue
+		}
+
+		// Add the dependency to our waiter
+		waiterInfo.deps[dep] = depInfo.DoneCh
+
+		// Record that the deps changed for this waiter
+		changedDeps.Add(waiter)
+	}
+
+	for _, raw := range changedDeps.List() {
+		v := raw.(Vertex)
+		info, ok := w.vertexMap[v]
+		if !ok {
+			// Vertex doesn't exist... shouldn't be possible but ignore.
+			continue
+		}
+
+		// Create a new done channel
+		doneCh := make(chan struct{})
+
+		// Create the channel we close for cancellation
+		cancelCh := make(chan struct{})
+		info.depsCancelCh = cancelCh
+
+		// Build a new deps copy
+		deps := make(map[Vertex]<-chan struct{})
+		for k, v := range info.deps {
+			deps[k] = v
+		}
+
+		// Update the update channel
+		info.DepsUpdateCh <- doneCh
+
+		// Start the waiter
+		go w.waitDeps(v, deps, doneCh, cancelCh)
+	}
+
+	// Kickstart all the vertices
+	for _, raw := range newVerts.List() {
+		v := raw.(Vertex)
+		go w.walkVertex(v, w.vertexMap[v])
+	}
+}
+
+// walkVertex walks a single vertex, waiting for any dependencies before
+// executing the callback.
+func (w *walker) walkVertex(v Vertex, info *walkerVertex) {
+	// When we're done executing, lower the waitgroup count
+	defer w.wait.Done()
+
+	// When we're done, always close our done channel
+	defer close(info.DoneCh)
+
+	// Wait for our dependencies
+	depsCh := info.DepsCh
+	for {
+		select {
+		case <-info.CancelCh:
+			// Cancel
+			return
+
+		case <-depsCh:
+			// Deps complete!
+			depsCh = nil
+
+		case depsCh = <-info.DepsUpdateCh:
+			// New deps, reloop
+		}
+
+		if depsCh == nil {
+			// One final check if we have an update
+			select {
+			case depsCh = <-info.DepsUpdateCh:
+			default:
+			}
+
+			if depsCh == nil {
+				break
+			}
+		}
+	}
+
+	// Call our callback
+	if err := w.Callback(v); err != nil {
+		w.errLock.Lock()
+		defer w.errLock.Unlock()
+
+		if w.errMap == nil {
+			w.errMap = make(map[Vertex]error)
+		}
+		w.errMap[v] = err
+	}
+}
+
+func (w *walker) waitDeps(
+	v Vertex,
+	deps map[Vertex]<-chan struct{},
+	doneCh chan<- struct{},
+	cancelCh <-chan struct{}) {
+	// Whenever we return, mark ourselves as complete
+	defer close(doneCh)
+
+	// For each dependency given to us, wait for it to complete
+	for dep, depCh := range deps {
+	DepSatisfied:
+		for {
+			select {
+			case <-depCh:
+				// Dependency satisfied!
+				break DepSatisfied
+
+			case <-cancelCh:
+				// Wait cancelled
+				return
+
+			case <-time.After(time.Second * 5):
+				log.Printf("[DEBUG] vertex %q, waiting for: %q",
+					VertexName(v), VertexName(dep))
+			}
+		}
+	}
+}

--- a/dag/walk.go
+++ b/dag/walk.go
@@ -135,7 +135,7 @@ func (w *Walker) Wait() error {
 //
 // Multiple Updates can be called in parallel. Update can be called at any
 // time during a walk.
-func (w *Walker) Update(g *Graph) {
+func (w *Walker) Update(g *AcyclicGraph) {
 	var v, e *Set
 	if g != nil {
 		v, e = g.vertices, g.edges

--- a/dag/walk.go
+++ b/dag/walk.go
@@ -136,7 +136,10 @@ func (w *Walker) Wait() error {
 // Multiple Updates can be called in parallel. Update can be called at any
 // time during a walk.
 func (w *Walker) Update(g *Graph) {
-	v, e := g.vertices, g.edges
+	var v, e *Set
+	if g != nil {
+		v, e = g.vertices, g.edges
+	}
 
 	// Grab the change lock so no more updates happen but also so that
 	// no new vertices are executed during this time since we may be

--- a/dag/walk_test.go
+++ b/dag/walk_test.go
@@ -33,6 +33,26 @@ func TestWalker_basic(t *testing.T) {
 	}
 }
 
+func TestWalker_updateNilGraph(t *testing.T) {
+	var g Graph
+	g.Add(1)
+	g.Add(2)
+	g.Connect(BasicEdge(1, 2))
+
+	// Run it a bunch of times since it is timing dependent
+	for i := 0; i < 50; i++ {
+		var order []interface{}
+		w := &Walker{Callback: walkCbRecord(&order)}
+		w.Update(&g)
+		w.Update(nil)
+
+		// Wait
+		if err := w.Wait(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+}
+
 func TestWalker_error(t *testing.T) {
 	var g Graph
 	g.Add(1)

--- a/dag/walk_test.go
+++ b/dag/walk_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestWalker_basic(t *testing.T) {
@@ -25,6 +26,129 @@ func TestWalker_basic(t *testing.T) {
 
 		// Check
 		expected := []interface{}{1, 2}
+		if !reflect.DeepEqual(order, expected) {
+			t.Fatalf("bad: %#v", order)
+		}
+	}
+}
+
+func TestWalker_newVertex(t *testing.T) {
+	// Run it a bunch of times since it is timing dependent
+	for i := 0; i < 50; i++ {
+		var g Graph
+		g.Add(1)
+		g.Add(2)
+		g.Connect(BasicEdge(1, 2))
+
+		var order []interface{}
+		w := &walker{Callback: walkCbRecord(&order)}
+		w.Update(g.vertices, g.edges)
+
+		// Wait a bit
+		time.Sleep(10 * time.Millisecond)
+
+		// Update the graph
+		g.Add(3)
+		w.Update(g.vertices, g.edges)
+
+		// Update the graph again but with the same vertex
+		g.Add(3)
+		w.Update(g.vertices, g.edges)
+
+		// Wait
+		if err := w.Wait(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		// Check
+		expected := []interface{}{1, 2, 3}
+		if !reflect.DeepEqual(order, expected) {
+			t.Fatalf("bad: %#v", order)
+		}
+	}
+}
+
+func TestWalker_removeVertex(t *testing.T) {
+	// Run it a bunch of times since it is timing dependent
+	for i := 0; i < 50; i++ {
+		var g Graph
+		g.Add(1)
+		g.Add(2)
+		g.Connect(BasicEdge(1, 2))
+
+		// Record function
+		var order []interface{}
+		recordF := walkCbRecord(&order)
+
+		// Build a callback that delays until we close a channel
+		gateCh := make(chan struct{})
+		cb := func(v Vertex) error {
+			if v == 1 {
+				<-gateCh
+			}
+
+			return recordF(v)
+		}
+
+		// Add the initial vertices
+		w := &walker{Callback: cb}
+		w.Update(g.vertices, g.edges)
+
+		// Remove a vertex
+		g.Remove(2)
+		w.Update(g.vertices, g.edges)
+
+		// Open gate
+		close(gateCh)
+
+		// Wait
+		if err := w.Wait(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		// Check
+		expected := []interface{}{1}
+		if !reflect.DeepEqual(order, expected) {
+			t.Fatalf("bad: %#v", order)
+		}
+	}
+}
+
+func TestWalker_newEdge(t *testing.T) {
+	// Run it a bunch of times since it is timing dependent
+	for i := 0; i < 50; i++ {
+		var g Graph
+		g.Add(1)
+		g.Add(2)
+		g.Connect(BasicEdge(1, 2))
+
+		// Record function
+		var order []interface{}
+		recordF := walkCbRecord(&order)
+
+		// Build a callback that delays until we close a channel
+		var w *walker
+		cb := func(v Vertex) error {
+			if v == 1 {
+				g.Add(3)
+				g.Connect(BasicEdge(3, 2))
+				w.Update(g.vertices, g.edges)
+			}
+
+			return recordF(v)
+		}
+
+		// Add the initial vertices
+		w = &walker{Callback: cb}
+		w.Update(g.vertices, g.edges)
+
+		// Wait
+		if err := w.Wait(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		// Check
+		expected := []interface{}{1, 3, 2}
 		if !reflect.DeepEqual(order, expected) {
 			t.Fatalf("bad: %#v", order)
 		}

--- a/dag/walk_test.go
+++ b/dag/walk_test.go
@@ -1,6 +1,7 @@
 package dag
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"testing"
@@ -149,6 +150,67 @@ func TestWalker_newEdge(t *testing.T) {
 
 		// Check
 		expected := []interface{}{1, 3, 2}
+		if !reflect.DeepEqual(order, expected) {
+			t.Fatalf("bad: %#v", order)
+		}
+	}
+}
+
+func TestWalker_removeEdge(t *testing.T) {
+	// Run it a bunch of times since it is timing dependent
+	for i := 0; i < 50; i++ {
+		var g Graph
+		g.Add(1)
+		g.Add(2)
+		g.Add(3)
+		g.Connect(BasicEdge(1, 2))
+		g.Connect(BasicEdge(3, 2))
+
+		// Record function
+		var order []interface{}
+		recordF := walkCbRecord(&order)
+
+		// The way this works is that our original graph forces
+		// the order of 1 => 3 => 2. During the execution of 1, we
+		// remove the edge forcing 3 before 2. Then, during the execution
+		// of 3, we wait on a channel that is only closed by 2, implicitly
+		// forcing 2 before 3 via the callback (and not the graph). If
+		// 2 cannot execute before 3 (edge removal is non-functional), then
+		// this test will timeout.
+		var w *walker
+		gateCh := make(chan struct{})
+		cb := func(v Vertex) error {
+			if v == 1 {
+				g.RemoveEdge(BasicEdge(3, 2))
+				w.Update(g.vertices, g.edges)
+			}
+
+			if v == 2 {
+				close(gateCh)
+			}
+
+			if v == 3 {
+				select {
+				case <-gateCh:
+				case <-time.After(50 * time.Millisecond):
+					return fmt.Errorf("timeout 3 waiting for 2")
+				}
+			}
+
+			return recordF(v)
+		}
+
+		// Add the initial vertices
+		w = &walker{Callback: cb}
+		w.Update(g.vertices, g.edges)
+
+		// Wait
+		if err := w.Wait(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		// Check
+		expected := []interface{}{1, 2, 3}
 		if !reflect.DeepEqual(order, expected) {
 			t.Fatalf("bad: %#v", order)
 		}

--- a/dag/walk_test.go
+++ b/dag/walk_test.go
@@ -1,0 +1,43 @@
+package dag
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestWalker_basic(t *testing.T) {
+	var g Graph
+	g.Add(1)
+	g.Add(2)
+	g.Connect(BasicEdge(1, 2))
+
+	// Run it a bunch of times since it is timing dependent
+	for i := 0; i < 50; i++ {
+		var order []interface{}
+		w := &walker{Callback: walkCbRecord(&order)}
+		w.Update(g.vertices, g.edges)
+
+		// Wait
+		if err := w.Wait(); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+
+		// Check
+		expected := []interface{}{1, 2}
+		if !reflect.DeepEqual(order, expected) {
+			t.Fatalf("bad: %#v", order)
+		}
+	}
+}
+
+// walkCbRecord is a test helper callback that just records the order called.
+func walkCbRecord(order *[]interface{}) WalkFunc {
+	var l sync.Mutex
+	return func(v Vertex) error {
+		l.Lock()
+		defer l.Unlock()
+		*order = append(*order, v)
+		return nil
+	}
+}

--- a/dag/walk_test.go
+++ b/dag/walk_test.go
@@ -18,7 +18,7 @@ func TestWalker_basic(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		var order []interface{}
 		w := &walker{Callback: walkCbRecord(&order)}
-		w.Update(g.vertices, g.edges)
+		w.Update(&g)
 
 		// Wait
 		if err := w.Wait(); err != nil {
@@ -57,7 +57,7 @@ func TestWalker_error(t *testing.T) {
 	}
 
 	w := &walker{Callback: cb}
-	w.Update(g.vertices, g.edges)
+	w.Update(&g)
 
 	// Wait
 	if err := w.Wait(); err == nil {
@@ -81,18 +81,18 @@ func TestWalker_newVertex(t *testing.T) {
 
 		var order []interface{}
 		w := &walker{Callback: walkCbRecord(&order)}
-		w.Update(g.vertices, g.edges)
+		w.Update(&g)
 
 		// Wait a bit
 		time.Sleep(10 * time.Millisecond)
 
 		// Update the graph
 		g.Add(3)
-		w.Update(g.vertices, g.edges)
+		w.Update(&g)
 
 		// Update the graph again but with the same vertex
 		g.Add(3)
-		w.Update(g.vertices, g.edges)
+		w.Update(&g)
 
 		// Wait
 		if err := w.Wait(); err != nil {
@@ -124,7 +124,7 @@ func TestWalker_removeVertex(t *testing.T) {
 		cb := func(v Vertex) error {
 			if v == 1 {
 				g.Remove(2)
-				w.Update(g.vertices, g.edges)
+				w.Update(&g)
 			}
 
 			return recordF(v)
@@ -132,7 +132,7 @@ func TestWalker_removeVertex(t *testing.T) {
 
 		// Add the initial vertices
 		w = &walker{Callback: cb}
-		w.Update(g.vertices, g.edges)
+		w.Update(&g)
 
 		// Wait
 		if err := w.Wait(); err != nil {
@@ -165,7 +165,7 @@ func TestWalker_newEdge(t *testing.T) {
 			if v == 1 {
 				g.Add(3)
 				g.Connect(BasicEdge(3, 2))
-				w.Update(g.vertices, g.edges)
+				w.Update(&g)
 			}
 
 			return recordF(v)
@@ -173,7 +173,7 @@ func TestWalker_newEdge(t *testing.T) {
 
 		// Add the initial vertices
 		w = &walker{Callback: cb}
-		w.Update(g.vertices, g.edges)
+		w.Update(&g)
 
 		// Wait
 		if err := w.Wait(); err != nil {
@@ -214,7 +214,7 @@ func TestWalker_removeEdge(t *testing.T) {
 		cb := func(v Vertex) error {
 			if v == 1 {
 				g.RemoveEdge(BasicEdge(3, 2))
-				w.Update(g.vertices, g.edges)
+				w.Update(&g)
 			}
 
 			if v == 2 {
@@ -234,7 +234,7 @@ func TestWalker_removeEdge(t *testing.T) {
 
 		// Add the initial vertices
 		w = &walker{Callback: cb}
-		w.Update(g.vertices, g.edges)
+		w.Update(&g)
 
 		// Wait
 		if err := w.Wait(); err != nil {

--- a/dag/walk_test.go
+++ b/dag/walk_test.go
@@ -17,7 +17,7 @@ func TestWalker_basic(t *testing.T) {
 	// Run it a bunch of times since it is timing dependent
 	for i := 0; i < 50; i++ {
 		var order []interface{}
-		w := &walker{Callback: walkCbRecord(&order)}
+		w := &Walker{Callback: walkCbRecord(&order)}
 		w.Update(&g)
 
 		// Wait
@@ -56,7 +56,7 @@ func TestWalker_error(t *testing.T) {
 		return recordF(v)
 	}
 
-	w := &walker{Callback: cb}
+	w := &Walker{Callback: cb}
 	w.Update(&g)
 
 	// Wait
@@ -80,7 +80,7 @@ func TestWalker_newVertex(t *testing.T) {
 		g.Connect(BasicEdge(1, 2))
 
 		var order []interface{}
-		w := &walker{Callback: walkCbRecord(&order)}
+		w := &Walker{Callback: walkCbRecord(&order)}
 		w.Update(&g)
 
 		// Wait a bit
@@ -120,7 +120,7 @@ func TestWalker_removeVertex(t *testing.T) {
 		recordF := walkCbRecord(&order)
 
 		// Build a callback that delays until we close a channel
-		var w *walker
+		var w *Walker
 		cb := func(v Vertex) error {
 			if v == 1 {
 				g.Remove(2)
@@ -131,7 +131,7 @@ func TestWalker_removeVertex(t *testing.T) {
 		}
 
 		// Add the initial vertices
-		w = &walker{Callback: cb}
+		w = &Walker{Callback: cb}
 		w.Update(&g)
 
 		// Wait
@@ -160,7 +160,7 @@ func TestWalker_newEdge(t *testing.T) {
 		recordF := walkCbRecord(&order)
 
 		// Build a callback that delays until we close a channel
-		var w *walker
+		var w *Walker
 		cb := func(v Vertex) error {
 			if v == 1 {
 				g.Add(3)
@@ -172,7 +172,7 @@ func TestWalker_newEdge(t *testing.T) {
 		}
 
 		// Add the initial vertices
-		w = &walker{Callback: cb}
+		w = &Walker{Callback: cb}
 		w.Update(&g)
 
 		// Wait
@@ -209,7 +209,7 @@ func TestWalker_removeEdge(t *testing.T) {
 		// forcing 2 before 3 via the callback (and not the graph). If
 		// 2 cannot execute before 3 (edge removal is non-functional), then
 		// this test will timeout.
-		var w *walker
+		var w *Walker
 		gateCh := make(chan struct{})
 		cb := func(v Vertex) error {
 			if v == 1 {
@@ -233,7 +233,7 @@ func TestWalker_removeEdge(t *testing.T) {
 		}
 
 		// Add the initial vertices
-		w = &walker{Callback: cb}
+		w = &Walker{Callback: cb}
 		w.Update(&g)
 
 		// Wait

--- a/dag/walk_test.go
+++ b/dag/walk_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestWalker_basic(t *testing.T) {
-	var g Graph
+	var g AcyclicGraph
 	g.Add(1)
 	g.Add(2)
 	g.Connect(BasicEdge(1, 2))
@@ -34,7 +34,7 @@ func TestWalker_basic(t *testing.T) {
 }
 
 func TestWalker_updateNilGraph(t *testing.T) {
-	var g Graph
+	var g AcyclicGraph
 	g.Add(1)
 	g.Add(2)
 	g.Connect(BasicEdge(1, 2))
@@ -54,7 +54,7 @@ func TestWalker_updateNilGraph(t *testing.T) {
 }
 
 func TestWalker_error(t *testing.T) {
-	var g Graph
+	var g AcyclicGraph
 	g.Add(1)
 	g.Add(2)
 	g.Add(3)
@@ -94,7 +94,7 @@ func TestWalker_error(t *testing.T) {
 func TestWalker_newVertex(t *testing.T) {
 	// Run it a bunch of times since it is timing dependent
 	for i := 0; i < 50; i++ {
-		var g Graph
+		var g AcyclicGraph
 		g.Add(1)
 		g.Add(2)
 		g.Connect(BasicEdge(1, 2))
@@ -130,7 +130,7 @@ func TestWalker_newVertex(t *testing.T) {
 func TestWalker_removeVertex(t *testing.T) {
 	// Run it a bunch of times since it is timing dependent
 	for i := 0; i < 50; i++ {
-		var g Graph
+		var g AcyclicGraph
 		g.Add(1)
 		g.Add(2)
 		g.Connect(BasicEdge(1, 2))
@@ -170,7 +170,7 @@ func TestWalker_removeVertex(t *testing.T) {
 func TestWalker_newEdge(t *testing.T) {
 	// Run it a bunch of times since it is timing dependent
 	for i := 0; i < 50; i++ {
-		var g Graph
+		var g AcyclicGraph
 		g.Add(1)
 		g.Add(2)
 		g.Connect(BasicEdge(1, 2))
@@ -211,7 +211,7 @@ func TestWalker_newEdge(t *testing.T) {
 func TestWalker_removeEdge(t *testing.T) {
 	// Run it a bunch of times since it is timing dependent
 	for i := 0; i < 50; i++ {
-		var g Graph
+		var g AcyclicGraph
 		g.Add(1)
 		g.Add(2)
 		g.Add(3)


### PR DESCRIPTION
This introduces a new parallel walker to dag with the primary highlight being that it supports walk-time modification of the graph being walked. 

**Note that Terraform doesn't yet use this new update functionality in any way. If we find we don't need it, we can just ignore it or remove it in the future.** However, the new walker outputs many more debug statements and is much better tested and I believe the code is more cleanly laid out. Because of this, I believe it is still an improvement over the old walker.

I've replaced the internals of `dag.AcyclicGraph.Walk` with 3 lines that simply setup the new walker structure and call that. All tests across the project still pass. This shows that the new walker is behaving as it should [without updates], too.

This change is API-stable: no API changes are made so it is a pure refactor in that sense.