### PR TITLE
Fix aws_lambda_function attributes when more than 50 versions

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -354,9 +354,9 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 			last := p.Versions[len(p.Versions)-1]
 			lastVersion = *last.Version
 			lastQualifiedArn = *last.FunctionArn
-			return true
+			return false
 		}
-		return false
+		return true
 	})
 	if err != nil {
 		return err
@@ -381,6 +381,7 @@ func listVersionsByFunctionPages(c *lambda.Lambda, input *lambda.ListVersionsByF
 		if !shouldContinue || lastPage {
 			break
 		}
+		input.Marker = page.NextMarker
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes the version and qualified_arn attributes, when the lambda
function has more than 50 versions.

Closes #11720