### PR TITLE
provider/aws: Fix Diff Suppress function for aws_db_instance

### DIFF
--- a/builtin/providers/aws/diff_suppress_funcs.go
+++ b/builtin/providers/aws/diff_suppress_funcs.go
@@ -19,12 +19,23 @@ func suppressEquivalentAwsPolicyDiffs(k, old, new string, d *schema.ResourceData
 
 // Suppresses minor version changes to the db_instance engine_version attribute
 func suppressAwsDbEngineVersionDiffs(k, old, new string, d *schema.ResourceData) bool {
-	if d.Get("auto_minor_version_upgrade").(bool) {
-		// If we're set to auto upgrade minor versions
-		// ignore a minor version diff between versions
-		if strings.HasPrefix(old, new) {
-			log.Printf("[DEBUG] Ignoring minor version diff")
-			return true
+	// First check if the old/new values are nil.
+	// If both are nil, we have no state to compare the values with, so register a diff.
+	// This populates the attribute field during a plan/apply with fresh state, allowing
+	// the attribute to still be used in future resources.
+	// See https://github.com/hashicorp/terraform/issues/11881
+	if old == "" && new == "" {
+		return false
+	}
+
+	if v, ok := d.GetOk("auto_minor_version_upgrade"); ok {
+		if v.(bool) {
+			// If we're set to auto upgrade minor versions
+			// ignore a minor version diff between versions
+			if strings.HasPrefix(old, new) {
+				log.Printf("[DEBUG] Ignoring minor version diff")
+				return true
+			}
 		}
 	}
 

--- a/builtin/providers/aws/provider_test.go
+++ b/builtin/providers/aws/provider_test.go
@@ -5,17 +5,21 @@ import (
 	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform/builtin/providers/template"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
+var testAccTemplateProvider *schema.Provider
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
+	testAccTemplateProvider = template.Provider().(*schema.Provider)
 	testAccProviders = map[string]terraform.ResourceProvider{
-		"aws": testAccProvider,
+		"aws":      testAccProvider,
+		"template": testAccTemplateProvider,
 	}
 }
 

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -325,6 +325,26 @@ func TestAccAWSDBInstance_MinorVersion(t *testing.T) {
 	})
 }
 
+// See https://github.com/hashicorp/terraform/issues/11881
+func TestAccAWSDBInstance_diffSuppressInitialState(t *testing.T) {
+	var v rds.DBInstance
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfigSuppressInitialState(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.bar", &v),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSDBInstanceDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).rdsconn
 
@@ -1163,3 +1183,25 @@ resource "aws_db_instance" "bar" {
 	skip_final_snapshot = true
 }
 `, acctest.RandInt())
+
+func testAccAWSDBInstanceConfigSuppressInitialState(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_db_instance" "bar" {
+  identifier = "foobarbaz-test-terraform-%d"
+	allocated_storage = 10
+	engine = "MySQL"
+	instance_class = "db.t1.micro"
+	name = "baz"
+	password = "barbarbarbar"
+	username = "foo"
+	skip_final_snapshot = true
+}
+
+data "template_file" "test" {
+  template = ""
+  vars = {
+    test_var = "${aws_db_instance.bar.engine_version}"
+  }
+}
+`, rInt)
+}


### PR DESCRIPTION
Introduced in #11369, this fixes an issue with the diff suppress function when creating a new `aws_db_instance` resource, while using the default `engine_version`.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBInstance_diffSuppressInitialState'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/13 11:52:12 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBInstance_diffSuppressInitialState -timeout 120m
=== RUN   TestAccAWSDBInstance_diffSuppressInitialState
--- PASS: TestAccAWSDBInstance_diffSuppressInitialState (480.78s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    480.793s
```

Fixes: #11881 