### PR TITLE
Remove error on empty outputs when `-json` is set

### DIFF
--- a/command/output.go
+++ b/command/output.go
@@ -75,7 +75,7 @@ func (c *OutputCommand) Run(args []string) int {
 		return 1
 	}
 
-	if state.Empty() || len(mod.Outputs) == 0 {
+	if !jsonOutput && (state.Empty() || len(mod.Outputs) == 0) {
 		c.Ui.Error(
 			"The state file either has no outputs defined, or all the defined\n" +
 				"outputs are empty. Please define an output in your configuration\n" +

--- a/command/output_test.go
+++ b/command/output_test.go
@@ -236,6 +236,69 @@ func TestOutput_json(t *testing.T) {
 	}
 }
 
+func TestOutput_emptyOutputsErr(t *testing.T) {
+	originalState := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			{
+				Path:    []string{"root"},
+				Outputs: map[string]*terraform.OutputState{},
+			},
+		},
+	}
+
+	statePath := testStateFile(t, originalState)
+
+	ui := new(cli.MockUi)
+	c := &OutputCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+	}
+	if code := c.Run(args); code != 1 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+}
+
+func TestOutput_jsonEmptyOutputs(t *testing.T) {
+	originalState := &terraform.State{
+		Modules: []*terraform.ModuleState{
+			{
+				Path:    []string{"root"},
+				Outputs: map[string]*terraform.OutputState{},
+			},
+		},
+	}
+
+	statePath := testStateFile(t, originalState)
+
+	ui := new(cli.MockUi)
+	c := &OutputCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-state", statePath,
+		"-json",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	actual := strings.TrimSpace(ui.OutputWriter.String())
+	expected := "{}"
+	if actual != expected {
+		t.Fatalf("bad:\n%#v\n%#v", expected, actual)
+	}
+}
+
 func TestMissingModuleOutput(t *testing.T) {
 	originalState := &terraform.State{
 		Modules: []*terraform.ModuleState{


### PR DESCRIPTION
- Fixes https://github.com/hashicorp/terraform/issues/11696
- This changes makes `terraform output -json` return '{}' instead of
  throwing an error about "no outputs defined"
- If `-json` is not set, the user will receive an error as before
  - This UX helps new users to understand how outputs are used
- Allows for easier automation of TF CLI as an empty set of outputs is
  usually acceptable, but any other error from `output` would be
  re-raised to the user.