### PR TITLE
provider/aws: Data source aws_caller_identity exposes resource from ARN

### DIFF
--- a/builtin/providers/aws/auth_helpers_test.go
+++ b/builtin/providers/aws/auth_helpers_test.go
@@ -32,7 +32,7 @@ func TestAWSGetAccountInfo_shouldBeValid_fromEC2Role(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	part, id, err := GetAccountInfo(iamConn, stsConn, ec2rolecreds.ProviderName)
+	part, id, resource, err := GetAccountInfo(iamConn, stsConn, ec2rolecreds.ProviderName)
 	if err != nil {
 		t.Fatalf("Getting account ID from EC2 metadata API failed: %s", err)
 	}
@@ -45,6 +45,11 @@ func TestAWSGetAccountInfo_shouldBeValid_fromEC2Role(t *testing.T) {
 	expectedAccountId := "123456789013"
 	if id != expectedAccountId {
 		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+	}
+
+	expectedResource := "instance-profile/my-instance-profile"
+	if resource != expectedResource {
+		t.Fatalf("Expected resource: %s, given: %s", expectedResource, resource)
 	}
 }
 
@@ -64,7 +69,7 @@ func TestAWSGetAccountInfo_shouldBeValid_EC2RoleHasPriority(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	part, id, err := GetAccountInfo(iamConn, stsConn, ec2rolecreds.ProviderName)
+	part, id, resource, err := GetAccountInfo(iamConn, stsConn, ec2rolecreds.ProviderName)
 	if err != nil {
 		t.Fatalf("Getting account ID from EC2 metadata API failed: %s", err)
 	}
@@ -77,6 +82,11 @@ func TestAWSGetAccountInfo_shouldBeValid_EC2RoleHasPriority(t *testing.T) {
 	expectedAccountId := "123456789013"
 	if id != expectedAccountId {
 		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+	}
+
+	expectedResource := "instance-profile/my-instance-profile"
+	if resource != expectedResource {
+		t.Fatalf("Expected resource: %s, given: %s", expectedResource, resource)
 	}
 }
 
@@ -91,7 +101,7 @@ func TestAWSGetAccountInfo_shouldBeValid_fromIamUser(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	part, id, err := GetAccountInfo(iamConn, stsConn, "")
+	part, id, resource, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via GetUser failed: %s", err)
 	}
@@ -104,6 +114,11 @@ func TestAWSGetAccountInfo_shouldBeValid_fromIamUser(t *testing.T) {
 	expectedAccountId := "123456789012"
 	if id != expectedAccountId {
 		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+	}
+
+	expectedResource := "user/division_abc/subdivision_xyz/Bob"
+	if resource != expectedResource {
+		t.Fatalf("Expected resource: %s, given: %s", expectedResource, resource)
 	}
 }
 
@@ -121,7 +136,7 @@ func TestAWSGetAccountInfo_shouldBeValid_fromGetCallerIdentity(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	part, id, err := GetAccountInfo(iamConn, stsConn, "")
+	part, id, resource, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via GetUser failed: %s", err)
 	}
@@ -134,6 +149,11 @@ func TestAWSGetAccountInfo_shouldBeValid_fromGetCallerIdentity(t *testing.T) {
 	expectedAccountId := "123456789012"
 	if id != expectedAccountId {
 		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+	}
+
+	expectedResource := "user/Alice"
+	if resource != expectedResource {
+		t.Fatalf("Expected resource: %s, given: %s", expectedResource, resource)
 	}
 }
 
@@ -155,7 +175,7 @@ func TestAWSGetAccountInfo_shouldBeValid_fromIamListRoles(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	part, id, err := GetAccountInfo(iamConn, stsConn, "")
+	part, id, resource, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via ListRoles failed: %s", err)
 	}
@@ -168,6 +188,11 @@ func TestAWSGetAccountInfo_shouldBeValid_fromIamListRoles(t *testing.T) {
 	expectedAccountId := "123456789012"
 	if id != expectedAccountId {
 		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+	}
+
+	expectedResource := "role/elasticbeanstalk-role"
+	if resource != expectedResource {
+		t.Fatalf("Expected resource: %s, given: %s", expectedResource, resource)
 	}
 }
 
@@ -185,7 +210,7 @@ func TestAWSGetAccountInfo_shouldBeValid_federatedRole(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	part, id, err := GetAccountInfo(iamConn, stsConn, "")
+	part, id, resource, err := GetAccountInfo(iamConn, stsConn, "")
 	if err != nil {
 		t.Fatalf("Getting account ID via ListRoles failed: %s", err)
 	}
@@ -198,6 +223,11 @@ func TestAWSGetAccountInfo_shouldBeValid_federatedRole(t *testing.T) {
 	expectedAccountId := "123456789012"
 	if id != expectedAccountId {
 		t.Fatalf("Expected account ID: %s, given: %s", expectedAccountId, id)
+	}
+
+	expectedResource := "role/elasticbeanstalk-role"
+	if resource != expectedResource {
+		t.Fatalf("Expected resource: %s, given: %s", expectedResource, resource)
 	}
 }
 
@@ -215,7 +245,7 @@ func TestAWSGetAccountInfo_shouldError_unauthorizedFromIam(t *testing.T) {
 	ts, iamConn, stsConn := getMockedAwsIamStsApi(iamEndpoints)
 	defer ts()
 
-	part, id, err := GetAccountInfo(iamConn, stsConn, "")
+	part, id, resource, err := GetAccountInfo(iamConn, stsConn, "")
 	if err == nil {
 		t.Fatal("Expected error when getting account ID")
 	}
@@ -227,13 +257,18 @@ func TestAWSGetAccountInfo_shouldError_unauthorizedFromIam(t *testing.T) {
 	if id != "" {
 		t.Fatalf("Expected no account ID, given: %s", id)
 	}
+
+	if resource != "" {
+		t.Fatalf("Expected no resource, given: %s", id)
+	}
 }
 
 func TestAWSParseAccountInfoFromArn(t *testing.T) {
 	validArn := "arn:aws:iam::101636750127:instance-profile/aws-elasticbeanstalk-ec2-role"
 	expectedPart := "aws"
 	expectedId := "101636750127"
-	part, id, err := parseAccountInfoFromArn(validArn)
+	expectedResource := "instance-profile/aws-elasticbeanstalk-ec2-role"
+	part, id, resource, err := parseAccountInfoFromArn(validArn)
 	if err != nil {
 		t.Fatalf("Expected no error when parsing valid ARN: %s", err)
 	}
@@ -243,9 +278,12 @@ func TestAWSParseAccountInfoFromArn(t *testing.T) {
 	if id != expectedId {
 		t.Fatalf("Parsed id doesn't match with expected (%q != %q)", id, expectedId)
 	}
+	if resource != expectedResource {
+		t.Fatalf("Parsed resource doesn't match with expected (%q != %q)", resource, expectedResource)
+	}
 
 	invalidArn := "blablah"
-	part, id, err = parseAccountInfoFromArn(invalidArn)
+	part, id, resource, err = parseAccountInfoFromArn(invalidArn)
 	if err == nil {
 		t.Fatalf("Expected error when parsing invalid ARN (%q)", invalidArn)
 	}

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -135,6 +135,7 @@ type AWSClient struct {
 	r53conn               *route53.Route53
 	partition             string
 	accountid             string
+	resource              string
 	region                string
 	rdsconn               *rds.RDS
 	iamconn               *iam.IAM
@@ -258,10 +259,11 @@ func (c *Config) Client() (interface{}, error) {
 	}
 
 	if !c.SkipRequestingAccountId {
-		partition, accountId, err := GetAccountInfo(client.iamconn, client.stsconn, cp.ProviderName)
+		partition, accountId, resource, err := GetAccountInfo(client.iamconn, client.stsconn, cp.ProviderName)
 		if err == nil {
 			client.partition = partition
 			client.accountid = accountId
+			client.resource = resource
 		}
 	}
 

--- a/builtin/providers/aws/data_source_aws_caller_identity.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"time"
 
-	"github.com/aws/aws-sdk-go/service/iam"
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -19,11 +17,7 @@ func dataSourceAwsCallerIdentity() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"user_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"user_name": {
+			"resource": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -43,14 +37,8 @@ func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) e
 			"skip_requesting_account_id is not set on the AWS provider.")
 	}
 
-	user, err := client.iamconn.GetUser(&iam.GetUserInput{})
-	if err != nil {
-		return errwrap.Wrapf("Error retrieving current IAM user: {{err}}", err)
-	}
-
-	log.Printf("[DEBUG] Setting AWS Account ID to %s, user_id %s, user_name %s", client.accountid, *user.User.UserId, *user.User.UserName)
+	log.Printf("[DEBUG] Setting AWS Account ID to %s, resource to %s", client.accountid, client.resource)
 	d.Set("account_id", meta.(*AWSClient).accountid)
-	d.Set("user_id", *user.User.UserId)
-	d.Set("user_name", *user.User.UserName)
+	d.Set("resource", meta.(*AWSClient).resource)
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_caller_identity_test.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity_test.go
@@ -34,17 +34,14 @@ func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Account Id resource ID not set.")
 		}
 
-		expected := testAccProvider.Meta().(*AWSClient).accountid
-		if rs.Primary.Attributes["account_id"] != expected {
-			return fmt.Errorf("Incorrect Account ID: expected %q, got %q", expected, rs.Primary.Attributes["account_id"])
+		expectedAccountId := testAccProvider.Meta().(*AWSClient).accountid
+		expectedResource := testAccProvider.Meta().(*AWSClient).resource
+		if rs.Primary.Attributes["account_id"] != expectedAccountId {
+			return fmt.Errorf("Incorrect Account ID: expected %q, got %q", expectedAccountId, rs.Primary.Attributes["account_id"])
 		}
 
-		if rs.Primary.Attributes["user_id"] == "" {
-			return fmt.Errorf("Missing user_id")
-		}
-
-		if rs.Primary.Attributes["user_id"] == "" {
-			return fmt.Errorf("Missing user_name")
+		if rs.Primary.Attributes["resource"] == expectedResource {
+			return fmt.Errorf("Incorrect resource: expected %q, got %q", expectedResource, rs.Primary.Attributes["resource"])
 		}
 
 		return nil

--- a/builtin/providers/aws/data_source_aws_caller_identity_test.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity_test.go
@@ -39,6 +39,14 @@ func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Incorrect Account ID: expected %q, got %q", expected, rs.Primary.Attributes["account_id"])
 		}
 
+		if rs.Primary.Attributes["user_id"] == "" {
+			return fmt.Errorf("Missing user_id")
+		}
+
+		if rs.Primary.Attributes["user_id"] == "" {
+			return fmt.Errorf("Missing user_name")
+		}
+
 		return nil
 	}
 }

--- a/website/source/docs/providers/aws/d/caller_identity.html.markdown
+++ b/website/source/docs/providers/aws/d/caller_identity.html.markdown
@@ -33,3 +33,5 @@ There are no arguments available for this data source.
 ## Attributes Reference
 
 `account_id` is set to the ID of the AWS account.
+
+`resource` is set to the resource name used to authenticate.


### PR DESCRIPTION
I was unable to find a data source that provides the IAM user name and ID for the access key currently being used. This is useful for environments where many users are creating resources and we want to attribute resources to the user who created them by adding a tag, for instance.

I'd be happy to break this out into a new data source - it seemed like there were already several sources for information about the access key in use.