### PR TITLE
provider/aws: Add support for import of aws_elasticsearch_domain

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -20,21 +20,24 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 		Read:   resourceAwsElasticSearchDomainRead,
 		Update: resourceAwsElasticSearchDomainUpdate,
 		Delete: resourceAwsElasticSearchDomainDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsElasticSearchDomainImport,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"access_policies": &schema.Schema{
+			"access_policies": {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
 				ValidateFunc:     validateJsonString,
 				DiffSuppressFunc: suppressEquivalentAwsPolicyDiffs,
 			},
-			"advanced_options": &schema.Schema{
+			"advanced_options": {
 				Type:     schema.TypeMap,
 				Optional: true,
 				Computed: true,
 			},
-			"domain_name": &schema.Schema{
+			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -47,92 +50,92 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 					return
 				},
 			},
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"domain_id": &schema.Schema{
+			"domain_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"endpoint": &schema.Schema{
+			"endpoint": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"ebs_options": &schema.Schema{
+			"ebs_options": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"ebs_enabled": &schema.Schema{
+						"ebs_enabled": {
 							Type:     schema.TypeBool,
 							Required: true,
 						},
-						"iops": &schema.Schema{
+						"iops": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-						"volume_size": &schema.Schema{
+						"volume_size": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-						"volume_type": &schema.Schema{
+						"volume_type": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 					},
 				},
 			},
-			"cluster_config": &schema.Schema{
+			"cluster_config": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"dedicated_master_count": &schema.Schema{
+						"dedicated_master_count": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-						"dedicated_master_enabled": &schema.Schema{
+						"dedicated_master_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
 						},
-						"dedicated_master_type": &schema.Schema{
+						"dedicated_master_type": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"instance_count": &schema.Schema{
+						"instance_count": {
 							Type:     schema.TypeInt,
 							Optional: true,
 							Default:  1,
 						},
-						"instance_type": &schema.Schema{
+						"instance_type": {
 							Type:     schema.TypeString,
 							Optional: true,
 							Default:  "m3.medium.elasticsearch",
 						},
-						"zone_awareness_enabled": &schema.Schema{
+						"zone_awareness_enabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
 					},
 				},
 			},
-			"snapshot_options": &schema.Schema{
+			"snapshot_options": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"automated_snapshot_start_hour": &schema.Schema{
+						"automated_snapshot_start_hour": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
 					},
 				},
 			},
-			"elasticsearch_version": &schema.Schema{
+			"elasticsearch_version": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "1.5",
@@ -142,6 +145,12 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 			"tags": tagsSchema(),
 		},
 	}
+}
+
+func resourceAwsElasticSearchDomainImport(
+	d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("domain_name", d.Id())
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface{}) error {
@@ -282,6 +291,7 @@ func resourceAwsElasticSearchDomainRead(d *schema.ResourceData, meta interface{}
 	if err != nil {
 		return err
 	}
+	d.SetId(*ds.ARN)
 	d.Set("domain_id", ds.DomainId)
 	d.Set("domain_name", ds.DomainName)
 	d.Set("elasticsearch_version", ds.ElasticsearchVersion)

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -21,13 +21,36 @@ func TestAccAWSElasticSearchDomain_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccESDomainConfig(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
 					resource.TestCheckResourceAttr(
 						"aws_elasticsearch_domain.example", "elasticsearch_version", "1.5"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSElasticSearchDomain_importBasic(t *testing.T) {
+	resourceName := "aws_elasticsearch_domain.example"
+	ri := acctest.RandInt()
+	resourceId := fmt.Sprintf("tf-test-%d", ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRedshiftClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccESDomainConfig(ri),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateId:     resourceId,
 			},
 		},
 	})
@@ -42,7 +65,7 @@ func TestAccAWSElasticSearchDomain_v23(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccESDomainConfigV23(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
@@ -63,7 +86,7 @@ func TestAccAWSElasticSearchDomain_complex(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckESDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccESDomainConfig_complex(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
@@ -83,14 +106,14 @@ func TestAccAWSElasticSearch_tags(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSELBDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccESDomainConfig(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccESDomainConfig_TagUpdate(ri),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckESDomainExists("aws_elasticsearch_domain.example", &domain),

--- a/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
+++ b/website/source/docs/providers/aws/r/elasticsearch_domain.html.markdown
@@ -90,3 +90,11 @@ The following attributes are exported:
 * `arn` - Amazon Resource Name (ARN) of the domain.
 * `domain_id` - Unique identifier for the domain.
 * `endpoint` - Domain-specific endpoint used to submit index, search, and data upload requests.
+
+## Import
+
+ElasticSearch domains can be imported using the `domain_name`, e.g.
+
+```
+$ terraform import aws_elasticsearch_domain.example domain_name
+```


### PR DESCRIPTION
Fixes: #12180

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticSearchDomain_importBasic'                                 1 ↵ ✹ ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/01 23:27:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSElasticSearchDomain_importBasic -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_importBasic
--- PASS: TestAccAWSElasticSearchDomain_importBasic (1412.90s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1412.930s
```