### PR TITLE
provider/aws: improve redshift cluster validation

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -863,9 +863,9 @@ func validateRedshiftClusterIdentifier(v interface{}, k string) (ws []string, er
 
 func validateRedshiftClusterDbName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z_$]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9a-z_$]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters, underscores, and dollar signs are allowed in %q", k))
+			"only lowercase alphanumeric characters, underscores, and dollar signs are allowed in %q", k))
 	}
 	if !regexp.MustCompile(`^[a-zA-Z_]`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -930,6 +930,10 @@ func validateRedshiftClusterMasterPassword(v interface{}, k string) (ws []string
 	if !regexp.MustCompile(`^.*[0-9].*`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q must contain at least one number", k))
+	}
+	if !regexp.MustCompile(`^[^\@\/'" ]*$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain [/@\"' ]", k))
 	}
 	if len(value) < 8 {
 		errors = append(errors, fmt.Errorf("%q must be at least 8 characters", k))

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -22,7 +22,6 @@ func TestValidateRedshiftClusterDbName(t *testing.T) {
 		"testdbname",
 		"test_dbname",
 		"testdbname123",
-		"TestDBname",
 		"testdbname$hashicorp",
 		"_dbname",
 	}
@@ -44,6 +43,7 @@ func TestValidateRedshiftClusterDbName(t *testing.T) {
 		"slash-at-the-end/",
 		"",
 		randomString(100),
+		"TestDBname",
 	}
 	for _, v := range invalidNames {
 		_, errors := validateRedshiftClusterDbName(v, "name")


### PR DESCRIPTION
Encountered the following two errors while working with redshift earlier today:

     * aws_redshift_cluster.redshift-cluster: InvalidParameterValue: Only lowercase Database names are supported.
    status code: 400, request id: 15b75510-fdd0-11e6-9100-013cfc7b1aeb

And:

    * aws_redshift_cluster.redshift-cluster: InvalidParameterValue: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters except for '/', '@', '"', ' ', '', ''' may be used.

This PR modified the existing validation for the db name and password to catch the above errors during terraform plan instead of terraform apply.