### PR TITLE
provider/google-cloud: Add maintenance window

### DIFF
--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -156,17 +156,22 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 						"maintenance_window": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
+							MaxItems: 1,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									"day": &schema.Schema{
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validateDay,
+										Type:     schema.TypeInt,
+										Optional: true,
+										ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+											return validateNumericRange(v, k, 1, 7)
+										},
 									},
 									"hour": &schema.Schema{
-										Type:         schema.TypeInt,
-										Optional:     true,
-										ValidateFunc: validateHour,
+										Type:     schema.TypeInt,
+										Optional: true,
+										ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+											return validateNumericRange(v, k, 0, 23)
+										},
 									},
 									"update_track": &schema.Schema{
 										Type:     schema.TypeString,
@@ -453,28 +458,21 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 		}
 	}
 
-	if v, ok := _settings["maintenance_window"]; ok {
-		_maintenanceWindowList := v.([]interface{})
-		if len(_maintenanceWindowList) > 1 {
-			return fmt.Errorf("At most one maintenance_window block is allowed")
+	if v, ok := _settings["maintenance_window"]; ok && len(v.([]interface{})) > 0 {
+		settings.MaintenanceWindow = &sqladmin.MaintenanceWindow{}
+		_maintenanceWindow := v.([]interface{})[0].(map[string]interface{})
+
+		if vp, okp := _maintenanceWindow["day"]; okp {
+			settings.MaintenanceWindow.Day = int64(vp.(int))
 		}
 
-		if len(_maintenanceWindowList) == 1 && _maintenanceWindowList[0] != nil {
-			settings.MaintenanceWindow = &sqladmin.MaintenanceWindow{}
-			_maintenanceWindow := _maintenanceWindowList[0].(map[string]interface{})
+		if vp, okp := _maintenanceWindow["hour"]; okp {
+			settings.MaintenanceWindow.Hour = int64(vp.(int))
+		}
 
-			if vp, okp := _maintenanceWindow["day"]; okp {
-				settings.MaintenanceWindow.Day = int64(vp.(int))
-			}
-
-			if vp, okp := _maintenanceWindow["hour"]; okp {
-				settings.MaintenanceWindow.Hour = int64(vp.(int))
-			}
-
-			if vp, ok := _maintenanceWindow["update_track"]; ok {
-				if len(vp.(string)) > 0 {
-					settings.MaintenanceWindow.UpdateTrack = vp.(string)
-				}
+		if vp, ok := _maintenanceWindow["update_track"]; ok {
+			if len(vp.(string)) > 0 {
+				settings.MaintenanceWindow.UpdateTrack = vp.(string)
 			}
 		}
 	}
@@ -793,31 +791,22 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	if v, ok := _settings["maintenance_window"]; ok {
-		_maintenanceWindowList := v.([]interface{})
-		if len(_maintenanceWindowList) > 1 {
-			return fmt.Errorf("At most one maintenance_window block is allowed")
+	if v, ok := _settings["maintenance_window"]; ok && len(v.([]interface{})) > 0 &&
+		settings.MaintenanceWindow != nil {
+		_maintenanceWindow := v.([]interface{})[0].(map[string]interface{})
+
+		if vp, okp := _maintenanceWindow["day"]; okp && vp != nil {
+			_maintenanceWindow["day"] = settings.MaintenanceWindow.Day
 		}
 
-		if len(_maintenanceWindowList) == 1 && _maintenanceWindowList[0] != nil {
-			_maintenanceWindow := _maintenanceWindowList[0].(map[string]interface{})
+		if vp, okp := _maintenanceWindow["hour"]; okp && vp != nil {
+			_maintenanceWindow["hour"] = settings.MaintenanceWindow.Hour
+		}
 
-			if vp, okp := _maintenanceWindow["day"]; okp && vp != nil {
-				_maintenanceWindow["day"] = settings.MaintenanceWindow.Day
+		if vp, ok := _maintenanceWindow["update_track"]; ok && vp != nil {
+			if len(vp.(string)) > 0 {
+				_maintenanceWindow["update_track"] = settings.MaintenanceWindow.UpdateTrack
 			}
-
-			if vp, okp := _maintenanceWindow["hour"]; okp && vp != nil {
-				_maintenanceWindow["hour"] = settings.MaintenanceWindow.Hour
-			}
-
-			if vp, ok := _maintenanceWindow["update_track"]; ok && vp != nil {
-				if len(vp.(string)) > 0 {
-					_maintenanceWindow["update_track"] = settings.MaintenanceWindow.UpdateTrack
-				}
-			}
-
-			_maintenanceWindowList[0] = _maintenanceWindow
-			_settings["maintenance_window"] = _maintenanceWindowList
 		}
 	}
 
@@ -1138,28 +1127,21 @@ func resourceSqlDatabaseInstanceUpdate(d *schema.ResourceData, meta interface{})
 			}
 		}
 
-		if v, ok := _settings["maintenance_window"]; ok {
-			_maintenanceWindowList := v.([]interface{})
-			if len(_maintenanceWindowList) > 1 {
-				return fmt.Errorf("At most one maintenance_window block is allowed")
+		if v, ok := _settings["maintenance_window"]; ok && len(v.([]interface{})) > 0 {
+			settings.MaintenanceWindow = &sqladmin.MaintenanceWindow{}
+			_maintenanceWindow := v.([]interface{})[0].(map[string]interface{})
+
+			if vp, okp := _maintenanceWindow["day"]; okp {
+				settings.MaintenanceWindow.Day = int64(vp.(int))
 			}
 
-			if len(_maintenanceWindowList) == 1 && _maintenanceWindowList[0] != nil {
-				settings.MaintenanceWindow = &sqladmin.MaintenanceWindow{}
-				_maintenanceWindow := _maintenanceWindowList[0].(map[string]interface{})
+			if vp, okp := _maintenanceWindow["hour"]; okp {
+				settings.MaintenanceWindow.Hour = int64(vp.(int))
+			}
 
-				if vp, okp := _maintenanceWindow["day"]; okp {
-					settings.MaintenanceWindow.Day = int64(vp.(int))
-				}
-
-				if vp, okp := _maintenanceWindow["hour"]; okp {
-					settings.MaintenanceWindow.Hour = int64(vp.(int))
-				}
-
-				if vp, ok := _maintenanceWindow["update_track"]; ok {
-					if len(vp.(string)) > 0 {
-						settings.MaintenanceWindow.UpdateTrack = vp.(string)
-					}
+			if vp, ok := _maintenanceWindow["update_track"]; ok {
+				if len(vp.(string)) > 0 {
+					settings.MaintenanceWindow.UpdateTrack = vp.(string)
 				}
 			}
 		}
@@ -1210,14 +1192,6 @@ func resourceSqlDatabaseInstanceDelete(d *schema.ResourceData, meta interface{})
 	}
 
 	return nil
-}
-
-func validateDay(v interface{}, k string) (ws []string, errors []error) {
-	return validateNumericRange(v, k, 1, 7)
-}
-
-func validateHour(v interface{}, k string) (ws []string, errors []error) {
-	return validateNumericRange(v, k, 0, 23)
 }
 
 func validateNumericRange(v interface{}, k string, min int, max int) (ws []string, errors []error) {

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -134,6 +134,17 @@ The optional `settings.location_preference` subblock supports:
 * `zone` - (Optional) The preferred compute engine
     [zone](https://cloud.google.com/compute/docs/zones?hl=en).
 
+The optional `settings.maintenance_window` subblock for Second Generation
+instances declares a one-hour [maintenance window](https://cloud.google.com/sql/docs/instance-settings?hl=en#maintenance-window-2ndgen)
+when an Instance can automatically restart to apply updates. It supports:
+
+* `day` - (Optional) Day of week (`1-7`), starting on Monday
+
+* `hour` - (Optional) Hour of day (`0-23`), ignored if `day` not set
+
+* `update_track` - (Optional) Receive updates earlier (`canary`) or later 
+(`stable`)
+
 The optional `replica_configuration` block must have `master_instance_name` set
 to work, cannot be updated, and supports:
 


### PR DESCRIPTION
Allows specification of the `maintenance_window` within the `settings` block. This controls when Google will restart a database in order to apply updates. It is also possible to select an `update_track` to relatively control updating between instances in the same project.