### PR TITLE
Add support for defining shared vcd_networks for vCloud

### DIFF
--- a/builtin/providers/vcd/resource_vcd_network.go
+++ b/builtin/providers/vcd/resource_vcd_network.go
@@ -79,6 +79,13 @@ func resourceVcdNetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"shared": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
 			"dhcp_pool": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -152,7 +159,7 @@ func resourceVcdNetworkCreate(d *schema.ResourceData, meta interface{}) error {
 		EdgeGateway: &types.Reference{
 			HREF: edgeGateway.EdgeGateway.HREF,
 		},
-		IsShared: false,
+		IsShared: d.Get("shared").(bool),
 	}
 
 	log.Printf("[INFO] NETWORK: %#v", newnetwork)

--- a/website/source/docs/providers/vcd/r/network.html.markdown
+++ b/website/source/docs/providers/vcd/r/network.html.markdown
@@ -42,6 +42,7 @@ The following arguments are supported:
 * `dns1` - (Optional) First DNS server to use. Defaults to `8.8.8.8`
 * `dns2` - (Optional) Second DNS server to use. Defaults to `8.8.4.4`
 * `dns_suffix` - (Optional) A FQDN for the virtual machines on this network
+* `shared` - (Optional) Defines if this network is shared between multiple vDCs in the vOrg. Boolean value, default is false.
 * `dhcp_pool` - (Optional) A range of IPs to issue to virtual machines that don't
   have a static IP; see [IP Pools](#ip-pools) below for details.
 * `static_ip_pool` - (Optional) A range of IPs permitted to be used as static IPs for


### PR DESCRIPTION
In our vCloud setup we have multiple virtual datacenters for HA reasons. The network therefore needs to be defined a shared between all vDCs in the vOrg.