### PR TITLE
aws/provider: aws_s3_bucket doesn't report bucket name when encounter…

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -450,7 +450,7 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsS3BucketUpdate(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 	if err := setTagsS3(s3conn, d); err != nil {
-		return err
+		return fmt.Errorf("%s %q", err, d.Get("bucket").(string))
 	}
 
 	if d.HasChange("policy") {

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -450,7 +450,7 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsS3BucketUpdate(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 	if err := setTagsS3(s3conn, d); err != nil {
-		return fmt.Errorf("%s %q", err, d.Get("bucket").(string))
+		return fmt.Errorf("%q: %s", d.Get("bucket").(string), err)
 	}
 
 	if d.HasChange("policy") {


### PR DESCRIPTION
…ing tag value problems

Tracking down which bucket was the source of the issue was difficult because the name wasn't included in the error:
    * aws_s3_bucket.bucket: InvalidTag: The TagValue you have provided is invalid
     	status code: 400, request id: 8033DBCA45EB0F291

This PR changes the output to be:

   * aws_s3_bucket.bucket: InvalidTag: The TagValue you have provided is invalid
	status code: 400, request id: C7CA2ED60DCE4678 "colg-sgp-state-cut-scores"

But the underlying issue here is that terraform should probably be doing some kind of validation on the tag string before it even tries to push the tags. So we probably need some validation rules from the [AWS docs](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions):
 * Maximum value length—255 Unicode characters in UTF-8
 * If your tagging schema will be used across multiple services and resources, remember that other services may have restrictions on allowed characters. Generally allowed characters are: letters, spaces, and numbers representable in UTF-8, plus the following special characters: + - = . _ : / @.

I'd be willing to tackle the above... but could use a pointer to the right spot in the code for a fix.