### PR TITLE
provider/spotinst: Disallow passing an empty user_data string

### DIFF
--- a/builtin/providers/spotinst/resource_spotinst_aws_group.go
+++ b/builtin/providers/spotinst/resource_spotinst_aws_group.go
@@ -2077,8 +2077,6 @@ func expandAwsGroupLaunchSpecification(data interface{}) (*spotinst.AwsGroupComp
 
 	if v, ok := m["user_data"].(string); ok && v != "" {
 		lc.UserData = spotinst.String(base64.StdEncoding.EncodeToString([]byte(v)))
-	} else {
-		lc.UserData = spotinst.String("")
 	}
 
 	if v, ok := m["security_group_ids"].([]interface{}); ok {


### PR DESCRIPTION
Was missed off the merged as I didn't merge from local to master