### PR TITLE
provider/aws: add bucket name to delete error notification

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -980,7 +980,7 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 				return resourceAwsS3BucketDelete(d, meta)
 			}
 		}
-		return fmt.Errorf("Error deleting S3 Bucket: %s", err)
+		return fmt.Errorf("Error deleting S3 Bucket: %s '%s'", err, d.Get("bucket"))
 	}
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -980,7 +980,7 @@ func resourceAwsS3BucketDelete(d *schema.ResourceData, meta interface{}) error {
 				return resourceAwsS3BucketDelete(d, meta)
 			}
 		}
-		return fmt.Errorf("Error deleting S3 Bucket: %s '%s'", err, d.Get("bucket"))
+		return fmt.Errorf("Error deleting S3 Bucket: %s %q", err, d.Get("bucket").(string))
 	}
 	return nil
 }


### PR DESCRIPTION
    * aws_s3_bucket.roster_archive: Error deleting S3 Bucket: BucketNotEmpty: The bucket you tried to delete is not empty
	    status code: 409, request id: A439DD5AEF8E8834

Which bucket is trying to be deleted? New message should be:

    * aws_s3_bucket.roster_archive: Error deleting S3 Bucket: BucketNotEmpty: The bucket you tried to delete is not empty 'mybucket'
	    status code: 409, request id: A439DD5AEF8E8834