### PR TITLE
provider/docker: Fix docker_registry_image resource to fetch the proper image sha using the v2 registry manifest

### DIFF
--- a/builtin/providers/docker/data_source_docker_registry_image.go
+++ b/builtin/providers/docker/data_source_docker_registry_image.go
@@ -74,6 +74,9 @@ func getImageDigest(registry, image, tag, username, password string) (string, er
 		req.SetBasicAuth(username, password)
 	}
 
+	// Set this accept header so that we get the v2 manifest back from the registry.
+	req.Header.Set("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
 	resp, err := client.Do(req)
 
 	if err != nil {


### PR DESCRIPTION
This fixes issue #12135. By setting this header we will receive a v2 manifest from the registry which will contain the correct ```Docker-Content-Digest``` return header. We parse this header a few lines below my change and use it to figure out when an image should be updated.

This fix means that terraform will not try to restart containers when no actual image change is present. This can be seen when a single image is tagged as v1 and v2 and terraform is told to switch from one tag to another.

I spoke to @kyhavlov about this as he was the original creator of the docker_registry_image resource, and he agrees that this fix was the originally intended behavior of the resource.