### PR TITLE
google_sql_database_instance: pricing_plan only applies to first gene…

### DIFF
--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -85,7 +85,7 @@ The required `settings` block supports:
 
 * `disk_type` - (Optional, Second Generation, Default: `PD_SSD`) The type of data disk: PD_SSD or PD_HDD.
 
-* `pricing_plan` - (Optional) Pricing plan for this instance, can be one of
+* `pricing_plan` - (Optional, First Generation) Pricing plan for this instance, can be one of
     `PER_USE` or `PACKAGE`.
 
 * `replication_type` - (Optional) Replication type for this instance, can be one


### PR DESCRIPTION
…ration instances

As stated in the second generation pricing documentation:

> Second Generation pricing is composed of the following charges:
> 
> Instance pricing
> Storage pricing
> Network pricing
> There is no choice of pricing plan.

cf. https://cloud.google.com/sql/pricing#2nd-gen-pricing