### PR TITLE
provider/aws: Bump Create and Delete timeouts to 60 mins on directory_service

### DIFF
--- a/builtin/providers/aws/resource_aws_directory_service_directory.go
+++ b/builtin/providers/aws/resource_aws_directory_service_directory.go
@@ -336,7 +336,7 @@ func resourceAwsDirectoryServiceDirectoryCreate(d *schema.ResourceData, meta int
 				d.Id(), *ds.Stage)
 			return ds, *ds.Stage, nil
 		},
-		Timeout: 45 * time.Minute,
+		Timeout: 60 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(
@@ -477,7 +477,7 @@ func resourceAwsDirectoryServiceDirectoryDelete(d *schema.ResourceData, meta int
 				d.Id(), *ds.Stage)
 			return ds, *ds.Stage, nil
 		},
-		Timeout: 30 * time.Minute,
+		Timeout: 60 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
Fixes: #11781 

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDirectoryServiceDirectory_'                     ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/08 18:12:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDirectoryServiceDirectory_ -timeout 120m
=== RUN   TestAccAWSDirectoryServiceDirectory_basic
--- PASS: TestAccAWSDirectoryServiceDirectory_basic (544.30s)
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoft
--- PASS: TestAccAWSDirectoryServiceDirectory_microsoft (2251.13s)
=== RUN   TestAccAWSDirectoryServiceDirectory_connector
--- PASS: TestAccAWSDirectoryServiceDirectory_connector (1064.98s)
=== RUN   TestAccAWSDirectoryServiceDirectory_withAliasAndSso
--- PASS: TestAccAWSDirectoryServiceDirectory_withAliasAndSso (627.41s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	4487.850s
```