### PR TITLE
provider/datadog: Adding default values to datadog_monitor

### DIFF
--- a/builtin/providers/datadog/resource_datadog_monitor.go
+++ b/builtin/providers/datadog/resource_datadog_monitor.go
@@ -104,6 +104,7 @@ func resourceDatadogMonitor() *schema.Resource {
 			"require_full_window": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 			"locked": {
 				Type:     schema.TypeBool,
@@ -122,6 +123,7 @@ func resourceDatadogMonitor() *schema.Resource {
 			"include_tags": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  true,
 			},
 			"tags": {
 				Type:     schema.TypeList,
@@ -147,8 +149,10 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 	}
 
 	o := datadog.Options{
-		Thresholds:   &thresholds,
-		NotifyNoData: datadog.Bool(d.Get("notify_no_data").(bool)),
+		Thresholds:        &thresholds,
+		NotifyNoData:      datadog.Bool(d.Get("notify_no_data").(bool)),
+		RequireFullWindow: datadog.Bool(d.Get("require_full_window").(bool)),
+		IncludeTags:       datadog.Bool(d.Get("include_tags").(bool)),
 	}
 	if attr, ok := d.GetOk("silenced"); ok {
 		s := make(map[string]int)
@@ -178,12 +182,6 @@ func buildMonitorStruct(d *schema.ResourceData) *datadog.Monitor {
 	}
 	if attr, ok := d.GetOk("escalation_message"); ok {
 		o.SetEscalationMessage(attr.(string))
-	}
-	if attr, ok := d.GetOk("include_tags"); ok {
-		o.SetIncludeTags(attr.(bool))
-	}
-	if attr, ok := d.GetOk("require_full_window"); ok {
-		o.SetRequireFullWindow(attr.(bool))
 	}
 	if attr, ok := d.GetOk("locked"); ok {
 		o.SetLocked(attr.(bool))


### PR DESCRIPTION
Fixes: #8055
Fixes: #10264
Fixes: #10881

We have swapped from using d.GetOk (as that func returns nil when a
default value is used) and moved to using default values that we can
pass directly to the Struct. The fact we have default values, means that
we can use d.Get which will work here

```
% make testacc TEST=./builtin/providers/datadog
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/02/22 18:56:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/datadog -v  -timeout 120m
=== RUN   TestDatadogMonitor_import
--- PASS: TestDatadogMonitor_import (8.66s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDatadogMonitor_Basic
--- PASS: TestAccDatadogMonitor_Basic (5.68s)
=== RUN   TestAccDatadogMonitor_BasicNoTreshold
--- PASS: TestAccDatadogMonitor_BasicNoTreshold (3.13s)
=== RUN   TestAccDatadogMonitor_Updated
--- PASS: TestAccDatadogMonitor_Updated (6.41s)
=== RUN   TestAccDatadogMonitor_TrimWhitespace
--- PASS: TestAccDatadogMonitor_TrimWhitespace (3.22s)
=== RUN   TestAccDatadogMonitor_Basic_float_int
--- PASS: TestAccDatadogMonitor_Basic_float_int (5.50s)
=== RUN   TestAccDatadogTimeboard_update
--- PASS: TestAccDatadogTimeboard_update (8.35s)
=== RUN   TestValidateAggregatorMethod
--- PASS: TestValidateAggregatorMethod (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/datadog	40.954s
```