### PR TITLE
provider/google: add local ssd count support for container clusters

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -231,6 +231,22 @@ func resourceContainerCluster() *schema.Resource {
 							},
 						},
 
+						"local_ssd_count": &schema.Schema{
+							Type:     schema.TypeInt,
+							Optional: true,
+							Computed: true,
+							ForceNew: true,
+							ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
+								value := v.(int)
+
+								if value < 0 {
+									errors = append(errors, fmt.Errorf(
+										"%q cannot be negative", k))
+								}
+								return
+							},
+						},
+
 						"oauth_scopes": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
@@ -388,6 +404,10 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 		if v, ok = nodeConfig["disk_size_gb"]; ok {
 			cluster.NodeConfig.DiskSizeGb = int64(v.(int))
+		}
+
+		if v, ok = nodeConfig["local_ssd_count"]; ok {
+			cluster.NodeConfig.LocalSsdCount = int64(v.(int))
 		}
 
 		if v, ok := nodeConfig["oauth_scopes"]; ok {
@@ -598,6 +618,7 @@ func flattenClusterNodeConfig(c *container.NodeConfig) []map[string]interface{} 
 		map[string]interface{}{
 			"machine_type":    c.MachineType,
 			"disk_size_gb":    c.DiskSizeGb,
+			"local_ssd_count": c.LocalSsdCount,
 			"service_account": c.ServiceAccount,
 			"metadata":        c.Metadata,
 			"image_type":      c.ImageType,

--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -191,6 +191,7 @@ func testAccCheckContainerCluster(n string) resource.TestCheckFunc {
 			{"subnetwork", cluster.Subnetwork},
 			{"node_config.0.machine_type", cluster.NodeConfig.MachineType},
 			{"node_config.0.disk_size_gb", strconv.FormatInt(cluster.NodeConfig.DiskSizeGb, 10)},
+			{"node_config.0.local_ssd_count", strconv.FormatInt(cluster.NodeConfig.LocalSsdCount, 10)},
 			{"node_config.0.oauth_scopes", cluster.NodeConfig.OauthScopes},
 			{"node_config.0.service_account", cluster.NodeConfig.ServiceAccount},
 			{"node_config.0.metadata", cluster.NodeConfig.Metadata},
@@ -361,8 +362,9 @@ resource "google_container_cluster" "with_node_config" {
 	}
 
 	node_config {
-		machine_type = "g1-small"
+		machine_type = "n1-standard-1"
 		disk_size_gb = 15
+		local_ssd_count = 1
 		oauth_scopes = [
 			"https://www.googleapis.com/auth/compute",
 			"https://www.googleapis.com/auth/devstorage.read_only",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3245,8 +3245,8 @@
 		{
 			"checksumSHA1": "lAMqZyc46cU5WaRuw4mVHFXpvps=",
 			"path": "google.golang.org/api/container/v1",
-			"revision": "bc20c61134e1d25265dd60049f5735381e79b631",
-			"revisionTime": "2017-02-10T21:56:36Z"
+			"revision": "64485db7e8c8be51e572801d06cdbcfadd3546c1",
+			"revisionTime": "2017-02-23T23:41:36Z"
 		},
 		{
 			"checksumSHA1": "JYl35km48fLrIx7YUtzcgd4J7Rk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3257,8 +3257,8 @@
 		{
 			"checksumSHA1": "C7k1pbU/WU4CBoBwA4EBUnV/iek=",
 			"path": "google.golang.org/api/gensupport",
-			"revision": "bc20c61134e1d25265dd60049f5735381e79b631",
-			"revisionTime": "2017-02-10T21:56:36Z"
+			"revision": "64485db7e8c8be51e572801d06cdbcfadd3546c1",
+			"revisionTime": "2017-02-23T23:41:36Z"
 		},
 		{
 			"checksumSHA1": "yQREK/OWrz9PLljbr127+xFk6J0=",

--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -109,6 +109,9 @@ which the cluster's instances are launched
 * `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
 
+* `local_ssd_count` - (Optional) The amount of local SSD disks that will be
+    attached to each cluster node. Defaults to 0.
+
 * `oauth_scopes` - (Optional) The set of Google API scopes to be made available
     on all of the node VMs under the "default" service account. These can be
     either FQDNs, or scope aliases. The following scopes are necessary to ensure


### PR DESCRIPTION
Support the `NodeConfig.localSsdConfig` property for `container_cluster` resources.

I have:
- Updated the `container/v1` and `gensupport` vendor dependencies
- Updated the website documentation
- Ran tests
- Formatted the code