### PR TITLE
provider/aws: Set the qualifier to an empty string if the parsing fai…

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_permission.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission.go
@@ -211,9 +211,10 @@ func resourceAwsLambdaPermissionRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	qualifier, err := getQualifierFromLambdaAliasOrVersionArn(statement.Resource)
-	if err == nil {
-		d.Set("qualifier", qualifier)
+	if err != nil {
+		log.Printf("[ERR] Error getting Lambda Qualifier: %s", err)
 	}
+	d.Set("qualifier", qualifier)
 
 	// Save Lambda function name in the same format
 	if strings.HasPrefix(d.Get("function_name").(string), "arn:"+meta.(*AWSClient).partition+":lambda:") {


### PR DESCRIPTION
…ls, to attempt to detect drift

Should fix `TestAccAWSLambdaPermission_basic`