### PR TITLE
provider/aws: Catch 400 error from rds_cluster

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -611,6 +611,13 @@ func resourceAwsRDSClusterDelete(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[DEBUG] RDS Cluster delete options: %s", deleteOpts)
 	_, err := conn.DeleteDBCluster(&deleteOpts)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if "InvalidDBClusterStateFault" == awsErr.Code() {
+				return fmt.Errorf("RDS Cluster cannot be deleted: %s", awsErr.Message())
+			}
+		}
+	}
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"available", "deleting", "backing-up", "modifying"},


### PR DESCRIPTION
Previously, an `aws_rds_cluster` that contains active instance groups would timeout on a destroy, if the destroy was able to only target the rds_cluster and not include the instance groups.
This would result in a `400` response from AWS, and Terraform would sit in a wait-loop until a 15-minute timeout while waiting for the cluster to be destroyed.

This catches the error returned from the `DeleteDBCluster` function call such that the proper error case can be returned to the user.

`400` from the AWS API:
```
2017/02/08 13:40:47 [DEBUG] plugin: terraform: ---[ RESPONSE ]--------------------------------------
2017/02/08 13:40:47 [DEBUG] plugin: terraform: HTTP/1.1 400 Bad Request
2017/02/08 13:40:47 [DEBUG] plugin: terraform: Connection: close
2017/02/08 13:40:47 [DEBUG] plugin: terraform: Content-Length: 337
2017/02/08 13:40:47 [DEBUG] plugin: terraform: Content-Type: text/xml
2017/02/08 13:40:47 [DEBUG] plugin: terraform: Date: Wed, 08 Feb 2017 18:40:46 GMT
2017/02/08 13:40:47 [DEBUG] plugin: terraform: X-Amzn-Requestid: 1b4a76cc-ee2e-11e6-867d-2311ebaffd3e
2017/02/08 13:40:47 [DEBUG] plugin: terraform:
2017/02/08 13:40:47 [DEBUG] plugin: terraform: <ErrorResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/">
2017/02/08 13:40:47 [DEBUG] plugin: terraform:   <Error>
2017/02/08 13:40:47 [DEBUG] plugin: terraform:     <Type>Sender</Type>
2017/02/08 13:40:47 [DEBUG] plugin: terraform:     <Code>InvalidDBClusterStateFault</Code>
2017/02/08 13:40:47 [DEBUG] plugin: terraform:     <Message>Cluster cannot be deleted, it still contains DB instances in non-deleting state.</Message>
2017/02/08 13:40:47 [DEBUG] plugin: terraform:   </Error>
2017/02/08 13:40:47 [DEBUG] plugin: terraform:   <RequestId>1b4a76cc-ee2e-11e6-867d-2311ebaffd3e</RequestId>
2017/02/08 13:40:47 [DEBUG] plugin: terraform: </ErrorResponse>
2017/02/08 13:40:47 [DEBUG] plugin: terraform:
2017/02/08 13:40:47 [DEBUG] plugin: terraform: -----------------------------------------------------
```

Error returns now,  as expected:
```
Error applying plan:

2017/02/08 13:40:47 [DEBUG] plugin: waiting for all plugin processes to complete...
1 error(s) occurred:

* aws_rds_cluster.jake (destroy): 1 error(s) occurred:

2017/02/08 13:40:47 [DEBUG] plugin: terraform: aws-provider (internal) 2017/02/08 13:40:47 [DEBUG] plugin: waiting for all plugin processes to complete...
* aws_rds_cluster.jake: RDS Cluster cannot be deleted: Cluster cannot be deleted, it still contains DB instances in non-deleting state.
```

Fixes: #11378 