### PR TITLE
Add support for missing attributes for PagerDuty service resource 

### DIFF
--- a/builtin/providers/pagerduty/import_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_service_test.go
@@ -26,3 +26,24 @@ func TestAccPagerDutyService_import(t *testing.T) {
 		},
 	})
 }
+
+func TestAccPagerDutyServiceWithIncidentUrgency_import(t *testing.T) {
+	resourceName := "pagerduty_service.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
@@ -117,6 +117,11 @@ resource "pagerduty_service" "foo" {
   auto_resolve_timeout    = 1800
   acknowledgement_timeout = 1800
   escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type = "constant"
+    urgency = "high"
+  }
 }
 
 data "pagerduty_vendor" "datadog" {
@@ -162,6 +167,11 @@ resource "pagerduty_service" "foo" {
   auto_resolve_timeout    = 3600
   acknowledgement_timeout = 3600
   escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
 }
 
 data "pagerduty_vendor" "datadog" {

--- a/builtin/providers/pagerduty/resource_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_test.go
@@ -329,7 +329,7 @@ func testAccCheckPagerDutyServiceExists(n string) resource.TestCheckFunc {
 }
 
 const testAccCheckPagerDutyServiceConfig = `
-	resource "pagerduty_user" "foo" {
+resource "pagerduty_user" "foo" {
 	name        = "foo"
 	email       = "foo@example.com"
 	color       = "green"
@@ -365,7 +365,7 @@ resource "pagerduty_service" "foo" {
 `
 
 const testAccCheckPagerDutyServiceConfigUpdated = `
-	resource "pagerduty_user" "foo" {
+resource "pagerduty_user" "foo" {
 	name        = "foo"
 	email       = "foo@example.com"
 	color       = "green"

--- a/builtin/providers/pagerduty/resource_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_test.go
@@ -27,6 +27,12 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
 			resource.TestStep{
@@ -38,9 +44,241 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "bar"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "auto_resolve_timeout", "0"),
+						"pagerduty_service.foo", "auto_resolve_timeout", "3600"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "acknowledgement_timeout", "0"),
+						"pagerduty_service.foo", "acknowledgement_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.0.type", "constant"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.0.type", "constant"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.0.urgency", "low"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "use_support_hours"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.at.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.at.0.name", "support_hours_start"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.to_urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.type", "urgency_change"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.#", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.0", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.1", "2"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.2", "3"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.3", "4"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.4", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.end_time", "17:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.start_time", "09:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.time_zone", "America/Lima"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.type", "fixed_time_per_day"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", "bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "description", "bar bar bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_resolve_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "acknowledgement_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.0.type", "constant"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.0.type", "constant"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.0.urgency", "low"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "use_support_hours"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.at.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.at.0.name", "support_hours_start"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.to_urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.type", "urgency_change"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.#", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.0", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.1", "2"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.2", "3"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.3", "4"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.4", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.end_time", "17:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.start_time", "09:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.time_zone", "America/Lima"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.type", "fixed_time_per_day"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "description", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_resolve_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "acknowledgement_timeout", "1800"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "name", "bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "description", "bar bar bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "auto_resolve_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "acknowledgement_timeout", "3600"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.0.type", "constant"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.during_support_hours.0.urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.0.type", "constant"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.outside_support_hours.0.urgency", "low"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "incident_urgency_rule.0.type", "use_support_hours"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.at.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.at.0.name", "support_hours_start"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.to_urgency", "high"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "scheduled_actions.0.type", "urgency_change"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.#", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.#", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.0", "1"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.1", "2"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.2", "3"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.3", "4"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.days_of_week.4", "5"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.end_time", "17:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.start_time", "09:00:00"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.time_zone", "America/Lima"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service.foo", "support_hours.0.type", "fixed_time_per_day"),
 				),
 			},
 		},
@@ -70,6 +308,7 @@ func testAccCheckPagerDutyServiceExists(n string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("Not found: %s", n)
 		}
+
 		if rs.Primary.ID == "" {
 			return fmt.Errorf("No Service ID is set")
 		}
@@ -90,67 +329,200 @@ func testAccCheckPagerDutyServiceExists(n string) resource.TestCheckFunc {
 }
 
 const testAccCheckPagerDutyServiceConfig = `
-resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
-  color       = "green"
-  role        = "user"
-  job_title   = "foo"
-  description = "foo"
+	resource "pagerduty_user" "foo" {
+	name        = "foo"
+	email       = "foo@example.com"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "bar"
-  description = "bar"
-  num_loops   = 2
-
-  rule {
-    escalation_delay_in_minutes = 10
-
-    target {
-      type = "user_reference"
-      id   = "${pagerduty_user.foo.id}"
-    }
-  }
+	name        = "bar"
+	description = "bar"
+	num_loops   = 2
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = "${pagerduty_user.foo.id}"
+		}
+	}
 }
 
 resource "pagerduty_service" "foo" {
-  name                    = "foo"
-  description             = "foo"
-  auto_resolve_timeout    = 1800
-  acknowledgement_timeout = 1800
-  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+	name                    = "foo"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+	incident_urgency_rule {
+		type    = "constant"
+		urgency = "high"
+	}
 }
 `
 
 const testAccCheckPagerDutyServiceConfigUpdated = `
-resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
-  color       = "green"
-  role        = "user"
-  job_title   = "foo"
-  description = "foo"
+	resource "pagerduty_user" "foo" {
+	name        = "foo"
+	email       = "foo@example.com"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "bar"
-  description = "bar"
-  num_loops   = 2
+	name        = "bar"
+	description = "bar"
+	num_loops   = 2
 
-  rule {
-    escalation_delay_in_minutes = 10
-
-    target {
-      type = "user_reference"
-      id   = "${pagerduty_user.foo.id}"
-    }
-  }
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = "${pagerduty_user.foo.id}"
+		}
+	}
 }
 
 resource "pagerduty_service" "foo" {
-  name              = "bar"
-  description       = "bar"
-  escalation_policy = "${pagerduty_escalation_policy.foo.id}"
+	name                    = "bar"
+	description             = "bar"
+	auto_resolve_timeout    = 3600
+	acknowledgement_timeout = 3600
+
+	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+	incident_urgency_rule {
+		type    = "constant"
+		urgency = "high"
+	}
+}
+`
+
+const testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig = `
+resource "pagerduty_user" "foo" {
+	name        = "foo"
+	email       = "foo@example.com"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+	name        = "bar"
+	description = "bar"
+	num_loops   = 2
+
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = "${pagerduty_user.foo.id}"
+		}
+	}
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "foo"
+	description             = "foo"
+	auto_resolve_timeout    = 1800
+	acknowledgement_timeout = 1800
+	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+	incident_urgency_rule {
+		type = "use_support_hours"
+
+		during_support_hours {
+			type    = "constant"
+			urgency = "high"
+		}
+		outside_support_hours {
+			type    = "constant"
+			urgency = "low"
+		}
+	}
+
+	support_hours = [{
+		type         = "fixed_time_per_day"
+		time_zone    = "America/Lima"
+		start_time   = "09:00:00"
+		end_time     = "17:00:00"
+		days_of_week = [ 1, 2, 3, 4, 5 ]
+	}]
+
+	scheduled_actions {
+		type = "urgency_change"
+		to_urgency = "high"
+		at {
+			type = "named_time",
+			name = "support_hours_start"
+		}
+	}
+}
+`
+
+const testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated = `
+	resource "pagerduty_user" "foo" {
+	name        = "foo"
+	email       = "foo@example.com"
+	color       = "green"
+	role        = "user"
+	job_title   = "foo"
+	description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+	name        = "bar"
+	description = "bar"
+	num_loops   = 2
+
+	rule {
+		escalation_delay_in_minutes = 10
+		target {
+			type = "user_reference"
+			id   = "${pagerduty_user.foo.id}"
+		}
+	}
+}
+
+resource "pagerduty_service" "foo" {
+	name                    = "bar"
+	description             = "bar bar bar"
+	auto_resolve_timeout    = 3600
+	acknowledgement_timeout = 3600
+	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+	
+	incident_urgency_rule {
+		type = "use_support_hours"
+		during_support_hours {
+			type    = "constant"
+			urgency = "high"
+		}
+		outside_support_hours {
+			type    = "constant"
+			urgency = "low"
+		}
+	}
+
+	support_hours = [{
+		type         = "fixed_time_per_day"
+		time_zone    = "America/Lima"
+		start_time   = "09:00:00"
+		end_time     = "17:00:00"
+		days_of_week = [ 1, 2, 3, 4, 5 ]
+	}]
+
+	scheduled_actions {
+		type = "urgency_change"
+		to_urgency = "high"
+		at {
+			type = "named_time",
+			name = "support_hours_start"
+		}
+	}
 }
 `

--- a/builtin/providers/pagerduty/structure.go
+++ b/builtin/providers/pagerduty/structure.go
@@ -188,9 +188,14 @@ func expandStringList(configured []interface{}) []string {
 // Expands attribute slice to incident urgency rule, returns it and true if successful
 func expandIncidentUrgencyRule(incidentUrgencyList interface{}) (*pagerduty.IncidentUrgencyRule, bool) {
 	i := incidentUrgencyList.([]interface{})
-	m := i[0].(map[string]interface{})
 
-	if len(m) == 0 {
+	i, ok := incidentUrgencyList.([]interface{})
+	if !ok {
+		return nil, false
+	}
+
+	m, ok := i[0].(map[string]interface{})
+	if !ok || len(m) == 0 {
 		return nil, false
 	}
 
@@ -355,7 +360,7 @@ func expandScheduledActions(input interface{}) (scheduledActions []pagerduty.Sch
 	return scheduledActions
 }
 
-// Returns service's scheduled actions as slice of length one
+// Returns service's scheduled actions
 func flattenScheduledActions(service *pagerduty.Service) []interface{} {
 	scheduledActions := []interface{}{}
 
@@ -364,7 +369,7 @@ func flattenScheduledActions(service *pagerduty.Service) []interface{} {
 			m := map[string]interface{}{}
 			m["to_urgency"] = sa.ToUrgency
 			m["type"] = sa.Type
-			if at, ok := atMap(sa.At); ok {
+			if at, ok := scheduledActionsAt(sa.At); ok {
 				m["at"] = at
 			}
 			scheduledActions = append(scheduledActions, m)
@@ -375,7 +380,7 @@ func flattenScheduledActions(service *pagerduty.Service) []interface{} {
 }
 
 // Returns service's scheduled action's at attribute as slice of length one
-func atMap(inlineModel pagerduty.InlineModel) ([]interface{}, bool) {
+func scheduledActionsAt(inlineModel pagerduty.InlineModel) ([]interface{}, bool) {
 	if inlineModel.Type == "" || inlineModel.Name == "" {
 		return nil, false
 	}

--- a/builtin/providers/pagerduty/structure.go
+++ b/builtin/providers/pagerduty/structure.go
@@ -184,3 +184,202 @@ func expandStringList(configured []interface{}) []string {
 	}
 	return vs
 }
+
+// Expands attribute slice to incident urgency rule, returns it and true if successful
+func expandIncidentUrgencyRule(incidentUrgencyList interface{}) (*pagerduty.IncidentUrgencyRule, bool) {
+	i := incidentUrgencyList.([]interface{})
+	m := i[0].(map[string]interface{})
+
+	if len(m) == 0 {
+		return nil, false
+	}
+
+	iur := pagerduty.IncidentUrgencyRule{}
+	if val, ok := m["type"]; ok {
+		iur.Type = val.(string)
+	}
+	if val, ok := m["urgency"]; ok {
+		iur.Urgency = val.(string)
+	}
+	if val, ok := m["during_support_hours"]; ok {
+		iur.DuringSupportHours = expandIncidentUrgencyType(val)
+	}
+	if val, ok := m["outside_support_hours"]; ok {
+		iur.OutsideSupportHours = expandIncidentUrgencyType(val)
+	}
+
+	return &iur, true
+}
+
+// Expands attribute to inline model
+func expandActionInlineModel(inlineModelVal interface{}) *pagerduty.InlineModel {
+	inlineModel := pagerduty.InlineModel{}
+
+	if slice, ok := inlineModelVal.([]interface{}); ok && len(slice) == 1 {
+		m := slice[0].(map[string]interface{})
+
+		if val, ok := m["type"]; ok {
+			inlineModel.Type = val.(string)
+		}
+		if val, ok := m["name"]; ok {
+			inlineModel.Name = val.(string)
+		}
+	}
+
+	return &inlineModel
+}
+
+// Expands attribute into incident urgency type
+func expandIncidentUrgencyType(attribute interface{}) *pagerduty.IncidentUrgencyType {
+	ict := pagerduty.IncidentUrgencyType{}
+
+	slice := attribute.([]interface{})
+	if len(slice) != 1 {
+		return &ict
+	}
+
+	m := slice[0].(map[string]interface{})
+
+	if val, ok := m["type"]; ok {
+		ict.Type = val.(string)
+	}
+	if val, ok := m["urgency"]; ok {
+		ict.Urgency = val.(string)
+	}
+
+	return &ict
+}
+
+// Returns service's incident urgency rule as slice of length one and bool indicating success
+func flattenIncidentUrgencyRule(service *pagerduty.Service) ([]interface{}, bool) {
+	if service.IncidentUrgencyRule.Type == "" && service.IncidentUrgencyRule.Urgency == "" {
+		return nil, false
+	}
+
+	m := map[string]interface{}{
+		"type":    service.IncidentUrgencyRule.Type,
+		"urgency": service.IncidentUrgencyRule.Urgency,
+	}
+
+	if dsh := service.IncidentUrgencyRule.DuringSupportHours; dsh != nil {
+		m["during_support_hours"] = flattenIncidentUrgencyType(dsh)
+	}
+	if osh := service.IncidentUrgencyRule.OutsideSupportHours; osh != nil {
+		m["outside_support_hours"] = flattenIncidentUrgencyType(osh)
+	}
+
+	return []interface{}{m}, true
+}
+
+func flattenIncidentUrgencyType(iut *pagerduty.IncidentUrgencyType) []interface{} {
+	incidenUrgencyType := map[string]interface{}{
+		"type":    iut.Type,
+		"urgency": iut.Urgency,
+	}
+	return []interface{}{incidenUrgencyType}
+}
+
+// Expands attribute to support hours
+func expandSupportHours(attribute interface{}) (sh *pagerduty.SupportHours) {
+	if slice, ok := attribute.([]interface{}); ok && len(slice) >= 1 {
+		m := slice[0].(map[string]interface{})
+		sh = &pagerduty.SupportHours{}
+
+		if val, ok := m["type"]; ok {
+			sh.Type = val.(string)
+		}
+		if val, ok := m["time_zone"]; ok {
+			sh.Timezone = val.(string)
+		}
+		if val, ok := m["start_time"]; ok {
+			sh.StartTime = val.(string)
+		}
+		if val, ok := m["end_time"]; ok {
+			sh.EndTime = val.(string)
+		}
+		if val, ok := m["days_of_week"]; ok {
+			daysOfWeekInt := val.([]interface{})
+			var daysOfWeek []uint
+
+			for _, i := range daysOfWeekInt {
+				daysOfWeek = append(daysOfWeek, uint(i.(int)))
+			}
+
+			sh.DaysOfWeek = daysOfWeek
+		}
+	}
+
+	return
+}
+
+// Returns service's support hours as slice of length one
+func flattenSupportHours(service *pagerduty.Service) []interface{} {
+	if service.SupportHours == nil {
+		return nil
+	}
+
+	m := map[string]interface{}{}
+
+	if s := service.SupportHours; s != nil {
+		m["type"] = s.Type
+		m["time_zone"] = s.Timezone
+		m["start_time"] = s.StartTime
+		m["end_time"] = s.EndTime
+		m["days_of_week"] = s.DaysOfWeek
+	}
+
+	return []interface{}{m}
+}
+
+// Expands attribute to scheduled action
+func expandScheduledActions(input interface{}) (scheduledActions []pagerduty.ScheduledAction) {
+	inputs := input.([]interface{})
+
+	for _, i := range inputs {
+		m := i.(map[string]interface{})
+		sa := pagerduty.ScheduledAction{}
+
+		if val, ok := m["type"]; ok {
+			sa.Type = val.(string)
+		}
+		if val, ok := m["to_urgency"]; ok {
+			sa.ToUrgency = val.(string)
+		}
+		if val, ok := m["at"]; ok {
+			sa.At = *expandActionInlineModel(val)
+		}
+
+		scheduledActions = append(scheduledActions, sa)
+	}
+
+	return scheduledActions
+}
+
+// Returns service's scheduled actions as slice of length one
+func flattenScheduledActions(service *pagerduty.Service) []interface{} {
+	scheduledActions := []interface{}{}
+
+	if sas := service.ScheduledActions; sas != nil {
+		for _, sa := range sas {
+			m := map[string]interface{}{}
+			m["to_urgency"] = sa.ToUrgency
+			m["type"] = sa.Type
+			if at, ok := atMap(sa.At); ok {
+				m["at"] = at
+			}
+			scheduledActions = append(scheduledActions, m)
+		}
+	}
+
+	return scheduledActions
+}
+
+// Returns service's scheduled action's at attribute as slice of length one
+func atMap(inlineModel pagerduty.InlineModel) ([]interface{}, bool) {
+	if inlineModel.Type == "" || inlineModel.Name == "" {
+		return nil, false
+	}
+
+	m := map[string]interface{}{"type": inlineModel.Type, "name": inlineModel.Name}
+	return []interface{}{m}, true
+}


### PR DESCRIPTION
Currently, the `PagerDuty` `service` resource does not support the `incident_urgency_rule`, `scheduled_actions` and `support_hours` attribute. This PR adds support for the three attributes.

We also add acceptance tests which can be used as examples. If the tests are not essential enough, they can of course be removed.

Please note that update operations (`PUT /services/:id`) on the three attributes don't seem to be working with the SDK or v2 PagerDuty API in spite of being [documented](https://v2.developer.pagerduty.com/v2/page/api-reference#!/Services/put_services_id). We therefore made the attributes `ForceNew: true`.

~~Furthermore, there is an issue with a PagerDuty acceptance test in the current master on my build system. (I did not find an open issue of this; the problem may or may not have to do with my PagerDuty account.) The current implementation does not fix this error but it should be independent of the changes. The other unit and acceptance tests are fine. The error is as follows (both on master and this PR):~~ -> 

**UPDATE**: sorry, my account on PagerDuty contained something braking the tests; all tests are passing fine on master and this branch.