### PR TITLE
provider/openstack: Rename provider to loadbalancer_provider

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -75,7 +75,7 @@ func resourceLoadBalancerV2() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"provider": &schema.Schema{
+			"loadbalancer_provider": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -85,6 +85,7 @@ func resourceLoadBalancerV2() *schema.Resource {
 			"security_group_ids": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
@@ -108,7 +109,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 		VipAddress:   d.Get("vip_address").(string),
 		AdminStateUp: &adminStateUp,
 		Flavor:       d.Get("flavor").(string),
-		Provider:     d.Get("provider").(string),
+		Provider:     d.Get("loadbalancer_provider").(string),
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
@@ -168,7 +169,7 @@ func resourceLoadBalancerV2Read(d *schema.ResourceData, meta interface{}) error 
 	d.Set("vip_port_id", lb.VipPortID)
 	d.Set("admin_state_up", lb.AdminStateUp)
 	d.Set("flavor", lb.Flavor)
-	d.Set("provider", lb.Provider)
+	d.Set("loadbalancer_provider", lb.Provider)
 
 	// Get any security groups on the VIP Port
 	if lb.VipPortID != "" {

--- a/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2.go
+++ b/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2.go
@@ -75,6 +75,14 @@ func resourceLoadBalancerV2() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"provider": &schema.Schema{
+				Type:       schema.TypeString,
+				Optional:   true,
+				Computed:   true,
+				ForceNew:   true,
+				Deprecated: "Please use loadbalancer_provider",
+			},
+
 			"loadbalancer_provider": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -100,6 +108,11 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Error creating OpenStack networking client: %s", err)
 	}
 
+	var lbProvider string
+	if v, ok := d.GetOk("loadbalancer_provider"); ok {
+		lbProvider = v.(string)
+	}
+
 	adminStateUp := d.Get("admin_state_up").(bool)
 	createOpts := loadbalancers.CreateOpts{
 		Name:         d.Get("name").(string),
@@ -109,7 +122,7 @@ func resourceLoadBalancerV2Create(d *schema.ResourceData, meta interface{}) erro
 		VipAddress:   d.Get("vip_address").(string),
 		AdminStateUp: &adminStateUp,
 		Flavor:       d.Get("flavor").(string),
-		Provider:     d.Get("loadbalancer_provider").(string),
+		Provider:     lbProvider,
 	}
 
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)

--- a/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_lb_loadbalancer_v2_test.go
@@ -190,6 +190,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 
 resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
   name = "loadbalancer_1"
+  loadbalancer_provider = "haproxy"
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }
 `
@@ -209,6 +210,7 @@ resource "openstack_networking_subnet_v2" "subnet_1" {
 
 resource "openstack_lb_loadbalancer_v2" "loadbalancer_1" {
   name = "loadbalancer_1_updated"
+  loadbalancer_provider = "haproxy"
   admin_state_up = "true"
   vip_subnet_id = "${openstack_networking_subnet_v2.subnet_1.id}"
 }

--- a/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
@@ -50,8 +50,10 @@ The following arguments are supported:
 * `flavor` - (Optional) The UUID of a flavor. Changing this creates a new
     loadbalancer.
 
-* `loadbalancer_provider` - (Optional) The name of the provider. Changing this creates a new
-    loadbalancer.
+* `provider` - (Deprecated) Use `loadbalancer_provider` instead.
+
+* `loadbalancer_provider` - (Optional) The name of the provider. Changing this
+  creates a new loadbalancer.
 
 * `security_group_ids` - (Optional) A list of security group IDs to apply to the
     loadbalancer. The security groups must be specified by ID and not name (as

--- a/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_loadbalancer_v2.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 * `flavor` - (Optional) The UUID of a flavor. Changing this creates a new
     loadbalancer.
 
-* `provider` - (Optional) The name of the provider. Changing this creates a new
+* `loadbalancer_provider` - (Optional) The name of the provider. Changing this creates a new
     loadbalancer.
 
 * `security_group_ids` - (Optional) A list of security group IDs to apply to the
@@ -69,6 +69,6 @@ The following attributes are exported:
 * `vip_address` - See Argument Reference above.
 * `admin_state_up` - See Argument Reference above.
 * `flavor` - See Argument Reference above.
-* `provider` - See Argument Reference above.
+* `loadbalancer_provider` - See Argument Reference above.
 * `security_group_ids` - See Argument Reference above.
 * `vip_port_id` - The Port ID of the Load Balancer IP.


### PR DESCRIPTION
This commit renames provider to loadbalancer_provider in the
openstack_lb_loadbalancer_v2 resource.

It also changes security_group_ids to Computed so default
security groups are added to the state correctly.

Fixes #12237