### PR TITLE
command: Display state ID in PreApply+PostApply

### DIFF
--- a/command/hook_ui_test.go
+++ b/command/hook_ui_test.go
@@ -1,0 +1,70 @@
+package command
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestTruncateId(t *testing.T) {
+	testCases := []struct {
+		Input    string
+		Expected string
+		MaxLen   int
+	}{
+		{
+			Input:    "Hello world",
+			Expected: "H...d",
+			MaxLen:   3,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "H...d",
+			MaxLen:   5,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "He...d",
+			MaxLen:   6,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "He...ld",
+			MaxLen:   7,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "Hel...ld",
+			MaxLen:   8,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "Hel...rld",
+			MaxLen:   9,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "Hell...rld",
+			MaxLen:   10,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "Hello world",
+			MaxLen:   11,
+		},
+		{
+			Input:    "Hello world",
+			Expected: "Hello world",
+			MaxLen:   12,
+		},
+	}
+	for i, tc := range testCases {
+		testName := fmt.Sprintf("%d", i)
+		t.Run(testName, func(t *testing.T) {
+			out := truncateId(tc.Input, tc.MaxLen)
+			if out != tc.Expected {
+				t.Fatalf("Expected %q to be shortened to %d as %q (given: %q)",
+					tc.Input, tc.MaxLen, tc.Expected, out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I noticed when working with many resources that take time to create, destroy or modify it's often difficult to tell what exactly is happening only from the config references.

I think the messages should include the state ID, not only the reference name from the config, which would make it useful especially when folks use `count` and some fields are generated.

### Examples

```
$ terraform apply
kubernetes_namespace.n.1: Creating...
...
kubernetes_namespace.n.0: Creating...
...
kubernetes_namespace.n.0: Creation complete (ID: gen-pgt6q)
kubernetes_namespace.n.1: Creation complete (ID: gen-jbw57)
```
```
$ terraform apply
kubernetes_namespace.n.1: Refreshing state... (ID: gen-jbw57)
kubernetes_namespace.n.0: Refreshing state... (ID: gen-pgt6q)
kubernetes_namespace.n.1: Modifying... (ID: gen-jbw57)
  metadata.0.annotations.name: "old" => "new"
kubernetes_namespace.n.0: Modifying... (ID: gen-pgt6q)
  metadata.0.annotations.name: "old" => "new"
kubernetes_namespace.n.1: Modifications complete (ID: gen-jbw57)
kubernetes_namespace.n.0: Modifications complete (ID: gen-pgt6q)
```
```
$ terraform destroy
kubernetes_namespace.n.1: Refreshing state... (ID: gen-jbw57)
kubernetes_namespace.n.0: Refreshing state... (ID: gen-pgt6q)
kubernetes_namespace.n.0: Destroying... (ID: gen-pgt6q)
kubernetes_namespace.n.1: Destroying... (ID: gen-jbw57)
kubernetes_namespace.n.1: Still destroying... (ID: gen-jbw57, 10s elapsed)
kubernetes_namespace.n.0: Still destroying... (ID: gen-pgt6q, 10s elapsed)
kubernetes_namespace.n.1: Destruction complete
kubernetes_namespace.n.0: Destruction complete
```

Eventually I think we could go even further and display state IDs in the `plan` output, but that's for a separate PR potentially.