### PR TITLE
Add locking during backend configuration

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1020,7 +1020,7 @@ func (m *Meta) backend_C_r_S_changed(
 	copy, err := m.confirm(&terraform.InputOpts{
 		Id:          "backend-migrate-to-new",
 		Query:       fmt.Sprintf("Do you want to copy the state from %q?", c.Type),
-		Description: strings.TrimSpace(inputBackendMigrateChange),
+		Description: strings.TrimSpace(fmt.Sprintf(inputBackendMigrateChange, c.Type, s.Backend.Type)),
 	})
 	if err != nil {
 		return nil, fmt.Errorf(
@@ -1572,7 +1572,7 @@ Current Serial: %[2]d
 
 const inputBackendMigrateChange = `
 Would you like to copy the state from your prior backend %q to the
-newly configured backend %q? If you're reconfiguring the same backend,
+newly configured %q backend? If you're reconfiguring the same backend,
 answering "yes" or "no" shouldn't make a difference. Please answer exactly
 "yes" or "no".
 `

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -20,7 +20,21 @@ import (
 //
 // After migrating the state, the existing state in the first backend
 // remains untouched.
+//
+// This will attempt to lock both states for the migration.
 func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
+	unlockOne, err := lockState(opts.One, "migrate from")
+	if err != nil {
+		return err
+	}
+	defer unlockOne()
+
+	unlockTwo, err := lockState(opts.Two, "migrate to")
+	if err != nil {
+		return err
+	}
+	defer unlockTwo()
+
 	one := opts.One.State()
 	two := opts.Two.State()
 

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -354,6 +354,7 @@ func TestMetaBackend_configureNewWithState(t *testing.T) {
 	if state == nil {
 		t.Fatal("state is nil")
 	}
+
 	if state.Lineage != "backend-new-migrate" {
 		t.Fatalf("bad: %#v", state)
 	}

--- a/state/local.go
+++ b/state/local.go
@@ -97,6 +97,7 @@ func (s *LocalState) Unlock() error {
 	fileName := s.stateFileOut.Name()
 
 	unlockErr := s.unlock()
+
 	s.stateFileOut.Close()
 	s.stateFileOut = nil
 
@@ -201,6 +202,11 @@ func (s *LocalState) RefreshState() error {
 			reader = f
 		}
 	} else {
+		// no state to refresh
+		if s.stateFileOut == nil {
+			return nil
+		}
+
 		// we have a state file, make sure we're at the start
 		s.stateFileOut.Seek(0, os.SEEK_SET)
 		reader = s.stateFileOut

--- a/state/remote/s3.go
+++ b/state/remote/s3.go
@@ -231,7 +231,7 @@ func (c *S3Client) Lock(info string) error {
 
 		resp, err := c.dynClient.GetItem(getParams)
 		if err != nil {
-			return fmt.Errorf("s3 state file %q locked, failed to retrive info: %s", stateName, err)
+			return fmt.Errorf("s3 state file %q locked, failed to retrieve info: %s", stateName, err)
 		}
 
 		var infoData string

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1808,7 +1808,9 @@ var ErrNoState = errors.New("no state")
 // was written by WriteState.
 func ReadState(src io.Reader) (*State, error) {
 	buf := bufio.NewReader(src)
-	if _, err := buf.Peek(1); err == io.EOF {
+	if _, err := buf.Peek(1); err != nil {
+		// the error is either io.EOF or "invalid argument", and both are from
+		// an empty state.
 		return nil, ErrNoState
 	}
 

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -1574,6 +1575,20 @@ func TestReadStateNewVersion(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "does not support state version") {
 		t.Fatalf("err: %v", err)
+	}
+}
+
+func TestReadStateEmptyOrNilFile(t *testing.T) {
+	var emptyState bytes.Buffer
+	_, err := ReadState(&emptyState)
+	if err != ErrNoState {
+		t.Fatal("expected ErrNostate, got", err)
+	}
+
+	var nilFile *os.File
+	_, err = ReadState(nilFile)
+	if err != ErrNoState {
+		t.Fatal("expected ErrNostate, got", err)
 	}
 }
 


### PR DESCRIPTION
During backend initialization, especially during a migration, there is a
chance that an existing state could be overwritten.

Attempt to get a locks when writing the new state. It would be nice to
always have a lock when reading the states, but the recursive structure
of the Meta.Backend config functions makes that quite complex.