### PR TITLE
provider/fastly Allows for conditional settings across fastly

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -368,21 +368,22 @@ func resourceServiceV1() *schema.Resource {
 							Default:     100,
 							Description: "Lower priorities execute first. (Default: 100.)",
 						},
-						// These fields represent Fastly options that Terraform does not
-						// currently support
 						"request_condition": {
 							Type:        schema.TypeString,
-							Computed:    true,
+							Optional:    true,
+							Default:     "",
 							Description: "Optional name of a RequestCondition to apply.",
 						},
 						"cache_condition": {
 							Type:        schema.TypeString,
-							Computed:    true,
+							Optional:    true,
+							Default:     "",
 							Description: "Optional name of a CacheCondition to apply.",
 						},
 						"response_condition": {
 							Type:        schema.TypeString,
-							Computed:    true,
+							Optional:    true,
+							Default:     "",
 							Description: "Optional name of a ResponseCondition to apply.",
 						},
 					},

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -170,7 +170,7 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "Condition, which if met, will select this backend during a request.",
+							Description: "Name of a condition, which if met, will select this backend during a request.",
 						},
 						"shield": {
 							Type:        schema.TypeString,
@@ -228,7 +228,7 @@ func resourceServiceV1() *schema.Resource {
 						"cache_condition": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Condition to check if this Cache Setting applies",
+							Description: "Name of a condition to check if this Cache Setting applies",
 						},
 						"action": {
 							Type:        schema.TypeString,
@@ -279,7 +279,7 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "The cache condition controlling when this gzip configuration applies.",
+							Description: "Name of a condition controlling when this gzip configuration applies.",
 						},
 					},
 				},
@@ -372,19 +372,19 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "Optional name of a RequestCondition to apply.",
+							Description: "Optional name of a request condition to apply.",
 						},
 						"cache_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "Optional name of a CacheCondition to apply.",
+							Description: "Optional name of a cache condition to apply.",
 						},
 						"response_condition": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "Optional name of a ResponseCondition to apply.",
+							Description: "Optional name of a response condition to apply.",
 						},
 					},
 				},
@@ -538,7 +538,7 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "When to execute the s3. If empty, always execute.",
+							Description: "Name of a condition to apply this logging.",
 						},
 					},
 				},
@@ -576,7 +576,7 @@ func resourceServiceV1() *schema.Resource {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "",
-							Description: "When to execute logging to papertrail. If empty, always execute.",
+							Description: "Name of a condition to apply this logging",
 						},
 					},
 				},
@@ -596,7 +596,7 @@ func resourceServiceV1() *schema.Resource {
 						"request_condition": {
 							Type:        schema.TypeString,
 							Required:    true,
-							Description: "Name of a RequestCondition to apply.",
+							Description: "Name of a request condition to apply.",
 						},
 						// Optional fields
 						"max_stale_age": {

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -559,12 +559,18 @@ func resourceServiceV1() *schema.Resource {
 							Required:    true,
 							Description: "The port of the papertrail service",
 						},
-						// Optional
+						// Optional fields
 						"format": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Default:     "%h %l %u %t %r %>s",
 							Description: "Apache-style string or VCL variables to use for log formatting",
+						},
+						"response_condition": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "When to execute logging to papertrail. If empty, always execute.",
 						},
 					},
 				},
@@ -1245,12 +1251,13 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				pf := pRaw.(map[string]interface{})
 
 				opts := gofastly.CreatePapertrailInput{
-					Service: d.Id(),
-					Version: latestVersion,
-					Name:    pf["name"].(string),
-					Address: pf["address"].(string),
-					Port:    uint(pf["port"].(int)),
-					Format:  pf["format"].(string),
+					Service:           d.Id(),
+					Version:           latestVersion,
+					Name:              pf["name"].(string),
+					Address:           pf["address"].(string),
+					Port:              uint(pf["port"].(int)),
+					Format:            pf["format"].(string),
+					ResponseCondition: pf["response_condition"].(string),
 				}
 
 				log.Printf("[DEBUG] Create Papertrail Opts: %#v", opts)
@@ -2023,10 +2030,11 @@ func flattenPapertrails(papertrailList []*gofastly.Papertrail) []map[string]inte
 	for _, p := range papertrailList {
 		// Convert S3s to a map for saving to state.
 		ns := map[string]interface{}{
-			"name":    p.Name,
-			"address": p.Address,
-			"port":    p.Port,
-			"format":  p.Format,
+			"name":               p.Name,
+			"address":            p.Address,
+			"port":               p.Port,
+			"format":             p.Format,
+			"response_condition": p.ResponseCondition,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -534,6 +534,12 @@ func resourceServiceV1() *schema.Resource {
 							Default:     "%Y-%m-%dT%H:%M:%S.000",
 							Description: "specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`)",
 						},
+						"response_condition": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "When to execute the s3. If empty, always execute.",
+						},
 					},
 				},
 			},
@@ -1193,19 +1199,20 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 				}
 
 				opts := gofastly.CreateS3Input{
-					Service:         d.Id(),
-					Version:         latestVersion,
-					Name:            sf["name"].(string),
-					BucketName:      sf["bucket_name"].(string),
-					AccessKey:       sf["s3_access_key"].(string),
-					SecretKey:       sf["s3_secret_key"].(string),
-					Period:          uint(sf["period"].(int)),
-					GzipLevel:       uint(sf["gzip_level"].(int)),
-					Domain:          sf["domain"].(string),
-					Path:            sf["path"].(string),
-					Format:          sf["format"].(string),
-					FormatVersion:   uint(sf["format_version"].(int)),
-					TimestampFormat: sf["timestamp_format"].(string),
+					Service:           d.Id(),
+					Version:           latestVersion,
+					Name:              sf["name"].(string),
+					BucketName:        sf["bucket_name"].(string),
+					AccessKey:         sf["s3_access_key"].(string),
+					SecretKey:         sf["s3_secret_key"].(string),
+					Period:            uint(sf["period"].(int)),
+					GzipLevel:         uint(sf["gzip_level"].(int)),
+					Domain:            sf["domain"].(string),
+					Path:              sf["path"].(string),
+					Format:            sf["format"].(string),
+					FormatVersion:     uint(sf["format_version"].(int)),
+					TimestampFormat:   sf["timestamp_format"].(string),
+					ResponseCondition: sf["response_condition"].(string),
 				}
 
 				log.Printf("[DEBUG] Create S3 Logging Opts: %#v", opts)
@@ -2000,17 +2007,18 @@ func flattenS3s(s3List []*gofastly.S3) []map[string]interface{} {
 	for _, s := range s3List {
 		// Convert S3s to a map for saving to state.
 		ns := map[string]interface{}{
-			"name":             s.Name,
-			"bucket_name":      s.BucketName,
-			"s3_access_key":    s.AccessKey,
-			"s3_secret_key":    s.SecretKey,
-			"path":             s.Path,
-			"period":           s.Period,
-			"domain":           s.Domain,
-			"gzip_level":       s.GzipLevel,
-			"format":           s.Format,
-			"format_version":   s.FormatVersion,
-			"timestamp_format": s.TimestampFormat,
+			"name":               s.Name,
+			"bucket_name":        s.BucketName,
+			"s3_access_key":      s.AccessKey,
+			"s3_secret_key":      s.SecretKey,
+			"path":               s.Path,
+			"period":             s.Period,
+			"domain":             s.Domain,
+			"gzip_level":         s.GzipLevel,
+			"format":             s.Format,
+			"format_version":     s.FormatVersion,
+			"timestamp_format":   s.TimestampFormat,
+			"response_condition": s.ResponseCondition,
 		}
 
 		// prune any empty values that come from the default string value in structs

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -275,12 +275,11 @@ func resourceServiceV1() *schema.Resource {
 							Description: "File extensions to apply automatic gzip to. Do not include '.'",
 							Elem:        &schema.Schema{Type: schema.TypeString},
 						},
-						// These fields represent Fastly options that Terraform does not
-						// currently support
 						"cache_condition": {
 							Type:        schema.TypeString,
-							Computed:    true,
-							Description: "Optional name of a CacheCondition to apply.",
+							Optional:    true,
+							Default:     "",
+							Description: "The cache condition controlling when this gzip configuration applies.",
 						},
 					},
 				},
@@ -1056,9 +1055,10 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			for _, dRaw := range add {
 				df := dRaw.(map[string]interface{})
 				opts := gofastly.CreateGzipInput{
-					Service: d.Id(),
-					Version: latestVersion,
-					Name:    df["name"].(string),
+					Service:        d.Id(),
+					Version:        latestVersion,
+					Name:           df["name"].(string),
+					CacheCondition: df["cache_condition"].(string),
 				}
 
 				if v, ok := df["content_types"]; ok {

--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -196,7 +196,7 @@ resource "fastly_service_v1" "foo" {
     name      = "testing_condition"
     type      = "CACHE"
     priority  = 10
-    statement = "!beresp.cachable"
+    statement = "req.url ~ "^/articles/""
   }
 
   gzip {

--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -2,6 +2,7 @@ package fastly
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -106,6 +107,26 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
+	log1 := gofastly.Gzip{
+		Version:        "1",
+		Name:           "gzip file types",
+		Extensions:     "css js",
+		CacheCondition: "testing_condition",
+	}
+
+	log2 := gofastly.Gzip{
+		Version:    "1",
+		Name:       "gzip extensions",
+		Extensions: "text/html text/css",
+	}
+
+	log3 := gofastly.Gzip{
+		Version:      "1",
+		Name:         "all",
+		Extensions:   "css js html",
+		ContentTypes: "text/html text/css application/x-javascript text/css application/javascript text/javascript",
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -115,21 +136,11 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 				Config: testAccServiceV1GzipsConfig(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1GzipsAttributes(&service, name, 2),
+					testAccCheckFastlyServiceV1GzipsAttributes(&service, []*gofastly.Gzip{&log1, &log2}),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "name", name),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "gzip.#", "2"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3704620722.cache_condition", "testing_condition"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3704620722.extensions.#", "2"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3704620722.content_types.#", "0"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3820313126.content_types.#", "2"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3820313126.extensions.#", "0"),
 				),
 			},
 
@@ -137,27 +148,19 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 				Config: testAccServiceV1GzipsConfig_update(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1GzipsAttributes(&service, name, 1),
+					testAccCheckFastlyServiceV1GzipsAttributes(&service, []*gofastly.Gzip{&log3}),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "name", name),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "gzip.#", "1"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3694165387.extensions.#", "3"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3694165387.content_types.#", "5"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckFastlyServiceV1GzipsAttributes(service *gofastly.ServiceDetail, name string, gzipCount int) resource.TestCheckFunc {
+func testAccCheckFastlyServiceV1GzipsAttributes(service *gofastly.ServiceDetail, gzips []*gofastly.Gzip) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
-		if service.Name != name {
-			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
-		}
 
 		conn := testAccProvider.Meta().(*FastlyClient).conn
 		gzipsList, err := conn.ListGzips(&gofastly.ListGzipsInput{
@@ -169,8 +172,27 @@ func testAccCheckFastlyServiceV1GzipsAttributes(service *gofastly.ServiceDetail,
 			return fmt.Errorf("[ERR] Error looking up Gzips for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
-		if len(gzipsList) != gzipCount {
-			return fmt.Errorf("Gzip count mismatch, expected (%d), got (%d)", gzipCount, len(gzipsList))
+		if len(gzipsList) != len(gzips) {
+			return fmt.Errorf("Gzip count mismatch, expected (%d), got (%d)", len(gzips), len(gzipsList))
+		}
+
+		var found int
+		for _, g := range gzips {
+			for _, lg := range gzipsList {
+				if g.Name == lg.Name {
+					// we don't know these things ahead of time, so populate them now
+					g.ServiceID = service.ID
+					g.Version = service.ActiveVersion.Number
+					if !reflect.DeepEqual(g, lg) {
+						return fmt.Errorf("Bad match Gzip match, expected (%#v), got (%#v)", g, lg)
+					}
+					found++
+				}
+			}
+		}
+
+		if found != len(gzips) {
+			return fmt.Errorf("Error matching Gzip rules")
 		}
 
 		return nil

--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -121,7 +121,7 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "gzip.#", "2"),
 					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "gzip.3704620722.cache_condition", "!beresp.cachable"),
+						"fastly_service_v1.foo", "gzip.3704620722.cache_condition", "testing_condition"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "gzip.3704620722.extensions.#", "2"),
 					resource.TestCheckResourceAttr(
@@ -192,11 +192,17 @@ resource "fastly_service_v1" "foo" {
     name    = "amazon docs"
   }
 
+	condition {
+    name      = "testing_condition"
+    type      = "CACHE"
+    priority  = 10
+    statement = "!beresp.cachable"
+  }
+
   gzip {
     name       			= "gzip file types"
     extensions 			= ["css", "js"]
-		cache_condition = "!beresp.cachable"
-
+		cache_condition = "testing_condition"
   }
 
   gzip {

--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -110,21 +110,21 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 	log1 := gofastly.Gzip{
 		Version:        "1",
 		Name:           "gzip file types",
-		Extensions:     "css js",
+		Extensions:     "js css",
 		CacheCondition: "testing_condition",
 	}
 
 	log2 := gofastly.Gzip{
-		Version:    "1",
-		Name:       "gzip extensions",
-		Extensions: "text/html text/css",
+		Version:      "1",
+		Name:         "gzip extensions",
+		ContentTypes: "text/css text/html",
 	}
 
 	log3 := gofastly.Gzip{
 		Version:      "1",
 		Name:         "all",
-		Extensions:   "css js html",
-		ContentTypes: "text/html text/css application/x-javascript text/css application/javascript text/javascript",
+		Extensions:   "js html css",
+		ContentTypes: "text/javascript application/x-javascript application/javascript text/css text/html",
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -218,7 +218,7 @@ resource "fastly_service_v1" "foo" {
     name      = "testing_condition"
     type      = "CACHE"
     priority  = 10
-    statement = "req.url ~ "^/articles/""
+    statement = "req.url ~ \"^/articles/\""
   }
 
   gzip {

--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -121,6 +121,8 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "gzip.#", "2"),
 					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "gzip.3704620722.cache_condition", "!beresp.cachable"),
+					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "gzip.3704620722.extensions.#", "2"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "gzip.3704620722.content_types.#", "0"),
@@ -191,8 +193,10 @@ resource "fastly_service_v1" "foo" {
   }
 
   gzip {
-    name       = "gzip file types"
-    extensions = ["css", "js"]
+    name       			= "gzip file types"
+    extensions 			= ["css", "js"]
+		cache_condition = "!beresp.cachable"
+
   }
 
   gzip {

--- a/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
@@ -109,6 +109,12 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 						"fastly_service_v1.foo", "header.#", "3"),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "header.1147514417.source", "server.identity"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "header.1147514417.request_condition", "req.url ~ \"^/foo/bar$\""),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "header.1147514417.cache_condition", "!beresp.cachable"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "header.1147514417.response_condition", "resp.status == 404"),
 				),
 			},
 		},
@@ -223,11 +229,14 @@ resource "fastly_service_v1" "foo" {
   }
 
   header {
-    destination = "http.server-name"
-    type        = "request"
-    action      = "set"
-    source      = "server.identity"
-    name        = "Add server name"
+    destination 			 = "http.server-name"
+    type        			 = "request"
+    action      			 = "set"
+    source      			 = "server.identity"
+    name        			 = "Add server name"
+		request_condition  = "req.url ~ \"^/foo/bar$\""
+		cache_condition    = "!beresp.cachable"
+		response_condition = "resp.status == 404"
   }
 
   force_destroy = true

--- a/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
@@ -110,11 +110,11 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "header.1147514417.source", "server.identity"),
 					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "header.1147514417.request_condition", "req.url ~ \"^/foo/bar$\""),
+						"fastly_service_v1.foo", "header.1147514417.request_condition", "test_req_condition"),
 					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "header.1147514417.cache_condition", "!beresp.cachable"),
+						"fastly_service_v1.foo", "header.1147514417.cache_condition", "test_cache_condition"),
 					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "header.1147514417.response_condition", "resp.status == 404"),
+						"fastly_service_v1.foo", "header.1147514417.response_condition", "test_res_condition"),
 				),
 			},
 		},
@@ -228,15 +228,36 @@ resource "fastly_service_v1" "foo" {
     name        = "DESTROY S3"
   }
 
+	condition {
+    name      = "test_req_condition"
+    type      = "REQUEST"
+    priority  = 5
+    statement = "req.url ~ \"^/foo/bar$\""
+  }
+
+	condition {
+    name      = "test_cache_condition"
+    type      = "CACHE"
+    priority  = 9
+    statement = "!beresp.cachable"
+  }
+
+	condition {
+    name      = "test_res_condition"
+    type      = "RESPONSE"
+    priority  = 10
+    statement = "resp.status == 404"
+  }
+
   header {
     destination 			 = "http.server-name"
     type        			 = "request"
     action      			 = "set"
     source      			 = "server.identity"
     name        			 = "Add server name"
-		request_condition  = "req.url ~ \"^/foo/bar$\""
-		cache_condition    = "!beresp.cachable"
-		response_condition = "resp.status == 404"
+		request_condition  = "test_req_condition"
+		cache_condition    = "test_cache_condition"
+		response_condition = "test_res_condition"
   }
 
   force_destroy = true

--- a/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
@@ -3,7 +3,6 @@ package fastly
 import (
 	"fmt"
 	"reflect"
-	"sort"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -81,6 +80,42 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
+	log1 := gofastly.Header{
+		Version:     "1",
+		Name:        "remove x-amz-request-id",
+		Destination: "http.x-amz-request-id",
+		Type:        "cache",
+		Action:      "delete",
+	}
+
+	log2 := gofastly.Header{
+		Version:     "1",
+		Name:        "remove s3 server",
+		Destination: "http.Server",
+		Type:        "cache",
+		Action:      "delete",
+		IgnoreIfSet: true,
+	}
+
+	log3 := gofastly.Header{
+		Version:     "1",
+		Name:        "DESTROY S3",
+		Destination: "http.Server",
+		Type:        "cache",
+		Action:      "delete",
+	}
+
+	log4 := gofastly.Header{
+		Version:           "1",
+		Name:              "Add server name",
+		Destination:       "http.server-name",
+		Type:              "request",
+		Action:            "set",
+		RequestCondition:  "test_req_condition",
+		CacheCondition:    "test_cache_condition",
+		ResponseCondition: "test_res_condition",
+	}
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -90,7 +125,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 				Config: testAccServiceV1HeadersConfig(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1HeaderAttributes(&service, name, []string{"http.x-amz-request-id", "http.Server"}, nil),
+					testAccCheckFastlyServiceV1HeaderAttributes(&service, []*gofastly.Header{&log1, &log2}),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "name", name),
 					resource.TestCheckResourceAttr(
@@ -102,31 +137,19 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 				Config: testAccServiceV1HeadersConfig_update(name, domainName1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
-					testAccCheckFastlyServiceV1HeaderAttributes(&service, name, []string{"http.x-amz-request-id", "http.Server"}, []string{"http.server-name"}),
+					testAccCheckFastlyServiceV1HeaderAttributes(&service, []*gofastly.Header{&log1, &log3, &log4}),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "name", name),
 					resource.TestCheckResourceAttr(
 						"fastly_service_v1.foo", "header.#", "3"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "header.1147514417.source", "server.identity"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "header.1147514417.request_condition", "test_req_condition"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "header.1147514417.cache_condition", "test_cache_condition"),
-					resource.TestCheckResourceAttr(
-						"fastly_service_v1.foo", "header.1147514417.response_condition", "test_res_condition"),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckFastlyServiceV1HeaderAttributes(service *gofastly.ServiceDetail, name string, headersDeleted, headersAdded []string) resource.TestCheckFunc {
+func testAccCheckFastlyServiceV1HeaderAttributes(service *gofastly.ServiceDetail, headers []*gofastly.Header) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-
-		if service.Name != name {
-			return fmt.Errorf("Bad name, expected (%s), got (%s)", name, service.Name)
-		}
 
 		conn := testAccProvider.Meta().(*FastlyClient).conn
 		headersList, err := conn.ListHeaders(&gofastly.ListHeadersInput{
@@ -138,27 +161,27 @@ func testAccCheckFastlyServiceV1HeaderAttributes(service *gofastly.ServiceDetail
 			return fmt.Errorf("[ERR] Error looking up Headers for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
-		var deleted []string
-		var added []string
-		for _, h := range headersList {
-			if h.Action == gofastly.HeaderActionDelete {
-				deleted = append(deleted, h.Destination)
-			}
-			if h.Action == gofastly.HeaderActionSet {
-				added = append(added, h.Destination)
+		if len(headersList) != len(headers) {
+			return fmt.Errorf("Healthcheck List count mismatch, expected (%d), got (%d)", len(headers), len(headersList))
+		}
+
+		var found int
+		for _, h := range headers {
+			for _, lh := range headersList {
+				if h.Name == lh.Name {
+					// we don't know these things ahead of time, so populate them now
+					h.ServiceID = service.ID
+					h.Version = service.ActiveVersion.Number
+					if !reflect.DeepEqual(h, lh) {
+						return fmt.Errorf("Bad match Header match, expected (%#v), got (%#v)", h, lh)
+					}
+					found++
+				}
 			}
 		}
 
-		sort.Strings(headersAdded)
-		sort.Strings(headersDeleted)
-		sort.Strings(deleted)
-		sort.Strings(added)
-
-		if !reflect.DeepEqual(headersDeleted, deleted) {
-			return fmt.Errorf("Deleted Headers did not match.\n\tExpected: (%#v)\n\tGot: (%#v)", headersDeleted, deleted)
-		}
-		if !reflect.DeepEqual(headersAdded, added) {
-			return fmt.Errorf("Added Headers did not match.\n\tExpected: (%#v)\n\tGot: (%#v)", headersAdded, added)
+		if found != len(headers) {
+			return fmt.Errorf("Error matching Header rules")
 		}
 
 		return nil
@@ -239,7 +262,7 @@ resource "fastly_service_v1" "foo" {
     name      = "test_cache_condition"
     type      = "CACHE"
     priority  = 9
-    statement = "!beresp.cachable"
+    statement = "req.url ~ "^/articles/""
   }
 
 	condition {

--- a/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
@@ -86,6 +86,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 		Destination: "http.x-amz-request-id",
 		Type:        "cache",
 		Action:      "delete",
+		Priority:    uint(100),
 	}
 
 	log2 := gofastly.Header{
@@ -95,6 +96,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 		Type:        "cache",
 		Action:      "delete",
 		IgnoreIfSet: true,
+		Priority:    uint(100),
 	}
 
 	log3 := gofastly.Header{
@@ -103,6 +105,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 		Destination: "http.Server",
 		Type:        "cache",
 		Action:      "delete",
+		Priority:    uint(100),
 	}
 
 	log4 := gofastly.Header{
@@ -111,6 +114,8 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 		Destination:       "http.server-name",
 		Type:              "request",
 		Action:            "set",
+		Source:            "server.identity",
+		Priority:          uint(100),
 		RequestCondition:  "test_req_condition",
 		CacheCondition:    "test_cache_condition",
 		ResponseCondition: "test_res_condition",
@@ -262,7 +267,7 @@ resource "fastly_service_v1" "foo" {
     name      = "test_cache_condition"
     type      = "CACHE"
     priority  = 9
-    statement = "req.url ~ "^/articles/""
+    statement = "req.url ~ \"^/articles/\""
   }
 
 	condition {

--- a/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -26,11 +26,11 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 	}
 
 	log2 := gofastly.Papertrail{
-		Version:           "1",
-		Name:              "papertrailtesting2",
-		Address:           "test2.papertrailapp.com",
-		Port:              uint(8080),
-		Format:            "%h %l %u %t %r %>s",
+		Version: "1",
+		Name:    "papertrailtesting2",
+		Address: "test2.papertrailapp.com",
+		Port:    uint(8080),
+		Format:  "%h %l %u %t %r %>s",
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -22,7 +22,7 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 		Address:           "test1.papertrailapp.com",
 		Port:              uint(3600),
 		Format:            "%h %l %u %t %r %>s",
-		ResponseCondition: "resp.status >= 400 && resp.status < 600",
+		ResponseCondition: "test_response_condition",
 	}
 
 	log2 := gofastly.Papertrail{
@@ -31,7 +31,6 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 		Address:           "test2.papertrailapp.com",
 		Port:              uint(8080),
 		Format:            "%h %l %u %t %r %>s",
-		ResponseCondition: "resp.status = 418",
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -125,11 +124,18 @@ resource "fastly_service_v1" "foo" {
     name    = "amazon docs"
   }
 
+	condition {
+    name      = "test_response_condition"
+    type      = "RESPONSE"
+    priority  = 5
+    statement = "resp.status >= 400 && resp.status < 600"
+  }
+
   papertrail {
     name               = "papertrailtesting"
     address            = "test1.papertrailapp.com"
     port               = 3600
-		response_condition = "resp.status >= 400 && resp.status < 600"
+		response_condition = "test_response_condition"
   }
 
   force_destroy = true
@@ -151,18 +157,24 @@ resource "fastly_service_v1" "foo" {
     name    = "amazon docs"
   }
 
+	condition {
+    name      = "test_response_condition"
+    type      = "RESPONSE"
+    priority  = 5
+    statement = "resp.status >= 400 && resp.status < 600"
+  }
+
 	papertrail {
     name               = "papertrailtesting"
     address            = "test1.papertrailapp.com"
     port               = 3600
-		response_condition = "resp.status >= 400 && resp.status < 600"
+		response_condition = "test_response_condition"
   }
 
 	papertrail {
     name               = "papertrailtesting2"
     address            = "test2.papertrailapp.com"
     port               = 8080
-		response_condition = "resp.status = 418"
   }
 
   force_destroy = true

--- a/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -17,19 +17,21 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.Papertrail{
-		Version: "1",
-		Name:    "papertrailtesting",
-		Address: "test1.papertrailapp.com",
-		Port:    uint(3600),
-		Format:  "%h %l %u %t %r %>s",
+		Version:           "1",
+		Name:              "papertrailtesting",
+		Address:           "test1.papertrailapp.com",
+		Port:              uint(3600),
+		Format:            "%h %l %u %t %r %>s",
+		ResponseCondition: "resp.status >= 400 && resp.status < 600",
 	}
 
 	log2 := gofastly.Papertrail{
-		Version: "1",
-		Name:    "papertrailtesting2",
-		Address: "test2.papertrailapp.com",
-		Port:    uint(8080),
-		Format:  "%h %l %u %t %r %>s",
+		Version:           "1",
+		Name:              "papertrailtesting2",
+		Address:           "test2.papertrailapp.com",
+		Port:              uint(8080),
+		Format:            "%h %l %u %t %r %>s",
+		ResponseCondition: "resp.status = 418",
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -124,9 +126,10 @@ resource "fastly_service_v1" "foo" {
   }
 
   papertrail {
-    name    = "papertrailtesting"
-    address = "test1.papertrailapp.com"
-    port    = 3600
+    name               = "papertrailtesting"
+    address            = "test1.papertrailapp.com"
+    port               = 3600
+		response_condition = "resp.status >= 400 && resp.status < 600"
   }
 
   force_destroy = true
@@ -149,15 +152,17 @@ resource "fastly_service_v1" "foo" {
   }
 
 	papertrail {
-    name    = "papertrailtesting"
-    address = "test1.papertrailapp.com"
-    port    = 3600
+    name               = "papertrailtesting"
+    address            = "test1.papertrailapp.com"
+    port               = 3600
+		response_condition = "resp.status >= 400 && resp.status < 600"
   }
 
 	papertrail {
-    name    = "papertrailtesting2"
-    address = "test2.papertrailapp.com"
-    port    = 8080
+    name               = "papertrailtesting2"
+    address            = "test2.papertrailapp.com"
+    port               = 8080
+		response_condition = "resp.status = 418"
   }
 
   force_destroy = true

--- a/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -18,17 +18,18 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.S3{
-		Version:         "1",
-		Name:            "somebucketlog",
-		BucketName:      "fastlytestlogging",
-		Domain:          "s3-us-west-2.amazonaws.com",
-		AccessKey:       "somekey",
-		SecretKey:       "somesecret",
-		Period:          uint(3600),
-		GzipLevel:       uint(0),
-		Format:          "%h %l %u %t %r %>s",
-		FormatVersion:   1,
-		TimestampFormat: "%Y-%m-%dT%H:%M:%S.000",
+		Version:           "1",
+		Name:              "somebucketlog",
+		BucketName:        "fastlytestlogging",
+		Domain:            "s3-us-west-2.amazonaws.com",
+		AccessKey:         "somekey",
+		SecretKey:         "somesecret",
+		Period:            uint(3600),
+		GzipLevel:         uint(0),
+		Format:            "%h %l %u %t %r %>s",
+		FormatVersion:     1,
+		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
+		ResponseCondition: "resp.status == 418",
 	}
 
 	log2 := gofastly.S3{
@@ -220,11 +221,12 @@ resource "fastly_service_v1" "foo" {
   }
 
   s3logging {
-    name       = "somebucketlog"
-    bucket_name = "fastlytestlogging"
-    domain     = "s3-us-west-2.amazonaws.com"
-    s3_access_key = "somekey"
-    s3_secret_key = "somesecret"
+    name               = "somebucketlog"
+    bucket_name        = "fastlytestlogging"
+    domain             = "s3-us-west-2.amazonaws.com"
+    s3_access_key      = "somekey"
+    s3_secret_key      = "somesecret"
+		response_condition = "resp.status == 418"
   }
 
   force_destroy = true

--- a/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -29,7 +29,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 		Format:            "%h %l %u %t %r %>s",
 		FormatVersion:     1,
 		TimestampFormat:   "%Y-%m-%dT%H:%M:%S.000",
-		ResponseCondition: "resp.status == 418",
+		ResponseCondition: "response_condition_test",
 	}
 
 	log2 := gofastly.S3{
@@ -220,13 +220,20 @@ resource "fastly_service_v1" "foo" {
     name    = "amazon docs"
   }
 
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status = 418"
+  }
+
   s3logging {
     name               = "somebucketlog"
     bucket_name        = "fastlytestlogging"
     domain             = "s3-us-west-2.amazonaws.com"
     s3_access_key      = "somekey"
     s3_secret_key      = "somesecret"
-		response_condition = "resp.status == 418"
+		response_condition = "response_condition_test"
   }
 
   force_destroy = true

--- a/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -224,7 +224,7 @@ resource "fastly_service_v1" "foo" {
     name      = "response_condition_test"
     type      = "RESPONSE"
     priority  = 8
-    statement = "resp.status = 418"
+    statement = "resp.status == 418"
   }
 
   s3logging {

--- a/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -255,12 +255,20 @@ resource "fastly_service_v1" "foo" {
     name    = "amazon docs"
   }
 
+	condition {
+    name      = "response_condition_test"
+    type      = "RESPONSE"
+    priority  = 8
+    statement = "resp.status == 418"
+  }
+
   s3logging {
-    name          = "somebucketlog"
-    bucket_name   = "fastlytestlogging"
-    domain        = "s3-us-west-2.amazonaws.com"
-    s3_access_key = "somekey"
-    s3_secret_key = "somesecret"
+    name               = "somebucketlog"
+    bucket_name        = "fastlytestlogging"
+    domain             = "s3-us-west-2.amazonaws.com"
+    s3_access_key      = "somekey"
+    s3_secret_key      = "somesecret"
+		response_condition = "response_condition_test"
   }
 
   s3logging {

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -232,6 +232,10 @@ content. (Does not apply to the `delete` action.)
 * `regex` - (Optional) Regular expression to use (Only applies to the `regex` and `regex_repeat` actions.)
 * `substitution` - (Optional) Value to substitute in place of regular expression. (Only applies to the `regex` and `regex_repeat` actions.)
 * `priority` - (Optional) Lower priorities execute first. Default: `100`.
+* `request_condition` - (Optional) Name of a RequestCondition to apply.
+* `cache_condition` - (Optional) Name of a CacheCondition to apply.
+* `response_condition` - (Optional) Name of a ResponseCondition to apply.For detailed information about Conditionals,
+see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 The `healthcheck` block supports:
 

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -300,8 +300,7 @@ compression. `1` is fastest and least compressed, `9` is slowest and most
 compressed. Default `0`.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `timestamp_format` - (Optional) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
-* `request_condition` - (Optional) The VCL request condition to check if this
-Request Setting should be applied. For detailed information about Conditionals,
+* `request_condition` - (Optional) When to execute the s3. If empty, always execute. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 The `papertrail` block supports:

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -213,6 +213,8 @@ The `gzip` block supports:
 have dynamically gzip'ed. Example: `["text/html", "text/css"]`.
 * `extensions` - (Optional) File extensions for each file type to dynamically
 gzip. Example: `["css", "js"]`.
+* `cache_condition` - (Optional) The cache condition controlling when this gzip configuration applies. For detailed information about Conditionals,
+see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 
 The `Header` block supports adding, removing, or modifying Request and Response

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -176,7 +176,7 @@ Default `1000`
 * `max_conn` - (Optional) Maximum number of connections for this Backend.
 Default `200`.
 * `port` - (Optional) The port number on which the Backend responds. Default `80`.
-* `request_condition` - (Optional, string) Condition, which if met, will select this backend during a request.
+* `request_condition` - (Optional, string) Name of already defined `condition`, which if met, will select this backend during a request.
 * `ssl_check_cert` - (Optional) Be strict about checking SSL certs. Default `true`.
 * `ssl_hostname` - (Optional) Used for both SNI during the TLS handshake and to validate the cert.
 * `shield` - (Optional) The POP of the shield designated to reduce inbound load.
@@ -201,7 +201,7 @@ The `cache_setting` block supports:
 * `name` - (Required) Unique name for this Cache Setting.
 * `action` - (Required) One of `cache`, `pass`, or `restart`, as defined
 on Fastly's documentation under ["Caching action descriptions"](https://docs.fastly.com/guides/performance-tuning/controlling-caching#caching-action-descriptions).
-* `cache_condition` - (Required) Name of the condition used to test whether this settings object should be used. This Condition must be of type `CACHE`.
+* `cache_condition` - (Required) Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.
 * `stale_ttl` - (Optional) Max "Time To Live" for stale (unreachable) objects.
 Default `300`.
 * `ttl` - (Optional) The Time-To-Live (TTL) for the object.
@@ -213,7 +213,7 @@ The `gzip` block supports:
 have dynamically gzip'ed. Example: `["text/html", "text/css"]`.
 * `extensions` - (Optional) File extensions for each file type to dynamically
 gzip. Example: `["css", "js"]`.
-* `cache_condition` - (Optional) The cache condition controlling when this gzip configuration applies. For detailed information about Conditionals,
+* `cache_condition` - (Optional) Name of already defined `condition` controlling when this gzip configuration applies. This `condition` must be of type `CACHE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 
@@ -232,9 +232,9 @@ content. (Does not apply to the `delete` action.)
 * `regex` - (Optional) Regular expression to use (Only applies to the `regex` and `regex_repeat` actions.)
 * `substitution` - (Optional) Value to substitute in place of regular expression. (Only applies to the `regex` and `regex_repeat` actions.)
 * `priority` - (Optional) Lower priorities execute first. Default: `100`.
-* `request_condition` - (Optional) Name of a RequestCondition to apply.
-* `cache_condition` - (Optional) Name of a CacheCondition to apply.
-* `response_condition` - (Optional) Name of a ResponseCondition to apply.For detailed information about Conditionals,
+* `request_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`.
+* `cache_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `CACHE`.
+* `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 The `healthcheck` block supports:
@@ -255,9 +255,8 @@ The `request_setting` block allow you to customize Fastly's request handling, by
 defining behavior that should change based on a predefined `condition`:
 
 * `name` - (Required) The domain for this request setting.
-* `request_condition` - (Required) The name of the corresponding `condition` to
-determine if this request setting should be applied. The `request_condition` must
-match the name of a defined `condition`.
+* `request_condition` - (Required) Name of already defined `condition` to
+determine if this request setting should be applied.
 * `max_stale_age` - (Optional) How old an object is allowed to be to serve
 `stale-if-error` or `stale-while-revalidate`, in seconds. Default `60`.
 * `force_miss` - (Optional) Force a cache miss for the request. If specified,
@@ -300,7 +299,7 @@ compression. `1` is fastest and least compressed, `9` is slowest and most
 compressed. Default `0`.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `timestamp_format` - (Optional) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
-* `request_condition` - (Optional) When to execute the s3. If empty, always execute. For detailed information about Conditionals,
+* `request_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 The `papertrail` block supports:
@@ -309,8 +308,7 @@ The `papertrail` block supports:
 * `address` - (Required) The address of the Papertrail endpoint.
 * `port` - (Required) The port associated with the address where the Papertrail endpoint can be accessed.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
-* `request_condition` - (Optional) The VCL request condition to check if this
-Request Setting should be applied. For detailed information about Conditionals,
+* `request_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 The `vcl` block supports:


### PR DESCRIPTION
In Fastly:
* Allows user to set `cache_condition` for Gzip
* Allows user to set `cache_condition`, `request_condition` and `response_condition` for Header
* Adds optional `response_condition` setting for S3Logging
* Adds optional `response_condition` setting for Papertrail

- [x] Tests included
- [x] Website documentation included

#7554 