### PR TITLE
Add aws_ecr_repository_policy_statement

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -266,6 +266,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_ebs_volume":                               resourceAwsEbsVolume(),
 			"aws_ecr_repository":                           resourceAwsEcrRepository(),
 			"aws_ecr_repository_policy":                    resourceAwsEcrRepositoryPolicy(),
+			"aws_ecr_repository_policy_statement":          resourceAwsEcrRepositoryPolicyStatement(),
 			"aws_ecs_cluster":                              resourceAwsEcsCluster(),
 			"aws_ecs_service":                              resourceAwsEcsService(),
 			"aws_ecs_task_definition":                      resourceAwsEcsTaskDefinition(),

--- a/builtin/providers/aws/resource_aws_ecr_repository_policy_statement.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_policy_statement.go
@@ -1,0 +1,294 @@
+package aws
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type ecrPolicy struct {
+	Version    string                `json:",omitempty"`
+	ID         string                `json:",omitempty"`
+	Statements []*ecrPolicyStatement `json:"Statement"`
+}
+
+type ecrPolicyStatement struct {
+	Sid           string
+	Effect        string      `json:",omitempty"`
+	Actions       interface{} `json:"Action,omitempty"`
+	NotActions    interface{} `json:"NotAction,omitempty"`
+	Resources     interface{} `json:"Resource,omitempty"`
+	NotResources  interface{} `json:"NotResource,omitempty"`
+	Principals    interface{} `json:"Principal,omitempty"`
+	NotPrincipals interface{} `json:"NotPrincipal,omitempty"`
+	Conditions    interface{} `json:"Condition,omitempty"`
+}
+
+func resourceAwsEcrRepositoryPolicyStatement() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsEcrRepositoryPolicyStatementCreate,
+		Read:   resourceAwsEcrRepositoryPolicyStatementRead,
+		Update: resourceAwsEcrRepositoryPolicyStatementUpdate,
+		Delete: resourceAwsEcrRepositoryPolicyStatementDelete,
+
+		Schema: map[string]*schema.Schema{
+			"sid": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"sid_prefix"},
+			},
+
+			"sid_prefix": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"repository": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"statement": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"registry_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsEcrRepositoryPolicyStatementCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
+	var sid string
+
+	conn := meta.(*AWSClient).ecrconn
+	registryID := d.Get("registry_id").(string)
+	repository := d.Get("repository").(string)
+	stmtText := d.Get("statement").(string)
+
+	if v, ok := d.GetOk("sid"); ok {
+		sid = v.(string)
+	} else if v, ok := d.GetOk("sid_prefix"); ok {
+		sid = resource.PrefixedUniqueId(v.(string))
+	} else {
+		sid = resource.UniqueId()
+	}
+
+	awsMutexKV.Lock(repository)
+	defer awsMutexKV.Unlock(repository)
+
+	_, policy, err := readOrBuildEcrPolicy(conn, registryID, repository)
+	if err != nil {
+		return err
+	}
+
+	index, found := findEcrPolicyStatement(policy, sid)
+
+	statement := &ecrPolicyStatement{}
+	if found {
+		statement = policy.Statements[index]
+	} else {
+		policy.Statements = append(policy.Statements, statement)
+	}
+
+	if err := json.Unmarshal([]byte(stmtText), statement); err != nil {
+		return err
+	}
+
+	// Force Sid to be the one defined in the resource
+	statement.Sid = sid
+
+	repositoryPolicy, err := resourceAwsEcrRepositoryPolicyStatementUpdateWith(d, meta, policy)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(sid)
+	d.Set("sid", sid)
+	d.Set("repository", *repositoryPolicy.RepositoryName)
+	d.Set("registry_id", repositoryPolicy.RegistryId)
+
+	return nil
+}
+
+func resourceAwsEcrRepositoryPolicyStatementCreate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAwsEcrRepositoryPolicyStatementCreateOrUpdate(d, meta)
+}
+
+func resourceAwsEcrRepositoryPolicyStatementRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+	sid := d.Get("sid").(string)
+	registryID := d.Get("registry_id").(string)
+	repository := d.Get("repository").(string)
+
+	awsMutexKV.Lock(repository)
+	defer awsMutexKV.Unlock(repository)
+
+	log.Printf("[DEBUG] Reading repository policy statement %s", d.Id())
+
+	repositoryPolicy, policy, err := readOrBuildEcrPolicy(conn, registryID, repository)
+	if err != nil {
+		return err
+	}
+
+	index, found := findEcrPolicyStatement(policy, sid)
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	statement := policy.Statements[index]
+
+	d.SetId(statement.Sid)
+	d.Set("sid", statement.Sid)
+	d.Set("registry_id", repositoryPolicy.RegistryId)
+	d.Set("repository", *repositoryPolicy.RepositoryName)
+
+	return nil
+}
+
+func resourceAwsEcrRepositoryPolicyStatementUpdate(d *schema.ResourceData, meta interface{}) error {
+	return resourceAwsEcrRepositoryPolicyStatementCreateOrUpdate(d, meta)
+}
+
+func resourceAwsEcrRepositoryPolicyStatementDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ecrconn
+	sid := d.Get("sid").(string)
+	registryID := d.Get("registry_id").(string)
+	repository := d.Get("repository").(string)
+
+	awsMutexKV.Lock(repository)
+	defer awsMutexKV.Unlock(repository)
+
+	log.Printf("[DEBUG] Reading repository policy statement %s", d.Id())
+
+	_, policy, err := readOrBuildEcrPolicy(conn, registryID, repository)
+	if err != nil {
+		return err
+	}
+
+	index, found := findEcrPolicyStatement(policy, sid)
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	policy.Statements = append(policy.Statements[:index], policy.Statements[index+1:]...)
+
+	_, err = resourceAwsEcrRepositoryPolicyStatementUpdateWith(d, meta, policy)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] repository policy statement %s deleted.", d.Id())
+
+	return nil
+}
+
+func resourceAwsEcrRepositoryPolicyStatementUpdateWith(d *schema.ResourceData, meta interface{}, policy *ecrPolicy) (*ecr.SetRepositoryPolicyOutput, error) {
+	conn := meta.(*AWSClient).ecrconn
+	registryID := d.Get("registry_id").(string)
+	repository := d.Get("repository").(string)
+
+	if len(policy.Statements) == 0 {
+		input := ecr.DeleteRepositoryPolicyInput{
+			RepositoryName: aws.String(repository),
+		}
+
+		if registryID != "" {
+			input.RegistryId = aws.String(registryID)
+		}
+
+		_, err := conn.DeleteRepositoryPolicy(&input)
+
+		if err != nil {
+			return nil, err
+		}
+
+		return nil, nil
+	}
+
+	policyText, err := json.Marshal(policy)
+	if err != nil {
+		return nil, err
+	}
+
+	input := ecr.SetRepositoryPolicyInput{
+		RepositoryName: aws.String(repository),
+		PolicyText:     aws.String(string(policyText)),
+	}
+
+	if registryID != "" {
+		input.RegistryId = aws.String(registryID)
+	}
+
+	out, err := conn.SetRepositoryPolicy(&input)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+func readOrBuildEcrPolicy(conn *ecr.ECR, registryID string, repositoryName string) (*ecr.GetRepositoryPolicyOutput, *ecrPolicy, error) {
+	input := &ecr.GetRepositoryPolicyInput{
+		RepositoryName: aws.String(repositoryName),
+	}
+
+	if registryID != "" {
+		input.RegistryId = aws.String(registryID)
+	}
+
+	out, err := conn.GetRepositoryPolicy(input)
+
+	if err != nil {
+		if ecrerr, ok := err.(awserr.Error); ok {
+			switch ecrerr.Code() {
+			case "RepositoryNotFoundException", "RepositoryPolicyNotFoundException":
+				// Do nothing
+			default:
+				return nil, nil, err
+			}
+		} else {
+			return nil, nil, err
+		}
+	}
+
+	policy := &ecrPolicy{}
+	if out != nil && out.PolicyText != nil {
+		if err := json.Unmarshal([]byte(*out.PolicyText), policy); err != nil {
+			return nil, nil, err
+		}
+	} else {
+		policy.Version = "2008-10-17"
+	}
+
+	if policy.Statements == nil {
+		policy.Statements = make([]*ecrPolicyStatement, 0)
+	}
+
+	return out, policy, nil
+}
+
+func findEcrPolicyStatement(policy *ecrPolicy, sid string) (int, bool) {
+	for i, statement := range policy.Statements {
+		if statement.Sid == sid {
+			return i, true
+		}
+	}
+
+	return 0, false
+}

--- a/builtin/providers/aws/resource_aws_ecr_repository_policy_statement_test.go
+++ b/builtin/providers/aws/resource_aws_ecr_repository_policy_statement_test.go
@@ -1,0 +1,220 @@
+package aws
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSEcrRepositoryPolicyStatement_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSEcrRepositoryPolicyStatementDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEcrRepositoryPolicyStatement,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryPolicyStatementExists("aws_ecr_repository_policy_statement.default"),
+					testAccCheckAWSEcrRepositoryPolicyStatementExists("aws_ecr_repository_policy_statement.other"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSEcrRepositoryPolicyStatementWithoutOther,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEcrRepositoryPolicyStatementIntegrity("aws_ecr_repository.foo", "testpolicy", "anotherpolicy"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSEcrRepositoryPolicyStatementDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).ecrconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_ecr_repository_policy_statement" {
+			continue
+		}
+
+		_, err := conn.GetRepositoryPolicy(&ecr.GetRepositoryPolicyInput{
+			RegistryId:     aws.String(rs.Primary.Attributes["registry_id"]),
+			RepositoryName: aws.String(rs.Primary.Attributes["repository"]),
+		})
+
+		if err != nil {
+			if ecrerr, ok := err.(awserr.Error); ok && ecrerr.Code() == "RepositoryNotFoundException" {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckAWSEcrRepositoryPolicyStatementExists(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ecrconn
+		rs, ok := s.RootModule().Resources[name]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		out, err := conn.GetRepositoryPolicy(&ecr.GetRepositoryPolicyInput{
+			RegistryId:     aws.String(rs.Primary.Attributes["registry_id"]),
+			RepositoryName: aws.String(rs.Primary.Attributes["repository"]),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		policy := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(*out.PolicyText), &policy); err != nil {
+			return err
+		}
+
+		stmts := policy["Statement"].([]interface{})
+		found := false
+
+		for _, s := range stmts {
+			stmt := s.(map[string]interface{})
+
+			if stmt["Sid"] == rs.Primary.Attributes["sid"] {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return fmt.Errorf("Not found on AWS: %s", name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSEcrRepositoryPolicyStatementIntegrity(repo, sid, removedSid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ecrconn
+		rs, ok := s.RootModule().Resources[repo]
+
+		if !ok {
+			return fmt.Errorf("Repository not found: %s", repo)
+		}
+
+		out, err := conn.GetRepositoryPolicy(&ecr.GetRepositoryPolicyInput{
+			RegistryId:     aws.String(rs.Primary.Attributes["registry_id"]),
+			RepositoryName: aws.String(rs.Primary.Attributes["name"]),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		policy := make(map[string]interface{})
+		if err := json.Unmarshal([]byte(*out.PolicyText), &policy); err != nil {
+			return err
+		}
+
+		stmts := policy["Statement"].([]interface{})
+		sidFound := false
+		removedFound := false
+
+		for _, s := range stmts {
+			stmt := s.(map[string]interface{})
+
+			if stmt["Sid"] == sid {
+				sidFound = true
+			}
+
+			if stmt["Sid"] == removedSid {
+				removedFound = true
+			}
+		}
+
+		if !sidFound {
+			return fmt.Errorf("Not found on AWS: %s", sid)
+		}
+
+		if removedFound {
+			return fmt.Errorf("Dangling resource found on AWS: %s", removedSid)
+		}
+
+		return nil
+	}
+}
+
+var testAccAWSEcrRepositoryPolicyStatement = `
+# ECR initially only available in us-east-1
+# https://aws.amazon.com/blogs/aws/ec2-container-registry-now-generally-available/
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_ecr_repository" "foo" {
+	name = "bar"
+}
+
+resource "aws_ecr_repository_policy_statement" "default" {
+	repository = "${aws_ecr_repository.foo.name}"
+	sid = "testpolicy"
+	statement = <<EOF
+{
+	"Effect": "Allow",
+	"Principal": "*",
+	"Action": [
+		"ecr:ListImages"
+	]
+}
+EOF
+}
+
+resource "aws_ecr_repository_policy_statement" "other" {
+	repository = "${aws_ecr_repository.foo.name}"
+	sid = "anotherpolicy"
+	statement = <<EOF
+{
+	"Effect": "Deny",
+	"Principal": "*",
+	"Action": [
+		"ecr:ListImages"
+	]
+}
+EOF
+}
+`
+
+var testAccAWSEcrRepositoryPolicyStatementWithoutOther = `
+# ECR initially only available in us-east-1
+# https://aws.amazon.com/blogs/aws/ec2-container-registry-now-generally-available/
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_ecr_repository" "foo" {
+	name = "bar"
+}
+
+resource "aws_ecr_repository_policy_statement" "default" {
+	repository = "${aws_ecr_repository.foo.name}"
+	sid = "testpolicy"
+	statement = <<EOF
+{
+	"Effect": "Allow",
+	"Principal": "*",
+	"Action": [
+		"ecr:ListImages"
+	]
+}
+EOF
+}
+`

--- a/website/source/docs/providers/aws/r/ecr_repository_policy_statement.html.markdown
+++ b/website/source/docs/providers/aws/r/ecr_repository_policy_statement.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "aws"
+page_title: "AWS: aws_ecr_repository_policy_statement"
+sidebar_current: "docs-aws-resource-ecr-repository-policy-statement"
+description: |-
+  Provides an ECR Repository Policy.
+---
+
+# aws\_ecr\_repository\_policy\_statement
+
+Provides a single ECR repository policy statement. This is useful when you need to inject statements from different modules to the same ecr_repository, as only one policy document is allowed by AWS.
+
+Please note that this can't be used with aws_ecr_repository_policy, as one might override the other.
+
+~> **NOTE on ECR Availability**: The EC2 Container Registry is not yet rolled out
+in all regions - available regions are listed  
+[the AWS Docs](https://docs.aws.amazon.com/general/latest/gr/rande.html#ecr_region).
+
+## Example Usage
+
+```
+resource "aws_ecr_repository" "foo" {
+  name = "bar"
+}
+
+resource "aws_ecr_repository_policy_statement" "foostatement" {
+  repository = "${aws_ecr_repository.foo.name}"
+  sid = "new policy"
+
+  statement = <<EOF
+{
+    "Effect": "Allow",
+    "Principal": "*",
+    "Action": [
+        "ecr:GetDownloadUrlForLayer",
+        "ecr:BatchGetImage",
+        "ecr:BatchCheckLayerAvailability",
+        "ecr:PutImage",
+        "ecr:InitiateLayerUpload",
+        "ecr:UploadLayerPart",
+        "ecr:CompleteLayerUpload",
+        "ecr:DescribeRepositories",
+        "ecr:GetRepositoryPolicy",
+        "ecr:ListImages",
+        "ecr:DeleteRepository",
+        "ecr:BatchDeleteImage",
+        "ecr:SetRepositoryPolicy",
+        "ecr:DeleteRepositoryPolicy"
+    ]
+}
+EOF
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `sid` - (Optional) Sid of the statement to apply to the repository police. If omitted, Terraform will
+assign a random, unique name.
+* `sid_prefix` - (Optional, Forces new resource) Creates a unique Sid beginning with the specified
+  prefix. Conflicts with `sid`.
+* `repository` - (Required) Name of the repository to apply the policy.
+* `statement` - (Required) The statement definition. This is a JSON formatted string.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `sid` - The Sid of the statement.
+* `repository` - The name of the repository.
+* `registry_id` - The registry ID where the repository was created.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -540,6 +540,10 @@
                             <a href="/docs/providers/aws/r/ecr_repository_policy.html">aws_ecr_repository_policy</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-ecr-repository-policy-statement") %>>
+                            <a href="/docs/providers/aws/r/ecr_repository_policy_statement.html">aws_ecr_repository_policy_statement</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-ecs-cluster") %>>
                             <a href="/docs/providers/aws/r/ecs_cluster.html">aws_ecs_cluster</a>
                         </li>


### PR DESCRIPTION
This resource allows to manage ECR policy statements as single resources, allowing to spread them across several modules. This is useful as a ECR repository can have only one policy document.

It was implemented in the same way that `aws_security_group_rule` works: It locks the resource mutex and applies the diff (add, remove or change the statement) over the policy document and applies it on the repository.