### PR TITLE
Add shield provider

### DIFF
--- a/builtin/bins/provider-shield/main.go
+++ b/builtin/bins/provider-shield/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/shield"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: shield.Provider,
+	})
+}

--- a/builtin/providers/shield/client.go
+++ b/builtin/providers/shield/client.go
@@ -1,0 +1,104 @@
+package shield
+
+import (
+	"bytes"
+	"crypto/tls"
+	"net/http"
+)
+
+type ShieldClient struct {
+	ServerUrl string
+	Username  string
+	Password  string
+	Insecure  bool
+}
+
+func (c *ShieldClient) Get(endpoint string) (*http.Response, error) {
+
+	client := &http.Client{}
+	if c.Insecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{Transport: tr}
+	}
+
+	req, err := http.NewRequest("GET", "https://"+c.ServerUrl+"/"+endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.SetBasicAuth(c.Username, c.Password)
+
+	return client.Do(req)
+
+}
+
+func (c *ShieldClient) Post(endpoint string, jsonpayload *bytes.Buffer) (*http.Response, error) {
+	client := &http.Client{}
+	if c.Insecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{Transport: tr}
+	}
+
+	req, err := http.NewRequest("POST", "https://"+c.ServerUrl+"/"+endpoint, jsonpayload)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.Username, c.Password)
+	req.Header.Add("content-type", "application/json")
+	return client.Do(req)
+}
+
+func (c *ShieldClient) Put(endpoint string, jsonpayload *bytes.Buffer) (*http.Response, error) {
+	client := &http.Client{}
+	if c.Insecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{Transport: tr}
+	}
+
+	req, err := http.NewRequest("PUT", "https://"+c.ServerUrl+"/"+endpoint, jsonpayload)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.Username, c.Password)
+	req.Header.Add("content-type", "application/json")
+	return client.Do(req)
+}
+
+func (c *ShieldClient) PutOnly(endpoint string) (*http.Response, error) {
+	client := &http.Client{}
+	if c.Insecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{Transport: tr}
+	}
+	req, err := http.NewRequest("PUT", "https://"+c.ServerUrl+"/"+endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.Username, c.Password)
+	return client.Do(req)
+}
+
+func (c *ShieldClient) Delete(endpoint string) (*http.Response, error) {
+	client := &http.Client{}
+	if c.Insecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{Transport: tr}
+	}
+
+	req, err := http.NewRequest("DELETE", "https://"+c.ServerUrl+"/"+endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.SetBasicAuth(c.Username, c.Password)
+	return client.Do(req)
+}

--- a/builtin/providers/shield/provider.go
+++ b/builtin/providers/shield/provider.go
@@ -1,0 +1,54 @@
+package shield
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"serverurl": {
+				Required:    true,
+				Type:        schema.TypeString,
+				DefaultFunc: schema.EnvDefaultFunc("SHIELD_SERVER_URL", nil),
+			},
+			"username": {
+				Required:    true,
+				Type:        schema.TypeString,
+				DefaultFunc: schema.EnvDefaultFunc("SHIELD_USERNAME", nil),
+			},
+			"password": {
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("SHIELD_PASSWORD", nil),
+			},
+			"insecure": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("OS_INSECURE", ""),
+			},
+		},
+		ConfigureFunc: providerConfigure,
+		ResourcesMap: map[string]*schema.Resource{
+			"shield_target":           resourceTarget(),
+			"shield_schedule":         resourceSchedule(),
+			"shield_retention_policy": resourceRetention(),
+			"shield_store":            resourceStore(),
+			"shield_job":              resourceJob(),
+			//"shield_archive": resourceArchive(),
+			//"shield_task": resourceTask(),
+		},
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	client := &ShieldClient{
+		ServerUrl: d.Get("serverurl").(string),
+		Username:  d.Get("username").(string),
+		Password:  d.Get("password").(string),
+		Insecure:  d.Get("insecure").(bool),
+	}
+
+	return client, nil
+}

--- a/builtin/providers/shield/provider_test.go
+++ b/builtin/providers/shield/provider_test.go
@@ -1,0 +1,41 @@
+package shield
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"shield": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("SHIELD_SERVER_URL"); v == "" {
+		t.Fatal("SHIELD_SERVER_URL must be set for acceptence tests")
+	}
+
+	if v := os.Getenv("SHIELD_USERNAME"); v == "" {
+		t.Fatal("SHIELD_USERNAME must be set for acceptence tests")
+	}
+	if v := os.Getenv("SHIELD_PASSWORD"); v == "" {
+		t.Fatal("SHIELD_PASSWORD must be set for acceptence tests")
+	}
+}

--- a/builtin/providers/shield/resource_job.go
+++ b/builtin/providers/shield/resource_job.go
@@ -1,0 +1,207 @@
+package shield
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type Job struct {
+	Name      string `json:"name,omitempty"`
+	Summary   string `json:"summary,omitempty"`
+	Store     string `json:"store,omitempty"`
+	Target    string `json:"target,omitempty"`
+	Retention string `json:"retention,omitempty"`
+	Schedule  string `json:"schedule,omitempty"`
+	Paused    bool   `json:"paused,omitempty"`
+	Uuid      string `json:"uuid,omitempty"`
+}
+
+func resourceJob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceJobCreate,
+		Read:   resourceJobRead,
+		Update: resourceJobUpdate,
+		Delete: resourceJobDelete,
+		Exists: resourceJobExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"summary": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"store": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"target": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"retention": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"schedule": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"paused": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
+			"uuid": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createJob(d *schema.ResourceData) *Job {
+
+	return &Job{
+		Name:      d.Get("name").(string),
+		Summary:   d.Get("summary").(string),
+		Store:     d.Get("store").(string),
+		Target:    d.Get("target").(string),
+		Retention: d.Get("retention").(string),
+		Schedule:  d.Get("schedule").(string),
+		Paused:    d.Get("paused").(bool),
+		Uuid:      d.Get("uuid").(string),
+	}
+
+}
+
+func resourceJobCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	job := createJob(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(job)
+
+	job_req, err := client.Post(fmt.Sprintf("v1/jobs"), jsonpayload)
+
+	decoder := json.NewDecoder(job_req.Body)
+	err = decoder.Decode(&job)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(job.Uuid)
+	d.Set("uuid", job.Uuid)
+
+	return resourceJobRead(d, m)
+}
+
+func resourceJobRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	job_req, err := client.Get(fmt.Sprintf("v1/jobs"))
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(job_req.Body)
+	decoder.Token()
+
+	for decoder.More() {
+		var job Job
+
+		err := decoder.Decode(&job)
+		if err != nil {
+			return err
+		}
+		if job.Uuid == d.Get("uuid") {
+			d.Set("uuid", job.Uuid)
+			d.Set("name", job.Name)
+			d.Set("summary", job.Summary)
+			d.Set("store", job.Store)
+			d.Set("target", job.Target)
+			d.Set("retention", job.Retention)
+			d.Set("schedule", job.Schedule)
+			d.Set("paused", job.Paused)
+			d.Set("uuid", job.Uuid)
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceJobUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	job := createJob(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(job)
+
+	job_req, err := client.Put(fmt.Sprintf("v1/job/%s",
+		d.Get("uuid").(string),
+	), jsonpayload)
+
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(job_req.Body)
+	err = decoder.Decode(&job)
+	if err != nil {
+		return err
+	}
+
+	return resourceJobRead(d, m)
+}
+
+func resourceJobExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*ShieldClient)
+	if _, okay := d.GetOk("uuid"); okay {
+		job_req, err := client.Get(fmt.Sprintf("v1/job/%s",
+			d.Get("uuid").(string),
+		))
+
+		if err != nil {
+			panic(err)
+		}
+
+		if job_req.StatusCode != 200 {
+			d.SetId("")
+			return false, nil
+		}
+
+		return true, nil
+	} else {
+		return false, nil
+	}
+
+}
+
+func resourceJobDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	_, err := client.Delete(fmt.Sprintf("v1/job/%s",
+		d.Get("uuid").(string),
+	))
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/builtin/providers/shield/resource_job_test.go
+++ b/builtin/providers/shield/resource_job_test.go
@@ -1,0 +1,96 @@
+package shield
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestShieldJob_basic(t *testing.T) {
+	var job Job
+
+	t.Skip(" After applying this step, the plan was not empty. ")
+
+	testShieldJobConfig := fmt.Sprintf(`
+		resource "shield_target" "test_job_target" {
+		  name = "Test-Target"
+		  summary = "Terraform Test Target"
+		  plugin = "mysql"
+		  endpoint = "{\"mysql_user\":\"root\",\"mysql_password\":\"secure-pw\",\"mysql_host\": \"localhost\",\"mysql_port\": 3306}"
+		  agent = "localhost:5444"
+		}
+		resource "shield_retention_policy" "test_job_retention" {
+		  name = "Test-Retention"
+		  summary = "Terraform Test Retention"
+		  expires = 86400
+		}
+		resource "shield_schedule" "test_job_schedule" {
+		  name = "Test-Schedule"
+		  summary = "Terraform Test Schedule"
+		  when = "daily 1am"
+		}
+		resource "shield_store" "test_job_store" {
+		  name = "Test-Store"
+		  summary = "Terraform Test Store"
+		  plugin = "fs"
+		  endpoint = "{\"base_dir\": \"/backup_test\"}"
+		}
+		resource "shield_job" "test_job" {
+		  name = "Test-Job-Tests"
+		  summary = "Terraform Test Job"
+		  store = "${ shield_store.test_job_store.uuid }"
+		  target = "${ shield_target.test_job_target.uuid }"
+		  retention = "${ shield_retention_policy.test_job_retention.uuid }"
+		  schedule = "${ shield_schedule.test_job_schedule.uuid }"
+		  paused = false
+		}
+	`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testShieldJobDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testShieldJobConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testShieldCheckJobExists("shield_job.test_job", &job),
+				),
+			},
+		},
+	})
+}
+
+func testShieldJobDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ShieldClient)
+	rs, ok := s.RootModule().Resources["shield_job.test_job"]
+	if !ok {
+		return fmt.Errorf("Not found %s", "shield_job.test_job")
+	}
+
+	response, err := client.Get(fmt.Sprintf("v1/job/%s", rs.Primary.Attributes["uuid"]))
+
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != 404 {
+		return fmt.Errorf("Job still exists")
+	}
+
+	return nil
+}
+
+func testShieldCheckJobExists(n string, job *Job) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Job UUID is set")
+		}
+		return nil
+	}
+}

--- a/builtin/providers/shield/resource_retention_policy.go
+++ b/builtin/providers/shield/resource_retention_policy.go
@@ -1,0 +1,173 @@
+package shield
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type Retention struct {
+	Name    string `json:"name,omitempty"`
+	Summary string `json:"summary,omitempty"`
+	Expires int    `json:"expires,omitempty"`
+	Uuid    string `json:"uuid,omitempty"`
+}
+
+func resourceRetention() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceRetentionCreate,
+		Read:   resourceRetentionRead,
+		Update: resourceRetentionUpdate,
+		Delete: resourceRetentionDelete,
+		Exists: resourceRetentionExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"summary": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"expires": &schema.Schema{
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"uuid": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createRetention(d *schema.ResourceData) *Retention {
+
+	return &Retention{
+		Name:    d.Get("name").(string),
+		Summary: d.Get("summary").(string),
+		Expires: d.Get("expires").(int),
+	}
+
+}
+
+func resourceRetentionCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	retention := createRetention(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(retention)
+
+	retention_req, err := client.Post(fmt.Sprintf("v1/retention"), jsonpayload)
+
+	decoder := json.NewDecoder(retention_req.Body)
+	err = decoder.Decode(&retention)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(retention.Uuid)
+	d.Set("uuid", retention.Uuid)
+
+	return resourceRetentionRead(d, m)
+}
+
+func resourceRetentionRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	retention_req, err := client.Get(fmt.Sprintf("v1/retention"))
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(retention_req.Body)
+	decoder.Token()
+
+	for decoder.More() {
+		var retention Retention
+
+		err := decoder.Decode(&retention)
+		if err != nil {
+			return err
+		}
+		if retention.Uuid == d.Get("uuid") {
+			d.Set("uuid", retention.Uuid)
+			d.Set("name", retention.Name)
+			d.Set("summary", retention.Summary)
+			d.Set("expires", retention.Expires)
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceRetentionUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	retention := createRetention(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(retention)
+
+	retention_req, err := client.Put(fmt.Sprintf("v1/retention/%s",
+		d.Get("uuid").(string),
+	), jsonpayload)
+
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(retention_req.Body)
+	err = decoder.Decode(&retention)
+	if err != nil {
+		return err
+	}
+
+	return resourceRetentionRead(d, m)
+}
+
+func resourceRetentionExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*ShieldClient)
+	if _, okay := d.GetOk("uuid"); okay {
+		retention_req, err := client.Get(fmt.Sprintf("v1/retention/%s",
+			d.Get("uuid").(string),
+		))
+
+		if err != nil {
+			panic(err)
+		}
+
+		if retention_req.StatusCode != 200 {
+			d.SetId("")
+			return false, nil
+		}
+
+		return true, nil
+	} else {
+		return false, nil
+	}
+
+}
+
+func resourceRetentionDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	_, err := client.Delete(fmt.Sprintf("v1/retention/%s",
+		d.Get("uuid").(string),
+	))
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/builtin/providers/shield/resource_retention_policy_test.go
+++ b/builtin/providers/shield/resource_retention_policy_test.go
@@ -1,0 +1,67 @@
+package shield
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestShieldRetention_basic(t *testing.T) {
+	var retention Retention
+
+	testShieldRetentionConfig := fmt.Sprintf(`
+		resource "shield_retention_policy" "test_retention" {
+		  name = "Test-Retention"
+		  summary = "Terraform Test Retention"
+		  expires = 86400
+		}
+	`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testShieldRetentionDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testShieldRetentionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testShieldCheckRetentionExists("shield_retention_policy.test_retention", &retention),
+				),
+			},
+		},
+	})
+}
+
+func testShieldRetentionDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ShieldClient)
+	rs, ok := s.RootModule().Resources["shield_retention_policy.test_retention"]
+	if !ok {
+		return fmt.Errorf("Not found %s", "shield_retention_policy.test_retention")
+	}
+
+	response, err := client.Get(fmt.Sprintf("v1/retention/%s", rs.Primary.Attributes["uuid"]))
+
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != 404 {
+		return fmt.Errorf("Retention still exists")
+	}
+
+	return nil
+}
+
+func testShieldCheckRetentionExists(n string, retention *Retention) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Retention UUID is set")
+		}
+		return nil
+	}
+}

--- a/builtin/providers/shield/resource_schedule.go
+++ b/builtin/providers/shield/resource_schedule.go
@@ -1,0 +1,173 @@
+package shield
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type Schedule struct {
+	Name    string `json:"name,omitempty"`
+	Summary string `json:"summary,omitempty"`
+	When    string `json:"when,omitempty"`
+	Uuid    string `json:"uuid,omitempty"`
+}
+
+func resourceSchedule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceScheduleCreate,
+		Read:   resourceScheduleRead,
+		Update: resourceScheduleUpdate,
+		Delete: resourceScheduleDelete,
+		Exists: resourceScheduleExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"summary": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"when": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"uuid": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createSchedule(d *schema.ResourceData) *Schedule {
+
+	return &Schedule{
+		Name:    d.Get("name").(string),
+		Summary: d.Get("summary").(string),
+		When:    d.Get("when").(string),
+	}
+
+}
+
+func resourceScheduleCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	schedule := createSchedule(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(schedule)
+
+	schedule_req, err := client.Post(fmt.Sprintf("v1/schedules"), jsonpayload)
+
+	decoder := json.NewDecoder(schedule_req.Body)
+	err = decoder.Decode(&schedule)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(schedule.Uuid)
+	d.Set("uuid", schedule.Uuid)
+
+	return resourceScheduleRead(d, m)
+}
+
+func resourceScheduleRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	schedule_req, err := client.Get(fmt.Sprintf("v1/schedules"))
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(schedule_req.Body)
+	decoder.Token()
+
+	for decoder.More() {
+		var schedule Schedule
+
+		err := decoder.Decode(&schedule)
+		if err != nil {
+			return err
+		}
+		if schedule.Uuid == d.Get("uuid") {
+			d.Set("uuid", schedule.Uuid)
+			d.Set("name", schedule.Name)
+			d.Set("summary", schedule.Summary)
+			d.Set("when", schedule.When)
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceScheduleUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	schedule := createSchedule(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(schedule)
+
+	schedule_req, err := client.Put(fmt.Sprintf("v1/schedule/%s",
+		d.Get("uuid").(string),
+	), jsonpayload)
+
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(schedule_req.Body)
+	err = decoder.Decode(&schedule)
+	if err != nil {
+		return err
+	}
+
+	return resourceScheduleRead(d, m)
+}
+
+func resourceScheduleExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*ShieldClient)
+	if _, okay := d.GetOk("uuid"); okay {
+		schedule_req, err := client.Get(fmt.Sprintf("v1/schedule/%s",
+			d.Get("uuid").(string),
+		))
+
+		if err != nil {
+			panic(err)
+		}
+
+		if schedule_req.StatusCode != 200 {
+			d.SetId("")
+			return false, nil
+		}
+
+		return true, nil
+	} else {
+		return false, nil
+	}
+
+}
+
+func resourceScheduleDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	_, err := client.Delete(fmt.Sprintf("v1/schedule/%s",
+		d.Get("uuid").(string),
+	))
+
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/builtin/providers/shield/resource_schedule_test.go
+++ b/builtin/providers/shield/resource_schedule_test.go
@@ -1,0 +1,67 @@
+package shield
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestShieldSchedule_basic(t *testing.T) {
+	var schedule Schedule
+
+	testShieldScheduleConfig := fmt.Sprintf(`
+		resource "shield_schedule" "test_schedule" {
+		  name = "Test-Schedule"
+		  summary = "Terraform Test Schedule"
+		  when = "daily 1am"
+		}
+	`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testShieldScheduleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testShieldScheduleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testShieldCheckScheduleExists("shield_schedule.test_schedule", &schedule),
+				),
+			},
+		},
+	})
+}
+
+func testShieldScheduleDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ShieldClient)
+	rs, ok := s.RootModule().Resources["shield_schedule.test_schedule"]
+	if !ok {
+		return fmt.Errorf("Not found %s", "shield_schedule.test_schedule")
+	}
+
+	response, err := client.Get(fmt.Sprintf("v1/schedule/%s", rs.Primary.Attributes["uuid"]))
+
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != 404 {
+		return fmt.Errorf("Schedule still exists")
+	}
+
+	return nil
+}
+
+func testShieldCheckScheduleExists(n string, schedule *Schedule) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Schedule UUID is set")
+		}
+		return nil
+	}
+}

--- a/builtin/providers/shield/resource_store.go
+++ b/builtin/providers/shield/resource_store.go
@@ -1,0 +1,193 @@
+package shield
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type Store struct {
+	Name     string `json:"name,omitempty"`
+	Summary  string `json:"summary,omitempty"`
+	Plugin   string `json:"plugin,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Uuid     string `json:"uuid,omitempty"`
+}
+
+func resourceStore() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceStoreCreate,
+		Read:   resourceStoreRead,
+		Update: resourceStoreUpdate,
+		Delete: resourceStoreDelete,
+		Exists: resourceStoreExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"summary": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"plugin": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"endpoint": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidateStoreJSON,
+			},
+
+			"uuid": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createStore(d *schema.ResourceData) *Store {
+
+	return &Store{
+		Name:     d.Get("name").(string),
+		Summary:  d.Get("summary").(string),
+		Plugin:   d.Get("plugin").(string),
+		Endpoint: d.Get("endpoint").(string),
+	}
+
+}
+
+func resourceStoreCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	store := createStore(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(store)
+
+	store_req, err := client.Post(fmt.Sprintf("v1/stores"), jsonpayload)
+
+	decoder := json.NewDecoder(store_req.Body)
+	err = decoder.Decode(&store)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(store.Uuid)
+	d.Set("uuid", store.Uuid)
+
+	return resourceStoreRead(d, m)
+}
+
+func resourceStoreRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	store_req, err := client.Get(fmt.Sprintf("v1/stores"))
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(store_req.Body)
+	decoder.Token()
+
+	for decoder.More() {
+		var store Store
+
+		err := decoder.Decode(&store)
+		if err != nil {
+			return err
+		}
+		if store.Uuid == d.Get("uuid") {
+			d.Set("uuid", store.Uuid)
+			d.Set("name", store.Name)
+			d.Set("summary", store.Summary)
+			d.Set("plugin", store.Plugin)
+			d.Set("endpoint", store.Endpoint)
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceStoreUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	store := createStore(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(store)
+
+	store_req, err := client.Put(fmt.Sprintf("v1/store/%s",
+		d.Get("uuid").(string),
+	), jsonpayload)
+
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(store_req.Body)
+	err = decoder.Decode(&store)
+	if err != nil {
+		return err
+	}
+
+	return resourceStoreRead(d, m)
+}
+
+func resourceStoreExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*ShieldClient)
+	if _, okay := d.GetOk("uuid"); okay {
+		store_req, err := client.Get(fmt.Sprintf("v1/store/%s",
+			d.Get("uuid").(string),
+		))
+
+		if err != nil {
+			panic(err)
+		}
+
+		if store_req.StatusCode != 200 {
+			d.SetId("")
+			return false, nil
+		}
+
+		return true, nil
+	} else {
+		return false, nil
+	}
+
+}
+
+func resourceStoreDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	_, err := client.Delete(fmt.Sprintf("v1/store/%s",
+		d.Get("uuid").(string),
+	))
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValidateStoreJSON(configI interface{}, k string) ([]string, []error) {
+	configJSON := configI.(string)
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
+}

--- a/builtin/providers/shield/resource_store_test.go
+++ b/builtin/providers/shield/resource_store_test.go
@@ -1,0 +1,68 @@
+package shield
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestShieldStore_basic(t *testing.T) {
+	var store Store
+
+	testShieldStoreConfig := fmt.Sprintf(`
+		resource "shield_store" "test_store" {
+		  name = "Test-Store"
+		  summary = "Terraform Test Store"
+		  plugin = "fs"
+		  endpoint = "{\"base_dir\": \"/backup_test\"}"
+		}
+	`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testShieldStoreDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testShieldStoreConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testShieldCheckStoreExists("shield_store.test_store", &store),
+				),
+			},
+		},
+	})
+}
+
+func testShieldStoreDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ShieldClient)
+	rs, ok := s.RootModule().Resources["shield_store.test_store"]
+	if !ok {
+		return fmt.Errorf("Not found %s", "shield_store.test_store")
+	}
+
+	response, err := client.Get(fmt.Sprintf("v1/store/%s", rs.Primary.Attributes["uuid"]))
+
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != 404 {
+		return fmt.Errorf("Store still exists")
+	}
+
+	return nil
+}
+
+func testShieldCheckStoreExists(n string, store *Store) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Store UUID is set")
+		}
+		return nil
+	}
+}

--- a/builtin/providers/shield/resource_target.go
+++ b/builtin/providers/shield/resource_target.go
@@ -1,0 +1,201 @@
+package shield
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type Target struct {
+	Name     string `json:"name,omitempty"`
+	Summary  string `json:"summary,omitempty"`
+	Plugin   string `json:"plugin,omitempty"`
+	Agent    string `json:"agent,omitempty"`
+	Endpoint string `json:"endpoint,omitempty"`
+	Uuid     string `json:"uuid,omitempty"`
+}
+
+func resourceTarget() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTargetCreate,
+		Read:   resourceTargetRead,
+		Update: resourceTargetUpdate,
+		Delete: resourceTargetDelete,
+		Exists: resourceTargetExists,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"summary": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
+			"plugin": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"agent": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"endpoint": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: ValidateTargetJSON,
+			},
+
+			"uuid": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func createTarget(d *schema.ResourceData) *Target {
+
+	return &Target{
+		Name:     d.Get("name").(string),
+		Summary:  d.Get("summary").(string),
+		Plugin:   d.Get("plugin").(string),
+		Agent:    d.Get("agent").(string),
+		Endpoint: d.Get("endpoint").(string),
+	}
+
+}
+
+func resourceTargetCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	target := createTarget(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(target)
+
+	target_req, err := client.Post(fmt.Sprintf("v1/targets"), jsonpayload)
+
+	decoder := json.NewDecoder(target_req.Body)
+	err = decoder.Decode(&target)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(target.Uuid)
+	d.Set("uuid", target.Uuid)
+
+	return resourceTargetRead(d, m)
+}
+
+func resourceTargetRead(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	target_req, err := client.Get(fmt.Sprintf("v1/targets"))
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(target_req.Body)
+	decoder.Token()
+
+	for decoder.More() {
+		var target Target
+
+		err := decoder.Decode(&target)
+		if err != nil {
+			return err
+		}
+		if target.Uuid == d.Get("uuid") {
+			d.Set("uuid", target.Uuid)
+			d.Set("name", target.Name)
+			d.Set("summary", target.Summary)
+			d.Set("plugin", target.Plugin)
+			d.Set("endpoint", target.Endpoint)
+			d.Set("agent", target.Agent)
+			break
+		}
+	}
+
+	return nil
+}
+
+func resourceTargetUpdate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	target := createTarget(d)
+
+	var jsonbuffer []byte
+
+	jsonpayload := bytes.NewBuffer(jsonbuffer)
+	enc := json.NewEncoder(jsonpayload)
+	enc.Encode(target)
+
+	target_req, err := client.Put(fmt.Sprintf("v1/target/%s",
+		d.Get("uuid").(string),
+	), jsonpayload)
+
+	if err != nil {
+		return err
+	}
+
+	decoder := json.NewDecoder(target_req.Body)
+	err = decoder.Decode(&target)
+	if err != nil {
+		return err
+	}
+
+	return resourceTargetRead(d, m)
+}
+
+func resourceTargetExists(d *schema.ResourceData, m interface{}) (bool, error) {
+	client := m.(*ShieldClient)
+	if _, okay := d.GetOk("uuid"); okay {
+		target_req, err := client.Get(fmt.Sprintf("v1/target/%s",
+			d.Get("uuid").(string),
+		))
+
+		if err != nil {
+			panic(err)
+		}
+
+		if target_req.StatusCode != 200 {
+			d.SetId("")
+			return false, nil
+		}
+
+		return true, nil
+	} else {
+		return false, nil
+	}
+
+}
+
+func resourceTargetDelete(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ShieldClient)
+	_, err := client.Delete(fmt.Sprintf("v1/target/%s",
+		d.Get("uuid").(string),
+	))
+
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func ValidateTargetJSON(configI interface{}, k string) ([]string, []error) {
+	configJSON := configI.(string)
+	configMap := map[string]interface{}{}
+	err := json.Unmarshal([]byte(configJSON), &configMap)
+	if err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
+}

--- a/builtin/providers/shield/resource_target_test.go
+++ b/builtin/providers/shield/resource_target_test.go
@@ -1,0 +1,69 @@
+package shield
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"testing"
+)
+
+func TestShieldTarget_basic(t *testing.T) {
+	var target Target
+
+	testShieldTargetConfig := fmt.Sprintf(`
+		resource "shield_target" "test_target" {
+		  name = "Test-Target"
+		  summary = "Terraform Test Target"
+		  plugin = "mysql"
+		  endpoint = "{\"mysql_user\":\"root\",\"mysql_password\":\"secure-pw\",\"mysql_host\": \"localhost\",\"mysql_port\": 3306}"
+		  agent = "localhost:5444"
+		}
+	`)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testShieldTargetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testShieldTargetConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testShieldCheckTargetExists("shield_target.test_target", &target),
+				),
+			},
+		},
+	})
+}
+
+func testShieldTargetDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ShieldClient)
+	rs, ok := s.RootModule().Resources["shield_target.test_target"]
+	if !ok {
+		return fmt.Errorf("Not found %s", "shield_target.test_target")
+	}
+
+	response, err := client.Get(fmt.Sprintf("v1/target/%s", rs.Primary.Attributes["uuid"]))
+
+	if err != nil {
+		return err
+	}
+
+	if response.StatusCode != 404 {
+		return fmt.Errorf("Target still exists")
+	}
+
+	return nil
+}
+
+func testShieldCheckTargetExists(n string, target *Target) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Target UUID is set")
+		}
+		return nil
+	}
+}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -56,6 +56,7 @@ import (
 	randomprovider "github.com/hashicorp/terraform/builtin/providers/random"
 	rundeckprovider "github.com/hashicorp/terraform/builtin/providers/rundeck"
 	scalewayprovider "github.com/hashicorp/terraform/builtin/providers/scaleway"
+	shieldprovider "github.com/hashicorp/terraform/builtin/providers/shield"
 	softlayerprovider "github.com/hashicorp/terraform/builtin/providers/softlayer"
 	statuscakeprovider "github.com/hashicorp/terraform/builtin/providers/statuscake"
 	templateprovider "github.com/hashicorp/terraform/builtin/providers/template"
@@ -129,6 +130,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"random":       randomprovider.Provider,
 	"rundeck":      rundeckprovider.Provider,
 	"scaleway":     scalewayprovider.Provider,
+	"shield":       shieldprovider.Provider,
 	"softlayer":    softlayerprovider.Provider,
 	"statuscake":   statuscakeprovider.Provider,
 	"template":     templateprovider.Provider,

--- a/website/source/docs/providers/shield/index.html.markdown
+++ b/website/source/docs/providers/shield/index.html.markdown
@@ -1,0 +1,77 @@
+---
+layout: "shield"
+page_title: "Provider: Shield"
+sidebar_current: "docs-shield-index"
+description: |-
+  Shield is a standalone system that can perform backup and restore functions for a wide variety of pluggable data systems.
+---
+
+# Shield Provider
+
+[Shield](https://github.com/starkandwayne/shield) is a standalone system that can perform backup and restore functions for a wide variety of pluggable data systems . The Shield
+provider exposes resources to interact with a Shield server.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```
+# Configure the Nomad provider
+provider "shield" {
+  serverurl = "shield.example.com"
+  username = "admin"
+  password = "fancypassword"
+  insecure = false
+}
+
+# Register a target
+resource "shield_target" "test_target" {
+  name = "Test-Target"
+  summary = "Terraform Test Target"
+  plugin = "mysql"
+  endpoint = "${file("test-target.json")}"
+  agent = "127.0.0.1:5444"
+}
+
+# Register a schedule
+resource "shield_schedule" "test_schedule" {
+  name = "Test-Schedule"
+  summary = "Terraform Test Schedule"
+  when = "daily 1am"
+}
+
+# Register a store
+resource "shield_store" "test_store" {
+  name = "Test-Store"
+  summary = "Terraform Test Store"
+  plugin = "fs"
+  endpoint = "${file("test-store.json")}"
+}
+
+# Register a retention policy
+resource "shield_retention_policy" "test_retention" {
+  name = "Test Retention"
+  summary = "Terraform Test Retention"
+  expires = 86400
+}
+
+# Register a job
+resource "shield_job" "test_job" {
+  name = "Test-Job"
+  summary = "Terraform Test Job"
+  store = "${ shield_store.test_store.uuid }"
+  target = "${ shield_target.test_target.uuid }"
+  retention = "${ shield_retention_policy.test_retention.uuid }"
+  schedule = "${ shield_schedule.test_schedule.uuid }"
+  paused = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `serverurl` - (Required) The HTTPS endpoint of the shield daemon.
+* `username` - (Required) Username of the shield user.
+* `password` - (Required) Password of the shield user.
+* `insecure` - (Optional) Ignores certificate warnings (eg. allows self-signed certificates)

--- a/website/source/docs/providers/shield/r/job.html.markdown
+++ b/website/source/docs/providers/shield/r/job.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "shield"
+page_title: "Shield: shield_job"
+sidebar_current: "docs-shield-resource-job"
+description: |-
+  Manages a job in Shield.
+---
+
+# shield\_job
+
+Manages a job in Shield.
+
+A job in Shield combines store, target, retention policy and schedule
+into a logical construct.
+
+## Example Usage
+
+Registering a job:
+
+```
+resource "shield_job" "test_job" {
+  name = "Test-Job"
+  summary = "Terraform Test Job"
+  store = "${ shield_store.test_store.uuid }"
+  target = "${ shield_target.test_target.uuid }"
+  retention = "${ shield_retention_policy.test_retention.uuid }"
+  schedule = "${ shield_schedule.test_schedule.uuid }"
+  paused = false
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the target.
+
+* `summary` - (Optional) A summary of the target.
+
+* `store` - (Required) The UUID of the store to use.
+
+* `target` - (Required) The UUID of the target to use.
+
+* `retention` - (Required) The UUID of the retention policy to use.
+
+* `schedule` - (Required) The UUID of the schedule to use.
+
+* `paused` - (Optional) Boolean if the job is paused.

--- a/website/source/docs/providers/shield/r/retention_policy.html.markdown
+++ b/website/source/docs/providers/shield/r/retention_policy.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "shield"
+page_title: "Shield: shield_retention_policy"
+sidebar_current: "docs-shield-resource-retention-policy"
+description: |-
+  Manages a retention policy in Shield.
+---
+
+# shield\_target
+
+Manages a retention policy in Shield.
+
+A retention policy defines how long a backup gets stored.
+
+## Example Usage
+
+Registering a target:
+
+```
+resource "shield_retention_policy" "test_retention" {
+  name = "Test Retention"
+  summary = "Terraform Test Retention"
+  expires = 86400
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the target.
+
+* `summary` - (Optional) A summary of the target.
+
+* `expires` - (Required) The amount of seconds to keep a backup.

--- a/website/source/docs/providers/shield/r/schedule.html.markdown
+++ b/website/source/docs/providers/shield/r/schedule.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "shield"
+page_title: "Shield: shield_schedule"
+sidebar_current: "docs-shield-resource-schedule"
+description: |-
+  Manages a schedule in Shield.
+---
+
+# shield\_schedule
+
+Manages a schedule in Shield.
+
+A schedule in Shield defines when a job gets executed.
+
+## Example Usage
+
+Registering a schedule:
+
+```
+resource "shield_schedule" "test_schedule" {
+  name = "Test-Schedule"
+  summary = "Terraform Test Schedule"
+  when = "daily 1am"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the schedule.
+
+* `summary` - (Optional) A summary of the schedule.
+
+* `when` - (Required) The declaration when a job gets executed.

--- a/website/source/docs/providers/shield/r/store.html.markdown
+++ b/website/source/docs/providers/shield/r/store.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "shield"
+page_title: "Shield: shield_store"
+sidebar_current: "docs-shield-resource-store"
+description: |-
+  Manages a store in Shield.
+---
+
+# shield\_store
+
+Manages a store in Shield.
+
+A store in Shield defines where the output of a job gets stored.
+
+## Example Usage
+
+Registering a store:
+
+```
+resource "shield_store" "test_store" {
+  name = "Test-Store"
+  summary = "Terraform Test Store"
+  plugin = "fs"
+  endpoint = "${file("test-store.json")}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the store.
+
+* `summary` - (Optional) A summary of the store.
+
+* `plugin` - (Required) The plugin to use for the store.
+
+* `endpoint` - (Required) The configuration of the plugin.

--- a/website/source/docs/providers/shield/r/target.html.markdown
+++ b/website/source/docs/providers/shield/r/target.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "shield"
+page_title: "Shield: shield_target"
+sidebar_current: "docs-shield-resource-target"
+description: |-
+  Manages a target in Shield.
+---
+
+# shield\_target
+
+Manages a target in Shield.
+
+A target in Shield defines the plugin, it’s the corresponding [configuration](https://github.com/starkandwayne/shield#plugins)
+and the shield agents which will execute the job.
+
+## Example Usage
+
+Registering a target:
+
+```
+resource "shield_target" "test_target" {
+  name = "Test-Target"
+  summary = "Terraform Test Target"
+  plugin = "mysql"
+  endpoint = "${file("test-target.json")}"
+  agent = "localhost:5444"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the target.
+
+* `summary` - (Optional) A summary of the target.
+
+* `plugin` - (Required) The plugin to use for the target.
+
+* `agent` - (Required) The agent including port which will run the job.


### PR DESCRIPTION
Shield (https://github.com/starkandwayne/shield) is a standalone system that
can perform backup and restore functions for a wide variety of pluggable data
systems.

It is released under the MIT license.

The `shield` provider currently supports:

* Target
* Storage
* Retention Policy
* Schedule
* Job

Currently not supported (may be introduced in a later version):

* Archive Endpoint
* Tasks Endpoint
* Metadata Endpoint


 