### PR TITLE
terraform: data source on refresh should just delete from state

### DIFF
--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -571,6 +571,38 @@ func TestContext2Refresh_stateBasic(t *testing.T) {
 	}
 }
 
+func TestContext2Refresh_dataOrphan(t *testing.T) {
+	p := testProvider("null")
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"data.null_data_source.bar": &ResourceState{
+						Type: "foo",
+						Primary: &InstanceState{
+							ID: "foo",
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Providers: map[string]ResourceProviderFactory{
+			"null": testProviderFuncFixed(p),
+		},
+		State: state,
+	})
+
+	s, err := ctx.Refresh()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	checkStateString(t, s, `<no state>`)
+}
+
 func TestContext2Refresh_dataState(t *testing.T) {
 	p := testProvider("null")
 	m := testModule(t, "refresh-data-resource-basic")

--- a/terraform/node_data_destroy.go
+++ b/terraform/node_data_destroy.go
@@ -1,0 +1,22 @@
+package terraform
+
+// NodeDestroyableDataResource represents a resource that is "plannable":
+// it is ready to be planned in order to create a diff.
+type NodeDestroyableDataResource struct {
+	*NodeAbstractResource
+}
+
+// GraphNodeEvalable
+func (n *NodeDestroyableDataResource) EvalTree() EvalNode {
+	addr := n.NodeAbstractResource.Addr
+
+	// stateId is the ID to put into the state
+	stateId := addr.stateId()
+
+	// Just destroy it.
+	var state *InstanceState
+	return &EvalWriteState{
+		Name:  stateId,
+		State: &state, // state is nil here
+	}
+}

--- a/terraform/node_resource_refresh.go
+++ b/terraform/node_resource_refresh.go
@@ -23,9 +23,19 @@ func (n *NodeRefreshableResource) EvalTree() EvalNode {
 	switch mode := n.Addr.Mode; mode {
 	case config.ManagedResourceMode:
 		return n.evalTreeManagedResource()
+
 	case config.DataResourceMode:
-		dn := &NodeRefreshableDataResourceInstance{
-			NodeAbstractResource: n.NodeAbstractResource,
+		// Get the data source node. If we don't have a configuration
+		// then it is an orphan so we destroy it (remove it from the state).
+		var dn GraphNodeEvalable
+		if n.Config != nil {
+			dn = &NodeRefreshableDataResourceInstance{
+				NodeAbstractResource: n.NodeAbstractResource,
+			}
+		} else {
+			dn = &NodeDestroyableDataResource{
+				NodeAbstractResource: n.NodeAbstractResource,
+			}
 		}
 
 		return dn.EvalTree()


### PR DESCRIPTION
This was caught by an acceptance test. We've now added a unit test. When
refreshing, an orphan (no config) data source should just be deleted.

This only affects master/0.9 since these graph changes aren't in 0.8.x