### PR TITLE
provider/aws: Fix bug to allow update of maintenance_window in elasticache_replication_group

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -17,38 +17,38 @@ import (
 func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 
 	return map[string]*schema.Schema{
-		"availability_zones": &schema.Schema{
+		"availability_zones": {
 			Type:     schema.TypeSet,
 			Optional: true,
 			ForceNew: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 		},
-		"node_type": &schema.Schema{
+		"node_type": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"engine": &schema.Schema{
+		"engine": {
 			Type:     schema.TypeString,
 			Required: true,
 		},
-		"engine_version": &schema.Schema{
+		"engine_version": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
 		},
-		"parameter_group_name": &schema.Schema{
+		"parameter_group_name": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
 		},
-		"subnet_group_name": &schema.Schema{
+		"subnet_group_name": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
 			ForceNew: true,
 		},
-		"security_group_names": &schema.Schema{
+		"security_group_names": {
 			Type:     schema.TypeSet,
 			Optional: true,
 			Computed: true,
@@ -56,7 +56,7 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 		},
-		"security_group_ids": &schema.Schema{
+		"security_group_ids": {
 			Type:     schema.TypeSet,
 			Optional: true,
 			Computed: true,
@@ -69,26 +69,26 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 		//
 		// See also:
 		// https://github.com/aws/aws-sdk-go/blob/4862a174f7fc92fb523fc39e68f00b87d91d2c3d/service/elasticache/api.go#L2079
-		"snapshot_arns": &schema.Schema{
+		"snapshot_arns": {
 			Type:     schema.TypeSet,
 			Optional: true,
 			ForceNew: true,
 			Elem:     &schema.Schema{Type: schema.TypeString},
 			Set:      schema.HashString,
 		},
-		"snapshot_window": &schema.Schema{
+		"snapshot_window": {
 			Type:         schema.TypeString,
 			Optional:     true,
 			Computed:     true,
 			ValidateFunc: validateOnceADayWindowFormat,
 		},
-		"snapshot_name": &schema.Schema{
+		"snapshot_name": {
 			Type:     schema.TypeString,
 			Optional: true,
 			ForceNew: true,
 		},
 
-		"maintenance_window": &schema.Schema{
+		"maintenance_window": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
@@ -99,17 +99,17 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 			},
 			ValidateFunc: validateOnceAWeekWindowFormat,
 		},
-		"port": &schema.Schema{
+		"port": {
 			Type:     schema.TypeInt,
 			Required: true,
 			ForceNew: true,
 		},
-		"notification_topic_arn": &schema.Schema{
+		"notification_topic_arn": {
 			Type:     schema.TypeString,
 			Optional: true,
 		},
 
-		"snapshot_retention_limit": &schema.Schema{
+		"snapshot_retention_limit": {
 			Type:     schema.TypeInt,
 			Optional: true,
 			ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
@@ -122,7 +122,7 @@ func resourceAwsElastiCacheCommonSchema() map[string]*schema.Schema {
 			},
 		},
 
-		"apply_immediately": &schema.Schema{
+		"apply_immediately": {
 			Type:     schema.TypeBool,
 			Optional: true,
 			Computed: true,
@@ -187,19 +187,19 @@ func resourceAwsElasticacheCluster() *schema.Resource {
 		Computed: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"id": &schema.Schema{
+				"id": {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"address": &schema.Schema{
+				"address": {
 					Type:     schema.TypeString,
 					Computed: true,
 				},
-				"port": &schema.Schema{
+				"port": {
 					Type:     schema.TypeInt,
 					Computed: true,
 				},
-				"availability_zone": &schema.Schema{
+				"availability_zone": {
 					Type:     schema.TypeString,
 					Computed: true,
 				},

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -305,8 +305,8 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 		}
 	}
 
-	if d.HasChange("preferred_maintenance_window") {
-		params.PreferredMaintenanceWindow = aws.String(d.Get("preferred_maintenance_window").(string))
+	if d.HasChange("maintenance_window") {
+		params.PreferredMaintenanceWindow = aws.String(d.Get("maintenance_window").(string))
 		requestUpdate = true
 	}
 

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -20,7 +20,7 @@ func TestAccAWSElasticacheReplicationGroup_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(acctest.RandString(10)),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -42,7 +42,7 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -55,7 +55,7 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedDescription(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -71,6 +71,34 @@ func TestAccAWSElasticacheReplicationGroup_updateDescription(t *testing.T) {
 	})
 }
 
+func TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "maintenance_window", "tue:06:30-tue:07:30"),
+				),
+			},
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedMaintenanceWindow(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "maintenance_window", "wed:03:00-wed:06:00"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 	var rg elasticache.ReplicationGroup
 	rName := acctest.RandString(10)
@@ -79,7 +107,7 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -90,7 +118,7 @@ func TestAccAWSElasticacheReplicationGroup_updateNodeSize(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedNodeSize(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -113,7 +141,7 @@ func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -122,7 +150,7 @@ func TestAccAWSElasticacheReplicationGroup_updateParameterGroup(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupConfigUpdatedParameterGroup(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -141,7 +169,7 @@ func TestAccAWSElasticacheReplicationGroup_vpc(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -162,7 +190,7 @@ func TestAccAWSElasticacheReplicationGroup_multiAzInVpc(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupMultiAZInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -189,7 +217,7 @@ func TestAccAWSElasticacheReplicationGroup_redisClusterInVpc2(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSElasticacheReplicationGroupRedisClusterInVPCConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
@@ -362,6 +390,8 @@ resource "aws_elasticache_replication_group" "bar" {
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
     auto_minor_version_upgrade = false
+    maintenance_window = "tue:06:30-tue:07:30"
+    snapshot_window = "01:00-02:00"
 }`, rName, rName, rName)
 }
 
@@ -441,6 +471,43 @@ resource "aws_elasticache_replication_group" "bar" {
     security_group_names = ["${aws_elasticache_security_group.bar.name}"]
     apply_immediately = true
     auto_minor_version_upgrade = true
+}`, rName, rName, rName)
+}
+
+func testAccAWSElasticacheReplicationGroupConfigUpdatedMaintenanceWindow(rName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+	region = "us-east-1"
+}
+resource "aws_security_group" "bar" {
+    name = "tf-test-security-group-%s"
+    description = "tf-test-security-group-descr"
+    ingress {
+        from_port = -1
+        to_port = -1
+        protocol = "icmp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_elasticache_security_group" "bar" {
+    name = "tf-test-security-group-%s"
+    description = "tf-test-security-group-descr"
+    security_group_names = ["${aws_security_group.bar.name}"]
+}
+
+resource "aws_elasticache_replication_group" "bar" {
+    replication_group_id = "tf-%s"
+    replication_group_description = "updated description"
+    node_type = "cache.m1.small"
+    number_cache_clusters = 2
+    port = 6379
+    parameter_group_name = "default.redis3.2"
+    security_group_names = ["${aws_elasticache_security_group.bar.name}"]
+    apply_immediately = true
+    auto_minor_version_upgrade = true
+    maintenance_window = "wed:03:00-wed:06:00"
+    snapshot_window = "01:00-02:00"
 }`, rName, rName, rName)
 }
 


### PR DESCRIPTION
Fixes: #11832

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/10 13:34:15 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow
--- PASS: TestAccAWSElasticacheReplicationGroup_updateMaintenanceWindow (1023.52s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1023.552s
```