### PR TITLE
provider/aws: Fix matching regexp in invalid role config test

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_role_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_test.go
@@ -91,7 +91,7 @@ func TestAccAWSRole_badJSON(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccAWSRoleConfig_badJson,
-				ExpectError: regexp.MustCompile(`"assume_role_policy" contains an invalid JSON:.*`),
+				ExpectError: regexp.MustCompile(`.*contains an invalid JSON:.*`),
 			},
 		},
 	})


### PR DESCRIPTION
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRole_badJSON'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/16 10:08:07 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRole_badJSON -timeout 120m
=== RUN   TestAccAWSRole_badJSON
--- PASS: TestAccAWSRole_badJSON (0.00s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    0.011s
```