### PR TITLE
provider/aws: JSON Validate iam_role

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_role.go
+++ b/builtin/providers/aws/resource_aws_iam_role.go
@@ -82,10 +82,11 @@ func resourceAwsIamRole() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"assume_role_policy": &schema.Schema{
+			"assume_role_policy": {
 				Type:             schema.TypeString,
 				Required:         true,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
+				ValidateFunc:     validateJsonString,
 			},
 
 			"create_date": {


### PR DESCRIPTION
Validate the policy supplied via `assume_role_policy` in an `aws_iam_role`

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRole_badJSON'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/13 14:13:47 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRole_badJSON -timeout 120m
=== RUN   TestAccAWSRole_badJSON
--- PASS: TestAccAWSRole_badJSON (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    0.019s
```

Fixes: #11906 