### PR TITLE
provider/fastly Documentation addition for fastly healthchecks

### DIFF
--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -142,6 +142,7 @@ when an item is not to be cached based on an above `condition`. Defined below
 content. Defined below.
 * `header` - (Optional) A set of Headers to manipulate for each request. Defined
 below.
+* `healthcheck` - (Optional) Automated healthchecks on the cache that can change how fastly interacts with the cache based on its health.
 * `default_host` - (Optional) The default hostname.
 * `default_ttl` - (Optional) The default Time-to-live (TTL) for
 requests.


### PR DESCRIPTION
Healthchecks are already a part of version `0.8.6`

There is already documentation on the implementation details of the healthcheck resource, but the resource was not mentioned in the main section of the fastly cache description. This fixes that discrepancy.