### PR TITLE
state/remote: export ClientLocker, test for implementation

### DIFF
--- a/backend/remote-state/consul/client_test.go
+++ b/backend/remote-state/consul/client_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestRemoteClient_impl(t *testing.T) {
 	var _ remote.Client = new(RemoteClient)
+	var _ remote.ClientLocker = new(RemoteClient)
 }
 
 func TestRemoteClient(t *testing.T) {

--- a/state/backup_test.go
+++ b/state/backup_test.go
@@ -6,6 +6,10 @@ import (
 	"testing"
 )
 
+func TestBackupState_locker(t *testing.T) {
+	var _ Locker = new(BackupState)
+}
+
 func TestBackupState(t *testing.T) {
 	f, err := ioutil.TempFile("", "tf")
 	if err != nil {

--- a/state/remote/remote.go
+++ b/state/remote/remote.go
@@ -2,6 +2,8 @@ package remote
 
 import (
 	"fmt"
+
+	"github.com/hashicorp/terraform/state"
 )
 
 // Client is the interface that must be implemented for a remote state
@@ -11,6 +13,15 @@ type Client interface {
 	Get() (*Payload, error)
 	Put([]byte) error
 	Delete() error
+}
+
+// ClientLocker is an optional interface that allows a remote state
+// backend to enable state lock/unlock.
+type ClientLocker interface {
+	Client
+
+	Lock(*state.LockInfo) (string, error)
+	Unlock(string) error
 }
 
 // Payload is the return value from the remote state storage.

--- a/state/remote/remote.go
+++ b/state/remote/remote.go
@@ -19,9 +19,7 @@ type Client interface {
 // backend to enable state lock/unlock.
 type ClientLocker interface {
 	Client
-
-	Lock(*state.LockInfo) (string, error)
-	Unlock(string) error
+	state.Locker
 }
 
 // Payload is the return value from the remote state storage.

--- a/state/remote/s3_test.go
+++ b/state/remote/s3_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestS3Client_impl(t *testing.T) {
 	var _ Client = new(S3Client)
+	var _ ClientLocker = new(S3Client)
 }
 
 func TestS3Factory(t *testing.T) {

--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"bytes"
 
+	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -62,24 +63,17 @@ func (s *State) PersistState() error {
 }
 
 // Lock calls the Client's Lock method if it's implemented.
-func (s *State) Lock(reason string) error {
-	if c, ok := s.Client.(stateLocker); ok {
-		return c.Lock(reason)
+func (s *State) Lock(info *state.LockInfo) (string, error) {
+	if c, ok := s.Client.(ClientLocker); ok {
+		return c.Lock(info)
 	}
-	return nil
+	return "", nil
 }
 
 // Unlock calls the Client's Unlock method if it's implemented.
-func (s *State) Unlock() error {
-	if c, ok := s.Client.(stateLocker); ok {
-		return c.Unlock()
+func (s *State) Unlock(id string) error {
+	if c, ok := s.Client.(ClientLocker); ok {
+		return c.Unlock(id)
 	}
 	return nil
-}
-
-// stateLocker mirrors the state.Locker interface.  This can be implemented by
-// Clients to provide methods for locking and unlocking remote state.
-type stateLocker interface {
-	Lock(reason string) error
-	Unlock() error
 }

--- a/state/remote/state_test.go
+++ b/state/remote/state_test.go
@@ -24,4 +24,5 @@ func TestState_impl(t *testing.T) {
 	var _ state.StateWriter = new(State)
 	var _ state.StatePersister = new(State)
 	var _ state.StateRefresher = new(State)
+	var _ state.Locker = new(State)
 }


### PR DESCRIPTION
This adds unit tests (that will fail at compile time) if various structs
don't implement the right interfaces for locking