### PR TITLE
documentation: add missing allowed_uses in certificate signing

### DIFF
--- a/website/source/docs/providers/tls/r/locally_signed_cert.html.md
+++ b/website/source/docs/providers/tls/r/locally_signed_cert.html.md
@@ -79,6 +79,7 @@ both [Key Usage](https://tools.ietf.org/html/rfc5280#section-4.2.1.3) and
 * `data_encipherment`
 * `key_agreement`
 * `cert_signing`
+* `crl_signing`
 * `encipher_only`
 * `decipher_only`
 * `any_extended`

--- a/website/source/docs/providers/tls/r/self_signed_cert.html.md
+++ b/website/source/docs/providers/tls/r/self_signed_cert.html.md
@@ -99,6 +99,7 @@ both [Key Usage](https://tools.ietf.org/html/rfc5280#section-4.2.1.3) and
 * `data_encipherment`
 * `key_agreement`
 * `cert_signing`
+* `crl_signing`
 * `encipher_only`
 * `decipher_only`
 * `any_extended`


### PR DESCRIPTION
While I was using the `tls` provider's `self_signed_cert` resource for creating my CA cert I realized that although `crl_signing` is in the code, it's missing from the documentation. This PR aims to fix this.