### PR TITLE
terraform: outputs should not be included if not targeted

### DIFF
--- a/terraform/context.go
+++ b/terraform/context.go
@@ -215,6 +215,7 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 			State:        c.state,
 			Providers:    c.components.ResourceProviders(),
 			Provisioners: c.components.ResourceProvisioners(),
+			Targets:      c.targets,
 			Destroy:      c.destroy,
 			Validate:     opts.Validate,
 		}).Build(RootModulePath)

--- a/terraform/graph_builder_apply.go
+++ b/terraform/graph_builder_apply.go
@@ -28,6 +28,12 @@ type ApplyGraphBuilder struct {
 	// Provisioners is the list of provisioners supported.
 	Provisioners []string
 
+	// Targets are resources to target. This is only required to make sure
+	// unnecessary outputs aren't included in the apply graph. The plan
+	// builder successfully handles targeting resources. In the future,
+	// outputs should go into the diff so that this is unnecessary.
+	Targets []string
+
 	// DisableReduce, if true, will not reduce the graph. Great for testing.
 	DisableReduce bool
 
@@ -113,6 +119,9 @@ func (b *ApplyGraphBuilder) Steps() []GraphTransformer {
 
 		// Add the node to fix the state count boundaries
 		&CountBoundaryTransformer{},
+
+		// Target
+		&TargetsTransformer{Targets: b.Targets},
 
 		// Single root
 		&RootTransformer{},

--- a/terraform/graph_builder_apply_test.go
+++ b/terraform/graph_builder_apply_test.go
@@ -95,17 +95,15 @@ func TestApplyGraphBuilder_depCbd(t *testing.T) {
 		Modules: []*ModuleDiff{
 			&ModuleDiff{
 				Path: []string{"root"},
-				Resources: map[string]*InstanceDiff{
-					"aws_instance.A": &InstanceDiff{
-						Destroy: true,
-						Attributes: map[string]*ResourceAttrDiff{
-							"name": &ResourceAttrDiff{
-								Old:         "",
-								New:         "foo",
-								RequiresNew: true,
-							},
+				Resources: map[string]*InstanceDiff{"aws_instance.A": &InstanceDiff{Destroy: true,
+					Attributes: map[string]*ResourceAttrDiff{
+						"name": &ResourceAttrDiff{
+							Old:         "",
+							New:         "foo",
+							RequiresNew: true,
 						},
 					},
+				},
 
 					"aws_instance.B": &InstanceDiff{
 						Attributes: map[string]*ResourceAttrDiff{
@@ -438,6 +436,54 @@ func TestApplyGraphBuilder_provisionerDestroy(t *testing.T) {
 		t, g,
 		"provisioner.local",
 		"null_resource.foo (destroy)")
+}
+
+func TestApplyGraphBuilder_targetModule(t *testing.T) {
+	diff := &Diff{
+		Modules: []*ModuleDiff{
+			&ModuleDiff{
+				Path: []string{"root"},
+				Resources: map[string]*InstanceDiff{
+					"null_resource.foo": &InstanceDiff{
+						Attributes: map[string]*ResourceAttrDiff{
+							"name": &ResourceAttrDiff{
+								Old: "",
+								New: "foo",
+							},
+						},
+					},
+				},
+			},
+
+			&ModuleDiff{
+				Path: []string{"root", "child2"},
+				Resources: map[string]*InstanceDiff{
+					"null_resource.foo": &InstanceDiff{
+						Attributes: map[string]*ResourceAttrDiff{
+							"name": &ResourceAttrDiff{
+								Old: "",
+								New: "foo",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	b := &ApplyGraphBuilder{
+		Module:    testModule(t, "graph-builder-apply-target-module"),
+		Diff:      diff,
+		Providers: []string{"null"},
+		Targets:   []string{"module.child2"},
+	}
+
+	g, err := b.Build(RootModulePath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	testGraphNotContains(t, g, "module.child1.output.instance_id")
 }
 
 const testApplyGraphBuilderStr = `

--- a/terraform/node_output.go
+++ b/terraform/node_output.go
@@ -28,6 +28,13 @@ func (n *NodeApplyableOutput) Path() []string {
 	return n.PathValue
 }
 
+// RemovableIfNotTargeted
+func (n *NodeApplyableOutput) RemoveIfNotTargeted() bool {
+	// We need to add this so that this node will be removed if
+	// it isn't targeted or a dependency of a target.
+	return true
+}
+
 // GraphNodeReferenceable
 func (n *NodeApplyableOutput) ReferenceableName() []string {
 	name := fmt.Sprintf("output.%s", n.Config.Name)

--- a/terraform/test-fixtures/apply-targeted-module-unrelated-outputs/child1/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-unrelated-outputs/child1/main.tf
@@ -1,0 +1,10 @@
+variable "instance_id" {
+}
+
+output "instance_id" {
+  value = "${var.instance_id}"
+}
+
+resource "aws_instance" "foo" {
+  foo = "${var.instance_id}"
+}

--- a/terraform/test-fixtures/apply-targeted-module-unrelated-outputs/child2/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-unrelated-outputs/child2/main.tf
@@ -1,0 +1,2 @@
+resource "aws_instance" "foo" {
+}

--- a/terraform/test-fixtures/apply-targeted-module-unrelated-outputs/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-unrelated-outputs/main.tf
@@ -1,0 +1,10 @@
+resource "aws_instance" "foo" {}
+
+module "child1" {
+  source = "./child1"
+  instance_id = "${aws_instance.foo.id}"
+}
+
+module "child2" {
+  source = "./child2"
+}

--- a/terraform/test-fixtures/graph-builder-apply-target-module/child1/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-target-module/child1/main.tf
@@ -1,0 +1,12 @@
+variable "instance_id" {
+}
+
+output "instance_id" {
+  value = "${var.instance_id}"
+}
+
+resource "null_resource" "foo" {
+  triggers = {
+    instance_id = "${var.instance_id}"
+  }
+}

--- a/terraform/test-fixtures/graph-builder-apply-target-module/child2/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-target-module/child2/main.tf
@@ -1,0 +1,2 @@
+resource "null_resource" "foo" {
+}

--- a/terraform/test-fixtures/graph-builder-apply-target-module/main.tf
+++ b/terraform/test-fixtures/graph-builder-apply-target-module/main.tf
@@ -1,0 +1,10 @@
+resource "null_resource" "foo" {}
+
+module "child1" {
+  source = "./child1"
+  instance_id = "${null_resource.foo.id}"
+}
+
+module "child2" {
+  source = "./child2"
+}


### PR DESCRIPTION
Fixes #10911

Outputs that aren't targeted shouldn't be included in the graph.

This requires passing targets to the apply graph. This is unfortunate
but long term should be removable since I'd like to move output changes
to the diff as well.