### PR TITLE
provider/aws: Fix argument documentation and error messages for aws_ssm_document resource

### DIFF
--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -384,7 +384,7 @@ func validateAwsSSMDocumentType(v interface{}, k string) (ws []string, errors []
 	}
 
 	if !types[value] {
-		errors = append(errors, fmt.Errorf("CodeBuild: Arifacts Namespace Type can only be NONE / BUILD_ID"))
+		errors = append(errors, fmt.Errorf("Document type %s is invalid. Valid types are Command, Policy or Automation", value))
 	}
 	return
 }

--- a/website/source/docs/providers/aws/r/ssm_document.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_document.html.markdown
@@ -46,7 +46,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the document.
 * `content` - (Required) The json content of the document.
 * `document_type` - (Required) The type of the document. Valid document types include: `Command`, `Policy` and `Automation`
-* `permission` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
+* `permissions` - (Optional) Additional Permissions to attach to the document. See [Permissions](#permissions) below for details.
 
 ## Attributes Reference
 
@@ -64,16 +64,16 @@ The following attributes are exported:
 * `owner` - The AWS user account of the person who created the document.
 * `status` - "Creating", "Active" or "Deleting". The current status of the document.
 * `parameter` - The parameters that are available to this document.
-* `permission` - The permissions of how this document should be shared.
+* `permissions` - The permissions of how this document should be shared.
 * `platform_types` - A list of OS platforms compatible with this SSM document, either "Windows" or "Linux".
 
 ## Permissions
 
-The permission attribute specifies how you want to share the document. If you share a document privately,
+The permissions attribute specifies how you want to share the document. If you share a document privately,
 you must specify the AWS user account IDs for those people who can use the document. If you share a document
 publicly, you must specify All as the account ID.
 
-The permission mapping support the following:
+The permissions mapping supports the following:
 
 * `type` - The permission type for the document. The permission type can be `Share`.
 * `account_ids` - The AWS user accounts that should have access to the document. The account IDs can either be a group of account IDs or `All`.


### PR DESCRIPTION
Currently, the `aws_ssm_document` resource [documentation](https://www.terraform.io/docs/providers/aws/r/ssm_document.html#permission) shows an incorrect argument called `permission` which should be `permissions`. If you follow the documentation, you get the following error:

```LNGDAYM-4172503:ssm westfaex$ terraform plan
module root: module ssm: permission is not a valid parameter
```
This change makes the documentation reflect the correct plural argument.

Lastly, when the `aws_ssm_document` resource detects and invalid `document_type`, it returns an incorrect error message that appears to have been copy/pasted from the  `resource_aws_codebuild_project` resource. The error message provides incorrect information about valid AWS SSM document types. 

```
Errors:

  * aws_ssm_document.main: CodeBuild: Arifacts Namespace Type can only be NONE / BUILD_ID
```

This change updates the error message to provide an appropriate error message when an invalid document type is provided:

```
1 error(s) occurred:

* module.ssm.aws_ssm_document.main: Document type Foo is invalid. Valid types are Command, Policy or Automation
```