### PR TITLE
provider/digitalocean: Update digital ocean acceptance tests

### DIFF
--- a/builtin/providers/digitalocean/import_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_droplet_test.go
@@ -3,11 +3,13 @@ package digitalocean
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
 	resourceName := "digitalocean_droplet.foobar"
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +17,7 @@ func TestAccDigitalOceanDroplet_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_basic,
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 			},
 
 			{

--- a/builtin/providers/digitalocean/import_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_floating_ip_test.go
@@ -3,6 +3,7 @@ package digitalocean
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -29,6 +30,7 @@ func TestAccDigitalOceanFloatingIP_importBasicRegion(t *testing.T) {
 
 func TestAccDigitalOceanFloatingIP_importBasicDroplet(t *testing.T) {
 	resourceName := "digitalocean_floating_ip.foobar"
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -36,7 +38,7 @@ func TestAccDigitalOceanFloatingIP_importBasicDroplet(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet,
+				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt),
 			},
 
 			{

--- a/builtin/providers/digitalocean/import_digitalocean_ssh_key_test.go
+++ b/builtin/providers/digitalocean/import_digitalocean_ssh_key_test.go
@@ -15,7 +15,7 @@ func TestAccDigitalOceanSSHKey_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanSSHKeyConfig_basic,
+				Config: testAccCheckDigitalOceanSSHKeyConfig_basic(testAccValidImportPublicKey),
 			},
 
 			{

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 	var droplet godo.Droplet
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,12 +22,42 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_basic,
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", "foo"),
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "size", "512mb"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "image", "centos-7-x64"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "region", "nyc3"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "user_data", "foobar"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
+	var droplet godo.Droplet
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_withSSH(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
+					testAccCheckDigitalOceanDropletAttributes(&droplet),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "512mb"),
 					resource.TestCheckResourceAttr(
@@ -42,6 +74,7 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 	var droplet godo.Droplet
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -49,20 +82,22 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_basic,
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_RenameAndResize,
+				Config: testAccCheckDigitalOceanDropletConfig_RenameAndResize(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletRenamedAndResized(&droplet),
 					resource.TestCheckResourceAttr(
-						"digitalocean_droplet.foobar", "name", "baz"),
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("baz-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "1gb"),
 					resource.TestCheckResourceAttr(
@@ -75,6 +110,7 @@ func TestAccDigitalOceanDroplet_Update(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 	var droplet godo.Droplet
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -82,18 +118,22 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_basic,
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes(&droplet),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk,
+				Config: testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletResizeWithOutDisk(&droplet),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "size", "1gb"),
 					resource.TestCheckResourceAttr(
@@ -106,6 +146,7 @@ func TestAccDigitalOceanDroplet_ResizeWithOutDisk(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 	var afterCreate, afterUpdate godo.Droplet
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -113,17 +154,21 @@ func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_basic,
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
 					testAccCheckDigitalOceanDropletAttributes(&afterCreate),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_userdata_update,
+				Config: testAccCheckDigitalOceanDropletConfig_userdata_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar",
 						"user_data",
@@ -138,6 +183,7 @@ func TestAccDigitalOceanDroplet_UpdateUserData(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 	var afterCreate, afterUpdate godo.Droplet
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -145,17 +191,21 @@ func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_basic,
+				Config: testAccCheckDigitalOceanDropletConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterCreate),
 					testAccCheckDigitalOceanDropletAttributes(&afterCreate),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 				),
 			},
 
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_tag_update,
+				Config: testAccCheckDigitalOceanDropletConfig_tag_update(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &afterUpdate),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "name", fmt.Sprintf("foo-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar",
 						"tags.#",
@@ -172,6 +222,7 @@ func TestAccDigitalOceanDroplet_UpdateTags(t *testing.T) {
 
 func TestAccDigitalOceanDroplet_PrivateNetworkingIpv6(t *testing.T) {
 	var droplet godo.Droplet
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -179,7 +230,7 @@ func TestAccDigitalOceanDroplet_PrivateNetworkingIpv6(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6,
+				Config: testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
 					testAccCheckDigitalOceanDropletAttributes_PrivateNetworkingIpv6(&droplet),
@@ -236,9 +287,6 @@ func testAccCheckDigitalOceanDropletAttributes(droplet *godo.Droplet) resource.T
 			return fmt.Errorf("Bad region_slug: %s", droplet.Region.Slug)
 		}
 
-		if droplet.Name != "foo" {
-			return fmt.Errorf("Bad name: %s", droplet.Name)
-		}
 		return nil
 	}
 }
@@ -248,10 +296,6 @@ func testAccCheckDigitalOceanDropletRenamedAndResized(droplet *godo.Droplet) res
 
 		if droplet.Size.Slug != "1gb" {
 			return fmt.Errorf("Bad size_slug: %s", droplet.SizeSlug)
-		}
-
-		if droplet.Name != "baz" {
-			return fmt.Errorf("Bad name: %s", droplet.Name)
 		}
 
 		if droplet.Disk != 30 {
@@ -290,10 +334,6 @@ func testAccCheckDigitalOceanDropletAttributes_PrivateNetworkingIpv6(droplet *go
 
 		if droplet.Region.Slug != "sgp1" {
 			return fmt.Errorf("Bad region_slug: %s", droplet.Region.Slug)
-		}
-
-		if droplet.Name != "baz" {
-			return fmt.Errorf("Bad name: %s", droplet.Name)
 		}
 
 		if findIPv4AddrByType(droplet, "private") == "" {
@@ -371,105 +411,97 @@ func testAccCheckDigitalOceanDropletRecreated(t *testing.T,
 	}
 }
 
-var testAccCheckDigitalOceanDropletConfig_basic = fmt.Sprintf(`
+func testAccCheckDigitalOceanDropletConfig_basic(rInt int) string {
+	return fmt.Sprintf(`
+resource "digitalocean_droplet" "foobar" {
+  name      = "foo-%d"
+  size      = "512mb"
+  image     = "centos-7-x64"
+  region    = "nyc3"
+  user_data = "foobar"
+}`, rInt)
+}
+
+func testAccCheckDigitalOceanDropletConfig_withSSH(rInt int) string {
+	return fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
+  name       = "foobar-%d"
   public_key = "%s"
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo"
+  name      = "foo-%d"
   size      = "512mb"
   image     = "centos-7-x64"
   region    = "nyc3"
   user_data = "foobar"
   ssh_keys  = ["${digitalocean_ssh_key.foobar.id}"]
+}`, rInt, testAccValidPublicKey, rInt)
 }
-`, testAccValidPublicKey)
 
-var testAccCheckDigitalOceanDropletConfig_tag_update = fmt.Sprintf(`
+func testAccCheckDigitalOceanDropletConfig_tag_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "digitalocean_tag" "barbaz" {
   name       = "barbaz"
 }
 
-resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
-  public_key = "%s"
-}
-
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo"
+  name      = "foo-%d"
   size      = "512mb"
   image     = "centos-7-x64"
   region    = "nyc3"
   user_data = "foobar"
-  ssh_keys  = ["${digitalocean_ssh_key.foobar.id}"]
   tags  = ["${digitalocean_tag.barbaz.id}"]
 }
-`, testAccValidPublicKey)
-
-var testAccCheckDigitalOceanDropletConfig_userdata_update = fmt.Sprintf(`
-resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
-  public_key = "%s"
+`, rInt)
 }
 
+func testAccCheckDigitalOceanDropletConfig_userdata_update(rInt int) string {
+	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name      = "foo"
+  name      = "foo-%d"
   size      = "512mb"
   image     = "centos-7-x64"
   region    = "nyc3"
   user_data = "foobar foobar"
-  ssh_keys  = ["${digitalocean_ssh_key.foobar.id}"]
 }
-`, testAccValidPublicKey)
-
-var testAccCheckDigitalOceanDropletConfig_RenameAndResize = fmt.Sprintf(`
-resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
-  public_key = "%s"
+`, rInt)
 }
 
+func testAccCheckDigitalOceanDropletConfig_RenameAndResize(rInt int) string {
+	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name     = "baz"
+  name     = "baz-%d"
   size     = "1gb"
   image    = "centos-7-x64"
   region   = "nyc3"
-  ssh_keys = ["${digitalocean_ssh_key.foobar.id}"]
 }
-`, testAccValidPublicKey)
-
-var testAccCheckDigitalOceanDropletConfig_resize_without_disk = fmt.Sprintf(`
-resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
-  public_key = "%s"
+`, rInt)
 }
 
+func testAccCheckDigitalOceanDropletConfig_resize_without_disk(rInt int) string {
+	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name     = "foo"
+  name     = "foo-%d"
   size     = "1gb"
   image    = "centos-7-x64"
   region   = "nyc3"
   user_data = "foobar"
-  ssh_keys = ["${digitalocean_ssh_key.foobar.id}"]
   resize_disk = false
 }
-`, testAccValidPublicKey)
-
-// IPV6 only in singapore
-var testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6 = fmt.Sprintf(`
-resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
-  public_key = "%s"
+`, rInt)
 }
 
+// IPV6 only in singapore
+func testAccCheckDigitalOceanDropletConfig_PrivateNetworkingIpv6(rInt int) string {
+	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name               = "baz"
+  name               = "baz-%d"
   size               = "1gb"
   image              = "centos-7-x64"
   region             = "sgp1"
   ipv6               = true
   private_networking = true
-  ssh_keys           = ["${digitalocean_ssh_key.foobar.id}"]
 }
-`, testAccValidPublicKey)
+`, rInt)
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_floating_ip_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -31,6 +32,7 @@ func TestAccDigitalOceanFloatingIP_Region(t *testing.T) {
 
 func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
 	var floatingIP godo.FloatingIP
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -38,7 +40,7 @@ func TestAccDigitalOceanFloatingIP_Droplet(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanFloatingIPDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet,
+				Config: testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanFloatingIPExists("digitalocean_floating_ip.foobar", &floatingIP),
 					resource.TestCheckResourceAttr(
@@ -104,23 +106,19 @@ resource "digitalocean_floating_ip" "foobar" {
   region = "nyc3"
 }`
 
-var testAccCheckDigitalOceanFloatingIPConfig_droplet = fmt.Sprintf(`
-resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
-  public_key = "%s"
-}
-
+func testAccCheckDigitalOceanFloatingIPConfig_droplet(rInt int) string {
+	return fmt.Sprintf(`
 resource "digitalocean_droplet" "foobar" {
-  name               = "baz"
+  name               = "baz-%d"
   size               = "1gb"
   image              = "centos-7-x64"
   region             = "nyc3"
   ipv6               = true
   private_networking = true
-  ssh_keys           = ["${digitalocean_ssh_key.foobar.id}"]
 }
 
 resource "digitalocean_floating_ip" "foobar" {
   droplet_id = "${digitalocean_droplet.foobar.id}"
   region     = "${digitalocean_droplet.foobar.region}"
-}`, testAccValidPublicKey)
+}`, rInt)
+}

--- a/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_ssh_key_test.go
@@ -20,7 +20,7 @@ func TestAccDigitalOceanSSHKey_Basic(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanSSHKeyDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckDigitalOceanSSHKeyConfig_basic,
+				Config: testAccCheckDigitalOceanSSHKeyConfig_basic(testAccValidPublicKey),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanSSHKeyExists("digitalocean_ssh_key.foobar", &key),
 					testAccCheckDigitalOceanSSHKeyAttributes(&key),
@@ -105,10 +105,13 @@ func testAccCheckDigitalOceanSSHKeyExists(n string, key *godo.Key) resource.Test
 	}
 }
 
-var testAccCheckDigitalOceanSSHKeyConfig_basic = fmt.Sprintf(`
+func testAccCheckDigitalOceanSSHKeyConfig_basic(key string) string {
+	return fmt.Sprintf(`
 resource "digitalocean_ssh_key" "foobar" {
     name = "foobar"
     public_key = "%s"
-}`, testAccValidPublicKey)
+}`, key)
+}
 
 var testAccValidPublicKey = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR`
+var testAccValidImportPublicKey = `ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwelf/LV8TKOd6ZCcDwU9L8YRdVwfR2q8E+Bzamcxwb1U41vnfyvEZbzx0aeXimdHipOql0SG2tu9Z+bzekROVc13OP/gtGRlWwZ9RoKE8hFHanhi0K2tC6OWagsvmHpW/xptsYAo2k+eRJJo0iy/hLNG2c1v5rrjg6xwnSL3+a7bFM4xNDux5sNYCmxIBfIL+4rQ8XBlxsjMrGoev/uumZ0yc75JtBCOSZbdie936pvVmoAf4nhxNbe5lOxp+18zHhBbO2fjhux4xmf4hLM2gHsdBGqtnphzLh3d1+uMIpv7ZMTKN7pBw53xQxw7hhDYuNKc8FkQ8xK6IL5bu/Ar/`

--- a/builtin/providers/digitalocean/resource_digitalocean_volume_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_volume_test.go
@@ -97,6 +97,7 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 		volume  = godo.Volume{Name: fmt.Sprintf("volume-%s", acctest.RandString(10))}
 		droplet godo.Droplet
 	)
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -105,7 +106,7 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(
-					testAccCheckDigitalOceanVolumeConfig_droplet,
+					testAccCheckDigitalOceanVolumeConfig_droplet(rInt, volume.Name),
 					testAccValidPublicKey, volume.Name,
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -120,12 +121,8 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 	})
 }
 
-const testAccCheckDigitalOceanVolumeConfig_droplet = `
-resource "digitalocean_ssh_key" "foobar" {
-  name       = "foobar"
-  public_key = "%s"
-}
-
+func testAccCheckDigitalOceanVolumeConfig_droplet(rInt int, vName string) string {
+	return fmt.Sprintf(`
 resource "digitalocean_volume" "foobar" {
 	region      = "nyc1"
 	name        = "%s"
@@ -134,7 +131,7 @@ resource "digitalocean_volume" "foobar" {
 }
 
 resource "digitalocean_droplet" "foobar" {
-  name               = "baz"
+  name               = "baz-%d"
   size               = "1gb"
   image              = "coreos-stable"
   region             = "nyc1"
@@ -142,4 +139,5 @@ resource "digitalocean_droplet" "foobar" {
   private_networking = true
   ssh_keys           = ["${digitalocean_ssh_key.foobar.id}"]
   volume_ids         = ["${digitalocean_volume.foobar.id}"]
-}`
+}`, vName, rInt)
+}


### PR DESCRIPTION
Digital Ocean doesn't let you upload multiple SSH keys regardless of key_name, but on the fingerprint of the key contents. Which broke all of our tests when ran in parallel.

These changes maintain our acctest validity, and still let them pass.

```
##teamcity[testStarted timestamp='2017-02-10T16:19:12.532' name='TestAccDigitalOceanDroplet_Basic']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_Basic' out='=== RUN   TestAccDigitalOceanDroplet_Basic|n--- PASS: TestAccDigitalOceanDroplet_Basic (47.33s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_Basic' out='']
##teamcity[testFinished timestamp='2017-02-10T16:19:59.898' name='TestAccDigitalOceanDroplet_Basic']
##teamcity[testStarted timestamp='2017-02-10T16:19:12.532' name='TestAccDigitalOceanDroplet_UpdateTags']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_UpdateTags' out='=== RUN   TestAccDigitalOceanDroplet_UpdateTags|n--- PASS: TestAccDigitalOceanDroplet_UpdateTags (50.96s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_UpdateTags' out='']
##teamcity[testFinished timestamp='2017-02-10T16:20:03.516' name='TestAccDigitalOceanDroplet_UpdateTags']
##teamcity[testStarted timestamp='2017-02-10T16:19:12.530' name='TestAccDigitalOceanDroplet_importBasic']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_importBasic' out='=== RUN   TestAccDigitalOceanDroplet_importBasic|n--- PASS: TestAccDigitalOceanDroplet_importBasic (56.78s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_importBasic' out='']
##teamcity[testFinished timestamp='2017-02-10T16:20:09.335' name='TestAccDigitalOceanDroplet_importBasic']
##teamcity[testStarted timestamp='2017-02-10T16:19:12.530' name='TestAccDigitalOceanDroplet_PrivateNetworkingIpv6']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_PrivateNetworkingIpv6' out='=== RUN   TestAccDigitalOceanDroplet_PrivateNetworkingIpv6|n--- PASS: TestAccDigitalOceanDroplet_PrivateNetworkingIpv6 (57.60s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_PrivateNetworkingIpv6' out='']
##teamcity[testFinished timestamp='2017-02-10T16:20:10.157' name='TestAccDigitalOceanDroplet_PrivateNetworkingIpv6']
##teamcity[testStarted timestamp='2017-02-10T16:19:12.533' name='TestAccDigitalOceanDroplet_withSSH']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_withSSH' out='=== RUN   TestAccDigitalOceanDroplet_withSSH|n--- PASS: TestAccDigitalOceanDroplet_withSSH (59.76s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_withSSH' out='']
##teamcity[testFinished timestamp='2017-02-10T16:20:12.326' name='TestAccDigitalOceanDroplet_withSSH']
##teamcity[testStarted timestamp='2017-02-10T16:19:12.530' name='TestAccDigitalOceanDroplet_Update']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_Update' out='=== RUN   TestAccDigitalOceanDroplet_Update|n--- PASS: TestAccDigitalOceanDroplet_Update (83.65s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_Update' out='']
##teamcity[testFinished timestamp='2017-02-10T16:20:36.213' name='TestAccDigitalOceanDroplet_Update']
##teamcity[testStarted timestamp='2017-02-10T16:19:12.530' name='TestAccDigitalOceanDroplet_UpdateUserData']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_UpdateUserData' out='=== RUN   TestAccDigitalOceanDroplet_UpdateUserData|n--- PASS: TestAccDigitalOceanDroplet_UpdateUserData (103.18s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_UpdateUserData' out='']
##teamcity[testFinished timestamp='2017-02-10T16:20:55.738' name='TestAccDigitalOceanDroplet_UpdateUserData']
##teamcity[testStarted timestamp='2017-02-10T16:19:12.533' name='TestAccDigitalOceanDroplet_ResizeWithOutDisk']
##teamcity[testStdOut name='TestAccDigitalOceanDroplet_ResizeWithOutDisk' out='=== RUN   TestAccDigitalOceanDroplet_ResizeWithOutDisk|n--- PASS: TestAccDigitalOceanDroplet_ResizeWithOutDisk (118.98s)|nPASS|n']
##teamcity[testStdErr name='TestAccDigitalOceanDroplet_ResizeWithOutDisk' out='']
##teamcity[testFinished timestamp='2017-02-10T16:21:11.558' name='TestAccDigitalOceanDroplet_ResizeWithOutDisk']
```