### PR TITLE
missing default cases in sort from #12219

### DIFF
--- a/terraform/state.go
+++ b/terraform/state.go
@@ -2074,7 +2074,7 @@ func (r resourceNameSort) Less(i, j int) bool {
 		}
 	}
 
-	return false
+	return r[i] < r[j]
 }
 
 // moduleStateSort implements sort.Interface to sort module states

--- a/terraform/state_test.go
+++ b/terraform/state_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -1894,5 +1895,39 @@ func TestReadState_prune(t *testing.T) {
 
 	if !reflect.DeepEqual(actual, expected) {
 		t.Fatalf("got:\n%#v", actual)
+	}
+}
+
+func TestResourceNameSort(t *testing.T) {
+	names := []string{
+		"a",
+		"b",
+		"a.0",
+		"a.c",
+		"a.d",
+		"c",
+		"a.b.0",
+		"a.b.1",
+		"a.b.10",
+		"a.b.2",
+	}
+
+	sort.Sort(resourceNameSort(names))
+
+	expected := []string{
+		"a",
+		"a.0",
+		"a.b.0",
+		"a.b.1",
+		"a.b.2",
+		"a.b.10",
+		"a.c",
+		"a.d",
+		"b",
+		"c",
+	}
+
+	if !reflect.DeepEqual(names, expected) {
+		t.Fatalf("got: %q\nexpected: %q\n", names, expected)
 	}
 }


### PR DESCRIPTION
Need to properly catch a sort case around 0-1 indexing
This can cause output to shift slightly, resulting in an intermittent
test failure.

Add a test to make sure this sort function is correct.