### PR TITLE
provider/fastly: Make Backends optional if used in VCL

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -109,7 +109,7 @@ func resourceServiceV1() *schema.Resource {
 
 			"backend": {
 				Type:     schema.TypeSet,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						// required fields

--- a/builtin/providers/fastly/resource_fastly_service_v1_vcl_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_vcl_test.go
@@ -82,11 +82,6 @@ resource "fastly_service_v1" "foo" {
     comment = "tf-testing-domain"
   }
 
-  backend {
-    address = "aws.amazon.com"
-    name    = "amazon docs"
-  }
-
   vcl {
     name    = "my_custom_main_vcl"
     content = <<EOF
@@ -98,6 +93,11 @@ sub vcl_recv {
     }
 
     return(lookup);
+}
+
+backend amazondocs {
+  .host = "127.0.0.1";
+  .port = "80";
 }
 EOF
     main    = true
@@ -117,11 +117,6 @@ resource "fastly_service_v1" "foo" {
     comment = "tf-testing-domain"
   }
 
-  backend {
-    address = "aws.amazon.com"
-    name    = "amazon docs"
-  }
-
   vcl {
     name    = "my_custom_main_vcl"
     content = <<EOF
@@ -134,6 +129,11 @@ sub vcl_recv {
 
     return(lookup);
 }
+
+backend amazondocs {
+  .host = "127.0.0.1";
+  .port = "80";
+}
 EOF
     main    = true
   }
@@ -143,6 +143,11 @@ EOF
                 content = <<EOF
 sub vcl_error {
 #FASTLY error
+}
+
+backend amazondocs {
+  .host = "127.0.0.1";
+  .port = "80";
 }
 EOF
         }

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -132,8 +132,9 @@ The following arguments are supported:
 * `name` - (Required) The unique name for the Service to create.
 * `domain` - (Required) A set of Domain names to serve as entry points for your
 Service. Defined below.
-* `backend` - (Required) A set of Backends to service requests from your Domains.
-Defined below.
+* `backend` - (Optional) A set of Backends to service requests from your Domains.
+Defined below. Backends must be defined in this argument, or defined in the
+`vcl` argument below
 * `condition` - (Optional) A set of conditions to add logic to any basic
 configuration object in this service. Defined below.
 * `cache_setting` - (Optional) A set of Cache Settings, allowing you to override


### PR DESCRIPTION
Backends must be defined in the config, but may optionally be declared
inside custom VCL. 

In this PR we make `backend` optional to enable that, and modify the VCL test to use `backend` in the VCL configuration.

```
TF_ACC=1 go test ./builtin/providers/fastly -v -run=TestAccFastlyServiceV1_ -timeout 120m
=== RUN   TestAccFastlyServiceV1_conditional_basic
--- PASS: TestAccFastlyServiceV1_conditional_basic (15.93s)
=== RUN   TestAccFastlyServiceV1_gzips_basic
--- PASS: TestAccFastlyServiceV1_gzips_basic (35.54s)
=== RUN   TestAccFastlyServiceV1_headers_basic
--- PASS: TestAccFastlyServiceV1_headers_basic (35.93s)
=== RUN   TestAccFastlyServiceV1_healthcheck_basic
--- PASS: TestAccFastlyServiceV1_healthcheck_basic (33.94s)
=== RUN   TestAccFastlyServiceV1_papertrail_basic
jjjj --- PASS: TestAccFastlyServiceV1_papertrail_basic (33.64s)
=== RUN   TestAccFastlyServiceV1_s3logging_basic
--- PASS: TestAccFastlyServiceV1_s3logging_basic (33.57s)
=== RUN   TestAccFastlyServiceV1_s3logging_s3_env
--- PASS: TestAccFastlyServiceV1_s3logging_s3_env (13.62s)
=== RUN   TestAccFastlyServiceV1_s3logging_formatVersion
--- PASS: TestAccFastlyServiceV1_s3logging_formatVersion (14.42s)
=== RUN   TestAccFastlyServiceV1_updateDomain
--- PASS: TestAccFastlyServiceV1_updateDomain (34.04s)
=== RUN   TestAccFastlyServiceV1_updateBackend
--- PASS: TestAccFastlyServiceV1_updateBackend (35.15s)
=== RUN   TestAccFastlyServiceV1_basic
--- PASS: TestAccFastlyServiceV1_basic (13.60s)
=== RUN   TestAccFastlyServiceV1_disappears
--- PASS: TestAccFastlyServiceV1_disappears (7.36s)
=== RUN   TestAccFastlyServiceV1_VCL_basic
--- PASS: TestAccFastlyServiceV1_VCL_basic (33.39s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/fastly 340.138s
```

Fixes #7609