### PR TITLE
Remove the AWS Access Key and Secret Access keys from the`consul_agent_self` data source.

### DIFF
--- a/builtin/providers/consul/data_source_consul_agent_self.go
+++ b/builtin/providers/consul/data_source_consul_agent_self.go
@@ -86,11 +86,9 @@ const (
 )
 
 const (
-	agentSelfRetryJoinAWSAccessKeyID     = "access_key_id"
-	agentSelfRetryJoinAWSRegion          = "region"
-	agentSelfRetryJoinAWSSecretAccessKey = "secret_access_key"
-	agentSelfRetryJoinAWSTagKey          = "tag_key"
-	agentSelfRetryJoinAWSTagValue        = "tag_value"
+	agentSelfRetryJoinAWSRegion   = "region"
+	agentSelfRetryJoinAWSTagKey   = "tag_key"
+	agentSelfRetryJoinAWSTagValue = "tag_value"
 )
 
 const (
@@ -567,16 +565,6 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 						agentSelfRetryJoinAWSTagValue: &schema.Schema{
 							Type:     schema.TypeString,
 							Computed: true,
-						},
-						agentSelfRetryJoinAWSAccessKeyID: &schema.Schema{
-							Type:      schema.TypeString,
-							Computed:  true,
-							Sensitive: true,
-						},
-						agentSelfRetryJoinAWSSecretAccessKey: &schema.Schema{
-							Type:      schema.TypeString,
-							Computed:  true,
-							Sensitive: true,
 						},
 					},
 				},
@@ -1187,14 +1175,6 @@ func dataSourceConsulAgentSelfRead(d *schema.ResourceData, meta interface{}) err
 
 		if v, found := ec2Config["TagValue"]; found {
 			m[agentSelfRetryJoinAWSTagValue] = v.(string)
-		}
-
-		if v, found := ec2Config["AccessKeyID"]; found {
-			m[agentSelfRetryJoinAWSAccessKeyID] = v.(string)
-		}
-
-		if v, found := ec2Config["SecretAccessKey"]; found {
-			m[agentSelfRetryJoinAWSSecretAccessKey] = v.(string)
 		}
 
 		if err := d.Set(agentSelfRetryJoinEC2, m); err != nil {

--- a/website/source/docs/providers/consul/d/agent_self.html.markdown
+++ b/website/source/docs/providers/consul/d/agent_self.html.markdown
@@ -127,9 +127,7 @@ The following attributes are exported:
 
 ### Retry Join EC2 Attributes
 
-* [`access_key_id`](https://www.consul.io/docs/agent/options.html#access_key_id)
 * [`region`](https://www.consul.io/docs/agent/options.html#region)
-* [`secret_access_key`](https://www.consul.io/docs/agent/options.html#secret_access_key)
 * [`tag_key`](https://www.consul.io/docs/agent/options.html#tag_key)
 * [`tag_value`](https://www.consul.io/docs/agent/options.html#tag_value)
 


### PR DESCRIPTION
Pro tip: update consul!  I was using an old branch of Consul, not
`origin/master`.

Hat tip to @slackpad for pointing out that these keys were removed.  Insta-merge to `0-8-stable` after a review.