### PR TITLE
terraform: default shadow to false

### DIFF
--- a/helper/experiment/experiment.go
+++ b/helper/experiment/experiment.go
@@ -52,7 +52,7 @@ import (
 var (
 	// Shadow graph. This is already on by default. Disabling it will be
 	// allowed for awhile in order for it to not block operations.
-	X_shadow = newBasicID("shadow", "SHADOW", true)
+	X_shadow = newBasicID("shadow", "SHADOW", false)
 )
 
 // Global variables this package uses because we are a package

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -748,19 +748,20 @@ func (c *Context) walk(
 		shadow = nil
 	}
 
+	// Just log this so we can see it in a debug log
+	if !c.shadow {
+		log.Printf("[WARN] terraform: shadow graph disabled")
+		shadow = nil
+	}
+
 	// If we have a shadow graph, walk that as well
 	var shadowCtx *Context
 	var shadowCloser Shadow
-	if c.shadow && shadow != nil {
+	if shadow != nil {
 		// Build the shadow context. In the process, override the real context
 		// with the one that is wrapped so that the shadow context can verify
 		// the results of the real.
 		realCtx, shadowCtx, shadowCloser = newShadowContext(c)
-	}
-
-	// Just log this so we can see it in a debug log
-	if !c.shadow {
-		log.Printf("[WARN] terraform: shadow graph disabled")
 	}
 
 	log.Printf("[DEBUG] Starting graph walk: %s", operation.String())

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -23,6 +23,10 @@ import (
 const fixtureDir = "./test-fixtures"
 
 func TestMain(m *testing.M) {
+	// We want to shadow on tests just to make sure the shadow graph works
+	// in case we need it and to find any race issues.
+	experiment.SetEnabled(experiment.X_shadow, true)
+
 	experiment.Flag(flag.CommandLine)
 	flag.Parse()
 


### PR DESCRIPTION
To avoid chasing down issues like #11635 I'm proposing we disable the
shadow graph for end users now that we have merged in all the new
graphs. I've kept it around and default-on for tests so that we can use
it to test new features as we build them. I think it'll still have value
going forward but I don't want to hold us for making it work 100% with
all of Terraform at all times.

I propose backporting this to 0-8-stable, too.