### PR TITLE
provider/pagerduty: Setting incident_urgency_rule as optional

### DIFF
--- a/builtin/providers/pagerduty/resource_pagerduty_service.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service.go
@@ -52,7 +52,7 @@ func resourcePagerDutyService() *schema.Resource {
 			},
 			"incident_urgency_rule": &schema.Schema{
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"type": {


### PR DESCRIPTION
This PR sets the `incident_urgency_rule` to `Optional` which is currently set as `Required` but according to the resource documentation and the PagerDuty API reference it's an optional. 

This should resolve https://github.com/hashicorp/terraform/issues/12149