### PR TITLE
provider/datadog: Update go-datadog-api for #1106

### DIFF
--- a/vendor/github.com/zorkian/go-datadog-api/client.go
+++ b/vendor/github.com/zorkian/go-datadog-api/client.go
@@ -44,6 +44,12 @@ func NewClient(apiKey, appKey string) *Client {
 	}
 }
 
+// SetKeys changes the value of apiKey and appKey.
+func (c *Client) SetKeys(apiKey, appKey string) {
+	c.apiKey = apiKey
+	c.appKey = appKey
+}
+
 // Validate checks if the API and application keys are valid.
 func (client *Client) Validate() (bool, error) {
 	var bodyreader io.Reader

--- a/vendor/github.com/zorkian/go-datadog-api/request.go
+++ b/vendor/github.com/zorkian/go-datadog-api/request.go
@@ -69,9 +69,9 @@ func (client *Client) doJsonRequest(method, api string,
 		req.Header.Add("Content-Type", "application/json")
 	}
 
-	// Perform the request and retry it if it's not a POST request
+	// Perform the request and retry it if it's not a POST or PUT request
 	var resp *http.Response
-	if method == "POST" {
+	if method == "POST" || method == "PUT" {
 		resp, err = client.HttpClient.Do(req)
 	} else {
 		resp, err = client.doRequestWithRetries(req, client.RetryTimeout)

--- a/vendor/github.com/zorkian/go-datadog-api/series.go
+++ b/vendor/github.com/zorkian/go-datadog-api/series.go
@@ -22,6 +22,7 @@ type Metric struct {
 	Type   string      `json:"type,omitempty"`
 	Host   string      `json:"host,omitempty"`
 	Tags   []string    `json:"tags,omitempty"`
+	Unit   string	   `json:"unit,omitempty"`
 }
 
 // Series represents a collection of data points we get when we query for timeseries data

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2144,16 +2144,16 @@
 			"revision": "85659debe44fab5792fc92cf755c04b115b9dc19"
 		},
 		{
-			"checksumSHA1": "OUZ1FFXyKs+Cfg9M9rmXqqweQck=",
-			"path": "github.com/miekg/dns",
-			"revision": "db96a2b759cdef4f11a34506a42eb8d1290c598e",
-			"revisionTime": "2016-07-26T03:20:27Z"
-		},
-		{
 			"checksumSHA1": "GSum+utW01N3KeMdvAPnsW0TemM=",
 			"path": "github.com/michaelklishin/rabbit-hole",
 			"revision": "88550829bcdcf614361c73459c903578eb44074e",
 			"revisionTime": "2016-07-06T11:10:56Z"
+		},
+		{
+			"checksumSHA1": "OUZ1FFXyKs+Cfg9M9rmXqqweQck=",
+			"path": "github.com/miekg/dns",
+			"revision": "db96a2b759cdef4f11a34506a42eb8d1290c598e",
+			"revisionTime": "2016-07-26T03:20:27Z"
 		},
 		{
 			"checksumSHA1": "7niW29CvYceZ6zbia6b/LT+yD/M=",
@@ -2653,10 +2653,10 @@
 			"revision": "75ce5fbba34b1912a3641adbd58cf317d7315821"
 		},
 		{
-			"checksumSHA1": "uynUzdKeOsfi7flpYWFx835Nafo=",
+			"checksumSHA1": "/b+DVZKOPuFdFPZGV/o+l3QBK2w=",
 			"path": "github.com/zorkian/go-datadog-api",
-			"revision": "6308094e4aca46eb16a227b50be29772242bf3aa",
-			"revisionTime": "2017-02-02T00:47:50Z"
+			"revision": "c83bf4fdbc4878fbce31fe4ae2f9ca109a570771",
+			"revisionTime": "2017-02-18T20:48:08Z"
 		},
 		{
 			"checksumSHA1": "9x64JhJGo6z8TS0Q33cGcR64kjA=",


### PR DESCRIPTION
This PR updates go-datadog-api to `c83bf4fd` in order to solve #11106, and should also make #11107 less likely to manifest.

The relevant PR is: https://github.com/zorkian/go-datadog-api/pull/91

I'm not sure about the `github.com/miekg/dns` changes. I ran `govendor fetch github.com/zorkian/go-datadog-api` but am very unfamiliar with govendor.

Thanks!