### PR TITLE
provider/aws: Fix spot_fleet request tests

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request_test.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request_test.go
@@ -428,10 +428,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -469,7 +492,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigChangeSpotBidPrice(rName string, rInt int) string {
@@ -479,10 +502,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -520,7 +566,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigWithAzs(rName string, rInt int) string {
@@ -530,10 +576,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -578,7 +647,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigWithSubnet(rName string, rInt int) string {
@@ -588,10 +657,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -652,7 +744,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameAz(rName string, rInt int) string {
@@ -662,10 +754,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -710,7 +825,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigMultipleInstanceTypesinSameSubnet(rName string, rInt int) string {
@@ -720,10 +835,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -778,7 +916,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigOverridingSpotPrice(rName string, rInt int) string {
@@ -788,10 +926,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -837,7 +998,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigDiversifiedAllocation(rName string, rInt int) string {
@@ -847,10 +1008,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -902,7 +1086,7 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestConfigWithWeightedCapacity(rName string, rInt int) string {
@@ -912,10 +1096,33 @@ resource "aws_key_pair" "debugging" {
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -962,15 +1169,38 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rName, rInt, rName)
+`, rName, rInt, rInt, rName)
 }
 
 func testAccAWSSpotFleetRequestEBSConfig(rName string, rInt int) string {
 	return fmt.Sprintf(`
+resource "aws_iam_policy" "test-policy" {
+  name = "test-policy-%d"
+  path = "/"
+  description = "Spot Fleet Request ACCTest Policy"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": [
+       "ec2:DescribeImages",
+       "ec2:DescribeSubnets",
+       "ec2:RequestSpotInstances",
+       "ec2:TerminateInstances",
+       "ec2:DescribeInstanceStatus",
+       "iam:PassRole"
+        ],
+    "Resource": ["*"]
+  }]
+}
+EOF
+}
+
 resource "aws_iam_policy_attachment" "test-attach" {
     name = "test-attachment-%d"
     roles = ["${aws_iam_role.test-role.name}"]
-    policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole"
+    policy_arn = "${aws_iam_policy.test-policy.arn}"
 }
 
 resource "aws_iam_role" "test-role" {
@@ -1019,5 +1249,5 @@ resource "aws_spot_fleet_request" "foo" {
     }
     depends_on = ["aws_iam_policy_attachment.test-attach"]
 }
-`, rInt, rName)
+`, rInt, rInt, rName)
 }


### PR DESCRIPTION
Due to the fact that an iam_policy_attachment can only be used once PER iam_policy, these changes create a specific iam_policy for each test, so that when they are ran in parallel we will no longer get the iam_policy_attachment clobbers that we've gotten previously.

```
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName' out='=== RUN   TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName|n--- PASS: TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName (0.00s)|
nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName' out='']
##teamcity[testFinished timestamp='2017-02-08T09:11:38.420' name='TestAccAWSSpotFleetRequest_CannotUseEmptyKeyName']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion' out='=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion|n--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzO
rSubnetInRegion (54.59s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion' out='']
##teamcity[testFinished timestamp='2017-02-08T09:12:33.046' name='TestAccAWSSpotFleetRequest_lowestPriceAzOrSubnetInRegion']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz' out='=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz|n--- PASS: TestAccAWSSpotFleetRequest_multipleInstan
ceTypesInSameAz (55.50s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz' out='']
##teamcity[testFinished timestamp='2017-02-08T09:12:33.937' name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameAz']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList' out='=== RUN   TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList|n--- PASS: TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList
 (56.05s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList' out='']
##teamcity[testFinished timestamp='2017-02-08T09:12:34.492' name='TestAccAWSSpotFleetRequest_lowestPriceAzInGivenList']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_withEBSDisk']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_withEBSDisk' out='=== RUN   TestAccAWSSpotFleetRequest_withEBSDisk|n--- PASS: TestAccAWSSpotFleetRequest_withEBSDisk (58.02s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_withEBSDisk' out='']
##teamcity[testFinished timestamp='2017-02-08T09:12:36.457' name='TestAccAWSSpotFleetRequest_withEBSDisk']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.362' name='TestAccAWSSpotFleetRequest_overriddingSpotPrice']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_overriddingSpotPrice' out='=== RUN   TestAccAWSSpotFleetRequest_overriddingSpotPrice|n--- PASS: TestAccAWSSpotFleetRequest_overriddingSpotPrice (58.84s)|nP
ASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_overriddingSpotPrice' out='']
##teamcity[testFinished timestamp='2017-02-08T09:12:37.286' name='TestAccAWSSpotFleetRequest_overriddingSpotPrice']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.362' name='TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList' out='=== RUN   TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList|n--- PASS: TestAccAWSSpotFleetRequest_lowestPriceSubne
tInGivenList (60.75s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList' out='']
##teamcity[testFinished timestamp='2017-02-08T09:12:39.206' name='TestAccAWSSpotFleetRequest_lowestPriceSubnetInGivenList']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.362' name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet' out='=== RUN   TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet|n--- PASS: TestAccAWSSpotFleetRequest_multip
leInstanceTypesInSameSubnet (61.80s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet' out='']
##teamcity[testFinished timestamp='2017-02-08T09:12:40.241' name='TestAccAWSSpotFleetRequest_multipleInstanceTypesInSameSubnet']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_changePriceForcesNewRequest']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_changePriceForcesNewRequest' out='=== RUN   TestAccAWSSpotFleetRequest_changePriceForcesNewRequest|n--- PASS: TestAccAWSSpotFleetRequest_changePriceForcesN
ewRequest (98.70s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_changePriceForcesNewRequest' out='']
##teamcity[testFinished timestamp='2017-02-08T09:13:17.142' name='TestAccAWSSpotFleetRequest_changePriceForcesNewRequest']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_withWeightedCapacity']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_withWeightedCapacity' out='=== RUN   TestAccAWSSpotFleetRequest_withWeightedCapacity|n--- PASS: TestAccAWSSpotFleetRequest_withWeightedCapacity (269.12s)|n
PASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_withWeightedCapacity' out='']
##teamcity[testFinished timestamp='2017-02-08T09:16:07.554' name='TestAccAWSSpotFleetRequest_withWeightedCapacity']
##teamcity[testStarted timestamp='2017-02-08T09:11:38.361' name='TestAccAWSSpotFleetRequest_diversifiedAllocation']
##teamcity[testStdOut name='TestAccAWSSpotFleetRequest_diversifiedAllocation' out='=== RUN   TestAccAWSSpotFleetRequest_diversifiedAllocation|n--- PASS: TestAccAWSSpotFleetRequest_diversifiedAllocation (348.36s
)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSpotFleetRequest_diversifiedAllocation' out='']
##teamcity[testFinished timestamp='2017-02-08T09:17:26.802' name='TestAccAWSSpotFleetRequest_diversifiedAllocation']
```