### PR TITLE
provider/aws: New DataSource: aws_partition

### DIFF
--- a/builtin/providers/aws/data_source_aws_partition.go
+++ b/builtin/providers/aws/data_source_aws_partition.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsPartition() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsPartitionRead,
+
+		Schema: map[string]*schema.Schema{
+			"partition": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsPartitionRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*AWSClient)
+
+	log.Printf("[DEBUG] Reading Partition.")
+	d.SetId(time.Now().UTC().String())
+
+	log.Printf("[DEBUG] Setting AWS Partition to %s.", client.partition)
+	d.Set("partition", meta.(*AWSClient).partition)
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_partition_test.go
+++ b/builtin/providers/aws/data_source_aws_partition_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSPartition_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAwsPartitionConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsPartition("data.aws_partition.current"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsPartition(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find resource: %s", n)
+		}
+
+		expected := testAccProvider.Meta().(*AWSClient).partition
+		if rs.Primary.Attributes["partition"] != expected {
+			return fmt.Errorf("Incorrect Partition: expected %q, got %q", expected, rs.Primary.Attributes["partition"])
+		}
+
+		return nil
+	}
+}
+
+const testAccCheckAwsPartitionConfig_basic = `
+data "aws_partition" "current" { }
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -174,6 +174,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_server_certificate":   dataSourceAwsIAMServerCertificate(),
 			"aws_instance":                 dataSourceAwsInstance(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
+			"aws_partition":                dataSourceAwsPartition(),
 			"aws_prefix_list":              dataSourceAwsPrefixList(),
 			"aws_redshift_service_account": dataSourceAwsRedshiftServiceAccount(),
 			"aws_region":                   dataSourceAwsRegion(),

--- a/website/source/docs/providers/aws/d/partition.html.markdown
+++ b/website/source/docs/providers/aws/d/partition.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: aws_partition"
+sidebar_current: "docs-aws-datasource-partition"
+description: |-
+  Get AWS partition identifier
+---
+
+# aws\_partition
+
+Use this data source to lookup current AWS partition in which Terraform is working
+
+## Example Usage
+
+```
+data "aws_partition" "current" { }
+
+data "aws_iam_policy_document" "s3_policy" {
+  statement {
+    sid = "1"
+
+    actions = [
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      "arn:${data.aws_partition.current.partition}:s3:::my-bucket",
+    ]
+  }
+}
+
+```
+
+## Argument Reference
+
+There are no arguments available for this data source.
+
+## Attributes Reference
+
+`partition` is set to the identifier of the current partition.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -80,6 +80,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-kms-secret") %>>
                             <a href="/docs/providers/aws/d/kms_secret.html">aws_kms_secret</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-partition") %>>
+                            <a href="/docs/providers/aws/d/partition.html">aws_partition</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-prefix-list") %>>
                             <a href="/docs/providers/aws/d/prefix_list.html">aws_prefix_list</a>
                         </li>


### PR DESCRIPTION
Hello, my first PR here.

This data source allows AWS partition too be looked up when constructing resource ARN's, for example, in IAM policy documents. One less variable to keep track of when writing manifests to be reused in different partitions, e.g. `aws`/`aws-cn`. Inspiration taken from `aws_caller_identity`.

```
data "aws_partition" "current" { }

data "aws_iam_policy_document" "s3_policy" {
  statement {
    sid = "1"

    actions = [
      "s3:ListBucket",
    ]

    resources = [
      "arn:${data.aws_partition.current.partition}:s3:::my-bucket",
    ]
  }
}

resource "aws_iam_policy" "s3_policy" {
  name   = "my-policy"
  path   = "/"
  policy = "${data.aws_iam_policy_document.s3_policy.json}"
}
```

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSPartition_basic -timeout 120m
=== RUN   TestAccAWSPartition_basic
--- PASS: TestAccAWSPartition_basic (10.81s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	10.837s
```