### PR TITLE
Feature/allow vault resource to update

### DIFF
--- a/builtin/providers/vault/resource_generic_secret.go
+++ b/builtin/providers/vault/resource_generic_secret.go
@@ -43,7 +43,7 @@ func genericSecretResource() *schema.Resource {
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
-				Description: "True if the provided token is allowed to read the secret from vault, and therefore canupdate values",
+				Description: "True if the provided token is allowed to read the secret from vault",
 			},
 		},
 	}
@@ -134,16 +134,6 @@ func genericSecretResourceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(path)
+	log.Printf("[WARN] vault_generic_secret does not automatically refresh if allow_read is set to false")
 	return nil
-
-	// We don't actually attempt to read back the secret data
-	// here, so that Terraform can be configured with a token
-	// that has only write access to the relevant part of the
-	// store.
-	//
-	// This means that Terraform cannot detect drift for
-	// generic secrets, but detecting drift seems less important
-	// than being able to limit the effect of exposure of
-	// Terraform's Vault token.
-	// log.Printf("[WARN] vault_generic_secret does not automatically refresh")
 }

--- a/builtin/providers/vault/resource_generic_secret_test.go
+++ b/builtin/providers/vault/resource_generic_secret_test.go
@@ -31,6 +31,7 @@ var testResourceGenericSecret_initialConfig = `
 
 resource "vault_generic_secret" "test" {
     path = "secret/foo"
+    allow_read = true
     data_json = <<EOT
 {
     "zip": "zap"
@@ -77,6 +78,7 @@ var testResourceGenericSecret_updateConfig = `
 
 resource "vault_generic_secret" "test" {
     path = "secret/foo"
+    allow_read = true
     data_json = <<EOT
 {
     "zip": "zoop"

--- a/website/source/docs/providers/vault/r/generic_secret.html.md
+++ b/website/source/docs/providers/vault/r/generic_secret.html.md
@@ -51,6 +51,10 @@ see which endpoints support the `PUT` and `DELETE` methods.
 * `data_json` - (Required) String containing a JSON-encoded object that
 will be written as the secret data at the given path.
 
+* `allow_read` - (Optional) True/false. Set this to true if your vault
+authentication is able to read the data, this allows the resource to be
+compared and updated. Defaults to false.
+
 ## Required Vault Capabilities
 
 Use of this resource requires the `create` or `update` capability
@@ -59,10 +63,11 @@ along with the `delete` capbility if the resource is removed from
 configuration.
 
 This resource does not *read* the secret data back from Terraform
-on refresh. This avoids the need for `read` access on the given
+on refresh by default. This avoids the need for `read` access on the given
 path, but it means that Terraform is not able to detect and repair
 "drift" on this resource should the data be updated or deleted outside
-of Terraform.
+of Terraform. This limitation can be negated by setting `allow_read` to
+true
 
 ## Attributes Reference
 


### PR DESCRIPTION
By default the vault_generic_secret resource is not configured to read back from vault. This means that changes cannot properly be compared. This is done for security reasons (see: Required Vault Capabilities on https://www.terraform.io/docs/providers/vault/r/generic_secret.html), so that a token can be limited to only writing to the vault server.

However, there are reason why you would want to be able to compare and update resources. This change allows this by setting allow_read value to true on the resource.