### PR TITLE
provider/aws: Validate aws_ecs_task_definition.container_definitions

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition.go
@@ -45,6 +45,7 @@ func resourceAwsEcsTaskDefinition() *schema.Resource {
 					hash := sha1.Sum([]byte(v.(string)))
 					return hex.EncodeToString(hash[:])
 				},
+				ValidateFunc: validateAwsEcsTaskDefinitionContainerDefinitions,
 			},
 
 			"task_role_arn": {
@@ -115,6 +116,15 @@ func validateAwsEcsTaskDefinitionNetworkMode(v interface{}, k string) (ws []stri
 
 	if _, ok := validTypes[value]; !ok {
 		errors = append(errors, fmt.Errorf("ECS Task Definition network_mode %q is invalid, must be `bridge`, `host` or `none`", value))
+	}
+	return
+}
+
+func validateAwsEcsTaskDefinitionContainerDefinitions(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	_, err := expandEcsContainerDefinitions(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("ECS Task Definition container_definitions is invalid: %s", err))
 	}
 	return
 }

--- a/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
+++ b/builtin/providers/aws/resource_aws_ecs_task_definition_test.go
@@ -168,6 +168,28 @@ func TestValidateAwsEcsTaskDefinitionNetworkMode(t *testing.T) {
 	}
 }
 
+func TestValidateAwsEcsTaskDefinitionContainerDefinitions(t *testing.T) {
+	validDefinitions := []string{
+		testValidateAwsEcsTaskDefinitionValidContainerDefinitions,
+	}
+	for _, v := range validDefinitions {
+		_, errors := validateAwsEcsTaskDefinitionContainerDefinitions(v, "container_definitions")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid AWS ECS Task Definition Container Definitions: %q", v, errors)
+		}
+	}
+
+	invalidDefinitions := []string{
+		testValidateAwsEcsTaskDefinitionInvalidCommandContainerDefinitions,
+	}
+	for _, v := range invalidDefinitions {
+		_, errors := validateAwsEcsTaskDefinitionContainerDefinitions(v, "container_definitions")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid AWS ECS Task Definition Container Definitions", v)
+		}
+	}
+}
+
 func testAccCheckAWSEcsTaskDefinitionDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).ecsconn
 
@@ -581,4 +603,30 @@ TASK_DEFINITION
     host_path = "/ecs/jenkins-home"
   }
 }
+`
+
+var testValidateAwsEcsTaskDefinitionValidContainerDefinitions = `
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": ["sleep","360"],
+    "memory": 10,
+    "essential": true
+  }
+]
+`
+
+var testValidateAwsEcsTaskDefinitionInvalidCommandContainerDefinitions = `
+[
+  {
+    "name": "sleep",
+    "image": "busybox",
+    "cpu": 10,
+    "command": "sleep 360",
+    "memory": 10,
+    "essential": true
+  }
+]
 `


### PR DESCRIPTION
Currently there is no validation in `aws_ecs_task_definition.container_definitions`,
but I would like to be able to validate it at plan.

The following is an example for invalid definition.
Note that `"sleep 360"` in `command` should be array as `["sleep", "360"]`.
This is easy to make a mistake. I was actually wrong and suffer for a while.
```
provider "aws" {
  region = "us-east-1"
}

resource "aws_ecs_task_definition" "test" {
  family = "test"

  container_definitions = <<EOF
[
  {
    "name": "sleep",
    "image": "busybox",
    "cpu": 10,
    "command": "sleep 360",
    "memory": 10,
    "essential": true
  }
]
EOF
}
```

## Before change
There is no error at plan. ( Of course, it will be an error when applied. )

```
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ aws_ecs_task_definition.test
    arn:                   "<computed>"
    container_definitions: "f3458871d51e9a7690213fb82dba565e66458870"
    family:                "test"
    network_mode:          "<computed>"
    revision:              "<computed>"


Plan: 1 to add, 0 to change, 0 to destroy.
```

## After change
We can now detect the error at plan:

```
$ terraform plan
1 error(s) occurred:

* aws_ecs_task_definition.test: ECS Task Definition container_definitions is invalid: Error decoding JSON: json: cannot unmarshal string into Go struct field ContainerDefinition.Command of type []*string
```

Furthermore, field names that failed in `json.Unmarshal` are now included in error messages thanks to recent update of terraform Go version to 1.8.