### PR TITLE
provider/aws: Fix aws_db_event_subscription import

### DIFF
--- a/builtin/providers/aws/import_aws_db_event_subscription.go
+++ b/builtin/providers/aws/import_aws_db_event_subscription.go
@@ -1,0 +1,17 @@
+package aws
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func resourceAwsDbEventSubscriptionImport(
+	d *schema.ResourceData,
+	meta interface{}) ([]*schema.ResourceData, error) {
+
+	// The db event subscription Read function only needs the "name" of the event subscription
+	// in order to populate the necessary values. This takes the "id" from the supplied StateFunc
+	// and sets it as the "name" attribute, as described in the import documentation. This allows
+	// the Read function to actually succeed and set the ID of the resource
+	results := make([]*schema.ResourceData, 1, 1)
+	d.Set("name", d.Id())
+	results[0] = d
+	return results, nil
+}

--- a/builtin/providers/aws/import_aws_db_event_subscription_test.go
+++ b/builtin/providers/aws/import_aws_db_event_subscription_test.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -10,6 +11,7 @@ import (
 func TestAccAWSDBEventSubscription_importBasic(t *testing.T) {
 	resourceName := "aws_db_event_subscription.bar"
 	rInt := acctest.RandInt()
+	subscriptionName := fmt.Sprintf("tf-acc-test-rds-event-subs-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,6 +26,7 @@ func TestAccAWSDBEventSubscription_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateId:     subscriptionName,
 			},
 		},
 	})

--- a/builtin/providers/aws/resource_aws_db_event_subscription.go
+++ b/builtin/providers/aws/resource_aws_db_event_subscription.go
@@ -19,26 +19,26 @@ func resourceAwsDbEventSubscription() *schema.Resource {
 		Update: resourceAwsDbEventSubscriptionUpdate,
 		Delete: resourceAwsDbEventSubscriptionDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			State: resourceAwsDbEventSubscriptionImport,
 		},
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:         schema.TypeString,
 				Required:     true,
 				ForceNew:     true,
 				ValidateFunc: validateDbEventSubscriptionName,
 			},
-			"sns_topic": &schema.Schema{
+			"sns_topic": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"event_categories": &schema.Schema{
+			"event_categories": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"source_ids": &schema.Schema{
+			"source_ids": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -46,16 +46,16 @@ func resourceAwsDbEventSubscription() *schema.Resource {
 				// ValidateFunc: validateDbEventSubscriptionSourceIds,
 				// requires source_type to be set, does not seem to be a way to validate this
 			},
-			"source_type": &schema.Schema{
+			"source_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
-			"customer_aws_id": &schema.Schema{
+			"customer_aws_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},


### PR DESCRIPTION
Previously the db_event_subscription import would only work if there was a single db_event_subscription resource. This fixes the import, allowing it to work as expected.

Also fixes the acceptance test for the resource to reflect this.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBEventSubscription_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/07 10:38:10 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBEventSubscription_importBasic -timeout 120m
=== RUN   TestAccAWSDBEventSubscription_importBasic
--- PASS: TestAccAWSDBEventSubscription_importBasic (633.33s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    633.353s
```