### PR TITLE
helper/schema: Add configurable Timeouts

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -25,6 +25,12 @@ func resourceAwsDbInstance() *schema.Resource {
 			State: resourceAwsDbInstanceImport,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(40 * time.Minute),
+			Update: schema.DefaultTimeout(80 * time.Minute),
+			Delete: schema.DefaultTimeout(40 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -480,7 +486,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 					"maintenance", "renaming", "rebooting", "upgrading"},
 				Target:     []string{"available"},
 				Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-				Timeout:    40 * time.Minute,
+				Timeout:    d.Timeout("create"),
 				MinTimeout: 10 * time.Second,
 				Delay:      30 * time.Second, // Wait 30 secs before starting
 			}
@@ -638,7 +644,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			"maintenance", "renaming", "rebooting", "upgrading", "configuring-enhanced-monitoring"},
 		Target:     []string{"available"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-		Timeout:    40 * time.Minute,
+		Timeout:    d.Timeout("create"),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
@@ -811,7 +817,7 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 			"modifying", "deleting", "available"},
 		Target:     []string{},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-		Timeout:    40 * time.Minute,
+		Timeout:    d.Timeout("delete"),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
@@ -978,7 +984,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 				"maintenance", "renaming", "rebooting", "upgrading", "configuring-enhanced-monitoring", "moving-to-vpc"},
 			Target:     []string{"available"},
 			Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-			Timeout:    80 * time.Minute,
+			Timeout:    d.Timeout("update"),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // Wait 30 secs before starting
 		}

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -486,7 +486,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 					"maintenance", "renaming", "rebooting", "upgrading"},
 				Target:     []string{"available"},
 				Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-				Timeout:    d.Timeout("create"),
+				Timeout:    d.Timeout(schema.TimeoutCreate),
 				MinTimeout: 10 * time.Second,
 				Delay:      30 * time.Second, // Wait 30 secs before starting
 			}
@@ -644,7 +644,7 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			"maintenance", "renaming", "rebooting", "upgrading", "configuring-enhanced-monitoring"},
 		Target:     []string{"available"},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-		Timeout:    d.Timeout("create"),
+		Timeout:    d.Timeout(schema.TimeoutCreate),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
@@ -817,7 +817,7 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 			"modifying", "deleting", "available"},
 		Target:     []string{},
 		Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-		Timeout:    d.Timeout("delete"),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}
@@ -984,7 +984,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 				"maintenance", "renaming", "rebooting", "upgrading", "configuring-enhanced-monitoring", "moving-to-vpc"},
 			Target:     []string{"available"},
 			Refresh:    resourceAwsDbInstanceStateRefreshFunc(d, meta),
-			Timeout:    d.Timeout("update"),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // Wait 30 secs before starting
 		}

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -22,12 +22,6 @@ func resourceAwsVpc() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Timeouts: &schema.ResourceTimeout{
-			Create:  schema.DefaultTimeout(10 * time.Minute),
-			Update:  schema.DefaultTimeout(5 * time.Minute),
-			Default: schema.DefaultTimeout(5 * time.Minute),
-		},
-
 		Schema: map[string]*schema.Schema{
 			"cidr_block": {
 				Type:         schema.TypeString,
@@ -92,7 +86,6 @@ func resourceAwsVpc() *schema.Resource {
 }
 
 func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
-	d.Timeout("create")
 	conn := meta.(*AWSClient).ec2conn
 	instance_tenancy := "default"
 	if v, ok := d.GetOk("instance_tenancy"); ok {
@@ -139,7 +132,6 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
-	d.Timeout("read")
 	conn := meta.(*AWSClient).ec2conn
 
 	// Refresh the VPC state
@@ -245,7 +237,6 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	d.Timeout("update")
 
 	// Turn on partial mode
 	d.Partial(true)
@@ -329,7 +320,6 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
-	d.Timeout("delete")
 	conn := meta.(*AWSClient).ec2conn
 	vpcID := d.Id()
 	DeleteVpcOpts := &ec2.DeleteVpcInput{

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -23,8 +23,9 @@ func resourceAwsVpc() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(10 * time.Minute),
-			Update: schema.DefaultTimeout(5 * time.Minute),
+			Create:  schema.DefaultTimeout(10 * time.Minute),
+			Update:  schema.DefaultTimeout(5 * time.Minute),
+			Default: schema.DefaultTimeout(5 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -22,6 +22,11 @@ func resourceAwsVpc() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"cidr_block": {
 				Type:         schema.TypeString,
@@ -86,6 +91,7 @@ func resourceAwsVpc() *schema.Resource {
 }
 
 func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
+	d.Timeout("create")
 	conn := meta.(*AWSClient).ec2conn
 	instance_tenancy := "default"
 	if v, ok := d.GetOk("instance_tenancy"); ok {
@@ -132,6 +138,7 @@ func resourceAwsVpcCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
+	d.Timeout("read")
 	conn := meta.(*AWSClient).ec2conn
 
 	// Refresh the VPC state
@@ -237,6 +244,7 @@ func resourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
+	d.Timeout("update")
 
 	// Turn on partial mode
 	d.Partial(true)
@@ -320,6 +328,7 @@ func resourceAwsVpcUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsVpcDelete(d *schema.ResourceData, meta interface{}) error {
+	d.Timeout("delete")
 	conn := meta.(*AWSClient).ec2conn
 	vpcID := d.Id()
 	DeleteVpcOpts := &ec2.DeleteVpcInput{

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -140,7 +140,6 @@ func (r *Resource) Apply(
 	rt := ResourceTimeout{}
 	if _, ok := d.Meta[TimeoutKey]; ok {
 		if err := rt.DiffDecode(d); err != nil {
-			//TODO-cts: verify what kind of error may be thrown here
 			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
 		}
 	} else {
@@ -216,7 +215,6 @@ func (r *Resource) Diff(
 
 	if instanceDiff != nil {
 		if err := t.DiffEncode(instanceDiff); err != nil {
-			// not sure DiffEncode will actually return an error
 			log.Printf("[ERR] Error encoding timeout to instance diff: %s", err)
 		}
 	} else {

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -139,7 +139,7 @@ func (r *Resource) Apply(
 	// ResourceData meta
 	rt := ResourceTimeout{}
 	if _, ok := d.Meta[TimeoutKey]; ok {
-		if err := rt.MetaDecode(d); err != nil {
+		if err := rt.DiffDecode(d); err != nil {
 			//TODO-cts: verify what kind of error may be thrown here
 			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
 		}
@@ -273,12 +273,20 @@ func (r *Resource) Refresh(
 		return nil, nil
 	}
 
-	//TODO-cts: Refresh doesn't seem to have Timeout data
+	rt := ResourceTimeout{}
+	if _, ok := s.Meta[TimeoutKey]; ok {
+		if err := rt.StateDecode(s); err != nil {
+			//TODO-cts: verify what kind of error may be thrown here
+			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+		}
+	}
 
 	if r.Exists != nil {
 		// Make a copy of data so that if it is modified it doesn't
 		// affect our Read later.
 		data, err := schemaMap(r.Schema).Data(s, nil)
+		data.timeouts = &rt
+
 		if err != nil {
 			return s, err
 		}
@@ -301,6 +309,7 @@ func (r *Resource) Refresh(
 	}
 
 	data, err := schemaMap(r.Schema).Data(s, nil)
+	data.timeouts = &rt
 	if err != nil {
 		return s, err
 	}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -274,7 +274,6 @@ func (r *Resource) Refresh(
 	rt := ResourceTimeout{}
 	if _, ok := s.Meta[TimeoutKey]; ok {
 		if err := rt.StateDecode(s); err != nil {
-			//TODO-cts: verify what kind of error may be thrown here
 			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
 		}
 	}

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -364,9 +364,8 @@ func (d *ResourceData) Timeout(key string) time.Duration {
 		return *d.timeouts.Default
 	}
 
-	// Return system default of 10 minutes
-	// return 10 * time.Minute
-	return 0
+	// Return system default of 20 minutes
+	return 20 * time.Minute
 }
 
 func (d *ResourceData) init() {

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -19,11 +20,12 @@ import (
 // The most relevant methods to take a look at are Get, Set, and Partial.
 type ResourceData struct {
 	// Settable (internally)
-	schema map[string]*Schema
-	config *terraform.ResourceConfig
-	state  *terraform.InstanceState
-	diff   *terraform.InstanceDiff
-	meta   map[string]interface{}
+	schema   map[string]*Schema
+	config   *terraform.ResourceConfig
+	state    *terraform.InstanceState
+	diff     *terraform.InstanceDiff
+	meta     map[string]interface{}
+	timeouts *ResourceTimeout
 
 	// Don't set
 	multiReader *MultiLevelFieldReader
@@ -250,6 +252,12 @@ func (d *ResourceData) State() *terraform.InstanceState {
 		return nil
 	}
 
+	if d.timeouts != nil {
+		if err := d.timeouts.StateEncode(&result); err != nil {
+			log.Printf("[ERR] Error encoding Timeout meta to Instance State: %s", err)
+		}
+	}
+
 	// Look for a magic key in the schema that determines we skip the
 	// integrity check of fields existing in the schema, allowing dynamic
 	// keys to be created.
@@ -329,6 +337,39 @@ func (d *ResourceData) State() *terraform.InstanceState {
 	}
 
 	return &result
+}
+
+// Timeout returns the data for the given timeout key
+// Returns zero for any key not found, or not found and no default.
+func (d *ResourceData) Timeout(key string) time.Duration {
+	key = strings.ToLower(key)
+
+	switch key {
+	case "create":
+		if d.timeouts.Create != nil {
+			return *d.timeouts.Create
+		}
+	case "read":
+		if d.timeouts.Read != nil {
+			return *d.timeouts.Read
+		}
+	case "update":
+		if d.timeouts.Update != nil {
+			return *d.timeouts.Update
+		}
+	case "delete":
+		if d.timeouts.Delete != nil {
+			return *d.timeouts.Delete
+		}
+	}
+
+	if d.timeouts.Default != nil {
+		return *d.timeouts.Default
+	}
+
+	// Return system default of 10 minutes
+	// return 10 * time.Minute
+	return 0
 }
 
 func (d *ResourceData) init() {

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -346,13 +346,13 @@ func (d *ResourceData) Timeout(key string) time.Duration {
 
 	var timeout *time.Duration
 	switch key {
-	case resourceTimeoutCreateKey:
+	case TimeoutCreate:
 		timeout = d.timeouts.Create
-	case resourceTimeoutReadKey:
+	case TimeoutRead:
 		timeout = d.timeouts.Read
-	case resourceTimeoutUpdateKey:
+	case TimeoutUpdate:
 		timeout = d.timeouts.Update
-	case resourceTimeoutDeleteKey:
+	case TimeoutDelete:
 		timeout = d.timeouts.Delete
 	}
 

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -340,7 +340,7 @@ func (d *ResourceData) State() *terraform.InstanceState {
 }
 
 // Timeout returns the data for the given timeout key
-// Returns zero for any key not found, or not found and no default.
+// Returns a duration of 20 minutes for any key not found, or not found and no default.
 func (d *ResourceData) Timeout(key string) time.Duration {
 	key = strings.ToLower(key)
 

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -345,19 +345,19 @@ func (d *ResourceData) Timeout(key string) time.Duration {
 	key = strings.ToLower(key)
 
 	switch key {
-	case "create":
+	case resourceTimeoutCreateKey:
 		if d.timeouts.Create != nil {
 			return *d.timeouts.Create
 		}
-	case "read":
+	case resourceTimeoutReadKey:
 		if d.timeouts.Read != nil {
 			return *d.timeouts.Read
 		}
-	case "update":
+	case resourceTimeoutUpdateKey:
 		if d.timeouts.Update != nil {
 			return *d.timeouts.Update
 		}
-	case "delete":
+	case resourceTimeoutDeleteKey:
 		if d.timeouts.Delete != nil {
 			return *d.timeouts.Delete
 		}

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -344,23 +344,20 @@ func (d *ResourceData) State() *terraform.InstanceState {
 func (d *ResourceData) Timeout(key string) time.Duration {
 	key = strings.ToLower(key)
 
+	var timeout *time.Duration
 	switch key {
 	case resourceTimeoutCreateKey:
-		if d.timeouts.Create != nil {
-			return *d.timeouts.Create
-		}
+		timeout = d.timeouts.Create
 	case resourceTimeoutReadKey:
-		if d.timeouts.Read != nil {
-			return *d.timeouts.Read
-		}
+		timeout = d.timeouts.Read
 	case resourceTimeoutUpdateKey:
-		if d.timeouts.Update != nil {
-			return *d.timeouts.Update
-		}
+		timeout = d.timeouts.Update
 	case resourceTimeoutDeleteKey:
-		if d.timeouts.Delete != nil {
-			return *d.timeouts.Delete
-		}
+		timeout = d.timeouts.Delete
+	}
+
+	if timeout != nil {
+		return *timeout
 	}
 
 	if d.timeouts.Default != nil {

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1123,15 +1123,15 @@ func TestResourceDataTimeout(t *testing.T) {
 				got := c.Rd.Timeout(k)
 				var ex *time.Duration
 				switch k {
-				case resourceTimeoutCreateKey:
+				case TimeoutCreate:
 					ex = c.Expected.Create
-				case resourceTimeoutReadKey:
+				case TimeoutRead:
 					ex = c.Expected.Read
-				case resourceTimeoutUpdateKey:
+				case TimeoutUpdate:
 					ex = c.Expected.Update
-				case resourceTimeoutDeleteKey:
+				case TimeoutDelete:
 					ex = c.Expected.Delete
-				case resourceTimeoutDefaultKey:
+				case TimeoutDefault:
 					ex = c.Expected.Default
 				}
 

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1129,15 +1129,15 @@ func TestResourceDataTimeout(t *testing.T) {
 			got := c.Rd.Timeout(k)
 			var ex *time.Duration
 			switch k {
-			case "create":
+			case resourceTimeoutCreateKey:
 				ex = c.Expected.Create
-			case "read":
+			case resourceTimeoutReadKey:
 				ex = c.Expected.Read
-			case "update":
+			case resourceTimeoutUpdateKey:
 				ex = c.Expected.Update
-			case "delete":
+			case resourceTimeoutDeleteKey:
 				ex = c.Expected.Delete
-			case "default":
+			case resourceTimeoutDefaultKey:
 				ex = c.Expected.Default
 			}
 

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1123,7 +1123,7 @@ func TestResourceDataTimeout(t *testing.T) {
 		},
 	}
 
-	keys := timeKeys()
+	keys := timeoutKeys()
 	for i, c := range cases {
 		for _, k := range keys {
 			got := c.Rd.Timeout(k)

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -19,7 +19,7 @@ const (
 	resourceTimeoutDefaultKey = "default"
 )
 
-func timeKeys() []string {
+func timeoutKeys() []string {
 	return []string{
 		resourceTimeoutCreateKey,
 		resourceTimeoutReadKey,
@@ -68,7 +68,7 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig)
 			for timeKey, timeValue := range timeoutValues {
 				// validate that we're dealing with the normal CRUD actions
 				var found bool
-				for _, key := range timeKeys() {
+				for _, key := range timeoutKeys() {
 					if timeKey == key {
 						found = true
 						break
@@ -157,7 +157,7 @@ func (t *ResourceTimeout) metaEncode(ids interface{}) error {
 		m[resourceTimeoutDefaultKey] = t.Default.Nanoseconds()
 		// for any key above that is nil, if default is specified, we need to
 		// populate it with the default
-		for _, k := range timeKeys() {
+		for _, k := range timeoutKeys() {
 			if _, ok := m[k]; !ok {
 				m[k] = t.Default.Nanoseconds()
 			}

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -178,7 +178,7 @@ func (t *ResourceTimeout) metaEncode(ids interface{}) error {
 			}
 			instance.Meta[TimeoutKey] = m
 		default:
-			return fmt.Errorf("[ERR] Error matching type for Diff Encode")
+			return fmt.Errorf("Error matching type for Diff Encode")
 		}
 	}
 

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -207,11 +207,10 @@ func (t *ResourceTimeout) metaDecode(ids interface{}) error {
 			return nil
 		}
 	default:
-		return fmt.Errorf("[ERR] Unknown or unsupported type in metaDecode: %#v", ids)
+		return fmt.Errorf("Unknown or unsupported type in metaDecode: %#v", ids)
 	}
 
 	times := rawMeta.(map[string]interface{})
-	//TODO-cts - I don't think this is needed
 	if len(times) == 0 {
 		return nil
 	}

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -12,20 +12,20 @@ import (
 const TimeoutKey = "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0"
 
 const (
-	resourceTimeoutCreateKey  = "create"
-	resourceTimeoutReadKey    = "read"
-	resourceTimeoutUpdateKey  = "update"
-	resourceTimeoutDeleteKey  = "delete"
-	resourceTimeoutDefaultKey = "default"
+	TimeoutCreate  = "create"
+	TimeoutRead    = "read"
+	TimeoutUpdate  = "update"
+	TimeoutDelete  = "delete"
+	TimeoutDefault = "default"
 )
 
 func timeoutKeys() []string {
 	return []string{
-		resourceTimeoutCreateKey,
-		resourceTimeoutReadKey,
-		resourceTimeoutUpdateKey,
-		resourceTimeoutDeleteKey,
-		resourceTimeoutDefaultKey,
+		TimeoutCreate,
+		TimeoutRead,
+		TimeoutUpdate,
+		TimeoutDelete,
+		TimeoutDefault,
 	}
 }
 
@@ -87,15 +87,15 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig)
 
 				var timeout *time.Duration
 				switch timeKey {
-				case resourceTimeoutCreateKey:
+				case TimeoutCreate:
 					timeout = t.Create
-				case resourceTimeoutUpdateKey:
+				case TimeoutUpdate:
 					timeout = t.Update
-				case resourceTimeoutReadKey:
+				case TimeoutRead:
 					timeout = t.Read
-				case resourceTimeoutDeleteKey:
+				case TimeoutDelete:
 					timeout = t.Delete
-				case resourceTimeoutDefaultKey:
+				case TimeoutDefault:
 					timeout = t.Default
 				}
 
@@ -140,19 +140,19 @@ func (t *ResourceTimeout) metaEncode(ids interface{}) error {
 	m := make(map[string]interface{})
 
 	if t.Create != nil {
-		m[resourceTimeoutCreateKey] = t.Create.Nanoseconds()
+		m[TimeoutCreate] = t.Create.Nanoseconds()
 	}
 	if t.Read != nil {
-		m[resourceTimeoutReadKey] = t.Read.Nanoseconds()
+		m[TimeoutRead] = t.Read.Nanoseconds()
 	}
 	if t.Update != nil {
-		m[resourceTimeoutUpdateKey] = t.Update.Nanoseconds()
+		m[TimeoutUpdate] = t.Update.Nanoseconds()
 	}
 	if t.Delete != nil {
-		m[resourceTimeoutDeleteKey] = t.Delete.Nanoseconds()
+		m[TimeoutDelete] = t.Delete.Nanoseconds()
 	}
 	if t.Default != nil {
-		m[resourceTimeoutDefaultKey] = t.Default.Nanoseconds()
+		m[TimeoutDefault] = t.Default.Nanoseconds()
 		// for any key above that is nil, if default is specified, we need to
 		// populate it with the default
 		for _, k := range timeoutKeys() {
@@ -213,19 +213,19 @@ func (t *ResourceTimeout) metaDecode(ids interface{}) error {
 		return nil
 	}
 
-	if v, ok := times[resourceTimeoutCreateKey]; ok {
+	if v, ok := times[TimeoutCreate]; ok {
 		t.Create = DefaultTimeout(v)
 	}
-	if v, ok := times[resourceTimeoutReadKey]; ok {
+	if v, ok := times[TimeoutRead]; ok {
 		t.Read = DefaultTimeout(v)
 	}
-	if v, ok := times[resourceTimeoutUpdateKey]; ok {
+	if v, ok := times[TimeoutUpdate]; ok {
 		t.Update = DefaultTimeout(v)
 	}
-	if v, ok := times[resourceTimeoutDeleteKey]; ok {
+	if v, ok := times[TimeoutDelete]; ok {
 		t.Delete = DefaultTimeout(v)
 	}
-	if v, ok := times[resourceTimeoutDefaultKey]; ok {
+	if v, ok := times[TimeoutDefault]; ok {
 		t.Default = DefaultTimeout(v)
 	}
 

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -124,8 +124,6 @@ func unsupportedTimeoutKeyError(key string) error {
 // StateEncode encodes the timeout into the ResourceData's InstanceState for
 // saving to state
 //
-// TODO: when should this error?
-// func (t *ResourceTimeout) DiffEncode(id *terraform.InstanceDiff) error {
 func (t *ResourceTimeout) DiffEncode(id *terraform.InstanceDiff) error {
 	return t.metaEncode(id)
 }

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -1,0 +1,233 @@
+package schema
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/copystructure"
+)
+
+const TimeoutKey = "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0"
+
+const (
+	rtCreate  = "create"
+	rtRead    = "read"
+	rtUpdate  = "update"
+	rtDelete  = "delete"
+	rtDefault = "default"
+)
+
+func timeKeys() []string {
+	return []string{"create", "read", "update", "delete", "default"}
+}
+
+func DefaultTimeout(tx time.Duration) *time.Duration {
+	return &tx
+}
+
+type ResourceTimeout struct {
+	Create, Read, Update, Delete, Default *time.Duration
+}
+
+// ConfigDecode takes a schema and the configuration (available in Diff) and
+// validates, parses the timeouts into `t`
+func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig) error {
+	if s.Timeouts != nil {
+		raw, err := copystructure.Copy(s.Timeouts)
+		if err != nil {
+			log.Printf("[DEBUG] Error with deep copy: %s", err)
+		}
+		*t = *raw.(*ResourceTimeout)
+	}
+
+	if v, ok := c.Config["timeout"]; ok {
+		raw := v.([]map[string]interface{})
+		for _, tv := range raw {
+			for mk, mv := range tv {
+				var found bool
+				for _, key := range timeKeys() {
+					if mk == key {
+						found = true
+						break
+					}
+				}
+
+				if !found {
+					return fmt.Errorf("Unsupported timeout key found (%s)", mk)
+				}
+
+				//TODO-cts: refactor this to remove duplication, using something like a swich
+				//on the type
+				if mk == "create" {
+					if t.Create == nil {
+						return fmt.Errorf("Timeout (%s) is not supported", mk)
+					} else {
+						rt, err := time.ParseDuration(mv.(string))
+						if err != nil {
+							return fmt.Errorf("Error parsing Timeout for (%s): %s", mk, err)
+						}
+						t.Create = &rt
+						continue
+					}
+				}
+
+				if mk == "read" {
+					if t.Read == nil {
+						return fmt.Errorf("Timeout (%s) is not supported", mk)
+					} else {
+						rt, err := time.ParseDuration(mv.(string))
+						if err != nil {
+							return fmt.Errorf("Error parsing Timeout for (%s): %s", mk, err)
+						}
+						t.Read = &rt
+						continue
+					}
+				}
+
+				if mk == "update" {
+					if t.Update == nil {
+						return fmt.Errorf("Timeout (%s) is not supported", mk)
+					} else {
+						rt, err := time.ParseDuration(mv.(string))
+						if err != nil {
+							return fmt.Errorf("Error parsing Timeout for (%s): %s", mk, err)
+						}
+						t.Update = &rt
+						continue
+					}
+				}
+
+				if mk == "delete" {
+					if t.Delete == nil {
+						return fmt.Errorf("Timeout (%s) is not supported", mk)
+					} else {
+						rt, err := time.ParseDuration(mv.(string))
+						if err != nil {
+							return fmt.Errorf("Error parsing Timeout for (%s): %s", mk, err)
+						}
+						t.Delete = &rt
+						continue
+					}
+				}
+
+				if mk == "default" {
+					if t.Default == nil {
+						return fmt.Errorf("Timeout (%s) is not supported", mk)
+					} else {
+						rt, err := time.ParseDuration(mv.(string))
+						if err != nil {
+							return fmt.Errorf("Error parsing Timeout for (%s): %s", mk, err)
+						}
+						t.Default = &rt
+						continue
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// DiffEncode, StateEncode, and MetaDecode are analogous to the Go stdlib JSONEncoder
+// interface: they encode/decode a timeouts struct from an instance diff, which is
+// where the timeout data is stored after a diff to pass into Apply.
+//
+// StateEncode encodes the timeout into the ResourceData's InstanceState for
+// saving to state
+//
+// TODO: when should this error?
+// func (t *ResourceTimeout) DiffEncode(id *terraform.InstanceDiff) error {
+func (t *ResourceTimeout) DiffEncode(id *terraform.InstanceDiff) error {
+	return t.metaEncode(id)
+}
+
+func (t *ResourceTimeout) StateEncode(is *terraform.InstanceState) error {
+	return t.metaEncode(is)
+}
+
+// metaEncode encodes the ResourceTimeout into a map[string]interface{} format
+// and stores it in the Meta field of the interface it's given.
+// Assumes the interface is either *terraform.InstanceState or
+// *terraform.InstanceDiff, returns an error otherwise
+func (t *ResourceTimeout) metaEncode(ids interface{}) error {
+	m := make(map[string]interface{})
+
+	if t.Create != nil {
+		m["create"] = t.Create.Nanoseconds()
+	}
+	if t.Read != nil {
+		m["read"] = t.Read.Nanoseconds()
+	}
+	if t.Update != nil {
+		m["update"] = t.Update.Nanoseconds()
+	}
+	if t.Delete != nil {
+		m["delete"] = t.Delete.Nanoseconds()
+	}
+	if t.Default != nil {
+		m["default"] = t.Default.Nanoseconds()
+		// for any key above that is nil, if default is specified, we need to
+		// populate it with the default
+		for _, k := range timeKeys() {
+			if _, ok := m[k]; !ok {
+				m[k] = t.Default.Nanoseconds()
+			}
+		}
+	}
+
+	// only add the Timeout to the Meta if we have values
+	if len(m) > 0 {
+		switch instance := ids.(type) {
+		case *terraform.InstanceDiff:
+			if instance.Meta == nil {
+				instance.Meta = make(map[string]interface{})
+			}
+			instance.Meta[TimeoutKey] = m
+		case *terraform.InstanceState:
+			if instance.Meta == nil {
+				instance.Meta = make(map[string]interface{})
+			}
+			instance.Meta[TimeoutKey] = m
+		default:
+			return fmt.Errorf("[ERR] Error matching type for Diff Encode")
+		}
+
+	}
+
+	return nil
+}
+
+func (t *ResourceTimeout) MetaDecode(id *terraform.InstanceDiff) error {
+	//TODO-cts - I don't think this is needed
+	if len(id.Meta) == 0 {
+		return nil
+	}
+
+	tv, ok := id.Meta[TimeoutKey]
+	if !ok {
+		return nil
+	}
+
+	times := tv.(map[string]interface{})
+
+	if v, ok := times[rtCreate]; ok {
+		t.Create = DefaultTimeout(time.Duration(v.(int64)))
+	}
+	if v, ok := times[rtRead]; ok {
+		t.Read = DefaultTimeout(time.Duration(v.(int64)))
+	}
+	if v, ok := times[rtUpdate]; ok {
+		t.Update = DefaultTimeout(time.Duration(v.(int64)))
+	}
+	if v, ok := times[rtDelete]; ok {
+		t.Delete = DefaultTimeout(time.Duration(v.(int64)))
+	}
+	if v, ok := times[rtDefault]; ok {
+		t.Default = DefaultTimeout(time.Duration(v.(int64)))
+	}
+
+	return nil
+}

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -35,7 +35,7 @@ func TestResourceTimeout_ConfigDecode_badkey(t *testing.T) {
 			Expected:               timeoutForValues(2, 0, 7, 0, 0),
 			ShouldErr:              false,
 		},
-		// 1 - Config overrides create, default provided. Note that expected still
+		// 2 - Config overrides create, default provided. Note that expected still
 		// has zero values, even with a config. The default lookup is handled in
 		// ResourceData
 		{
@@ -43,6 +43,16 @@ func TestResourceTimeout_ConfigDecode_badkey(t *testing.T) {
 			Config:                 expectedConfigForValues(2, 0, 7, 0, 0),
 			Expected:               timeoutForValues(2, 0, 7, 0, 3),
 			ShouldErr:              false,
+		},
+		// 3 - use something besides "minutes"
+		{
+			ResourceDefaultTimeout: timeoutForValues(10, 0, 5, 0, 3),
+			Config: []map[string]interface{}{
+				map[string]interface{}{
+					"create": "2h",
+				}},
+			Expected:  timeoutForValues(120, 0, 5, 0, 3),
+			ShouldErr: false,
 		},
 	}
 

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -183,7 +183,7 @@ func TestResourceTimeout_MetaDecode_basic(t *testing.T) {
 
 	for _, c := range cases {
 		rt := &ResourceTimeout{}
-		err := rt.MetaDecode(c.State)
+		err := rt.DiffDecode(c.State)
 		if err != nil && !c.ShouldErr {
 			t.Fatalf("Error, expected:\n%#v\n got:\n%#v\n", c.Expected, rt)
 		}

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -276,7 +276,7 @@ func expectedForValues(create, read, update, del, def int) map[string]interface{
 		defNano := DefaultTimeout(time.Duration(def) * time.Minute).Nanoseconds()
 		ex["default"] = defNano
 
-		for _, k := range timeKeys() {
+		for _, k := range timeoutKeys() {
 			if _, ok := ex[k]; !ok {
 				ex[k] = defNano
 			}

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -266,6 +266,38 @@ func timeoutForValues(create, read, update, del, def int) *ResourceTimeout {
 	return &rt
 }
 
+// Generates a ResourceTimeout struct that should reflect the
+// d.Timeout("key") results
+func expectedTimeoutForValues(create, read, update, del, def int) *ResourceTimeout {
+	rt := ResourceTimeout{}
+
+	defaultValues := []*int{&create, &read, &update, &del, &def}
+	for _, v := range defaultValues {
+		if *v == 0 {
+			*v = 20
+		}
+	}
+
+	if create != 0 {
+		rt.Create = DefaultTimeout(time.Duration(create) * time.Minute)
+	}
+	if read != 0 {
+		rt.Read = DefaultTimeout(time.Duration(read) * time.Minute)
+	}
+	if update != 0 {
+		rt.Update = DefaultTimeout(time.Duration(update) * time.Minute)
+	}
+	if del != 0 {
+		rt.Delete = DefaultTimeout(time.Duration(del) * time.Minute)
+	}
+
+	if def != 0 {
+		rt.Default = DefaultTimeout(time.Duration(def) * time.Minute)
+	}
+
+	return &rt
+}
+
 func expectedForValues(create, read, update, del, def int) map[string]interface{} {
 	ex := make(map[string]interface{})
 

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -1,0 +1,250 @@
+package schema
+
+import (
+	"log"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestResourceTimeout_ConfigDecode_badkey(t *testing.T) {
+	r := &Resource{
+		Timeouts: &ResourceTimeout{
+			Create: DefaultTimeout(10 * time.Minute),
+			Update: DefaultTimeout(5 * time.Minute),
+		},
+	}
+
+	//@TODO convert to test table
+	raw, err := config.NewRawConfig(
+		map[string]interface{}{
+			"foo": "bar",
+			"timeout": []map[string]interface{}{
+				map[string]interface{}{
+					"create": "2m",
+				},
+				map[string]interface{}{
+					"delete": "1m",
+				},
+			},
+		})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	c := terraform.NewResourceConfig(raw)
+
+	timeout := &ResourceTimeout{}
+	err = timeout.ConfigDecode(r, c)
+	if err == nil {
+		log.Println("Expected bad timeout key")
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestResourceTimeout_ConfigDecode(t *testing.T) {
+	r := &Resource{
+		Timeouts: &ResourceTimeout{
+			Create: DefaultTimeout(10 * time.Minute),
+			Update: DefaultTimeout(5 * time.Minute),
+		},
+	}
+
+	raw, err := config.NewRawConfig(
+		map[string]interface{}{
+			"foo": "bar",
+			"timeout": []map[string]interface{}{
+				map[string]interface{}{
+					"create": "2m",
+				},
+				map[string]interface{}{
+					"update": "1m",
+				},
+			},
+		})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	c := terraform.NewResourceConfig(raw)
+
+	timeout := &ResourceTimeout{}
+	err = timeout.ConfigDecode(r, c)
+	if err != nil {
+		log.Println("Expected good timeout returned")
+		t.Fatalf("err: %s", err)
+	}
+
+	expected := &ResourceTimeout{
+		Create: DefaultTimeout(2 * time.Minute),
+		Update: DefaultTimeout(1 * time.Minute),
+	}
+
+	if !reflect.DeepEqual(timeout, expected) {
+		t.Fatalf("bad timeout decode, expected (%#v), got (%#v)", expected, timeout)
+	}
+}
+
+func TestResourceTimeout_DiffEncode_basic(t *testing.T) {
+	cases := []struct {
+		Timeout  *ResourceTimeout
+		Expected map[string]interface{}
+		// Not immediately clear when an error would hit
+		ShouldErr bool
+	}{
+		// Two fields
+		{
+			Timeout:   timeoutForValues(10, 0, 5, 0, 0),
+			Expected:  map[string]interface{}{TimeoutKey: expectedForValues(10, 0, 5, 0, 0)},
+			ShouldErr: false,
+		},
+		// Two fields, one is Default
+		{
+			Timeout:   timeoutForValues(10, 0, 0, 0, 7),
+			Expected:  map[string]interface{}{TimeoutKey: expectedForValues(10, 0, 0, 0, 7)},
+			ShouldErr: false,
+		},
+		// All fields
+		{
+			Timeout:   timeoutForValues(10, 3, 4, 1, 7),
+			Expected:  map[string]interface{}{TimeoutKey: expectedForValues(10, 3, 4, 1, 7)},
+			ShouldErr: false,
+		},
+		// No fields
+		{
+			Timeout:   &ResourceTimeout{},
+			Expected:  nil,
+			ShouldErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		state := &terraform.InstanceDiff{}
+		err := c.Timeout.DiffEncode(state)
+		if err != nil && !c.ShouldErr {
+			t.Fatalf("Error, expected:\n%#v\n got:\n%#v\n", c.Expected, state.Meta)
+		}
+
+		// should maybe just compare [TimeoutKey] but for now we're assuming only
+		// that in Meta
+		if !reflect.DeepEqual(state.Meta, c.Expected) {
+			t.Fatalf("Encode not equal, expected:\n%#v\n\ngot:\n%#v\n", c.Expected, state.Meta)
+		}
+	}
+	// same test cases but for InstanceState
+	for _, c := range cases {
+		state := &terraform.InstanceState{}
+		err := c.Timeout.StateEncode(state)
+		if err != nil && !c.ShouldErr {
+			t.Fatalf("Error, expected:\n%#v\n got:\n%#v\n", c.Expected, state.Meta)
+		}
+
+		// should maybe just compare [TimeoutKey] but for now we're assuming only
+		// that in Meta
+		if !reflect.DeepEqual(state.Meta, c.Expected) {
+			t.Fatalf("Encode not equal, expected:\n%#v\n\ngot:\n%#v\n", c.Expected, state.Meta)
+		}
+	}
+}
+
+func TestResourceTimeout_MetaDecode_basic(t *testing.T) {
+	cases := []struct {
+		State    *terraform.InstanceDiff
+		Expected *ResourceTimeout
+		// Not immediately clear when an error would hit
+		ShouldErr bool
+	}{
+		// Two fields
+		{
+			State:     &terraform.InstanceDiff{Meta: map[string]interface{}{TimeoutKey: expectedForValues(10, 0, 5, 0, 0)}},
+			Expected:  timeoutForValues(10, 0, 5, 0, 0),
+			ShouldErr: false,
+		},
+		// Two fields, one is Default
+		{
+			State:     &terraform.InstanceDiff{Meta: map[string]interface{}{TimeoutKey: expectedForValues(10, 0, 0, 0, 7)}},
+			Expected:  timeoutForValues(10, 7, 7, 7, 7),
+			ShouldErr: false,
+		},
+		// All fields
+		{
+			State:     &terraform.InstanceDiff{Meta: map[string]interface{}{TimeoutKey: expectedForValues(10, 3, 4, 1, 7)}},
+			Expected:  timeoutForValues(10, 3, 4, 1, 7),
+			ShouldErr: false,
+		},
+		// No fields
+		{
+			State:     &terraform.InstanceDiff{},
+			Expected:  &ResourceTimeout{},
+			ShouldErr: false,
+		},
+	}
+
+	for _, c := range cases {
+		rt := &ResourceTimeout{}
+		err := rt.MetaDecode(c.State)
+		if err != nil && !c.ShouldErr {
+			t.Fatalf("Error, expected:\n%#v\n got:\n%#v\n", c.Expected, rt)
+		}
+
+		// should maybe just compare [TimeoutKey] but for now we're assuming only
+		// that in Meta
+		if !reflect.DeepEqual(rt, c.Expected) {
+			t.Fatalf("Encode not equal, expected:\n%#v\n\ngot:\n%#v\n", c.Expected, rt)
+		}
+	}
+}
+
+func timeoutForValues(create, read, update, del, def int) *ResourceTimeout {
+	rt := ResourceTimeout{}
+
+	if create != 0 {
+		rt.Create = DefaultTimeout(time.Duration(create) * time.Minute)
+	}
+	if read != 0 {
+		rt.Read = DefaultTimeout(time.Duration(read) * time.Minute)
+	}
+	if update != 0 {
+		rt.Update = DefaultTimeout(time.Duration(update) * time.Minute)
+	}
+	if del != 0 {
+		rt.Delete = DefaultTimeout(time.Duration(del) * time.Minute)
+	}
+
+	if def != 0 {
+		rt.Default = DefaultTimeout(time.Duration(def) * time.Minute)
+	}
+
+	return &rt
+}
+
+func expectedForValues(create, read, update, del, def int) map[string]interface{} {
+	ex := make(map[string]interface{})
+
+	if create != 0 {
+		ex["create"] = DefaultTimeout(time.Duration(create) * time.Minute).Nanoseconds()
+	}
+	if read != 0 {
+		ex["read"] = DefaultTimeout(time.Duration(read) * time.Minute).Nanoseconds()
+	}
+	if update != 0 {
+		ex["update"] = DefaultTimeout(time.Duration(update) * time.Minute).Nanoseconds()
+	}
+	if del != 0 {
+		ex["delete"] = DefaultTimeout(time.Duration(del) * time.Minute).Nanoseconds()
+	}
+
+	if def != 0 {
+		defNano := DefaultTimeout(time.Duration(def) * time.Minute).Nanoseconds()
+		ex["default"] = defNano
+
+		for _, k := range timeKeys() {
+			if _, ok := ex[k]; !ok {
+				ex[k] = defNano
+			}
+		}
+	}
+
+	return ex
+}

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1327,6 +1327,9 @@ func (m schemaMap) validateObject(
 	if m, ok := raw.(map[string]interface{}); ok {
 		for subk, _ := range m {
 			if _, ok := schema[subk]; !ok {
+				if subk == "timeout" {
+					continue
+				}
 				es = append(es, fmt.Errorf(
 					"%s: invalid or unknown key: %s", k, subk))
 			}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4773,6 +4773,23 @@ func TestSchemaMap_Validate(t *testing.T) {
 
 			Err: false,
 		},
+
+		"special timeout field": {
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+					ForceNew: true,
+				},
+			},
+
+			Config: map[string]interface{}{
+				"timeout": "bar",
+			},
+
+			Err: false,
+		},
 	}
 
 	for tn, tc := range cases {

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -97,6 +97,41 @@ Additionally you can also use a single entry with a wildcard (e.g. `"*"`)
 which will match all attribute names. Using a partial string together with a
 wildcard (e.g. `"rout*"`) is **not** supported.
 
+
+<a id="timeouts"></a>
+
+### Timeouts
+
+Individual Resources may provide a `timeout` block to enable users to configure the
+amount of time a specific operation is allowed to take before being considered
+an error. For example, `aws_db_instance` provides configurable timeouts for the 
+`create`, `update`, and `delete` operations. Any Resource that provies Timeouts
+will document the default values for that operation, and users can overwrite
+them in their configuration. 
+
+Example overwriting the `create` and `delete` timeouts:
+
+```
+resource "aws_db_instance" "timeout_example" {
+  allocated_storage    = 10
+  engine               = "mysql"
+  engine_version       = "5.6.17"
+  instance_class       = "db.t1.micro"
+  name                 = "mydb"
+  [...]
+
+  timeout {
+    create = "60m"
+    delete = "120m"
+  }
+}
+```
+
+Individual Resources must opt-in to providing configurable Timeouts, and
+attempting to configure the timeout for a Resource that does not support
+Timeouts, or overwriting a specific action that the Resource does not specify as
+an option, will result in an error.
+
 <a id="explicit-dependencies"></a>
 
 ### Explicit Dependencies

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -104,7 +104,9 @@ wildcard (e.g. `"rout*"`) is **not** supported.
 
 Individual Resources may provide a `timeout` block to enable users to configure the
 amount of time a specific operation is allowed to take before being considered
-an error. For example, `aws_db_instance` provides configurable timeouts for the 
+an error. For example, the 
+[aws_db_instance](/docs/providers/aws/r/db_instance.html#timeouts) 
+resource provides configurable timeouts for the 
 `create`, `update`, and `delete` operations. Any Resource that provies Timeouts
 will document the default values for that operation, and users can overwrite
 them in their configuration. 
@@ -122,7 +124,7 @@ resource "aws_db_instance" "timeout_example" {
 
   timeout {
     create = "60m"
-    delete = "120m"
+    delete = "2h"
   }
 }
 ```
@@ -130,7 +132,7 @@ resource "aws_db_instance" "timeout_example" {
 Individual Resources must opt-in to providing configurable Timeouts, and
 attempting to configure the timeout for a Resource that does not support
 Timeouts, or overwriting a specific action that the Resource does not specify as
-an option, will result in an error.
+an option, will result in an error. Valid units of time are  `s`, `m`, `h`.
 
 <a id="explicit-dependencies"></a>
 

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -144,6 +144,19 @@ On Oracle instances the following is exported additionally:
 
 * `character_set_name` - The character set used on Oracle instances.
 
+
+<a id="timeouts"></a>
+## Timeouts
+
+`aws_db_instance` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `40 minutes`) Used for Creating Instances, Replicas, and
+restoring from Snapshots
+- `update` - (Default `80 minutes`) Used for Database modifications 
+- `delete` - (Default `40 minutes`) Used for destroying databases. This includes
+the time required to take snapshots
+
 [1]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Overview.Replication.html
 [2]: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_UpgradeDBInstance.Maintenance.html
 


### PR DESCRIPTION
This adds to `helper/schema` the concept of `Timeouts`, allowing Provider developers to opt-in to offering customizable timeouts for a given Create, Read, Update, Delete action. By exposing timeouts per action, operators can customize the amount of time Terraform is allowed to operate a specific action before timing out. 

A concrete example can be found in `aws_db_instance.go`, a resource that notoriously takes a very long time to provision. In the past there have been frequent requests to increase the amount of time allowed for provisioning, modification, and deletion. Because these actions vary on configuration (instance size, backup creation requirements), some require more time than others. While bumping the timeout is generally fine, it does have drawbacks, mainly being that any change requires a new release of Terraform, and there exists possibilities of unknown issues that would cause an operation to get stuck in a retry loop, thus taking a very long time to surface a currently uncaught error. 

With Timeouts, Resource/Provider developers expose configurable options for users like so:

- The Resource defines Timeouts for `Create`, `Update`, and `Delete` operations, alongside the schema:
```go
Schema: &schema.Schema{
  [...],
},
Timeouts: &schema.ResourceTimeout{
  Create: schema.DefaultTimeout(40 * time.Minute),
  Update: schema.DefaultTimeout(80 * time.Minute),
  Delete: schema.DefaultTimeout(40 * time.Minute),
},
```
- The Resource code references these via the new `ResourceData` method `Timeout`:
```
    d.Timeout("create") 
```
- Users can overwrite these builtin times in their configuration:

```hcl
resource "aws_db_instance" "timeout_example" {
  allocated_storage    = 10
  engine               = "mysql"
  engine_version       = "5.6.17"
  instance_class       = "db.t1.micro"
  name                 = "mydb"
  [...]

  timeout {
    create = "60m"
    delete = "2h"
  }
}
```

This allows Provider/Resource developers the ability to provide good default timeouts for operations, but allows for users with possibly very different workload expectations to customize this time. 