### PR TITLE
provider/aws: Fix OnceADayWindowFormat Validator

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -655,9 +655,15 @@ func validateOnceADayWindowFormat(v interface{}, k string) (ws []string, errors 
 	validTimeFormat := "([0-1][0-9]|2[0-3]):([0-5][0-9])"
 
 	value := v.(string)
+	// If you do not specify this parameter, ElastiCache automatically chooses an
+	// appropriate time range.
+	if value == "" {
+		return
+	}
+
 	if !regexp.MustCompile(validTimeFormat + "-" + validTimeFormat).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must satisfy the format of \"hh24:mi-hh24:mi\".", k))
+			"%q must satisfy the format of \"hh24:mi-hh24:mi\". Recieved: %s", k, value))
 	}
 	return
 }

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1042,6 +1042,10 @@ func TestValidateOnceADayWindowFormat(t *testing.T) {
 			Value:    "04:00-05:00",
 			ErrCount: 0,
 		},
+		{
+			Value:    "",
+			ErrCount: 0,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
If an attribute that would normally be validated by `validateOnceADayWindowFormat()` is an empty string, in every case AWS supplies a default time window to use.

Thus, an empty string for these attributes is a valid value.

Fixes: #11663 