### PR TITLE
Update google-two-tier example to be idempotent

### DIFF
--- a/examples/google-two-tier/main.tf
+++ b/examples/google-two-tier/main.tf
@@ -17,14 +17,14 @@ resource "google_compute_http_health_check" "default" {
 
 resource "google_compute_target_pool" "default" {
   name          = "tf-www-target-pool"
-  instances     = ["${google_compute_instance.www.*.self_link}"]
+  instances     = ["${formatlist("%s/%s", var.region_zone, google_compute_instance.www.*.name)}"]
   health_checks = ["${google_compute_http_health_check.default.name}"]
 }
 
 resource "google_compute_forwarding_rule" "default" {
   name       = "tf-www-forwarding-rule"
   target     = "${google_compute_target_pool.default.self_link}"
-  port_range = "80"
+  port_range = "80-80"
 }
 
 resource "google_compute_instance" "www" {


### PR DESCRIPTION
The google-two-tier example in master adds or changes 2 things on each re-apply. This PR makes it idempotent.

* `google_compute_forwarding_rule.default.port_range = "80"` would save okay, but then would save to state file as "80-80", so it would always think a change was needed
* `google_compute_target_pool.default.instances` items would resolve to full URLs, but saved in state as just `{zone}/{instance.name}`.
  * This PR uses a [workaround](https://github.com/hashicorp/terraform/issues/9121#issuecomment-274910248) mentioned in #9121