### PR TITLE
config: validate backend configuration can't contain interpolations

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/hil"
 	"github.com/hashicorp/hil/ast"
 	"github.com/hashicorp/terraform/helper/hilmapstructure"
@@ -254,26 +253,7 @@ func (c *Config) Validate() error {
 
 	// Validate the Terraform config
 	if tf := c.Terraform; tf != nil {
-		if raw := tf.RequiredVersion; raw != "" {
-			// Check that the value has no interpolations
-			rc, err := NewRawConfig(map[string]interface{}{
-				"root": raw,
-			})
-			if err != nil {
-				errs = append(errs, fmt.Errorf(
-					"terraform.required_version: %s", err))
-			} else if len(rc.Interpolations) > 0 {
-				errs = append(errs, fmt.Errorf(
-					"terraform.required_version: cannot contain interpolations"))
-			} else {
-				// Check it is valid
-				_, err := version.NewConstraint(raw)
-				if err != nil {
-					errs = append(errs, fmt.Errorf(
-						"terraform.required_version: invalid syntax: %s", err))
-				}
-			}
-		}
+		errs = append(errs, c.Terraform.Validate()...)
 	}
 
 	vars := c.InterpolatedVariables()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -194,6 +194,13 @@ func TestConfigValidate_table(t *testing.T) {
 			false,
 			"",
 		},
+
+		{
+			"backend config with interpolations",
+			"validate-backend-interpolate",
+			true,
+			"cannot contain interp",
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/test-fixtures/validate-backend-interpolate/main.tf
+++ b/config/test-fixtures/validate-backend-interpolate/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "foo" {
+    key = "${var.var}"
+  }
+}


### PR DESCRIPTION
Validate that backend configuration doesn't contain interpolations.