### PR TITLE
provider/aws: Update of inspector_assessment_target should use ARN not Name

### DIFF
--- a/builtin/providers/aws/resource_aws_inspector_assessment_target.go
+++ b/builtin/providers/aws/resource_aws_inspector_assessment_target.go
@@ -19,16 +19,16 @@ func resourceAWSInspectorAssessmentTarget() *schema.Resource {
 		Delete: resourceAwsInspectorAssessmentTargetDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
 			},
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"resource_group_arn": &schema.Schema{
+			"resource_group_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -86,17 +86,9 @@ func resourceAwsInspectorAssessmentTargetUpdate(d *schema.ResourceData, meta int
 	conn := meta.(*AWSClient).inspectorconn
 
 	input := inspector.UpdateAssessmentTargetInput{
-		AssessmentTargetArn: aws.String(d.Id()),
-	}
-
-	if d.HasChange("name") {
-		_, n := d.GetChange("name")
-		input.AssessmentTargetName = aws.String(n.(string))
-	}
-
-	if d.HasChange("resource_group_arn") {
-		_, n := d.GetChange("resource_group_arn")
-		input.AssessmentTargetName = aws.String(n.(string))
+		AssessmentTargetArn:  aws.String(d.Id()),
+		AssessmentTargetName: aws.String(d.Get("name").(string)),
+		ResourceGroupArn:     aws.String(d.Get("resource_group_arn").(string)),
 	}
 
 	_, err := conn.UpdateAssessmentTarget(&input)

--- a/builtin/providers/aws/resource_aws_inspector_assessment_target_test.go
+++ b/builtin/providers/aws/resource_aws_inspector_assessment_target_test.go
@@ -17,14 +17,20 @@ func TestAccAWSInspectorTarget_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSInspectorTargetAssessmentDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSInspectorTargetAssessment,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSInspectorTargetExists("aws_inspector_assessment_target.foo"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckAWSInspectorTargetAssessmentModified,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInspectorTargetExists("aws_inspector_assessment_target.foo"),
+				),
+			},
+			{
+				Config: testAccCheckAWSInspectorTargetAssessmentUpdatedResourceGroup,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSInspectorTargetExists("aws_inspector_assessment_target.foo"),
 				),
@@ -98,4 +104,23 @@ resource "aws_inspector_resource_group" "foo" {
 resource "aws_inspector_assessment_target" "foo" {
 	name = "bar"
 	resource_group_arn =  "${aws_inspector_resource_group.foo.arn}"
+}`
+
+var testAccCheckAWSInspectorTargetAssessmentUpdatedResourceGroup = `
+
+resource "aws_inspector_resource_group" "foo" {
+	tags {
+	  Name  = "bar"
+  }
+}
+
+resource "aws_inspector_resource_group" "bar" {
+	tags {
+	  Name  = "test"
+  }
+}
+
+resource "aws_inspector_assessment_target" "foo" {
+	name = "bar"
+	resource_group_arn =  "${aws_inspector_resource_group.bar.arn}"
 }`


### PR DESCRIPTION
fixes: #12112

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSInspectorTarget_basic'                                                  ✚
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/20 19:08:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInspectorTarget_basic -timeout 120m
=== RUN   TestAccAWSInspectorTarget_basic
--- PASS: TestAccAWSInspectorTarget_basic (33.58s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	33.607s
```