### PR TITLE
provider/azurerm: Fixing a bug in the VM Extension Resource

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine_extension.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_extension.go
@@ -153,12 +153,13 @@ func resourceArmVirtualMachineExtensionsRead(d *schema.ResourceData, meta interf
 	name := id.Path["extensions"]
 
 	resp, err := client.Get(resGroup, vmName, name, "")
+
 	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Error making Read request on Virtual Machine Extension %s: %s", name, err)
-	}
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
 	}
 
 	d.Set("name", resp.Name)


### PR DESCRIPTION
I encountered a scenario where a resource group was deleted via the Portal - but still existed in state. Upon calculating a plan - Terraform throws the following exception:

```
Error refreshing state: 3 error(s) occurred:

* azurerm_virtual_machine_extension.combined: Error making Read request on Virtual Machine Extension combined: compute.VirtualMachineExtensionsClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'XXX' could not be found."

(duplicate output removed)
```

Updated so that the resource group not existing causes it to be cleared from state (to match other resources) - need to confirm the acceptance tests are still fine (which I'll do a bit later on) - but this fixes the bug I was seeing.