### PR TITLE
Fix invalid markdown syntax

### DIFF
--- a/website/source/docs/providers/aws/d/kms_secret.html.markdown
+++ b/website/source/docs/providers/aws/d/kms_secret.html.markdown
@@ -3,7 +3,7 @@ layout: "aws"
 page_title: "AWS: aws_kms_secret"
 sidebar_current: "docs-aws-datasource-kms-secret"
 description: |-
-	Provides secret data encrypted with the KMS service
+    Provides secret data encrypted with the KMS service
 ---
 
 # aws\_kms\_secret


### PR DESCRIPTION
https://www.terraform.io/docs/providers/aws/d/kms_secret.html is broken. This PR will fix it.