### PR TITLE
Fix AWS ECS placement strategy spread fields

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -357,7 +357,13 @@ func flattenPlacementStrategy(pss []*ecs.PlacementStrategy) []map[string]interfa
 	for _, ps := range pss {
 		c := make(map[string]interface{})
 		c["type"] = *ps.Type
-		c["field"] = strings.ToLower(*ps.Field)
+		c["field"] = *ps.Field
+
+		// for some fields the API requires lowercase for creation but will return uppercase on query
+		if *ps.Field == "MEMORY" || *ps.Field == "CPU" {
+			c["field"] = strings.ToLower(*ps.Field)
+		}
+
 		results = append(results, c)
 	}
 	return results


### PR DESCRIPTION
Fix for #11844 

AWS API requires ECS placement strategies "field" attribute to be
"memory" or "cpu" (lowercase) when type=bin, but these read back as
"MEMORY" and "CPU" (uppercase) respectively.

PR #11565 (which fixed separately reported #11644) deals with this by
always lowering the case of the resource received from the API, but this
breaks for other "field" values (e.g. "instanceId" -> "instanceid").

This PR only lowers the case of the returned resource when field
"MEMORY" or "CPU". Haven't checked if any other fields need this
treatment.