### PR TITLE
provider/aws: Update documentation for CodePipeline (import)

### DIFF
--- a/website/source/docs/providers/aws/r/codepipeline.markdown
+++ b/website/source/docs/providers/aws/r/codepipeline.markdown
@@ -145,3 +145,11 @@ A `stage` block supports the following arguments:
 The following attributes are exported:
 
 * `id` - The codepipeline ID.
+
+## Import
+
+CodePipelines can be imported using the name, e.g.
+
+```
+$ terraform import aws_codepipeline.foo example
+```


### PR DESCRIPTION
This PR updates the documentation for `aws_codepipeline`, 
specifically documenting how to import a CodePipeline. 