### PR TITLE
Hash custom_data in state storage

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -1,6 +1,9 @@
 package azurerm
 
 import (
+	"crypto/sha1"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"reflect"
@@ -322,4 +325,32 @@ func ignoreCaseDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool
 // supplied value to lower before saving to state for consistency.
 func ignoreCaseStateFunc(val interface{}) string {
 	return strings.ToLower(val.(string))
+}
+
+func userDataStateFunc(v interface{}) string {
+	switch s := v.(type) {
+	case string:
+		s = base64Encode(s)
+		hash := sha1.Sum([]byte(s))
+		return hex.EncodeToString(hash[:])
+	default:
+		return ""
+	}
+}
+
+// Base64Encode encodes data if the input isn't already encoded using
+// base64.StdEncoding.EncodeToString. If the input is already base64 encoded,
+// return the original input unchanged.
+func base64Encode(data string) string {
+	// Check whether the data is already Base64 encoded; don't double-encode
+	if isBase64Encoded(data) {
+		return data
+	}
+	// data has not been encoded encode and return
+	return base64.StdEncoding.EncodeToString([]byte(data))
+}
+
+func isBase64Encoded(data string) bool {
+	_, err := base64.StdEncoding.DecodeString(data)
+	return err == nil
 }


### PR DESCRIPTION
This PR changes custom_data to be hashed in the statefile instead of plain-textified. This reduces the size of the statefile and is more in line with how other providers behave.

This also switches to helpers for b64.

/cc @stack72 