### PR TITLE
Add VRRP to allowed protocols in network ACL rules

### DIFF
--- a/builtin/providers/aws/network_acl_entry.go
+++ b/builtin/providers/aws/network_acl_entry.go
@@ -88,6 +88,7 @@ func protocolIntegers() map[string]int {
 		"tcp":  6,
 		"icmp": 1,
 		"all":  -1,
+		"vrrp": 112,
 	}
 	return protocolIntegers
 }


### PR DESCRIPTION
This will add VRRP to the allowed protocols list in ACL entries. This is a fix for  #12103. I saw that a lot of the protocols defined in https://www.iana.org/assignments/protocol-numbers/protocol-numbers.xhtml are not in this list. Is there a reason not to? 

If needed I can add more of the protocols defined in iana.