### PR TITLE
provider/openstack: Toggle Creation of Default Security Group Rules

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_secgroup_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_secgroup_v2_test.go
@@ -23,7 +23,7 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckNetworkingV2SecGroupExists(
 						"openstack_networking_secgroup_v2.secgroup_1", &security_group),
-					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 0),
+					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 2),
 				),
 			},
 			resource.TestStep{
@@ -31,6 +31,26 @@ func TestAccNetworkingV2SecGroup_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"openstack_networking_secgroup_v2.secgroup_1", "name", "security_group_2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2SecGroup_noDefaultRules(t *testing.T) {
+	var security_group groups.SecGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SecGroupDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2SecGroup_noDefaultRules,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_1", &security_group),
+					testAccCheckNetworkingV2SecGroupRuleCount(&security_group, 0),
 				),
 			},
 		},
@@ -113,5 +133,13 @@ const testAccNetworkingV2SecGroup_update = `
 resource "openstack_networking_secgroup_v2" "secgroup_1" {
   name = "security_group_2"
   description = "terraform security group acceptance test"
+}
+`
+
+const testAccNetworkingV2SecGroup_noDefaultRules = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+	name = "security_group_1"
+	description = "terraform security group acceptance test"
+	delete_default_rules = true
 }
 `

--- a/website/source/docs/providers/openstack/r/networking_secgroup_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_secgroup_v2.html.markdown
@@ -40,6 +40,10 @@ The following arguments are supported:
     wants to create a port for another tenant. Changing this creates a new
     security group.
 
+* `delete_default_rules` - (Optional) Whether or not to delete the default
+    egress security rules. This is `false` by default. See the below note
+    for more information.
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -48,6 +52,34 @@ The following attributes are exported:
 * `name` - See Argument Reference above.
 * `description` - See Argument Reference above.
 * `tenant_id` - See Argument Reference above.
+
+## Default Security Group Rules
+
+In most cases, OpenStack will create some egress security group rules for each
+new security group. These security group rules will not be managed by
+Terraform, so if you prefer to have *all* aspects of your infrastructure
+managed by Terraform, set `delete_default_rules` to `true` and then create
+separate security group rules such as the following:
+
+```
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_v4" {
+  direction = "egress"
+  ethertype = "IPv4"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup.id}"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_v6" {
+  direction = "egress"
+  ethertype = "IPv6"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup.id}"
+}
+```
+
+Please note that this behavior may differ depending on the configuration of
+the OpenStack cloud. The above illustrates the current default Neutron
+behavior. Some OpenStack clouds might provide additional rules and some might
+not provide any rules at all (in which case the `delete_default_rules` setting
+is moot).
 
 ## Import
 


### PR DESCRIPTION
This commit modifies the behavior implemented in #9799 by enabling
the user to be able to toggle the creation of the default security
group rules.

Fixes #12102

non-commit note: This effectively changes the behavior introduced in #9799 to be opt-in instead of dictated, which I agree is a better solution. I tried to make the new argument intuitive as well as provide documentation about how to recreate the default rules. Caveats are mentioned for OpenStack environments that have deviated from the default behavior.

Between #9799 and now, there will be three sets of `openstack_networking_secgroup_v2`'s in the wild, however, no changes should happen to existing deployments since there is not a default value specified and an explicit value of `true` must be given for the rules to be deleted.

In addition, no destructive behavior is expected (and by destructive, I mean the loss of data and stateful services). If someone chooses to add this argument with a value of `true` or `false` to their configuration, then the security group and the rules connected to it will be recreated. All resources that consume security groups are able to handle security group updates without being destroyed. If such a thing happens, it is a bug and should be reported.