### PR TITLE
provider/aws: Provide ability to opt-out of internal AWS tag filtering

### DIFF
--- a/builtin/providers/aws/data_source_aws_instance.go
+++ b/builtin/providers/aws/data_source_aws_instance.go
@@ -225,7 +225,7 @@ func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	if tagsOk {
 		params.Filters = append(params.Filters, buildEC2TagFilterList(
-			tagsFromMap(tags.(map[string]interface{})),
+			tagsFromMap(tags.(map[string]interface{}), true),
 		)...)
 	}
 

--- a/builtin/providers/aws/data_source_aws_route53_zone.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone.go
@@ -60,7 +60,7 @@ func dataSourceAwsRoute53ZoneRead(d *schema.ResourceData, meta interface{}) erro
 	name = hostedZoneName(name.(string))
 	id, idExists := d.GetOk("zone_id")
 	vpcId, vpcIdExists := d.GetOk("vpc_id")
-	tags := tagsFromMap(d.Get("tags").(map[string]interface{}))
+	tags := tagsFromMap(d.Get("tags").(map[string]interface{}), true)
 	if nameExists && idExists {
 		return fmt.Errorf("zone_id and name arguments can't be used together")
 	} else if !nameExists && !idExists {

--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -119,7 +119,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(tags.(map[string]interface{})),
+		tagsFromMap(tags.(map[string]interface{}), true),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		filter.(*schema.Set),
@@ -142,7 +142,7 @@ func dataSourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error
 	d.SetId(aws.StringValue(rt.RouteTableId))
 	d.Set("route_table_id", rt.RouteTableId)
 	d.Set("vpc_id", rt.VpcId)
-	d.Set("tags", tagsToMap(rt.Tags))
+	d.Set("tags", tagsToMap(rt.Tags, true))
 	if err := d.Set("routes", dataSourceRoutesRead(rt.Routes)); err != nil {
 		return err
 	}

--- a/builtin/providers/aws/data_source_aws_security_group.go
+++ b/builtin/providers/aws/data_source_aws_security_group.go
@@ -51,7 +51,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		tagsFromMap(d.Get("tags").(map[string]interface{}), true),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),
@@ -80,7 +80,7 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("name", sg.GroupName)
 	d.Set("description", sg.Description)
 	d.Set("vpc_id", sg.VpcId)
-	d.Set("tags", tagsToMap(sg.Tags))
+	d.Set("tags", tagsToMap(sg.Tags, true))
 
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_subnet.go
+++ b/builtin/providers/aws/data_source_aws_subnet.go
@@ -86,7 +86,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		tagsFromMap(d.Get("tags").(map[string]interface{}), true),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),
@@ -117,7 +117,7 @@ func dataSourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", subnet.CidrBlock)
 	d.Set("default_for_az", subnet.DefaultForAz)
 	d.Set("state", subnet.State)
-	d.Set("tags", tagsToMap(subnet.Tags))
+	d.Set("tags", tagsToMap(subnet.Tags, true))
 
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_vpc.go
+++ b/builtin/providers/aws/data_source_aws_vpc.go
@@ -84,7 +84,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		tagsFromMap(d.Get("tags").(map[string]interface{}), true),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),
@@ -115,7 +115,7 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
 	d.Set("default", vpc.IsDefault)
 	d.Set("state", vpc.State)
-	d.Set("tags", tagsToMap(vpc.Tags))
+	d.Set("tags", tagsToMap(vpc.Tags, true))
 
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/data_source_aws_vpc_peering_connection.go
@@ -93,7 +93,7 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 		},
 	)
 	req.Filters = append(req.Filters, buildEC2TagFilterList(
-		tagsFromMap(d.Get("tags").(map[string]interface{})),
+		tagsFromMap(d.Get("tags").(map[string]interface{}), true),
 	)...)
 	req.Filters = append(req.Filters, buildEC2CustomFilterList(
 		d.Get("filter").(*schema.Set),
@@ -125,7 +125,7 @@ func dataSourceAwsVpcPeeringConnectionRead(d *schema.ResourceData, meta interfac
 	d.Set("peer_vpc_id", pcx.AccepterVpcInfo.VpcId)
 	d.Set("peer_owner_id", pcx.AccepterVpcInfo.OwnerId)
 	d.Set("peer_cidr_block", pcx.AccepterVpcInfo.CidrBlock)
-	d.Set("tags", tagsToMap(pcx.Tags))
+	d.Set("tags", tagsToMap(pcx.Tags, true))
 
 	if pcx.AccepterVpcInfo.PeeringOptions != nil {
 		if err := d.Set("accepter", flattenPeeringOptions(pcx.AccepterVpcInfo.PeeringOptions)[0]); err != nil {

--- a/builtin/providers/aws/resource_aws_ami.go
+++ b/builtin/providers/aws/resource_aws_ami.go
@@ -208,7 +208,7 @@ func resourceAwsAmiRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("ebs_block_device", ebsBlockDevs)
 	d.Set("ephemeral_block_device", ephemeralBlockDevs)
 
-	d.Set("tags", tagsToMap(image.Tags))
+	d.Set("tags", tagsToMap(image.Tags, false))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_customer_gateway.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway.go
@@ -157,7 +157,7 @@ func resourceAwsCustomerGatewayRead(d *schema.ResourceData, meta interface{}) er
 	customerGateway := resp.CustomerGateways[0]
 	d.Set("ip_address", customerGateway.IpAddress)
 	d.Set("type", customerGateway.Type)
-	d.Set("tags", tagsToMap(customerGateway.Tags))
+	d.Set("tags", tagsToMap(customerGateway.Tags, false))
 
 	if *customerGateway.BgpAsn != "" {
 		val, err := strconv.ParseInt(*customerGateway.BgpAsn, 0, 0)

--- a/builtin/providers/aws/resource_aws_ebs_volume.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume.go
@@ -258,7 +258,7 @@ func readVolume(d *schema.ResourceData, volume *ec2.Volume) error {
 	}
 
 	if volume.Tags != nil {
-		d.Set("tags", tagsToMap(volume.Tags))
+		d.Set("tags", tagsToMap(volume.Tags, false))
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -518,7 +518,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("monitoring", monitoringState == "enabled" || monitoringState == "pending")
 	}
 
-	d.Set("tags", tagsToMap(instance.Tags))
+	d.Set("tags", tagsToMap(instance.Tags, false))
 
 	if err := readSecurityGroups(d, instance); err != nil {
 		return err

--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -95,7 +95,7 @@ func resourceAwsInternetGatewayRead(d *schema.ResourceData, meta interface{}) er
 		d.Set("vpc_id", ig.Attachments[0].VpcId)
 	}
 
-	d.Set("tags", tagsToMap(ig.Tags))
+	d.Set("tags", tagsToMap(ig.Tags, false))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -205,7 +205,7 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("vpc_id", networkAcl.VpcId)
-	d.Set("tags", tagsToMap(networkAcl.Tags))
+	d.Set("tags", tagsToMap(networkAcl.Tags, false))
 
 	var s []string
 	for _, a := range networkAcl.Associations {

--- a/builtin/providers/aws/resource_aws_network_interface.go
+++ b/builtin/providers/aws/resource_aws_network_interface.go
@@ -153,7 +153,7 @@ func resourceAwsNetworkInterfaceRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	// Tags
-	d.Set("tags", tagsToMap(eni.TagSet))
+	d.Set("tags", tagsToMap(eni.TagSet, false))
 
 	if eni.Attachment != nil {
 		attachment := []map[string]interface{}{flattenAttachment(eni.Attachment)}

--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -187,7 +187,7 @@ func resourceAwsRouteTableRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("route", route)
 
 	// Tags
-	d.Set("tags", tagsToMap(rt.Tags))
+	d.Set("tags", tagsToMap(rt.Tags, false))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -314,7 +314,7 @@ func resourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) erro
 		log.Printf("[WARN] Error setting Egress rule set for (%s): %s", d.Id(), err)
 	}
 
-	d.Set("tags", tagsToMap(sg.Tags))
+	d.Set("tags", tagsToMap(sg.Tags, false))
 	return nil
 }
 

--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -215,7 +215,7 @@ func resourceAwsSpotInstanceRequestRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("spot_request_state", request.State)
 	d.Set("block_duration_minutes", request.BlockDurationMinutes)
-	d.Set("tags", tagsToMap(request.Tags))
+	d.Set("tags", tagsToMap(request.Tags, false))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -119,7 +119,7 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("availability_zone", subnet.AvailabilityZone)
 	d.Set("cidr_block", subnet.CidrBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
-	d.Set("tags", tagsToMap(subnet.Tags))
+	d.Set("tags", tagsToMap(subnet.Tags, false))
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -152,7 +152,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("instance_tenancy", vpc.InstanceTenancy)
 
 	// Tags
-	d.Set("tags", tagsToMap(vpc.Tags))
+	d.Set("tags", tagsToMap(vpc.Tags, false))
 
 	// Attributes
 	attribute := "enableDnsSupport"

--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
@@ -155,7 +155,7 @@ func resourceAwsVpcDhcpOptionsRead(d *schema.ResourceData, meta interface{}) err
 	}
 
 	opts := resp.DhcpOptions[0]
-	d.Set("tags", tagsToMap(opts.Tags))
+	d.Set("tags", tagsToMap(opts.Tags, false))
 
 	for _, cfg := range opts.DhcpConfigurations {
 		tfKey := strings.Replace(*cfg.Key, "-", "_", -1)

--- a/builtin/providers/aws/resource_aws_vpc_peering_connection.go
+++ b/builtin/providers/aws/resource_aws_vpc_peering_connection.go
@@ -170,7 +170,7 @@ func resourceAwsVPCPeeringRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	err = d.Set("tags", tagsToMap(pc.Tags))
+	err = d.Set("tags", tagsToMap(pc.Tags, false))
 	if err != nil {
 		return errwrap.Wrapf("Error setting VPC Peering Connection tags: {{err}}", err)
 	}

--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -299,7 +299,7 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("vpn_gateway_id", vpnConnection.VpnGatewayId)
 	d.Set("customer_gateway_id", vpnConnection.CustomerGatewayId)
 	d.Set("type", vpnConnection.Type)
-	d.Set("tags", tagsToMap(vpnConnection.Tags))
+	d.Set("tags", tagsToMap(vpnConnection.Tags, false))
 
 	if vpnConnection.Options != nil {
 		if err := d.Set("static_routes_only", vpnConnection.Options.StaticRoutesOnly); err != nil {

--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -98,7 +98,7 @@ func resourceAwsVpnGatewayRead(d *schema.ResourceData, meta interface{}) error {
 	if vpnGateway.AvailabilityZone != nil && *vpnGateway.AvailabilityZone != "" {
 		d.Set("availability_zone", vpnGateway.AvailabilityZone)
 	}
-	d.Set("tags", tagsToMap(vpnGateway.Tags))
+	d.Set("tags", tagsToMap(vpnGateway.Tags, false))
 
 	return nil
 }

--- a/builtin/providers/aws/tags_test.go
+++ b/builtin/providers/aws/tags_test.go
@@ -50,15 +50,71 @@ func TestDiffTags(t *testing.T) {
 	}
 
 	for i, tc := range cases {
-		c, r := diffTags(tagsFromMap(tc.Old), tagsFromMap(tc.New))
-		cm := tagsToMap(c)
-		rm := tagsToMap(r)
+		c, r := diffTags(tagsFromMap(tc.Old, false), tagsFromMap(tc.New, false))
+		cm := tagsToMap(c, false)
+		rm := tagsToMap(r, false)
 		if !reflect.DeepEqual(cm, tc.Create) {
 			t.Fatalf("%d: bad create: %#v", i, cm)
 		}
 		if !reflect.DeepEqual(rm, tc.Remove) {
 			t.Fatalf("%d: bad remove: %#v", i, rm)
 		}
+	}
+}
+
+// Test the ability to opt-out of internal AWS tag filtering when calling the
+// tagsFromMap and tagsToMap functions.
+func TestAllowInternalTags(t *testing.T) {
+	var ignoredTags []*ec2.Tag
+	var ignoredTagsMap map[string]interface{}
+
+	const (
+		tagKey   string = "aws:cloudformation:logical-id"
+		tagValue string = "foo"
+	)
+
+	ignoredTags = append(ignoredTags,
+		&ec2.Tag{
+			Key:   aws.String(tagKey),
+			Value: aws.String(tagValue),
+		})
+
+	ignoredTagsMap = make(map[string]interface{})
+	ignoredTagsMap[tagKey] = tagValue
+
+	// Make two calls, one that should allow internal AWS tags and one that should not.
+	failFromMap := tagsFromMap(ignoredTagsMap, false)
+	successFromMap := tagsFromMap(ignoredTagsMap, true)
+	if len(failFromMap) != 0 {
+		t.Fatalf("Test[tagsFromMap]: Tag %v with value %v was not ignored and should have been.", tagKey, tagValue)
+	}
+
+	if len(successFromMap) != 0 {
+		for _, tag := range successFromMap {
+			if (*tag.Key != tagKey) || (*tag.Value != tagValue) {
+				t.Fatalf("Test[tagsFromMap]: Tag %v with value %v does not match the expected tag %v with value %v.", *tag.Key, *tag.Value, tagKey, tagValue)
+			}
+		}
+	} else {
+		t.Fatalf("Test[tagsFromMap]: Tag %v with value %v was ignored and should not have been.", tagKey, tagValue)
+	}
+
+	// Make two calls, one that should allow internal AWS tags and one that should not.
+	successToMap := tagsToMap(ignoredTags, true)
+	failToMap := tagsToMap(ignoredTags, false)
+
+	if len(successToMap) != 0 {
+		for tag, value := range successToMap {
+			if (tag != tagKey) || (value != tagValue) {
+				t.Fatalf("Test[tagsToMap]: Tag %v with value %v does not match the expected tag %v with value %v.", tag, value, tagKey, tagValue)
+			}
+		}
+	} else {
+		t.Fatalf("Test[tagsToMap]: Tag %v with value %v was ignored and should not have been.", tagKey, tagValue)
+	}
+
+	if len(failToMap) != 0 {
+		t.Fatalf("Test[tagsToMap]: Tag %v with value %v was not ignored and should have been.", tagKey, tagValue)
 	}
 }
 
@@ -84,7 +140,7 @@ func TestIgnoringTags(t *testing.T) {
 func testAccCheckTags(
 	ts *[]*ec2.Tag, key string, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		m := tagsToMap(*ts)
+		m := tagsToMap(*ts, false)
 		v, ok := m[key]
 		if value != "" && !ok {
 			return fmt.Errorf("Missing tag: %s", key)


### PR DESCRIPTION
See the following issue: #11838

In PR #7454, functionality was introduced to filter and ignore any AWS internally reserved tags (e.g. tags that begin with `aws:`). This functionality is integrated directly into various functions, including the shared `tagsToMap()` and `tagsFromMap()` functions which are called by quite a few resources and data sources. 

While we cannot modify these AWS reserved tags, we absolutely should be able to reference them for read-only operations. 

The proposed solution here is to add a boolean flag, `allowInternalTags`, to the common `tagsFromMap` and `tagsToMap` functions. This flag will allow callers to decide how they want to process AWS reserved tags. 

All standard resources that call the common `tagsFromMap` and `tagsToMap` functions will pass `false` and retain the normal filtering behavior where any tag that begins with `aws:` will be ignored. 

Data sources can pass `true` to opt-out of the filtering and thereby gain the ability to reference AWS reserved tags. 

It is worth noting, that quite a few resources contain independent implementations of the `tagsFromMap`, `tagsToMap` and `tagIgnored` functionality - [here is an example](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/tagsEC.go#L105) of the ElastiCache implementation. This change does not presently modify the behavior of resources that have their own internal implementation, only the common `tagsFromMap` and `tagsToMap` functions in [tags.go](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/tags.go).