### PR TITLE
doc: gcs - Update storage_class documentation and tests

### DIFF
--- a/builtin/providers/google/resource_storage_bucket_test.go
+++ b/builtin/providers/google/resource_storage_bucket_test.go
@@ -68,12 +68,12 @@ func TestAccStorageStorageClass(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "STANDARD"),
+				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "MULTI_REGIONAL"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName),
 					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", "storage_class", "STANDARD"),
+						"google_storage_bucket.bucket", "storage_class", "MULTI_REGIONAL"),
 				),
 			},
 			{
@@ -86,12 +86,12 @@ func TestAccStorageStorageClass(t *testing.T) {
 				),
 			},
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "DURABLE_REDUCED_AVAILABILITY"),
+				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "REGIONAL"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName),
 					resource.TestCheckResourceAttr(
-						"google_storage_bucket.bucket", "storage_class", "DURABLE_REDUCED_AVAILABILITY"),
+						"google_storage_bucket.bucket", "storage_class", "REGIONAL"),
 				),
 			},
 		},

--- a/website/source/docs/providers/google/r/storage_bucket.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket.html.markdown
@@ -48,7 +48,7 @@ to `google_storage_bucket_acl.predefined_acl`.
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
-* `storage_class` - (Optional) The [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of the new bucket. Supported values include: `STANDARD`, `NEARLINE`, `DURABLE_REDUCED_AVAILABILITY`
+* `storage_class` - (Optional) The [Storage Class](https://cloud.google.com/storage/docs/storage-classes) of the new bucket. Supported values include: `MULTI_REGIONAL`, `REGIONAL`, `NEARLINE`, `COLDLINE`.
 
 * `website` - (Optional) Configuration if the bucket acts as a website.
 


### PR DESCRIPTION
Hi,

Since November 1, 2016, `STANDARD` storage_class is now replaced by
`MULTI_REGIONAL` depending the bucket location. Same for
`DURABLE_REDUCED_AVAILABILITY` replaced by `REGIONAL`.

refs: https://cloud.google.com/storage/docs/storage-classes#standard

Thanks!