### PR TITLE
provider/aws: Fix redshift parameter group acctests

### DIFF
--- a/builtin/providers/aws/import_aws_redshift_parameter_group_test.go
+++ b/builtin/providers/aws/import_aws_redshift_parameter_group_test.go
@@ -3,22 +3,24 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSRedshiftParameterGroup_importBasic(t *testing.T) {
 	resourceName := "aws_redshift_parameter_group.bar"
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftParameterGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSRedshiftParameterGroupConfig,
+			{
+				Config: testAccAWSRedshiftParameterGroupConfig(rInt),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/aws/resource_aws_redshift_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_parameter_group_test.go
@@ -7,24 +7,26 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/redshift"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSRedshiftParameterGroup_withParameters(t *testing.T) {
 	var v redshift.ClusterParameterGroup
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftParameterGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSRedshiftParameterGroupConfig,
+			{
+				Config: testAccAWSRedshiftParameterGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRedshiftParameterGroupExists("aws_redshift_parameter_group.bar", &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "name", "parameter-group-test-terraform"),
+						"aws_redshift_parameter_group.bar", "name", fmt.Sprintf("test-terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_parameter_group.bar", "family", "redshift-1.0"),
 					resource.TestCheckResourceAttr(
@@ -49,18 +51,19 @@ func TestAccAWSRedshiftParameterGroup_withParameters(t *testing.T) {
 
 func TestAccAWSRedshiftParameterGroup_withoutParameters(t *testing.T) {
 	var v redshift.ClusterParameterGroup
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRedshiftParameterGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSRedshiftParameterGroupOnlyConfig,
+			{
+				Config: testAccAWSRedshiftParameterGroupOnlyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRedshiftParameterGroupExists("aws_redshift_parameter_group.bar", &v),
 					resource.TestCheckResourceAttr(
-						"aws_redshift_parameter_group.bar", "name", "parameter-group-test-terraform"),
+						"aws_redshift_parameter_group.bar", "name", fmt.Sprintf("test-terraform-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"aws_redshift_parameter_group.bar", "family", "redshift-1.0"),
 					resource.TestCheckResourceAttr(
@@ -179,28 +182,31 @@ func testAccCheckAWSRedshiftParameterGroupExists(n string, v *redshift.ClusterPa
 	}
 }
 
-const testAccAWSRedshiftParameterGroupOnlyConfig = `
-resource "aws_redshift_parameter_group" "bar" {
-	name = "parameter-group-test-terraform"
-	family = "redshift-1.0"
-	description = "Test parameter group for terraform"
-}`
-
-const testAccAWSRedshiftParameterGroupConfig = `
-resource "aws_redshift_parameter_group" "bar" {
-	name = "parameter-group-test-terraform"
-	family = "redshift-1.0"
-	parameter {
-	  name = "require_ssl"
-	  value = "true"
-	}
-	parameter {
-	  name = "query_group"
-	  value = "example"
-	}
-	parameter{
-	  name = "enable_user_activity_logging"
-	  value = "true"
-	}
+func testAccAWSRedshiftParameterGroupOnlyConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_redshift_parameter_group" "bar" {
+		name = "test-terraform-%d"
+		family = "redshift-1.0"
+		description = "Test parameter group for terraform"
+	}`, rInt)
 }
-`
+
+func testAccAWSRedshiftParameterGroupConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_redshift_parameter_group" "bar" {
+		name = "test-terraform-%d"
+		family = "redshift-1.0"
+		parameter {
+			name = "require_ssl"
+			value = "true"
+		}
+		parameter {
+			name = "query_group"
+			value = "example"
+		}
+		parameter{
+			name = "enable_user_activity_logging"
+			value = "true"
+		}
+	}`, rInt)
+}


### PR DESCRIPTION
Allows the redshift parameter group acceptance tests handle being ran in parallel better

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRedshiftParameterGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/09 10:16:19 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftParameterGroup_ -timeout 120m
=== RUN   TestAccAWSRedshiftParameterGroup_importBasic
--- PASS: TestAccAWSRedshiftParameterGroup_importBasic (15.17s)
=== RUN   TestAccAWSRedshiftParameterGroup_withParameters
--- PASS: TestAccAWSRedshiftParameterGroup_withParameters (13.16s)
=== RUN   TestAccAWSRedshiftParameterGroup_withoutParameters
--- PASS: TestAccAWSRedshiftParameterGroup_withoutParameters (12.58s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    40.940s
```