### PR TITLE
provider/azurerm: Remove location argument from azurerm_lb_*

### DIFF
--- a/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
@@ -39,7 +39,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-  location = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id = "${azurerm_lb.test.id}"
   name = "BackEndAddressPool"
@@ -52,7 +51,6 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Backend Address Pool.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `location` - (Required) Specifies the supported Azure location where the resource exists.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the Backend Address Pool. 
 
 ## Attributes Reference

--- a/website/source/docs/providers/azurerm/r/loadbalancer_probe.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_probe.html.markdown
@@ -39,7 +39,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_probe" "test" {
-  location = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id = "${azurerm_lb.test.id}"
   name = "SSH Running Probe"
@@ -53,7 +52,6 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Probe.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `location` - (Required) Specifies the supported Azure location where the resource exists.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule.
 * `protocol` - (Optional) Specifies the protocol of the end point. Possible values are `Http` or `Tcp`. If Tcp is specified, a received ACK is required for the probe to be successful. If Http is specified, a 200 OK response from the specified URI is required for the probe to be successful.
 * `port` - (Required) Port on which the Probe queries the backend endpoint. Possible values range from 1 to 65535, inclusive.
@@ -75,4 +73,3 @@ Load Balancer Probes can be imported using the `resource id`, e.g.
 ```
 terraform import azurerm_lb_probe.test /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/group1/providers/Microsoft.Network/loadBalancers/lb1/probes/probe1
 ```
-

--- a/website/source/docs/providers/azurerm/r/loadbalancer_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_rule.html.markdown
@@ -39,7 +39,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_rule" "test" {
-  location = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   loadbalancer_id = "${azurerm_lb.test.id}"
   name = "LBRule"
@@ -56,10 +55,9 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the LB Rule.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `location` - (Required) Specifies the supported Azure location where the resource exists.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the Rule.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration to which the rule is associated.
-* `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp` or `Tcp`. 
+* `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp` or `Tcp`.
 * `frontend_port` - (Required) The port for the external endpoint. Port numbers for each Rule must be unique within the Load Balancer. Possible values range between 1 and 65534, inclusive.
 * `backend_port` - (Required) The port used for internal connections on the endpoint. Possible values range between 1 and 65535, inclusive.
 * `backend_address_pool_id` - (Optional) A reference to a Backend Address Pool over which this Load Balancing Rule operates.


### PR DESCRIPTION
(Similar to #11963. The changes in #11963 are showing in this PR as well, despite having updated my branches. Please do comment with any hints you might have.)

Applying a Terraform execution plan containing a azurerm_lb_rule with a location argument throws a warning:

```
Warnings:

  * azurerm_lb_rule.test: "location": [DEPRECATED] location is no longer used

No errors found. Continuing with 1 warning(s).
```

Removing the (required) location argument from the documentation as it is deprecated as per the warning.