### PR TITLE
provider/aws: Add support for AWS EBS Elastic Volumes

### DIFF
--- a/builtin/providers/aws/resource_aws_ebs_volume.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume.go
@@ -40,7 +40,6 @@ func resourceAwsEbsVolume() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"kms_key_id": {
 				Type:         schema.TypeString,
@@ -53,7 +52,6 @@ func resourceAwsEbsVolume() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"snapshot_id": {
 				Type:     schema.TypeString,
@@ -65,7 +63,6 @@ func resourceAwsEbsVolume() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
-				ForceNew: true,
 			},
 			"tags": tagsSchema(),
 		},
@@ -117,8 +114,7 @@ func resourceAwsEbsVolumeCreate(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error creating EC2 volume: %s", err)
 	}
 
-	log.Println(
-		"[DEBUG] Waiting for Volume to become available")
+	log.Println("[DEBUG] Waiting for Volume to become available")
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"creating"},
@@ -154,6 +150,50 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 			return errwrap.Wrapf("Error updating tags for EBS Volume: {{err}}", err)
 		}
 	}
+
+	requestUpdate := false
+	params := &ec2.ModifyVolumeInput{
+		VolumeId: aws.String(d.Id()),
+	}
+
+	if d.HasChange("size") {
+		requestUpdate = true
+		params.Size = aws.Int64(int64(d.Get("size").(int)))
+	}
+
+	if d.HasChange("type") {
+		requestUpdate = true
+		params.VolumeType = aws.String(d.Get("type").(string))
+	}
+
+	if d.HasChange("iops") {
+		requestUpdate = true
+		params.Iops = aws.Int64(int64(d.Get("iops").(int)))
+	}
+
+	if requestUpdate {
+		result, err := conn.ModifyVolume(params)
+		if err != nil {
+			return err
+		}
+
+		stateConf := &resource.StateChangeConf{
+			Pending:    []string{"creating", "modifying"},
+			Target:     []string{"available"},
+			Refresh:    volumeStateRefreshFunc(conn, *result.VolumeModification.VolumeId),
+			Timeout:    5 * time.Minute,
+			Delay:      10 * time.Second,
+			MinTimeout: 3 * time.Second,
+		}
+
+		_, err = stateConf.WaitForState()
+		if err != nil {
+			return fmt.Errorf(
+				"Error waiting for Volume (%s) to become available: %s",
+				*result.VolumeModification.VolumeId, err)
+		}
+	}
+
 	return resourceAwsEbsVolumeRead(d, meta)
 }
 

--- a/builtin/providers/aws/resource_aws_ebs_volume_test.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume_test.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 	"testing"
 
+	"regexp"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"regexp"
 )
 
 func TestAccAWSEBSVolume_basic(t *testing.T) {
@@ -23,6 +24,81 @@ func TestAccAWSEBSVolume_basic(t *testing.T) {
 				Config: testAccAwsEbsVolumeConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEBSVolume_updateSize(t *testing.T) {
+	var v ec2.Volume
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_ebs_volume.test",
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsVolumeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					resource.TestCheckResourceAttr("aws_ebs_volume.test", "size", "1"),
+				),
+			},
+			{
+				Config: testAccAwsEbsVolumeConfigUpdateSize,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					resource.TestCheckResourceAttr("aws_ebs_volume.test", "size", "10"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEBSVolume_updateType(t *testing.T) {
+	var v ec2.Volume
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_ebs_volume.test",
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsVolumeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					resource.TestCheckResourceAttr("aws_ebs_volume.test", "type", "gp2"),
+				),
+			},
+			{
+				Config: testAccAwsEbsVolumeConfigUpdateType,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					resource.TestCheckResourceAttr("aws_ebs_volume.test", "type", "sc1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEBSVolume_updateIops(t *testing.T) {
+	var v ec2.Volume
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_ebs_volume.test",
+		Providers:     testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsEbsVolumeConfigWithIops,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					resource.TestCheckResourceAttr("aws_ebs_volume.test", "iops", "100"),
+				),
+			},
+			{
+				Config: testAccAwsEbsVolumeConfigWithIopsUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckVolumeExists("aws_ebs_volume.test", &v),
+					resource.TestCheckResourceAttr("aws_ebs_volume.test", "iops", "200"),
 				),
 			},
 		},
@@ -116,7 +192,57 @@ func testAccCheckVolumeExists(n string, v *ec2.Volume) resource.TestCheckFunc {
 const testAccAwsEbsVolumeConfig = `
 resource "aws_ebs_volume" "test" {
   availability_zone = "us-west-2a"
+  type = "gp2"
   size = 1
+  tags {
+    Name = "tf-acc-test-ebs-volume-test"
+  }
+}
+`
+
+const testAccAwsEbsVolumeConfigUpdateSize = `
+resource "aws_ebs_volume" "test" {
+  availability_zone = "us-west-2a"
+  type = "gp2"
+  size = 10
+  tags {
+    Name = "tf-acc-test-ebs-volume-test"
+  }
+}
+`
+
+const testAccAwsEbsVolumeConfigUpdateType = `
+resource "aws_ebs_volume" "test" {
+  availability_zone = "us-west-2a"
+  type = "sc1"
+  size = 500
+  tags {
+    Name = "tf-acc-test-ebs-volume-test"
+  }
+}
+`
+
+const testAccAwsEbsVolumeConfigWithIops = `
+resource "aws_ebs_volume" "test" {
+  availability_zone = "us-west-2a"
+  type = "io1"
+  size = 4
+  iops = 100
+  tags {
+    Name = "tf-acc-test-ebs-volume-test"
+  }
+}
+`
+
+const testAccAwsEbsVolumeConfigWithIopsUpdated = `
+resource "aws_ebs_volume" "test" {
+  availability_zone = "us-west-2a"
+  type = "io1"
+  size = 4
+  iops = 200
+  tags {
+    Name = "tf-acc-test-ebs-volume-test"
+  }
 }
 `
 


### PR DESCRIPTION
This allows for updates to size, type and iops

Fixes: #11931

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEBSVolume_update'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/15 22:35:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEBSVolume_update -timeout 120m
=== RUN   TestAccAWSEBSVolume_updateSize
--- PASS: TestAccAWSEBSVolume_updateSize (53.57s)
=== RUN   TestAccAWSEBSVolume_updateType
--- PASS: TestAccAWSEBSVolume_updateType (57.53s)
=== RUN   TestAccAWSEBSVolume_updateIops
--- PASS: TestAccAWSEBSVolume_updateIops (53.63s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	164.753s
```