### PR TITLE
terraform: node referenceable name from state shuldn't contain path

### DIFF
--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -210,6 +210,76 @@ func TestApplyGraphBuilder_doubleCBD(t *testing.T) {
 	}
 }
 
+// This tests the ordering of two resources being destroyed that depend
+// on each other from only state. GH-11749
+func TestApplyGraphBuilder_destroyStateOnly(t *testing.T) {
+	diff := &Diff{
+		Modules: []*ModuleDiff{
+			&ModuleDiff{
+				Path: []string{"root", "child"},
+				Resources: map[string]*InstanceDiff{
+					"aws_instance.A": &InstanceDiff{
+						Destroy: true,
+					},
+
+					"aws_instance.B": &InstanceDiff{
+						Destroy: true,
+					},
+				},
+			},
+		},
+	}
+
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: []string{"root", "child"},
+				Resources: map[string]*ResourceState{
+					"aws_instance.A": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID:         "foo",
+							Attributes: map[string]string{},
+						},
+					},
+
+					"aws_instance.B": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID:         "bar",
+							Attributes: map[string]string{},
+						},
+						Dependencies: []string{"aws_instance.A"},
+					},
+				},
+			},
+		},
+	}
+
+	b := &ApplyGraphBuilder{
+		Module:        testModule(t, "empty"),
+		Diff:          diff,
+		State:         state,
+		Providers:     []string{"aws"},
+		DisableReduce: true,
+	}
+
+	g, err := b.Build(RootModulePath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	t.Logf("Graph: %s", g.String())
+
+	if !reflect.DeepEqual(g.Path, RootModulePath) {
+		t.Fatalf("bad: %#v", g.Path)
+	}
+
+	testGraphHappensBefore(
+		t, g,
+		"module.child.aws_instance.B (destroy)",
+		"module.child.aws_instance.A (destroy)")
+}
+
 // This tests the ordering of destroying a single count of a resource.
 func TestApplyGraphBuilder_destroyCount(t *testing.T) {
 	diff := &Diff{

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -53,7 +53,8 @@ func (n *NodeAbstractResource) ReferenceableName() []string {
 		id = n.Config.Id()
 	} else if n.Addr != nil {
 		addrCopy := n.Addr.Copy()
-		addrCopy.Index = -1
+		addrCopy.Path = nil // ReferenceTransformer handles paths
+		addrCopy.Index = -1 // We handle indexes below
 		id = addrCopy.String()
 	} else {
 		// No way to determine our type.name, just return


### PR DESCRIPTION
Fixes #11749

I'm **really** surprised this didn't come up earlier.

When only the state is available for a node, the advertised
referenceable name (the name used for dependency connections) included
the module path. This module path is automatically prepended to the
name. This means that probably every non-root resource for state-only
operations (destroys) didn't order properly.

This fixes that by omitting the path properly.

Multiple tests added to verify both graph correctness as well as a
higher level context test.

Will backport to 0.8.x