### PR TITLE
Add auto_upgrade_minor_version documentation

### DIFF
--- a/website/source/docs/providers/azurerm/r/virtual_machine_extension.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine_extension.html.markdown
@@ -147,6 +147,9 @@ The following arguments are supported:
 * `type_handler_version` - (Required) Specifies the version of the extension to
     use, available versions can be found using the Azure CLI.
 
+* `auto_upgrade_minor_version` - (Optional) Specifies if the platform deploys
+    the latest minor version update to the `type_handler_version` specified.
+
 * `settings` - (Required) The settings passed to the extension, these are
     specified as a JSON object in a string.
 


### PR DESCRIPTION
`auto_upgrade_minor_version` argument in `azurerm_virtual_machine_extension` is already implemented but not documented.

Reference
  - https://github.com/hashicorp/terraform/blob/master/builtin/providers/azurerm/resource_arm_virtual_machine_extension.go#L59
  - https://docs.microsoft.com/en-us/rest/api/compute/extensions/extensions-add-or-update