### PR TITLE
command: migrating envs when changing backends

### DIFF
--- a/backend/backend.go
+++ b/backend/backend.go
@@ -13,9 +13,13 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+// This is the name of the default, initial state that every backend
+// must have. This state cannot be deleted.
 const DefaultStateName = "default"
 
-// Error value to return when a named state operation isn't supported
+// Error value to return when a named state operation isn't supported.
+// This must be returned rather than a custom error so that the Terraform
+// CLI can detect it and handle it appropriately.
 var ErrNamedStatesNotSupported = errors.New("named states not supported")
 
 // Backend is the minimal interface that must be implemented to enable Terraform.

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -449,6 +449,28 @@ func testInteractiveInput(t *testing.T, answers []string) func() {
 	}
 }
 
+// testInputMap configures tests so that the given answers are returned
+// for calls to Input when the right question is asked. The key is the
+// question "Id" that is used.
+func testInputMap(t *testing.T, answers map[string]string) func() {
+	// Disable test mode so input is called
+	test = false
+
+	// Setup reader/writers
+	defaultInputReader = bytes.NewBufferString("")
+	defaultInputWriter = new(bytes.Buffer)
+
+	// Setup answers
+	testInputResponse = nil
+	testInputResponseMap = answers
+
+	// Return the cleanup
+	return func() {
+		test = true
+		testInputResponseMap = nil
+	}
+}
+
 // testBackendState is used to make a test HTTP server to test a configured
 // backend. This returns the complete state that can be saved. Use
 // `testStateFileRemote` to write the returned state.

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -646,28 +646,9 @@ func (m *Meta) backend_c_r_S(
 			return nil, fmt.Errorf(strings.TrimSpace(errBackendLocalRead), err)
 		}
 
-		env := m.Env()
-
-		localState, err := localB.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendLocalRead), err)
-		}
-		if err := localState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendLocalRead), err)
-		}
-
 		// Initialize the configured backend
 		b, err := m.backend_C_r_S_unchanged(c, sMgr)
 		if err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
-		backendState, err := b.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
-		if err := backendState.RefreshState(); err != nil {
 			return nil, fmt.Errorf(
 				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
 		}
@@ -676,8 +657,8 @@ func (m *Meta) backend_c_r_S(
 		err = m.backendMigrateState(&backendMigrateOpts{
 			OneType: s.Backend.Type,
 			TwoType: "local",
-			One:     backendState,
-			Two:     localState,
+			One:     b,
+			Two:     localB,
 		})
 		if err != nil {
 			return nil, err
@@ -758,16 +739,6 @@ func (m *Meta) backend_c_R_S(
 		return nil, fmt.Errorf(errBackendLocalRead, err)
 	}
 
-	env := m.Env()
-
-	localState, err := localB.State(env)
-	if err != nil {
-		return nil, fmt.Errorf(errBackendLocalRead, err)
-	}
-	if err := localState.RefreshState(); err != nil {
-		return nil, fmt.Errorf(errBackendLocalRead, err)
-	}
-
 	// Grab the state
 	s := sMgr.State()
 
@@ -791,22 +762,13 @@ func (m *Meta) backend_c_R_S(
 		if err != nil {
 			return nil, err
 		}
-		oldState, err := oldB.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
-		if err := oldState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
 
 		// Perform the migration
 		err = m.backendMigrateState(&backendMigrateOpts{
 			OneType: s.Remote.Type,
 			TwoType: "local",
-			One:     oldState,
-			Two:     localState,
+			One:     oldB,
+			Two:     localB,
 		})
 		if err != nil {
 			return nil, err
@@ -894,33 +856,12 @@ func (m *Meta) backend_C_R_s(
 			return nil, err
 		}
 
-		env := m.Env()
-
-		oldState, err := oldB.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
-		if err := oldState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
-
-		// Get the new state
-		newState, err := b.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendNewRead), err)
-		}
-		if err := newState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendNewRead), err)
-		}
-
 		// Perform the migration
 		err = m.backendMigrateState(&backendMigrateOpts{
 			OneType: s.Remote.Type,
 			TwoType: c.Type,
-			One:     oldState,
-			Two:     newState,
+			One:     oldB,
+			Two:     b,
 		})
 		if err != nil {
 			return nil, err
@@ -975,20 +916,12 @@ func (m *Meta) backend_C_r_s(
 	// If the local state is not empty, we need to potentially do a
 	// state migration to the new backend (with user permission).
 	if localS := localState.State(); !localS.Empty() {
-		backendState, err := b.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(errBackendRemoteRead, err)
-		}
-		if err := backendState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(errBackendRemoteRead, err)
-		}
-
 		// Perform the migration
 		err = m.backendMigrateState(&backendMigrateOpts{
 			OneType: "local",
 			TwoType: c.Type,
-			One:     localState,
-			Two:     backendState,
+			One:     localB,
+			Two:     b,
 		})
 		if err != nil {
 			return nil, err
@@ -1080,33 +1013,12 @@ func (m *Meta) backend_C_r_S_changed(
 				"Error loading previously configured backend: %s", err)
 		}
 
-		env := m.Env()
-
-		oldState, err := oldB.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
-		if err := oldState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Backend.Type, err)
-		}
-
-		// Get the new state
-		newState, err := b.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendNewRead), err)
-		}
-		if err := newState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendNewRead), err)
-		}
-
 		// Perform the migration
 		err = m.backendMigrateState(&backendMigrateOpts{
 			OneType: s.Backend.Type,
 			TwoType: c.Type,
-			One:     oldState,
-			Two:     newState,
+			One:     oldB,
+			Two:     b,
 		})
 		if err != nil {
 			return nil, err
@@ -1244,33 +1156,12 @@ func (m *Meta) backend_C_R_S_unchanged(
 			return nil, err
 		}
 
-		env := m.Env()
-
-		oldState, err := oldB.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Remote.Type, err)
-		}
-		if err := oldState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(
-				strings.TrimSpace(errBackendSavedUnsetConfig), s.Remote.Type, err)
-		}
-
-		// Get the new state
-		newState, err := b.State(env)
-		if err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendNewRead), err)
-		}
-		if err := newState.RefreshState(); err != nil {
-			return nil, fmt.Errorf(strings.TrimSpace(errBackendNewRead), err)
-		}
-
 		// Perform the migration
 		err = m.backendMigrateState(&backendMigrateOpts{
 			OneType: s.Remote.Type,
 			TwoType: s.Backend.Type,
-			One:     oldState,
-			Two:     newState,
+			One:     oldB,
+			Two:     b,
 		})
 		if err != nil {
 			return nil, err

--- a/command/meta_backend_migrate.go
+++ b/command/meta_backend_migrate.go
@@ -67,7 +67,6 @@ func (m *Meta) backendMigrateState(opts *backendMigrateOpts) error {
 		// If the source only has one state and it is the default,
 		// treat it as if it doesn't support multi-state.
 		if len(oneStates) == 1 && oneStates[0] == backend.DefaultStateName {
-			panic("YO")
 			return m.backendMigrateState_s_s(opts)
 		}
 

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -1126,6 +1126,73 @@ func TestMetaBackend_configuredChangeCopy_multiToSingle(t *testing.T) {
 	}
 }
 
+// Changing a configured backend that supports multi-state to a
+// backend that only supports single states.
+func TestMetaBackend_configuredChangeCopy_multiToSingleCurrentEnv(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("backend-change-multi-to-single"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// Register the single-state backend
+	backendinit.Set("local-single", backendlocal.TestNewLocalSingle)
+	defer backendinit.Set("local-single", nil)
+
+	// Ask input
+	defer testInputMap(t, map[string]string{
+		"backend-migrate-to-new":               "yes",
+		"backend-migrate-multistate-to-single": "yes",
+		"backend-migrate-copy-to-empty":        "yes",
+	})()
+
+	// Setup the meta
+	m := testMetaBackend(t, nil)
+
+	// Change env
+	if err := m.SetEnv("env2"); err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	// Get the backend
+	b, err := m.Backend(&BackendOpts{Init: true})
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	// Check the state
+	s, err := b.State(backend.DefaultStateName)
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	if err := s.RefreshState(); err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+	state := s.State()
+	if state == nil {
+		t.Fatal("state should not be nil")
+	}
+	if state.Lineage != "backend-change-env2" {
+		t.Fatalf("bad: %#v", state)
+	}
+
+	// Verify no local state
+	if _, err := os.Stat(DefaultStateFilename); err == nil {
+		t.Fatal("file should not exist")
+	}
+
+	// Verify no local backup
+	if _, err := os.Stat(DefaultStateFilename + DefaultBackupExtension); err == nil {
+		t.Fatal("file should not exist")
+	}
+
+	// Verify existing environments exist
+	envPath := filepath.Join(backendlocal.DefaultEnvDir, "env2", backendlocal.DefaultStateFilename)
+	if _, err := os.Stat(envPath); err != nil {
+		t.Fatal("env should exist")
+	}
+}
+
 // Unsetting a saved backend
 func TestMetaBackend_configuredUnset(t *testing.T) {
 	// Create a temporary working directory that is empty

--- a/command/test-fixtures/backend-change-multi-default-to-single/.terraform/terraform.tfstate
+++ b/command/test-fixtures/backend-change-multi-default-to-single/.terraform/terraform.tfstate
@@ -1,0 +1,22 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": "local-state.tfstate"
+        },
+        "hash": 9073424445967744180
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/command/test-fixtures/backend-change-multi-default-to-single/local-state.tfstate
+++ b/command/test-fixtures/backend-change-multi-default-to-single/local-state.tfstate
@@ -1,0 +1,6 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 7,
+    "lineage": "backend-change"
+}

--- a/command/test-fixtures/backend-change-multi-default-to-single/main.tf
+++ b/command/test-fixtures/backend-change-multi-default-to-single/main.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local-single" {
+        path = "local-state-2.tfstate"
+    }
+}

--- a/command/test-fixtures/backend-change-multi-to-multi/.terraform/terraform.tfstate
+++ b/command/test-fixtures/backend-change-multi-to-multi/.terraform/terraform.tfstate
@@ -1,0 +1,22 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": "local-state.tfstate"
+        },
+        "hash": 9073424445967744180
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/command/test-fixtures/backend-change-multi-to-multi/local-state.tfstate
+++ b/command/test-fixtures/backend-change-multi-to-multi/local-state.tfstate
@@ -1,0 +1,6 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 7,
+    "lineage": "backend-change"
+}

--- a/command/test-fixtures/backend-change-multi-to-multi/main.tf
+++ b/command/test-fixtures/backend-change-multi-to-multi/main.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local" {
+        environment_dir = "envdir-new"
+    }
+}

--- a/command/test-fixtures/backend-change-multi-to-multi/terraform.tfstate.d/env2/terraform.tfstate
+++ b/command/test-fixtures/backend-change-multi-to-multi/terraform.tfstate.d/env2/terraform.tfstate
@@ -1,0 +1,6 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 7,
+    "lineage": "backend-change-env2"
+}

--- a/command/test-fixtures/backend-change-multi-to-single/.terraform/terraform.tfstate
+++ b/command/test-fixtures/backend-change-multi-to-single/.terraform/terraform.tfstate
@@ -1,0 +1,22 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local",
+        "config": {
+            "path": "local-state.tfstate"
+        },
+        "hash": 9073424445967744180
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/command/test-fixtures/backend-change-multi-to-single/local-state.tfstate
+++ b/command/test-fixtures/backend-change-multi-to-single/local-state.tfstate
@@ -1,0 +1,6 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 7,
+    "lineage": "backend-change"
+}

--- a/command/test-fixtures/backend-change-multi-to-single/main.tf
+++ b/command/test-fixtures/backend-change-multi-to-single/main.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local-single" {
+        path = "local-state-2.tfstate"
+    }
+}

--- a/command/test-fixtures/backend-change-multi-to-single/terraform.tfstate.d/env2/terraform.tfstate
+++ b/command/test-fixtures/backend-change-multi-to-single/terraform.tfstate.d/env2/terraform.tfstate
@@ -1,0 +1,6 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 7,
+    "lineage": "backend-change-env2"
+}

--- a/command/test-fixtures/backend-change-single-to-single/.terraform/terraform.tfstate
+++ b/command/test-fixtures/backend-change-single-to-single/.terraform/terraform.tfstate
@@ -1,0 +1,22 @@
+{
+    "version": 3,
+    "serial": 0,
+    "lineage": "666f9301-7e65-4b19-ae23-71184bb19b03",
+    "backend": {
+        "type": "local-single",
+        "config": {
+            "path": "local-state.tfstate"
+        },
+        "hash": 9073424445967744180
+    },
+    "modules": [
+        {
+            "path": [
+                "root"
+            ],
+            "outputs": {},
+            "resources": {},
+            "depends_on": []
+        }
+    ]
+}

--- a/command/test-fixtures/backend-change-single-to-single/local-state.tfstate
+++ b/command/test-fixtures/backend-change-single-to-single/local-state.tfstate
@@ -1,0 +1,6 @@
+{
+    "version": 3,
+    "terraform_version": "0.8.2",
+    "serial": 7,
+    "lineage": "backend-change"
+}

--- a/command/test-fixtures/backend-change-single-to-single/main.tf
+++ b/command/test-fixtures/backend-change-single-to-single/main.tf
@@ -1,0 +1,5 @@
+terraform {
+    backend "local-single" {
+        path = "local-state-2.tfstate"
+    }
+}

--- a/command/ui_input.go
+++ b/command/ui_input.go
@@ -20,6 +20,7 @@ import (
 var defaultInputReader io.Reader
 var defaultInputWriter io.Writer
 var testInputResponse []string
+var testInputResponseMap map[string]string
 
 // UIInput is an implementation of terraform.UIInput that asks the CLI
 // for input stdin.
@@ -65,10 +66,22 @@ func (i *UIInput) Input(opts *terraform.InputOpts) (string, error) {
 		return "", errors.New("interrupted")
 	}
 
-	// If we have test results, return those
+	// If we have test results, return those. testInputResponse is the
+	// "old" way of doing it and we should remove that.
 	if testInputResponse != nil {
 		v := testInputResponse[0]
 		testInputResponse = testInputResponse[1:]
+		return v, nil
+	}
+
+	// testInputResponseMap is the new way for test responses, based on
+	// the query ID.
+	if testInputResponseMap != nil {
+		v, ok := testInputResponseMap[opts.Id]
+		if !ok {
+			return "", fmt.Errorf("unexpected input request in test: %s", opts.Id)
+		}
+
 		return v, nil
 	}
 


### PR DESCRIPTION
This updates the backend state migration function to handle the matrix (4 choices) of possibilities when changing a backend to:

  * When possible (only a default state on the source), act as normal, keep it simple.
  * When multiple states on the source and single state on the destination, warn the user and only copy the default (after confirmation).
  * When multiple states on both sides, copy all (after confirmation).