### PR TITLE
terraformrc can contain env var references

### DIFF
--- a/config.go
+++ b/config.go
@@ -74,6 +74,14 @@ func LoadConfig(path string) (*Config, error) {
 		return nil, err
 	}
 
+	// Replace all env vars
+	for k, v := range result.Providers {
+		result.Providers[k] = os.ExpandEnv(v)
+	}
+	for k, v := range result.Provisioners {
+		result.Provisioners[k] = os.ExpandEnv(v)
+	}
+
 	return &result, nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -19,6 +20,30 @@ func TestLoadConfig(t *testing.T) {
 		Providers: map[string]string{
 			"aws": "foo",
 			"do":  "bar",
+		},
+	}
+
+	if !reflect.DeepEqual(c, expected) {
+		t.Fatalf("bad: %#v", c)
+	}
+}
+
+func TestLoadConfig_env(t *testing.T) {
+	defer os.Unsetenv("TFTEST")
+	os.Setenv("TFTEST", "hello")
+
+	c, err := LoadConfig(filepath.Join(fixtureDir, "config-env"))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &Config{
+		Providers: map[string]string{
+			"aws":    "hello",
+			"google": "bar",
+		},
+		Provisioners: map[string]string{
+			"local": "hello",
 		},
 	}
 

--- a/test-fixtures/config-env
+++ b/test-fixtures/config-env
@@ -1,0 +1,8 @@
+providers {
+  aws = "$TFTEST"
+  google = "bar"
+}
+
+provisioners {
+  local = "$TFTEST"
+}


### PR DESCRIPTION
This allows the use case where installation of a plugin can simply say
to add `$GOPATH/bin/foo` to your terraformrc and the user can do that
verbatim. Additionally terraformrc files become portable for certain
environments which are self-contained.

I was hesitant at first about this because it diverges the syntax a bit
from our standard interpolation syntax. However, due to the special
nature of terraformrc and the strong use cases cited I'm okay with this.

/cc @grubernaut 