### PR TITLE
provider/digitalocean: Fix faililng acceptance test

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_volume_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_volume_test.go
@@ -105,10 +105,7 @@ func TestAccDigitalOceanVolume_Droplet(t *testing.T) {
 		CheckDestroy: testAccCheckDigitalOceanVolumeDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: fmt.Sprintf(
-					testAccCheckDigitalOceanVolumeConfig_droplet(rInt, volume.Name),
-					testAccValidPublicKey, volume.Name,
-				),
+				Config: testAccCheckDigitalOceanVolumeConfig_droplet(rInt, volume.Name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDigitalOceanVolumeExists("digitalocean_volume.foobar", &volume),
 					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
@@ -133,11 +130,10 @@ resource "digitalocean_volume" "foobar" {
 resource "digitalocean_droplet" "foobar" {
   name               = "baz-%d"
   size               = "1gb"
-  image              = "coreos-stable"
+  image              = "centos-7-x64"
   region             = "nyc1"
   ipv6               = true
   private_networking = true
-  ssh_keys           = ["${digitalocean_ssh_key.foobar.id}"]
   volume_ids         = ["${digitalocean_volume.foobar.id}"]
 }`, vName, rInt)
 }


### PR DESCRIPTION
The volume_Droplet test was failing from an incorrect fix pushed on Friday. Fixes the failing test.

```
$ make testacc TEST=./builtin/providers/digitalocean TESTARGS='-run=TestAccDigitalOceanVolume_Droplet'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/11 17:55:09 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/digitalocean -v -run=TestAccDigitalOceanVolume_Droplet -timeout 120m
=== RUN   TestAccDigitalOceanVolume_Droplet
--- PASS: TestAccDigitalOceanVolume_Droplet (52.78s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/digitalocean   52.797s
```