### PR TITLE
provider/aws: ignore NoEcho parameters in diff

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack.go
@@ -67,6 +67,10 @@ func resourceAwsCloudFormationStack() *schema.Resource {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// ignore NoEcho parameters
+					return old == "****"
+				},
 			},
 			"outputs": &schema.Schema{
 				Type:     schema.TypeMap,


### PR DESCRIPTION
Hi there - this ignores NoEcho params when determining if a CFN stack should be updated - fixes:

https://github.com/hashicorp/terraform/issues/4335

I thought about parsing the ```template_body``` to really see if a parameter has been set to ```NoEcho``` but since ```template_url``` could also be specified it seems pretty heavy-handed to potentially pull down the template and then parse it for each compared parameter.