### PR TITLE
Add a prefix option to random_id provider

### DIFF
--- a/builtin/providers/random/resource_id.go
+++ b/builtin/providers/random/resource_id.go
@@ -30,6 +30,12 @@ func resourceId() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"prefix": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"b64": {
 				Type:       schema.TypeString,
 				Computed:   true,
@@ -78,6 +84,7 @@ func CreateID(d *schema.ResourceData, meta interface{}) error {
 }
 
 func RepopulateEncodings(d *schema.ResourceData, _ interface{}) error {
+	prefix := d.Get("prefix").(string)
 	base64Str := d.Id()
 
 	bytes, err := base64.RawURLEncoding.DecodeString(base64Str)
@@ -92,12 +99,12 @@ func RepopulateEncodings(d *schema.ResourceData, _ interface{}) error {
 	bigInt.SetBytes(bytes)
 	decStr := bigInt.String()
 
-	d.Set("b64", base64Str)
-	d.Set("b64_url", base64Str)
-	d.Set("b64_std", b64StdStr)
+	d.Set("b64", prefix+base64Str)
+	d.Set("b64_url", prefix+base64Str)
+	d.Set("b64_std", prefix+b64StdStr)
 
-	d.Set("hex", hexStr)
-	d.Set("dec", decStr)
+	d.Set("hex", prefix+hexStr)
+	d.Set("dec", prefix+decStr)
 
 	return nil
 }

--- a/builtin/providers/random/resource_id_test.go
+++ b/builtin/providers/random/resource_id_test.go
@@ -8,6 +8,13 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+type idLens struct {
+	b64Len    int
+	b64UrlLen int
+	b64StdLen int
+	hexLen    int
+}
+
 func TestAccResourceID(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -16,14 +23,25 @@ func TestAccResourceID(t *testing.T) {
 			{
 				Config: testAccResourceIDConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccResourceIDCheck("random_id.foo"),
+					testAccResourceIDCheck("random_id.foo", &idLens{
+						b64Len:    6,
+						b64UrlLen: 6,
+						b64StdLen: 8,
+						hexLen:    8,
+					}),
+					testAccResourceIDCheck("random_id.bar", &idLens{
+						b64Len:    12,
+						b64UrlLen: 12,
+						b64StdLen: 14,
+						hexLen:    14,
+					}),
 				),
 			},
 		},
 	})
 }
 
-func testAccResourceIDCheck(id string) resource.TestCheckFunc {
+func testAccResourceIDCheck(id string, want *idLens) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {
@@ -39,16 +57,16 @@ func testAccResourceIDCheck(id string) resource.TestCheckFunc {
 		hexStr := rs.Primary.Attributes["hex"]
 		decStr := rs.Primary.Attributes["dec"]
 
-		if got, want := len(b64Str), 6; got != want {
+		if got, want := len(b64Str), want.b64Len; got != want {
 			return fmt.Errorf("base64 string length is %d; want %d", got, want)
 		}
-		if got, want := len(b64UrlStr), 6; got != want {
+		if got, want := len(b64UrlStr), want.b64UrlLen; got != want {
 			return fmt.Errorf("base64 URL string length is %d; want %d", got, want)
 		}
-		if got, want := len(b64StdStr), 8; got != want {
+		if got, want := len(b64StdStr), want.b64StdLen; got != want {
 			return fmt.Errorf("base64 STD string length is %d; want %d", got, want)
 		}
-		if got, want := len(hexStr), 8; got != want {
+		if got, want := len(hexStr), want.hexLen; got != want {
 			return fmt.Errorf("hex string length is %d; want %d", got, want)
 		}
 		if len(decStr) < 1 {
@@ -59,8 +77,15 @@ func testAccResourceIDCheck(id string) resource.TestCheckFunc {
 	}
 }
 
-const testAccResourceIDConfig = `
+const (
+	testAccResourceIDConfig = `
 resource "random_id" "foo" {
-    byte_length = 4
+  byte_length = 4
+}
+
+resource "random_id" "bar" {
+  byte_length = 4
+	prefix      = "cloud-"
 }
 `
+)

--- a/website/source/docs/providers/random/r/id.html.md
+++ b/website/source/docs/providers/random/r/id.html.md
@@ -60,6 +60,10 @@ The following arguments are supported:
   trigger a new id to be generated. See
   [the main provider documentation](../index.html) for more information.
 
+* `prefix` - (Optional) Arbitrary string to prefix the output value with. This
+  string is supplied as-is, meaning it is not guaranteed to be URL-safe or
+  base64 encoded.
+
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This allows the user to specify a transparent prefix (as a string) to put before all random-id values. This is useful when you are using the random IDs in multiple places and want to ensure the prefix is both consistent, but also that a change of the prefix triggers a new random_id.

- Fixes https://github.com/hashicorp/terraform/issues/8302