### PR TITLE
website: describe API Gateway ARN's

### DIFF
--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -82,7 +82,9 @@ resource "aws_lambda_permission" "apigw_lambda" {
   action        = "lambda:InvokeFunction"
   function_name = "${aws_lambda_function.lambda.arn}"
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.method.http_method}/"
+
+  # More: http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html
+  source_arn    = "arn:aws:execute-api:${var.myregion}:${var.accountId}:${aws_api_gateway_rest_api.api.id}/*/${aws_api_gateway_method.method.http_method}/resourcepath/subresourcepath"
 }
 
 resource "aws_lambda_function" "lambda" {

--- a/website/source/docs/providers/aws/r/lambda_permission.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_permission.html.markdown
@@ -119,6 +119,8 @@ EOF
  	e.g. `arn:aws:lambda:aws-region:acct-id:function:function-name:2`
  * `source_account` - (Optional) The AWS account ID (without a hyphen) of the source owner.
  * `source_arn` - (Optional) When granting Amazon S3 or CloudWatch Events permission to
-  invoke your function, you should specify this field with the Amazon Resource Name (ARN)
-  for the S3 Bucket or CloudWatch Events Rule as its value.  This ensures that only events
-  generated from the specified bucket or rule can invoke the function.
+ 	invoke your function, you should specify this field with the Amazon Resource Name (ARN)
+ 	for the S3 Bucket or CloudWatch Events Rule as its value.  This ensures that only events
+ 	generated from the specified bucket or rule can invoke the function.
+ 	API Gateway ARNs have a unique structure described
+ 	[here](http://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-control-access-using-iam-policies-to-invoke-api.html).


### PR DESCRIPTION
I lost a few hours figuring out the right way to describe an ARN for an API
Gateway resource. Specifically I translated the example poorly since I didn't
realize I had to append the path onto the end of the ARN.

Adds two links to an Amazon documentation page describing the format for API
Gateway ARN's. Adds an additional path component to the ARN example so you can
see you need to specify paths.