### PR TITLE
Move AWS Config to be alphabetically correct

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -300,6 +300,29 @@
                     </ul>
                 </li>
 
+                <li<%= sidebar_current(/^docs-aws-resource-config/) %>>
+                    <a href="#">Config Resources</a>
+                    <ul class="nav nav-visible">
+
+                        <li<%= sidebar_current("docs-aws-resource-config-config-rule") %>>
+                            <a href="/docs/providers/aws/r/config_config_rule.html">aws_config_config_rule</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-config-configuration-recorder") %>>
+                            <a href="/docs/providers/aws/r/config_configuration_recorder.html">aws_config_configuration_recorder</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-config-configuration-recorder-status") %>>
+                            <a href="/docs/providers/aws/r/config_configuration_recorder_status.html">aws_config_configuration_recorder_status</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-config-delivery-channel") %>>
+                            <a href="/docs/providers/aws/r/config_delivery_channel.html">aws_config_delivery_channel</a>
+                        </li>
+
+                    </ul>
+                </li>
+
                 <li<%= sidebar_current(/^docs-aws-resource-dms/) %>>
                     <a href="#">Database Migration Service</a>
                     <ul class="nav nav-visible">
@@ -322,29 +345,6 @@
 
                         <li<%= sidebar_current("docs-aws-resource-dms-replication-task") %>>
                             <a href="/docs/providers/aws/r/dms_replication_task.html">aws_dms_replication_task</a>
-                        </li>
-
-                    </ul>
-                </li>
-
-                <li<%= sidebar_current(/^docs-aws-resource-config/) %>>
-                    <a href="#">Config Resources</a>
-                    <ul class="nav nav-visible">
-
-                        <li<%= sidebar_current("docs-aws-resource-config-config-rule") %>>
-                            <a href="/docs/providers/aws/r/config_config_rule.html">aws_config_config_rule</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-aws-resource-config-configuration-recorder") %>>
-                            <a href="/docs/providers/aws/r/config_configuration_recorder.html">aws_config_configuration_recorder</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-aws-resource-config-configuration-recorder-status") %>>
-                            <a href="/docs/providers/aws/r/config_configuration_recorder_status.html">aws_config_configuration_recorder_status</a>
-                        </li>
-
-                        <li<%= sidebar_current("docs-aws-resource-config-delivery-channel") %>>
-                            <a href="/docs/providers/aws/r/config_delivery_channel.html">aws_config_delivery_channel</a>
                         </li>
 
                     </ul>


### PR DESCRIPTION
Noticed the recently added AWS Config resources are not quite in the right place in the sidebar for the documentation. This PR just shuffles the links to the right place.