### PR TITLE
provider/azurerm: Remove location argument from loadbalancer_backend_address_pool

### DIFF
--- a/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
@@ -39,7 +39,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  location = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id = "${azurerm_lb.test.id}"
   name = "BackEndAddressPool"
@@ -52,7 +51,6 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Backend Address Pool.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `location` - (Required) Specifies the supported Azure location where the resource exists.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the Backend Address Pool. 
 
 ## Attributes Reference


### PR DESCRIPTION
Applying a Terraform execution plan containing a loadbalancer_backend_address_pool with a location argument throws a warning:

```
Warnings:

  * azurerm_lb_backend_address_pool.test: "location": [DEPRECATED] location is no longer used

  No errors found. Continuing with 1 warning(s).
```

Removing the (required) location argument from the documentation as it is deprecated as per the warning.

(Feedbak is welcome, by all means. Apologies for misunderstanding the contribution guidelines if I missed something.)