### PR TITLE
provider/aws: Fix nil pointer crash in resource_aws_codebuild_project

### DIFF
--- a/builtin/providers/aws/resource_aws_codebuild_project.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project.go
@@ -588,7 +588,7 @@ func sourceAuthToMap(sourceAuth *codebuild.SourceAuth) map[string]interface{} {
 	auth := map[string]interface{}{}
 	auth["type"] = *sourceAuth.Type
 
-	if sourceAuth.Type != nil {
+	if sourceAuth.Resource != nil {
 		auth["resource"] = *sourceAuth.Resource
 	}
 


### PR DESCRIPTION
Fixes the following crash
```
2017/02/07 10:43:34 [DEBUG] plugin: terraform: panic: runtime error: invalid memory address or nil pointer dereference
2017/02/07 10:43:34 [DEBUG] plugin: terraform: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x461d52]
2017/02/07 10:43:34 [DEBUG] plugin: terraform:
2017/02/07 10:43:34 [DEBUG] plugin: terraform: goroutine 1270 [running]:
2017/02/07 10:43:34 [DEBUG] plugin: terraform: panic(0x3203d00, 0xc4200140d0)
2017/02/07 10:43:34 [DEBUG] plugin: terraform:  /usr/local/Cellar/go/1.7.4_1/libexec/src/runtime/panic.go:500 +0x1a1
2017/02/07 10:43:34 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/aws.flattenAwsCodebuildProjectSource(0xc422154980, 0x1c)
2017/02/07 10:43:34 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_codebuild_project.go:512 +0x3d2
```