### PR TITLE
provider/aws: Raise the codebuild_project create timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_codebuild_project.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project.go
@@ -201,7 +201,7 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	var resp *codebuild.CreateProjectOutput
-	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		var err error
 
 		resp, err = conn.CreateProject(params)


### PR DESCRIPTION
Found in testing that a timeout of 30 seconds didn't allow for the error
message that codebuild wasn't supported in eu-west-2

Discussed this with @radeksimko and he suggested a timeout raise