### PR TITLE
Documentation fix for random_id

### DIFF
--- a/website/source/docs/providers/random/r/id.html.md
+++ b/website/source/docs/providers/random/r/id.html.md
@@ -66,4 +66,4 @@ The following attributes are exported:
 
 * `b64` - The generated id presented in base64, using the URL-friendly character set: case-sensitive letters, digits and the characters `_` and `-`.
 * `hex` - The generated id presented in padded hexadecimal digits. This result will always be twice as long as the requested byte length.
-* `decimal` - The generated id presented in non-padded decimal digits.
+* `dec` - The generated id presented in non-padded decimal digits.


### PR DESCRIPTION
This attribute, `decimal`, should actually be `dec`.

reference: https://github.com/hashicorp/terraform/blob/a0c5d42fa41c4c3d38f74d493fa7922028aa267f/builtin/providers/random/resource_id.go#L54