### PR TITLE
provider/aws: aws_lambda_function Allow empty environment variables map

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -248,16 +248,13 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 
 	if v, ok := d.GetOk("environment"); ok {
 		environments := v.([]interface{})
-		environment, ok := environments[0].(map[string]interface{})
-		if !ok {
-			return errors.New("At least one field is expected inside environment")
-		}
+		if environment, ok := environments[0].(map[string]interface{}); ok {
+			if environmentVariables, ok := environment["variables"]; ok {
+				variables := readEnvironmentVariables(environmentVariables.(map[string]interface{}))
 
-		if environmentVariables, ok := environment["variables"]; ok {
-			variables := readEnvironmentVariables(environmentVariables.(map[string]interface{}))
-
-			params.Environment = &lambda.Environment{
-				Variables: aws.StringMap(variables),
+				params.Environment = &lambda.Environment{
+					Variables: aws.StringMap(variables),
+				}
 			}
 		}
 	}


### PR DESCRIPTION
We use a single module to deploy all of our lamba functions.  When adding the ability to push in a map of environment variables to the module, I discovered that TF would through an error if an empty map was passed.  This should be allowed as some lambdas do not need env vars, but there's no need to have 2 separate modules because of this.

Example:
```hcl
variable "name" {}
variable "filename" {}
variable "handler" {}
variable "runtime" {
  default = "nodejs4.3"
}
variable "environment_variables" {
  type    = "map"
  default = {}
}

resource "aws_lambda_function" "main" {
  function_name         = "${var.name}"
  filename              = "${var.filename}"
  runtime               = "${var.runtime}"
  handler               = "${var.handler}"
  // truncated for brevity
  environment {
    variables = "${var.environment_variables}"
  }
```

If this is used without passing a populated map, terraform will error with `aws_lambda_function.main: At least one field is expected inside environment`