### PR TITLE
provider/google: update DNS names in tests.

### DIFF
--- a/builtin/providers/google/resource_dns_managed_zone_test.go
+++ b/builtin/providers/google/resource_dns_managed_zone_test.go
@@ -79,5 +79,5 @@ func testAccCheckDnsManagedZoneExists(n string, zone *dns.ManagedZone) resource.
 var testAccDnsManagedZone_basic = fmt.Sprintf(`
 resource "google_dns_managed_zone" "foobar" {
 	name = "mzone-test-%s"
-	dns_name = "terraform.test."
+	dns_name = "hashicorptest.com."
 }`, acctest.RandString(10))

--- a/builtin/providers/google/resource_dns_record_set_test.go
+++ b/builtin/providers/google/resource_dns_record_set_test.go
@@ -138,12 +138,12 @@ func testAccDnsRecordSet_basic(zoneName string, addr2 string, ttl int) string {
 	return fmt.Sprintf(`
 	resource "google_dns_managed_zone" "parent-zone" {
 		name = "%s"
-		dns_name = "terraform.test."
+		dns_name = "hashicorptest.com."
 		description = "Test Description"
 	}
 	resource "google_dns_record_set" "foobar" {
 		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
-		name = "test-record.terraform.test."
+		name = "test-record.hashicorptest.com."
 		type = "A"
 		rrdatas = ["127.0.0.1", "%s"]
 		ttl = %d
@@ -155,12 +155,12 @@ func testAccDnsRecordSet_bigChange(zoneName string, ttl int) string {
 	return fmt.Sprintf(`
 	resource "google_dns_managed_zone" "parent-zone" {
 		name = "%s"
-		dns_name = "terraform.test."
+		dns_name = "hashicorptest.com."
 		description = "Test Description"
 	}
 	resource "google_dns_record_set" "foobar" {
 		managed_zone = "${google_dns_managed_zone.parent-zone.name}"
-		name = "test-record.terraform.test."
+		name = "test-record.hashicorptest.com."
 		type = "CNAME"
 		rrdatas = ["www.terraform.io."]
 		ttl = %d


### PR DESCRIPTION
Our DNS tests were using terraform.test as a DNS name, which GCP was
erroring on, as we haven't proven we own the domain (and can't, as we
don't). To solve this, I updated the tests to use hashicorptest.com,
which we _do_ own, and which we have proven ownership of. The tests now
pass.

Test output after changes:
```
=== RUN   TestAccDnsManagedZone_basic
--- PASS: TestAccDnsManagedZone_basic (3.51s)
=== RUN   TestAccDnsRecordSet_basic
--- PASS: TestAccDnsRecordSet_basic (25.45s)
=== RUN   TestAccDnsRecordSet_modify
--- PASS: TestAccDnsRecordSet_modify (159.13s)
=== RUN   TestAccDnsRecordSet_changeType
--- PASS: TestAccDnsRecordSet_changeType (36.80s)
PASS
```

Test output before changes:
```
=== RUN TestAccDnsRecordSet_basic
 --- FAIL: TestAccDnsRecordSet_basic (0.41s) testing.go:265: Step 0 error: Error applying: 1 error(s) occurred: * google_dns_managed_zone.parent-zone: Error creating DNS ManagedZone: googleapi: Error 400: Please verify ownership of the 'terraform.test.' domain (or a parent) at http://www.google.com/webmasters/verification/ and try again, verifyManagedZoneDnsNameOwnership FAIL
```