### PR TITLE
provider/aws: Fix SecurityGroupRule regression

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -608,9 +608,10 @@ func validateAwsSecurityGroupRule(d *schema.ResourceData) error {
 	_, blocksOk := d.GetOk("cidr_blocks")
 	_, sourceOk := d.GetOk("source_security_group_id")
 	_, selfOk := d.GetOk("self")
-	if !blocksOk && !sourceOk && !selfOk {
+	_, prefixOk := d.GetOk("prefix_list_ids")
+	if !blocksOk && !sourceOk && !selfOk && !prefixOk {
 		return fmt.Errorf(
-			"One of ['cidr_blocks', 'self', 'source_security_group_id'] must be set to create an AWS Security Group Rule")
+			"One of ['cidr_blocks', 'self', 'source_security_group_id', 'prefix_list_ids'] must be set to create an AWS Security Group Rule")
 	}
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -12,7 +13,6 @@ import (
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestIpPermissionIDHash(t *testing.T) {

--- a/builtin/providers/aws/resource_aws_security_group_rule_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule_test.go
@@ -110,6 +110,7 @@ func TestIpPermissionIDHash(t *testing.T) {
 
 func TestAccAWSSecurityGroupRule_Ingress_VPC(t *testing.T) {
 	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
 
 	testRuleCount := func(*terraform.State) error {
 		if len(group.IpPermissions) != 1 {
@@ -132,7 +133,7 @@ func TestAccAWSSecurityGroupRule_Ingress_VPC(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRuleIngressConfig,
+				Config: testAccAWSSecurityGroupRuleIngressConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -184,6 +185,7 @@ func TestAccAWSSecurityGroupRule_Ingress_Protocol(t *testing.T) {
 
 func TestAccAWSSecurityGroupRule_Ingress_Classic(t *testing.T) {
 	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
 
 	testRuleCount := func(*terraform.State) error {
 		if len(group.IpPermissions) != 1 {
@@ -206,7 +208,7 @@ func TestAccAWSSecurityGroupRule_Ingress_Classic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRuleIngressClassicConfig,
+				Config: testAccAWSSecurityGroupRuleIngressClassicConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress_1", &group, nil, "ingress"),
@@ -261,6 +263,7 @@ func TestAccAWSSecurityGroupRule_MultiIngress(t *testing.T) {
 
 func TestAccAWSSecurityGroupRule_Egress(t *testing.T) {
 	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -268,7 +271,7 @@ func TestAccAWSSecurityGroupRule_Egress(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRuleEgressConfig,
+				Config: testAccAWSSecurityGroupRuleEgressConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.egress_1", &group, nil, "egress"),
@@ -297,13 +300,14 @@ func TestAccAWSSecurityGroupRule_SelfReference(t *testing.T) {
 }
 
 func TestAccAWSSecurityGroupRule_ExpectInvalidTypeError(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSSecurityGroupRuleExpectInvalidType,
+				Config:      testAccAWSSecurityGroupRuleExpectInvalidType(rInt),
 				ExpectError: regexp.MustCompile(`\\"type\\" contains an invalid Security Group Rule type \\"foobar\\"`),
 			},
 		},
@@ -313,6 +317,7 @@ func TestAccAWSSecurityGroupRule_ExpectInvalidTypeError(t *testing.T) {
 // testing partial match implementation
 func TestAccAWSSecurityGroupRule_PartialMatching_basic(t *testing.T) {
 	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
 
 	p := ec2.IpPermission{
 		FromPort:   aws.Int64(80),
@@ -340,7 +345,7 @@ func TestAccAWSSecurityGroupRule_PartialMatching_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRulePartialMatching,
+				Config: testAccAWSSecurityGroupRulePartialMatching(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupRuleAttributes("aws_security_group_rule.ingress", &group, &p, "ingress"),
@@ -356,6 +361,7 @@ func TestAccAWSSecurityGroupRule_PartialMatching_Source(t *testing.T) {
 	var group ec2.SecurityGroup
 	var nat ec2.SecurityGroup
 	var p ec2.IpPermission
+	rInt := acctest.RandInt()
 
 	// This function creates the expected IPPermission with the group id from an
 	// external security group, needed because Security Group IDs are generated on
@@ -383,7 +389,7 @@ func TestAccAWSSecurityGroupRule_PartialMatching_Source(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRulePartialMatching_Source,
+				Config: testAccAWSSecurityGroupRulePartialMatching_Source(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.nat", &nat),
@@ -433,6 +439,7 @@ func TestAccAWSSecurityGroupRule_Race(t *testing.T) {
 
 func TestAccAWSSecurityGroupRule_SelfSource(t *testing.T) {
 	var group ec2.SecurityGroup
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -440,7 +447,7 @@ func TestAccAWSSecurityGroupRule_SelfSource(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSecurityGroupRuleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSSecurityGroupRuleSelfInSource,
+				Config: testAccAWSSecurityGroupRuleSelfInSource(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSecurityGroupRuleExists("aws_security_group.web", &group),
 				),
@@ -667,26 +674,27 @@ func testAccCheckAWSSecurityGroupRuleAttributes(n string, group *ec2.SecurityGro
 	}
 }
 
-const testAccAWSSecurityGroupRuleIngressConfig = `
-resource "aws_security_group" "web" {
-  name = "terraform_acceptance_test_example"
-  description = "Used in the terraform acceptance tests"
+func testAccAWSSecurityGroupRuleIngressConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_security_group" "web" {
+		name = "terraform_test_%d"
+		description = "Used in the terraform acceptance tests"
 
-        tags {
-                Name = "tf-acc-test"
-        }
+					tags {
+									Name = "tf-acc-test"
+					}
+	}
+
+	resource "aws_security_group_rule" "ingress_1" {
+		type = "ingress"
+		protocol = "tcp"
+		from_port = 80
+		to_port = 8000
+		cidr_blocks = ["10.0.0.0/8"]
+
+		security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
 }
-
-resource "aws_security_group_rule" "ingress_1" {
-  type = "ingress"
-  protocol = "tcp"
-  from_port = 80
-  to_port = 8000
-  cidr_blocks = ["10.0.0.0/8"]
-
-  security_group_id = "${aws_security_group.web.id}"
-}
-`
 
 const testAccAWSSecurityGroupRuleIngress_protocolConfig = `
 resource "aws_vpc" "tftest" {
@@ -737,51 +745,53 @@ resource "aws_security_group_rule" "issue_5310" {
 }
 `
 
-const testAccAWSSecurityGroupRuleIngressClassicConfig = `
-provider "aws" {
-        region = "us-east-1"
+func testAccAWSSecurityGroupRuleIngressClassicConfig(rInt int) string {
+	return fmt.Sprintf(`
+	provider "aws" {
+					region = "us-east-1"
+	}
+
+	resource "aws_security_group" "web" {
+		name = "terraform_test_%d"
+		description = "Used in the terraform acceptance tests"
+
+					tags {
+									Name = "tf-acc-test"
+					}
+	}
+
+	resource "aws_security_group_rule" "ingress_1" {
+		type = "ingress"
+		protocol = "tcp"
+		from_port = 80
+		to_port = 8000
+		cidr_blocks = ["10.0.0.0/8"]
+
+		security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
 }
 
-resource "aws_security_group" "web" {
-  name = "terraform_acceptance_test_example"
-  description = "Used in the terraform acceptance tests"
+func testAccAWSSecurityGroupRuleEgressConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_security_group" "web" {
+		name = "terraform_test_%d"
+		description = "Used in the terraform acceptance tests"
 
-        tags {
-                Name = "tf-acc-test"
-        }
+					tags {
+									Name = "tf-acc-test"
+					}
+	}
+
+	resource "aws_security_group_rule" "egress_1" {
+		type = "egress"
+		protocol = "tcp"
+		from_port = 80
+		to_port = 8000
+		cidr_blocks = ["10.0.0.0/8"]
+
+		security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
 }
-
-resource "aws_security_group_rule" "ingress_1" {
-  type = "ingress"
-  protocol = "tcp"
-  from_port = 80
-  to_port = 8000
-  cidr_blocks = ["10.0.0.0/8"]
-
-  security_group_id = "${aws_security_group.web.id}"
-}
-`
-
-const testAccAWSSecurityGroupRuleEgressConfig = `
-resource "aws_security_group" "web" {
-  name = "terraform_acceptance_test_example"
-  description = "Used in the terraform acceptance tests"
-
-        tags {
-                Name = "tf-acc-test"
-        }
-}
-
-resource "aws_security_group_rule" "egress_1" {
-  type = "egress"
-  protocol = "tcp"
-  from_port = 80
-  to_port = 8000
-  cidr_blocks = ["10.0.0.0/8"]
-
-  security_group_id = "${aws_security_group.web.id}"
-}
-`
 
 const testAccAWSSecurityGroupRuleConfigMultiIngress = `
 resource "aws_security_group" "web" {
@@ -847,106 +857,108 @@ resource "aws_security_group_rule" "self" {
 }
 `
 
-const testAccAWSSecurityGroupRulePartialMatching = `
-resource "aws_vpc" "default" {
-  cidr_block = "10.0.0.0/16"
-  tags {
-    Name = "tf-sg-rule-bug"
-  }
+func testAccAWSSecurityGroupRulePartialMatching(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "default" {
+		cidr_block = "10.0.0.0/16"
+		tags {
+			Name = "tf-sg-rule-bug"
+		}
+	}
+
+	resource "aws_security_group" "web" {
+			name = "tf-other-%d"
+			vpc_id = "${aws_vpc.default.id}"
+			tags {
+					Name        = "tf-other-sg"
+			}
+	}
+
+	resource "aws_security_group" "nat" {
+			name = "tf-nat-%d"
+			vpc_id = "${aws_vpc.default.id}"
+			tags {
+					Name        = "tf-nat-sg"
+			}
+	}
+
+	resource "aws_security_group_rule" "ingress" {
+			type        = "ingress"
+			from_port   = 80
+			to_port     = 80
+			protocol    = "tcp"
+			cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+
+		 security_group_id = "${aws_security_group.web.id}"
+	}
+
+	resource "aws_security_group_rule" "other" {
+			type        = "ingress"
+			from_port   = 80
+			to_port     = 80
+			protocol    = "tcp"
+			cidr_blocks = ["10.0.5.0/24"]
+
+		 security_group_id = "${aws_security_group.web.id}"
+	}
+
+	// same a above, but different group, to guard against bad hashing
+	resource "aws_security_group_rule" "nat_ingress" {
+			type        = "ingress"
+			from_port   = 80
+			to_port     = 80
+			protocol    = "tcp"
+			cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+
+		 security_group_id = "${aws_security_group.nat.id}"
+	}`, rInt, rInt)
 }
 
-resource "aws_security_group" "web" {
-    name = "tf-other"
-    vpc_id = "${aws_vpc.default.id}"
-    tags {
-        Name        = "tf-other-sg"
-    }
+func testAccAWSSecurityGroupRulePartialMatching_Source(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "default" {
+		cidr_block = "10.0.0.0/16"
+		tags {
+			Name = "tf-sg-rule-bug"
+		}
+	}
+
+	resource "aws_security_group" "web" {
+			name = "tf-other-%d"
+			vpc_id = "${aws_vpc.default.id}"
+			tags {
+					Name        = "tf-other-sg"
+			}
+	}
+
+	resource "aws_security_group" "nat" {
+			name = "tf-nat-%d"
+			vpc_id = "${aws_vpc.default.id}"
+			tags {
+					Name        = "tf-nat-sg"
+			}
+	}
+
+	resource "aws_security_group_rule" "source_ingress" {
+			type        = "ingress"
+			from_port   = 80
+			to_port     = 80
+			protocol    = "tcp"
+
+									source_security_group_id = "${aws_security_group.nat.id}"
+		 security_group_id = "${aws_security_group.web.id}"
+	}
+
+	resource "aws_security_group_rule" "other_ingress" {
+			type        = "ingress"
+			from_port   = 80
+			to_port     = 80
+			protocol    = "tcp"
+			cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
+
+		 security_group_id = "${aws_security_group.web.id}"
+	}`, rInt, rInt)
 }
-
-resource "aws_security_group" "nat" {
-    name = "tf-nat"
-    vpc_id = "${aws_vpc.default.id}"
-    tags {
-        Name        = "tf-nat-sg"
-    }
-}
-
-resource "aws_security_group_rule" "ingress" {
-    type        = "ingress"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
-
-   security_group_id = "${aws_security_group.web.id}"
-}
-
-resource "aws_security_group_rule" "other" {
-    type        = "ingress"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.5.0/24"]
-
-   security_group_id = "${aws_security_group.web.id}"
-}
-
-// same a above, but different group, to guard against bad hashing
-resource "aws_security_group_rule" "nat_ingress" {
-    type        = "ingress"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
-
-   security_group_id = "${aws_security_group.nat.id}"
-}
-`
-
-const testAccAWSSecurityGroupRulePartialMatching_Source = `
-resource "aws_vpc" "default" {
-  cidr_block = "10.0.0.0/16"
-  tags {
-    Name = "tf-sg-rule-bug"
-  }
-}
-
-resource "aws_security_group" "web" {
-    name = "tf-other"
-    vpc_id = "${aws_vpc.default.id}"
-    tags {
-        Name        = "tf-other-sg"
-    }
-}
-
-resource "aws_security_group" "nat" {
-    name = "tf-nat"
-    vpc_id = "${aws_vpc.default.id}"
-    tags {
-        Name        = "tf-nat-sg"
-    }
-}
-
-resource "aws_security_group_rule" "source_ingress" {
-    type        = "ingress"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-
-                source_security_group_id = "${aws_security_group.nat.id}"
-   security_group_id = "${aws_security_group.web.id}"
-}
-
-resource "aws_security_group_rule" "other_ingress" {
-    type        = "ingress"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["10.0.2.0/24", "10.0.3.0/24", "10.0.4.0/24"]
-
-   security_group_id = "${aws_security_group.web.id}"
-}
-`
 
 var testAccAWSSecurityGroupRuleRace = func() string {
 	var b bytes.Buffer
@@ -1035,52 +1047,54 @@ resource "aws_security_group_rule" "egress_1" {
 }
 `
 
-const testAccAWSSecurityGroupRuleSelfInSource = `
-resource "aws_vpc" "foo" {
-  cidr_block = "10.1.0.0/16"
+func testAccAWSSecurityGroupRuleSelfInSource(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "foo" {
+		cidr_block = "10.1.0.0/16"
 
-  tags {
-    Name = "tf_sg_rule_self_group"
-  }
+		tags {
+			Name = "tf_sg_rule_self_group"
+		}
+	}
+
+	resource "aws_security_group" "web" {
+		name        = "allow_all-%d"
+		description = "Allow all inbound traffic"
+		vpc_id      = "${aws_vpc.foo.id}"
+	}
+
+	resource "aws_security_group_rule" "allow_self" {
+		type                     = "ingress"
+		from_port                = 0
+		to_port                  = 0
+		protocol                 = "-1"
+		security_group_id        = "${aws_security_group.web.id}"
+		source_security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
 }
 
-resource "aws_security_group" "web" {
-  name        = "allow_all"
-  description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.foo.id}"
-}
+func testAccAWSSecurityGroupRuleExpectInvalidType(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_vpc" "foo" {
+		cidr_block = "10.1.0.0/16"
 
-resource "aws_security_group_rule" "allow_self" {
-  type                     = "ingress"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  security_group_id        = "${aws_security_group.web.id}"
-  source_security_group_id = "${aws_security_group.web.id}"
-}
-`
+		tags {
+			Name = "tf_sg_rule_self_group"
+		}
+	}
 
-const testAccAWSSecurityGroupRuleExpectInvalidType = `
-resource "aws_vpc" "foo" {
-  cidr_block = "10.1.0.0/16"
+	resource "aws_security_group" "web" {
+		name        = "allow_all-%d"
+		description = "Allow all inbound traffic"
+		vpc_id      = "${aws_vpc.foo.id}"
+	}
 
-  tags {
-    Name = "tf_sg_rule_self_group"
-  }
+	resource "aws_security_group_rule" "allow_self" {
+		type                     = "foobar"
+		from_port                = 0
+		to_port                  = 0
+		protocol                 = "-1"
+		security_group_id        = "${aws_security_group.web.id}"
+		source_security_group_id = "${aws_security_group.web.id}"
+	}`, rInt)
 }
-
-resource "aws_security_group" "web" {
-  name        = "allow_all"
-  description = "Allow all inbound traffic"
-  vpc_id      = "${aws_vpc.foo.id}"
-}
-
-resource "aws_security_group_rule" "allow_self" {
-  type                     = "foobar"
-  from_port                = 0
-  to_port                  = 0
-  protocol                 = "-1"
-  security_group_id        = "${aws_security_group.web.id}"
-  source_security_group_id = "${aws_security_group.web.id}"
-}
-`


### PR DESCRIPTION
A security_group_rule can also be created from a `prefix_list_id`.
Introduced in #11809

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSecurityGroupRule_PrefixListEgress'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/10 12:41:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSecurityGroupRule_PrefixListEgress -timeout 120m
=== RUN   TestAccAWSSecurityGroupRule_PrefixListEgress
--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (33.94s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    33.970s
```

Full test output: 
```
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_ExpectInvalidTypeError']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_ExpectInvalidTypeError' out='=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidTypeError|n--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidTypeError (0.02s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_ExpectInvalidTypeError' out='']
##teamcity[testFinished timestamp='2017-02-10T13:13:20.344' name='TestAccAWSSecurityGroupRule_ExpectInvalidTypeError']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.241' name='TestAccAWSSecurityGroupRule_Issue5310']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_Issue5310' out='=== RUN   TestAccAWSSecurityGroupRule_Issue5310|n--- PASS: TestAccAWSSecurityGroupRule_Issue5310 (14.24s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_Issue5310' out='']
##teamcity[testFinished timestamp='2017-02-10T13:13:34.574' name='TestAccAWSSecurityGroupRule_Issue5310']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_Ingress_Classic']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_Ingress_Classic' out='=== RUN   TestAccAWSSecurityGroupRule_Ingress_Classic|n--- PASS: TestAccAWSSecurityGroupRule_Ingress_Classic (14.28s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_Ingress_Classic' out='']
##teamcity[testFinished timestamp='2017-02-10T13:13:34.602' name='TestAccAWSSecurityGroupRule_Ingress_Classic']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_Egress']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_Egress' out='=== RUN   TestAccAWSSecurityGroupRule_Egress|n--- PASS: TestAccAWSSecurityGroupRule_Egress (18.69s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_Egress' out='']
##teamcity[testFinished timestamp='2017-02-10T13:13:39.029' name='TestAccAWSSecurityGroupRule_Egress']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_Ingress_VPC']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_Ingress_VPC' out='=== RUN   TestAccAWSSecurityGroupRule_Ingress_VPC|n--- PASS: TestAccAWSSecurityGroupRule_Ingress_VPC (18.78s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_Ingress_VPC' out='']
##teamcity[testFinished timestamp='2017-02-10T13:13:39.101' name='TestAccAWSSecurityGroupRule_Ingress_VPC']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_MultiIngress']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_MultiIngress' out='=== RUN   TestAccAWSSecurityGroupRule_MultiIngress|n--- PASS: TestAccAWSSecurityGroupRule_MultiIngress (29.15s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_MultiIngress' out='']
##teamcity[testFinished timestamp='2017-02-10T13:13:49.486' name='TestAccAWSSecurityGroupRule_MultiIngress']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_SelfReference']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_SelfReference' out='=== RUN   TestAccAWSSecurityGroupRule_SelfReference|n--- PASS: TestAccAWSSecurityGroupRule_SelfReference (47.06s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_SelfReference' out='']
##teamcity[testFinished timestamp='2017-02-10T13:14:07.387' name='TestAccAWSSecurityGroupRule_SelfReference']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_SelfSource']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_SelfSource' out='=== RUN   TestAccAWSSecurityGroupRule_SelfSource|n--- PASS: TestAccAWSSecurityGroupRule_SelfSource (51.90s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_SelfSource' out='']
##teamcity[testFinished timestamp='2017-02-10T13:14:12.224' name='TestAccAWSSecurityGroupRule_SelfSource']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.241' name='TestAccAWSSecurityGroupRule_PartialMatching_basic']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_PartialMatching_basic' out='=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_basic|n--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_basic (53.34s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_PartialMatching_basic' out='']
##teamcity[testFinished timestamp='2017-02-10T13:14:13.682' name='TestAccAWSSecurityGroupRule_PartialMatching_basic']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_Ingress_Protocol']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_Ingress_Protocol' out='=== RUN   TestAccAWSSecurityGroupRule_Ingress_Protocol|n--- PASS: TestAccAWSSecurityGroupRule_Ingress_Protocol (55.43s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_Ingress_Protocol' out='']
##teamcity[testFinished timestamp='2017-02-10T13:14:15.768' name='TestAccAWSSecurityGroupRule_Ingress_Protocol']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.241' name='TestAccAWSSecurityGroupRule_PrefixListEgress']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_PrefixListEgress' out='=== RUN   TestAccAWSSecurityGroupRule_PrefixListEgress|n--- PASS: TestAccAWSSecurityGroupRule_PrefixListEgress (56.25s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_PrefixListEgress' out='']
##teamcity[testFinished timestamp='2017-02-10T13:14:16.581' name='TestAccAWSSecurityGroupRule_PrefixListEgress']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_PartialMatching_Source']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_PartialMatching_Source' out='=== RUN   TestAccAWSSecurityGroupRule_PartialMatching_Source|n--- PASS: TestAccAWSSecurityGroupRule_PartialMatching_Source (59.66s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_PartialMatching_Source' out='']
##teamcity[testFinished timestamp='2017-02-10T13:14:20.005' name='TestAccAWSSecurityGroupRule_PartialMatching_Source']
##teamcity[testStarted timestamp='2017-02-10T13:13:20.240' name='TestAccAWSSecurityGroupRule_Race']
##teamcity[testStdOut name='TestAccAWSSecurityGroupRule_Race' out='=== RUN   TestAccAWSSecurityGroupRule_Race|n--- PASS: TestAccAWSSecurityGroupRule_Race (319.31s)|nPASS|n']
##teamcity[testStdErr name='TestAccAWSSecurityGroupRule_Race' out='']
##teamcity[testFinished timestamp='2017-02-10T13:18:39.638' name='TestAccAWSSecurityGroupRule_Race']
```