### PR TITLE
provider/aws: deprecating the creation of replicas from aws_db_instance

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -258,8 +258,9 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"replicate_source_db": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:       schema.TypeString,
+				Optional:   true,
+				Deprecated: "DB Instance Replicas will be moving to a separate resource as of Terraform 0.9",
 			},
 
 			"replicas": {


### PR DESCRIPTION
This will go out as part of Terraform 0.8.8

In Terraform 0.9, we will introduce a new resource
aws_db_instance_replica which will handle it