### PR TITLE
command: refresh state in old commands for backend

### DIFF
--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/state"
@@ -111,11 +110,6 @@ func (b *Local) State() (state.State, error) {
 	var s state.State = &state.LocalState{
 		Path:    b.StatePath,
 		PathOut: b.StateOutPath,
-	}
-
-	// Load the state as a sanity check
-	if err := s.RefreshState(); err != nil {
-		return nil, errwrap.Wrapf("Error reading local state: {{err}}", err)
 	}
 
 	// If we are backing up the state, wrap it

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -103,6 +103,9 @@ func TestMetaBackend_emptyWithDefaultState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("bad: %s", err)
 	}
+	if err := s.RefreshState(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 	if actual := s.State().String(); actual != testState().String() {
 		t.Fatalf("bad: %s", actual)
 	}
@@ -172,6 +175,9 @@ func TestMetaBackend_emptyWithExplicitState(t *testing.T) {
 	s, err := b.State()
 	if err != nil {
 		t.Fatalf("bad: %s", err)
+	}
+	if err := s.RefreshState(); err != nil {
+		t.Fatalf("err: %s", err)
 	}
 	if actual := s.State().String(); actual != testState().String() {
 		t.Fatalf("bad: %s", actual)

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -38,6 +38,11 @@ func (c *StateListCommand) Run(args []string) int {
 		return 1
 	}
 
+	if err := state.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
+
 	stateReal := state.State()
 	if stateReal == nil {
 		c.Ui.Error(fmt.Sprintf(errStateNotFound))

--- a/command/state_list_test.go
+++ b/command/state_list_test.go
@@ -1,9 +1,11 @@
 package command
 
 import (
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/copy"
 	"github.com/mitchellh/cli"
 )
 
@@ -29,6 +31,35 @@ func TestStateList(t *testing.T) {
 
 	// Test that outputs were displayed
 	expected := strings.TrimSpace(testStateListOutput) + "\n"
+	actual := ui.OutputWriter.String()
+	if actual != expected {
+		t.Fatalf("Expected:\n%q\n\nTo equal: %q", actual, expected)
+	}
+}
+
+func TestStateList_backendState(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("state-list-backend"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	p := testProvider()
+	ui := new(cli.MockUi)
+	c := &StateListCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(p),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	// Test that outputs were displayed
+	expected := "null_resource.a\n"
 	actual := ui.OutputWriter.String()
 	if actual != expected {
 		t.Fatalf("Expected:\n%q\n\nTo equal: %q", actual, expected)

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -45,14 +45,14 @@ func (c *StateMvCommand) Run(args []string) int {
 		return cli.RunResultHelp
 	}
 
-	stateFromReal := stateFrom.State()
-	if stateFromReal == nil {
-		c.Ui.Error(fmt.Sprintf(errStateNotFound))
+	if err := stateFrom.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
 
-	if err := stateFrom.RefreshState(); err != nil {
-		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+	stateFromReal := stateFrom.State()
+	if stateFromReal == nil {
+		c.Ui.Error(fmt.Sprintf(errStateNotFound))
 		return 1
 	}
 

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -51,6 +51,11 @@ func (c *StateMvCommand) Run(args []string) int {
 		return 1
 	}
 
+	if err := stateFrom.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
+
 	// Read the destination state
 	stateTo := stateFrom
 	stateToReal := stateFromReal
@@ -59,6 +64,11 @@ func (c *StateMvCommand) Run(args []string) int {
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 			return cli.RunResultHelp
+		}
+
+		if err := stateTo.RefreshState(); err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+			return 1
 		}
 
 		stateToReal = stateTo.State()

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -30,6 +30,10 @@ func (c *StateRmCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf(errStateLoadingState, err))
 		return cli.RunResultHelp
 	}
+	if err := state.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
 
 	stateReal := state.State()
 	if stateReal == nil {

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -39,6 +39,10 @@ func (c *StateShowCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
+	if err := state.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
 
 	stateReal := state.State()
 	if stateReal == nil {

--- a/command/taint.go
+++ b/command/taint.go
@@ -72,6 +72,10 @@ func (c *TaintCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
+	if err := st.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
 
 	if c.Meta.stateLock {
 		lockInfo := state.NewLockInfo()

--- a/command/test-fixtures/state-list-backend/.terraform/terraform.tfstate
+++ b/command/test-fixtures/state-list-backend/.terraform/terraform.tfstate
@@ -1,0 +1,22 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": "local-state.tfstate"
+        },
+        "hash": 9073424445967744180
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/command/test-fixtures/state-list-backend/local-state.tfstate
+++ b/command/test-fixtures/state-list-backend/local-state.tfstate
@@ -1,0 +1,31 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 7,
+    "lineage": "configuredUnchanged",
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {
+                "null_resource.a": {
+                    "type": "null_resource",
+                    "depends_on": [],
+                    "primary": {
+                        "id": "5416263284413907707",
+                        "attributes": {
+                            "id": "5416263284413907707"
+                        },
+                        "meta": {},
+                        "tainted": false
+                    },
+                    "deposed": [],
+                    "provider": ""
+                }
+            },
+            "depends_on": []
+        }
+    ]
+}

--- a/command/test-fixtures/state-list-backend/main.tf
+++ b/command/test-fixtures/state-list-backend/main.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local" {
+        path = "local-state.tfstate"
+    }
+}

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -60,6 +60,10 @@ func (c *UntaintCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
 		return 1
 	}
+	if err := st.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
 
 	if c.Meta.stateLock {
 		lockInfo := state.NewLockInfo()

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -207,6 +207,7 @@ func (c *Context) Graph(typ GraphType, opts *ContextGraphOpts) (*Graph, error) {
 		opts = &ContextGraphOpts{Validate: true}
 	}
 
+	log.Printf("[INFO] terraform: building graph: %s", typ)
 	switch typ {
 	case GraphTypeApply:
 		return (&ApplyGraphBuilder{


### PR DESCRIPTION
Fixes #12148 

The Backend API doesn't automatically `RefreshState` for you like the old Meta State API did. We have to manually do this across all commands.

I considered making it a requirement to do a refresh but we call State() multiple times on a backend and the point of _not_ refreshing it was so that calling State() was cheap. I think its worth it to keep it that way.