### PR TITLE
log the Go runtime version at TF startup

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,6 +103,7 @@ func wrappedMain() int {
 	log.Printf(
 		"[INFO] Terraform version: %s %s %s",
 		Version, VersionPrerelease, GitCommit)
+	log.Printf("[INFO] Go runtime version: %s", runtime.Version())
 	log.Printf("[INFO] CLI args: %#v", os.Args)
 
 	// Load the configuration


### PR DESCRIPTION
This will help us debug issues which have been caused by Go bugs.