### PR TITLE
Revert backwards incompatibility in google_project.policy_data

### DIFF
--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -196,20 +196,6 @@ func resourceGoogleProjectRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("org_id", p.Parent.Id)
 	}
 
-	// Read the IAM policy
-	pol, err := getProjectIamPolicy(pid, config)
-	if err != nil {
-		return err
-	}
-
-	polBytes, err := json.Marshal(pol)
-	if err != nil {
-		return err
-	}
-
-	d.Set("policy_etag", pol.Etag)
-	d.Set("policy_data", string(polBytes))
-
 	return nil
 }
 

--- a/builtin/providers/google/resource_google_project_test.go
+++ b/builtin/providers/google/resource_google_project_test.go
@@ -48,6 +48,34 @@ func TestAccGoogleProject_create(t *testing.T) {
 	})
 }
 
+// Test that a Project resource merges the IAM policies that already
+// exist, and won't lock people out.
+func TestAccGoogleProject_merge(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// when policy_data is set, merge
+			{
+				Config: testAccGoogleProject_toMerge(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+					testAccCheckGoogleProjectHasMoreBindingsThan(pid, 1),
+				),
+			},
+			// when policy_data is unset, restore to what it was
+			{
+				Config: testAccGoogleProject_mergeEmpty(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+					testAccCheckGoogleProjectHasMoreBindingsThan(pid, 0),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckGoogleProjectExists(r, pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[r]
@@ -63,6 +91,19 @@ func testAccCheckGoogleProjectExists(r, pid string) resource.TestCheckFunc {
 			return fmt.Errorf("Expected project %q to match ID %q in state", pid, rs.Primary.ID)
 		}
 
+		return nil
+	}
+}
+
+func testAccCheckGoogleProjectHasMoreBindingsThan(pid string, count int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		policy, err := getProjectIamPolicy(pid, testAccProvider.Meta().(*Config))
+		if err != nil {
+			return err
+		}
+		if len(policy.Bindings) <= count {
+			return fmt.Errorf("Expected more than %d bindings, got %d: %#v", count, len(policy.Bindings), policy.Bindings)
+		}
 		return nil
 	}
 }
@@ -97,4 +138,32 @@ data "google_iam_policy" "admin" {
     ]
   }
 }`, pid)
+}
+
+func testAccGoogleProject_toMerge(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+    policy_data = "${data.google_iam_policy.acceptance.policy_data}"
+}
+
+data "google_iam_policy" "acceptance" {
+    binding {
+        role = "roles/storage.objectViewer"
+	members = [
+	  "user:evanbrown@google.com",
+	]
+    }
+}`, pid, name, org)
+}
+
+func testAccGoogleProject_mergeEmpty(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+}`, pid, name, org)
 }


### PR DESCRIPTION
For 0.8.5, we introduced a backwards incompatibility in the `google_project` resource on accident. The `policy_data` attribute, rather than being merged with whatever was set on the project, now overwrote it entirely. This reverts that unintentional change by not recording `policy_data` in state. See #11556 for more detailed analysis. This also adds a test that would have caught the backwards incompatibility.

Output with test before fix:

```
make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccGoogleProject_merge'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/06 22:01:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccGoogleProject_merge -timeout 120m
=== RUN   TestAccGoogleProject_merge
--- FAIL: TestAccGoogleProject_merge (18.73s)
	testing.go:265: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: google_project.acceptance
		  policy_data: "{\"bindings\":[{\"members\":[\"serviceAccount:terraform-acceptance-tests@hc-terraform-testing.iam.gserviceaccount.com\"],\"role\":\"roles/owner\"},{\"members\":[\"user:evanbrown@google.com\"],\"role\":\"roles/storage.objectViewer\"}],\"etag\":\"BwVH6nxEBFM=\",\"version\":1}" => "{\"bindings\":[{\"members\":[\"user:evanbrown@google.com\"],\"role\":\"roles/storage.objectViewer\"}]}"

		STATE:

		data.google_iam_policy.acceptance:
		  ID = 574982951
		  binding.# = 1
		  binding.3022625951.members.# = 1
		  binding.3022625951.members.2619455798 = user:evanbrown@google.com
		  binding.3022625951.role = roles/storage.objectViewer
		  policy_data = {"bindings":[{"members":["user:evanbrown@google.com"],"role":"roles/storage.objectViewer"}]}
		google_project.acceptance:
		  ID = terraform-imb7onf6n6
		  name = Terraform Acceptance Tests
		  number = 453549873197
		  org_id = 622235425790
		  policy_data = {"bindings":[{"members":["serviceAccount:terraform-acceptance-tests@hc-terraform-testing.iam.gserviceaccount.com"],"role":"roles/owner"},{"members":["user:evanbrown@google.com"],"role":"roles/storage.objectViewer"}],"etag":"BwVH6nxEBFM=","version":1}
		  policy_etag = BwVH6nxEBFM=
		  project_id = terraform-imb7onf6n6

		  Dependencies:
		    data.google_iam_policy.acceptance
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/google	18.755s
```

Output after fix:

```
make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccGoogleProject_merge'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/06 22:03:44 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccGoogleProject_merge -timeout 120m
=== RUN   TestAccGoogleProject_merge
--- PASS: TestAccGoogleProject_merge (16.80s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	16.818s
```

The fix is @evandbrown's and comes from #11728, but I couldn't push to that branch, and wanted to add an acceptance test. And we were short on time. :)

Fixes #11556 