### PR TITLE
provider/fastly Fixes logging response condition documentation

### DIFF
--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -300,7 +300,7 @@ compression. `1` is fastest and least compressed, `9` is slowest and most
 compressed. Default `0`.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
 * `timestamp_format` - (Optional) `strftime` specified timestamp formatting (default `%Y-%m-%dT%H:%M:%S.000`).
-* `request_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`. For detailed information about Conditionals,
+* `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 The `papertrail` block supports:
@@ -309,7 +309,7 @@ The `papertrail` block supports:
 * `address` - (Required) The address of the Papertrail endpoint.
 * `port` - (Required) The port associated with the address where the Papertrail endpoint can be accessed.
 * `format` - (Optional) Apache-style string or VCL variables to use for log formatting. Defaults to Apache Common Log format (`%h %l %u %t %r %>s`)
-* `request_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `REQUEST`. For detailed information about Conditionals,
+* `response_condition` - (Optional) Name of already defined `condition` to apply. This `condition` must be of type `RESPONSE`. For detailed information about Conditionals,
 see [Fastly's Documentation on Conditionals][fastly-conditionals].
 
 The `vcl` block supports:


### PR DESCRIPTION
In #11843 conditions were added across the fastly service. In the documentation for the website it should say `response_condition` for s3 and papertrail logging. Instead the documentation says `request_condition`. This PR fixes this documentation change for both logging services related to fastly caches. 