### PR TITLE
Provide the certificate ID in the aws data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_iam_server_certificate.go
+++ b/builtin/providers/aws/data_source_aws_iam_server_certificate.go
@@ -58,6 +58,11 @@ func dataSourceAwsIAMServerCertificate() *schema.Resource {
 				Computed: true,
 			},
 
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"path": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -125,6 +130,7 @@ func dataSourceAwsIAMServerCertificateRead(d *schema.ResourceData, meta interfac
 	d.SetId(*metadata.ServerCertificateId)
 	d.Set("arn", *metadata.Arn)
 	d.Set("path", *metadata.Path)
+	d.Set("id", *metadata.ServerCertificateId)
 	d.Set("name", *metadata.ServerCertificateName)
 	if metadata.Expiration != nil {
 		d.Set("expiration_date", metadata.Expiration.Format("2006-01-02T15:04:05"))

--- a/builtin/providers/aws/data_source_aws_iam_server_certificate_test.go
+++ b/builtin/providers/aws/data_source_aws_iam_server_certificate_test.go
@@ -48,6 +48,7 @@ func TestAccAWSDataSourceIAMServerCertificate_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrSet("aws_iam_server_certificate.test_cert", "arn"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "arn"),
+					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "id"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "name"),
 					resource.TestCheckResourceAttrSet("data.aws_iam_server_certificate.test", "path"),
 				),


### PR DESCRIPTION
ID is used in aws cloudfront distributions and probably in other aws resources as well

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDataSourceIAMServerCertificate_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMServerCertificate_basic
--- PASS: TestAccAWSDataSourceIAMServerCertificate_basic (21.55s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	21.570s
```