### PR TITLE
providers/terraform: remote state data source supports backends

### DIFF
--- a/backend/init/init.go
+++ b/backend/init/init.go
@@ -1,0 +1,55 @@
+// Package init contains the list of backends that can be initialized and
+// basic helper functions for initializing those backends.
+package init
+
+import (
+	"sync"
+
+	"github.com/hashicorp/terraform/backend"
+
+	backendlegacy "github.com/hashicorp/terraform/backend/legacy"
+	backendlocal "github.com/hashicorp/terraform/backend/local"
+	backendconsul "github.com/hashicorp/terraform/backend/remote-state/consul"
+	backendinmem "github.com/hashicorp/terraform/backend/remote-state/inmem"
+)
+
+// backends is the list of available backends. This is a global variable
+// because backends are currently hardcoded into Terraform and can't be
+// modified without recompilation.
+//
+// To read an available backend, use the Backend function. This ensures
+// safe concurrent read access to the list of built-in backends.
+//
+// Backends are hardcoded into Terraform because the API for backends uses
+// complex structures and supporting that over the plugin system is currently
+// prohibitively difficult. For those wanting to implement a custom backend,
+// they can do so with recompilation.
+var backends map[string]func() backend.Backend
+var backendsLock sync.Mutex
+
+func init() {
+	// Our hardcoded backends. We don't need to acquire a lock here
+	// since init() code is serial and can't spawn goroutines.
+	backends = map[string]func() backend.Backend{
+		"local":  func() backend.Backend { return &backendlocal.Local{} },
+		"consul": func() backend.Backend { return backendconsul.New() },
+		"inmem":  func() backend.Backend { return backendinmem.New() },
+	}
+
+	// Add the legacy remote backends that haven't yet been convertd to
+	// the new backend API.
+	backendlegacy.Init(backends)
+}
+
+// Backend returns the initialization factory for the given backend, or
+// nil if none exists.
+func Backend(name string) func() backend.Backend {
+	backendsLock.Lock()
+	defer backendsLock.Unlock()
+	return backends[name]
+}
+
+// NOTE(@mitchellh): At some point I'm sure we'll want Add() to add a backend
+// to the list. Right now we hardcode all backends and there isn't a reasonable
+// use case for this so we're leaving it out. It would be trivial to add in
+// the future.

--- a/backend/init/init.go
+++ b/backend/init/init.go
@@ -49,7 +49,21 @@ func Backend(name string) func() backend.Backend {
 	return backends[name]
 }
 
-// NOTE(@mitchellh): At some point I'm sure we'll want Add() to add a backend
-// to the list. Right now we hardcode all backends and there isn't a reasonable
-// use case for this so we're leaving it out. It would be trivial to add in
-// the future.
+// Set sets a new backend in the list of backends. If f is nil then the
+// backend will be removed from the map. If this backend already exists
+// then it will be overwritten.
+//
+// This method sets this backend globally and care should be taken to do
+// this only before Terraform is executing to prevent odd behavior of backends
+// changing mid-execution.
+func Set(name string, f func() backend.Backend) {
+	backendsLock.Lock()
+	defer backendsLock.Unlock()
+
+	if f == nil {
+		delete(backends, name)
+		return
+	}
+
+	backends[name] = f
+}

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/terraform/backend"
+	backendinit "github.com/hashicorp/terraform/backend/init"
 	clistate "github.com/hashicorp/terraform/command/state"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/state"
@@ -24,8 +25,6 @@ import (
 
 	backendlegacy "github.com/hashicorp/terraform/backend/legacy"
 	backendlocal "github.com/hashicorp/terraform/backend/local"
-	backendconsul "github.com/hashicorp/terraform/backend/remote-state/consul"
-	backendinmem "github.com/hashicorp/terraform/backend/remote-state/inmem"
 )
 
 // BackendOpts are the options used to initialize a backend.Backend.
@@ -1149,8 +1148,8 @@ func (m *Meta) backend_C_r_S_unchanged(
 	config := terraform.NewResourceConfig(rawC)
 
 	// Get the backend
-	f, ok := Backends[s.Backend.Type]
-	if !ok {
+	f := backendinit.Backend(s.Backend.Type)
+	if f == nil {
 		return nil, fmt.Errorf(strings.TrimSpace(errBackendSavedUnknown), s.Backend.Type)
 	}
 	b := f()
@@ -1300,8 +1299,8 @@ func (m *Meta) backendInitFromConfig(c *config.Backend) (backend.Backend, error)
 	config := terraform.NewResourceConfig(c.RawConfig)
 
 	// Get the backend
-	f, ok := Backends[c.Type]
-	if !ok {
+	f := backendinit.Backend(c.Type)
+	if f == nil {
 		return nil, fmt.Errorf(strings.TrimSpace(errBackendNewUnknown), c.Type)
 	}
 	b := f()
@@ -1374,8 +1373,8 @@ func (m *Meta) backendInitFromSaved(s *terraform.BackendState) (backend.Backend,
 	config := terraform.NewResourceConfig(rawC)
 
 	// Get the backend
-	f, ok := Backends[s.Type]
-	if !ok {
+	f := backendinit.Backend(s.Type)
+	if f == nil {
 		return nil, fmt.Errorf(strings.TrimSpace(errBackendSavedUnknown), s.Type)
 	}
 	b := f()
@@ -1396,27 +1395,6 @@ func (m *Meta) backendInitRequired(reason string) {
 //-------------------------------------------------------------------
 // Output constants and initialization code
 //-------------------------------------------------------------------
-
-// Backends is the list of available backends. This is currently a hardcoded
-// list that can't be modified without recompiling Terraform. This is done
-// because the API for backends uses complex structures and supporting that
-// over the plugin system is currently prohibitively difficult. For those
-// wanting to implement a custom backend, recompilation should not be a
-// high barrier.
-var Backends map[string]func() backend.Backend
-
-func init() {
-	// Our hardcoded backends
-	Backends = map[string]func() backend.Backend{
-		"local":  func() backend.Backend { return &backendlocal.Local{} },
-		"consul": func() backend.Backend { return backendconsul.New() },
-		"inmem":  func() backend.Backend { return backendinmem.New() },
-	}
-
-	// Add the legacy remote backends that haven't yet been convertd to
-	// the new backend API.
-	backendlegacy.Init(Backends)
-}
 
 // errBackendInitRequired is the final error message shown when reinit
 // is required for some reason. The error message includes the reason.


### PR DESCRIPTION
This changes the `terraform_remote_state` data source to support backends rather than going through the legacy remote state interface. 

To support this change without duplicating the list of backends, I introduce a new package `backend/init` which simply provides an API for looking up backend initializers. The `command` package was changed to use this as well. This means that we have a uniform way to lookup and initialize a backend.