### PR TITLE
website: Fixes data entry errors on /d/aws_db_instance

### DIFF
--- a/website/source/docs/providers/aws/d/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/d/db_instance.html.markdown
@@ -6,9 +6,9 @@ description: |-
   Get information on an RDS Database Instance.
 ---
 
-# aws\_ebs\_snapshot
+# aws\_db\_instance
 
-Use this data source to get information about an EBS Snapshot for use when provisioning EBS Volumes
+Use this data source to get information about an RDS instance
 
 ## Example Usage
 


### PR DESCRIPTION
Corrected so \<h1\> shows correct topic and intro text is applicable. This applies to shipping versions of terraform.