### PR TITLE
provider/aws: No longer ForceNew resource on lambda_function runtime update

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -95,7 +95,6 @@ func resourceAwsLambdaFunction() *schema.Resource {
 			"runtime": {
 				Type:         schema.TypeString,
 				Required:     true,
-				ForceNew:     true,
 				ValidateFunc: validateRuntime,
 			},
 			"timeout": {
@@ -530,6 +529,10 @@ func resourceAwsLambdaFunctionUpdate(d *schema.ResourceData, meta interface{}) e
 			}
 			configUpdate = true
 		}
+	}
+	if d.HasChange("runtime") {
+		configReq.Runtime = aws.String(d.Get("runtime").(string))
+		configUpdate = true
 	}
 	if d.HasChange("environment") {
 		if v, ok := d.GetOk("environment"); ok {

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -40,6 +40,35 @@ func TestAccAWSLambdaFunction_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaFunction_updateRuntime(t *testing.T) {
+	var conf lambda.GetFunctionOutput
+
+	rSt := acctest.RandString(5)
+	rName := fmt.Sprintf("tf_test_%s", rSt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaConfigBasic(rName, rSt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs4.3"),
+				),
+			},
+			{
+				Config: testAccAWSLambdaConfigBasicUpdateRuntime(rName, rSt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAwsLambdaFunctionExists("aws_lambda_function.lambda_function_test", rName, &conf),
+					resource.TestCheckResourceAttr("aws_lambda_function.lambda_function_test", "runtime", "nodejs4.3-edge"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLambdaFunction_expectFilenameAndS3Attributes(t *testing.T) {
 	rSt := acctest.RandString(5)
 	rName := fmt.Sprintf("tf_test_%s", rSt)
@@ -788,6 +817,18 @@ resource "aws_lambda_function" "lambda_function_test" {
     role = "${aws_iam_role.iam_for_lambda.arn}"
     handler = "exports.example"
     runtime = "nodejs4.3"
+}
+`, rName)
+}
+
+func testAccAWSLambdaConfigBasicUpdateRuntime(rName, rSt string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3-edge"
 }
 `, rName)
 }


### PR DESCRIPTION
Fixes: #12181

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLambdaFunction_updateRuntime'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/01 11:20:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLambdaFunction_updateRuntime -timeout 120m
=== RUN   TestAccAWSLambdaFunction_updateRuntime
--- PASS: TestAccAWSLambdaFunction_updateRuntime (110.25s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	110.279s
```