### PR TITLE
docs: remove ambiguousity regarding s3_key

### DIFF
--- a/website/source/docs/providers/aws/r/lambda_function.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_function.html.markdown
@@ -54,7 +54,7 @@ resource "aws_lambda_function" "test_lambda" {
 
 * `filename` - (Optional) A [zip file][2] containing your lambda function source code. If defined, The `s3_*` options cannot be used.
 * `s3_bucket` - (Optional) The S3 bucket location containing your lambda function source code. Conflicts with `filename`.
-* `s3_key` - (Optional) The S3 key containing your lambda function source code. Conflicts with `filename`.
+* `s3_key` - (Optional) The S3 key of a [zip file][2] containing your lambda function source code. Conflicts with `filename`.
 * `s3_object_version` - (Optional) The object version of your lambda function source code. Conflicts with `filename`.
 * `function_name` - (Required) A unique name for your Lambda Function.
 * `handler` - (Required) The function [entrypoint][3] in your code.


### PR DESCRIPTION
This changes the doc to deliberately specify that the `s3_key` target must contain a zip file as well. Pointing it to a raw source file will result in:
```
Error applying plan:

1 error(s) occurred:

* aws_lambda_function.lambda: Error modifying Lambda Function Code githubControl: InvalidParameterValueException: Could not unzip uploaded file. Please check your file, then try to upload again.
```