### PR TITLE
provider/google: Check for errors when deleting project metadata.

### DIFF
--- a/builtin/providers/google/resource_compute_project_metadata.go
+++ b/builtin/providers/google/resource_compute_project_metadata.go
@@ -192,6 +192,10 @@ func resourceComputeProjectMetadataDelete(d *schema.ResourceData, meta interface
 
 	op, err := config.clientCompute.Projects.SetCommonInstanceMetadata(projectID, md).Do()
 
+	if err != nil {
+		return fmt.Errorf("Error removing metadata from project %s: %s", projectID, err)
+	}
+
 	log.Printf("[DEBUG] SetCommonMetadata: %d (%s)", op.Id, op.SelfLink)
 
 	err = computeOperationWaitGlobal(config, op, project.Name, "SetCommonMetadata")


### PR DESCRIPTION
Our delete operation for google_compute_project_metadata didn't check an
error when making the call to delete metadata, which led to a panic in
our tests. This is also probably indicative of why our tests
failed/metadata got left dangling.