### PR TITLE
command: use backend.CLIInit

### DIFF
--- a/backend/cli.go
+++ b/backend/cli.go
@@ -25,7 +25,11 @@ type CLI interface {
 	// CLIIinit is called once with options. The options passed to this
 	// function may not be modified after calling this since they can be
 	// read/written at any time by the Backend implementation.
-	CLIIinit(*CLIOpts) error
+	//
+	// This may be called before or after Configure is called, so if settings
+	// here affect configurable settings, care should be taken to handle
+	// whether they should be overwritten or not.
+	CLIInit(*CLIOpts) error
 }
 
 // CLIOpts are the options passed into CLIInit for the CLI interface.

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -207,6 +207,7 @@ func (b *Local) schemaConfigure(ctx context.Context) error {
 		}
 
 		b.StatePath = path
+		b.StateOutPath = path
 	}
 
 	return nil

--- a/backend/local/backend_test.go
+++ b/backend/local/backend_test.go
@@ -12,6 +12,7 @@ import (
 func TestLocal_impl(t *testing.T) {
 	var _ backend.Enhanced = new(Local)
 	var _ backend.Local = new(Local)
+	var _ backend.CLI = new(Local)
 }
 
 func checkState(t *testing.T, path, expected string) {

--- a/backend/local/cli.go
+++ b/backend/local/cli.go
@@ -1,0 +1,23 @@
+package local
+
+import (
+	"github.com/hashicorp/terraform/backend"
+)
+
+// backend.CLI impl.
+func (b *Local) CLIInit(opts *backend.CLIOpts) error {
+	b.CLI = opts.CLI
+	b.CLIColor = opts.CLIColor
+	b.ContextOpts = opts.ContextOpts
+	b.OpInput = opts.Input
+	b.OpValidation = opts.Validation
+
+	// Only configure state paths if we didn't do so via the configure func.
+	if b.StatePath == "" {
+		b.StatePath = opts.StatePath
+		b.StateOutPath = opts.StateOutPath
+		b.StateBackupPath = opts.StateBackupPath
+	}
+
+	return nil
+}


### PR DESCRIPTION
I made this interface way back with the original backend work and I
guess I forgot to hook it up! This is becoming an issue as I'm working
on our 2nd enhanced backend that requires this information and I
realized it was hardcoded before.

This propertly uses the CLIInit interface allowing any backend to gain
access to this data.