### PR TITLE
terraform: don't include providers if not targeted

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -2519,6 +2519,39 @@ STATE:
 	}
 }
 
+func TestContext2Plan_targetedModuleWithProvider(t *testing.T) {
+	m := testModule(t, "plan-targeted-module-with-provider")
+	p := testProvider("null")
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"null": testProviderFuncFixed(p),
+		},
+		Targets: []string{"module.child2"},
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.String())
+	expected := strings.TrimSpace(`
+DIFF:
+
+module.child2:
+  CREATE: null_resource.foo
+
+STATE:
+
+<no state>
+	`)
+	if actual != expected {
+		t.Fatalf("expected:\n%s\n\ngot:\n%s", expected, actual)
+	}
+}
+
 func TestContext2Plan_targetedOrphan(t *testing.T) {
 	m := testModule(t, "plan-targeted-orphan")
 	p := testProvider("aws")

--- a/terraform/graph_builder_plan_test.go
+++ b/terraform/graph_builder_plan_test.go
@@ -33,6 +33,24 @@ func TestPlanGraphBuilder(t *testing.T) {
 	}
 }
 
+func TestPlanGraphBuilder_targetModule(t *testing.T) {
+	b := &PlanGraphBuilder{
+		Module:    testModule(t, "graph-builder-plan-target-module-provider"),
+		Providers: []string{"null"},
+		Targets:   []string{"module.child2"},
+	}
+
+	g, err := b.Build(RootModulePath)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	t.Logf("Graph: %s", g.String())
+
+	testGraphNotContains(t, g, "module.child1.provider.null")
+	testGraphNotContains(t, g, "module.child1.null_resource.foo")
+}
+
 const testPlanGraphBuilderStr = `
 aws_instance.web
   aws_security_group.firewall

--- a/terraform/node_provider_abstract.go
+++ b/terraform/node_provider_abstract.go
@@ -38,6 +38,13 @@ func (n *NodeAbstractProvider) Path() []string {
 	return n.PathValue
 }
 
+// RemovableIfNotTargeted
+func (n *NodeAbstractProvider) RemoveIfNotTargeted() bool {
+	// We need to add this so that this node will be removed if
+	// it isn't targeted or a dependency of a target.
+	return true
+}
+
 // GraphNodeReferencer
 func (n *NodeAbstractProvider) References() []string {
 	if n.Config == nil {

--- a/terraform/test-fixtures/graph-builder-plan-target-module-provider/child1/main.tf
+++ b/terraform/test-fixtures/graph-builder-plan-target-module-provider/child1/main.tf
@@ -1,0 +1,4 @@
+variable "key" {}
+provider "null" { key = "${var.key}" }
+
+resource "null_resource" "foo" {}

--- a/terraform/test-fixtures/graph-builder-plan-target-module-provider/child2/main.tf
+++ b/terraform/test-fixtures/graph-builder-plan-target-module-provider/child2/main.tf
@@ -1,0 +1,4 @@
+variable "key" {}
+provider "null" { key = "${var.key}" }
+
+resource "null_resource" "foo" {}

--- a/terraform/test-fixtures/graph-builder-plan-target-module-provider/main.tf
+++ b/terraform/test-fixtures/graph-builder-plan-target-module-provider/main.tf
@@ -1,0 +1,2 @@
+module "child1" { source = "./child1" }
+module "child2" { source = "./child2" }

--- a/terraform/test-fixtures/plan-targeted-module-with-provider/child1/main.tf
+++ b/terraform/test-fixtures/plan-targeted-module-with-provider/child1/main.tf
@@ -1,0 +1,4 @@
+variable "key" {}
+provider "null" { key = "${var.key}" }
+
+resource "null_resource" "foo" {}

--- a/terraform/test-fixtures/plan-targeted-module-with-provider/child2/main.tf
+++ b/terraform/test-fixtures/plan-targeted-module-with-provider/child2/main.tf
@@ -1,0 +1,4 @@
+variable "key" {}
+provider "null" { key = "${var.key}" }
+
+resource "null_resource" "foo" {}

--- a/terraform/test-fixtures/plan-targeted-module-with-provider/main.tf
+++ b/terraform/test-fixtures/plan-targeted-module-with-provider/main.tf
@@ -1,0 +1,9 @@
+module "child1" {
+  source = "./child1"
+  key = "value"
+}
+
+module "child2" {
+  source = "./child2"
+  key = "value"
+}

--- a/terraform/transform_provider.go
+++ b/terraform/transform_provider.go
@@ -355,6 +355,13 @@ func (n *graphNodeCloseProvider) DotNode(name string, opts *dag.DotOpts) *dag.Do
 	}
 }
 
+// RemovableIfNotTargeted
+func (n *graphNodeCloseProvider) RemoveIfNotTargeted() bool {
+	// We need to add this so that this node will be removed if
+	// it isn't targeted or a dependency of a target.
+	return true
+}
+
 // graphNodeProviderConsumerDummy is a struct that never enters the real
 // graph (though it could to no ill effect). It implements
 // GraphNodeProviderConsumer and GraphNodeSubpath as a way to force

--- a/terraform/transform_provider_test.go
+++ b/terraform/transform_provider_test.go
@@ -147,11 +147,7 @@ func TestCloseProviderTransformer_withTargets(t *testing.T) {
 	}
 
 	actual := strings.TrimSpace(g.String())
-	expected := strings.TrimSpace(`
-provider.aws
-provider.aws (close)
-  provider.aws
-	`)
+	expected := strings.TrimSpace(``)
 	if actual != expected {
 		t.Fatalf("expected:%s\n\ngot:\n\n%s", expected, actual)
 	}


### PR DESCRIPTION
Fixes #12009

This is a simple change similar to #10911 where we need to exclude
providers that aren't targeted.