### PR TITLE
Azure SQL Server name cannot be mixed case

### DIFF
--- a/website/source/docs/providers/azurerm/r/sql_server.html.markdown
+++ b/website/source/docs/providers/azurerm/r/sql_server.html.markdown
@@ -18,7 +18,7 @@ resource "azurerm_resource_group" "test" {
    location = "West US"
 }
 resource "azurerm_sql_server" "test" {
-    name = "MySqlServer"
+    name = "mysqlserver"
     resource_group_name = "${azurerm_resource_group.test.name}"
     location = "West US"
     version = "12.0"


### PR DESCRIPTION
Can only be made up of lowercase letters 'a'-'z', the numbers 0-9 and the hyphen. The hyphen may not lead or trail in the name.

Changed MySqlServer to mysqlserver