### PR TITLE
Add some support for Github conditional requests

### DIFF
--- a/builtin/providers/github/config.go
+++ b/builtin/providers/github/config.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"net/http"
 	"net/url"
 
 	"github.com/google/go-github/github"
@@ -14,26 +15,70 @@ type Config struct {
 }
 
 type Organization struct {
-	name   string
-	client *github.Client
+	name    string
+	Token   string
+	BaseURL *url.URL
 }
 
-// Client configures and returns a fully initialized GithubClient
-func (c *Config) Client() (interface{}, error) {
+type Client struct {
+	*github.Client
+
+	Transport *conditionalTransport
+}
+
+type conditionalTransport struct {
+	Base *oauth2.Transport
+
+	etag         string
+	LastModified string
+}
+
+func (c *conditionalTransport) RoundTrip(req *http.Request) (resp *http.Response, err error) {
+	if c.LastModified != "" {
+		req.Header.Set("If-Modified-Since", c.LastModified)
+	} else {
+		// fallback to using etag if we don't have a LastModified value
+		req.Header.Set("If-None-Match", c.etag)
+	}
+
+	return c.Base.RoundTrip(req)
+}
+
+// Create and return an Organization
+func (c *Config) NewOrganization() (interface{}, error) {
 	var org Organization
 	org.name = c.Organization
-	ts := oauth2.StaticTokenSource(
-		&oauth2.Token{AccessToken: c.Token},
-	)
-	tc := oauth2.NewClient(oauth2.NoContext, ts)
+	org.Token = c.Token
 
-	org.client = github.NewClient(tc)
 	if c.BaseURL != "" {
 		u, err := url.Parse(c.BaseURL)
 		if err != nil {
 			return nil, err
 		}
-		org.client.BaseURL = u
+		org.BaseURL = u
 	}
 	return &org, nil
+}
+
+// Create and return a new github client.
+func (o *Organization) Client() *Client {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: o.Token},
+	)
+	tr := &oauth2.Transport{Source: ts}
+	transport := &conditionalTransport{Base: tr}
+	tc := &http.Client{
+		Transport: transport,
+	}
+
+	client := Client{
+		Client:    github.NewClient(tc),
+		Transport: transport,
+	}
+
+	if o.BaseURL != nil {
+		client.BaseURL = o.BaseURL
+	}
+
+	return &client
 }

--- a/builtin/providers/github/provider.go
+++ b/builtin/providers/github/provider.go
@@ -67,5 +67,5 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		BaseURL:      d.Get("base_url").(string),
 	}
 
-	return config.Client()
+	return config.NewOrganization()
 }

--- a/builtin/providers/github/resource_github_branch_protection_test.go
+++ b/builtin/providers/github/resource_github_branch_protection_test.go
@@ -86,7 +86,7 @@ func testAccCheckGithubProtectedBranchExists(n string, protection *github.Protec
 			return fmt.Errorf("Expected ID to be %v, got %v", "test-repo:master", rs.Primary.ID)
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		o := testAccProvider.Meta().(*Organization).name
 		r, b := parseTwoPartID(rs.Primary.ID)
 
@@ -161,7 +161,7 @@ func testAccCheckGithubBranchProtectionNoRestrictionsExist(protection *github.Pr
 }
 
 func testAccGithubBranchProtectionDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_branch_protection" {

--- a/builtin/providers/github/resource_github_issue_label_test.go
+++ b/builtin/providers/github/resource_github_issue_label_test.go
@@ -72,7 +72,7 @@ func testAccCheckGithubIssueLabelExists(n string, label *github.Label) resource.
 			return fmt.Errorf("No issue label ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		o := testAccProvider.Meta().(*Organization).name
 		r, n := parseTwoPartID(rs.Primary.ID)
 
@@ -101,7 +101,7 @@ func testAccCheckGithubIssueLabelAttributes(label *github.Label, name, color str
 }
 
 func testAccGithubIssueLabelDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_issue_label" {

--- a/builtin/providers/github/resource_github_membership.go
+++ b/builtin/providers/github/resource_github_membership.go
@@ -30,12 +30,16 @@ func resourceGithubMembership() *schema.Resource {
 				ValidateFunc: validateValueFunc([]string{"member", "admin"}),
 				Default:      "member",
 			},
+			"etag": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func resourceGithubMembershipCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	n := d.Get("username").(string)
 	r := d.Get("role").(string)
 
@@ -51,10 +55,15 @@ func resourceGithubMembershipCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	_, n := parseTwoPartID(d.Id())
 
-	membership, _, err := client.Organizations.GetOrgMembership(context.TODO(), n, meta.(*Organization).name)
+	client.Transport.etag = d.Get("etag").(string)
+	membership, resp, err := client.Organizations.GetOrgMembership(context.TODO(), n, meta.(*Organization).name)
+	if resp.StatusCode == 304 {
+		// no changes
+		return nil
+	}
 	if err != nil {
 		d.SetId("")
 		return nil
@@ -62,11 +71,12 @@ func resourceGithubMembershipRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("username", membership.User.Login)
 	d.Set("role", membership.Role)
+	d.Set("etag", resp.Header.Get("ETag"))
 	return nil
 }
 
 func resourceGithubMembershipUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	n := d.Get("username").(string)
 	r := d.Get("role").(string)
 
@@ -82,7 +92,7 @@ func resourceGithubMembershipUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubMembershipDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	n := d.Get("username").(string)
 
 	_, err := client.Organizations.RemoveOrgMembership(context.TODO(), n, meta.(*Organization).name)

--- a/builtin/providers/github/resource_github_membership_test.go
+++ b/builtin/providers/github/resource_github_membership_test.go
@@ -48,7 +48,7 @@ func TestAccGithubMembership_importBasic(t *testing.T) {
 }
 
 func testAccCheckGithubMembershipDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_membership" {
@@ -83,7 +83,7 @@ func testAccCheckGithubMembershipExists(n string, membership *github.Membership)
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		o, u := parseTwoPartID(rs.Primary.ID)
 
 		githubMembership, _, err := conn.Organizations.GetOrgMembership(context.TODO(), u, o)
@@ -106,7 +106,7 @@ func testAccCheckGithubMembershipRoleState(n string, membership *github.Membersh
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		o, u := parseTwoPartID(rs.Primary.ID)
 
 		githubMembership, _, err := conn.Organizations.GetOrgMembership(context.TODO(), u, o)

--- a/builtin/providers/github/resource_github_organization_webhook_test.go
+++ b/builtin/providers/github/resource_github_organization_webhook_test.go
@@ -70,7 +70,7 @@ func testAccCheckGithubOrganizationWebhookExists(n string, hook *github.Hook) re
 		}
 
 		org := testAccProvider.Meta().(*Organization)
-		conn := org.client
+		conn := org.Client()
 		getHook, _, err := conn.Organizations.GetHook(context.TODO(), org.name, hookID)
 		if err != nil {
 			return err
@@ -111,7 +111,7 @@ func testAccCheckGithubOrganizationWebhookAttributes(hook *github.Hook, want *te
 }
 
 func testAccCheckGithubOrganizationWebhookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 	orgName := testAccProvider.Meta().(*Organization).name
 
 	for _, rs := range s.RootModule().Resources {

--- a/builtin/providers/github/resource_github_repository.go
+++ b/builtin/providers/github/resource_github_repository.go
@@ -78,6 +78,10 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"last_modified": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -107,7 +111,7 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 }
 
 func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 
 	repoReq := resourceGithubRepositoryObject(d)
 	log.Printf("[DEBUG] create github repository %s/%s", meta.(*Organization).name, *repoReq.Name)
@@ -121,11 +125,16 @@ func resourceGithubRepositoryCreate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	repoName := d.Id()
 
 	log.Printf("[DEBUG] read github repository %s/%s", meta.(*Organization).name, repoName)
+	client.Transport.LastModified = d.Get("last_modified").(string)
 	repo, resp, err := client.Repositories.Get(context.TODO(), meta.(*Organization).name, repoName)
+	if resp.StatusCode == 304 {
+		// no changes
+		return nil
+	}
 	if err != nil {
 		if resp.StatusCode == 404 {
 			log.Printf(
@@ -151,11 +160,12 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("svn_url", repo.SVNURL)
 	d.Set("git_clone_url", repo.GitURL)
 	d.Set("http_clone_url", repo.CloneURL)
+	d.Set("last_modified", resp.Header.Get("Last-Modified"))
 	return nil
 }
 
 func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	repoReq := resourceGithubRepositoryObject(d)
 	repoName := d.Id()
 	log.Printf("[DEBUG] update github repository %s/%s", meta.(*Organization).name, repoName)
@@ -169,7 +179,7 @@ func resourceGithubRepositoryUpdate(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceGithubRepositoryDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	repoName := d.Id()
 	log.Printf("[DEBUG] delete github repository %s/%s", meta.(*Organization).name, repoName)
 	_, err := client.Repositories.Delete(context.TODO(), meta.(*Organization).name, repoName)

--- a/builtin/providers/github/resource_github_repository_collaborator.go
+++ b/builtin/providers/github/resource_github_repository_collaborator.go
@@ -40,7 +40,7 @@ func resourceGithubRepositoryCollaborator() *schema.Resource {
 }
 
 func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	u := d.Get("username").(string)
 	r := d.Get("repository").(string)
 	p := d.Get("permission").(string)
@@ -58,7 +58,7 @@ func resourceGithubRepositoryCollaboratorCreate(d *schema.ResourceData, meta int
 }
 
 func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	r, u := parseTwoPartID(d.Id())
 
 	// First, check if the user has been invited but has not yet accepted
@@ -111,7 +111,7 @@ func resourceGithubRepositoryCollaboratorRead(d *schema.ResourceData, meta inter
 }
 
 func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*Organization).client
+	client := meta.(*Organization).Client()
 	u := d.Get("username").(string)
 	r := d.Get("repository").(string)
 
@@ -128,10 +128,10 @@ func resourceGithubRepositoryCollaboratorDelete(d *schema.ResourceData, meta int
 	return err
 }
 
-func findRepoInvitation(client *github.Client, owner string, repo string, collaborator string) (*github.RepositoryInvitation, error) {
+func findRepoInvitation(client *Client, owner string, repo string, collaborator string) (*github.RepositoryInvitation, error) {
 	opt := &github.ListOptions{PerPage: maxPerPage}
 	for {
-		invitations, resp, err := client.Repositories.ListInvitations(context.TODO(), owner, repo, opt)
+		invitations, resp, err := client.Client.Repositories.ListInvitations(context.TODO(), owner, repo, opt)
 		if err != nil {
 			return nil, err
 		}

--- a/builtin/providers/github/resource_github_repository_collaborator_test.go
+++ b/builtin/providers/github/resource_github_repository_collaborator_test.go
@@ -47,7 +47,7 @@ func TestAccGithubRepositoryCollaborator_importBasic(t *testing.T) {
 }
 
 func testAccCheckGithubRepositoryCollaboratorDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_repository_collaborator" {
@@ -83,7 +83,7 @@ func testAccCheckGithubRepositoryCollaboratorExists(n string) resource.TestCheck
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		o := testAccProvider.Meta().(*Organization).name
 		r, u := parseTwoPartID(rs.Primary.ID)
 
@@ -119,7 +119,7 @@ func testAccCheckGithubRepositoryCollaboratorPermission(n string) resource.TestC
 			return fmt.Errorf("No membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		o := testAccProvider.Meta().(*Organization).name
 		r, u := parseTwoPartID(rs.Primary.ID)
 

--- a/builtin/providers/github/resource_github_repository_test.go
+++ b/builtin/providers/github/resource_github_repository_test.go
@@ -87,7 +87,7 @@ func testAccCheckGithubRepositoryExists(n string, repo *github.Repository) resou
 		}
 
 		org := testAccProvider.Meta().(*Organization)
-		conn := org.client
+		conn := org.Client()
 		gotRepo, _, err := conn.Repositories.Get(context.TODO(), org.name, repoName)
 		if err != nil {
 			return err
@@ -173,7 +173,7 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 }
 
 func testAccCheckGithubRepositoryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 	orgName := testAccProvider.Meta().(*Organization).name
 
 	for _, rs := range s.RootModule().Resources {

--- a/builtin/providers/github/resource_github_repository_webhook_test.go
+++ b/builtin/providers/github/resource_github_repository_webhook_test.go
@@ -72,7 +72,7 @@ func testAccCheckGithubRepositoryWebhookExists(n string, repoName string, hook *
 		}
 
 		org := testAccProvider.Meta().(*Organization)
-		conn := org.client
+		conn := org.Client()
 		getHook, _, err := conn.Repositories.GetHook(context.TODO(), org.name, repoName, hookID)
 		if err != nil {
 			return err
@@ -113,7 +113,7 @@ func testAccCheckGithubRepositoryWebhookAttributes(hook *github.Hook, want *test
 }
 
 func testAccCheckGithubRepositoryWebhookDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 	orgName := testAccProvider.Meta().(*Organization).name
 
 	for _, rs := range s.RootModule().Resources {

--- a/builtin/providers/github/resource_github_team_membership_test.go
+++ b/builtin/providers/github/resource_github_team_membership_test.go
@@ -77,7 +77,7 @@ func TestAccGithubTeamMembership_importBasic(t *testing.T) {
 }
 
 func testAccCheckGithubTeamMembershipDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team_membership" {
@@ -110,7 +110,7 @@ func testAccCheckGithubTeamMembershipExists(n string, membership *github.Members
 			return fmt.Errorf("No team membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		t, u := parseTwoPartID(rs.Primary.ID)
 
 		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), u)
@@ -134,7 +134,7 @@ func testAccCheckGithubTeamMembershipRoleState(n, expected string, membership *g
 			return fmt.Errorf("No team membership ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		t, u := parseTwoPartID(rs.Primary.ID)
 
 		teamMembership, _, err := conn.Organizations.GetTeamMembership(context.TODO(), toGithubID(t), u)

--- a/builtin/providers/github/resource_github_team_repository_test.go
+++ b/builtin/providers/github/resource_github_team_repository_test.go
@@ -110,7 +110,7 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 			return fmt.Errorf("No team repository ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		t, r := parseTwoPartID(rs.Primary.ID)
 
 		repo, _, err := conn.Organizations.IsTeamRepo(context.TODO(),
@@ -126,7 +126,7 @@ func testAccCheckGithubTeamRepositoryExists(n string, repository *github.Reposit
 }
 
 func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team_repository" {

--- a/builtin/providers/github/resource_github_team_test.go
+++ b/builtin/providers/github/resource_github_team_test.go
@@ -71,7 +71,7 @@ func testAccCheckGithubTeamExists(n string, team *github.Team) resource.TestChec
 			return fmt.Errorf("No Team ID is set")
 		}
 
-		conn := testAccProvider.Meta().(*Organization).client
+		conn := testAccProvider.Meta().(*Organization).Client()
 		githubTeam, _, err := conn.Organizations.GetTeam(context.TODO(), toGithubID(rs.Primary.ID))
 		if err != nil {
 			return err
@@ -96,7 +96,7 @@ func testAccCheckGithubTeamAttributes(team *github.Team, name, description strin
 }
 
 func testAccCheckGithubTeamDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*Organization).client
+	conn := testAccProvider.Meta().(*Organization).Client()
 
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "github_team" {


### PR DESCRIPTION
This is an attempt at fixing #6016

This is done by storing the `ETag` or `Last-Modified` headers from github's API responses into the terraform state.
Next time the resource is refreshed, add a `If-None-Match` or `If-Modified-Since` header to the request.
Github then returns a HTTP 304 if the resource has not changed since last terraform refresh. (which does not count against our rate limits, as per https://developer.github.com/v3/#conditional-requests)

I had to change the provider config so that a new `github.Client` is created for each resource, so that we can pass in a separate `conditionalTransport` object for each resource (`conditionalTransport` is used to add the headers to the request)

I have absolutely no experience with Go and there might be better ways to do it?