### PR TITLE
provider/aws: Refresh cloudwatch log subscription filter on 404

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -144,7 +144,9 @@ func resourceAwsCloudwatchLogSubscriptionFilterRead(d *schema.ResourceData, meta
 		}
 	}
 
-	return fmt.Errorf("Subscription filter for log group %s with name prefix %s not found!", log_group_name, d.Get("name").(string))
+	log.Printf("[DEBUG] Subscription Filter%q Not Found", name)
+	d.SetId("")
+	return nil
 }
 
 func resourceAwsCloudwatchLogSubscriptionFilterDelete(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter_test.go
@@ -102,7 +102,7 @@ func testAccCheckAWSCloudwatchLogSubscriptionFilterAttributes(function *lambda.G
 func testAccAWSCloudwatchLogSubscriptionFilterConfig(rstring string) string {
 	return fmt.Sprintf(`
 resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter" {
-  name            = "test_lambdafunction_logfilter"
+  name            = "test_lambdafunction_logfilter_%s"
   log_group_name  = "example_lambda_name"
   filter_pattern  = "logtype test"
   destination_arn = "${aws_lambda_function.test_lambdafunction.arn}"
@@ -117,7 +117,7 @@ resource "aws_lambda_function" "test_lambdafunction" {
 }
 
 resource "aws_cloudwatch_log_group" "logs" {
-  name              = "example_lambda_name"
+  name              = "example_lambda_name_%s"
   retention_in_days = 1
 }
 
@@ -149,7 +149,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "test_lambdafunction_iam_policy" {
-  name = "test_lambdafunction_iam_policy"
+  name = "test_lambdafunction_iam_policy_%s"
   role = "${aws_iam_role.iam_for_lambda.id}"
 
   policy = <<EOF
@@ -160,7 +160,7 @@ resource "aws_iam_role_policy" "test_lambdafunction_iam_policy" {
       "Sid": "Stmt1441111030000",
       "Effect": "Allow",
       "Action": [
-        "dynamodb:*"
+        "lambda:*"
       ],
       "Resource": [
         "*"
@@ -170,5 +170,5 @@ resource "aws_iam_role_policy" "test_lambdafunction_iam_policy" {
 }
 EOF
 }
-`, rstring, rstring)
+`, rstring, rstring, rstring, rstring, rstring)
 }


### PR DESCRIPTION
Fixes:#11750

Before this change, adding a log_subscription_filter and then deleting
it manually would yield this error on terraform plan/apply:

```
% terraform plan                                                                                                             ✹ ✭
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_iam_role.iam_for_lambda: Refreshing state... (ID: test_lambdafuntion_iam_role_example123)
aws_cloudwatch_log_group.logs: Refreshing state... (ID: example_lambda_name)
aws_iam_role_policy.test_lambdafunction_iam_policy: Refreshing state... (ID: test_lambdafuntion_iam_role_example123:test_lambdafunction_iam_policy)
aws_lambda_function.test_lambdafunction: Refreshing state... (ID: example_lambda_name_example123)
aws_lambda_permission.allow_cloudwatch_logs: Refreshing state... (ID: AllowExecutionFromCloudWatchLogs)
aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: Refreshing state... (ID: cwlsf-992677504)
Error refreshing state: 1 error(s) occurred:

* aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: Subscription filter for log group example_lambda_name with name prefix test_lambdafunction_logfilter not found!
```

After this patch, we get the following behaviour:

```
% terraform plan                                                                                                             ✹ ✭
[WARN] /Users/stacko/Code/go/bin/terraform-provider-aws overrides an internal plugin for aws-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_iam_role.iam_for_lambda: Refreshing state... (ID: test_lambdafuntion_iam_role_example123)
aws_cloudwatch_log_group.logs: Refreshing state... (ID: example_lambda_name)
aws_lambda_function.test_lambdafunction: Refreshing state... (ID: example_lambda_name_example123)
aws_iam_role_policy.test_lambdafunction_iam_policy: Refreshing state... (ID: test_lambdafuntion_iam_role_example123:test_lambdafunction_iam_policy)
aws_lambda_permission.allow_cloudwatch_logs: Refreshing state... (ID: AllowExecutionFromCloudWatchLogs)
aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: Refreshing state... (ID: cwlsf-992677504)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter
    destination_arn: "arn:aws:lambda:us-west-2:187416307283:function:example_lambda_name_example123"
    filter_pattern:  "logtype test"
    log_group_name:  "example_lambda_name"
    name:            "test_lambdafunction_logfilter"
    role_arn:        "<computed>"
    
Plan: 1 to add, 0 to change, 0 to destroy.
```
