### PR TITLE
core: non-CBD depending on CBD won't depend on destroy

### DIFF
--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -146,6 +146,10 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 		"aws_instance.A (destroy)")
 	testGraphHappensBefore(
 		t, g,
+		"aws_instance.A",
+		"aws_instance.B")
+	testGraphHappensBefore(
+		t, g,
 		"aws_instance.B",
 		"aws_instance.A (destroy)")
 }

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -46,9 +46,21 @@ func (n *NodeDestroyResource) ModifyCreateBeforeDestroy(v bool) error {
 
 // GraphNodeReferenceable, overriding NodeAbstractResource
 func (n *NodeDestroyResource) ReferenceableName() []string {
+	// We modify our referenceable name to have the suffix of ".destroy"
+	// since depending on the creation side doesn't necessarilly mean
+	// depending on destruction.
+	suffix := ".destroy"
+
+	// If we're CBD, we also append "-cbd". This is because CBD will setup
+	// its own edges (in CBDEdgeTransformer). Depending on the "destroy"
+	// side generally doesn't mean depending on CBD as well. See GH-11349
+	if n.CreateBeforeDestroy() {
+		suffix += "-cbd"
+	}
+
 	result := n.NodeAbstractResource.ReferenceableName()
 	for i, v := range result {
-		result[i] = v + ".destroy"
+		result[i] = v + suffix
 	}
 
 	return result

--- a/terraform/test-fixtures/graph-builder-apply-dep-cbd/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-dep-cbd/main.tf
@@ -1,0 +1,7 @@
+resource "aws_instance" "A" {
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_instance" "B" {
+  value = ["${aws_instance.A.*.id}"]
+}

--- a/terraform/test-fixtures/transform-destroy-edge-splat/main.tf
+++ b/terraform/test-fixtures/transform-destroy-edge-splat/main.tf
@@ -1,0 +1,5 @@
+resource "test" "A" {}
+resource "test" "B" {
+    count = 2
+    value = "${test.A.*.value}"
+}

--- a/terraform/transform_destroy_cbd.go
+++ b/terraform/transform_destroy_cbd.go
@@ -89,9 +89,20 @@ func (t *CBDEdgeTransformer) Transform(g *Graph) error {
 			g.Connect(&DestroyEdge{S: de.Target(), T: de.Source()})
 		}
 
+		// If the address has an index, we strip that. Our depMap creation
+		// graph doesn't expand counts so we don't currently get _exact_
+		// dependencies. One day when we limit dependencies more exactly
+		// this will have to change. We have a test case covering this
+		// (depNonCBDCountBoth) so it'll be caught.
+		addr := dn.DestroyAddr()
+		if addr.Index >= 0 {
+			addr = addr.Copy() // Copy so that we don't modify any pointers
+			addr.Index = -1
+		}
+
 		// Add this to the list of nodes that we need to fix up
 		// the edges for (step 2 above in the docs).
-		key := dn.DestroyAddr().String()
+		key := addr.String()
 		destroyMap[key] = append(destroyMap[key], v)
 	}
 
@@ -134,9 +145,19 @@ func (t *CBDEdgeTransformer) Transform(g *Graph) error {
 
 		// Get the address
 		addr := rn.CreateAddr()
-		key := addr.String()
+
+		// If the address has an index, we strip that. Our depMap creation
+		// graph doesn't expand counts so we don't currently get _exact_
+		// dependencies. One day when we limit dependencies more exactly
+		// this will have to change. We have a test case covering this
+		// (depNonCBDCount) so it'll be caught.
+		if addr.Index >= 0 {
+			addr = addr.Copy() // Copy so that we don't modify any pointers
+			addr.Index = -1
+		}
 
 		// If there is nothing this resource should depend on, ignore it
+		key := addr.String()
 		dns, ok := depMap[key]
 		if !ok {
 			continue

--- a/terraform/transform_destroy_cbd_test.go
+++ b/terraform/transform_destroy_cbd_test.go
@@ -68,6 +68,93 @@ func TestCBDEdgeTransformer_depNonCBD(t *testing.T) {
 	}
 }
 
+func TestCBDEdgeTransformer_depNonCBDCount(t *testing.T) {
+	g := Graph{Path: RootModulePath}
+	g.Add(&graphNodeCreatorTest{AddrString: "test.A"})
+	g.Add(&graphNodeCreatorTest{AddrString: "test.B[0]"})
+	g.Add(&graphNodeCreatorTest{AddrString: "test.B[1]"})
+	g.Add(&graphNodeDestroyerTest{AddrString: "test.A", CBD: true})
+
+	module := testModule(t, "transform-destroy-edge-splat")
+
+	{
+		tf := &DestroyEdgeTransformer{
+			Module: module,
+		}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		tf := &CBDEdgeTransformer{Module: module}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(`
+test.A
+test.A (destroy)
+  test.A
+  test.B[0]
+  test.B[1]
+test.B[0]
+test.B[1]
+	`)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
+func TestCBDEdgeTransformer_depNonCBDCountBoth(t *testing.T) {
+	g := Graph{Path: RootModulePath}
+	g.Add(&graphNodeCreatorTest{AddrString: "test.A[0]"})
+	g.Add(&graphNodeCreatorTest{AddrString: "test.A[1]"})
+	g.Add(&graphNodeCreatorTest{AddrString: "test.B[0]"})
+	g.Add(&graphNodeCreatorTest{AddrString: "test.B[1]"})
+	g.Add(&graphNodeDestroyerTest{AddrString: "test.A[0]", CBD: true})
+	g.Add(&graphNodeDestroyerTest{AddrString: "test.A[1]", CBD: true})
+
+	module := testModule(t, "transform-destroy-edge-splat")
+
+	{
+		tf := &DestroyEdgeTransformer{
+			Module: module,
+		}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	{
+		tf := &CBDEdgeTransformer{Module: module}
+		if err := tf.Transform(&g); err != nil {
+			t.Fatalf("err: %s", err)
+		}
+	}
+
+	actual := strings.TrimSpace(g.String())
+	expected := strings.TrimSpace(`
+test.A[0]
+test.A[0] (destroy)
+  test.A[0]
+  test.B[0]
+  test.B[1]
+test.A[1]
+test.A[1] (destroy)
+  test.A[1]
+  test.B[0]
+  test.B[1]
+test.B[0]
+test.B[1]
+	`)
+	if actual != expected {
+		t.Fatalf("bad:\n\n%s", actual)
+	}
+}
+
 const testTransformCBDEdgeBasicStr = `
 test.A
 test.A (destroy)


### PR DESCRIPTION
Fixes #11349 

There are actually two bugs fixed here. Both aren't obvious so I'll explain both in detail. Both bugs manifested themselves in #11349 although it was also possible to hit them in isolation as well.

## 1. CBD with Counts

When CBD is used with `count > 1`, the edge transform wasn't working correctly and would not create the proper dependencies. The `CBDEdgeTransformer` creates a non-CBD graph to determine what the normal dependencies would be, then uses that to _invert_ the edges for CBD.

This non-CBD graph doesn't expand counts, so if you had `type.A[0]` in your normal graph, it'd be `type.A` in the graph used to determine the edges. For now, the solution is simply to ignore indexes when comparing the graphs. 

In the future, this won't be sufficient as we want to make our edges exact (`type.A[0]` should only depend directly on `type.B[0]`, not `type.B[1]`). For now, we don't do this for a number of reasons much larger than CBD.

## 2. Non-CBD Depending on CBD Creates a Cycle

When a non-CBD resource depended on a CBD resource and the non-CBD resource wasn't being destroyed, a cycle would be created. This was caused by non-CBD resources advertising their dependence on any "destroy" portion of their dependencies as well. 

Let's use a concrete example of an ASG depending on an LC to explain this bug.

#### Case 1: No CBD on the ASG and LC

The change should be: `ASG(D) => LC(D) => LC => ASG`. 

This works correctly already.

#### Case 2: CBD on BOTH ASG and LC

The change should be: `LC => ASG => ASG(D) => LC(D)`

This also works correctly already since CBDEdgeTransformer modifies the edges of any CBD resource.

#### Case 3: CBD on ONLY ASG

This is identical to case 2, since we force all dependencies to also inherit CBD status.

#### Case 4: CBD on ONLY LC

The change should be: `LC => ASG (update) => LC(D)`

This is the case where we did the wrong thing. The ASG still advertised it depended on `LC(D)` because it looked like case 1 above. Instead, due to LC being CBD, we already handled the edge manipulations.

To fix this, we now have destroy nodes that are due to CBD advertise themselves as different from non-CBD destroy nodes. Regular nodes still depend on non-CBD destroy nodes for their dependencies. This makes everything connect together properly.