### PR TITLE
Add support for specifying the vSphere host

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -83,6 +83,7 @@ type virtualMachine struct {
 	cluster               string
 	resourcePool          string
 	datastore             string
+	host                  string
 	vcpu                  int32
 	memoryMb              int64
 	memoryAllocation      memoryAllocation
@@ -167,6 +168,12 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			},
 
 			"resource_pool": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"host": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
@@ -676,6 +683,10 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 
 	if v, ok := d.GetOk("cluster"); ok {
 		vm.cluster = v.(string)
+	}
+
+	if v, ok := d.GetOk("host"); ok {
+		vm.host = v.(string)
 	}
 
 	if v, ok := d.GetOk("resource_pool"); ok {
@@ -1517,7 +1528,7 @@ func buildNetworkDevice(f *find.Finder, label, adapterType string, macAddress st
 }
 
 // buildVMRelocateSpec builds VirtualMachineRelocateSpec to set a place for a new VirtualMachine.
-func buildVMRelocateSpec(rp *object.ResourcePool, ds *object.Datastore, vm *object.VirtualMachine, linkedClone bool, initType string) (types.VirtualMachineRelocateSpec, error) {
+func buildVMRelocateSpec(rp *object.ResourcePool, ds *object.Datastore, vm *object.VirtualMachine, hostSystem *object.HostSystem, linkedClone bool, initType string) (types.VirtualMachineRelocateSpec, error) {
 	var key int32
 	var moveType string
 	if linkedClone {
@@ -1541,10 +1552,16 @@ func buildVMRelocateSpec(rp *object.ResourcePool, ds *object.Datastore, vm *obje
 	eagerScrub := initType == "eager_zeroed"
 	rpr := rp.Reference()
 	dsr := ds.Reference()
+	var hsr *types.ManagedObjectReference
+	if hostSystem != nil {
+		ref := hostSystem.Reference()
+		hsr = &ref
+	}
 	return types.VirtualMachineRelocateSpec{
 		Datastore:    &dsr,
 		Pool:         &rpr,
 		DiskMoveType: moveType,
+		Host:         hsr,
 		Disk: []types.VirtualMachineRelocateSpecDiskLocator{
 			{
 				Datastore: dsr,
@@ -1723,6 +1740,15 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 		}
 	}
 	log.Printf("[DEBUG] resource pool: %#v", resourcePool)
+
+	var hostSystem *object.HostSystem
+	if vm.host != "" {
+		hostSystem, err = finder.HostSystem(context.TODO(), vm.host)
+		if err != nil {
+			return err
+		}
+		log.Printf("[DEBUG] hostSystem: %#v", hostSystem)
+	}
 
 	dcFolders, err := dc.Folders(context.TODO())
 	if err != nil {
@@ -1910,7 +1936,7 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 
 		configSpec.Files = &types.VirtualMachineFileInfo{VmPathName: fmt.Sprintf("[%s]", mds.Name)}
 
-		task, err = folder.CreateVM(context.TODO(), configSpec, resourcePool, nil)
+		task, err = folder.CreateVM(context.TODO(), configSpec, resourcePool, hostSystem)
 		if err != nil {
 			log.Printf("[ERROR] %s", err)
 		}
@@ -1922,7 +1948,7 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 
 	} else {
 
-		relocateSpec, err := buildVMRelocateSpec(resourcePool, datastore, template, vm.linkedClone, vm.hardDisks[0].initType)
+		relocateSpec, err := buildVMRelocateSpec(resourcePool, datastore, template, hostSystem, vm.linkedClone, vm.hardDisks[0].initType)
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -66,6 +66,9 @@ func setupBaseVars() (string, string) {
 	if v := os.Getenv("VSPHERE_DATASTORE"); v != "" {
 		datastoreOpt = fmt.Sprintf("        datastore = \"%s\"\n", v)
 	}
+	if v := os.Getenv("VSPHERE_HOST"); v != "" {
+		locationOpt += fmt.Sprintf("    host = \"%s\"\n", v)
+	}
 
 	return locationOpt, datastoreOpt
 }

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -57,6 +57,35 @@ resource "vsphere_virtual_machine" "lb" {
 }
 ```
 
+## Example Usage Force ESXi host
+
+```
+resource "vsphere_virtual_machine" "lb" {
+  name          = "lb01"
+  folder        = "Loadbalancers"
+  vcpu          = 2
+  memory        = 4096
+  domain        = "MYDOMAIN"
+  datacenter    = "EAST"
+  cluster       = "Production Cluster"
+  resource_pool = "Production Cluster/Resources/Production Servers"
+  host          = "Production Cluster/10.0.1.10"
+
+  gateway = "10.20.30.254"
+
+  network_interface {
+    label              = "10_20_30_VMNet"
+    ipv4_address       = "10.20.30.40"
+    ipv4_prefix_length = "24"
+  }
+
+  disk {
+    datastore = "EAST/VMFS01-EAST"
+    template  = "Templates/Centos7"
+  }
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -68,6 +97,7 @@ The following arguments are supported:
 * `datacenter` - (Optional) The name of a Datacenter in which to launch the virtual machine
 * `cluster` - (Optional) Name of a Cluster in which to launch the virtual machine
 * `resource_pool` (Optional) The name of a Resource Pool in which to launch the virtual machine. Requires full path (see cluster example).
+* `host` (Optional) A specific ESXi host to deploy this VM to. Requires full path (see ESXi host example).
 * `gateway` - __Deprecated, please use `network_interface.ipv4_gateway` instead__.
 * `domain` - (Optional) A FQDN for the virtual machine; defaults to "vsphere.local"
 * `time_zone` - (Optional) The [Linux](https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/timezone.html) or [Windows](https://msdn.microsoft.com/en-us/library/ms912391.aspx) time zone to set on the virtual machine. Defaults to "Etc/UTC"


### PR DESCRIPTION
This allows a vsphere_virtual_machine to specify which host to create the virtual machine on. If it is not specified, the default behavior of letting vSphere choose a host is maintained.

Fixes #11473
