### PR TITLE
[WIP] - Modify aws_ecs_service to prevent destroying tasks

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -293,8 +293,6 @@ func resourceAwsEcsServiceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("task_definition", taskDefinition)
 	}
 
-	d.Set("desired_count", service.DesiredCount)
-
 	// Save cluster in the same format
 	if strings.HasPrefix(d.Get("cluster").(string), "arn:"+meta.(*AWSClient).partition+":ecs:") {
 		d.Set("cluster", service.ClusterArn)


### PR DESCRIPTION
Hi everyone,

This is a Pull request to fix an annoying issue when using `aws_ecs_service` described by @BrunoBonacci here #9690.

The idea is to used `desired_count` to create or update the number of ECS service tasks, but the `desired_count` is not update in the state when reading from the real-infrastructure (during `refresh`).

WARNING: I didn't add tests because for some reasons the tests already fails in my laptop (branch `0-8-stable`)