### PR TITLE
provider/aws: Update KMS Alias acceptance tests

### DIFF
--- a/builtin/providers/aws/resource_aws_kms_alias_test.go
+++ b/builtin/providers/aws/resource_aws_kms_alias_test.go
@@ -11,19 +11,21 @@ import (
 )
 
 func TestAccAWSKmsAlias_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSKmsSingleAlias,
+			{
+				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.single"),
 				),
 			},
-			resource.TestStep{
-				Config: testAccAWSKmsSingleAlias_modified,
+			{
+				Config: testAccAWSKmsSingleAlias_modified(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.single"),
 				),
@@ -33,13 +35,15 @@ func TestAccAWSKmsAlias_basic(t *testing.T) {
 }
 
 func TestAccAWSKmsAlias_name_prefix(t *testing.T) {
+	rInt := acctest.RandInt()
+	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSKmsSingleAlias,
+			{
+				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.name_prefix"),
 				),
@@ -49,13 +53,15 @@ func TestAccAWSKmsAlias_name_prefix(t *testing.T) {
 }
 
 func TestAccAWSKmsAlias_no_name(t *testing.T) {
+	rInt := acctest.RandInt()
+	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSKmsSingleAlias,
+			{
+				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.nothing"),
 				),
@@ -65,13 +71,15 @@ func TestAccAWSKmsAlias_no_name(t *testing.T) {
 }
 
 func TestAccAWSKmsAlias_multiple(t *testing.T) {
+	rInt := acctest.RandInt()
+	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSKmsMultipleAliases,
+			{
+				Config: testAccAWSKmsMultipleAliases(rInt, kmsAliasTimestamp),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.one"),
 					testAccCheckAWSKmsAliasExists("aws_kms_alias.two"),
@@ -114,8 +122,8 @@ func testAccCheckAWSKmsAliasExists(name string) resource.TestCheckFunc {
 	}
 }
 
-var kmsAliasTimestamp = time.Now().Format(time.RFC1123)
-var testAccAWSKmsSingleAlias = fmt.Sprintf(`
+func testAccAWSKmsSingleAlias(rInt int, timestamp string) string {
+	return fmt.Sprintf(`
 resource "aws_kms_key" "one" {
     description = "Terraform acc test One %s"
     deletion_window_in_days = 7
@@ -126,7 +134,7 @@ resource "aws_kms_key" "two" {
 }
 
 resource "aws_kms_alias" "name_prefix" {
-	name_prefix = "alias/tf-acc-key-alias"
+	name_prefix = "alias/tf-acc-key-alias-%d"
 	target_key_id = "${aws_kms_key.one.key_id}"
 }
 
@@ -135,11 +143,13 @@ resource "aws_kms_alias" "nothing" {
 }
 
 resource "aws_kms_alias" "single" {
-    name = "alias/tf-acc-key-alias"
+    name = "alias/tf-acc-key-alias-%d"
     target_key_id = "${aws_kms_key.one.key_id}"
-}`, kmsAliasTimestamp, kmsAliasTimestamp)
+}`, timestamp, timestamp, rInt, rInt)
+}
 
-var testAccAWSKmsSingleAlias_modified = fmt.Sprintf(`
+func testAccAWSKmsSingleAlias_modified(rInt int, timestamp string) string {
+	return fmt.Sprintf(`
 resource "aws_kms_key" "one" {
     description = "Terraform acc test One %s"
     deletion_window_in_days = 7
@@ -150,21 +160,24 @@ resource "aws_kms_key" "two" {
 }
 
 resource "aws_kms_alias" "single" {
-    name = "alias/tf-acc-key-alias"
+    name = "alias/tf-acc-key-alias-%d"
     target_key_id = "${aws_kms_key.two.key_id}"
-}`, kmsAliasTimestamp, kmsAliasTimestamp)
+}`, timestamp, timestamp, rInt)
+}
 
-var testAccAWSKmsMultipleAliases = fmt.Sprintf(`
+func testAccAWSKmsMultipleAliases(rInt int, timestamp string) string {
+	return fmt.Sprintf(`
 resource "aws_kms_key" "single" {
     description = "Terraform acc test One %s"
     deletion_window_in_days = 7
 }
 
 resource "aws_kms_alias" "one" {
-    name = "alias/tf-acc-key-alias-%s"
+    name = "alias/tf-acc-alias-one-%d"
     target_key_id = "${aws_kms_key.single.key_id}"
 }
 resource "aws_kms_alias" "two" {
-    name = "alias/tf-acc-key-alias-%s"
+    name = "alias/tf-acc-alias-two-%d"
     target_key_id = "${aws_kms_key.single.key_id}"
-}`, kmsAliasTimestamp, acctest.RandString(5), acctest.RandString(5))
+}`, timestamp, rInt, rInt)
+}


### PR DESCRIPTION
Updates KMS tests to ensure compatibility with running our tests in parallel

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSKmsAlias_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/09 09:43:42 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSKmsAlias_ -timeout 120m
=== RUN   TestAccAWSKmsAlias_basic
--- PASS: TestAccAWSKmsAlias_basic (51.63s)
=== RUN   TestAccAWSKmsAlias_name_prefix
--- PASS: TestAccAWSKmsAlias_name_prefix (39.58s)
=== RUN   TestAccAWSKmsAlias_no_name
--- PASS: TestAccAWSKmsAlias_no_name (42.27s)
=== RUN   TestAccAWSKmsAlias_multiple
--- PASS: TestAccAWSKmsAlias_multiple (40.04s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    173.547s
```