### PR TITLE
website/docs fix #5448 - vm page was changed

### DIFF
--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -15,7 +15,7 @@ modify, and delete virtual machines.
 
 ```
 resource "vsphere_virtual_machine" "web" {
-  name   = "terraform_web"
+  name   = "terraform-web"
   vcpu   = 2
   memory = 4096
 
@@ -61,7 +61,7 @@ resource "vsphere_virtual_machine" "lb" {
 
 The following arguments are supported:
 
-* `name` - (Required) The virtual machine name
+* `name` - (Required) The virtual machine name (cannot contain underscores and must be less than 15 characters)
 * `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual machine
 * `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual machine
 * `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve physical memory resource; defaults to 0 (means not to reserve)


### PR DESCRIPTION
Hello!

According to issue #5448 I made more changes. "vsphere_virtual_machine" contains an underscore in the "name" var, and that is wrong. Also I added information about underscores and name length. I think it is an important information and can save the time for newbies. :)

If you think it is ok, please merge it. I do not see any additional places with this problem in the vSphere Provider. 

Thanks in advance!

Emil