### PR TITLE
Fixed broken build for netbsd

### DIFF
--- a/config/module/inode.go
+++ b/config/module/inode.go
@@ -1,4 +1,4 @@
-// +build linux darwin openbsd solaris
+// +build linux darwin openbsd netbsd solaris
 
 package module
 


### PR DESCRIPTION
Netbsd fails because inode isn't defined, see below.  The fix is to add build tag for netbsd for the inode.go file as it's skipped for netbsd builds. 
$:terraform jam [netbsd_build] $ XC_OS=netbsd XC_ARCH=amd64 make bin
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/22 00:24:15 Generated command/internal_plugin_list.go
==> Removing old directory...
==> Building...
Number of parallel builds: 7

-->    netbsd/amd64: github.com/hashicorp/terraform

1 errors occurred:
--> netbsd/amd64 error: exit status 2
Stderr: # github.com/hashicorp/terraform/config/module
config/module/copy_dir.go:93: undefined: inode
config/module/copy_dir.go:101: undefined: inode

==> Packaging...

==> Results: