### PR TITLE
provider/openstack: Don't allow floating IP and port

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -990,6 +990,15 @@ func getInstanceNetworks(computeClient *gophercloud.ServiceClient, d *schema.Res
 
 		rawMap := raw.(map[string]interface{})
 
+		// Both a floating IP and a port cannot be specified
+		if fip, ok := rawMap["floating_ip"].(string); ok {
+			if port, ok := rawMap["port"].(string); ok {
+				if fip != "" && port != "" {
+					return nil, fmt.Errorf("Only one of a floating IP or port may be specified per network.")
+				}
+			}
+		}
+
 		allPages, err := tenantnetworks.List(computeClient).AllPages()
 		if err != nil {
 			if _, ok := err.(gophercloud.ErrDefault404); ok {


### PR DESCRIPTION
This commit adds a check to prevent a user from specifying both
a floating IP and a port on a specific network. While this
configuration is currently allowed, the Port will be chosen and
applying the configuration again will show a state mismatch. This
attempts to prevent such a misconfiguration.

Fixes #10548