### PR TITLE
provider/aws: aws_ecs_service should output service name along with err

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -240,7 +240,7 @@ func resourceAwsEcsServiceCreate(d *schema.ResourceData, meta interface{}) error
 		return nil
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("%s %q", err, d.Get("name").(string))
 	}
 
 	service := *out.Service


### PR DESCRIPTION
With the below error output it is difficult to figure out which services are broken. This PR adds an output of the service name after the returned error.

    3 error(s) occurred:

        aws_ecs_service.windows_ecs_service: InvalidParameterException: Creation of service was not idempotent. status code: 400, request id: 06a64b68-f5a1-11e6-941a-4b0d3923f3bc
        aws_ecs_service.windows_ecs_service: InvalidParameterException: Creation of service was not idempotent. status code: 400, request id: 06b2806d-f5a1-11e6-941a-4b0d3923f3bc
        aws_ecs_service.windows_ecs_service: InvalidParameterException: Creation of service was not idempotent. status code: 400, request id: 06a44ef2-f5a1-11e6-8d4a-1d0a5a451caf

