### PR TITLE
provider/aws: Make aws_dms_endpoint database_name optional

### DIFF
--- a/builtin/providers/aws/resource_aws_dms_endpoint.go
+++ b/builtin/providers/aws/resource_aws_dms_endpoint.go
@@ -32,7 +32,7 @@ func resourceAwsDmsEndpoint() *schema.Resource {
 			},
 			"database_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 			"endpoint_arn": {
 				Type:     schema.TypeString,
@@ -118,7 +118,6 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 	conn := meta.(*AWSClient).dmsconn
 
 	request := &dms.CreateEndpointInput{
-		DatabaseName:       aws.String(d.Get("database_name").(string)),
 		EndpointIdentifier: aws.String(d.Get("endpoint_id").(string)),
 		EndpointType:       aws.String(d.Get("endpoint_type").(string)),
 		EngineName:         aws.String(d.Get("engine_name").(string)),
@@ -129,6 +128,9 @@ func resourceAwsDmsEndpointCreate(d *schema.ResourceData, meta interface{}) erro
 		Username:           aws.String(d.Get("username").(string)),
 	}
 
+	if v, ok := d.GetOk("database_name"); ok {
+		request.DatabaseName = aws.String(v.(string))
+	}
 	if v, ok := d.GetOk("certificate_arn"); ok {
 		request.CertificateArn = aws.String(v.(string))
 	}

--- a/website/source/docs/providers/aws/r/dms_endpoint.html.markdown
+++ b/website/source/docs/providers/aws/r/dms_endpoint.html.markdown
@@ -38,7 +38,7 @@ resource "aws_dms_endpoint" "test" {
 The following arguments are supported:
 
 * `certificate_arn` - (Optional, Default: empty string) The Amazon Resource Name (ARN) for the certificate.
-* `database_name` - (Optional, Default: empty string) The name of the endpoint database.
+* `database_name` - (Optional) The name of the endpoint database.
 * `endpoint_id` - (Required) The database endpoint identifier.
 
     - Must contain from 1 to 255 alphanumeric characters or hyphens.


### PR DESCRIPTION
Not required for MySQL

Fixes: #11791 

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAwsDmsEndpointBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/08 18:04:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAwsDmsEndpointBasic -timeout 120m
=== RUN   TestAccAwsDmsEndpointBasic
--- PASS: TestAccAwsDmsEndpointBasic (133.42s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	133.442s
```