### PR TITLE
provider/aws: Fix aws_db_event_subscription acceptance test

### DIFF
--- a/builtin/providers/aws/import_aws_db_event_subscription_test.go
+++ b/builtin/providers/aws/import_aws_db_event_subscription_test.go
@@ -3,22 +3,24 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSDBEventSubscription_importBasic(t *testing.T) {
 	resourceName := "aws_db_event_subscription.bar"
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSDBEventSubscriptionConfig,
+			{
+				Config: testAccAWSDBEventSubscriptionConfig(rInt),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/aws/resource_aws_db_event_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_db_event_subscription_test.go
@@ -7,20 +7,22 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/rds"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 	var v rds.EventSubscription
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSDBEventSubscriptionConfig,
+			{
+				Config: testAccAWSDBEventSubscriptionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -28,13 +30,13 @@ func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_event_subscription.bar", "source_type", "db-instance"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "name", "tf-acc-test-rds-event-subs"),
+						"aws_db_event_subscription.bar", "name", fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"aws_db_event_subscription.bar", "tags.Name", "name"),
 				),
 			},
-			resource.TestStep{
-				Config: testAccAWSDBEventSubscriptionConfigUpdate,
+			{
+				Config: testAccAWSDBEventSubscriptionConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -51,14 +53,15 @@ func TestAccAWSDBEventSubscription_basicUpdate(t *testing.T) {
 
 func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 	var v rds.EventSubscription
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBEventSubscriptionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSDBEventSubscriptionConfigWithSourceIds,
+			{
+				Config: testAccAWSDBEventSubscriptionConfigWithSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -66,13 +69,13 @@ func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "name", "tf-acc-test-rds-event-subs-with-ids"),
+						"aws_db_event_subscription.bar", "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"aws_db_event_subscription.bar", "source_ids.#", "1"),
 				),
 			},
-			resource.TestStep{
-				Config: testAccAWSDBEventSubscriptionConfigUpdateSourceIds,
+			{
+				Config: testAccAWSDBEventSubscriptionConfigUpdateSourceIds(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBEventSubscriptionExists("aws_db_event_subscription.bar", &v),
 					resource.TestCheckResourceAttr(
@@ -80,7 +83,7 @@ func TestAccAWSDBEventSubscription_withSourceIds(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_event_subscription.bar", "source_type", "db-parameter-group"),
 					resource.TestCheckResourceAttr(
-						"aws_db_event_subscription.bar", "name", "tf-acc-test-rds-event-subs-with-ids"),
+						"aws_db_event_subscription.bar", "name", fmt.Sprintf("tf-acc-test-rds-event-subs-with-ids-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"aws_db_event_subscription.bar", "source_ids.#", "2"),
 				),
@@ -160,13 +163,14 @@ func testAccCheckAWSDBEventSubscriptionDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAWSDBEventSubscriptionConfig = `
+func testAccAWSDBEventSubscriptionConfig(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
 resource "aws_db_event_subscription" "bar" {
-  name = "tf-acc-test-rds-event-subs"
+  name = "tf-acc-test-rds-event-subs-%d"
   sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-instance"
   event_categories = [
@@ -179,16 +183,17 @@ resource "aws_db_event_subscription" "bar" {
   tags {
     Name = "name"
   }
+}`, rInt, rInt)
 }
-`
 
-var testAccAWSDBEventSubscriptionConfigUpdate = `
+func testAccAWSDBEventSubscriptionConfigUpdate(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
 resource "aws_db_event_subscription" "bar" {
-  name = "tf-acc-test-rds-event-subs"
+  name = "tf-acc-test-rds-event-subs-%d"
   sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
   enabled = false
   source_type = "db-parameter-group"
@@ -198,22 +203,23 @@ resource "aws_db_event_subscription" "bar" {
   tags {
     Name = "new-name"
   }
+}`, rInt, rInt)
 }
-`
 
-var testAccAWSDBEventSubscriptionConfigWithSourceIds = `
+func testAccAWSDBEventSubscriptionConfigWithSourceIds(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic"
+  name = "tf-acc-test-rds-event-subs-sns-topic-%d"
 }
 
 resource "aws_db_parameter_group" "bar" {
-  name = "db-parameter-group-event-1"
+  name = "db-parameter-group-event-%d"
   family = "mysql5.6"
   description = "Test parameter group for terraform"
 }
 
 resource "aws_db_event_subscription" "bar" {
-  name = "tf-acc-test-rds-event-subs-with-ids"
+  name = "tf-acc-test-rds-event-subs-with-ids-%d"
   sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
   source_type = "db-parameter-group"
   source_ids = ["${aws_db_parameter_group.bar.id}"]
@@ -223,36 +229,37 @@ resource "aws_db_event_subscription" "bar" {
   tags {
     Name = "name"
   }
-}
-`
-
-var testAccAWSDBEventSubscriptionConfigUpdateSourceIds = `
-resource "aws_sns_topic" "aws_sns_topic" {
-  name = "tf-acc-test-rds-event-subs-sns-topic"
+}`, rInt, rInt, rInt)
 }
 
-resource "aws_db_parameter_group" "bar" {
-  name = "db-parameter-group-event-1"
-  family = "mysql5.6"
-  description = "Test parameter group for terraform"
-}
+func testAccAWSDBEventSubscriptionConfigUpdateSourceIds(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_sns_topic" "aws_sns_topic" {
+		name = "tf-acc-test-rds-event-subs-sns-topic-%d"
+	}
 
-resource "aws_db_parameter_group" "foo" {
-  name = "db-parameter-group-event-2"
-  family = "mysql5.6"
-  description = "Test parameter group for terraform"
-}
+	resource "aws_db_parameter_group" "bar" {
+		name = "db-parameter-group-event-%d"
+		family = "mysql5.6"
+		description = "Test parameter group for terraform"
+	}
 
-resource "aws_db_event_subscription" "bar" {
-  name = "tf-acc-test-rds-event-subs-with-ids"
-  sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
-  source_type = "db-parameter-group"
-  source_ids = ["${aws_db_parameter_group.bar.id}","${aws_db_parameter_group.foo.id}"]
-  event_categories = [
-    "configuration change"
-  ]
-  tags {
-    Name = "name"
-  }
+	resource "aws_db_parameter_group" "foo" {
+		name = "db-parameter-group-event-2-%d"
+		family = "mysql5.6"
+		description = "Test parameter group for terraform"
+	}
+
+	resource "aws_db_event_subscription" "bar" {
+		name = "tf-acc-test-rds-event-subs-with-ids-%d"
+		sns_topic = "${aws_sns_topic.aws_sns_topic.arn}"
+		source_type = "db-parameter-group"
+		source_ids = ["${aws_db_parameter_group.bar.id}","${aws_db_parameter_group.foo.id}"]
+		event_categories = [
+			"configuration change"
+		]
+		tags {
+			Name = "name"
+		}
+	}`, rInt, rInt, rInt, rInt)
 }
-`


### PR DESCRIPTION
Fixes the `TestAccAWSDBEventSubscription_basicUpdate` acceptance test

`TestAccAWSDBEventSubscription_importBasic` is still failing, but has been failing since November.