### PR TITLE
show message if state lock acquisition/release is slow

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
+	clistate "github.com/hashicorp/terraform/command/state"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -28,8 +29,9 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 		return nil, nil, errwrap.Wrapf("Error loading state: {{err}}", err)
 	}
 
-	if s, ok := s.(state.Locker); op.LockState && ok {
-		if err := s.Lock(op.Type.String()); err != nil {
+	if op.LockState {
+		err := clistate.Lock(s, op.Type.String(), b.CLI, b.Colorize())
+		if err != nil {
 			return nil, nil, errwrap.Wrapf("Error locking state: {{err}}", err)
 		}
 	}

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	clistate "github.com/hashicorp/terraform/command/state"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -23,17 +24,17 @@ import (
 //
 // This will attempt to lock both states for the migration.
 func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
-	unlockOne, err := lockState(opts.One, "migrate from")
+	err := clistate.Lock(opts.One, "migration source state", m.Ui, m.Colorize())
 	if err != nil {
-		return err
+		return fmt.Errorf("Error locking source state: %s", err)
 	}
-	defer unlockOne()
+	defer clistate.Unlock(opts.One, m.Ui, m.Colorize())
 
-	unlockTwo, err := lockState(opts.Two, "migrate to")
+	err = clistate.Lock(opts.Two, "migration destination state", m.Ui, m.Colorize())
 	if err != nil {
-		return err
+		return fmt.Errorf("Error locking destination state: %s", err)
 	}
-	defer unlockTwo()
+	defer clistate.Unlock(opts.Two, m.Ui, m.Colorize())
 
 	one := opts.One.State()
 	two := opts.Two.State()

--- a/command/state/state.go
+++ b/command/state/state.go
@@ -1,0 +1,83 @@
+// Package state exposes common helpers for working with state from the CLI.
+//
+// This is a separate package so that backends can use this for consistent
+// messaging without creating a circular reference to the command package.
+package message
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/slowmessage"
+	"github.com/hashicorp/terraform/state"
+	"github.com/mitchellh/cli"
+	"github.com/mitchellh/colorstring"
+)
+
+const (
+	LockThreshold = 250 * time.Millisecond
+	LockMessage   = "Acquiring state lock. This may take a few moments..."
+	UnlockMessage = "Releasing state lock. This may take a few moments..."
+
+	UnlockErrorMessage = `
+[reset][bold][red]Error releasing the state lock![reset][red]
+
+Error message: %s
+
+Terraform acquires a lock when accessing your state to prevent others
+running Terraform to potentially modify the state at the same time. An
+error occurred while releasing this lock. This could mean that the lock
+did or did not release properly. If the lock didn't release properly,
+Terraform may not be able to run future commands since it'll appear as if
+the lock is held.
+
+In this scenario, please call the "force-unlock" command to unlock the
+state manually. This is a very dangerous operation since if it is done
+erroneously it could result in two people modifying state at the same time.
+Only call this command if you're certain that the unlock above failed and
+that no one else is holding a lock.
+`
+)
+
+// Lock locks the given state and outputs to the user if locking
+// is taking longer than the threshold.
+func Lock(s state.State, info string, ui cli.Ui, color *colorstring.Colorize) error {
+	sl, ok := s.(state.Locker)
+	if !ok {
+		return nil
+	}
+
+	return slowmessage.Do(LockThreshold, func() error {
+		return sl.Lock(info)
+	}, func() {
+		if ui != nil {
+			ui.Output(color.Color(LockMessage))
+		}
+	})
+}
+
+// Unlock unlocks the given state and outputs to the user if the
+// unlock fails what can be done.
+func Unlock(s state.State, ui cli.Ui, color *colorstring.Colorize) error {
+	sl, ok := s.(state.Locker)
+	if !ok {
+		return nil
+	}
+
+	err := slowmessage.Do(LockThreshold, sl.Unlock, func() {
+		if ui != nil {
+			ui.Output(color.Color(UnlockMessage))
+		}
+	})
+
+	if err != nil {
+		ui.Output(color.Color(fmt.Sprintf(
+			"\n"+strings.TrimSpace(UnlockErrorMessage)+"\n", err)))
+
+		err = fmt.Errorf(
+			"Error releasing the state lock. Please see the longer error message above.")
+	}
+
+	return err
+}

--- a/command/state/state.go
+++ b/command/state/state.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	LockThreshold = 250 * time.Millisecond
+	LockThreshold = 400 * time.Millisecond
 	LockMessage   = "Acquiring state lock. This may take a few moments..."
 	UnlockMessage = "Releasing state lock. This may take a few moments..."
 

--- a/command/taint.go
+++ b/command/taint.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform/state"
+	clistate "github.com/hashicorp/terraform/command/state"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -72,13 +72,14 @@ func (c *TaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	if s, ok := st.(state.Locker); c.Meta.stateLock && ok {
-		if err := s.Lock("taint"); err != nil {
-			c.Ui.Error(fmt.Sprintf("Failed to lock state: %s", err))
+	if c.Meta.stateLock {
+		err := clistate.Lock(st, "taint", c.Ui, c.Colorize())
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
 
-		defer s.Unlock()
+		defer clistate.Unlock(st, c.Ui, c.Colorize())
 	}
 
 	// Get the actual state structure

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -124,7 +124,7 @@ func (c *UnlockCommand) Synopsis() string {
 }
 
 const outputUnlockSuccess = `
-[reset][bold][red]Terraform state has been successfully unlocked![reset][red]
+[reset][bold][green]Terraform state has been successfully unlocked![reset][green]
 
 The state has been unlocked, and Terraform commands should now be able to
 obtain a new lock on the remote state.

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/hashicorp/terraform/state"
+	clistate "github.com/hashicorp/terraform/command/state"
 )
 
 // UntaintCommand is a cli.Command implementation that manually untaints
@@ -60,13 +60,14 @@ func (c *UntaintCommand) Run(args []string) int {
 		return 1
 	}
 
-	if s, ok := st.(state.Locker); c.Meta.stateLock && ok {
-		if err := s.Lock("untaint"); err != nil {
-			c.Ui.Error(fmt.Sprintf("Failed to lock state: %s", err))
+	if c.Meta.stateLock {
+		err := clistate.Lock(st, "untaint", c.Ui, c.Colorize())
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Error locking state: %s", err))
 			return 1
 		}
 
-		defer s.Unlock()
+		defer clistate.Unlock(st, c.Ui, c.Colorize())
 	}
 
 	// Get the actual state structure

--- a/helper/slowmessage/slowmessage.go
+++ b/helper/slowmessage/slowmessage.go
@@ -1,0 +1,34 @@
+package slowmessage
+
+import (
+	"time"
+)
+
+// SlowFunc is the function that could be slow. Usually, you'll have to
+// wrap an existing function in a lambda to make it match this type signature.
+type SlowFunc func() error
+
+// CallbackFunc is the function that is triggered when the threshold is reached.
+type CallbackFunc func()
+
+// Do calls sf. If threshold time has passed, cb is called. Note that this
+// call will be made concurrently to sf still running.
+func Do(threshold time.Duration, sf SlowFunc, cb CallbackFunc) error {
+	// Call the slow function
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sf()
+	}()
+
+	// Wait for it to complete or the threshold to pass
+	select {
+	case err := <-errCh:
+		return err
+	case <-time.After(threshold):
+		// Threshold reached, call the callback
+		cb()
+	}
+
+	// Wait an indefinite amount of time for it to finally complete
+	return <-errCh
+}

--- a/helper/slowmessage/slowmessage_test.go
+++ b/helper/slowmessage/slowmessage_test.go
@@ -1,0 +1,82 @@
+package slowmessage
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDo(t *testing.T) {
+	var sfErr error
+	cbCalled := false
+	sfCalled := false
+	sfSleep := 0 * time.Second
+
+	reset := func() {
+		cbCalled = false
+		sfCalled = false
+		sfErr = nil
+	}
+	sf := func() error {
+		sfCalled = true
+		time.Sleep(sfSleep)
+		return sfErr
+	}
+	cb := func() { cbCalled = true }
+
+	// SF is not slow
+	reset()
+	if err := Do(10*time.Millisecond, sf, cb); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !sfCalled {
+		t.Fatal("should call")
+	}
+	if cbCalled {
+		t.Fatal("should not call")
+	}
+
+	// SF is not slow (with error)
+	reset()
+	sfErr = errors.New("error")
+	if err := Do(10*time.Millisecond, sf, cb); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !sfCalled {
+		t.Fatal("should call")
+	}
+	if cbCalled {
+		t.Fatal("should not call")
+	}
+
+	// SF is slow
+	reset()
+	sfSleep = 50 * time.Millisecond
+	if err := Do(10*time.Millisecond, sf, cb); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !sfCalled {
+		t.Fatal("should call")
+	}
+	if !cbCalled {
+		t.Fatal("should call")
+	}
+
+	// SF is slow (with error)
+	reset()
+	sfErr = errors.New("error")
+	sfSleep = 50 * time.Millisecond
+	if err := Do(10*time.Millisecond, sf, cb); err == nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !sfCalled {
+		t.Fatal("should call")
+	}
+	if !cbCalled {
+		t.Fatal("should call")
+	}
+}


### PR DESCRIPTION
This is just a UX change, but please check for any behavior modifications.

This shows a message if a state lock/unlock is taking longer than a threshold set currently at 400ms. This is a period of time where we want to let the user know we're doing something. Most state lock/unlock is very quick so we don't want to pollute the output with messages all the time. This will only show when its slow.

Example:

![Slow Lock](https://cloud.githubusercontent.com/assets/1299/22945766/2f43b6c4-f2aa-11e6-8fcf-9a9af383a6e5.gif)

This also adds more verbose error messaging is unlocking fails:

![2017-02-14 at 11 40 am](https://cloud.githubusercontent.com/assets/1299/22945836/6e586d96-f2aa-11e6-9391-58d30ebe0075.png)
