### PR TITLE
provider/aws: reading multiple pages of aws_efs_file_system tags

### DIFF
--- a/builtin/providers/aws/resource_aws_efs_file_system_test.go
+++ b/builtin/providers/aws/resource_aws_efs_file_system_test.go
@@ -87,7 +87,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEfsFileSystemDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSEFSFileSystemConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -103,7 +103,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSEFSFileSystemConfigWithTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(
@@ -122,7 +122,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSEFSFileSystemConfigWithPerformanceMode,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(
@@ -136,6 +136,32 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 						"aws_efs_file_system.foo-with-performance-mode",
 						"maxIO",
 					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSEFSFileSystem_pagedTags(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEfsFileSystemDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSEFSFileSystemConfigPagedTags,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"aws_efs_file_system.foo",
+						"tags.%",
+						"11"),
+					//testAccCheckEfsFileSystem(
+					//	"aws_efs_file_system.foo",
+					//),
+					//testAccCheckEfsFileSystemPerformanceMode(
+					//	"aws_efs_file_system.foo",
+					//	"generalPurpose",
+					//),
 				),
 			},
 		},
@@ -283,6 +309,25 @@ func testAccCheckEfsFileSystemPerformanceMode(resourceID string, expectedMode st
 const testAccAWSEFSFileSystemConfig = `
 resource "aws_efs_file_system" "foo" {
 	creation_token = "radeksimko"
+}
+`
+
+const testAccAWSEFSFileSystemConfigPagedTags = `
+resource "aws_efs_file_system" "foo" {
+	creation_token = "radeksimko"
+	tags {
+		Name = "foo-efs"
+		Another = "tag"
+		Test = "yes"
+		User = "root"
+		Page = "1"
+		Environment = "prod"
+		CostCenter = "terraform"
+		AcceptanceTest = "PagedTags"
+		CreationToken = "radek"
+		PerfMode = "max"
+		Region = "us-west-2"
+	}
 }
 `
 


### PR DESCRIPTION
Fixes: #12232

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEFSFileSystem_pagedTags'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEFSFileSystem_pagedTags -timeout 120m
=== RUN   TestAccAWSEFSFileSystem_pagedTags
--- PASS: TestAccAWSEFSFileSystem_pagedTags (39.51s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    39.537s
```