### PR TITLE
hash rds and aurora password

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -55,6 +55,7 @@ func resourceAwsDbInstance() *schema.Resource {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
+				StateFunc: hashSum,
 			},
 
 			"engine": {

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -137,6 +137,7 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
+				StateFunc: hashSum,
 			},
 
 			"snapshot_identifier": {

--- a/builtin/providers/aws/utils.go
+++ b/builtin/providers/aws/utils.go
@@ -1,8 +1,10 @@
 package aws
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"reflect"
 	"regexp"
 )
@@ -39,4 +41,8 @@ func jsonBytesEqual(b1, b2 []byte) bool {
 	}
 
 	return reflect.DeepEqual(o1, o2)
+}
+
+func hashSum(contents interface{}) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(contents.(string))))
 }


### PR DESCRIPTION
1. Store RDS and Aurora master user password as hashed value in states file.
2. Change RDS operation timeout from 40 minutes to 120 minutes.
For SQL server EE version, the RDS creation takes about 60 minutes for 200GB (minimum size for SQL Server EE). Create Oracle RDS from a snpashot also may take longer than 40 minutes to completed
