### PR TITLE
provider/pagerduty: Import support for service integrations

### DIFF
--- a/builtin/providers/pagerduty/import_pagerduty_service_integration_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_service_integration_test.go
@@ -1,0 +1,28 @@
+package pagerduty
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccPagerDutyServiceIntegration_import(t *testing.T) {
+	resourceName := "pagerduty_service_integration.foo"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceIntegrationConfig,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_addon.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_addon.go
@@ -14,7 +14,7 @@ func resourcePagerDutyAddon() *schema.Resource {
 		Update: resourcePagerDutyAddonUpdate,
 		Delete: resourcePagerDutyAddonDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourcePagerDutyAddonImport,
+			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -104,11 +104,4 @@ func resourcePagerDutyAddonDelete(d *schema.ResourceData, meta interface{}) erro
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePagerDutyAddonImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	if err := resourcePagerDutyAddonRead(d, meta); err != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }

--- a/builtin/providers/pagerduty/resource_pagerduty_escalation_policy.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_escalation_policy.go
@@ -14,7 +14,7 @@ func resourcePagerDutyEscalationPolicy() *schema.Resource {
 		Update: resourcePagerDutyEscalationPolicyUpdate,
 		Delete: resourcePagerDutyEscalationPolicyDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourcePagerDutyEscalationPolicyImport,
+			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -166,11 +166,4 @@ func resourcePagerDutyEscalationPolicyDelete(d *schema.ResourceData, meta interf
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePagerDutyEscalationPolicyImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	if err := resourcePagerDutyEscalationPolicyRead(d, meta); err != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }

--- a/builtin/providers/pagerduty/resource_pagerduty_schedule.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_schedule.go
@@ -14,7 +14,7 @@ func resourcePagerDutySchedule() *schema.Resource {
 		Update: resourcePagerDutyScheduleUpdate,
 		Delete: resourcePagerDutyScheduleDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourcePagerDutyScheduleImport,
+			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -195,11 +195,4 @@ func resourcePagerDutyScheduleDelete(d *schema.ResourceData, meta interface{}) e
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePagerDutyScheduleImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	if err := resourcePagerDutyScheduleRead(d, meta); err != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }

--- a/builtin/providers/pagerduty/resource_pagerduty_service.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service.go
@@ -14,7 +14,7 @@ func resourcePagerDutyService() *schema.Resource {
 		Update: resourcePagerDutyServiceUpdate,
 		Delete: resourcePagerDutyServiceDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourcePagerDutyServiceImport,
+			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -302,12 +302,4 @@ func resourcePagerDutyServiceDelete(d *schema.ResourceData, meta interface{}) er
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePagerDutyServiceImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	if err := resourcePagerDutyServiceRead(d, meta); err != nil {
-		return nil, err
-	}
-
-	return []*schema.ResourceData{d}, nil
 }

--- a/builtin/providers/pagerduty/resource_pagerduty_team.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_team.go
@@ -14,7 +14,7 @@ func resourcePagerDutyTeam() *schema.Resource {
 		Update: resourcePagerDutyTeamUpdate,
 		Delete: resourcePagerDutyTeamDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourcePagerDutyTeamImport,
+			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -104,11 +104,4 @@ func resourcePagerDutyTeamDelete(d *schema.ResourceData, meta interface{}) error
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePagerDutyTeamImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	if err := resourcePagerDutyTeamRead(d, meta); err != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }

--- a/builtin/providers/pagerduty/resource_pagerduty_user.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_user.go
@@ -14,7 +14,7 @@ func resourcePagerDutyUser() *schema.Resource {
 		Update: resourcePagerDutyUserUpdate,
 		Delete: resourcePagerDutyUserDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourcePagerDutyUserImport,
+			State: schema.ImportStatePassthrough,
 		},
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -226,11 +226,4 @@ func resourcePagerDutyUserDelete(d *schema.ResourceData, meta interface{}) error
 	d.SetId("")
 
 	return nil
-}
-
-func resourcePagerDutyUserImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-	if err := resourcePagerDutyUserRead(d, meta); err != nil {
-		return nil, err
-	}
-	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
This PR adds support for importing service integrations as well as fixes an issue where `vendor` would never be set in the state.

Since we need two IDs when importing a service integration (the `serviceID` and the `serviceIntegrationID`) the import just tries to locate a service with the matching service integration ID, ~~but it would be even better to be explicit here and maybe have something like: `terraform import pagerduty_service_integration.main <serviceID>_<serviceIntegrationID>`~~ 
Update: Since it's only possible to have one service integration for one service at a time, this should be a safe to do.

This PR also removes the unnecessary use of custom imports for the other PagerDuty resources.
Since we're not doing anything fancy with those we can just use `schema.ImportStatePassthrough` instead.

Any feedback is more than welcome.