### PR TITLE
aws/provider: what was the value of the cluster id which caused the problem

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -36,23 +36,23 @@ func validateElastiCacheClusterId(v interface{}, k string) (ws []string, errors 
 	value := v.(string)
 	if (len(value) < 1) || (len(value) > 20) {
 		errors = append(errors, fmt.Errorf(
-			"%q must contain from 1 to 20 alphanumeric characters or hyphens", k))
+			"%q (%q) must contain from 1 to 20 alphanumeric characters or hyphens", k, value))
 	}
 	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+			"only lowercase alphanumeric characters and hyphens allowed in %q (%q)", k, value))
 	}
 	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"first character of %q must be a letter", k))
+			"first character of %q (%q) must be a letter", k, value))
 	}
 	if regexp.MustCompile(`--`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q cannot contain two consecutive hyphens", k))
+			"%q (%q) cannot contain two consecutive hyphens", k, value))
 	}
 	if regexp.MustCompile(`-$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q cannot end with a hyphen", k))
+			"%q (%q) cannot end with a hyphen", k, value))
 	}
 	return
 }


### PR DESCRIPTION
Found tracking down the exact source of this error:

    aws_elasticache_cluster.Cluster: "cluster_id" must contain from 1 to 20 alphanumeric characters or hyphens

So I've extended the error messages to include the value of the problematic cluster id:

  aws_elasticache_cluster.Cluster: "cluster_id" ("thisisaverylongclusterid") must contain from 1 to 20 alphanumeric characters or hyphens

Added this data to the other errors as well since I was in there. :-)