### PR TITLE
website/layouts fix Icinga2 provider link

### DIFF
--- a/website/source/layouts/icinga2.erb
+++ b/website/source/layouts/icinga2.erb
@@ -7,7 +7,7 @@
 				</li>
 
 				<li<%= sidebar_current("docs-icinga2-index") %>>
-					<a href="/docs/providers/influxdb/index.html">Icinga2 Provider</a>
+					<a href="/docs/providers/icinga2/index.html">Icinga2 Provider</a>
 				</li>
 
 				<li<%= sidebar_current(/^docs-icinga2-resource/) %>>


### PR DESCRIPTION
Hello!

There is a small bug in the Icinga2 layout file. "Icinga2 Provider" relays to the InfluxDB provider. Here is a fix. Could you please merge it into the master branch? Thanks in advance!

Best,

Emil