### PR TITLE
Minor fix to the triton_machine provider. The docs referred to a `net…

### DIFF
--- a/website/source/docs/providers/triton/r/triton_machine.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_machine.html.markdown
@@ -44,8 +44,8 @@ The following arguments are supported:
 * `image` - (string, Required)
     The UUID of the image to provision.
 
-* `networks` - (list of string)
-    A list of the IDs of the desired networks for the machine.
+* `nic` - (list of maps, Optional)
+    A list of maps with details for each nic. `nic` block described below.
 
 * `firewall_enabled` - (boolean)  Default: `false`
     Whether the cloud firewall should be enabled for this machine.
@@ -61,6 +61,10 @@ The following arguments are supported:
 
 * `administrator_pw` - (string)
     The initial password for the Administrator user. Only used for Windows virtual machines.
+
+The nested `nic` block supports the following:
+* `network` - (string, Optional)
+    The network id to attach to the network interface. It will be hex, in the format: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
 
 ## Attribute Reference
 


### PR DESCRIPTION
Terraform v0.8.6 triton provider seems to be out of sync with the docs. The docs describe a `networks` list of strings, while the code seems to be expecting a `nics` list of maps, with the `network` listed in an appropriate `nic` entry. 

There seems to be some additional functionality in the code for configuring a `nic`, but I haven't tried it, so didn't add the docs. 