### PR TITLE
Small doc updates

### DIFF
--- a/website/source/docs/providers/vault/index.html.markdown
+++ b/website/source/docs/providers/vault/index.html.markdown
@@ -129,13 +129,23 @@ The `client_auth` configuration block accepts the following arguments:
 ```
 provider "vault" {
   # It is strongly recommended to configure this provider through the
-  # environment variables described below, so that each user can have
+  # environment variables described above, so that each user can have
   # separate credentials set in the environment.
-  address = "https://vault.example.net:8200"
+  #
+  # This will default to using $VAULT_ADDR
+  # But can be set explicitly
+  # address = "https://vault.example.net:8200"
 }
 
-data "vault_generic_secret" "example" {
+resource "vault_generic_secret" "example" {
   path = "secret/foo"
+
+  data_json = <<EOT
+{
+  "foo":   "bar",
+  "pizza": "cheese"
+}
+EOT
 }
 ```
 


### PR DESCRIPTION
Changed the comment about configuring the provider

Replaced the `data` example, with a correct `resource` example.