### PR TITLE
aws/provider: add validation function to the tagsSchema

### DIFF
--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -360,8 +360,8 @@ func validateTags(v interface{}, k string) (ws []string, errors []error) {
 		if len(value.(string)) > 255 {
 			errors = append(errors, fmt.Errorf("tag %q value %q cannot be longer than '255' characters", key, value.(string)))
 		}
-		if !regexp.MustCompile(`^[0-9A-Za-z+-=._:\@]+$`).MatchString(value.(string)) {
-			errors = append(errors, fmt.Errorf("tag %q value %q contains invalid characters (^[0-9A-Za-z+-=._:\\@]+$)", k, value.(string)))
+		if !regexp.MustCompile(`^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$`).MatchString(value.(string)) {
+			errors = append(errors, fmt.Errorf("tag %q value %q contains invalid characters (must match this regex ^([\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*)$)", k, value.(string)))
 		}
 	}
 	return


### PR DESCRIPTION
Validate tag values. Ran into the following error today:

    * aws_s3_bucket.bucket: InvalidTag: The TagValue you have provided is invalid
    status code: 400, request id: C7CA2ED60DCE4678

I requested a PR to add the name of the bucket which generated the tag error, but felt it would also be valuable to have the tag actually validated so one would get errors about problem tags during plan.

So with this terraform template:

    resource "aws_instance" "test" {
      tags {
        abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz = "()abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz"
      }
       instance_type = "t2.micro"
      ami = "ami-1c221e76"
    }

I can now generate the following error output during terraform plan:

    3 error(s) occurred:

    * aws_instance.test: tag "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" name cannot be longer than '127' characters
    * aws_instance.test: tag "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" value "()abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" cannot be longer than '255' characters
    * aws_instance.test: tag "tags" value "()abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz" contains invalid characters (^[0-9A-Za-z+-=._:\@]+$)


