### PR TITLE
Adding in root level .gitattributes file.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+*.go  eol=lf


### PR DESCRIPTION
This is to pin the .go files to LF line endings.

Developing on windows and using the vagrant environment to build,
running `make fmt` will cause all the *.go files to be touched,
alterting their line endings and causing git to see them as changed.