### PR TITLE
Add Blue/Green Deployments to CodeDeploy DeploymentGroups.

### DIFF
--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -169,6 +169,7 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 			"load_balancer_info": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -77,6 +77,7 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 			"blue_green_deployment_config": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group.go
@@ -88,8 +88,9 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action_on_timeout": &schema.Schema{
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateDeploymentReadyOption,
 									},
 									"wait_time_in_minutes": &schema.Schema{
 										Type:     schema.TypeInt,
@@ -106,8 +107,9 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action": &schema.Schema{
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateGreenFleetProvisioningOption,
 									},
 								},
 							},
@@ -120,8 +122,9 @@ func resourceAwsCodeDeployDeploymentGroup() *schema.Resource {
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"action": &schema.Schema{
-										Type:     schema.TypeString,
-										Optional: true,
+										Type:         schema.TypeString,
+										Optional:     true,
+										ValidateFunc: validateBlueInstanceTerminationOption,
 									},
 									"termination_wait_time_in_minutes": &schema.Schema{
 										Type:     schema.TypeInt,
@@ -1032,6 +1035,45 @@ func validateDeploymentType(v interface{}, k string) (ws []string, errors []erro
 
 	if !validTypes[value] {
 		errors = append(errors, fmt.Errorf("%q must be a valid deployment type: %q", k, value))
+	}
+	return
+}
+
+func validateDeploymentReadyOption(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validOptions := map[string]bool{
+		"CONTINUE_DEPLOYMENT": true,
+		"STOP_DEPLOYMENT":     true,
+	}
+
+	if !validOptions[value] {
+		errors = append(errors, fmt.Errorf("%q must be a valid deployment_ready_option:action_on_timeout value: %q", k, value))
+	}
+	return
+}
+
+func validateGreenFleetProvisioningOption(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validOptions := map[string]bool{
+		"DISCOVER_EXISTING":       true,
+		"COPY_AUTO_SCALING_GROUP": true,
+	}
+
+	if !validOptions[value] {
+		errors = append(errors, fmt.Errorf("%q must be a valid green_fleet_provisioning_option:action value: %q", k, value))
+	}
+	return
+}
+
+func validateBlueInstanceTerminationOption(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	validOptions := map[string]bool{
+		"TERMINATE":  true,
+		"KEEP_ALIVE": true,
+	}
+
+	if !validOptions[value] {
+		errors = append(errors, fmt.Errorf("%q must be a valid terminate_blue_instances_on_deployment_success:action value: %q", k, value))
 	}
 	return
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -820,6 +820,170 @@ func skipTestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.
 	})
 }
 
+func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_create(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "0"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_create_with_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "COPY_AUTO_SCALING_GROUP"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_update_no_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "CONTINUE_DEPLOYMENT"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "KEEP_ALIVE"),
+				),
+			},
+		},
+	})
+}
+
+// TODO: Figure out why this test does not pass...
+// With no configuration, I would expect the remote resource to be deleted, except the previous state is returned
+func skipTestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete(t *testing.T) {
+	var group codedeploy.DeploymentGroupInfo
+
+	rName := acctest.RandString(5)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeDeployDeploymentGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_create_no_asg(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.action_on_timeout", "STOP_DEPLOYMENT"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.deployment_ready_option.0.wait_time_in_minutes", "60"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.green_fleet_provisioning_option.0.action", "DISCOVER_EXISTING"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.action", "TERMINATE"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.0.terminate_blue_instances_on_deployment_success.0.termination_wait_time_in_minutes", "120"),
+				),
+			},
+			resource.TestStep{
+				Config: test_config_blue_green_deployment_config_default(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -2068,5 +2232,126 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
   app_name = "${aws_codedeploy_app.foo_app.name}"
   deployment_group_name = "foo-group-%s"
   service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_blue_green_deployment_config_default(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_blue_green_deployment_config_create_with_asg(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_launch_configuration" "foo_lc" {
+  image_id = "ami-21f78e11"
+  instance_type = "t1.micro"
+  "name_prefix" = "foo-lc-"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_autoscaling_group" "foo_asg" {
+  name = "foo-asg-%s"
+  max_size = 2
+  min_size = 0
+  desired_capacity = 1
+
+  availability_zones = ["us-west-2a"]
+
+  launch_configuration = "${aws_launch_configuration.foo_lc.name}"
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  autoscaling_groups = ["${aws_autoscaling_group.foo_asg.name}"]
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "COPY_AUTO_SCALING_GROUP"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "TERMINATE"
+      termination_wait_time_in_minutes = 120
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName, rName)
+}
+
+func test_config_blue_green_deployment_config_create_no_asg(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "DISCOVER_EXISTING"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "TERMINATE"
+      termination_wait_time_in_minutes = 120
+    }
+  }
+}`, baseCodeDeployConfig(rName), rName)
+}
+
+func test_config_blue_green_deployment_config_update_no_asg(rName string) string {
+	return fmt.Sprintf(`
+
+  %s
+
+resource "aws_codedeploy_deployment_group" "foo_group" {
+  app_name = "${aws_codedeploy_app.foo_app.name}"
+  deployment_group_name = "foo-group-%s"
+  service_role_arn = "${aws_iam_role.foo_role.arn}"
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "CONTINUE_DEPLOYMENT"
+    }
+
+    green_fleet_provisioning_option {
+      action = "DISCOVER_EXISTING"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "KEEP_ALIVE"
+    }
+  }
 }`, baseCodeDeployConfig(rName), rName)
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -571,7 +571,7 @@ func TestAccAWSCodeDeployDeploymentGroup_alarmConfiguration_disable(t *testing.T
 	})
 }
 
-// by default, when no configuration is provided, a deploymentStyle object with default values is computed
+// When no configuration is provided, a deploymentStyle object with default values is computed
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
@@ -588,10 +588,10 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_default(t *testing.T) {
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
 				),
 			},
 		},
@@ -614,10 +614,10 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITHOUT_TRAFFIC_CONTROL"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "IN_PLACE"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
 				),
 			},
 			resource.TestStep{
@@ -674,7 +674,8 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_update(t *testing.T) {
 	})
 }
 
-// removing deployment_style from configuration does not trigger an update to the default state, but the previous state is retained...
+// Removing deployment_style from configuration does not trigger an update
+// to the default state, but the previous state is instead retained...
 func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
@@ -703,10 +704,10 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_delete(t *testing.T) {
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.#", "1"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
-					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option"),
+					resource.TestCheckResourceAttrSet(
+						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1586,7 +1586,7 @@ func TestAWSCodeDeployDeploymentGroup_validateDeploymentOption(t *testing.T) {
 	for _, tc := range cases {
 		_, errors := validateDeploymentOption(tc.Value, "deployment_option")
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("DeploymentOption validation failed for value %q: %q", tc.Value, errors)
+			t.Fatalf("deployment_option validation failed for value %q: %q", tc.Value, errors)
 		}
 	}
 }
@@ -1621,7 +1621,108 @@ func TestAWSCodeDeployDeploymentGroup_validateDeploymentType(t *testing.T) {
 	for _, tc := range cases {
 		_, errors := validateDeploymentType(tc.Value, "deployment_type")
 		if len(errors) != tc.ErrCount {
-			t.Fatalf("DeploymentType validation failed for value %q: %q", tc.Value, errors)
+			t.Fatalf("deployment_type validation failed for value %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateDeploymentReadyOption(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "CONTINUE_DEPLOYMENT",
+			ErrCount: 0,
+		},
+		{
+			Value:    "STOP_DEPLOYMENT",
+			ErrCount: 0,
+		},
+		{
+			Value:    "NOT_A_VALID_OPTION",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDeploymentReadyOption(tc.Value, "action_on_timeout")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("action_on_timeout validation failed for value %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateGreenFleetProvisioningOption(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "DISCOVER_EXISTING",
+			ErrCount: 0,
+		},
+		{
+			Value:    "COPY_AUTO_SCALING_GROUP",
+			ErrCount: 0,
+		},
+		{
+			Value:    "DISCOVER_AUTO_SCALING_GROUP",
+			ErrCount: 1,
+		},
+		{
+			Value:    "COPY_EXISTING_INSTANCES",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateGreenFleetProvisioningOption(tc.Value, "action")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("action validation failed for value %q: %q", tc.Value, errors)
+		}
+	}
+}
+
+func TestAWSCodeDeployDeploymentGroup_validateBlueInstanceTerminationOption(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "KEEP_ALIVE",
+			ErrCount: 0,
+		},
+		{
+			Value:    "TERMINATE",
+			ErrCount: 0,
+		},
+		{
+			Value:    "KEEP",
+			ErrCount: 1,
+		},
+		{
+			Value:    "STOP",
+			ErrCount: 1,
+		},
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateBlueInstanceTerminationOption(tc.Value, "action")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("action validation failed for value %q: %q", tc.Value, errors)
 		}
 	}
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -630,6 +630,13 @@ func TestAccAWSCodeDeployDeploymentGroup_deploymentStyle_create(t *testing.T) {
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_option", "WITH_TRAFFIC_CONTROL"),
 					resource.TestCheckResourceAttr(
 						"aws_codedeploy_deployment_group.foo_group", "deployment_style.0.deployment_type", "BLUE_GREEN"),
+
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.0.elb_info.2441772102.name", "foo-elb"),
 				),
 			},
 		},
@@ -2363,6 +2370,12 @@ resource "aws_codedeploy_deployment_group" "foo_group" {
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
     deployment_type = "BLUE_GREEN"
+  }
+
+  load_balancer_info {
+    elb_info {
+      name = "foo-elb"
+    }
   }
 }`, baseCodeDeployConfig(rName), rName)
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1260,20 +1260,20 @@ func TestLoadBalancerInfoToMap(t *testing.T) {
 func TestBuildBlueGreenDeploymentConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
-			"deployment_ready_option": []map[string]interface{}{
+			"deployment_ready_option": []interface{}{
 				map[string]interface{}{
 					"action_on_timeout":    "CONTINUE_DEPLOYMENT",
 					"wait_time_in_minutes": 60,
 				},
 			},
 
-			"green_fleet_provisioning_option": []map[string]interface{}{
+			"green_fleet_provisioning_option": []interface{}{
 				map[string]interface{}{
 					"action": "COPY_AUTO_SCALING_GROUP",
 				},
 			},
 
-			"terminate_blue_instances_on_deployment_success": []map[string]interface{}{
+			"terminate_blue_instances_on_deployment_success": []interface{}{
 				map[string]interface{}{
 					"action": "TERMINATE",
 					"termination_wait_time_in_minutes": 90,

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -1185,6 +1185,56 @@ func TestAutoRollbackConfigToMap(t *testing.T) {
 	}
 }
 
+func TestBuildDeploymentStyle(t *testing.T) {
+	input := []interface{}{
+		map[string]interface{}{
+			"deployment_option": "WITH_TRAFFIC_CONTROL",
+			"deployment_type":   "BLUE_GREEN",
+		},
+	}
+
+	expected := &codedeploy.DeploymentStyle{
+		DeploymentOption: aws.String("WITH_TRAFFIC_CONTROL"),
+		DeploymentType:   aws.String("BLUE_GREEN"),
+	}
+
+	actual := buildDeploymentStyle(input)
+
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("buildDeploymentStyle output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
+func TestDeploymentStyleToMap(t *testing.T) {
+	expected := map[string]interface{}{
+		"deployment_option": "WITHOUT_TRAFFIC_CONTROL",
+		"deployment_type":   "IN_PLACE",
+	}
+
+	input := &codedeploy.DeploymentStyle{
+		DeploymentOption: aws.String("WITHOUT_TRAFFIC_CONTROL"),
+		DeploymentType:   aws.String("IN_PLACE"),
+	}
+
+	actual := deploymentStyleToMap(input)[0]
+
+	fatal := false
+
+	if actual["deployment_option"] != expected["deployment_option"] {
+		fatal = true
+	}
+
+	if actual["deployment_type"] != expected["deployment_type"] {
+		fatal = true
+	}
+
+	if fatal {
+		t.Fatalf("deploymentStyleToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+			actual, expected)
+	}
+}
+
 func TestBuildLoadBalancerInfo(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
@@ -1252,7 +1302,7 @@ func TestLoadBalancerInfoToMap(t *testing.T) {
 	}
 
 	if fatal {
-		t.Fatalf("alarmConfigToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
+		t.Fatalf("loadBalancerInfoToMap output is not correct.\nGot:\n%#v\nExpected:\n%#v\n",
 			actual, expected)
 	}
 }

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -935,9 +935,9 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_update
 	})
 }
 
-// TODO: Figure out why this test does not pass...
-// With no configuration, I would expect the remote resource to be deleted, except the previous state is returned
-func skipTestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete(t *testing.T) {
+// Without "Computed: true" on blue_green_deployment_config, removing the resource
+// from configuration causes an error, becuase the remote resource still exists.
+func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
 	rName := acctest.RandString(5)
@@ -979,7 +979,7 @@ func skipTestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_de
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "0"),
+						"aws_codedeploy_deployment_group.foo_group", "blue_green_deployment_config.#", "1"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -986,7 +986,7 @@ func TestAccAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfiguration_delete
 	})
 }
 
-func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_validateAWSCodeDeployTriggerEvent(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -1049,7 +1049,7 @@ func TestValidateAWSCodeDeployTriggerEvent(t *testing.T) {
 	}
 }
 
-func TestBuildTriggerConfigs(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildTriggerConfigs(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"trigger_events": schema.NewSet(schema.HashString, []interface{}{
@@ -1078,7 +1078,7 @@ func TestBuildTriggerConfigs(t *testing.T) {
 	}
 }
 
-func TestTriggerConfigsToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_triggerConfigsToMap(t *testing.T) {
 	input := []*codedeploy.TriggerConfig{
 		&codedeploy.TriggerConfig{
 			TriggerEvents: []*string{
@@ -1123,7 +1123,7 @@ func TestTriggerConfigsToMap(t *testing.T) {
 	}
 }
 
-func TestBuildAutoRollbackConfig(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildAutoRollbackConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"events": schema.NewSet(schema.HashString, []interface{}{
@@ -1148,7 +1148,7 @@ func TestBuildAutoRollbackConfig(t *testing.T) {
 	}
 }
 
-func TestAutoRollbackConfigToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_autoRollbackConfigToMap(t *testing.T) {
 	input := &codedeploy.AutoRollbackConfiguration{
 		Events: []*string{
 			aws.String("DEPLOYMENT_FAILURE"),
@@ -1185,7 +1185,7 @@ func TestAutoRollbackConfigToMap(t *testing.T) {
 	}
 }
 
-func TestBuildDeploymentStyle(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildDeploymentStyle(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"deployment_option": "WITH_TRAFFIC_CONTROL",
@@ -1206,7 +1206,7 @@ func TestBuildDeploymentStyle(t *testing.T) {
 	}
 }
 
-func TestDeploymentStyleToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_deploymentStyleToMap(t *testing.T) {
 	expected := map[string]interface{}{
 		"deployment_option": "WITHOUT_TRAFFIC_CONTROL",
 		"deployment_type":   "IN_PLACE",
@@ -1235,7 +1235,7 @@ func TestDeploymentStyleToMap(t *testing.T) {
 	}
 }
 
-func TestBuildLoadBalancerInfo(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildLoadBalancerInfo(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"elb_info": schema.NewSet(elbInfoHash, []interface{}{
@@ -1268,7 +1268,7 @@ func TestBuildLoadBalancerInfo(t *testing.T) {
 	}
 }
 
-func TestLoadBalancerInfoToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_loadBalancerInfoToMap(t *testing.T) {
 	input := &codedeploy.LoadBalancerInfo{
 		ElbInfoList: []*codedeploy.ELBInfo{
 			{
@@ -1307,7 +1307,7 @@ func TestLoadBalancerInfoToMap(t *testing.T) {
 	}
 }
 
-func TestBuildBlueGreenDeploymentConfig(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildBlueGreenDeploymentConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"deployment_ready_option": []interface{}{
@@ -1356,7 +1356,7 @@ func TestBuildBlueGreenDeploymentConfig(t *testing.T) {
 	}
 }
 
-func TestBlueGreenDeploymentConfigToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_blueGreenDeploymentConfigToMap(t *testing.T) {
 	input := &codedeploy.BlueGreenDeploymentConfiguration{
 		DeploymentReadyOption: &codedeploy.DeploymentReadyOption{
 			ActionOnTimeout:   aws.String("STOP_DEPLOYMENT"),
@@ -1428,7 +1428,7 @@ func TestBlueGreenDeploymentConfigToMap(t *testing.T) {
 	}
 }
 
-func TestBuildAlarmConfig(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_buildAlarmConfig(t *testing.T) {
 	input := []interface{}{
 		map[string]interface{}{
 			"alarms": schema.NewSet(schema.HashString, []interface{}{
@@ -1457,7 +1457,7 @@ func TestBuildAlarmConfig(t *testing.T) {
 	}
 }
 
-func TestAlarmConfigToMap(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_alarmConfigToMap(t *testing.T) {
 	input := &codedeploy.AlarmConfiguration{
 		Alarms: []*codedeploy.Alarm{
 			{
@@ -1504,7 +1504,7 @@ func TestAlarmConfigToMap(t *testing.T) {
 	}
 }
 
-func TestValidateDeploymentOption(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_validateDeploymentOption(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -1535,7 +1535,7 @@ func TestValidateDeploymentOption(t *testing.T) {
 	}
 }
 
-func TestValidateDeploymentType(t *testing.T) {
+func TestAWSCodeDeployDeploymentGroup_validateDeploymentType(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int

--- a/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
+++ b/builtin/providers/aws/resource_aws_codedeploy_deployment_group_test.go
@@ -786,8 +786,9 @@ func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_update(t *testing.T) {
 	})
 }
 
-// TODO: Figure out why this test does not pass...
-func skipTestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
+// Without "Computed: true" on load_balancer_info, removing the resource
+// from configuration causes an error, becuase the remote resource still exists.
+func TestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.T) {
 	var group codedeploy.DeploymentGroupInfo
 
 	rName := acctest.RandString(5)
@@ -814,7 +815,7 @@ func skipTestAccAWSCodeDeployDeploymentGroup_loadBalancerInfo_delete(t *testing.
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeDeployDeploymentGroupExists("aws_codedeploy_deployment_group.foo_group", &group),
 					resource.TestCheckResourceAttr(
-						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "0"),
+						"aws_codedeploy_deployment_group.foo_group", "load_balancer_info.#", "1"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -15,6 +15,7 @@ Provides a CodeDeploy Deployment Group for a CodeDeploy Application
 ```hcl
 resource "aws_iam_role" "example" {
   name = "example-role"
+
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -35,6 +36,7 @@ EOF
 resource "aws_iam_role_policy" "example" {
   name = "example-policy"
   role = "${aws_iam_role.example.id}"
+
   policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -71,29 +73,29 @@ resource "aws_sns_topic" "example" {
 }
 
 resource "aws_codedeploy_deployment_group" "example" {
-  app_name = "${aws_codedeploy_app.example.name}"
+  app_name              = "${aws_codedeploy_app.example.name}"
   deployment_group_name = "example-group"
-  service_role_arn = "${aws_iam_role.example.arn}"
+  service_role_arn      = "${aws_iam_role.example.arn}"
 
   ec2_tag_filter {
-    key = "filterkey"
-    type = "KEY_AND_VALUE"
+    key   = "filterkey"
+    type  = "KEY_AND_VALUE"
     value = "filtervalue"
   }
 
   trigger_configuration {
-    trigger_events = ["DeploymentFailure"]
-    trigger_name = "example-trigger"
+    trigger_events     = ["DeploymentFailure"]
+    trigger_name       = "example-trigger"
     trigger_target_arn = "${aws_sns_topic.example.arn}"
   }
 
   auto_rollback_configuration {
     enabled = true
-    events = ["DEPLOYMENT_FAILURE"]
+    events  = ["DEPLOYMENT_FAILURE"]
   }
 
   alarm_configuration {
-    alarms = ["my-alarm-name"]
+    alarms  = ["my-alarm-name"]
     enabled = true
   }
 }
@@ -107,13 +109,13 @@ resource "aws_codedeploy_app" "example" {
 }
 
 resource "aws_codedeploy_deployment_group" "example" {
-  app_name = "${aws_codedeploy_app.example.name}"
+  app_name              = "${aws_codedeploy_app.example.name}"
   deployment_group_name = "example-group"
-  service_role_arn = "${aws_iam_role.example.arn}"
+  service_role_arn      = "${aws_iam_role.example.arn}"
 
   deployment_style {
     deployment_option = "WITH_TRAFFIC_CONTROL"
-    deployment_type = "BLUE_GREEN"
+    deployment_type   = "BLUE_GREEN"
   }
 
   load_balancer_info {
@@ -124,7 +126,7 @@ resource "aws_codedeploy_deployment_group" "example" {
 
   blue_green_deployment_config {
     deployment_ready_option {
-      action_on_timeout = "STOP_DEPLOYMENT"
+      action_on_timeout    = "STOP_DEPLOYMENT"
       wait_time_in_minutes = 60
     }
 

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -169,7 +169,7 @@ Both `ec2_tag_filter` and `on_premises_tag_filter` support the following:
 ### Trigger Configuration
 Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the **SNS** topic associated with the trigger. _CodeDeploy must have permission to publish to the topic from this deployment group_. `trigger_configuration` supports the following:
 
- * `trigger_events` - (Required) The event type or types for which notifications are triggered. Some values that are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.  See [the CodeDeploy documentation][1] for all possible values.
+ * `trigger_events` - (Required) The event type or types for which notifications are triggered. Some values that are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `DeploymentStop`, `DeploymentRollback`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.  See [the CodeDeploy documentation][1] for all possible values.
  * `trigger_name` - (Required) The name of the notification trigger.
  * `trigger_target_arn` - (Required) The ARN of the SNS topic through which notifications are sent.
 

--- a/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
+++ b/website/source/docs/providers/aws/r/codedeploy_deployment_group.html.markdown
@@ -8,47 +8,13 @@ description: |-
 
 # aws\_codedeploy\_deployment\_group
 
-Provides a CodeDeploy deployment group for an application
+Provides a CodeDeploy Deployment Group for a CodeDeploy Application
 
 ## Example Usage
 
 ```hcl
-resource "aws_codedeploy_app" "foo_app" {
-  name = "foo_app"
-}
-
-resource "aws_iam_role_policy" "foo_policy" {
-  name = "foo_policy"
-  role = "${aws_iam_role.foo_role.id}"
-
-  policy = <<EOF
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:CompleteLifecycleAction",
-                "autoscaling:DeleteLifecycleHook",
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:DescribeLifecycleHooks",
-                "autoscaling:PutLifecycleHook",
-                "autoscaling:RecordLifecycleActionHeartbeat",
-                "ec2:DescribeInstances",
-                "ec2:DescribeInstanceStatus",
-                "tag:GetTags",
-                "tag:GetResources"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-EOF
-}
-
-resource "aws_iam_role" "foo_role" {
-  name = "foo_role"
-
+resource "aws_iam_role" "example" {
+  name = "example-role"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -57,9 +23,7 @@ resource "aws_iam_role" "foo_role" {
       "Sid": "",
       "Effect": "Allow",
       "Principal": {
-        "Service": [
-          "codedeploy.amazonaws.com"
-        ]
+        "Service": "codedeploy.amazonaws.com"
       },
       "Action": "sts:AssumeRole"
     }
@@ -68,31 +32,109 @@ resource "aws_iam_role" "foo_role" {
 EOF
 }
 
-resource "aws_codedeploy_deployment_group" "foo" {
-  app_name              = "${aws_codedeploy_app.foo_app.name}"
-  deployment_group_name = "bar"
-  service_role_arn      = "${aws_iam_role.foo_role.arn}"
+resource "aws_iam_role_policy" "example" {
+  name = "example-policy"
+  role = "${aws_iam_role.example.id}"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "autoscaling:CompleteLifecycleAction",
+        "autoscaling:DeleteLifecycleHook",
+        "autoscaling:DescribeAutoScalingGroups",
+        "autoscaling:DescribeLifecycleHooks",
+        "autoscaling:PutLifecycleHook",
+        "autoscaling:RecordLifecycleActionHeartbeat",
+        "codedeploy:*",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "tag:GetTags",
+        "tag:GetResources",
+        "sns:Publish"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codedeploy_app" "example" {
+  name = "example-app"
+}
+
+resource "aws_sns_topic" "example" {
+  name = "example-topic"
+}
+
+resource "aws_codedeploy_deployment_group" "example" {
+  app_name = "${aws_codedeploy_app.example.name}"
+  deployment_group_name = "example-group"
+  service_role_arn = "${aws_iam_role.example.arn}"
 
   ec2_tag_filter {
-    key   = "filterkey"
-    type  = "KEY_AND_VALUE"
+    key = "filterkey"
+    type = "KEY_AND_VALUE"
     value = "filtervalue"
   }
 
   trigger_configuration {
-    trigger_events     = ["DeploymentFailure"]
-    trigger_name       = "foo-trigger"
-    trigger_target_arn = "foo-topic-arn"
+    trigger_events = ["DeploymentFailure"]
+    trigger_name = "example-trigger"
+    trigger_target_arn = "${aws_sns_topic.example.arn}"
   }
 
   auto_rollback_configuration {
     enabled = true
-    events  = ["DEPLOYMENT_FAILURE"]
+    events = ["DEPLOYMENT_FAILURE"]
   }
 
   alarm_configuration {
-    alarms  = ["my-alarm-name"]
+    alarms = ["my-alarm-name"]
     enabled = true
+  }
+}
+```
+
+### Using Blue Green Deployments
+
+```hcl
+resource "aws_codedeploy_app" "example" {
+  name = "example-app"
+}
+
+resource "aws_codedeploy_deployment_group" "example" {
+  app_name = "${aws_codedeploy_app.example.name}"
+  deployment_group_name = "example-group"
+  service_role_arn = "${aws_iam_role.example.arn}"
+
+  deployment_style {
+    deployment_option = "WITH_TRAFFIC_CONTROL"
+    deployment_type = "BLUE_GREEN"
+  }
+
+  load_balancer_info {
+    elb_info {
+      name = "example-elb"
+    }
+  }
+
+  blue_green_deployment_config {
+    deployment_ready_option {
+      action_on_timeout = "STOP_DEPLOYMENT"
+      wait_time_in_minutes = 60
+    }
+
+    green_fleet_provisioning_option {
+      action = "DISCOVER_EXISTING"
+    }
+
+    terminate_blue_instances_on_deployment_success {
+      action = "KEEP_ALIVE"
+    }
   }
 }
 ```
@@ -108,34 +150,107 @@ The following arguments are supported:
 * `deployment_config_name` - (Optional) The name of the group's deployment config. The default is "CodeDeployDefault.OneAtATime".
 * `ec2_tag_filter` - (Optional) Tag filters associated with the group. See the AWS docs for details.
 * `on_premises_instance_tag_filter` - (Optional) On premise tag filters associated with the group. See the AWS docs for details.
-* `trigger_configuration` - (Optional) A Trigger Configuration block. Trigger Configurations are documented below.
-* `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group, documented below.
-* `alarm_configuration` - (Optional) A list of alarms associated with the deployment group, documented below.
+* `trigger_configuration` - (Optional) A Trigger Configuration block (documented below).
+* `auto_rollback_configuration` - (Optional) The automatic rollback configuration associated with the deployment group (documented below).
+* `alarm_configuration` - (Optional) Information about alarms associated with the deployment group (documented below).
+* `deployment_style` - (Optional) Information about the type of deployment, either standard or blue/green, you want to run and whether to route deployment traffic behind a load balancer (documented below).
+* `load_balancer_info` - (Optional) Information about the load balancer to use in a blue/green deployment (documented below).
+* `blue_green_deployment_config` - (Optional) Information about blue/green deployment options for a deployment group (documented below).
 
-Both ec2_tag_filter and on_premises_tag_filter blocks support the following:
+### Tag Filters
+Both `ec2_tag_filter` and `on_premises_tag_filter` support the following:
 
 * `key` - (Optional) The key of the tag filter.
-* `type` - (Optional) The type of the tag filter, either KEY_ONLY, VALUE_ONLY, or KEY_AND_VALUE.
+* `type` - (Optional) The type of the tag filter, either `KEY_ONLY`, `VALUE_ONLY`, or `KEY_AND_VALUE`.
 * `value` - (Optional) The value of the tag filter.
 
-Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the SNS topic associated with the trigger. CodeDeploy must have permission to publish to the topic from this deployment group. Trigger Configurations support the following:
+### Trigger Configuration
+Add triggers to a Deployment Group to receive notifications about events related to deployments or instances in the group. Notifications are sent to subscribers of the **SNS** topic associated with the trigger. _CodeDeploy must have permission to publish to the topic from this deployment group_. `trigger_configuration` supports the following:
 
  * `trigger_events` - (Required) The event type or types for which notifications are triggered. Some values that are supported: `DeploymentStart`, `DeploymentSuccess`, `DeploymentFailure`, `InstanceStart`, `InstanceSuccess`, `InstanceFailure`.  See [the CodeDeploy documentation][1] for all possible values.
  * `trigger_name` - (Required) The name of the notification trigger.
  * `trigger_target_arn` - (Required) The ARN of the SNS topic through which notifications are sent.
 
-You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. Only one rollback configuration block is allowed.
+### Auto Rollback Configuration
+You can configure a deployment group to automatically rollback when a deployment fails or when a monitoring threshold you specify is met. In this case, the last known good version of an application revision is deployed. `auto_rollback_configuration` supports the following:
 
  * `enabled` - (Optional) Indicates whether a defined automatic rollback configuration is currently enabled for this Deployment Group. If you enable automatic rollback, you must specify at least one event type.
  * `events` - (Optional) The event type or types that trigger a rollback. Supported types are `DEPLOYMENT_FAILURE` and `DEPLOYMENT_STOP_ON_ALARM`.
 
-You can configure a deployment to stop when a CloudWatch alarm detects that a metric has fallen below or exceeded a defined threshold. Only one alarm configuration block is allowed.
+_Only one `auto_rollback_ configuration` block is allowed_.
 
- * `alarms` - (Optional) A list of alarms configured for the deployment group. A maximum of 10 alarms can be added to a deployment group.
+### Alarm Configuration
+You can configure a deployment to stop when a **CloudWatch** alarm detects that a metric has fallen below or exceeded a defined threshold. `alarm_configuration` supports the following:
+
+ * `alarms` - (Optional) A list of alarms configured for the deployment group. _A maximum of 10 alarms can be added to a deployment group_.
  * `enabled` - (Optional) Indicates whether the alarm configuration is enabled. This option is useful when you want to temporarily deactivate alarm monitoring for a deployment group without having to add the same alarms again later.
  * `ignore_poll_alarm_failure` - (Optional) Indicates whether a deployment should continue if information about the current state of alarms cannot be retrieved from CloudWatch. The default value is `false`.
     * `true`: The deployment will proceed even if alarm status information can't be retrieved.
     * `false`: The deployment will stop if alarm status information can't be retrieved.
+
+_Only one `alarm_configuration` block is allowed_.
+
+### Deployment Style
+You can configure the type of deployment, either standard or blue/green, you want to run and whether to route deployment traffic behind a load balancer. `deployment_style` supports the following:
+
+* `deployment_option` - (Optional) Indicates whether to route deployment traffic behind a load balancer. Valid Values are `WITH_TRAFFIC_CONTROL` or `WITHOUT_TRAFFIC_CONTROL`.
+
+* `deployment_type` - (Optional) Indicates whether to run a standard deployment or a blue/green deployment. Valid Values are `IN_PLACE` or `BLUE_GREEN`.
+
+  * `IN_PLACE` deployment type is not supported with the `WITH_TRAFFIC_CONTROL` deployment option.
+  * `BLUE_GREEN` deployment type is not supported with the `WITHOUT_TRAFFIC_CONTROL` deployment option.
+
+_Only one `deployment_style` block is allowed_.
+
+### Load Balancer Info
+You can configure the **Elastic Load Balancer** to use in a blue/green deployment. `load_balancer_info` supports the following:
+
+* `elb_info_list` - (Optional) The load balancers to use in a blue/green deployment.
+
+_Only one `load_balancer_info` block is allowed_.
+
+`elb_info_list` is a list of `elb_info`. `elb_info` supports the following:
+
+* `name` - (Optional) The name of the load balancer that will be used to route traffic from original instances to replacement instances in a blue/green deployment.
+
+_Only one `elb_info` block is supported at this time._
+
+### Blue Green Deployment Configuration
+You can configure options for a blue/green deployment. `blue_green_deployment_config` supports the following:
+
+* `deployment_ready_option` - (Optional) Information about the action to take when newly provisioned instances are ready to receive traffic in a blue/green deployment (documented below).
+
+* `green_fleet_provisioning_option` - (Optional) Information about how instances are provisioned for a replacement environment in a blue/green deployment (documented below).
+
+* `terminate_blue_instances_on_deployment_success` - (Optional) Information about whether to terminate instances in the original fleet during a blue/green deployment (documented below).
+
+_Only one `blue_green_deployment_config` block is allowed_.
+
+You can configure how traffic is rerouted to instances in a replacement environment in a blue/green deployment. `deployment_ready_option` supports the following:
+
+* `action_on_timeout` - (Optional) When to reroute traffic from an original environment to a replacement environment in a blue/green deployment.
+
+  * `CONTINUE_DEPLOYMENT`: Register new instances with the load balancer immediately after the new application revision is installed on the instances in the replacement environment.
+  * `STOP_DEPLOYMENT`: Do not register new instances with load balancer unless traffic is rerouted manually. If traffic is not rerouted manually before the end of the specified wait period, the deployment status is changed to Stopped.
+
+* `wait_time_in_minutes` - (Optional) The number of minutes to wait before the status of a blue/green deployment changed to Stopped if rerouting is not started manually. Applies only to the `STOP_DEPLOYMENT` option for `action_on_timeout`.
+
+You can configure how instances will be added to the replacement environment in a blue/green deployment. `green_fleet_provisioning_option` supports the following:
+
+* `action` - (Optional) The method used to add instances to a replacement environment.
+
+  * `DISCOVER_EXISTING`: Use instances that already exist or will be created manually.
+  * `COPY_AUTO_SCALING_GROUP`: Use settings from a specified **Auto Scaling** group to define and create instances in a new Auto Scaling group. _Exactly one Auto Scaling group must be specifed_ when selecting `COPY_AUTO_SCALING_GROUP`. Use `autoscaling_groups` to specify the Auto Scaling group.
+
+You can configure how instances in the original environment are terminated when a blue/green deployment is successful. `terminate_blue_instances_on_deployment_success` supports the following:
+
+* `action` - (Optional) The action to take on instances in the original environment after a successful blue/green deployment.
+
+  * `TERMINATE`: Instances are terminated after a specified wait time.
+
+  * `KEEP_ALIVE`: Instances are left running after they are deregistered from the load balancer and removed from the deployment group.
+
+* `termination_wait_time_in_minutes` - (Optional) The number of minutes to wait after a successful blue/green deployment before terminating instances from the original environment.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR has been migrated here: https://github.com/terraform-providers/terraform-provider-aws/pull/1162

### TODO:

Changes to the `aws_codedeploy_deployment_group` resource:

 * [x] Add `deployment_style`.
 * [x] Add `load_balancer_info`.
 * [x] Add `blue_green_deployment_config`.
 * [x] Refactoring...
 * [x] Update Documentation.
 * [x] Add Tests for `buildDeploymentStyle` and `deploymentStyleToMap`
 * [x] Consider prefixing all build/map/validation tests so none are missed.
 * [x] Write a complete test for a blue green deployment scenario that includes all three resources.
 * [x] Verify that the documented configurations are valid (DONE, tests not committed).
 * [x] Consider adding validation checks for `blue_green_deployment_config` values.
 