### PR TITLE
provider/google: Update node version in container cluster test

### DIFF
--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -215,7 +215,7 @@ var testAccContainerCluster_withVersion = fmt.Sprintf(`
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	node_version = "1.4.7"
+	node_version = "1.5.2"
 	initial_node_count = 1
 
 	master_auth {


### PR DESCRIPTION
The previous version is no longer valid, so the test was consistently failing.