### PR TITLE
validate aws_alb_target_group name is less than 32 characters

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group.go
@@ -37,9 +37,10 @@ func resourceAwsAlbTargetGroup() *schema.Resource {
 			},
 
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateAwsAlbTargetGroupName,
 			},
 
 			"port": {
@@ -433,6 +434,14 @@ func validateAwsAlbTargetGroupHealthCheckProtocol(v interface{}, k string) (ws [
 	}
 
 	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS"))
+	return
+}
+
+func validateAwsAlbTargetGroupName(v interface{}, k string) (ws []string, errors []error) {
+	name := v.(string)
+	if len(name) > 32 {
+		errors = append(errors, fmt.Errorf("%q (%q) cannot be longer than '32' characters", k, name))
+	}
 	return
 }
 


### PR DESCRIPTION
aws_alb_target_group.test: Error creating ALB Target Group: ValidationError: Target group name 'VeryLongGroupNameWhichCausesAnError' cannot be longer than '32' characters
    status code: 400, request id: cb020159-ea78-11e6-8546-15674f4fb6d2

I kept encountering this error during terraform apply and thought it would be better to validate that the field conforms to validation rules during plan. This PR adds a validation to the name field to ensure it is less than 32 characters.