### PR TITLE
provider/aws: Enable snapshotting by default on aws_redshift_cluster

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -188,7 +188,7 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			"skip_final_snapshot": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  true,
+				Default:  false,
 			},
 
 			"endpoint": {

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -2,8 +2,10 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,6 +72,26 @@ func TestAccAWSRedshiftCluster_basic(t *testing.T) {
 						"aws_redshift_cluster.default", "cluster_type", "single-node"),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_cluster.default", "publicly_accessible", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRedshiftCluster_withFinalSnapshot(t *testing.T) {
+	var v redshift.Cluster
+
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterSnapshot(rInt),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRedshiftClusterConfigWithFinalSnapshot(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRedshiftClusterExists("aws_redshift_cluster.default", &v),
 				),
 			},
 		},
@@ -332,6 +354,62 @@ func testAccCheckAWSRedshiftClusterDestroy(s *terraform.State) error {
 	return nil
 }
 
+func testAccCheckAWSRedshiftClusterSnapshot(rInt int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		for _, rs := range s.RootModule().Resources {
+			if rs.Type != "aws_redshift_cluster" {
+				continue
+			}
+
+			var err error
+
+			// Try and delete the snapshot before we check for the cluster not found
+			conn := testAccProvider.Meta().(*AWSClient).redshiftconn
+
+			snapshot_identifier := fmt.Sprintf("tf-acctest-snapshot-%d", rInt)
+			arn, err := buildRedshiftARN(snapshot_identifier, testAccProvider.Meta().(*AWSClient).partition, testAccProvider.Meta().(*AWSClient).accountid, testAccProvider.Meta().(*AWSClient).region)
+			tagsARN := strings.Replace(arn, ":cluster:", ":snapshot:", 1)
+			if err != nil {
+				return fmt.Errorf("Error building ARN for tags check with ARN (%s): %s", tagsARN, err)
+			}
+
+			log.Printf("[INFO] Deleting the Snapshot %s", snapshot_identifier)
+			_, snapDeleteErr := conn.DeleteClusterSnapshot(
+				&redshift.DeleteClusterSnapshotInput{
+					SnapshotIdentifier: aws.String(snapshot_identifier),
+				})
+			if snapDeleteErr != nil {
+				return err
+			}
+
+			//lastly check that the Cluster is missing
+			resp, err := conn.DescribeClusters(
+				&redshift.DescribeClustersInput{
+					ClusterIdentifier: aws.String(rs.Primary.ID),
+				})
+
+			if err == nil {
+				if len(resp.Clusters) != 0 &&
+					*resp.Clusters[0].ClusterIdentifier == rs.Primary.ID {
+					return fmt.Errorf("Redshift Cluster %s still exists", rs.Primary.ID)
+				}
+			}
+
+			// Return nil if the cluster is already destroyed
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == "ClusterNotFound" {
+					return nil
+				}
+
+				return err
+			}
+
+		}
+
+		return nil
+	}
+}
+
 func testAccCheckAWSRedshiftClusterExists(n string, v *redshift.Cluster) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -510,6 +588,7 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
   number_of_nodes = 2
+  skip_final_snapshot = true
 }
 `
 
@@ -523,7 +602,24 @@ resource "aws_redshift_cluster" "default" {
   node_type = "dc1.large"
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
+  skip_final_snapshot = true
 }`
+
+func testAccAWSRedshiftClusterConfigWithFinalSnapshot(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_redshift_cluster" "default" {
+  cluster_identifier = "tf-redshift-cluster-%d"
+  availability_zone = "us-west-2a"
+  database_name = "mydb"
+  master_username = "foo_test"
+  master_password = "Mustbe8characters"
+  node_type = "dc1.large"
+  automated_snapshot_retention_period = 0
+  allow_version_upgrade = false
+  skip_final_snapshot = false
+  final_snapshot_identifier = "tf-acctest-snapshot-%d"
+}`, rInt, rInt)
+}
 
 var testAccAWSRedshiftClusterConfig_kmsKey = `
 resource "aws_kms_key" "foo" {
@@ -558,6 +654,7 @@ resource "aws_redshift_cluster" "default" {
   allow_version_upgrade = false
   kms_key_id = "${aws_kms_key.foo.arn}"
   encrypted = true
+  skip_final_snapshot = true
 }`
 
 var testAccAWSRedshiftClusterConfig_enhancedVpcRoutingEnabled = `
@@ -571,6 +668,7 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
   enhanced_vpc_routing = true
+  skip_final_snapshot = true
 }
 `
 
@@ -585,6 +683,7 @@ resource "aws_redshift_cluster" "default" {
   automated_snapshot_retention_period = 0
   allow_version_upgrade = false
   enhanced_vpc_routing = false
+  skip_final_snapshot = true
 }
 `
 
@@ -635,6 +734,7 @@ func testAccAWSRedshiftClusterConfig_loggingEnabled(rInt int) string {
 EOF
  }
 
+
  resource "aws_redshift_cluster" "default" {
 	 cluster_identifier = "tf-redshift-cluster-%d"
 	 availability_zone = "us-west-2a"
@@ -646,6 +746,7 @@ EOF
 	 allow_version_upgrade = false
 	 enable_logging = true
 	 bucket_name = "${aws_s3_bucket.bucket.bucket}"
+	 skip_final_snapshot = true
  }`, rInt, rInt, rInt, rInt)
 }
 
@@ -659,6 +760,7 @@ resource "aws_redshift_cluster" "default" {
   node_type = "dc1.large"
   automated_snapshot_retention_period = 7
   allow_version_upgrade = false
+  skip_final_snapshot = true
   tags {
     environment = "Production"
     cluster = "reader"
@@ -676,6 +778,7 @@ resource "aws_redshift_cluster" "default" {
   node_type = "dc1.large"
   automated_snapshot_retention_period = 7
   allow_version_upgrade = false
+  skip_final_snapshot = true
   tags {
     environment = "Production"
   }
@@ -732,6 +835,7 @@ func testAccAWSRedshiftClusterConfig_notPubliclyAccessible(rInt int) string {
 		allow_version_upgrade = false
 		cluster_subnet_group_name = "${aws_redshift_subnet_group.foo.name}"
 		publicly_accessible = false
+		skip_final_snapshot = true
 	}`, rInt, rInt)
 }
 
@@ -786,6 +890,7 @@ func testAccAWSRedshiftClusterConfig_updatePubliclyAccessible(rInt int) string {
 		allow_version_upgrade = false
 		cluster_subnet_group_name = "${aws_redshift_subnet_group.foo.name}"
 		publicly_accessible = true
+		skip_final_snapshot = true
 	}`, rInt, rInt)
 }
 
@@ -812,6 +917,7 @@ resource "aws_redshift_cluster" "default" {
    automated_snapshot_retention_period = 0
    allow_version_upgrade = false
    iam_roles = ["${aws_iam_role.ec2-role.arn}", "${aws_iam_role.lambda-role.arn}"]
+   skip_final_snapshot = true
 }`
 
 var testAccAWSRedshiftClusterConfig_updateIamRoles = `
@@ -837,4 +943,5 @@ resource "aws_iam_role" "ec2-role" {
    automated_snapshot_retention_period = 0
    allow_version_upgrade = false
    iam_roles = ["${aws_iam_role.ec2-role.arn}"]
+   skip_final_snapshot = true
  }`


### PR DESCRIPTION
This extends the work in #11668 to enable final snapshots by default.
This time it's for redshift

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftCluster_withFinalSnapshot'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/04 13:53:02 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftCluster_withFinalSnapshot -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_withFinalSnapshot
--- PASS: TestAccAWSRedshiftCluster_withFinalSnapshot (859.96s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	859.986s
```