### PR TITLE
core: the great destroy provisioner 0.9 beta 1 bug fix

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -498,7 +498,7 @@ MISSING:
 	//
 	// For an input walk, computed values are okay to return because we're only
 	// looking for missing variables to prompt the user for.
-	if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkDestroy || i.Operation == walkInput {
+	if i.Operation == walkRefresh || i.Operation == walkPlanDestroy || i.Operation == walkInput {
 		return &unknownVariable, nil
 	}
 

--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -96,8 +96,10 @@ func (n *NodeAbstractResource) References() []string {
 		result = append(result, ReferencesFromConfig(c.RawCount)...)
 		result = append(result, ReferencesFromConfig(c.RawConfig)...)
 		for _, p := range c.Provisioners {
-			result = append(result, ReferencesFromConfig(p.ConnInfo)...)
-			result = append(result, ReferencesFromConfig(p.RawConfig)...)
+			if p.When == config.ProvisionerWhenCreate {
+				result = append(result, ReferencesFromConfig(p.ConnInfo)...)
+				result = append(result, ReferencesFromConfig(p.RawConfig)...)
+			}
 		}
 
 		return result

--- a/terraform/node_resource_destroy.go
+++ b/terraform/node_resource_destroy.go
@@ -68,6 +68,21 @@ func (n *NodeDestroyResource) ReferenceableName() []string {
 
 // GraphNodeReferencer, overriding NodeAbstractResource
 func (n *NodeDestroyResource) References() []string {
+	// If we have a config, then we need to include destroy-time dependencies
+	if c := n.Config; c != nil {
+		var result []string
+		for _, p := range c.Provisioners {
+			// We include conn info and config for destroy time provisioners
+			// as dependencies that we have.
+			if p.When == config.ProvisionerWhenDestroy {
+				result = append(result, ReferencesFromConfig(p.ConnInfo)...)
+				result = append(result, ReferencesFromConfig(p.RawConfig)...)
+			}
+		}
+
+		return result
+	}
+
 	return nil
 }
 

--- a/terraform/test-fixtures/apply-provisioner-destroy-module/child/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-module/child/main.tf
@@ -1,0 +1,10 @@
+variable "key" {}
+
+resource "aws_instance" "foo" {
+    foo = "bar"
+
+    provisioner "shell" {
+        foo  = "${var.key}"
+        when = "destroy"
+    }
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy-module/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-module/main.tf
@@ -1,0 +1,4 @@
+module "child" {
+    source = "./child"
+    key    = "value"
+}

--- a/terraform/test-fixtures/apply-provisioner-destroy-ref/main.tf
+++ b/terraform/test-fixtures/apply-provisioner-destroy-ref/main.tf
@@ -1,0 +1,12 @@
+resource "aws_instance" "bar" {
+    key = "hello"
+}
+
+resource "aws_instance" "foo" {
+    foo = "bar"
+
+    provisioner "shell" {
+        foo  = "${aws_instance.bar.key}"
+        when = "destroy"
+    }
+}

--- a/terraform/transform_destroy_edge.go
+++ b/terraform/transform_destroy_edge.go
@@ -159,9 +159,15 @@ func (t *DestroyEdgeTransformer) Transform(g *Graph) error {
 		// This part is a little bit weird but is the best way to
 		// find the dependencies we need to: build a graph and use the
 		// attach config and state transformers then ask for references.
-		node := &NodeAbstractResource{Addr: addr}
-		tempG.Add(node)
-		tempDestroyed = append(tempDestroyed, node)
+		abstract := &NodeAbstractResource{Addr: addr}
+		tempG.Add(abstract)
+		tempDestroyed = append(tempDestroyed, abstract)
+
+		// We also add the destroy version here since the destroy can
+		// depend on things that the creation doesn't (destroy provisioners).
+		destroy := &NodeDestroyResource{NodeAbstractResource: abstract}
+		tempG.Add(destroy)
+		tempDestroyed = append(tempDestroyed, destroy)
 	}
 
 	// Run the graph transforms so we have the information we need to


### PR DESCRIPTION
Fixes #12037 

This PR fixes multiple bugs related to destroy provisioners that I and others found during 0.9 beta 1. The only reported issue (#12037) is just one of the bugs fixed. 

I recommend reviewing one commit at a time as linked below.

The bugs fixed are:

  1. **Destroy resource should depend on required variables**: The destroy graph was never adding module variables because the destroy nodes weren't claiming they needed those values. This is #12037 and is 757217b

  2. **Resources should not be destroyed until destroy provisioners that depend on them are run**: Even if a resource doesn't depend on a resource during creation, it may during destruction due to destroy provisioners. The ReferenceTransformer had to be modified to support this. This is a1ec819

  3. **Interpolation failures in a destroy provisioner need to be surfaced**: The interpolator used to just mark these as "unknown" and continue. Our new graphs ensure we only interpolate when needed and any interpolation failure during destroy should be a failure. This is f6ab0bc

