### PR TITLE
aws_codecommit_trigger: fix typo that causes serialization to fail when events is non-empty

### DIFF
--- a/builtin/providers/aws/resource_aws_codecommit_trigger.go
+++ b/builtin/providers/aws/resource_aws_codecommit_trigger.go
@@ -143,7 +143,7 @@ func expandAwsCodeCommitTriggers(configured []interface{}) []*codecommit.Reposit
 			Name:           aws.String(data["name"].(string)),
 		}
 
-		branches := make([]*string, len(data["events"].([]interface{})))
+		branches := make([]*string, len(data["branches"].([]interface{})))
 		for i, vv := range data["branches"].([]interface{}) {
 			str := vv.(string)
 			branches[i] = aws.String(str)


### PR DESCRIPTION
Debug output (see invalid JSON):

```
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: ---[ REQUEST POST-SIGN ]-----------------------------
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: POST / HTTP/1.1
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: Host: codecommit.eu-west-1.amazonaws.com
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: User-Agent: APN/1.0 HashiCorp/1.0 Terraform/0.8.6
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: Content-Length: 236
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: Authorization: ...
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: Content-Type: application/x-amz-json-1.1
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: X-Amz-Date: 20170209T222740Z
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: X-Amz-Target: CodeCommit_20150413.PutRepositoryTriggers
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: Accept-Encoding: gzip
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe:
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: {"repositoryName":"foo","triggers":[{"branches":[,],"customData":"","destinationArn":"arn:aws:lambda:eu-west-1:...:function:codebuild-hook","events":["updateReference","createReference"],"name":"codebuild-hook"}]}
2017/02/09 23:27:40 [DEBUG] plugin: terraform.exe: -----------------------------------------------------
```

```
Error applying plan:

1 error(s) occurred:

* aws_codecommit_trigger.foo2017/02/09 23:27:40 [DEBUG] plugin: C:\HashiCorp\Terraform\bin\terraform.exe: plugin process exited
: Error creating CodeCommit Trigger: SerializationException:
        status code: 400, request id: ...

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```