### PR TITLE
provider/azurerm: suppport for primary network interface

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_interface_card.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card.go
@@ -67,6 +67,12 @@ func resourceArmNetworkInterface() *schema.Resource {
 							Required: true,
 						},
 
+						"primary": {
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
+						},
+
 						"subnet_id": {
 							Type:     schema.TypeString,
 							Required: true,
@@ -381,6 +387,10 @@ func expandAzureRmNetworkInterfaceIpConfigurations(d *schema.ResourceData) ([]ne
 				ID: &subnet_id,
 			},
 			PrivateIPAllocationMethod: allocationMethod,
+		}
+
+		if v, ok := data["primary"].(bool); ok {
+			properties.Primary = &v
 		}
 
 		if v := data["private_ip_address"].(string); v != "" {

--- a/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
@@ -83,6 +83,25 @@ func TestAccAzureRMNetworkInterface_multipleLoadBalancers(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMNetworkInterface_primaryNetworkInterface(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMNetworkInterface_primaryNetworkInterface(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMNetworkInterfaceExists("azurerm_network_interface.test1"),
+					resource.TestCheckResourceAttr("azurerm_network_interface.test1", "ip_configuration[0].primary", "true"),
+					resource.TestCheckResourceAttr("azurerm_network_interface.test1", "ip_configuration[1].primary", "false"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMNetworkInterface_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
@@ -144,6 +163,7 @@ func testCheckAzureRMNetworkInterfaceExists(name string) resource.TestCheckFunc 
 		return nil
 	}
 }
+
 
 func testCheckAzureRMNetworkInterfaceDisappears(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -473,4 +493,118 @@ resource "azurerm_network_interface" "test2" {
     }
 }
 `, rInt)
+}
+
+func testAccAzureRMNetworkInterface_primaryNetworkInterface(rInt int) string {
+	return fmt.Sprintf(`
+	resource "azurerm_resource_group" "test" {
+		name = "acctest-rg-%d"
+		location = "West US"
+	}
+
+	resource "azurerm_virtual_network" "test" {
+		name = "acceptanceTestVirtualNetwork1"
+		address_space = ["10.0.0.0/16"]
+		location = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+	}
+
+	resource "azurerm_subnet" "test" {
+		name = "testsubnet"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		virtual_network_name = "${azurerm_virtual_network.test.name}"
+		address_prefix = "10.0.2.0/24"
+	}
+
+	resource "azurerm_public_ip" "testext" {
+		name                         = "testpublicipext"
+		location                     = "West US"
+		resource_group_name          = "${azurerm_resource_group.test.name}"
+		public_ip_address_allocation = "static"
+	}
+
+	resource "azurerm_lb" "testext" {
+		name                = "testlbext"
+		location            = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+
+		frontend_ip_configuration {
+			name                 = "publicipext"
+			public_ip_address_id = "${azurerm_public_ip.testext.id}"
+		}
+	}
+
+	resource "azurerm_lb_backend_address_pool" "testext" {
+		location            = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		loadbalancer_id     = "${azurerm_lb.testext.id}"
+		name                = "testbackendpoolext"
+	}
+
+	resource "azurerm_lb_nat_rule" "testext" {
+		name = "testnatruleext"
+		location = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		loadbalancer_id = "${azurerm_lb.testext.id}"
+		protocol = "Tcp"
+		frontend_port = 3389
+		backend_port = 3390
+		frontend_ip_configuration_name = "publicipext"
+	}
+
+	resource "azurerm_public_ip" "testint" {
+		name                         = "testpublicipint"
+		location                     = "West US"
+		resource_group_name          = "${azurerm_resource_group.test.name}"
+		public_ip_address_allocation = "static"
+	}
+
+	resource "azurerm_lb" "testint" {
+		name                = "testlbint"
+		location            = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+
+		frontend_ip_configuration {
+			name                 		  = "publicipint"
+			subnet_id                     = "${azurerm_subnet.test.id}"
+			private_ip_address_allocation = "Dynamic"
+		}
+	}
+
+	resource "azurerm_lb_backend_address_pool" "testint" {
+		location            = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		loadbalancer_id     = "${azurerm_lb.testint.id}"
+		name                = "testbackendpoolint"
+	}
+
+	resource "azurerm_lb_nat_rule" "testint" {
+		name = "testnatruleint"
+		location = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		loadbalancer_id = "${azurerm_lb.testint.id}"
+		protocol = "Tcp"
+		frontend_port = 3389
+		backend_port = 3391
+		frontend_ip_configuration_name = "publicipint"
+	}
+
+	resource "azurerm_network_interface" "test1" {
+		name = "acceptanceTestNetworkInterface1"
+		location = "West US"
+		resource_group_name = "${azurerm_resource_group.test.name}"
+		enable_ip_forwarding = true
+
+		ip_configuration = [{
+			name = "testconfiguration1"
+			subnet_id = "${azurerm_subnet.test.id}"
+			private_ip_address_allocation = "dynamic"
+			primary = true
+		}, {
+			name = "testconfiguration2"
+			subnet_id = "${azurerm_subnet.test.id}"
+			private_ip_address_allocation = "dynamic"
+		}]
+	}
+	`, rInt)
 }


### PR DESCRIPTION
This brings support for setting the primary IP of a network interface.