### PR TITLE
provider/aws: Fix the panic in ssm_association with parameters

### DIFF
--- a/builtin/providers/aws/resource_aws_ssm_association.go
+++ b/builtin/providers/aws/resource_aws_ssm_association.go
@@ -114,7 +114,7 @@ func resourceAwsSsmAssociationDelete(d *schema.ResourceData, meta interface{}) e
 func expandSSMDocumentParameters(params map[string]interface{}) map[string][]*string {
 	var docParams = make(map[string][]*string)
 	for k, v := range params {
-		var values []*string
+		values := make([]*string, 1)
 		values[0] = aws.String(v.(string))
 		docParams[k] = values
 	}


### PR DESCRIPTION
Fixes: #12205

You cannot use an index of an empty slide therefore, we got a panic as follows:

```
aws_ssm_association.foo: Creating...
  instance_id:              "" => "i-002f3898dc95350e7"
  name:                     "" => "test_document_association-%s"
  parameters.%:             "" => "2"
  parameters.directoryId:   "" => "d-926720980b"
  parameters.directoryName: "" => "corp.mydomain.com"
Error applying plan:

1 error(s) occurred:

* aws_ssm_association.foo: 1 error(s) occurred:

* aws_ssm_association.foo: unexpected EOF

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
panic: runtime error: index out of range
2017/02/23 21:41:45 [DEBUG] plugin: terraform-provider-aws:
2017/02/23 21:41:45 [DEBUG] plugin: terraform-provider-aws: goroutine 1419 [running]:
2017/02/23 21:41:45 [DEBUG] plugin: terraform-provider-aws: panic(0x1567480, 0xc42000c110)
2017/02/23 21:41:45 [DEBUG] plugin: terraform-provider-aws: 	/usr/local/Cellar/go/1.7.4_1/libexec/src/runtime/panic.go:500 +0x1a1
```