### PR TITLE
backend/local: refresh with no config should not crash on input

### DIFF
--- a/backend/local/backend_refresh.go
+++ b/backend/local/backend_refresh.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/backend"
 	clistate "github.com/hashicorp/terraform/command/state"
+	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/state"
 )
 
@@ -40,6 +41,12 @@ func (b *Local) opRefresh(
 				b.StatePath, err)
 			return
 		}
+	}
+
+	// If we have no config module given to use, create an empty tree to
+	// avoid crashes when Terraform.Context is initialized.
+	if op.Module == nil {
+		op.Module = module.NewEmptyTree()
 	}
 
 	// Get our context


### PR DESCRIPTION
Fixes #12174 

[0.9 beta 1 bug]

You're allowed to refresh with a nil module (no configs) as long as you
have state. However, if `-input=true` (default) then this would crash
since the input attempts to read the configs.

The API contract with `terraform.Context` says that the module tree must
be non-nil and loaded. To do this for other commands we create an empty
module tree. We do that here now.