### PR TITLE
provider/datadog: Fix spelling mistake of monitor in datadog_monitor error message

### DIFF
--- a/builtin/providers/datadog/resource_datadog_monitor.go
+++ b/builtin/providers/datadog/resource_datadog_monitor.go
@@ -224,7 +224,7 @@ func resourceDatadogMonitorCreate(d *schema.ResourceData, meta interface{}) erro
 	m := buildMonitorStruct(d)
 	m, err := client.CreateMonitor(m)
 	if err != nil {
-		return fmt.Errorf("error updating montor: %s", err.Error())
+		return fmt.Errorf("error updating monitor: %s", err.Error())
 	}
 
 	d.SetId(strconv.Itoa(m.Id))


### PR DESCRIPTION
Fixes: #11951