### PR TITLE
Enable state locking for plan/apply/destroy/refresh/taint/untaint

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -22,7 +22,8 @@ type Backend interface {
 
 	// State returns the current state for this environment. This state may
 	// not be loaded locally: the proper APIs should be called on state.State
-	// to load the state.
+	// to load the state. If the state.State is a state.Locker, it's up to the
+	// caller to call Lock and Unlock as needed.
 	State() (state.State, error)
 }
 
@@ -38,6 +39,9 @@ type Enhanced interface {
 	// It is up to the implementation to determine what "performing" means.
 	// This DOES NOT BLOCK. The context returned as part of RunningOperation
 	// should be used to block for completion.
+	// If the state used in the operation can be locked, it is the
+	// responsibility of the Backend to lock the state for the duration of the
+	// running operation.
 	Operation(context.Context, *Operation) (*RunningOperation, error)
 }
 
@@ -99,6 +103,10 @@ type Operation struct {
 	// Input/output/control options.
 	UIIn  terraform.UIInput
 	UIOut terraform.UIOutput
+
+	// If LockState is true, the Operation must Lock any
+	// state.Lockers for its duration, and Unlock when complete.
+	LockState bool
 }
 
 // RunningOperation is the result of starting an operation.

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -34,6 +34,9 @@ type Local struct {
 	StateOutPath    string
 	StateBackupPath string
 
+	// we only want to create a single instance of the local state
+	state state.State
+
 	// ContextOpts are the base context options to set when initializing a
 	// Terraform context. Many of these will be overridden or merged by
 	// Operation. See Operation for more details.
@@ -100,6 +103,10 @@ func (b *Local) State() (state.State, error) {
 		return b.Backend.State()
 	}
 
+	if b.state != nil {
+		return b.state, nil
+	}
+
 	// Otherwise, we need to load the state.
 	var s state.State = &state.LocalState{
 		Path:    b.StatePath,
@@ -119,6 +126,7 @@ func (b *Local) State() (state.State, error) {
 		}
 	}
 
+	b.state = s
 	return s, nil
 }
 

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -28,11 +29,21 @@ func (b *Local) opApply(
 	b.ContextOpts.Hooks = append(b.ContextOpts.Hooks, countHook, stateHook)
 
 	// Get our context
-	tfCtx, state, err := b.context(op)
+	tfCtx, opState, err := b.context(op)
 	if err != nil {
 		runningOp.Err = err
 		return
 	}
+
+	// context acquired the state, and therefor the lock.
+	// Unlock it when the operation is complete
+	defer func() {
+		if s, ok := opState.(state.Locker); op.LockState && ok {
+			if err := s.Unlock(); err != nil {
+				log.Printf("[ERROR]: %s", err)
+			}
+		}
+	}()
 
 	// Setup the state
 	runningOp.State = tfCtx.State()
@@ -58,7 +69,7 @@ func (b *Local) opApply(
 	}
 
 	// Setup our hook for continuous state updates
-	stateHook.State = state
+	stateHook.State = opState
 
 	// Start the apply in a goroutine so that we can be interrupted.
 	var applyState *terraform.State
@@ -98,11 +109,11 @@ func (b *Local) opApply(
 	runningOp.State = applyState
 
 	// Persist the state
-	if err := state.WriteState(applyState); err != nil {
+	if err := opState.WriteState(applyState); err != nil {
 		runningOp.Err = fmt.Errorf("Failed to save state: %s", err)
 		return
 	}
-	if err := state.PersistState(); err != nil {
+	if err := opState.PersistState(); err != nil {
 		runningOp.Err = fmt.Errorf("Failed to save state: %s", err)
 		return
 	}

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -40,7 +40,14 @@ func (b *Local) opApply(
 	defer func() {
 		if s, ok := opState.(state.Locker); op.LockState && ok {
 			if err := s.Unlock(); err != nil {
-				log.Printf("[ERROR]: %s", err)
+				runningOp.Err = multierror.Append(runningOp.Err,
+					errwrap.Wrapf("Error unlocking state:\n\n"+
+						"{{err}}\n\n"+
+						"The Terraform operation completed but there was an error unlocking the state.\n"+
+						"This may require unlocking the state manually with the `terraform unlock` command\n",
+						err,
+					),
+				)
 			}
 		}
 	}()

--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -23,6 +23,13 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 	if err != nil {
 		return nil, nil, errwrap.Wrapf("Error loading state: {{err}}", err)
 	}
+
+	if s, ok := s.(state.Locker); op.LockState && ok {
+		if err := s.Lock(op.Type.String()); err != nil {
+			return nil, nil, errwrap.Wrapf("Error locking state: {{err}}", err)
+		}
+	}
+
 	if err := s.RefreshState(); err != nil {
 		return nil, nil, errwrap.Wrapf("Error loading state: {{err}}", err)
 	}

--- a/command/apply.go
+++ b/command/apply.go
@@ -47,6 +47,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
+	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -182,6 +183,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.Plan = plan
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply
+	opReq.LockState = c.Meta.lockState
 
 	// Perform the operation
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/command/apply.go
+++ b/command/apply.go
@@ -47,7 +47,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -183,7 +183,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	opReq.Plan = plan
 	opReq.PlanRefresh = refresh
 	opReq.Type = backend.OperationTypeApply
-	opReq.LockState = c.Meta.lockState
+	opReq.LockState = c.Meta.stateLock
 
 	// Perform the operation
 	ctx, ctxCancel := context.WithCancel(context.Background())

--- a/command/apply.go
+++ b/command/apply.go
@@ -47,7 +47,7 @@ func (c *ApplyCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -274,7 +274,7 @@ Options:
                          modifying. Defaults to the "-state-out" path with
                          ".backup" extension. Set to "-" to disable backup.
 
-  -lock-state=true       Lock the state file when locking is supported.
+  -lock=true             Lock the state file when locking is supported.
 
   -input=true            Ask for input for variables if not directly set.
 
@@ -323,7 +323,7 @@ Options:
 
   -force                 Don't ask for input for destroy confirmation.
 
-  -lock-state=true       Lock the state file when locking is supported.
+  -lock=true             Lock the state file when locking is supported.
 
   -no-color              If specified, output won't contain any color.
 

--- a/command/apply.go
+++ b/command/apply.go
@@ -274,6 +274,8 @@ Options:
                          modifying. Defaults to the "-state-out" path with
                          ".backup" extension. Set to "-" to disable backup.
 
+  -lock-state=true       Lock the state file when locking is supported.
+
   -input=true            Ask for input for variables if not directly set.
 
   -no-color              If specified, output won't contain any color.
@@ -320,6 +322,8 @@ Options:
                          ".backup" extension. Set to "-" to disable backup.
 
   -force                 Don't ask for input for destroy confirmation.
+
+  -lock-state=true       Lock the state file when locking is supported.
 
   -no-color              If specified, output won't contain any color.
 

--- a/command/apply_destroy_test.go
+++ b/command/apply_destroy_test.go
@@ -92,6 +92,58 @@ func TestApply_destroy(t *testing.T) {
 	}
 }
 
+func TestApply_destroyLockedState(t *testing.T) {
+	originalState := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo": &terraform.ResourceState{
+						Type: "test_instance",
+						Primary: &terraform.InstanceState{
+							ID: "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	statePath := testStateFile(t, originalState)
+
+	unlock, err := testLockState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &ApplyCommand{
+		Destroy: true,
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	// Run the apply command pointing to our existing state
+	args := []string{
+		"-force",
+		"-state", statePath,
+		testFixturePath("apply"),
+	}
+
+	if code := c.Run(args); code == 0 {
+		t.Fatal("expected error")
+	}
+
+	output := ui.ErrorWriter.String()
+	if !strings.Contains(output, "locked") {
+		t.Fatal("command output does not look like a lock error:", output)
+	}
+}
+
 func TestApply_destroyPlan(t *testing.T) {
 	planPath := testPlanFile(t, &terraform.Plan{
 		Module: testModule(t, "apply"),

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 )
@@ -550,7 +551,8 @@ func TestApply_plan(t *testing.T) {
 }
 
 func TestApply_plan_backup(t *testing.T) {
-	planPath := testPlanFile(t, testPlan(t))
+	plan := testPlan(t)
+	planPath := testPlanFile(t, plan)
 	statePath := testTempFile(t)
 	backupPath := testTempFile(t)
 
@@ -561,6 +563,12 @@ func TestApply_plan_backup(t *testing.T) {
 			ContextOpts: testCtxConfig(p),
 			Ui:          ui,
 		},
+	}
+
+	// create a state file that needs to be backed up
+	err := (&state.LocalState{Path: statePath}).WriteState(plan.State)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	args := []string{

--- a/command/meta.go
+++ b/command/meta.go
@@ -83,12 +83,15 @@ type Meta struct {
 	// shadow is used to enable/disable the shadow graph
 	//
 	// provider is to specify specific resource providers
+	//
+	// lockState is set to false to disable state locking
 	statePath    string
 	stateOutPath string
 	backupPath   string
 	parallelism  int
 	shadow       bool
 	provider     string
+	lockState    bool
 }
 
 // initStatePaths is used to initialize the default values for

--- a/command/meta.go
+++ b/command/meta.go
@@ -91,7 +91,7 @@ type Meta struct {
 	parallelism  int
 	shadow       bool
 	provider     string
-	lockState    bool
+	stateLock    bool
 }
 
 // initStatePaths is used to initialize the default values for

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/copy"
+	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/cli"
 )
@@ -2207,6 +2208,12 @@ func TestMetaBackend_planLocalStatePath(t *testing.T) {
 
 	// Create an alternate output path
 	statePath := "foo.tfstate"
+
+	// put a initial state there that needs to be backed up
+	err := (&state.LocalState{Path: statePath}).WriteState(original)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Setup the meta
 	m := testMetaBackend(t, nil)

--- a/command/plan.go
+++ b/command/plan.go
@@ -31,6 +31,7 @@ func (c *PlanCommand) Run(args []string) int {
 		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
+	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -84,6 +85,7 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
 	opReq.Type = backend.OperationTypePlan
+	opReq.LockState = c.Meta.lockState
 
 	// Perform the operation
 	op, err := b.Operation(context.Background(), opReq)

--- a/command/plan.go
+++ b/command/plan.go
@@ -143,6 +143,8 @@ Options:
 
   -input=true         Ask for input for variables if not directly set.
 
+  -lock-state=true    Lock the state file when locking is supported.
+
   -module-depth=n     Specifies the depth of modules to show in the output.
                       This does not affect the plan itself, only the output
                       shown. By default, this is -1, which will expand all.

--- a/command/plan.go
+++ b/command/plan.go
@@ -31,7 +31,7 @@ func (c *PlanCommand) Run(args []string) int {
 		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
-	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -85,7 +85,7 @@ func (c *PlanCommand) Run(args []string) int {
 	opReq.PlanRefresh = refresh
 	opReq.PlanOutPath = outPath
 	opReq.Type = backend.OperationTypePlan
-	opReq.LockState = c.Meta.lockState
+	opReq.LockState = c.Meta.stateLock
 
 	// Perform the operation
 	op, err := b.Operation(context.Background(), opReq)

--- a/command/plan.go
+++ b/command/plan.go
@@ -31,7 +31,7 @@ func (c *PlanCommand) Run(args []string) int {
 		&c.Meta.parallelism, "parallelism", DefaultParallelism, "parallelism")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", "", "path")
 	cmdFlags.BoolVar(&detailed, "detailed-exitcode", false, "detailed-exitcode")
-	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -143,7 +143,7 @@ Options:
 
   -input=true         Ask for input for variables if not directly set.
 
-  -lock-state=true    Lock the state file when locking is supported.
+  -lock=true          Lock the state file when locking is supported.
 
   -module-depth=n     Specifies the depth of modules to show in the output.
                       This does not affect the plan itself, only the output

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -96,6 +96,8 @@ Options:
 
   -input=true         Ask for input for variables if not directly set.
 
+  -lock-state=true    Lock the state file when locking is supported.
+
   -no-color           If specified, output won't contain any color.
 
   -state=path         Path to read and save state (unless state-out

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -23,7 +23,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -96,7 +96,7 @@ Options:
 
   -input=true         Ask for input for variables if not directly set.
 
-  -lock-state=true    Lock the state file when locking is supported.
+  -lock=true          Lock the state file when locking is supported.
 
   -no-color           If specified, output won't contain any color.
 

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -23,7 +23,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -53,7 +53,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	opReq := c.Operation()
 	opReq.Type = backend.OperationTypeRefresh
 	opReq.Module = mod
-	opReq.LockState = c.Meta.lockState
+	opReq.LockState = c.Meta.stateLock
 
 	// Perform the operation
 	op, err := b.Operation(context.Background(), opReq)

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -23,6 +23,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
+	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -52,6 +53,7 @@ func (c *RefreshCommand) Run(args []string) int {
 	opReq := c.Operation()
 	opReq.Type = backend.OperationTypeRefresh
 	opReq.Module = mod
+	opReq.LockState = c.Meta.lockState
 
 	// Perform the operation
 	op, err := b.Operation(context.Background(), opReq)

--- a/command/refresh_test.go
+++ b/command/refresh_test.go
@@ -59,6 +59,43 @@ func TestRefresh(t *testing.T) {
 	}
 }
 
+func TestRefresh_lockedState(t *testing.T) {
+	state := testState()
+	statePath := testStateFile(t, state)
+
+	unlock, err := testLockState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &RefreshCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	p.RefreshFn = nil
+	p.RefreshReturn = &terraform.InstanceState{ID: "yes"}
+
+	args := []string{
+		"-state", statePath,
+		testFixturePath("refresh"),
+	}
+
+	if code := c.Run(args); code == 0 {
+		t.Fatal("expected error")
+	}
+
+	output := ui.ErrorWriter.String()
+	if !strings.Contains(output, "locked") {
+		t.Fatal("command output does not look like a lock error:", output)
+	}
+}
+
 func TestRefresh_badState(t *testing.T) {
 	p := testProvider()
 	ui := new(cli.MockUi)

--- a/command/taint.go
+++ b/command/taint.go
@@ -26,7 +26,7 @@ func (c *TaintCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -177,7 +177,7 @@ Options:
                       modifying. Defaults to the "-state-out" path with
                       ".backup" extension. Set to "-" to disable backup.
 
-  -lock-state=true    Lock the state file when locking is supported.
+  -lock=true          Lock the state file when locking is supported.
 
   -module=path        The module path where the resource lives. By
                       default this will be root. Child modules can be specified

--- a/command/taint.go
+++ b/command/taint.go
@@ -26,7 +26,7 @@ func (c *TaintCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -72,7 +72,7 @@ func (c *TaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	if s, ok := st.(state.Locker); c.Meta.lockState && ok {
+	if s, ok := st.(state.Locker); c.Meta.stateLock && ok {
 		if err := s.Lock("taint"); err != nil {
 			c.Ui.Error(fmt.Sprintf("Failed to lock state: %s", err))
 			return 1

--- a/command/taint.go
+++ b/command/taint.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -25,6 +26,7 @@ func (c *TaintCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
+	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -64,14 +66,23 @@ func (c *TaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	state, err := b.State()
+	st, err := b.State()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
 
+	if s, ok := st.(state.Locker); c.Meta.lockState && ok {
+		if err := s.Lock("taint"); err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to lock state: %s", err))
+			return 1
+		}
+
+		defer s.Unlock()
+	}
+
 	// Get the actual state structure
-	s := state.State()
+	s := st.State()
 	if s.Empty() {
 		if allowMissing {
 			return c.allowMissingExit(name, module)
@@ -129,11 +140,11 @@ func (c *TaintCommand) Run(args []string) int {
 	rs.Taint()
 
 	log.Printf("[INFO] Writing state output to: %s", c.Meta.StateOutPath())
-	if err := state.WriteState(s); err != nil {
+	if err := st.WriteState(s); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}
-	if err := state.PersistState(); err != nil {
+	if err := st.PersistState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}
@@ -165,6 +176,8 @@ Options:
   -backup=path        Path to backup the existing state file before
                       modifying. Defaults to the "-state-out" path with
                       ".backup" extension. Set to "-" to disable backup.
+
+  -lock-state=true    Lock the state file when locking is supported.
 
   -module=path        The module path where the resource lives. By
                       default this will be root. Child modules can be specified

--- a/command/taint_test.go
+++ b/command/taint_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/terraform"
@@ -42,6 +43,50 @@ func TestTaint(t *testing.T) {
 	}
 
 	testStateOutput(t, statePath, testTaintStr)
+}
+
+func TestTaint_lockedState(t *testing.T) {
+	state := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo": &terraform.ResourceState{
+						Type: "test_instance",
+						Primary: &terraform.InstanceState{
+							ID: "bar",
+						},
+					},
+				},
+			},
+		},
+	}
+	statePath := testStateFile(t, state)
+
+	unlock, err := testLockState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+	ui := new(cli.MockUi)
+	c := &TaintCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+	}
+	if code := c.Run(args); code == 0 {
+		t.Fatal("expected error")
+	}
+
+	output := ui.ErrorWriter.String()
+	if !strings.Contains(output, "locked") {
+		t.Fatal("command output does not look like a lock error:", output)
+	}
 }
 
 func TestTaint_backup(t *testing.T) {

--- a/command/testdata/statelocker.go
+++ b/command/testdata/statelocker.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/terraform/state"
 )
@@ -38,6 +39,11 @@ func main() {
 	}()
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-	<-c
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+
+	// timeout after 10 second in case we don't get cleaned up by the test
+	select {
+	case <-time.After(10 * time.Second):
+	case <-c:
+	}
 }

--- a/command/testdata/statelocker.go
+++ b/command/testdata/statelocker.go
@@ -1,0 +1,43 @@
+// statelocker use used for testing command with a locked state.
+// This will lock the state file at a given path, then wait for a sigal. On
+// SIGINT and SIGTERM the state will be Unlocked before exit.
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/hashicorp/terraform/state"
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		log.Fatal(os.Args[0], "statefile")
+	}
+
+	s := &state.LocalState{
+		Path: os.Args[1],
+	}
+
+	err := s.Lock("command test")
+	if err != nil {
+		io.WriteString(os.Stderr, err.Error())
+		return
+	}
+
+	// signal to the caller that we're locked
+	io.WriteString(os.Stdout, "LOCKED")
+
+	defer func() {
+		if err := s.Unlock(); err != nil {
+			io.WriteString(os.Stderr, err.Error())
+		}
+	}()
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+	<-c
+}

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log"
 	"strings"
+
+	"github.com/hashicorp/terraform/state"
 )
 
 // UntaintCommand is a cli.Command implementation that manually untaints
@@ -51,14 +53,23 @@ func (c *UntaintCommand) Run(args []string) int {
 	}
 
 	// Get the state
-	state, err := b.State()
+	st, err := b.State()
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
 
+	if s, ok := st.(state.Locker); c.Meta.lockState && ok {
+		if err := s.Lock("untaint"); err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to lock state: %s", err))
+			return 1
+		}
+
+		defer s.Unlock()
+	}
+
 	// Get the actual state structure
-	s := state.State()
+	s := st.State()
 	if s.Empty() {
 		if allowMissing {
 			return c.allowMissingExit(name, module)
@@ -116,11 +127,11 @@ func (c *UntaintCommand) Run(args []string) int {
 	rs.Untaint()
 
 	log.Printf("[INFO] Writing state output to: %s", c.Meta.StateOutPath())
-	if err := state.WriteState(s); err != nil {
+	if err := st.WriteState(s); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}
-	if err := state.PersistState(); err != nil {
+	if err := st.PersistState(); err != nil {
 		c.Ui.Error(fmt.Sprintf("Error writing state file: %s", err))
 		return 1
 	}
@@ -152,6 +163,8 @@ Options:
   -backup=path        Path to backup the existing state file before
                       modifying. Defaults to the "-state-out" path with
                       ".backup" extension. Set to "-" to disable backup.
+
+  -lock-state=true    Lock the state file when locking is supported.
 
   -module=path        The module path where the resource lives. By
                       default this will be root. Child modules can be specified

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -25,7 +25,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -60,7 +60,7 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	if s, ok := st.(state.Locker); c.Meta.lockState && ok {
+	if s, ok := st.(state.Locker); c.Meta.stateLock && ok {
 		if err := s.Lock("untaint"); err != nil {
 			c.Ui.Error(fmt.Sprintf("Failed to lock state: %s", err))
 			return 1

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -25,6 +25,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
+	cmdFlags.BoolVar(&c.Meta.lockState, "state-lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -25,7 +25,7 @@ func (c *UntaintCommand) Run(args []string) int {
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.StringVar(&c.Meta.stateOutPath, "state-out", "", "path")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "", "path")
-	cmdFlags.BoolVar(&c.Meta.stateLock, "state-lock", true, "lock state")
+	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -165,7 +165,7 @@ Options:
                       modifying. Defaults to the "-state-out" path with
                       ".backup" extension. Set to "-" to disable backup.
 
-  -lock-state=true    Lock the state file when locking is supported.
+  -lock=true          Lock the state file when locking is supported.
 
   -module=path        The module path where the resource lives. By
                       default this will be root. Child modules can be specified

--- a/command/untaint_test.go
+++ b/command/untaint_test.go
@@ -50,6 +50,51 @@ test_instance.foo:
 	testStateOutput(t, statePath, expected)
 }
 
+func TestUntaint_lockedState(t *testing.T) {
+	state := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			&terraform.ModuleState{
+				Path: []string{"root"},
+				Resources: map[string]*terraform.ResourceState{
+					"test_instance.foo": &terraform.ResourceState{
+						Type: "test_instance",
+						Primary: &terraform.InstanceState{
+							ID:      "bar",
+							Tainted: true,
+						},
+					},
+				},
+			},
+		},
+	}
+	statePath := testStateFile(t, state)
+	unlock, err := testLockState(statePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	ui := new(cli.MockUi)
+	c := &UntaintCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"test_instance.foo",
+	}
+	if code := c.Run(args); code == 0 {
+		t.Fatal("expected error")
+	}
+
+	output := ui.ErrorWriter.String()
+	if !strings.Contains(output, "locked") {
+		t.Fatal("command output does not look like a lock error:", output)
+	}
+}
+
 func TestUntaint_backup(t *testing.T) {
 	// Get a temp cwd
 	tmp, cwd := testCwd(t)

--- a/state/local.go
+++ b/state/local.go
@@ -19,16 +19,14 @@ type lockInfo struct {
 	Path string
 	// The time the lock was taken
 	Created time.Time
-	// The time this lock expires
-	Expires time.Time
-	// The lock reason passed to State.Lock
+	// Extra info passed to State.Lock
 	Reason string
 }
 
 // return the lock info formatted in an error
 func (l *lockInfo) Err() error {
-	return fmt.Errorf("state file %q locked. created:%s, expires:%s, reason:%s",
-		l.Path, l.Created, l.Expires, l.Reason)
+	return fmt.Errorf("state file %q locked. created:%s, reason:%s",
+		l.Path, l.Created, l.Reason)
 }
 
 // LocalState manages a state storage that is local to the filesystem.
@@ -229,7 +227,6 @@ func (s *LocalState) writeLockInfo(reason string) error {
 	lockInfo := &lockInfo{
 		Path:    s.Path,
 		Created: time.Now().UTC(),
-		Expires: time.Now().Add(time.Hour).UTC(),
 		Reason:  reason,
 	}
 

--- a/state/local.go
+++ b/state/local.go
@@ -39,6 +39,10 @@ type LocalState struct {
 
 	// the file handle corresponding to PathOut
 	stateFileOut *os.File
+	// created is set to tru if stateFileOut didn't exist before we created it.
+	// This is mostly so we can clean up emtpy files during tests, but doesn't
+	// hurt to remove file we never wrote to.
+	created bool
 
 	state     *terraform.State
 	readState *terraform.State
@@ -75,8 +79,26 @@ func (s *LocalState) Lock(reason string) error {
 }
 
 func (s *LocalState) Unlock() error {
+	// we can't be locked if we don't have a file
+	if s.stateFileOut == nil {
+		return nil
+	}
+
 	os.Remove(s.lockInfoPath())
-	return s.unlock()
+
+	fileName := s.stateFileOut.Name()
+
+	unlockErr := s.unlock()
+	s.stateFileOut.Close()
+	s.stateFileOut = nil
+
+	// clean up the state file if we created it an never wrote to it
+	stat, err := os.Stat(fileName)
+	if err == nil && stat.Size() == 0 && s.created {
+		os.Remove(fileName)
+	}
+
+	return unlockErr
 }
 
 // Open the state file, creating the directories and file as needed.
@@ -85,26 +107,23 @@ func (s *LocalState) createStateFiles() error {
 		s.PathOut = s.Path
 	}
 
-	f, err := createFileAndDirs(s.PathOut)
+	// yes this could race, but we only use it to clean up empty files
+	if _, err := os.Stat(s.PathOut); os.IsNotExist(err) {
+		s.created = true
+	}
+
+	// Create all the directories
+	if err := os.MkdirAll(filepath.Dir(s.PathOut), 0755); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(s.PathOut, os.O_RDWR|os.O_CREATE, 0666)
 	if err != nil {
 		return err
 	}
+
 	s.stateFileOut = f
 	return nil
-}
-
-func createFileAndDirs(path string) (*os.File, error) {
-	// Create all the directories
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		return nil, err
-	}
-
-	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0666)
-	if err != nil {
-		return nil, err
-	}
-
-	return f, nil
 }
 
 // WriteState for LocalState always persists the state as well.

--- a/state/state.go
+++ b/state/state.go
@@ -42,7 +42,9 @@ type StatePersister interface {
 }
 
 // Locker is implemented to lock state during command execution.
+// The optional info parameter can be recorded with the lock, but the
+// implementation should not depend in its value.
 type Locker interface {
-	Lock(reason string) error
+	Lock(info string) error
 	Unlock() error
 }


### PR DESCRIPTION
This enables the locking of state through the command UI. 

This does change the behavior of 2 tests. Previously when running a plan with no existing state, the plan would be written out and then backed up on the next WriteState by another BackupState instance. Since we now maintain a single State instance throughout an operation, the backup happens before any state exists so no backup file is created. This shouldn't be a problem, as there really was nothing that required backing up. Now those tests will create the state file before running. 

The lock/unlock terraform commands will be added in another PR. Only local state is supported so far, so the commands aren't yet required. 