### PR TITLE
provider/openstack: Add Additional Targets for LBaaS v1 Member

### DIFF
--- a/builtin/providers/openstack/resource_openstack_lb_member_v1.go
+++ b/builtin/providers/openstack/resource_openstack_lb_member_v1.go
@@ -89,7 +89,7 @@ func resourceLBMemberV1Create(d *schema.ResourceData, meta interface{}) error {
 
 	stateConf := &resource.StateChangeConf{
 		Pending:    []string{"PENDING_CREATE"},
-		Target:     []string{"ACTIVE", "INACTIVE"},
+		Target:     []string{"ACTIVE", "INACTIVE", "CREATED", "DOWN"},
 		Refresh:    waitForLBMemberActive(networkingClient, m.ID),
 		Timeout:    2 * time.Minute,
 		Delay:      5 * time.Second,

--- a/builtin/providers/openstack/resource_openstack_lb_pool_v1_test.go
+++ b/builtin/providers/openstack/resource_openstack_lb_pool_v1_test.go
@@ -180,9 +180,9 @@ resource "openstack_lb_pool_v1" "pool_1" {
 `
 
 const testAccLBV1Pool_fullstack_1 = `
+resource "openstack_networking_network_v2" "network_1" {
   name = "network_1"
   admin_state_up = "true"
-  resource "openstack_networking_network_v2" "network_1" {
 }
 
 resource "openstack_networking_subnet_v2" "subnet_1" {


### PR DESCRIPTION
This commit adds CREATED and DOWN as additional valid targets
for creating LBaaS v1 members.

For #12257

The typo in the test file must have been some `vi` key mash that happened post-test / pre-commit. I know that test passed last time I ran it.