### PR TITLE
provider/statuscake: Add support for Port in statuscake_test

### DIFF
--- a/builtin/providers/statuscake/resource_statuscaketest.go
+++ b/builtin/providers/statuscake/resource_statuscaketest.go
@@ -18,50 +18,55 @@ func resourceStatusCakeTest() *schema.Resource {
 		Read:   ReadTest,
 
 		Schema: map[string]*schema.Schema{
-			"test_id": &schema.Schema{
+			"test_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"website_name": &schema.Schema{
+			"website_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"website_url": &schema.Schema{
+			"website_url": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"contact_id": &schema.Schema{
+			"contact_id": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
 
-			"check_rate": &schema.Schema{
+			"check_rate": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  300,
 			},
 
-			"test_type": &schema.Schema{
+			"test_type": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"paused": &schema.Schema{
+			"paused": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
 
-			"timeout": &schema.Schema{
+			"timeout": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  40,
 			},
 
-			"confirmations": &schema.Schema{
+			"confirmations": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+
+			"port": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
@@ -81,6 +86,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		Timeout:      d.Get("timeout").(int),
 		ContactID:    d.Get("contact_id").(int),
 		Confirmation: d.Get("confirmations").(int),
+		Port:         d.Get("port").(int),
 	}
 
 	log.Printf("[DEBUG] Creating new StatusCake Test: %s", d.Get("website_name").(string))
@@ -144,6 +150,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("timeout", testResp.Timeout)
 	d.Set("contact_id", testResp.ContactID)
 	d.Set("confirmations", testResp.Confirmation)
+	d.Set("port", testResp.Port)
 
 	return nil
 }
@@ -182,6 +189,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("confirmations"); ok {
 		test.Confirmation = v.(int)
+	}
+	if v, ok := d.GetOk("port"); ok {
+		test.Port = v.(int)
 	}
 	return test
 }

--- a/builtin/providers/statuscake/resource_statuscaketest_test.go
+++ b/builtin/providers/statuscake/resource_statuscaketest_test.go
@@ -18,8 +18,27 @@ func TestAccStatusCake_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccTestCheckDestroy(&test),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccTestConfig_basic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccTestCheckExists("statuscake_test.google", &test),
+					testAccTestCheckAttributes("statuscake_test.google", &test),
+				),
+			},
+		},
+	})
+}
+
+func TestAccStatusCake_tcp(t *testing.T) {
+	var test statuscake.Test
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccTestCheckDestroy(&test),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccTestConfig_tcp,
 				Check: resource.ComposeTestCheckFunc(
 					testAccTestCheckExists("statuscake_test.google", &test),
 					testAccTestCheckAttributes("statuscake_test.google", &test),
@@ -37,14 +56,14 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccTestCheckDestroy(&test),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccTestConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccTestCheckExists("statuscake_test.google", &test),
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccTestConfig_update,
 				Check: resource.ComposeTestCheckFunc(
 					testAccTestCheckExists("statuscake_test.google", &test),
@@ -161,5 +180,18 @@ resource "statuscake_test" "google" {
 	test_type = "HTTP"
 	check_rate = 500
 	paused = true
+}
+`
+
+const testAccTestConfig_tcp = `
+resource "statuscake_test" "google" {
+	website_name = "google.com"
+	website_url = "www.google.com"
+	test_type = "TCP"
+	check_rate = 300
+	timeout = 10
+	contact_id = 12345
+	confirmations = 1
+	port = 80
 }
 `

--- a/website/source/docs/providers/statuscake/r/test.html.markdown
+++ b/website/source/docs/providers/statuscake/r/test.html.markdown
@@ -35,6 +35,7 @@ The following arguments are supported:
 * `timeout` - (Optional) The timeout of the test in seconds.
 * `contact_id` - (Optional) The ID of the contact group to associate with the test.
 * `confirmations` - (Optional) The number of confirmation servers to use in order to detect downtime. Defaults to 0.
+* `port` - (Optional) The port to use when specifying a TCP test.
 
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes: #11923

This required the upstream library to have a PR accepted