### PR TITLE
command: tests should move to temporary cwd

### DIFF
--- a/command/get_test.go
+++ b/command/get_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestGet(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	ui := new(cli.MockUi)
 	c := &GetCommand{
 		Meta: Meta{
@@ -87,6 +90,9 @@ func TestGet_noArgs(t *testing.T) {
 }
 
 func TestGet_update(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	ui := new(cli.MockUi)
 	c := &GetCommand{
 		Meta: Meta{

--- a/command/graph_test.go
+++ b/command/graph_test.go
@@ -10,6 +10,9 @@ import (
 )
 
 func TestGraph(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	ui := new(cli.MockUi)
 	c := &GraphCommand{
 		Meta: Meta{
@@ -79,6 +82,9 @@ func TestGraph_noArgs(t *testing.T) {
 }
 
 func TestGraph_plan(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	planPath := testPlanFile(t, &terraform.Plan{
 		Diff: &terraform.Diff{
 			Modules: []*terraform.ModuleDiff{

--- a/command/plan_test.go
+++ b/command/plan_test.go
@@ -191,6 +191,9 @@ func TestPlan_noState(t *testing.T) {
 }
 
 func TestPlan_outPath(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	tf, err := ioutil.TempFile("", "tf")
 	if err != nil {
 		t.Fatalf("err: %s", err)
@@ -402,6 +405,9 @@ func TestPlan_outBackendLegacy(t *testing.T) {
 }
 
 func TestPlan_refresh(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &PlanCommand{
@@ -619,6 +625,9 @@ func TestPlan_validate(t *testing.T) {
 }
 
 func TestPlan_vars(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	p := testProvider()
 	ui := new(cli.MockUi)
 	c := &PlanCommand{
@@ -654,6 +663,9 @@ func TestPlan_vars(t *testing.T) {
 }
 
 func TestPlan_varsUnset(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	// Disable test mode so input would be asked
 	test = false
 	defer func() { test = true }()
@@ -678,6 +690,9 @@ func TestPlan_varsUnset(t *testing.T) {
 }
 
 func TestPlan_varFile(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	varFilePath := testTempFile(t)
 	if err := ioutil.WriteFile(varFilePath, []byte(planVarFile), 0644); err != nil {
 		t.Fatalf("err: %s", err)

--- a/command/state_test.go
+++ b/command/state_test.go
@@ -25,6 +25,9 @@ func testStateBackups(t *testing.T, dir string) []string {
 }
 
 func TestStateDefaultBackupExtension(t *testing.T) {
+	tmp, cwd := testCwd(t)
+	defer testFixCwd(t, tmp, cwd)
+
 	s, err := (&StateMeta{}).State(&Meta{})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This fixes any issues where rogue tfstate files may appear in the cwd
otherwise.