### PR TITLE
the invalid variable syntax error message was misleading. changed tex…

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -303,10 +303,10 @@ func (i *Interpolater) valueSimpleVar(
 	// relied on this for their template_file data sources. We should
 	// remove this at some point but there isn't any rush.
 	return fmt.Errorf(
-		"invalid variable syntax: %q. If this is part of inline `template` parameter\n"+
+		"invalid variable syntax: %q. Did you mean 'var.%s'? If this is part of inline `template` parameter\n"+
 			"then you must escape the interpolation with two dollar signs. For\n"+
 			"example: ${a} becomes $${a}.",
-		n)
+		n, n)
 }
 
 func (i *Interpolater) valueUserVar(


### PR DESCRIPTION
…t a little bit
From:

    * invalid variable syntax: "image". If this is part of inline `template` parameter then you must escape the interpolation with two dollar signs. For example: ${a} becomes $${a}.

to:

    * invalid variable syntax: "image". Did you mean 'var.image'? If this is part of inline `template` parameter then you must escape the interpolation with two dollar signs. For example: ${a} becomes $${a}.

