### PR TITLE
providers/google: Fix google_project IAM bug

### DIFF
--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -196,20 +196,6 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("org_id", p.Parent.Id)
 	}
 
-	// Read the IAM policy
-	pol, err := getProjectIamPolicy(pid, config)
-	if err != nil {
-		return err
-	}
-
-	polBytes, err := json.Marshal(pol)
-	if err != nil {
-		return err
-	}
-
-	d.Set("policy_etag", pol.Etag)
-	d.Set("policy_data", string(polBytes))
-
 	return nil
 }
 


### PR DESCRIPTION
This changes removes read of the deprecated `policy_data` attr in
the `google_project` resource.

0.8.5 introduced new behavior that incorrectly read the `policy_data`
field during the read lifecycle event. This caused Terraform to
assume it owned not just policy defined in the data source, but
everything that was associated with the project. Migrating from 0.8.4
to 0.8.5, this would cause the config (partial) to be compared to the
state (complete, as it was read from the API) and assume some
policies had been explicitly deleted. Terraform would then delete them.

Fixes #11556