### PR TITLE
google cloud: regression - enable reading of existing project on create

### DIFF
--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -93,52 +93,57 @@ func resourceGoogleProject() *schema.Resource {
 func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	var pid string
-	var err error
-	pid = d.Get("project_id").(string)
-	if pid == "" {
-		pid, err = getProject(d, config)
-		if err != nil {
-			return fmt.Errorf("Error getting project ID: %v", err)
-		}
-		if pid == "" {
-			return fmt.Errorf("'project_id' must be set in the config")
-		}
-	}
-
-	// we need to check if name and org_id are set, and throw an error if they aren't
-	// we can't just set these as required on the object, however, as that would break
-	// all configs that used previous iterations of the resource.
-	// TODO(paddy): remove this for 0.9 and set these attributes as required.
-	name, org_id := d.Get("name").(string), d.Get("org_id").(string)
-	if name == "" {
-		return fmt.Errorf("`name` must be set in the config if you're creating a project.")
-	}
-	if org_id == "" {
-		return fmt.Errorf("`org_id` must be set in the config if you're creating a project.")
-	}
-
-	log.Printf("[DEBUG]: Creating new project %q", pid)
-	project := &cloudresourcemanager.Project{
-		ProjectId: pid,
-		Name:      d.Get("name").(string),
-		Parent: &cloudresourcemanager.ResourceId{
-			Id:   d.Get("org_id").(string),
-			Type: "organization",
-		},
-	}
-
-	op, err := config.clientResourceManager.Projects.Create(project).Do()
+	pid, err := getProject(d, config)
 	if err != nil {
-		return fmt.Errorf("Error creating project %s (%s): %s.", project.ProjectId, project.Name, err)
+		return fmt.Errorf("Error getting project ID: %v", err)
 	}
 
-	d.SetId(pid)
+	if pid == "" {
+		return fmt.Errorf("'project_id' must be set in the config")
+	}
 
-	// Wait for the operation to complete
-	waitErr := resourceManagerOperationWait(config, op, "project to create")
-	if waitErr != nil {
-		return waitErr
+	// this does not fail when project does not exists
+	// it returns empty project at the time of this comment
+	p, err := config.clientResourceManager.Projects.Get(pid).Do()
+	if err != nil {
+		return fmt.Errorf("failed to get initial project: %s", err)
+	}
+
+	if p.ProjectNumber == 0 {
+		// we need to check if name and org_id are set, and throw an error if they aren't
+		// we can't just set these as required on the object, however, as that would break
+		// all configs that used previous iterations of the resource.
+		// TODO(paddy): remove this for 0.9 and set these attributes as required.
+		name, org_id := d.Get("name").(string), d.Get("org_id").(string)
+		if name == "" {
+			return fmt.Errorf("`name` must be set in the config if you're creating a project.")
+		}
+		if org_id == "" {
+			return fmt.Errorf("`org_id` must be set in the config if you're creating a project.")
+		}
+
+		log.Printf("[DEBUG]: Creating new project %q", pid)
+		project := &cloudresourcemanager.Project{
+			ProjectId: pid,
+			Name:      d.Get("name").(string),
+			Parent: &cloudresourcemanager.ResourceId{
+				Id:   d.Get("org_id").(string),
+				Type: "organization",
+			},
+		}
+
+		op, err := config.clientResourceManager.Projects.Create(project).Do()
+		if err != nil {
+			return fmt.Errorf("Error creating project %s (%s): %s.", project.ProjectId, project.Name, err)
+		}
+
+		d.SetId(pid)
+
+		// Wait for the operation to complete
+		waitErr := resourceManagerOperationWait(config, op, "project to create")
+		if waitErr != nil {
+			return waitErr
+		}
 	}
 
 	// Apply the IAM policy if it is set

--- a/builtin/providers/google/resource_google_project_test.go
+++ b/builtin/providers/google/resource_google_project_test.go
@@ -37,7 +37,6 @@ func TestAccGoogleProject_create(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			// This step imports an existing project
 			resource.TestStep{
 				Config: testAccGoogleProject_create(pid, pname, org),
 				Check: resource.ComposeTestCheckFunc(
@@ -71,6 +70,27 @@ func TestAccGoogleProject_merge(t *testing.T) {
 					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
 					testAccCheckGoogleProjectHasMoreBindingsThan(pid, 0),
 				),
+			},
+		},
+	})
+}
+
+// Test loading an existing project without a create, this
+// should not throw an error
+func TestAccGoogleProject_read(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGoogleProject_create(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectExists("google_project.acceptance", pid),
+				),
+			},
+			resource.TestStep{
+				Config: testAccGoogleProjectImportExisting(pid),
 			},
 		},
 	})


### PR DESCRIPTION
This is a regression - project read worked in version 0.8.4. Attempted to fix the regression in as minimal of a way as possible.

- docs say that existing projects can be used but a user
would never be able to use an existing project.
- we erroneously expected the user to set both name
and org_id when they only need to set project_id

Interesting note, the API doesn't fail if you look up a project that does not exist - this would have influenced by error check.