### PR TITLE
Website: Improved docs typography/legibility

### DIFF
--- a/website/source/assets/stylesheets/_docs.scss
+++ b/website/source/assets/stylesheets/_docs.scss
@@ -126,7 +126,6 @@ body.layout-intro{
 
 		> li {
 			padding: 10px 0;
-			margin: 0 30px;
 
 			>.nav{
 				li{
@@ -170,6 +169,7 @@ body.layout-intro{
 
 			> a {
 				text-transform: uppercase;
+				letter-spacing: 1px;
         -webkit-font-smoothing: antialiased;
 			}
 		}
@@ -194,9 +194,13 @@ body.layout-intro{
 	}
 }
 
-
 .bs-docs-section{
-	padding: 10px 10px 80px 10px;
+	@media(max-width: 767px){
+		padding: 10px 5px 80px 5px;
+	}
+	@media(min-width: 768px){
+		padding: 10px 20px 80px 20px;
+	}
 
 	.lead{
 		margin-bottom: 48px
@@ -208,14 +212,14 @@ body.layout-intro{
 
 	p, li, .alert {
 		font-size: 18px;
-    line-height: 1.5em;
+    line-height: 1.5;
 		margin: 0 0 18px;
     -webkit-font-smoothing: antialiased;
 	}
 
-    pre{
-        margin: 0 0 18px;
-    }
+  pre{
+    margin: 0 0 18px;
+  }
 
 	a{
 		color: $purple;
@@ -224,30 +228,40 @@ body.layout-intro{
 		}
 	}
 
-    img{
-        max-width: 650px;
-        margin-top: 25px;
-        margin-bottom: 25px;
-    }
+  img{
+    max-width: 650px;
+    margin-top: 25px;
+    margin-bottom: 25px;
+  }
 
 	h1{
+		margin-top: 72px;
 		color: $purple;
-    font-size: 36px;
+		font-weight: 400;
 		text-transform: uppercase;
+		letter-spacing: -1px;
     word-wrap: break-word;
-		padding-bottom: 24px;
-    margin-top: 24px;
-		margin-bottom: 30px;
-    border-bottom: 1px solid #eeeeee;
 	}
 
 	h2, h3, h4{
-		margin-bottom: 16px;
+		margin-top: 48px;
+		font-family: $font-family-open-sans;
+		text-transform: none;
 	}
 
-    #graph {
-        margin-top: 30px;
-    }
+	h2 {
+		margin-bottom: 16px;
+		padding-bottom: 10px;
+		border-bottom: 1px solid #eeeeee;
+	}
+
+	p {
+		color: $light-black;
+	}
+
+  #graph {
+    margin-top: 30px;
+  }
 }
 
 @media (max-width: 992px) {
@@ -314,6 +328,18 @@ body.layout-intro{
       padding-top: 24px;
       border-top: 1px solid #eeeeee;
     }
+
+		h2 {
+			font-size: 24px;
+		}
+
+		h2, h3, h4{
+			margin-top: 32px;
+		}
+
+		p, li, .alert {
+			font-size: 16px;
+		}
   }
 }
 

--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -38,6 +38,10 @@ h3{
   text-transform: uppercase;
 }
 
+h4 {
+  font-size: 18px;
+}
+
 p {
   margin-bottom: 30px;
   font-size: 16px;


### PR DESCRIPTION
:wave:

Last week, we shipped some general changes to the typography of the website. Those changes were broad and this PR is specifically aimed at improving the legibility of the docs. 

[In the original PR](https://github.com/hashicorp/terraform/pull/11927) @mattclegg noted that the H2s had become harder to read. After addressing that issue and I went a little further and formatted the headings, most effectively the whitespace, to make all of the sections and subsections easier to skim.

- improved whitespace for skimming/tracking
- improved container padding
- better differentiation between h2 and h3

Looks like this:

![terra-docs](https://cloud.githubusercontent.com/assets/416727/22999256/4b33ddec-f38f-11e6-8767-dd3e3c82ae66.png)

cc: @captainill  @sethvargo 