### PR TITLE
Docs: fix incorrect NOMAD_ADDR description

### DIFF
--- a/website/source/docs/providers/nomad/index.html.markdown
+++ b/website/source/docs/providers/nomad/index.html.markdown
@@ -32,5 +32,5 @@ resource "nomad_job" "monitoring" {
 
 The following arguments are supported:
 
-* `address` - (Optional) The HTTP(S) API address of the Nomad agent to use. Defaults to `127.0.0.1:4646`. The `NOMAD_ADDR` environment variable can also be used.
+* `address` - (Optional) The HTTP(S) API address of the Nomad agent to use. Defaults to `http://127.0.0.1:4646`. The `NOMAD_ADDR` environment variable can also be used.
 * `region` - (Optional) The Nomad region to target. The `NOMAD_REGION` environment variable can also be used.


### PR DESCRIPTION
Per [provider_test.go#L42](https://github.com/hashicorp/terraform/blob/master/builtin/providers/nomad/provider_test.go#L42).