### PR TITLE
Added `aws_iam_role' to list of importable AWS resources.

### DIFF
--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -63,6 +63,7 @@ To make a resource importable, please see the
 * aws_iam_account_password_policy
 * aws_iam_group
 * aws_iam_instance_profile
+* aws_iam_role
 * aws_iam_saml_provider
 * aws_iam_user
 * aws_instance


### PR DESCRIPTION
`aws_iam_role` isn't listed as importable in the docs but after inspecting the terraform source code it looked like it should work so I tried it out- and it works great!