### PR TITLE
provider/aws: Use proper Set for source.Auth in resource_aws_codebuild_project

### DIFF
--- a/builtin/providers/aws/resource_aws_codebuild_project.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project.go
@@ -503,12 +503,17 @@ func flattenAwsCodebuildProjectSource(source *codebuild.ProjectSource) *schema.S
 		F: resourceAwsCodeBuildProjectSourceHash,
 	}
 
+	authSet := schema.Set{
+		F: resourceAwsCodeBuildProjectSourceAuthHash,
+	}
+
 	sourceConfig := map[string]interface{}{}
 
 	sourceConfig["type"] = *source.Type
 
 	if source.Auth != nil {
-		sourceConfig["auth"] = sourceAuthToMap(source.Auth)
+		authSet.Add(sourceAuthToMap(source.Auth))
+		sourceConfig["auth"] = &authSet
 	}
 
 	if source.Buildspec != nil {
@@ -562,6 +567,19 @@ func resourceAwsCodeBuildProjectSourceHash(v interface{}) int {
 	buf.WriteString(fmt.Sprintf("%s-", sourceType))
 	buf.WriteString(fmt.Sprintf("%s-", buildspec))
 	buf.WriteString(fmt.Sprintf("%s-", location))
+
+	return hashcode.String(buf.String())
+}
+
+func resourceAwsCodeBuildProjectSourceAuthHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+
+	authType := m["type"].(string)
+	authResource := m["resource"].(string)
+
+	buf.WriteString(fmt.Sprintf("%s-", authType))
+	buf.WriteString(fmt.Sprintf("%s-", authResource))
 
 	return hashcode.String(buf.String())
 }

--- a/builtin/providers/aws/resource_aws_codebuild_project_test.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project_test.go
@@ -355,6 +355,10 @@ resource "aws_codebuild_project" "foo" {
   }
 
   source {
+    auth {
+      type = "OAUTH"
+    }
+
     type     = "GITHUB"
     location = "https://github.com/mitchellh/packer.git"
   }


### PR DESCRIPTION
The code was trying to store the auth part of the source as a map[string]interface{} but it was a TypeSet in the schema.
```
2017/02/07 13:51:00 [DEBUG] plugin: terraform: panic: interface conversion: interface {} is map[string]interface {}, not *schema.Set
2017/02/07 13:51:00 [DEBUG] plugin: terraform:
2017/02/07 13:51:00 [DEBUG] plugin: terraform: goroutine 1615 [running]:
2017/02/07 13:51:00 [DEBUG] plugin: terraform: panic(0x32591a0, 0xc4223d5fc0)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /usr/local/Cellar/go/1.7.4_1/libexec/src/runtime/panic.go:500 +0x1a1
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setSet(0xc4247e6660, 0xc42017b710, 0x3, 0x3, 0x31d38e0, 0xc42017b650, 0xc422d13c20, 0x0, 0x1)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:311 +0x4ca
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).set(0xc4247e6660, 0xc42017b710, 0x3, 0x3, 0x31d38e0, 0xc42017b650, 0x0, 0x0)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:94 +0x404
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setObject(0xc4247e6660, 0xc4247e6be0, 0x2, 0x2, 0x31d38e0, 0xc42017b620, 0xc4242620f0, 0xc42017b680, 0xc42425d320)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:200 +0x245
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).set(0xc4247e6660, 0xc4247e6be0, 0x2, 0x2, 0x31d38e0, 0xc42017b620, 0x6, 0x1)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:96 +0x383
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).setSet(0xc4247e6660, 0xc422e9ef10, 0x1, 0x1, 0x37eb120, 0xc4247e6bc0, 0xc422d14690, 0x1, 0x6)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:312 +0x2b7
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).set(0xc4247e6660, 0xc422e9ef10, 0x1, 0x1, 0x37eb120, 0xc4247e6bc0, 0x1, 0x0)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:94 +0x404
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*MapFieldWriter).WriteField(0xc4247e6660, 0xc422e9ef10, 0x1, 0x1, 0x37eb120, 0xc4247e6bc0, 0x0, 0x0)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/field_writer_map.go:76 +0x182
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*ResourceData).Set(0xc42454c540, 0x3953e1d, 0x6, 0x37eb120, 0xc4247e6bc0, 0x0, 0x0)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/helper/schema/resource_data.go:169 +0x13a
2017/02/07 13:51:00 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsCodeBuildProjectRead(0xc42454c540, 0x2dc03a0, 0xc422a44380, 0x0, 0x15)
2017/02/07 13:51:00 [DEBUG] plugin: terraform:  /Users/ejansson/.go/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_codebuild_project.go:364 +0x2b1

```
Not 100% sure this is the proper way to fix this.