### PR TITLE
provider/openstack: Updates to openstack_images_image_v2 resource

### DIFF
--- a/builtin/providers/openstack/provider_test.go
+++ b/builtin/providers/openstack/provider_test.go
@@ -60,6 +60,13 @@ func testAccPreCheck(t *testing.T) {
 	}
 }
 
+func testAccPreCheckAdminOnly(t *testing.T) {
+	v := os.Getenv("OS_USERNAME")
+	if v != "admin" {
+		t.Skip("Skipping test because it requires the admin user")
+	}
+}
+
 func TestProvider(t *testing.T) {
 	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)

--- a/builtin/providers/openstack/resource_openstack_images_image_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_images_image_v2_test.go
@@ -36,7 +36,7 @@ func TestAccImagesImageV2_basic(t *testing.T) {
 	})
 }
 
-func TestAccImagesImageV2_with_tags(t *testing.T) {
+func TestAccImagesImageV2_name(t *testing.T) {
 	var image images.Image
 
 	resource.Test(t, resource.TestCase{
@@ -45,12 +45,90 @@ func TestAccImagesImageV2_with_tags(t *testing.T) {
 		CheckDestroy: testAccCheckImagesImageV2Destroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccImagesImageV2_with_tags,
+				Config: testAccImagesImageV2_name_1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "name", "Rancher TerraformAccTest"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccImagesImageV2_name_2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "name", "TerraformAccTest Rancher"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImagesImageV2_tags(t *testing.T) {
+	var image images.Image
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckImagesImageV2Destroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccImagesImageV2_tags_1,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
 					testAccCheckImagesImageV2HasTag("openstack_images_image_v2.image_1", "foo"),
 					testAccCheckImagesImageV2HasTag("openstack_images_image_v2.image_1", "bar"),
 					testAccCheckImagesImageV2TagCount("openstack_images_image_v2.image_1", 2),
+				),
+			},
+			resource.TestStep{
+				Config: testAccImagesImageV2_tags_2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
+					testAccCheckImagesImageV2HasTag("openstack_images_image_v2.image_1", "foo"),
+					testAccCheckImagesImageV2HasTag("openstack_images_image_v2.image_1", "bar"),
+					testAccCheckImagesImageV2HasTag("openstack_images_image_v2.image_1", "baz"),
+					testAccCheckImagesImageV2TagCount("openstack_images_image_v2.image_1", 3),
+				),
+			},
+			resource.TestStep{
+				Config: testAccImagesImageV2_tags_3,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
+					testAccCheckImagesImageV2HasTag("openstack_images_image_v2.image_1", "foo"),
+					testAccCheckImagesImageV2HasTag("openstack_images_image_v2.image_1", "baz"),
+					testAccCheckImagesImageV2TagCount("openstack_images_image_v2.image_1", 2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccImagesImageV2_visibility(t *testing.T) {
+	var image images.Image
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			testAccPreCheckAdminOnly(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckImagesImageV2Destroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccImagesImageV2_visibility_1,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "visibility", "private"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccImagesImageV2_visibility_2,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckImagesImageV2Exists("openstack_images_image_v2.image_1", &image),
+					resource.TestCheckResourceAttr(
+						"openstack_images_image_v2.image_1", "visibility", "public"),
 				),
 			},
 		},
@@ -188,11 +266,63 @@ var testAccImagesImageV2_basic = `
       disk_format = "qcow2"
   }`
 
-var testAccImagesImageV2_with_tags = `
+var testAccImagesImageV2_name_1 = `
+  resource "openstack_images_image_v2" "image_1" {
+      name   = "Rancher TerraformAccTest"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+  }`
+
+var testAccImagesImageV2_name_2 = `
+  resource "openstack_images_image_v2" "image_1" {
+      name   = "TerraformAccTest Rancher"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+  }`
+
+var testAccImagesImageV2_tags_1 = `
   resource "openstack_images_image_v2" "image_1" {
       name   = "Rancher TerraformAccTest"
       image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
       container_format = "bare"
       disk_format = "qcow2"
       tags = ["foo","bar"]
+  }`
+
+var testAccImagesImageV2_tags_2 = `
+  resource "openstack_images_image_v2" "image_1" {
+      name   = "Rancher TerraformAccTest"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+      tags = ["foo","bar","baz"]
+  }`
+
+var testAccImagesImageV2_tags_3 = `
+  resource "openstack_images_image_v2" "image_1" {
+      name   = "Rancher TerraformAccTest"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+      tags = ["foo","baz"]
+  }`
+
+var testAccImagesImageV2_visibility_1 = `
+  resource "openstack_images_image_v2" "image_1" {
+      name   = "Rancher TerraformAccTest"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+      visibility = "private"
+  }`
+
+var testAccImagesImageV2_visibility_2 = `
+  resource "openstack_images_image_v2" "image_1" {
+      name   = "Rancher TerraformAccTest"
+      image_source_url = "https://releases.rancher.com/os/latest/rancheros-openstack.img"
+      container_format = "bare"
+      disk_format = "qcow2"
+      visibility = "public"
   }`

--- a/website/source/docs/providers/openstack/r/images_image_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/images_image_v2.html.markdown
@@ -35,11 +35,11 @@ The following arguments are supported:
    that will be uploaded to Glance. Conflicts with `image_source_url`.
 
 * `image_cache_path` - (Optional) This is the directory where the images will
-   be downloaded. Images will be stored with a filename corresponding to 
+   be downloaded. Images will be stored with a filename corresponding to
    the url's md5 hash. Defaults to "$HOME/.terraform/image_cache"
 
 * `image_source_url` - (Optional) This is the url of the raw image that will
-   be downloaded in the `image_cache_path` before being uploaded to Glance. 
+   be downloaded in the `image_cache_path` before being uploaded to Glance.
    Glance is able to download image from internet but the `gophercloud` library
    does not yet provide a way to do so.
    Conflicts with `local_file_path`.
@@ -49,9 +49,9 @@ The following arguments are supported:
 
 * `min_ram_mb` - (Optional) Amount of ram (in MB) required to boot image.
    Defauts to 0.
-   
+
 * `name` - (Required) The name of the image.
-   
+
 * `protected` - (Optional) If true, image will not be deletable.
    Defaults to false.
 
@@ -61,9 +61,11 @@ The following arguments are supported:
     is used. Changing this creates a new Image.
 
 * `tags` - (Optional) The tags of the image. It must be a list of strings.
-   
-* `visibility` - (Optional) The visibility of the image. Must be one of 
-   "public", "private", "community", or "shared". 
+    At this time, it is not possible to delete all tags of an image.
+
+* `visibility` - (Optional) The visibility of the image. Must be one of
+   "public", "private", "community", or "shared". The ability to set the
+   visibility depends upon the configuration of the OpenStack cloud.
 
 Note: The `properties` attribute handling in the gophercloud library is currently buggy
 and needs to be fixed before being implemented in this resource.
@@ -76,8 +78,8 @@ The following attributes are exported:
 * `container_format` - See Argument Reference above.
 * `created_at` - The date the image was created.
 * `disk_format` - See Argument Reference above.
-* `file` - the trailing path after the glance 
-   endpoint that represent the location of the image 
+* `file` - the trailing path after the glance
+   endpoint that represent the location of the image
    or the path to retrieve it.
 * `id` - A unique ID assigned by Glance.
 * `metadata` - The metadata associated with the image.
@@ -89,8 +91,8 @@ The following attributes are exported:
 * `owner` - The id of the openstack user who owns the image.
 * `protected` - See Argument Reference above.
 * `region` - See Argument Reference above.
-* `schema` - The path to the JSON-schema that represent 
-   the image or image 
+* `schema` - The path to the JSON-schema that represent
+   the image or image
 * `size_bytes` - The size in bytes of the data associated with the image.
 * `status` - The status of the image. It can be "queued", "active"
    or "saving".

--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -49,6 +49,15 @@
           </ul>
         </li>
 
+        <li<%= sidebar_current(/^docs-openstack-resource-images/) %>>
+          <a href="#">Images Resources</a>
+          <ul class="nav nav-visible">
+            <li<%= sidebar_current("docs-openstack-resource-images-image-v2") %>>
+              <a href="/docs/providers/openstack/r/images_image_v2.html">openstack_images_image_v2</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current(/^docs-openstack-resource-networking/) %>>
           <a href="#">Networking Resources</a>
           <ul class="nav nav-visible">


### PR DESCRIPTION
This commit has a few more fixes to the recently added
openstack_images_image_v2 resource:

* tags were changed to a Set because the OpenStack Image API does
not seem to respect ordering.
* The visibility argument was fixed.
* Acceptance tests for all updatable fields has been implemented.
* Documentation updates, including a new entry in the sidebar.