### PR TITLE
backend/local: check for empty config on apply

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -23,7 +23,7 @@ func (b *Local) opApply(
 
 	// If we have a nil module at this point, then set it to an empty tree
 	// to avoid any potential crashes.
-	if op.Module == nil && !op.Destroy {
+	if op.Plan == nil && op.Module == nil && !op.Destroy {
 		runningOp.Err = fmt.Errorf(strings.TrimSpace(applyErrNoConfig))
 		return
 	}

--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
 	clistate "github.com/hashicorp/terraform/command/state"
+	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -18,6 +20,19 @@ func (b *Local) opApply(
 	op *backend.Operation,
 	runningOp *backend.RunningOperation) {
 	log.Printf("[INFO] backend/local: starting Apply operation")
+
+	// If we have a nil module at this point, then set it to an empty tree
+	// to avoid any potential crashes.
+	if op.Module == nil && !op.Destroy {
+		runningOp.Err = fmt.Errorf(strings.TrimSpace(applyErrNoConfig))
+		return
+	}
+
+	// If we have a nil module at this point, then set it to an empty tree
+	// to avoid any potential crashes.
+	if op.Module == nil {
+		op.Module = module.NewEmptyTree()
+	}
 
 	// Setup our count hook that keeps track of resource changes
 	countHook := new(CountHook)
@@ -165,3 +180,12 @@ func (b *Local) opApply(
 		}
 	}
 }
+
+const applyErrNoConfig = `
+No configuration files found!
+
+Apply requires configuration to be present. Applying without a configuration
+would mark everything for destruction, which is normally not what is desired.
+If you would like to destroy everything, please run 'terraform destroy' instead
+which does not require any configuration files.
+`

--- a/backend/local/test-fixtures/apply-empty/hello.txt
+++ b/backend/local/test-fixtures/apply-empty/hello.txt
@@ -1,0 +1,1 @@
+This is an empty dir


### PR DESCRIPTION
Only affects 0.9.

This prevents Terraform from crashing on apply/destroy with a directory
with no Terraform configuration files. We allow a destroy with no files
but not an apply.