### PR TITLE
return 0 from resourceCountMax with a nil Resource

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -698,6 +698,10 @@ func (i *Interpolater) resourceCountMax(
 	// from the state. Plan and so on may not have any state yet so
 	// we do a full interpolation.
 	if i.Operation != walkApply {
+		if cr == nil {
+			return 0, nil
+		}
+
 		count, err := cr.Count()
 		if err != nil {
 			return 0, err

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -876,6 +876,31 @@ func TestInterpolator_sets(t *testing.T) {
 		interfaceToVariableSwallowError(set))
 }
 
+// When a splat reference is made to a resource that is unknown, we should
+// return an error.
+func TestInterpolater_resourceUnknownVariableList(t *testing.T) {
+	i := &Interpolater{
+		Module:    testModule(t, "plan-computed-data-resource"),
+		State:     NewState(), // state,
+		StateLock: new(sync.RWMutex),
+	}
+
+	scope := &InterpolationScope{
+		Path: rootModulePath,
+	}
+
+	// missing "data" from the reference here
+	v, err := config.NewInterpolatedVariable("aws_vpc.bar.*.foo")
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	_, err = i.Values(scope, map[string]config.InterpolatedVariable{"foo": v})
+	if err == nil {
+		t.Fatal("expected error interpolating invalid resource")
+	}
+}
+
 func testInterpolate(
 	t *testing.T, i *Interpolater,
 	scope *InterpolationScope,

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -877,7 +877,7 @@ func TestInterpolator_sets(t *testing.T) {
 }
 
 // When a splat reference is made to a resource that is unknown, we should
-// return an error.
+// return an empty list rather than panicking.
 func TestInterpolater_resourceUnknownVariableList(t *testing.T) {
 	i := &Interpolater{
 		Module:    testModule(t, "plan-computed-data-resource"),
@@ -889,16 +889,8 @@ func TestInterpolater_resourceUnknownVariableList(t *testing.T) {
 		Path: rootModulePath,
 	}
 
-	// missing "data" from the reference here
-	v, err := config.NewInterpolatedVariable("aws_vpc.bar.*.foo")
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	_, err = i.Values(scope, map[string]config.InterpolatedVariable{"foo": v})
-	if err == nil {
-		t.Fatal("expected error interpolating invalid resource")
-	}
+	testInterpolate(t, i, scope, "aws_vpc.bar.*.foo",
+		interfaceToVariableSwallowError([]interface{}{}))
 }
 
 func testInterpolate(

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -680,7 +680,7 @@ func TestInterpolator_interpolatedListOrder(t *testing.T) {
 			&ModuleState{
 				Path: rootModulePath,
 				Resources: map[string]*ResourceState{
-					"aws_route53_zone.list": &ResourceState{
+					"aws_route53_zone.yada": &ResourceState{
 						Type:         "aws_route53_zone",
 						Dependencies: []string{},
 						Primary: &InstanceState{
@@ -719,7 +719,7 @@ func TestInterpolator_interpolatedListOrder(t *testing.T) {
 
 	list := []interface{}{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"}
 
-	testInterpolate(t, i, scope, "aws_route53_zone.list.foo",
+	testInterpolate(t, i, scope, "aws_route53_zone.yada.foo",
 		interfaceToVariableSwallowError(list))
 }
 
@@ -844,7 +844,7 @@ func TestInterpolator_sets(t *testing.T) {
 			&ModuleState{
 				Path: rootModulePath,
 				Resources: map[string]*ResourceState{
-					"aws_network_interface.set": &ResourceState{
+					"aws_route53_zone.yada": &ResourceState{
 						Type:         "aws_network_interface",
 						Dependencies: []string{},
 						Primary: &InstanceState{
@@ -872,7 +872,7 @@ func TestInterpolator_sets(t *testing.T) {
 
 	set := []interface{}{"10.42.16.179"}
 
-	testInterpolate(t, i, scope, "aws_network_interface.set.private_ips",
+	testInterpolate(t, i, scope, "aws_route53_zone.yada.private_ips",
 		interfaceToVariableSwallowError(set))
 }
 


### PR DESCRIPTION
If a resource can't be found when looking up an interpolated variable in the config, make sure an error is returned with a nil Resource.

Fixes #12253 