### PR TITLE
add stun provider

### DIFF
--- a/builtin/bins/provider-stun/main.go
+++ b/builtin/bins/provider-stun/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/stun"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: stun.Provider,
+	})
+}

--- a/builtin/providers/stun/datasource_stun_result.go
+++ b/builtin/providers/stun/datasource_stun_result.go
@@ -1,0 +1,57 @@
+package stun
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/pixelbender/go-stun/stun"
+)
+
+func dataSourceStun() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceStunRead,
+
+		Schema: map[string]*schema.Schema{
+			"server": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				Description: "STUN server",
+			},
+			"ip_address": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP address",
+			},
+			"ip_family": &schema.Schema{
+				Type:        schema.TypeString,
+				Computed:    true,
+				Description: "IP family (IPv4 or IPv6)",
+			},
+		},
+	}
+}
+
+func dataSourceStunRead(d *schema.ResourceData, meta interface{}) error {
+	addr, err := getResult(d)
+	if err != nil {
+		return err
+	}
+	d.Set("ip_address", addr.IP.String())
+	d.Set("ip_family", "ipv4")
+	if addr.IP.To4() == nil {
+		d.Set("ip_family", "ipv6")
+	}
+	d.SetId(hash(addr.IP.String()))
+	return nil
+}
+
+func getResult(d *schema.ResourceData) (*stun.Addr, error) {
+	server := d.Get("server").(string)
+	return stun.Lookup("stun:"+server, "", "")
+}
+
+func hash(s string) string {
+	sha := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sha[:])
+}

--- a/builtin/providers/stun/datasource_stun_result_test.go
+++ b/builtin/providers/stun/datasource_stun_result_test.go
@@ -46,18 +46,6 @@ func TestStun(t *testing.T) {
 
 func TestStunIPV(t *testing.T) {
 	for _, ipv := range []string{"4", "6"} {
-		// start up a STUN server that will always respond with our target IP
-		s := stun.NewServer(nil)
-		s.Handler = stun.HandlerFunc(func(rw stun.ResponseWriter, _ *stun.Message) {
-			rw.WriteMessage(&stun.Message{
-				Method: stun.TypeResponse,
-				Attributes: stun.Attributes{
-					stun.AttrXorMappedAddress: rw.RemoteAddr(),
-					stun.AttrMappedAddress:    rw.RemoteAddr(),
-					stun.AttrResponseOrigin:   rw.LocalAddr(),
-				},
-			})
-		})
 
 		// start a UDP listener
 		l, err := net.ListenPacket("udp"+ipv, "")
@@ -66,8 +54,8 @@ func TestStunIPV(t *testing.T) {
 		}
 		defer l.Close()
 
-		// hand off the UDP listener to the STUN server in a goroutine
-		go s.ServePacket(l)
+		// hand off the UDP listener to a STUN server in a goroutine
+		go stun.NewServer(nil).ServePacket(l)
 
 		// setup our test
 		host := l.LocalAddr().String()

--- a/builtin/providers/stun/datasource_stun_result_test.go
+++ b/builtin/providers/stun/datasource_stun_result_test.go
@@ -1,0 +1,115 @@
+package stun
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/pixelbender/go-stun/stun"
+)
+
+var testProviders = map[string]terraform.ResourceProvider{
+	"stun": Provider(),
+}
+
+func TestStun(t *testing.T) {
+	var hosts = []string{
+		"stun.ekiga.net",
+		"stun.ekiga.net:3478",
+		"global.stun.twilio.com",
+	}
+
+	for _, host := range hosts {
+		r.UnitTest(t, r.TestCase{
+			Providers: testProviders,
+			Steps: []r.TestStep{
+				{
+					Config: testStunConfig(host),
+					Check: func(s *terraform.State) error {
+						got := s.RootModule().Outputs["ip_address"]
+						if got.Value == "" {
+							return fmt.Errorf("host:\n%s\nip_address:\n%s", host, got)
+						}
+						got = s.RootModule().Outputs["ip_family"]
+						if got.Value == "" {
+							return fmt.Errorf("host:\n%s\nip_family:\n%s", host, got)
+						}
+						return nil
+					},
+				},
+			},
+		})
+	}
+}
+
+func TestStunIPV(t *testing.T) {
+	for _, ipv := range []string{"4", "6"} {
+		// start up a STUN server that will always respond with our target IP
+		s := stun.NewServer(nil)
+		s.Handler = stun.HandlerFunc(func(rw stun.ResponseWriter, _ *stun.Message) {
+			rw.WriteMessage(&stun.Message{
+				Method: stun.TypeResponse,
+				Attributes: stun.Attributes{
+					stun.AttrXorMappedAddress: rw.RemoteAddr(),
+					stun.AttrMappedAddress:    rw.RemoteAddr(),
+					stun.AttrResponseOrigin:   rw.LocalAddr(),
+				},
+			})
+		})
+
+		// start a UDP listener
+		l, err := net.ListenPacket("udp"+ipv, "")
+		if err != nil {
+			t.Fatal("listen error", err)
+		}
+		defer l.Close()
+
+		// hand off the UDP listener to the STUN server in a goroutine
+		go s.ServePacket(l)
+
+		// setup our test
+		host := l.LocalAddr().String()
+		var loopback net.IP
+		switch ipv {
+		case "4":
+			loopback = net.ParseIP("127.0.0.1")
+		case "6":
+			loopback = net.IPv6loopback
+		}
+		r.UnitTest(t, r.TestCase{
+			Providers: testProviders,
+			Steps: []r.TestStep{
+				{
+					Config: testStunConfig(host),
+					Check: func(s *terraform.State) error {
+						ip_address := s.RootModule().Outputs["ip_address"]
+						if want := loopback.String(); ip_address.Value != want {
+							return fmt.Errorf("host:\n%s\nip_address:\n%s\nwant:\n%s", host, ip_address.Value, want)
+						}
+						ip_family := s.RootModule().Outputs["ip_family"]
+						want := "ipv" + ipv
+						if ip_family.Value != want {
+							return fmt.Errorf("host:\n%s\nip_family:\n%s\nwant:\n%s", host, ip_family, want)
+						}
+						return nil
+					},
+				},
+			},
+		})
+	}
+}
+
+func testStunConfig(host string) string {
+	return fmt.Sprintf(`
+	data "stun" "local" {
+		server = %q
+	}
+	output "ip_address" {
+		value = "${data.stun.local.ip_address}"
+	}
+	output "ip_family" {
+		value = "${data.stun.local.ip_family}"
+	}`, host)
+}

--- a/builtin/providers/stun/provider.go
+++ b/builtin/providers/stun/provider.go
@@ -1,0 +1,20 @@
+package stun
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		DataSourcesMap: map[string]*schema.Resource{
+			"stun": dataSourceStun(),
+		},
+		ResourcesMap: map[string]*schema.Resource{
+			"stun": schema.DataSourceResourceShim(
+				"stun",
+				dataSourceStun(),
+			),
+		},
+	}
+}

--- a/builtin/providers/stun/provider_test.go
+++ b/builtin/providers/stun/provider_test.go
@@ -1,0 +1,13 @@
+package stun
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -56,6 +56,7 @@ import (
 	scalewayprovider "github.com/hashicorp/terraform/builtin/providers/scaleway"
 	softlayerprovider "github.com/hashicorp/terraform/builtin/providers/softlayer"
 	statuscakeprovider "github.com/hashicorp/terraform/builtin/providers/statuscake"
+	stunprovider "github.com/hashicorp/terraform/builtin/providers/stun"
 	templateprovider "github.com/hashicorp/terraform/builtin/providers/template"
 	terraformprovider "github.com/hashicorp/terraform/builtin/providers/terraform"
 	testprovider "github.com/hashicorp/terraform/builtin/providers/test"
@@ -127,6 +128,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"scaleway":     scalewayprovider.Provider,
 	"softlayer":    softlayerprovider.Provider,
 	"statuscake":   statuscakeprovider.Provider,
+	"stun":         stunprovider.Provider,
 	"template":     templateprovider.Provider,
 	"terraform":    terraformprovider.Provider,
 	"test":         testprovider.Provider,

--- a/vendor/github.com/pixelbender/go-stun/LICENSE
+++ b/vendor/github.com/pixelbender/go-stun/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Vasily Vasilyev
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/pixelbender/go-stun/stun/address.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/address.go
@@ -1,0 +1,98 @@
+package stun
+
+import (
+	"net"
+	"reflect"
+	"strconv"
+)
+
+// Addr represents a transport address attribute.
+type Addr struct {
+	IP   net.IP
+	Port int
+}
+
+// String returns the "host:port" form of the transport address.
+func (addr *Addr) String() string {
+	return net.JoinHostPort(addr.IP.String(), strconv.Itoa(addr.Port))
+}
+
+var xorMask = []byte{0x21, 0x12, 0xa4, 0x42}
+
+// AddrCodec is the codec for a transport address attribute.
+const AddrCodec = addrCodec(false)
+
+// XorAddrCodec is the codec for a XOR-obfuscated transport address attribute.
+const XorAddrCodec = addrCodec(true)
+
+type addrCodec bool
+
+func (c addrCodec) Encode(w Writer, v interface{}) error {
+	switch addr := v.(type) {
+	case *net.UDPAddr:
+		c.writeAddress(w, addr.IP, addr.Port)
+	case *net.TCPAddr:
+		c.writeAddress(w, addr.IP, addr.Port)
+	case *Addr:
+		c.writeAddress(w, addr.IP, addr.Port)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c addrCodec) writeAddress(w Writer, ip net.IP, port int) {
+	fam, sh := byte(0x01), ip.To4()
+	if len(sh) == 0 {
+		fam, sh = byte(0x02), ip
+	}
+	b := w.Next(4 + len(sh))
+	b[0] = 0
+	b[1] = fam
+	if c {
+		be.PutUint16(b[2:], uint16(port)^0x2112)
+		b = b[4:]
+		if enc, ok := w.(*writer); ok {
+			for i, it := range sh {
+				b[i] = it ^ enc.buf[i+4]
+			}
+		} else {
+			for i, it := range sh {
+				b[i] = it ^ xorMask[i%4]
+			}
+		}
+	} else {
+		be.PutUint16(b[2:], uint16(port))
+		copy(b[4:], sh)
+	}
+}
+
+func (c addrCodec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(4)
+	if err != nil {
+		return nil, err
+	}
+	n, port := net.IPv4len, int(be.Uint16(b[2:]))
+	if b[1] == 0x02 {
+		n = net.IPv6len
+	}
+	if b, err = r.Next(n); err != nil {
+		return nil, err
+	}
+	ip := make([]byte, len(b))
+	if c {
+		if dec, ok := r.(*reader); ok {
+			for i, it := range b {
+				ip[i] = it ^ dec.msg[i+4]
+			}
+		} else {
+			for i, it := range b {
+				ip[i] = it ^ xorMask[i%4]
+			}
+		}
+		return &Addr{IP: ip, Port: port ^ 0x2112}, nil
+	} else {
+		copy(ip, b)
+	}
+	return &Addr{IP: ip, Port: port}, nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/attributes.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/attributes.go
@@ -1,0 +1,254 @@
+package stun
+
+import (
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// Attributes introduced by the RFC 5389 Section 18.2.
+const (
+	AttrMappedAddress     = uint16(0x0001)
+	AttrXorMappedAddress  = uint16(0x0020)
+	AttrUsername          = uint16(0x0006)
+	AttrMessageIntegrity  = uint16(0x0008)
+	AttrErrorCode         = uint16(0x0009)
+	AttrRealm             = uint16(0x0014)
+	AttrNonce             = uint16(0x0015)
+	AttrUnknownAttributes = uint16(0x000a)
+	AttrSoftware          = uint16(0x8022)
+	AttrAlternateServer   = uint16(0x8023)
+	AttrFingerprint       = uint16(0x8028)
+)
+
+// Attributes introduced by the RFC 5780 Section 7.
+const (
+	AttrChangeRequest  = uint16(0x0003)
+	AttrPadding        = uint16(0x0026)
+	AttrResponsePort   = uint16(0x0027)
+	AttrResponseOrigin = uint16(0x802b)
+	AttrOtherAddress   = uint16(0x802c)
+)
+
+// Attributes introduced by the RFC 3489 Section 11.2 except listed above.
+const (
+	AttrResponseAddress = uint16(0x0002)
+	AttrSourceAddress   = uint16(0x0004)
+	AttrChangedAddress  = uint16(0x0005)
+	AttrPassword        = uint16(0x0007)
+	AttrReflectedFrom   = uint16(0x000b)
+)
+
+// Bits definition of CHANGE-REQUEST attribute.
+const (
+	ChangeIP   = uint32(0x4)
+	ChangePort = uint32(0x2)
+)
+
+var attrNames = map[uint16]string{
+	AttrMappedAddress:     "MAPPED-ADDRESS",
+	AttrXorMappedAddress:  "XOR-MAPPED-ADDRESS",
+	AttrUsername:          "USERNAME",
+	AttrMessageIntegrity:  "MESSAGE-INTEGRITY",
+	AttrFingerprint:       "FINGERPRINT",
+	AttrErrorCode:         "ERROR-CODE",
+	AttrRealm:             "REALM",
+	AttrNonce:             "NONCE",
+	AttrUnknownAttributes: "UNKNOWN-ATTRIBUTES",
+	AttrSoftware:          "SOFTWARE",
+	AttrAlternateServer:   "ALTERNATE-SERVER",
+	AttrChangeRequest:     "CHANGE-REQUEST",
+	AttrPadding:           "PADDING",
+	AttrResponsePort:      "RESPONSE-PORT",
+	AttrResponseOrigin:    "RESPONSE-ORIGIN",
+	AttrOtherAddress:      "OTHER-ADDRESS",
+	AttrResponseAddress:   "RESPONSE-ADDRESS",
+	AttrSourceAddress:     "SOURCE-ADDRESS",
+	AttrChangedAddress:    "CHANGED-ADDRESS",
+	AttrPassword:          "PASSWORD",
+	AttrReflectedFrom:     "REFLECTED-FROM",
+}
+
+// GetAttributeName returns a STUN attribute name.
+// It returns the empty string if the attribute is unknown.
+func GetAttributeName(at uint16) (n string) {
+	if n = attrNames[at]; n == "" {
+		n = "0x" + strconv.FormatUint(uint64(at), 16)
+	}
+	return
+}
+
+// AttrCodec interface represents a STUN attribute encoder/decoder.
+type AttrCodec interface {
+	Encode(w Writer, v interface{}) error
+	Decode(r Reader) (interface{}, error)
+}
+
+var attrCodecs = map[uint16]AttrCodec{
+	AttrMappedAddress:     AddrCodec,
+	AttrXorMappedAddress:  XorAddrCodec,
+	AttrUsername:          StringCodec,
+	AttrMessageIntegrity:  RawCodec,
+	AttrErrorCode:         errorCodec{},
+	AttrRealm:             StringCodec,
+	AttrNonce:             StringCodec,
+	AttrUnknownAttributes: unkAttrCodec{},
+	AttrSoftware:          StringCodec,
+	AttrAlternateServer:   AddrCodec,
+	AttrFingerprint:       uint32Codec{},
+	AttrChangeRequest:     uint32Codec{},
+	AttrPadding:           RawCodec,
+	AttrResponsePort:      portCodec{},
+	AttrResponseOrigin:    AddrCodec,
+	AttrOtherAddress:      AddrCodec,
+	AttrResponseAddress:   AddrCodec,
+	AttrSourceAddress:     AddrCodec,
+	AttrChangedAddress:    AddrCodec,
+	AttrPassword:          StringCodec,
+	AttrReflectedFrom:     AddrCodec,
+}
+
+// GetAttributeCodec returns a STUN attribute codec for TURN.
+// It returns the nil if the attribute type is unknown.
+func GetAttributeCodec(at uint16) AttrCodec {
+	return attrCodecs[at]
+}
+
+type errUnsupportedAttrType struct {
+	reflect.Type
+}
+
+func (err errUnsupportedAttrType) Error() string {
+	return "stun: unsupported attribute type: " + reflect.Type(err).String()
+}
+
+// ErrUnknownAttrs is returned when a STUN message contains unknown comprehension-required attributes.
+type errUnknownAttrCodec struct {
+	Type uint16
+}
+
+func (err errUnknownAttrCodec) Error() string {
+	return "stun: no codec for attribute " + GetAttributeName(err.Type) + " is defined"
+}
+
+// Attributes represents a set of STUN attributes.
+type Attributes map[uint16]interface{}
+
+func (at Attributes) Has(id uint16) (ok bool) {
+	_, ok = at[id]
+	return
+}
+
+func (at Attributes) String(id uint16) string {
+	r, ok := at[id]
+	if ok {
+		switch v := r.(type) {
+		case []byte:
+			return string(v)
+		case string:
+			return v
+		case (fmt.Stringer):
+			return v.String()
+		default:
+			return fmt.Sprintf("%", r)
+		}
+	}
+	return ""
+}
+
+// RawCodec encodes and decodes a STUN attribute as a raw byte array.
+const RawCodec = rawCodec(false)
+
+// StringCodec encodes and decodes a STUN attribute as a string.
+const StringCodec = rawCodec(true)
+
+type rawCodec bool
+
+func (c rawCodec) Encode(w Writer, v interface{}) error {
+	switch attr := v.(type) {
+	case []byte:
+		copy(w.Next(len(attr)), attr)
+	case string:
+		copy(w.Next(len(attr)), attr)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c rawCodec) Decode(r Reader) (interface{}, error) {
+	b, _ := r.Next(r.Available())
+	if c {
+		return string(b), nil
+	}
+	return b, nil
+}
+
+type unkAttrCodec struct{}
+
+func (c unkAttrCodec) Encode(w Writer, v interface{}) error {
+	switch attr := v.(type) {
+	case []uint16:
+		c.writeAttributeTypes(w, attr)
+	case ErrUnknownAttrs:
+		c.writeAttributeTypes(w, attr.Attributes)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c unkAttrCodec) writeAttributeTypes(w Writer, attrs []uint16) {
+	b := w.Next(len(attrs) << 1)
+	for i, it := range attrs {
+		be.PutUint16(b[i<<1:], it)
+	}
+}
+
+func (c unkAttrCodec) Decode(r Reader) (interface{}, error) {
+	b, _ := r.Next(r.Available())
+	attrs := make([]uint16, len(b)>>1)
+	for i := range attrs {
+		attrs[i] = be.Uint16(b[i<<1:])
+	}
+	return &ErrUnknownAttrs{attrs}, nil
+}
+
+type uint32Codec struct{}
+
+func (c uint32Codec) Encode(w Writer, v interface{}) error {
+	if v, ok := v.(uint32); ok {
+		be.PutUint32(w.Next(4), v)
+		return nil
+	}
+	return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+}
+
+func (c uint32Codec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(4)
+	if err != nil {
+		return nil, err
+	}
+	return be.Uint32(b), nil
+}
+
+type portCodec struct{}
+
+func (c portCodec) Encode(w Writer, v interface{}) error {
+	if v, ok := v.(int); ok {
+		be.PutUint16(w.Next(2), uint16(v))
+		return nil
+	}
+	return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+}
+
+func (c portCodec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(2)
+	if err != nil {
+		return nil, err
+	}
+	return int(be.Uint16(b)), nil
+}
+
+var be = binary.BigEndian

--- a/vendor/github.com/pixelbender/go-stun/stun/client.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/client.go
@@ -1,0 +1,104 @@
+package stun
+
+import (
+	"bytes"
+	"crypto/rand"
+	"net"
+	"time"
+)
+
+var retransmissionTimeout = 500 * time.Millisecond
+var defaultTimeout = 39500 * time.Millisecond
+
+// Client is a STUN client.
+type Client struct {
+	*Conn
+	Timeout time.Duration
+}
+
+func NewClient(c net.Conn, config *Config) *Client {
+	return &Client{
+		Conn:    NewConn(c, config),
+		Timeout: defaultTimeout,
+	}
+}
+
+// RoundTrip sends STUN request and waits for a STUN response within the transaction.
+// Retransmits on unrelied over transport protocol connection.
+// Tries to authorize
+// No STUN redirect is supported.
+// Returns STUN error responses as errors.
+func (c *Client) RoundTrip(req *Message) (res *Message, err error) {
+	if err = c.WriteMessage(req); err != nil {
+		return
+	}
+
+	rto := retransmissionTimeout
+	deadline := time.Now().Add(c.Timeout)
+
+	if !c.reliable {
+		c.SetReadDeadline(time.Now().Add(rto))
+	} else if c.Timeout > 0 {
+		c.SetReadDeadline(deadline)
+	}
+
+	for {
+		res, err = c.ReadMessage()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Temporary() && !c.reliable && time.Now().Before(deadline) {
+				// Retransmit
+				if err = c.WriteMessage(req); err != nil {
+					return
+				}
+				rto *= 2
+				c.SetReadDeadline(time.Now().Add(rto))
+				continue
+			}
+			return
+		}
+		if !bytes.Equal(req.Transaction, res.Transaction) {
+			if c.reliable {
+				return nil, ErrFormat
+			}
+			continue
+		}
+		if attr, ok := res.Attributes[AttrErrorCode]; ok {
+			code := attr.(*Error)
+			if code.Code == CodeUnauthorized && req.Key == nil {
+				// TODO: store nonce
+				req.Attributes[AttrRealm] = res.Attributes[AttrRealm]
+				req.Attributes[AttrNonce] = res.Attributes[AttrNonce]
+				req.Key, err = c.config.getAuthKey(req.Attributes)
+				if err != nil {
+					return
+				}
+				if req.Key != nil {
+					// New transaction
+					rand.Read(req.Transaction[4:])
+					c.key = req.Key
+					if err = c.WriteMessage(req); err != nil {
+						return
+					}
+					continue
+				}
+			}
+			// TODO: handle alternate server
+		}
+		return res, nil
+	}
+}
+
+func GetServerAddress(h string, secure bool) string {
+	host, port, err := net.SplitHostPort(h)
+	if err != nil {
+		host = h
+	}
+	if port == "" {
+		if secure {
+			port = "5478"
+		} else {
+			port = "3478"
+		}
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/conn.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/conn.go
@@ -1,0 +1,176 @@
+package stun
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"time"
+)
+
+// Config represents a STUN connection configuration.
+type Config struct {
+	// GetAuthKey returns a key for a MESSAGE-INTEGRITY attribute generation and validation.
+	// Key = MD5(username ":" realm ":" SASLprep(password)) for long-term credentials.
+	// Key = SASLprep(password) for short-term credentials.
+	// SASLprep is defined in RFC 4013.
+	// The Username and Password fields are ignored if GetAuthKey is defined.
+	GetAuthKey func(attrs Attributes) ([]byte, error)
+
+	// GetAttributeCodec returns STUN attribute codec for the specified attribute type.
+	// Using stun.GetAttributeCodec if GetAttributeCodec is nil.
+	GetAttributeCodec func(at uint16) AttrCodec
+
+	// Fingerprint controls whether a FINGERPRINT attribute will be generated.
+	Fingerprint bool
+
+	// Software is a value for SOFTWARE attribute.
+	Software string
+}
+
+func (c *Config) getAuthKey(attrs Attributes) ([]byte, error) {
+	if c != nil && c.GetAuthKey != nil {
+		return c.GetAuthKey(attrs)
+	}
+	return nil, nil
+}
+
+func (c *Config) getAttrCodec(at uint16) AttrCodec {
+	if c != nil && c.GetAttributeCodec != nil {
+		return c.GetAttributeCodec(at)
+	}
+	return GetAttributeCodec(at)
+}
+
+var DefaultConfig = &Config{
+	GetAttributeCodec: GetAttributeCodec,
+}
+
+// A Conn represents the STUN connection and implements the STUN protocol over net.Conn interface.
+type Conn struct {
+	net.Conn
+	config   *Config
+	dec      *Decoder
+	enc      *Encoder
+	cr       connReader
+	reliable bool
+	key      []byte
+}
+
+// NewConn creates a Conn connection over the c with specified configuration.
+func NewConn(inner net.Conn, config *Config) *Conn {
+	if config == nil {
+		config = DefaultConfig
+	}
+	c := &Conn{
+		Conn:   inner,
+		config: config,
+		dec:    NewDecoder(config),
+		enc:    NewEncoder(config),
+	}
+	if _, ok := inner.(net.PacketConn); ok {
+		c.cr = newPacketReader(inner)
+		c.reliable = false
+	} else {
+		c.cr = newStreamReader(inner)
+		c.reliable = true
+	}
+	return c
+}
+
+// ReadMessage reads STUN messages from the connection.
+func (c *Conn) ReadMessage() (*Message, error) {
+	b, err := c.cr.PeekMessageBytes()
+	if err != nil {
+		return nil, err
+	}
+	msg, err := c.dec.Decode(b, c.key)
+	return msg, err
+}
+
+// WriteMessage writes the STUN message to the connection.
+func (c *Conn) WriteMessage(msg *Message) error {
+	b, err := c.enc.Encode(msg)
+	if err != nil {
+		return err
+	}
+	if _, err = c.Write(b); err != nil {
+		return err
+	}
+	return nil
+}
+
+type connReader interface {
+	// PeekMessageBytes returns the bytes, containing a STUN message.
+	// The bytes stop being valid at the next read call.
+	PeekMessageBytes() ([]byte, error)
+}
+
+var bufferSize = 1400
+
+// streamReader reads a STUN message transmitted over a stream-oriented network.
+type streamReader struct {
+	*bufio.Reader
+	r    io.Reader
+	skip int
+}
+
+func newStreamReader(r io.Reader) *streamReader {
+	if tcp, ok := r.(*net.TCPConn); ok {
+		tcp.SetKeepAlive(true)
+		tcp.SetKeepAlivePeriod(30 * time.Second)
+	}
+	return &streamReader{bufio.NewReaderSize(r, bufferSize), r, 0}
+}
+
+func (c *streamReader) Read(b []byte) (int, error) {
+	c.discard()
+	return c.Read(b)
+}
+
+func (c *streamReader) PeekMessageBytes() ([]byte, error) {
+	c.discard()
+	h, err := c.Peek(4)
+	if err != nil {
+		return nil, err
+	}
+	if be.Uint16(h)&0xc000 != 0 {
+		return nil, ErrFormat
+	}
+	n := int(be.Uint16(h[2:])) + 20
+	b, err := c.Peek(n)
+	if err != nil {
+		return nil, err
+	}
+	c.skip = n
+	return b, nil
+}
+
+func (c *streamReader) discard() {
+	if c.skip > 0 {
+		c.Discard(c.skip)
+		c.skip = 0
+	}
+}
+
+// packetConn reads a STUN message transmitted over a packet-oriented network.
+type packetReader struct {
+	io.Reader
+	buf []byte
+}
+
+func newPacketReader(r io.Reader) *packetReader {
+	return &packetReader{r, make([]byte, bufferSize)}
+}
+
+func (c *packetReader) PeekMessageBytes() ([]byte, error) {
+	n, err := c.Read(c.buf)
+	if err != nil {
+		return nil, err
+	}
+	b := c.buf[:n]
+	l := int(be.Uint16(b[2:])) + 20
+	if n < l {
+		return nil, ErrTruncated
+	}
+	return b, nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/decoder.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/decoder.go
@@ -1,0 +1,155 @@
+package stun
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrUnauthorized is returned by Decode or RoundTrip when GetAuthKey is defined
+// but a STUN request does not contain a MESSAGE-INTEGRITY attribute.
+var ErrUnauthorized = errors.New("stun: unauthorized")
+
+// ErrIntegrityCheckFailure is returned by Decode when a STUN message contains
+// a MESSAGE-INTEGRITY attribute and it does not equal to HMAC-SHA1 sum.
+var ErrIntegrityCheckFailure = errors.New("stun: integrity check failure")
+
+// ErrIncorrectFingerprint is returned by Decode when a STUN message contains
+// a FINGERPRINT attribute and it does not equal to checksum.
+var ErrIncorrectFingerprint = errors.New("stun: incorrect fingerprint")
+
+// ErrFormat is returned by Decode when a buffer is not a valid STUN message.
+var ErrFormat = errors.New("stun: incorrect format")
+
+// ErrFormat is returned by ReadMessage when a STUN message was truncated.
+var ErrTruncated = errors.New("stun: truncated")
+
+// ErrUnknownAttrs is returned when a STUN message contains unknown comprehension-required attributes.
+type ErrUnknownAttrs struct {
+	Attributes []uint16
+}
+
+func (e ErrUnknownAttrs) Error() string {
+	return fmt.Sprintf("stun: unknown attributes %#v", e.Attributes)
+}
+
+// A Decoder reads and decodes STUN messages from a buffer.
+type Decoder struct {
+	*Config
+	key []byte
+}
+
+func NewDecoder(config *Config) *Decoder {
+	if config == nil {
+		config = DefaultConfig
+	}
+	return &Decoder{Config: config}
+}
+
+// Decode reads STUN message from the buffer.
+// Checks MESSAGE-INTEGRITY attribute if GetAuthKey is specified.
+// Checks FINGERPRINT attribute if present.
+// Returns io.EOF if the buffer size is not enough.
+// Returns ErrUnknownAttrs containing unknown comprehension-required STUN attributes.
+func (dec *Decoder) Decode(b []byte, key []byte) (*Message, error) {
+	r := &reader{buf: append([]byte(nil), b...)}
+	h, err := r.Next(20)
+	if err != nil {
+		return nil, err
+	}
+	n := int(be.Uint16(h[2:]))
+	d, err := r.Next(n)
+	if err != nil {
+		return nil, err
+	}
+	p := 20
+	m := &Message{
+		Method:      be.Uint16(h),
+		Transaction: h[4:20],
+		Attributes:  make(Attributes),
+	}
+	var unk []uint16
+
+	for len(d) > 4 {
+		at, n := be.Uint16(d), int(be.Uint16(d[2:])+4)
+		// Padding
+		s := n
+		if mod := n & 3; mod != 0 {
+			s = n + 4 - mod
+		}
+		if len(d) < s {
+			return nil, io.EOF
+		}
+		buf := d[4:n]
+		d = d[s:]
+		codec := dec.getAttrCodec(at)
+		if codec == nil {
+			if at < 0x8000 {
+				unk = append(unk, at)
+			}
+			p += s
+			continue
+		}
+		attr, err := codec.Decode(&reader{msg: r.buf, buf: buf})
+		if err != nil {
+			return nil, err
+		}
+		m.Attributes[at] = attr
+		switch at {
+		case AttrMessageIntegrity:
+			be.PutUint16(h[2:], uint16(p+4))
+			if key == nil {
+				key, err = dec.getAuthKey(m.Attributes)
+				if err != nil {
+					return nil, err
+				}
+			}
+			sum := integrity(r.buf[:p], key)
+			if !bytes.Equal(attr.([]byte), sum) {
+				return nil, ErrIntegrityCheckFailure
+			}
+			m.Key = key
+			d = nil
+		case AttrFingerprint:
+			be.PutUint16(h[2:], uint16(p-12))
+			crc := fingerprint(r.buf[:p])
+			if attr.(uint32) != crc {
+				return nil, ErrIncorrectFingerprint
+			}
+			d = nil
+		}
+		p += s
+	}
+	if unk != nil {
+		return m, &ErrUnknownAttrs{unk}
+	}
+	return m, nil
+}
+
+type Reader interface {
+	// Next returns a slice of the next n bytes.
+	Next(n int) ([]byte, error)
+	// Available returns number of available unread bytes.
+	Available() int
+}
+
+type reader struct {
+	msg []byte
+	buf []byte
+	pos int
+}
+
+func (r *reader) Available() int {
+	return len(r.buf) - r.pos
+}
+
+func (r *reader) Next(n int) ([]byte, error) {
+	p := r.pos + n
+	if len(r.buf) < r.pos+n {
+		return nil, io.EOF
+	}
+	off := r.pos
+	r.pos = p
+	return r.buf[off : off+n], nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/encoder.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/encoder.go
@@ -1,0 +1,129 @@
+package stun
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha1"
+	"hash/crc32"
+)
+
+// An Encoder writes STUN message to a buffer.
+type Encoder struct {
+	*Config
+	w writer
+}
+
+func NewEncoder(config *Config) *Encoder {
+	if config == nil {
+		config = DefaultConfig
+	}
+	return &Encoder{Config: config}
+}
+
+// Encode writes STUN message to the buffer.
+// Generates MESSAGE-INTEGRITY attribute if Key is specified.
+// Appends FINGERPRINT attribute if Fingerprint is true.
+func (enc *Encoder) Encode(m *Message) ([]byte, error) {
+	w := &enc.w
+	w.pos = 0
+	h := w.Next(20)
+	be.PutUint16(h, m.Method)
+
+	if m.Transaction == nil {
+		tx := make([]byte, 16)
+		be.PutUint32(tx, magicCookie)
+		rand.Read(tx[4:])
+		m.Transaction = tx
+	}
+	if enc.Software != "" {
+		m.Attributes[AttrSoftware] = enc.Software
+	}
+
+	copy(h[4:], m.Transaction)
+
+	for at, v := range m.Attributes {
+		b := w.Next(4)
+		p := w.pos
+		codec := enc.getAttrCodec(at)
+		if codec == nil {
+			return nil, &errUnknownAttrCodec{at}
+		}
+		err := codec.Encode(w, v)
+		if err != nil {
+			return nil, err
+		}
+		n := w.pos - p
+		be.PutUint16(b, at)
+		be.PutUint16(b[2:], uint16(n))
+
+		// Padding
+		if mod := n & 3; mod != 0 {
+			b = w.Next(4 - mod)
+			for i := range b {
+				b[i] = 0
+			}
+		}
+	}
+	if m.Key == nil && enc.GetAuthKey != nil {
+		key, err := enc.getAuthKey(m.Attributes)
+		if err != nil {
+			return nil, err
+		}
+		m.Key = key
+	}
+	if m.Key != nil {
+		be.PutUint16(h[2:], uint16(w.pos+4))
+		p := w.pos
+		b := w.Next(24)
+		be.PutUint16(b, AttrMessageIntegrity)
+		be.PutUint16(b[2:], 20)
+		// TODO: sum into byte slice
+		copy(b[4:], integrity(w.buf[:p], m.Key))
+	}
+	if enc.Fingerprint {
+		be.PutUint16(h[2:], uint16(w.pos-12))
+		p := w.pos
+		b := w.Next(8)
+		be.PutUint16(b, AttrFingerprint)
+		be.PutUint16(b[2:], 4)
+		be.PutUint32(b[4:], fingerprint(w.buf[:p]))
+	}
+	be.PutUint16(h[2:], uint16(w.pos-20))
+	return w.buf[:w.pos], nil
+}
+
+// checksum calculates FINGERPRINT attribute value for the STUN message bytes.
+// See RFC 5389 Section 15.5
+func fingerprint(v []byte) uint32 {
+	return crc32.ChecksumIEEE(v) ^ 0x5354554e
+}
+
+// integrity calculates MESSAGE-INTEGRITY attribute value for the STUN message bytes.
+func integrity(v, key []byte) []byte {
+	h := hmac.New(sha1.New, key)
+	h.Write(v)
+	return h.Sum(nil)
+}
+
+type Writer interface {
+	// Next returns a slice of the next n bytes.
+	Next(n int) []byte
+}
+
+type writer struct {
+	buf []byte
+	pos int
+}
+
+func (w *writer) Next(n int) (b []byte) {
+	p := w.pos + n
+	if len(w.buf) < p {
+		b := make([]byte, (1+((p-1)>>10))<<10)
+		if w.pos > 0 {
+			copy(b, w.buf[:w.pos])
+		}
+		w.buf = b
+	}
+	b, w.pos = w.buf[w.pos:p], p
+	return
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/error.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/error.go
@@ -1,0 +1,83 @@
+package stun
+
+import "reflect"
+
+// Error codes introduced by the RFC 5389 Section 15.6
+const (
+	CodeTryAlternate     = 300
+	CodeBadRequest       = 400
+	CodeUnauthorized     = 401
+	CodeUnknownAttribute = 420
+	CodeStaleNonce       = 438
+	CodeServerError      = 500
+)
+
+// Error codes introduced by the RFC 3489 Section 11.2.9 except listed in RFC 5389.
+const (
+	CodeStaleCredentials      = 430
+	CodeIntegrityCheckFailure = 431
+	CodeMissingUsername       = 432
+	CodeUseTLS                = 433
+	CodeGlobalFailure         = 600
+)
+
+var errorText = map[int]string{
+	CodeTryAlternate:          "Try Alternate",
+	CodeBadRequest:            "Bad Request",
+	CodeUnauthorized:          "Unauthorized",
+	CodeUnknownAttribute:      "Unknown Attribute",
+	CodeStaleCredentials:      "Stale Credentials",
+	CodeIntegrityCheckFailure: "Integrity Check Failure",
+	CodeMissingUsername:       "Missing Username",
+	CodeUseTLS:                "Use TLS",
+	CodeStaleNonce:            "Stale Nonce",
+	CodeServerError:           "Server Error",
+	CodeGlobalFailure:         "Global Failure",
+}
+
+// ErrorText returns a reason phrase text for the STUN error code. It returns the empty string if the code is unknown.
+func ErrorText(code int) string {
+	return errorText[code]
+}
+
+// Error represents the ERROR-CODE attribute.
+type Error struct {
+	Code   int
+	Reason string
+}
+
+// NewError returns Error with code and default reason phrase.
+func NewError(code int) *Error {
+	return &Error{Code: code, Reason: ErrorText(code)}
+}
+
+type errorCodec struct{}
+
+func (c errorCodec) Encode(w Writer, v interface{}) error {
+	switch attr := v.(type) {
+	case *Error:
+		c.writeErrorCode(w, attr.Code, attr.Reason)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c errorCodec) writeErrorCode(w Writer, code int, reason string) {
+	b := w.Next(4 + len(reason))
+	b[0] = 0
+	b[1] = 0
+	b[2] = byte(code / 100)
+	b[3] = byte(code % 100)
+	copy(b[4:], reason)
+}
+
+func (c errorCodec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(4)
+	if err != nil {
+		return nil, err
+	}
+	code := int(b[2])*100 + int(b[3])
+	b, _ = r.Next(r.Available())
+	return &Error{code, string(b)}, nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/message.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/message.go
@@ -1,0 +1,27 @@
+package stun
+
+// MethodBinding is the STUN binding request method.
+const MethodBinding = uint16(0x0001)
+
+// Types of a STUN message.
+const (
+	TypeRequest    = uint16(0x0000)
+	TypeIndication = uint16(0x0010)
+	TypeResponse   = uint16(0x0100)
+	TypeError      = uint16(0x0110)
+)
+
+// Message represents a STUN message.
+type Message struct {
+	Method      uint16
+	Transaction []byte
+	Attributes  Attributes
+	Key         []byte
+}
+
+// IsType checks if the STUN message corresponds the specified type.
+func (m *Message) IsType(t uint16) bool {
+	return (m.Method & 0x110) == t
+}
+
+const magicCookie = uint32(0x2112a442)

--- a/vendor/github.com/pixelbender/go-stun/stun/server.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/server.go
@@ -1,0 +1,229 @@
+package stun
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"time"
+)
+
+// A Handler handles a STUN message.
+type Handler interface {
+	ServeSTUN(rw ResponseWriter, r *Message)
+}
+
+// The HandlerFunc type is an adapter to allow the use of ordinary functions as STUN handlers.
+type HandlerFunc func(rw ResponseWriter, r *Message)
+
+// ServeSTUN calls f(rw, r).
+func (f HandlerFunc) ServeSTUN(rw ResponseWriter, r *Message) {
+	f(rw, r)
+}
+
+type ResponseWriter interface {
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	// WriteResponse writes STUN response within the transaction.
+	WriteMessage(msg *Message) error
+}
+
+// Server represents a STUN server.
+type Server struct {
+	*Config
+	Realm   string
+	Handler Handler
+}
+
+func NewServer(config *Config) *Server {
+	if config == nil {
+		config = DefaultConfig
+	}
+	return &Server{Config: config}
+}
+
+// ListenAndServe listens on the network address and calls handler to serve requests.
+// Accepted connections are configured to enable TCP keep-alives.
+func (srv *Server) ListenAndServe(network, addr string) error {
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		l, err := net.Listen(network, addr)
+		if err != nil {
+			return err
+		}
+		return srv.Serve(l)
+	case "udp", "udp4", "udp6":
+		l, err := net.ListenPacket(network, addr)
+		if err != nil {
+			return err
+		}
+		return srv.ServePacket(l)
+	}
+	return fmt.Errorf("stun: listen unsupported network %v", network)
+}
+
+// ListenAndServeTLS listens on the network address secured by TLS and calls handler to serve requests.
+// Accepted connections are configured to enable TCP keep-alives.
+func (srv *Server) ListenAndServeTLS(network, addr, certFile, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	config := &tls.Config{Certificates: []tls.Certificate{cert}}
+	l, err := net.Listen(network, addr)
+	if err != nil {
+		return err
+	}
+	l = tls.NewListener(l, config)
+	return srv.Serve(l)
+}
+
+// ServePacket receives incoming packets on the packet-oriented network listener and calls handler to serve STUN requests.
+// Multiple goroutines may invoke ServePacket on the same PacketConn simultaneously.
+func (srv *Server) ServePacket(l net.PacketConn) error {
+	enc := NewEncoder(srv.Config)
+	dec := NewDecoder(srv.Config)
+	buf := make([]byte, bufferSize)
+
+	for {
+		n, addr, err := l.ReadFrom(buf)
+		if err != nil {
+			return err
+		}
+		msg, err := dec.Decode(buf[:n], nil)
+		rw := &packetResponseWriter{l, msg, addr, enc}
+		srv.serve(rw, msg, err)
+	}
+}
+
+// Serve accepts incoming connection on the listener and calls handler to serve STUN requests.
+// Multiple goroutines may invoke Serve on the same Listener simultaneously.
+func (srv *Server) Serve(l net.Listener) error {
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				time.Sleep(time.Millisecond)
+				continue
+			}
+			return err
+		}
+		go srv.serveConn(c)
+	}
+}
+
+func (srv *Server) serveConn(conn net.Conn) error {
+	c := NewConn(conn, srv.Config)
+	defer c.Close()
+	for {
+		msg, err := c.ReadMessage()
+		if err != nil {
+			return err
+		}
+		srv.serve(&connResponseWriter{c, msg}, msg, err)
+	}
+}
+
+func (srv *Server) serve(rw ResponseWriter, r *Message, err error) error {
+	if r.IsType(TypeRequest) || r.IsType(TypeIndication) {
+		if srv.GetAuthKey != nil {
+			if !r.Attributes.Has(AttrMessageIntegrity) || !r.Attributes.Has(AttrMessageIntegrity) {
+				err = ErrUnauthorized
+			}
+		}
+	}
+	if err != nil {
+		switch err {
+		case ErrUnauthorized, ErrIncorrectFingerprint:
+			// TODO: store nonce
+			nonce := make([]byte, 8)
+			rand.Read(nonce)
+			return rw.WriteMessage(&Message{
+				Method: r.Method | TypeError,
+				Attributes: Attributes{
+					AttrErrorCode: NewError(CodeUnauthorized),
+					AttrRealm:     srv.Realm,
+					AttrNonce:     hex.EncodeToString(nonce),
+				},
+			})
+		}
+		if unk, ok := err.(ErrUnknownAttrs); ok {
+			return rw.WriteMessage(&Message{
+				Method: r.Method | TypeError,
+				Attributes: Attributes{
+					AttrErrorCode:         NewError(CodeUnknownAttribute),
+					AttrUnknownAttributes: unk,
+				},
+			})
+		}
+		// TODO: log error
+		return nil
+	}
+	if h := srv.Handler; h != nil {
+		h.ServeSTUN(rw, r)
+	} else {
+		srv.ServeSTUN(rw, r)
+	}
+	return nil
+}
+
+// ServeSTUN responds to the simple STUN binding request.
+func (srv *Server) ServeSTUN(rw ResponseWriter, r *Message) {
+	switch r.Method {
+	case MethodBinding:
+		rw.WriteMessage(&Message{
+			Method: r.Method | TypeResponse,
+			Attributes: Attributes{
+				AttrXorMappedAddress: rw.RemoteAddr(),
+				AttrMappedAddress:    rw.RemoteAddr(),
+				AttrResponseOrigin:   rw.LocalAddr(),
+				// TODO: add other address
+				// TODO: handle change request
+			},
+		})
+	}
+}
+
+type connResponseWriter struct {
+	*Conn
+	msg *Message
+}
+
+func (w *connResponseWriter) WriteMessage(msg *Message) error {
+	if msg.Transaction == nil {
+		msg.Transaction = w.msg.Transaction
+	}
+	if msg.Key == nil {
+		msg.Key = w.msg.Key
+	}
+	return w.Conn.WriteMessage(msg)
+}
+
+type packetResponseWriter struct {
+	net.PacketConn
+	msg  *Message
+	addr net.Addr
+	enc  *Encoder
+}
+
+func (w *packetResponseWriter) RemoteAddr() net.Addr {
+	return w.addr
+}
+
+func (w *packetResponseWriter) WriteMessage(msg *Message) error {
+	if msg.Transaction == nil {
+		msg.Transaction = w.msg.Transaction
+	}
+	if msg.Key == nil {
+		msg.Key = w.msg.Key
+	}
+	b, err := w.enc.Encode(msg)
+	if err != nil {
+		return err
+	}
+	if _, err = w.WriteTo(b, w.addr); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun.go
@@ -1,0 +1,73 @@
+package stun
+
+import (
+	"crypto/md5"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+)
+
+var ErrUnsupportedScheme = errors.New("stun: unsupported scheme")
+var ErrNoAddressResponse = errors.New("stun: no mapped address")
+
+// Lookup connects to the given STUN URI and makes the STUN binding request.
+// Returns the server reflexive transport address (mapped address).
+func Lookup(uri, username, password string) (*Addr, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	var conn net.Conn
+	switch strings.ToLower(u.Scheme) {
+	case "stun":
+		conn, err = net.Dial("udp", GetServerAddress(u.Opaque, false))
+	case "stuns":
+		conn, err = tls.Dial("tcp", GetServerAddress(u.Opaque, true), nil)
+	default:
+		err = ErrUnsupportedScheme
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	c := NewClient(conn, &Config{GetAuthKey: LongTermAuthKey(username, password)})
+	defer c.Close()
+
+	msg, err := c.RoundTrip(&Message{Method: MethodBinding})
+	if err != nil {
+		return nil, err
+	}
+	if addr, ok := msg.Attributes[AttrXorMappedAddress]; ok {
+		return addr.(*Addr), nil
+	} else if addr, ok := msg.Attributes[AttrMappedAddress]; ok {
+		return addr.(*Addr), nil
+	}
+	return nil, ErrNoAddressResponse
+}
+
+// ListenAndServe listens on the network address and calls handler to serve requests.
+func ListenAndServe(network, addr string, handler Handler) error {
+	srv := &Server{Config: DefaultConfig, Handler: handler}
+	return srv.ListenAndServe(network, addr)
+}
+
+// ListenAndServeTLS listens on the network address secured by TLS and calls handler to serve requests.
+func ListenAndServeTLS(network, addr string, certFile, keyFile string, handler Handler) error {
+	srv := &Server{Config: DefaultConfig, Handler: handler}
+	return srv.ListenAndServeTLS(network, addr, certFile, keyFile)
+}
+
+func LongTermAuthKey(username, password string) func(attrs Attributes) ([]byte, error) {
+	return func(attrs Attributes) ([]byte, error) {
+		if attrs.Has(AttrRealm) {
+			attrs[AttrUsername] = username
+			h := md5.New()
+			h.Write([]byte(username + ":" + attrs.String(AttrRealm) + ":" + password))
+			return h.Sum(nil), nil
+		}
+		return nil, nil
+	}
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/address.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/address.go
@@ -1,0 +1,98 @@
+package stun
+
+import (
+	"net"
+	"reflect"
+	"strconv"
+)
+
+// Addr represents a transport address attribute.
+type Addr struct {
+	IP   net.IP
+	Port int
+}
+
+// String returns the "host:port" form of the transport address.
+func (addr *Addr) String() string {
+	return net.JoinHostPort(addr.IP.String(), strconv.Itoa(addr.Port))
+}
+
+var xorMask = []byte{0x21, 0x12, 0xa4, 0x42}
+
+// AddrCodec is the codec for a transport address attribute.
+const AddrCodec = addrCodec(false)
+
+// XorAddrCodec is the codec for a XOR-obfuscated transport address attribute.
+const XorAddrCodec = addrCodec(true)
+
+type addrCodec bool
+
+func (c addrCodec) Encode(w Writer, v interface{}) error {
+	switch addr := v.(type) {
+	case *net.UDPAddr:
+		c.writeAddress(w, addr.IP, addr.Port)
+	case *net.TCPAddr:
+		c.writeAddress(w, addr.IP, addr.Port)
+	case *Addr:
+		c.writeAddress(w, addr.IP, addr.Port)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c addrCodec) writeAddress(w Writer, ip net.IP, port int) {
+	fam, sh := byte(0x01), ip.To4()
+	if len(sh) == 0 {
+		fam, sh = byte(0x02), ip
+	}
+	b := w.Next(4 + len(sh))
+	b[0] = 0
+	b[1] = fam
+	if c {
+		be.PutUint16(b[2:], uint16(port)^0x2112)
+		b = b[4:]
+		if enc, ok := w.(*writer); ok {
+			for i, it := range sh {
+				b[i] = it ^ enc.buf[i+4]
+			}
+		} else {
+			for i, it := range sh {
+				b[i] = it ^ xorMask[i%4]
+			}
+		}
+	} else {
+		be.PutUint16(b[2:], uint16(port))
+		copy(b[4:], sh)
+	}
+}
+
+func (c addrCodec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(4)
+	if err != nil {
+		return nil, err
+	}
+	n, port := net.IPv4len, int(be.Uint16(b[2:]))
+	if b[1] == 0x02 {
+		n = net.IPv6len
+	}
+	if b, err = r.Next(n); err != nil {
+		return nil, err
+	}
+	ip := make([]byte, len(b))
+	if c {
+		if dec, ok := r.(*reader); ok {
+			for i, it := range b {
+				ip[i] = it ^ dec.msg[i+4]
+			}
+		} else {
+			for i, it := range b {
+				ip[i] = it ^ xorMask[i%4]
+			}
+		}
+		return &Addr{IP: ip, Port: port ^ 0x2112}, nil
+	} else {
+		copy(ip, b)
+	}
+	return &Addr{IP: ip, Port: port}, nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/attributes.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/attributes.go
@@ -1,0 +1,254 @@
+package stun
+
+import (
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"strconv"
+)
+
+// Attributes introduced by the RFC 5389 Section 18.2.
+const (
+	AttrMappedAddress     = uint16(0x0001)
+	AttrXorMappedAddress  = uint16(0x0020)
+	AttrUsername          = uint16(0x0006)
+	AttrMessageIntegrity  = uint16(0x0008)
+	AttrErrorCode         = uint16(0x0009)
+	AttrRealm             = uint16(0x0014)
+	AttrNonce             = uint16(0x0015)
+	AttrUnknownAttributes = uint16(0x000a)
+	AttrSoftware          = uint16(0x8022)
+	AttrAlternateServer   = uint16(0x8023)
+	AttrFingerprint       = uint16(0x8028)
+)
+
+// Attributes introduced by the RFC 5780 Section 7.
+const (
+	AttrChangeRequest  = uint16(0x0003)
+	AttrPadding        = uint16(0x0026)
+	AttrResponsePort   = uint16(0x0027)
+	AttrResponseOrigin = uint16(0x802b)
+	AttrOtherAddress   = uint16(0x802c)
+)
+
+// Attributes introduced by the RFC 3489 Section 11.2 except listed above.
+const (
+	AttrResponseAddress = uint16(0x0002)
+	AttrSourceAddress   = uint16(0x0004)
+	AttrChangedAddress  = uint16(0x0005)
+	AttrPassword        = uint16(0x0007)
+	AttrReflectedFrom   = uint16(0x000b)
+)
+
+// Bits definition of CHANGE-REQUEST attribute.
+const (
+	ChangeIP   = uint32(0x4)
+	ChangePort = uint32(0x2)
+)
+
+var attrNames = map[uint16]string{
+	AttrMappedAddress:     "MAPPED-ADDRESS",
+	AttrXorMappedAddress:  "XOR-MAPPED-ADDRESS",
+	AttrUsername:          "USERNAME",
+	AttrMessageIntegrity:  "MESSAGE-INTEGRITY",
+	AttrFingerprint:       "FINGERPRINT",
+	AttrErrorCode:         "ERROR-CODE",
+	AttrRealm:             "REALM",
+	AttrNonce:             "NONCE",
+	AttrUnknownAttributes: "UNKNOWN-ATTRIBUTES",
+	AttrSoftware:          "SOFTWARE",
+	AttrAlternateServer:   "ALTERNATE-SERVER",
+	AttrChangeRequest:     "CHANGE-REQUEST",
+	AttrPadding:           "PADDING",
+	AttrResponsePort:      "RESPONSE-PORT",
+	AttrResponseOrigin:    "RESPONSE-ORIGIN",
+	AttrOtherAddress:      "OTHER-ADDRESS",
+	AttrResponseAddress:   "RESPONSE-ADDRESS",
+	AttrSourceAddress:     "SOURCE-ADDRESS",
+	AttrChangedAddress:    "CHANGED-ADDRESS",
+	AttrPassword:          "PASSWORD",
+	AttrReflectedFrom:     "REFLECTED-FROM",
+}
+
+// GetAttributeName returns a STUN attribute name.
+// It returns the empty string if the attribute is unknown.
+func GetAttributeName(at uint16) (n string) {
+	if n = attrNames[at]; n == "" {
+		n = "0x" + strconv.FormatUint(uint64(at), 16)
+	}
+	return
+}
+
+// AttrCodec interface represents a STUN attribute encoder/decoder.
+type AttrCodec interface {
+	Encode(w Writer, v interface{}) error
+	Decode(r Reader) (interface{}, error)
+}
+
+var attrCodecs = map[uint16]AttrCodec{
+	AttrMappedAddress:     AddrCodec,
+	AttrXorMappedAddress:  XorAddrCodec,
+	AttrUsername:          StringCodec,
+	AttrMessageIntegrity:  RawCodec,
+	AttrErrorCode:         errorCodec{},
+	AttrRealm:             StringCodec,
+	AttrNonce:             StringCodec,
+	AttrUnknownAttributes: unkAttrCodec{},
+	AttrSoftware:          StringCodec,
+	AttrAlternateServer:   AddrCodec,
+	AttrFingerprint:       uint32Codec{},
+	AttrChangeRequest:     uint32Codec{},
+	AttrPadding:           RawCodec,
+	AttrResponsePort:      portCodec{},
+	AttrResponseOrigin:    AddrCodec,
+	AttrOtherAddress:      AddrCodec,
+	AttrResponseAddress:   AddrCodec,
+	AttrSourceAddress:     AddrCodec,
+	AttrChangedAddress:    AddrCodec,
+	AttrPassword:          StringCodec,
+	AttrReflectedFrom:     AddrCodec,
+}
+
+// GetAttributeCodec returns a STUN attribute codec for TURN.
+// It returns the nil if the attribute type is unknown.
+func GetAttributeCodec(at uint16) AttrCodec {
+	return attrCodecs[at]
+}
+
+type errUnsupportedAttrType struct {
+	reflect.Type
+}
+
+func (err errUnsupportedAttrType) Error() string {
+	return "stun: unsupported attribute type: " + reflect.Type(err).String()
+}
+
+// ErrUnknownAttrs is returned when a STUN message contains unknown comprehension-required attributes.
+type errUnknownAttrCodec struct {
+	Type uint16
+}
+
+func (err errUnknownAttrCodec) Error() string {
+	return "stun: no codec for attribute " + GetAttributeName(err.Type) + " is defined"
+}
+
+// Attributes represents a set of STUN attributes.
+type Attributes map[uint16]interface{}
+
+func (at Attributes) Has(id uint16) (ok bool) {
+	_, ok = at[id]
+	return
+}
+
+func (at Attributes) String(id uint16) string {
+	r, ok := at[id]
+	if ok {
+		switch v := r.(type) {
+		case []byte:
+			return string(v)
+		case string:
+			return v
+		case (fmt.Stringer):
+			return v.String()
+		default:
+			return fmt.Sprintf("%", r)
+		}
+	}
+	return ""
+}
+
+// RawCodec encodes and decodes a STUN attribute as a raw byte array.
+const RawCodec = rawCodec(false)
+
+// StringCodec encodes and decodes a STUN attribute as a string.
+const StringCodec = rawCodec(true)
+
+type rawCodec bool
+
+func (c rawCodec) Encode(w Writer, v interface{}) error {
+	switch attr := v.(type) {
+	case []byte:
+		copy(w.Next(len(attr)), attr)
+	case string:
+		copy(w.Next(len(attr)), attr)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c rawCodec) Decode(r Reader) (interface{}, error) {
+	b, _ := r.Next(r.Available())
+	if c {
+		return string(b), nil
+	}
+	return b, nil
+}
+
+type unkAttrCodec struct{}
+
+func (c unkAttrCodec) Encode(w Writer, v interface{}) error {
+	switch attr := v.(type) {
+	case []uint16:
+		c.writeAttributeTypes(w, attr)
+	case ErrUnknownAttrs:
+		c.writeAttributeTypes(w, attr.Attributes)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c unkAttrCodec) writeAttributeTypes(w Writer, attrs []uint16) {
+	b := w.Next(len(attrs) << 1)
+	for i, it := range attrs {
+		be.PutUint16(b[i<<1:], it)
+	}
+}
+
+func (c unkAttrCodec) Decode(r Reader) (interface{}, error) {
+	b, _ := r.Next(r.Available())
+	attrs := make([]uint16, len(b)>>1)
+	for i := range attrs {
+		attrs[i] = be.Uint16(b[i<<1:])
+	}
+	return &ErrUnknownAttrs{attrs}, nil
+}
+
+type uint32Codec struct{}
+
+func (c uint32Codec) Encode(w Writer, v interface{}) error {
+	if v, ok := v.(uint32); ok {
+		be.PutUint32(w.Next(4), v)
+		return nil
+	}
+	return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+}
+
+func (c uint32Codec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(4)
+	if err != nil {
+		return nil, err
+	}
+	return be.Uint32(b), nil
+}
+
+type portCodec struct{}
+
+func (c portCodec) Encode(w Writer, v interface{}) error {
+	if v, ok := v.(int); ok {
+		be.PutUint16(w.Next(2), uint16(v))
+		return nil
+	}
+	return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+}
+
+func (c portCodec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(2)
+	if err != nil {
+		return nil, err
+	}
+	return int(be.Uint16(b)), nil
+}
+
+var be = binary.BigEndian

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/client.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/client.go
@@ -1,0 +1,104 @@
+package stun
+
+import (
+	"bytes"
+	"crypto/rand"
+	"net"
+	"time"
+)
+
+var retransmissionTimeout = 500 * time.Millisecond
+var defaultTimeout = 39500 * time.Millisecond
+
+// Client is a STUN client.
+type Client struct {
+	*Conn
+	Timeout time.Duration
+}
+
+func NewClient(c net.Conn, config *Config) *Client {
+	return &Client{
+		Conn:    NewConn(c, config),
+		Timeout: defaultTimeout,
+	}
+}
+
+// RoundTrip sends STUN request and waits for a STUN response within the transaction.
+// Retransmits on unrelied over transport protocol connection.
+// Tries to authorize
+// No STUN redirect is supported.
+// Returns STUN error responses as errors.
+func (c *Client) RoundTrip(req *Message) (res *Message, err error) {
+	if err = c.WriteMessage(req); err != nil {
+		return
+	}
+
+	rto := retransmissionTimeout
+	deadline := time.Now().Add(c.Timeout)
+
+	if !c.reliable {
+		c.SetReadDeadline(time.Now().Add(rto))
+	} else if c.Timeout > 0 {
+		c.SetReadDeadline(deadline)
+	}
+
+	for {
+		res, err = c.ReadMessage()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Temporary() && !c.reliable && time.Now().Before(deadline) {
+				// Retransmit
+				if err = c.WriteMessage(req); err != nil {
+					return
+				}
+				rto *= 2
+				c.SetReadDeadline(time.Now().Add(rto))
+				continue
+			}
+			return
+		}
+		if !bytes.Equal(req.Transaction, res.Transaction) {
+			if c.reliable {
+				return nil, ErrFormat
+			}
+			continue
+		}
+		if attr, ok := res.Attributes[AttrErrorCode]; ok {
+			code := attr.(*Error)
+			if code.Code == CodeUnauthorized && req.Key == nil {
+				// TODO: store nonce
+				req.Attributes[AttrRealm] = res.Attributes[AttrRealm]
+				req.Attributes[AttrNonce] = res.Attributes[AttrNonce]
+				req.Key, err = c.config.getAuthKey(req.Attributes)
+				if err != nil {
+					return
+				}
+				if req.Key != nil {
+					// New transaction
+					rand.Read(req.Transaction[4:])
+					c.key = req.Key
+					if err = c.WriteMessage(req); err != nil {
+						return
+					}
+					continue
+				}
+			}
+			// TODO: handle alternate server
+		}
+		return res, nil
+	}
+}
+
+func GetServerAddress(h string, secure bool) string {
+	host, port, err := net.SplitHostPort(h)
+	if err != nil {
+		host = h
+	}
+	if port == "" {
+		if secure {
+			port = "5478"
+		} else {
+			port = "3478"
+		}
+	}
+	return net.JoinHostPort(host, port)
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/conn.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/conn.go
@@ -1,0 +1,176 @@
+package stun
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"time"
+)
+
+// Config represents a STUN connection configuration.
+type Config struct {
+	// GetAuthKey returns a key for a MESSAGE-INTEGRITY attribute generation and validation.
+	// Key = MD5(username ":" realm ":" SASLprep(password)) for long-term credentials.
+	// Key = SASLprep(password) for short-term credentials.
+	// SASLprep is defined in RFC 4013.
+	// The Username and Password fields are ignored if GetAuthKey is defined.
+	GetAuthKey func(attrs Attributes) ([]byte, error)
+
+	// GetAttributeCodec returns STUN attribute codec for the specified attribute type.
+	// Using stun.GetAttributeCodec if GetAttributeCodec is nil.
+	GetAttributeCodec func(at uint16) AttrCodec
+
+	// Fingerprint controls whether a FINGERPRINT attribute will be generated.
+	Fingerprint bool
+
+	// Software is a value for SOFTWARE attribute.
+	Software string
+}
+
+func (c *Config) getAuthKey(attrs Attributes) ([]byte, error) {
+	if c != nil && c.GetAuthKey != nil {
+		return c.GetAuthKey(attrs)
+	}
+	return nil, nil
+}
+
+func (c *Config) getAttrCodec(at uint16) AttrCodec {
+	if c != nil && c.GetAttributeCodec != nil {
+		return c.GetAttributeCodec(at)
+	}
+	return GetAttributeCodec(at)
+}
+
+var DefaultConfig = &Config{
+	GetAttributeCodec: GetAttributeCodec,
+}
+
+// A Conn represents the STUN connection and implements the STUN protocol over net.Conn interface.
+type Conn struct {
+	net.Conn
+	config   *Config
+	dec      *Decoder
+	enc      *Encoder
+	cr       connReader
+	reliable bool
+	key      []byte
+}
+
+// NewConn creates a Conn connection over the c with specified configuration.
+func NewConn(inner net.Conn, config *Config) *Conn {
+	if config == nil {
+		config = DefaultConfig
+	}
+	c := &Conn{
+		Conn:   inner,
+		config: config,
+		dec:    NewDecoder(config),
+		enc:    NewEncoder(config),
+	}
+	if _, ok := inner.(net.PacketConn); ok {
+		c.cr = newPacketReader(inner)
+		c.reliable = false
+	} else {
+		c.cr = newStreamReader(inner)
+		c.reliable = true
+	}
+	return c
+}
+
+// ReadMessage reads STUN messages from the connection.
+func (c *Conn) ReadMessage() (*Message, error) {
+	b, err := c.cr.PeekMessageBytes()
+	if err != nil {
+		return nil, err
+	}
+	msg, err := c.dec.Decode(b, c.key)
+	return msg, err
+}
+
+// WriteMessage writes the STUN message to the connection.
+func (c *Conn) WriteMessage(msg *Message) error {
+	b, err := c.enc.Encode(msg)
+	if err != nil {
+		return err
+	}
+	if _, err = c.Write(b); err != nil {
+		return err
+	}
+	return nil
+}
+
+type connReader interface {
+	// PeekMessageBytes returns the bytes, containing a STUN message.
+	// The bytes stop being valid at the next read call.
+	PeekMessageBytes() ([]byte, error)
+}
+
+var bufferSize = 1400
+
+// streamReader reads a STUN message transmitted over a stream-oriented network.
+type streamReader struct {
+	*bufio.Reader
+	r    io.Reader
+	skip int
+}
+
+func newStreamReader(r io.Reader) *streamReader {
+	if tcp, ok := r.(*net.TCPConn); ok {
+		tcp.SetKeepAlive(true)
+		tcp.SetKeepAlivePeriod(30 * time.Second)
+	}
+	return &streamReader{bufio.NewReaderSize(r, bufferSize), r, 0}
+}
+
+func (c *streamReader) Read(b []byte) (int, error) {
+	c.discard()
+	return c.Read(b)
+}
+
+func (c *streamReader) PeekMessageBytes() ([]byte, error) {
+	c.discard()
+	h, err := c.Peek(4)
+	if err != nil {
+		return nil, err
+	}
+	if be.Uint16(h)&0xc000 != 0 {
+		return nil, ErrFormat
+	}
+	n := int(be.Uint16(h[2:])) + 20
+	b, err := c.Peek(n)
+	if err != nil {
+		return nil, err
+	}
+	c.skip = n
+	return b, nil
+}
+
+func (c *streamReader) discard() {
+	if c.skip > 0 {
+		c.Discard(c.skip)
+		c.skip = 0
+	}
+}
+
+// packetConn reads a STUN message transmitted over a packet-oriented network.
+type packetReader struct {
+	io.Reader
+	buf []byte
+}
+
+func newPacketReader(r io.Reader) *packetReader {
+	return &packetReader{r, make([]byte, bufferSize)}
+}
+
+func (c *packetReader) PeekMessageBytes() ([]byte, error) {
+	n, err := c.Read(c.buf)
+	if err != nil {
+		return nil, err
+	}
+	b := c.buf[:n]
+	l := int(be.Uint16(b[2:])) + 20
+	if n < l {
+		return nil, ErrTruncated
+	}
+	return b, nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/decoder.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/decoder.go
@@ -1,0 +1,155 @@
+package stun
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrUnauthorized is returned by Decode or RoundTrip when GetAuthKey is defined
+// but a STUN request does not contain a MESSAGE-INTEGRITY attribute.
+var ErrUnauthorized = errors.New("stun: unauthorized")
+
+// ErrIntegrityCheckFailure is returned by Decode when a STUN message contains
+// a MESSAGE-INTEGRITY attribute and it does not equal to HMAC-SHA1 sum.
+var ErrIntegrityCheckFailure = errors.New("stun: integrity check failure")
+
+// ErrIncorrectFingerprint is returned by Decode when a STUN message contains
+// a FINGERPRINT attribute and it does not equal to checksum.
+var ErrIncorrectFingerprint = errors.New("stun: incorrect fingerprint")
+
+// ErrFormat is returned by Decode when a buffer is not a valid STUN message.
+var ErrFormat = errors.New("stun: incorrect format")
+
+// ErrFormat is returned by ReadMessage when a STUN message was truncated.
+var ErrTruncated = errors.New("stun: truncated")
+
+// ErrUnknownAttrs is returned when a STUN message contains unknown comprehension-required attributes.
+type ErrUnknownAttrs struct {
+	Attributes []uint16
+}
+
+func (e ErrUnknownAttrs) Error() string {
+	return fmt.Sprintf("stun: unknown attributes %#v", e.Attributes)
+}
+
+// A Decoder reads and decodes STUN messages from a buffer.
+type Decoder struct {
+	*Config
+	key []byte
+}
+
+func NewDecoder(config *Config) *Decoder {
+	if config == nil {
+		config = DefaultConfig
+	}
+	return &Decoder{Config: config}
+}
+
+// Decode reads STUN message from the buffer.
+// Checks MESSAGE-INTEGRITY attribute if GetAuthKey is specified.
+// Checks FINGERPRINT attribute if present.
+// Returns io.EOF if the buffer size is not enough.
+// Returns ErrUnknownAttrs containing unknown comprehension-required STUN attributes.
+func (dec *Decoder) Decode(b []byte, key []byte) (*Message, error) {
+	r := &reader{buf: append([]byte(nil), b...)}
+	h, err := r.Next(20)
+	if err != nil {
+		return nil, err
+	}
+	n := int(be.Uint16(h[2:]))
+	d, err := r.Next(n)
+	if err != nil {
+		return nil, err
+	}
+	p := 20
+	m := &Message{
+		Method:      be.Uint16(h),
+		Transaction: h[4:20],
+		Attributes:  make(Attributes),
+	}
+	var unk []uint16
+
+	for len(d) > 4 {
+		at, n := be.Uint16(d), int(be.Uint16(d[2:])+4)
+		// Padding
+		s := n
+		if mod := n & 3; mod != 0 {
+			s = n + 4 - mod
+		}
+		if len(d) < s {
+			return nil, io.EOF
+		}
+		buf := d[4:n]
+		d = d[s:]
+		codec := dec.getAttrCodec(at)
+		if codec == nil {
+			if at < 0x8000 {
+				unk = append(unk, at)
+			}
+			p += s
+			continue
+		}
+		attr, err := codec.Decode(&reader{msg: r.buf, buf: buf})
+		if err != nil {
+			return nil, err
+		}
+		m.Attributes[at] = attr
+		switch at {
+		case AttrMessageIntegrity:
+			be.PutUint16(h[2:], uint16(p+4))
+			if key == nil {
+				key, err = dec.getAuthKey(m.Attributes)
+				if err != nil {
+					return nil, err
+				}
+			}
+			sum := integrity(r.buf[:p], key)
+			if !bytes.Equal(attr.([]byte), sum) {
+				return nil, ErrIntegrityCheckFailure
+			}
+			m.Key = key
+			d = nil
+		case AttrFingerprint:
+			be.PutUint16(h[2:], uint16(p-12))
+			crc := fingerprint(r.buf[:p])
+			if attr.(uint32) != crc {
+				return nil, ErrIncorrectFingerprint
+			}
+			d = nil
+		}
+		p += s
+	}
+	if unk != nil {
+		return m, &ErrUnknownAttrs{unk}
+	}
+	return m, nil
+}
+
+type Reader interface {
+	// Next returns a slice of the next n bytes.
+	Next(n int) ([]byte, error)
+	// Available returns number of available unread bytes.
+	Available() int
+}
+
+type reader struct {
+	msg []byte
+	buf []byte
+	pos int
+}
+
+func (r *reader) Available() int {
+	return len(r.buf) - r.pos
+}
+
+func (r *reader) Next(n int) ([]byte, error) {
+	p := r.pos + n
+	if len(r.buf) < r.pos+n {
+		return nil, io.EOF
+	}
+	off := r.pos
+	r.pos = p
+	return r.buf[off : off+n], nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/encoder.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/encoder.go
@@ -1,0 +1,129 @@
+package stun
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha1"
+	"hash/crc32"
+)
+
+// An Encoder writes STUN message to a buffer.
+type Encoder struct {
+	*Config
+	w writer
+}
+
+func NewEncoder(config *Config) *Encoder {
+	if config == nil {
+		config = DefaultConfig
+	}
+	return &Encoder{Config: config}
+}
+
+// Encode writes STUN message to the buffer.
+// Generates MESSAGE-INTEGRITY attribute if Key is specified.
+// Appends FINGERPRINT attribute if Fingerprint is true.
+func (enc *Encoder) Encode(m *Message) ([]byte, error) {
+	w := &enc.w
+	w.pos = 0
+	h := w.Next(20)
+	be.PutUint16(h, m.Method)
+
+	if m.Transaction == nil {
+		tx := make([]byte, 16)
+		be.PutUint32(tx, magicCookie)
+		rand.Read(tx[4:])
+		m.Transaction = tx
+	}
+	if enc.Software != "" {
+		m.Attributes[AttrSoftware] = enc.Software
+	}
+
+	copy(h[4:], m.Transaction)
+
+	for at, v := range m.Attributes {
+		b := w.Next(4)
+		p := w.pos
+		codec := enc.getAttrCodec(at)
+		if codec == nil {
+			return nil, &errUnknownAttrCodec{at}
+		}
+		err := codec.Encode(w, v)
+		if err != nil {
+			return nil, err
+		}
+		n := w.pos - p
+		be.PutUint16(b, at)
+		be.PutUint16(b[2:], uint16(n))
+
+		// Padding
+		if mod := n & 3; mod != 0 {
+			b = w.Next(4 - mod)
+			for i := range b {
+				b[i] = 0
+			}
+		}
+	}
+	if m.Key == nil && enc.GetAuthKey != nil {
+		key, err := enc.getAuthKey(m.Attributes)
+		if err != nil {
+			return nil, err
+		}
+		m.Key = key
+	}
+	if m.Key != nil {
+		be.PutUint16(h[2:], uint16(w.pos+4))
+		p := w.pos
+		b := w.Next(24)
+		be.PutUint16(b, AttrMessageIntegrity)
+		be.PutUint16(b[2:], 20)
+		// TODO: sum into byte slice
+		copy(b[4:], integrity(w.buf[:p], m.Key))
+	}
+	if enc.Fingerprint {
+		be.PutUint16(h[2:], uint16(w.pos-12))
+		p := w.pos
+		b := w.Next(8)
+		be.PutUint16(b, AttrFingerprint)
+		be.PutUint16(b[2:], 4)
+		be.PutUint32(b[4:], fingerprint(w.buf[:p]))
+	}
+	be.PutUint16(h[2:], uint16(w.pos-20))
+	return w.buf[:w.pos], nil
+}
+
+// checksum calculates FINGERPRINT attribute value for the STUN message bytes.
+// See RFC 5389 Section 15.5
+func fingerprint(v []byte) uint32 {
+	return crc32.ChecksumIEEE(v) ^ 0x5354554e
+}
+
+// integrity calculates MESSAGE-INTEGRITY attribute value for the STUN message bytes.
+func integrity(v, key []byte) []byte {
+	h := hmac.New(sha1.New, key)
+	h.Write(v)
+	return h.Sum(nil)
+}
+
+type Writer interface {
+	// Next returns a slice of the next n bytes.
+	Next(n int) []byte
+}
+
+type writer struct {
+	buf []byte
+	pos int
+}
+
+func (w *writer) Next(n int) (b []byte) {
+	p := w.pos + n
+	if len(w.buf) < p {
+		b := make([]byte, (1+((p-1)>>10))<<10)
+		if w.pos > 0 {
+			copy(b, w.buf[:w.pos])
+		}
+		w.buf = b
+	}
+	b, w.pos = w.buf[w.pos:p], p
+	return
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/error.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/error.go
@@ -1,0 +1,83 @@
+package stun
+
+import "reflect"
+
+// Error codes introduced by the RFC 5389 Section 15.6
+const (
+	CodeTryAlternate     = 300
+	CodeBadRequest       = 400
+	CodeUnauthorized     = 401
+	CodeUnknownAttribute = 420
+	CodeStaleNonce       = 438
+	CodeServerError      = 500
+)
+
+// Error codes introduced by the RFC 3489 Section 11.2.9 except listed in RFC 5389.
+const (
+	CodeStaleCredentials      = 430
+	CodeIntegrityCheckFailure = 431
+	CodeMissingUsername       = 432
+	CodeUseTLS                = 433
+	CodeGlobalFailure         = 600
+)
+
+var errorText = map[int]string{
+	CodeTryAlternate:          "Try Alternate",
+	CodeBadRequest:            "Bad Request",
+	CodeUnauthorized:          "Unauthorized",
+	CodeUnknownAttribute:      "Unknown Attribute",
+	CodeStaleCredentials:      "Stale Credentials",
+	CodeIntegrityCheckFailure: "Integrity Check Failure",
+	CodeMissingUsername:       "Missing Username",
+	CodeUseTLS:                "Use TLS",
+	CodeStaleNonce:            "Stale Nonce",
+	CodeServerError:           "Server Error",
+	CodeGlobalFailure:         "Global Failure",
+}
+
+// ErrorText returns a reason phrase text for the STUN error code. It returns the empty string if the code is unknown.
+func ErrorText(code int) string {
+	return errorText[code]
+}
+
+// Error represents the ERROR-CODE attribute.
+type Error struct {
+	Code   int
+	Reason string
+}
+
+// NewError returns Error with code and default reason phrase.
+func NewError(code int) *Error {
+	return &Error{Code: code, Reason: ErrorText(code)}
+}
+
+type errorCodec struct{}
+
+func (c errorCodec) Encode(w Writer, v interface{}) error {
+	switch attr := v.(type) {
+	case *Error:
+		c.writeErrorCode(w, attr.Code, attr.Reason)
+	default:
+		return &errUnsupportedAttrType{Type: reflect.TypeOf(v)}
+	}
+	return nil
+}
+
+func (c errorCodec) writeErrorCode(w Writer, code int, reason string) {
+	b := w.Next(4 + len(reason))
+	b[0] = 0
+	b[1] = 0
+	b[2] = byte(code / 100)
+	b[3] = byte(code % 100)
+	copy(b[4:], reason)
+}
+
+func (c errorCodec) Decode(r Reader) (interface{}, error) {
+	b, err := r.Next(4)
+	if err != nil {
+		return nil, err
+	}
+	code := int(b[2])*100 + int(b[3])
+	b, _ = r.Next(r.Available())
+	return &Error{code, string(b)}, nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/message.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/message.go
@@ -1,0 +1,27 @@
+package stun
+
+// MethodBinding is the STUN binding request method.
+const MethodBinding = uint16(0x0001)
+
+// Types of a STUN message.
+const (
+	TypeRequest    = uint16(0x0000)
+	TypeIndication = uint16(0x0010)
+	TypeResponse   = uint16(0x0100)
+	TypeError      = uint16(0x0110)
+)
+
+// Message represents a STUN message.
+type Message struct {
+	Method      uint16
+	Transaction []byte
+	Attributes  Attributes
+	Key         []byte
+}
+
+// IsType checks if the STUN message corresponds the specified type.
+func (m *Message) IsType(t uint16) bool {
+	return (m.Method & 0x110) == t
+}
+
+const magicCookie = uint32(0x2112a442)

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/server.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/server.go
@@ -1,0 +1,229 @@
+package stun
+
+import (
+	"crypto/rand"
+	"crypto/tls"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"time"
+)
+
+// A Handler handles a STUN message.
+type Handler interface {
+	ServeSTUN(rw ResponseWriter, r *Message)
+}
+
+// The HandlerFunc type is an adapter to allow the use of ordinary functions as STUN handlers.
+type HandlerFunc func(rw ResponseWriter, r *Message)
+
+// ServeSTUN calls f(rw, r).
+func (f HandlerFunc) ServeSTUN(rw ResponseWriter, r *Message) {
+	f(rw, r)
+}
+
+type ResponseWriter interface {
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	// WriteResponse writes STUN response within the transaction.
+	WriteMessage(msg *Message) error
+}
+
+// Server represents a STUN server.
+type Server struct {
+	*Config
+	Realm   string
+	Handler Handler
+}
+
+func NewServer(config *Config) *Server {
+	if config == nil {
+		config = DefaultConfig
+	}
+	return &Server{Config: config}
+}
+
+// ListenAndServe listens on the network address and calls handler to serve requests.
+// Accepted connections are configured to enable TCP keep-alives.
+func (srv *Server) ListenAndServe(network, addr string) error {
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+		l, err := net.Listen(network, addr)
+		if err != nil {
+			return err
+		}
+		return srv.Serve(l)
+	case "udp", "udp4", "udp6":
+		l, err := net.ListenPacket(network, addr)
+		if err != nil {
+			return err
+		}
+		return srv.ServePacket(l)
+	}
+	return fmt.Errorf("stun: listen unsupported network %v", network)
+}
+
+// ListenAndServeTLS listens on the network address secured by TLS and calls handler to serve requests.
+// Accepted connections are configured to enable TCP keep-alives.
+func (srv *Server) ListenAndServeTLS(network, addr, certFile, keyFile string) error {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return err
+	}
+	config := &tls.Config{Certificates: []tls.Certificate{cert}}
+	l, err := net.Listen(network, addr)
+	if err != nil {
+		return err
+	}
+	l = tls.NewListener(l, config)
+	return srv.Serve(l)
+}
+
+// ServePacket receives incoming packets on the packet-oriented network listener and calls handler to serve STUN requests.
+// Multiple goroutines may invoke ServePacket on the same PacketConn simultaneously.
+func (srv *Server) ServePacket(l net.PacketConn) error {
+	enc := NewEncoder(srv.Config)
+	dec := NewDecoder(srv.Config)
+	buf := make([]byte, bufferSize)
+
+	for {
+		n, addr, err := l.ReadFrom(buf)
+		if err != nil {
+			return err
+		}
+		msg, err := dec.Decode(buf[:n], nil)
+		rw := &packetResponseWriter{l, msg, addr, enc}
+		srv.serve(rw, msg, err)
+	}
+}
+
+// Serve accepts incoming connection on the listener and calls handler to serve STUN requests.
+// Multiple goroutines may invoke Serve on the same Listener simultaneously.
+func (srv *Server) Serve(l net.Listener) error {
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			if ne, ok := err.(net.Error); ok && ne.Temporary() {
+				time.Sleep(time.Millisecond)
+				continue
+			}
+			return err
+		}
+		go srv.serveConn(c)
+	}
+}
+
+func (srv *Server) serveConn(conn net.Conn) error {
+	c := NewConn(conn, srv.Config)
+	defer c.Close()
+	for {
+		msg, err := c.ReadMessage()
+		if err != nil {
+			return err
+		}
+		srv.serve(&connResponseWriter{c, msg}, msg, err)
+	}
+}
+
+func (srv *Server) serve(rw ResponseWriter, r *Message, err error) error {
+	if r.IsType(TypeRequest) || r.IsType(TypeIndication) {
+		if srv.GetAuthKey != nil {
+			if !r.Attributes.Has(AttrMessageIntegrity) || !r.Attributes.Has(AttrMessageIntegrity) {
+				err = ErrUnauthorized
+			}
+		}
+	}
+	if err != nil {
+		switch err {
+		case ErrUnauthorized, ErrIncorrectFingerprint:
+			// TODO: store nonce
+			nonce := make([]byte, 8)
+			rand.Read(nonce)
+			return rw.WriteMessage(&Message{
+				Method: r.Method | TypeError,
+				Attributes: Attributes{
+					AttrErrorCode: NewError(CodeUnauthorized),
+					AttrRealm:     srv.Realm,
+					AttrNonce:     hex.EncodeToString(nonce),
+				},
+			})
+		}
+		if unk, ok := err.(ErrUnknownAttrs); ok {
+			return rw.WriteMessage(&Message{
+				Method: r.Method | TypeError,
+				Attributes: Attributes{
+					AttrErrorCode:         NewError(CodeUnknownAttribute),
+					AttrUnknownAttributes: unk,
+				},
+			})
+		}
+		// TODO: log error
+		return nil
+	}
+	if h := srv.Handler; h != nil {
+		h.ServeSTUN(rw, r)
+	} else {
+		srv.ServeSTUN(rw, r)
+	}
+	return nil
+}
+
+// ServeSTUN responds to the simple STUN binding request.
+func (srv *Server) ServeSTUN(rw ResponseWriter, r *Message) {
+	switch r.Method {
+	case MethodBinding:
+		rw.WriteMessage(&Message{
+			Method: r.Method | TypeResponse,
+			Attributes: Attributes{
+				AttrXorMappedAddress: rw.RemoteAddr(),
+				AttrMappedAddress:    rw.RemoteAddr(),
+				AttrResponseOrigin:   rw.LocalAddr(),
+				// TODO: add other address
+				// TODO: handle change request
+			},
+		})
+	}
+}
+
+type connResponseWriter struct {
+	*Conn
+	msg *Message
+}
+
+func (w *connResponseWriter) WriteMessage(msg *Message) error {
+	if msg.Transaction == nil {
+		msg.Transaction = w.msg.Transaction
+	}
+	if msg.Key == nil {
+		msg.Key = w.msg.Key
+	}
+	return w.Conn.WriteMessage(msg)
+}
+
+type packetResponseWriter struct {
+	net.PacketConn
+	msg  *Message
+	addr net.Addr
+	enc  *Encoder
+}
+
+func (w *packetResponseWriter) RemoteAddr() net.Addr {
+	return w.addr
+}
+
+func (w *packetResponseWriter) WriteMessage(msg *Message) error {
+	if msg.Transaction == nil {
+		msg.Transaction = w.msg.Transaction
+	}
+	if msg.Key == nil {
+		msg.Key = w.msg.Key
+	}
+	b, err := w.enc.Encode(msg)
+	if err != nil {
+		return err
+	}
+	if _, err = w.WriteTo(b, w.addr); err != nil {
+		return err
+	}
+	return nil
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/stun.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/stun.go
@@ -1,0 +1,73 @@
+package stun
+
+import (
+	"crypto/md5"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/url"
+	"strings"
+)
+
+var ErrUnsupportedScheme = errors.New("stun: unsupported scheme")
+var ErrNoAddressResponse = errors.New("stun: no mapped address")
+
+// Lookup connects to the given STUN URI and makes the STUN binding request.
+// Returns the server reflexive transport address (mapped address).
+func Lookup(uri, username, password string) (*Addr, error) {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, err
+	}
+
+	var conn net.Conn
+	switch strings.ToLower(u.Scheme) {
+	case "stun":
+		conn, err = net.Dial("udp", GetServerAddress(u.Opaque, false))
+	case "stuns":
+		conn, err = tls.Dial("tcp", GetServerAddress(u.Opaque, true), nil)
+	default:
+		err = ErrUnsupportedScheme
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	c := NewClient(conn, &Config{GetAuthKey: LongTermAuthKey(username, password)})
+	defer c.Close()
+
+	msg, err := c.RoundTrip(&Message{Method: MethodBinding})
+	if err != nil {
+		return nil, err
+	}
+	if addr, ok := msg.Attributes[AttrXorMappedAddress]; ok {
+		return addr.(*Addr), nil
+	} else if addr, ok := msg.Attributes[AttrMappedAddress]; ok {
+		return addr.(*Addr), nil
+	}
+	return nil, ErrNoAddressResponse
+}
+
+// ListenAndServe listens on the network address and calls handler to serve requests.
+func ListenAndServe(network, addr string, handler Handler) error {
+	srv := &Server{Config: DefaultConfig, Handler: handler}
+	return srv.ListenAndServe(network, addr)
+}
+
+// ListenAndServeTLS listens on the network address secured by TLS and calls handler to serve requests.
+func ListenAndServeTLS(network, addr string, certFile, keyFile string, handler Handler) error {
+	srv := &Server{Config: DefaultConfig, Handler: handler}
+	return srv.ListenAndServeTLS(network, addr, certFile, keyFile)
+}
+
+func LongTermAuthKey(username, password string) func(attrs Attributes) ([]byte, error) {
+	return func(attrs Attributes) ([]byte, error) {
+		if attrs.Has(AttrRealm) {
+			attrs[AttrUsername] = username
+			h := md5.New()
+			h.Write([]byte(username + ":" + attrs.String(AttrRealm) + ":" + password))
+			return h.Sum(nil), nil
+		}
+		return nil, nil
+	}
+}

--- a/vendor/github.com/pixelbender/go-stun/stun/stun/stun_test.go
+++ b/vendor/github.com/pixelbender/go-stun/stun/stun/stun_test.go
@@ -1,0 +1,189 @@
+package stun
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"net"
+	"testing"
+)
+
+func TestTCPClientServer(t *testing.T) {
+	srv := NewServer(nil)
+	l, err := net.Listen("tcp", "")
+	if err != nil {
+		t.Fatal("listen error", err)
+	}
+	defer l.Close()
+	go srv.Serve(l)
+
+	c, err := net.Dial(l.Addr().Network(), l.Addr().String())
+	if err != nil {
+		t.Fatal("dial error", err)
+	}
+	conn := NewClient(c, nil)
+	defer conn.Close()
+
+	req := &Message{Method: MethodBinding}
+	msg, err := conn.RoundTrip(req)
+	if err != nil {
+		t.Fatal("exchange error", err)
+	}
+	if msg == nil || msg.Attributes[AttrXorMappedAddress] == nil {
+		t.Fatal("response error")
+	}
+}
+
+func TestUDPClientServer(t *testing.T) {
+	srv := NewServer(nil)
+	l, err := net.ListenPacket("udp", "")
+	if err != nil {
+		t.Fatal("listen error", err)
+	}
+	defer l.Close()
+	go srv.ServePacket(l)
+
+	c, err := net.Dial(l.LocalAddr().Network(), l.LocalAddr().String())
+	if err != nil {
+		t.Fatal("dial error", err)
+	}
+	conn := NewClient(c, nil)
+	defer conn.Close()
+
+	req := &Message{Method: MethodBinding}
+	msg, err := conn.RoundTrip(req)
+	if err != nil {
+		t.Fatal("exchange error", err)
+	}
+	if msg == nil {
+		t.Fatal("response error")
+	}
+	if msg == nil || msg.Attributes[AttrXorMappedAddress] == nil {
+		t.Fatal("response error")
+	}
+}
+
+func TestLookupAddr(t *testing.T) {
+	srv := NewServer(nil)
+	l, err := net.ListenPacket("udp", "")
+	if err != nil {
+		t.Fatal("listen error", err)
+	}
+	defer l.Close()
+	go srv.ServePacket(l)
+
+	addr, err := Lookup("stun:"+l.LocalAddr().String(), "", "")
+	if err != nil {
+		t.Fatal("lookup", err)
+	}
+	if addr == nil {
+		t.Fatal("no address")
+	}
+}
+
+// Test Vectors for STUN. RFC 5769.
+
+func TestVectorsSampleRequest(t *testing.T) {
+	b, err := hex.DecodeString("000100582112a442b7e7a701bc34d686fa87dfae802200105354554e207465737420636c69656e74002400046e0001ff80290008932ff9b151263b36000600096576746a3a68367659202020000800149aeaa70cbfd8cb56781ef2b5b2d3f249c1b571a280280004e57a3bcf")
+	if err != nil {
+		t.Fatal("decode hex", err)
+	}
+	dec := NewDecoder(nil)
+	msg, err := dec.Decode(b, []byte("VOkJxbRl1RmTxUk/WvJxBt"))
+	if unk, ok := err.(*ErrUnknownAttrs); ok {
+		if len(unk.Attributes) == 1 && unk.Attributes[0] == 0x24 {
+			err = nil
+		} else {
+			t.Fatal("unknown attributes")
+		}
+	}
+	if err != nil {
+		t.Fatal("decode error", err)
+	}
+	if !msg.IsType(TypeRequest) || msg.Method&^0x110 != MethodBinding {
+		t.Fatal("message type error", msg.Method)
+	}
+	if v := msg.Attributes.String(AttrSoftware); v != "STUN test client" {
+		t.Fatal("software check", v)
+	}
+	if v := msg.Attributes.String(AttrUsername); v != "evtj:h6vY" {
+		t.Fatal("username check", v)
+	}
+}
+
+func TestVectorsSampleIPv4Response(t *testing.T) {
+	b, err := hex.DecodeString("0101003c2112a442b7e7a701bc34d686fa87dfae8022000b7465737420766563746f7220002000080001a147e112a643000800142b91f599fd9e90c38c7489f92af9ba53f06be7d780280004c07d4c96")
+	if err != nil {
+		t.Fatal("decode hex", err)
+	}
+	dec := NewDecoder(nil)
+	msg, err := dec.Decode(b, []byte("VOkJxbRl1RmTxUk/WvJxBt"))
+	if err != nil {
+		t.Fatal("decode error", err)
+	}
+	if !msg.IsType(TypeResponse) || msg.Method&^0x110 != MethodBinding {
+		t.Fatal("message type error", msg.Method)
+	}
+	if v := msg.Attributes.String(AttrSoftware); v != "test vector" {
+		t.Fatal("software check", v)
+	}
+	addr := msg.Attributes[AttrXorMappedAddress].(*Addr)
+	if addr == nil || !addr.IP.Equal(net.ParseIP("192.0.2.1")) || addr.Port != 32853 {
+		t.Fatal("address check", addr)
+	}
+}
+
+func TestVectorsSampleIPv6Response(t *testing.T) {
+	b, err := hex.DecodeString("010100482112a442b7e7a701bc34d686fa87dfae8022000b7465737420766563746f7220002000140002a1470113a9faa5d3f179bc25f4b5bed2b9d900080014a382954e4be67bf11784c97c8292c275bfe3ed4180280004c8fb0b4c")
+	if err != nil {
+		t.Fatal("decode hex", err)
+	}
+	dec := NewDecoder(nil)
+	msg, err := dec.Decode(b, []byte("VOkJxbRl1RmTxUk/WvJxBt"))
+	if err != nil {
+		t.Fatal("decode error", err)
+	}
+	if !msg.IsType(TypeResponse) || msg.Method&^0x110 != MethodBinding {
+		t.Fatal("message type error", msg.Method)
+	}
+	if v := msg.Attributes.String(AttrSoftware); v != "test vector" {
+		t.Fatal("software check", v)
+	}
+	addr := msg.Attributes[AttrXorMappedAddress].(*Addr)
+	if addr == nil || !addr.IP.Equal(net.ParseIP("2001:db8:1234:5678:11:2233:4455:6677")) || addr.Port != 32853 {
+		t.Fatal("address check", addr)
+	}
+}
+
+func TestVectorsSampleLongTermAuth(t *testing.T) {
+	b, err := hex.DecodeString("000100602112a44278ad3433c6ad72c029da412e00060012e3839ee38388e383aae38383e382afe382b900000015001c662f2f3439396b39353464364f4c33346f4c394653547679363473410014000b6578616d706c652e6f72670000080014f67024656dd64a3e02b8e0712e85c9a28ca89666")
+	if err != nil {
+		t.Fatal("decode hex", err)
+	}
+	checked := false
+	config := &Config{
+		GetAuthKey: func(attrs Attributes) ([]byte, error) {
+			checked = true
+			u, r := attrs.String(AttrUsername), attrs.String(AttrRealm)
+			h := md5.New()
+			h.Write([]byte(u + ":" + r + ":TheMatrIX"))
+			return h.Sum(nil), nil
+		},
+	}
+	dec := NewDecoder(config)
+	msg, err := dec.Decode(b, nil)
+	if err != nil {
+		t.Fatal("decode error", err)
+	}
+	if !msg.IsType(TypeRequest) || msg.Method&^0x110 != MethodBinding {
+		t.Fatal("message type error", msg.Method)
+	}
+	if !checked {
+		t.Fatal("message integrity not checked")
+	}
+	if v := msg.Attributes.String(AttrNonce); v != "f//499k954d6OL34oL9FSTvy64sA" {
+		t.Fatal("nonce check", v)
+	}
+	if v := msg.Attributes.String(AttrRealm); v != "example.org" {
+		t.Fatal("realm check", v)
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2333,6 +2333,12 @@
 			"revisionTime": "2015-10-22T18:22:18Z"
 		},
 		{
+			"checksumSHA1": "Rg+ECEfwYLhrBk189Rn2xGKyQy0=",
+			"path": "github.com/pixelbender/go-stun/stun",
+			"revision": "0b7811ed3bc852c024c91e052179c2d5f9812049",
+			"revisionTime": "2016-08-28T01:33:38Z"
+		},
+		{
 			"checksumSHA1": "ynJSWoF6v+3zMnh9R0QmmG6iGV8=",
 			"comment": "v0.3.0",
 			"path": "github.com/pkg/errors",


### PR DESCRIPTION
Uses the provided STUN server to determine a public IP address.

```
data "stun" "local" {
  server = "stun1.l.google.com"
}
```

Outputs `ip_address` and `ip_family` (`ipv4` or `ipv6`)

implements #7992