### PR TITLE
remove codebuild docs from layouts; doc files missing

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -247,6 +247,9 @@
 
                     </ul>
                 </li>
+                <%
+=begin
+                %>
 
                 <li<%= sidebar_current(/^docs-aws-resource-codebuild/) %>>
                     <a href="#">CodeBuild Resources</a>
@@ -258,6 +261,9 @@
 
                     </ul>
                 </li>
+                <%
+=end
+              %>
 
                 <li<%= sidebar_current(/^docs-aws-resource-codecommit/) %>>
                     <a href="#">CodeCommit Resources</a>


### PR DESCRIPTION
removing the link in the AWS layouts page to `aws_codebuild` while we fix an issue with the corresponding doc files