### PR TITLE
make flatmap.Expand understand computed sets

### DIFF
--- a/flatmap/expand.go
+++ b/flatmap/expand.go
@@ -57,6 +57,7 @@ func expandArray(m map[string]string, prefix string) []interface{} {
 	// regardless of value, and expand them in numeric order.
 	// See GH-11042 for more details.
 	keySet := map[int]bool{}
+	computed := map[string]bool{}
 	for k := range m {
 		if !strings.HasPrefix(k, prefix+".") {
 			continue
@@ -71,6 +72,12 @@ func expandArray(m map[string]string, prefix string) []interface{} {
 		// skip the count value
 		if key == "#" {
 			continue
+		}
+
+		// strip the computed flag if there is one
+		if strings.HasPrefix(key, "~") {
+			key = key[1:]
+			computed[key] = true
 		}
 
 		k, err := strconv.Atoi(key)
@@ -88,7 +95,11 @@ func expandArray(m map[string]string, prefix string) []interface{} {
 
 	result := make([]interface{}, num)
 	for i, key := range keysList {
-		result[i] = Expand(m, fmt.Sprintf("%s.%d", prefix, key))
+		keyString := strconv.Itoa(key)
+		if computed[keyString] {
+			keyString = "~" + keyString
+		}
+		result[i] = Expand(m, fmt.Sprintf("%s.%s", prefix, keyString))
 	}
 
 	return result

--- a/flatmap/expand_test.go
+++ b/flatmap/expand_test.go
@@ -122,6 +122,19 @@ func TestExpand(t *testing.T) {
 
 		{
 			Map: map[string]string{
+				"computed_set.#":       "1",
+				"computed_set.~1234.a": "a",
+				"computed_set.~1234.b": "b",
+				"computed_set.~1234.c": "c",
+			},
+			Key: "computed_set",
+			Output: []interface{}{
+				map[string]interface{}{"a": "a", "b": "b", "c": "c"},
+			},
+		},
+
+		{
+			Map: map[string]string{
 				"struct.#":         "1",
 				"struct.0.name":    "hello",
 				"struct.0.rules.#": hil.UnknownValue,


### PR DESCRIPTION
For historical reasons, sets are represented as sparse lists in a
flatmap, however a computed set does not have a numeric index.

Strip the `~` flag from a computed set's index during expansion, and add
it back in the prefix after sorting.

fixes #12145