### PR TITLE
No instance security groups and interface

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -349,10 +349,11 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 	}
 
 	var groupIds []*string
+	var secGroups []*ec2.GroupIdentifier
 	if v, ok := d["vpc_security_group_ids"]; ok {
 		if s := v.(*schema.Set); s.Len() > 0 {
 			for _, v := range s.List() {
-				opts.SecurityGroups = append(opts.SecurityGroups, &ec2.GroupIdentifier{GroupId: aws.String(v.(string))})
+				secGroups = append(opts.SecurityGroups, &ec2.GroupIdentifier{GroupId: aws.String(v.(string))})
 				groupIds = append(groupIds, aws.String(v.(string)))
 			}
 		}
@@ -383,6 +384,8 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 
 		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
 		opts.SubnetId = aws.String("")
+	} else {
+		opts.SecurityGroups = secGroups
 	}
 
 	blockDevices, err := readSpotFleetBlockDeviceMappingsFromConfig(d, conn)

--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -353,7 +353,7 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 	if v, ok := d["vpc_security_group_ids"]; ok {
 		if s := v.(*schema.Set); s.Len() > 0 {
 			for _, v := range s.List() {
-				secGroups = append(opts.SecurityGroups, &ec2.GroupIdentifier{GroupId: aws.String(v.(string))})
+				secGroups = append(secGroups, &ec2.GroupIdentifier{GroupId: aws.String(v.(string))})
 				groupIds = append(groupIds, aws.String(v.(string)))
 			}
 		}


### PR DESCRIPTION
The comment makes this clear, but the code was still adding security
groups to the instance definition.  This moves that assignment to a code
path that evaluates whether an interface definition is being created.

Signed-off-by: Stephen Gran <stephen.gran@piksel.com>