### PR TITLE
provider/pagerduty: Updated implementation of pagerduty_vendor & pagerduty_service_integration

### DIFF
--- a/builtin/providers/pagerduty/data_source_pagerduty_vendor_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_vendor_test.go
@@ -8,23 +8,65 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccPagerDutyVendor_Basic(t *testing.T) {
+func TestAccDataSourcePagerDutyVendor_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccPagerDutyVendorsConfig,
+				Config: testAccDataSourcePagerDutyVendorConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccPagerDutyVendors("data.pagerduty_vendor.datadog"),
+					testAccDataSourcePagerDutyVendor("data.pagerduty_vendor.foo"),
 				),
 			},
 		},
 	})
 }
 
-func testAccPagerDutyVendors(n string) resource.TestCheckFunc {
+func TestAccDataSourcePagerDutyVendorLegacy_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourcePagerDutyVendorLegacyConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourcePagerDutyVendorLegacy("data.pagerduty_vendor.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourcePagerDutyVendor(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get a vendor ID from PagerDuty")
+		}
+
+		if a["id"] != "PZQ6AUS" {
+			return fmt.Errorf("Expected the Datadog Vendor ID to be: PZQ6AUS, but got: %s", a["id"])
+		}
+
+		if a["name"] != "Amazon Cloudwatch" {
+			return fmt.Errorf("Expected the Datadog Vendor Name to be: Datadog, but got: %s", a["name"])
+		}
+
+		if a["type"] != "api" {
+			return fmt.Errorf("Expected the Datadog Vendor Type to be: api, but got: %s", a["type"])
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourcePagerDutyVendorLegacy(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		r := s.RootModule().Resources[n]
@@ -50,8 +92,14 @@ func testAccPagerDutyVendors(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccPagerDutyVendorsConfig = `
-data "pagerduty_vendor" "datadog" {
-	name_regex = "Datadog"
+const testAccDataSourcePagerDutyVendorConfig = `
+data "pagerduty_vendor" "foo" {
+  name = "cloudwatch"
+}
+`
+
+const testAccDataSourcePagerDutyVendorLegacyConfig = `
+data "pagerduty_vendor" "foo" {
+  name_regex = "Datadog"
 }
 `

--- a/builtin/providers/pagerduty/resource_pagerduty_service_integration.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_integration.go
@@ -27,9 +27,11 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 				Optional: true,
 			},
 			"type": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				Computed:      true,
+				ConflictsWith: []string{"vendor"},
 				ValidateFunc: validateValueFunc([]string{
 					"aws_cloudwatch_inbound_integration",
 					"cloudkick_inbound_integration",
@@ -43,9 +45,11 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 				}),
 			},
 			"vendor": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"type"},
+				Computed:      true,
 			},
 			"integration_key": {
 				Type:     schema.TypeString,
@@ -64,9 +68,8 @@ func resourcePagerDutyServiceIntegration() *schema.Resource {
 func buildServiceIntegrationStruct(d *schema.ResourceData) *pagerduty.Integration {
 	serviceIntegration := pagerduty.Integration{
 		Name: d.Get("name").(string),
-		Type: d.Get("type").(string),
 		Service: &pagerduty.APIObject{
-			Type: "service_reference",
+			Type: "service",
 			ID:   d.Get("service").(string),
 		},
 		APIObject: pagerduty.APIObject{
@@ -83,10 +86,14 @@ func buildServiceIntegrationStruct(d *schema.ResourceData) *pagerduty.Integratio
 		serviceIntegration.IntegrationEmail = attr.(string)
 	}
 
+	if attr, ok := d.GetOk("type"); ok {
+		serviceIntegration.Type = attr.(string)
+	}
+
 	if attr, ok := d.GetOk("vendor"); ok {
 		serviceIntegration.Vendor = &pagerduty.APIObject{
 			ID:   attr.(string),
-			Type: "vendor_reference",
+			Type: "vendor",
 		}
 	}
 

--- a/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
@@ -43,6 +43,36 @@ func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
 	})
 }
 
+func TestAccPagerDutyServiceIntegrationGeneric_Basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceIntegrationGenericConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_integration.foo", "name", "foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_integration.foo", "type", "generic_events_api_inbound_integration"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccCheckPagerDutyServiceIntegrationGenericConfigUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_integration.foo", "name", "bar"),
+					resource.TestCheckResourceAttr(
+						"pagerduty_service_integration.foo", "type", "generic_events_api_inbound_integration"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckPagerDutyServiceIntegrationDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*pagerduty.Client)
 	for _, r := range s.RootModule().Resources {
@@ -125,12 +155,11 @@ resource "pagerduty_service" "foo" {
 }
 
 data "pagerduty_vendor" "datadog" {
-  name_regex = "datadog"
+  name = "datadog"
 }
 
 resource "pagerduty_service_integration" "foo" {
   name    = "foo"
-  type    = "generic_events_api_inbound_integration"
   service = "${pagerduty_service.foo.id}"
   vendor  = "${data.pagerduty_vendor.datadog.id}"
 }
@@ -175,13 +204,98 @@ resource "pagerduty_service" "foo" {
 }
 
 data "pagerduty_vendor" "datadog" {
-  name_regex = "datadog"
+  name = "datadog"
 }
 
 resource "pagerduty_service_integration" "foo" {
   name    = "bar"
-  type    = "generic_events_api_inbound_integration"
   service = "${pagerduty_service.foo.id}"
   vendor  = "${data.pagerduty_vendor.datadog.id}"
+}
+`
+
+const testAccCheckPagerDutyServiceIntegrationGenericConfig = `
+resource "pagerduty_user" "foo" {
+  name        = "foo"
+  email       = "foo@bar.com"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "foo"
+  description = "foo"
+  num_loops   = 1
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = "${pagerduty_user.foo.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "foo"
+  description             = "foo"
+  auto_resolve_timeout    = 1800
+  acknowledgement_timeout = 1800
+  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_service_integration" "foo" {
+  name    = "foo"
+  service = "${pagerduty_service.foo.id}"
+  type    = "generic_events_api_inbound_integration"
+}
+`
+
+const testAccCheckPagerDutyServiceIntegrationGenericConfigUpdated = `
+resource "pagerduty_user" "foo" {
+  name        = "foo"
+  email       = "foo@bar.com"
+  color       = "green"
+  role        = "user"
+  job_title   = "foo"
+  description = "foo"
+}
+
+resource "pagerduty_escalation_policy" "foo" {
+  name        = "bar"
+  description = "bar"
+  num_loops   = 2
+
+  rule {
+    escalation_delay_in_minutes = 10
+
+    target {
+      type = "user_reference"
+      id   = "${pagerduty_user.foo.id}"
+    }
+  }
+}
+
+resource "pagerduty_service" "foo" {
+  name                    = "bar"
+  description             = "bar"
+  auto_resolve_timeout    = 3600
+  acknowledgement_timeout = 3600
+  escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
+
+  incident_urgency_rule {
+    type    = "constant"
+    urgency = "high"
+  }
+}
+
+resource "pagerduty_service_integration" "foo" {
+  name    = "bar"
+  service = "${pagerduty_service.foo.id}"
+  type    = "generic_events_api_inbound_integration"
 }
 `

--- a/vendor/github.com/PagerDuty/go-pagerduty/event.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/event.go
@@ -40,11 +40,11 @@ func CreateEvent(e Event) (*EventResponse, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("HTTP Status Code: %d", resp.StatusCode)
 	}
 	var eventResponse EventResponse
-	defer resp.Body.Close()
 	if err := json.NewDecoder(resp.Body).Decode(&eventResponse); err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/PagerDuty/go-pagerduty/log_entry.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/log_entry.go
@@ -46,8 +46,8 @@ type ListLogEntryResponse struct {
 type ListLogEntriesOptions struct {
 	APIListObject
 	TimeZone   string   `url:"time_zone"`
-	Since      string   `url:"omitempty"`
-	Until      string   `url:"omitempty"`
+	Since      string   `url:"since,omitempty"`
+	Until      string   `url:"until,omitempty"`
 	IsOverview bool     `url:"is_overview,omitempty"`
 	Includes   []string `url:"include,omitempty,brackets"`
 }

--- a/vendor/github.com/PagerDuty/go-pagerduty/vendor.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/vendor.go
@@ -30,6 +30,7 @@ type ListVendorResponse struct {
 // ListVendorOptions is the data structure used when calling the ListVendors API endpoint.
 type ListVendorOptions struct {
 	APIListObject
+	Query string `url:"query,omitempty"`
 }
 
 // ListVendors lists existing vendors.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -381,10 +381,10 @@
 			"revisionTime": "2016-11-03T18:56:17Z"
 		},
 		{
-			"checksumSHA1": "trj+UY2oSzP0O1WJKz8auncslVs=",
+			"checksumSHA1": "ibs+ylGiQibNx5GeZlCKx7A/zH8=",
 			"path": "github.com/PagerDuty/go-pagerduty",
-			"revision": "fad777c9c72ec7c62aeec0194f01684d6a2efd0e",
-			"revisionTime": "2017-01-28T02:14:22Z"
+			"revision": "fcea06d066d768bf90755d1071dd444c6abff524",
+			"revisionTime": "2017-03-01T18:59:23Z"
 		},
 		{
 			"checksumSHA1": "NX4v3cbkXAJxFlrncqT9yEUBuoA=",

--- a/website/source/docs/providers/pagerduty/d/vendor.html.markdown
+++ b/website/source/docs/providers/pagerduty/d/vendor.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get information about a specific [vendor][1] that you ca
 
 ```
 data "pagerduty_vendor" "datadog" {
-  name_regex = "^Datadog$"
+  name = "Datadog"
 }
 
 resource "pagerduty_user" "example" {
@@ -56,7 +56,7 @@ resource "pagerduty_service_integration" "example" {
 
 The following arguments are supported:
 
-* `name_regex` - (Required) A regex string to apply to the vendor list returned by the PagerDuty API. This regex should be very specific. If your regex matches several vendors a list of found vendors will be returned so you can tweak your regex further. The final regex string is made case insensitive.
+* `name` - (Required) The vendor name to use to find a vendor in the PagerDuty API.
 
 ## Attributes Reference
 * `name` - The short name of the found vendor.

--- a/website/source/docs/providers/pagerduty/r/service_integration.html.markdown
+++ b/website/source/docs/providers/pagerduty/r/service_integration.html.markdown
@@ -50,22 +50,20 @@ data "pagerduty_vendor" "datadog" {
   name = "Datadog"
 }
 
+resource "pagerduty_service_integration" "datadog" {
+  name    = "${data.pagerduty_vendor.datadog.name}"
+  service = "${pagerduty_service.example.id}"
+  vendor  = "${data.pagerduty_vendor.datadog.id}"
+}
+
 data "pagerduty_vendor" "cloudwatch" {
-  name_regex = "Amazon CloudWatch"
+  name = "Cloudwatch"
 }
 
-resource "pagerduty_service_integration" "datadog" {
-  name    = "${data.pagerduty_vendor.datadog.name}"
-  type    = "generic_events_api_inbound_integration"
+resource "pagerduty_service_integration" "cloudwatch" {
+  name    = "${data.pagerduty_vendor.cloudwatch.name}"
   service = "${pagerduty_service.example.id}"
-  vendor  = "${data.pagerduty_vendor.datadog.id}"
-}
-
-resource "pagerduty_service_integration" "datadog" {
-  name    = "${data.pagerduty_vendor.datadog.name}"
-  type    = "generic_events_api_inbound_integration"
-  service = "${pagerduty_service.example.id}"
-  vendor  = "${data.pagerduty_vendor.datadog.id}"
+  vendor  = "${data.pagerduty_vendor.cloudwatch.id}"
 }
 ```
 
@@ -74,20 +72,23 @@ resource "pagerduty_service_integration" "datadog" {
 The following arguments are supported:
 
   * `name` - (Optional) The name of the service integration.
-  * `type` - (Optional) The service type. Can be `aws_cloudwatch_inbound_integration`, `cloudkick_inbound_integration`,
+  * `type` - (Optional) The service type. Can be:
+  `aws_cloudwatch_inbound_integration`,
+  `cloudkick_inbound_integration`,
   `event_transformer_api_inbound_integration`,
   `generic_email_inbound_integration`,
   `generic_events_api_inbound_integration`,
   `keynote_inbound_integration`,
   `nagios_inbound_integration`,
-  `pingdom_inbound_integration`,
-  `sql_monitor_inbound_integration`.
+  `pingdom_inbound_integration`or `sql_monitor_inbound_integration`.
 
-    When integrating with a `vendor` this can usually be set to: `${data.pagerduty_vendor.datadog.type}`
+    **Note:** This is meant for **generic** service integrations.
+    To integrate with a **vendor** (e.g Datadog or Amazon Cloudwatch) use the `vendor` field instead.
 
-  * `service` - (Optional) The PagerDuty service that the integration belongs to.
-  * `vendor` - (Optional) The vendor that this integration integrates with, if applicable. (e.g Datadog)
+  * `service` - (Optional) The ID of the service the integration should belong to.
+  * `vendor` - (Optional) The ID of the vendor the integration should integrate with (e.g Datadog or Amazon Cloudwatch).
 
+    **Note:** You can use the `pagerduty_vendor` data source to locate the appropriate vendor ID.
 ## Attributes Reference
 
 The following attributes are exported:


### PR DESCRIPTION
This PR aims to solve some issues related to service integrations, example issue: https://github.com/hashicorp/terraform/issues/11656.

**Changes to `pagerduty_vendor`**
 - Previously it wasn't possible to query vendors by name, this is now possible and simplifies the data source (`pagerduty_vendor`) significantly. To support the old behaviour we just mark the field `name_regex` as deprecated and point the user to start using the `name` field instead which should use the new query lookup. 
- Updated documentation
- Updated tests

Before:
```hcl
data "pagerduty_vendor" "foo" {
  name_regex = "^Datadog$"
}
```

After:
```hcl
data "pagerduty_vendor" "foo" {
  name = "Datadog"
}
```

**Changes to `pagerduty_service_integration`**
- `type` now conflicts with `vendor` and vice-versa. `type` is meant for generic service integrations and `vendor` is meant for vendor integrations. While the current implementation might "work" with both set, it may cause strange behaviour (API responds with another type) and just adds confusion.
- `type` is now an optional field
- `type` can now be computed
- `vendor`can now be computed
- Updated documentation
  - Added more examples
  - Clarify the difference between generic and vendor integrations.
- Updated tests

Before:
```hcl
data "pagerduty_vendor" "foo" {
  name_regex = "^Datadog$"
}

// Vendor integration
resource "pagerduty_service_integration" "foo" {
  name    = "bar"
  type = "generic_events_api_inbound_integration"
  service = "${pagerduty_service.foo.id}"
  vendor  = "${data.pagerduty_vendor.foo.id}"
}

// Generic integration
resource "pagerduty_service_integration" "foo" {
  name    = "bar"
  type = "generic_events_api_inbound_integration"
  service = "${pagerduty_service.foo.id}"
}
```

After:
```hcl
data "pagerduty_vendor" "foo" {
  name = "Datadog"
}

// Vendor integration
resource "pagerduty_service_integration" "foo" {
  name    = "bar"
  service = "${pagerduty_service.foo.id}"
  vendor  = "${data.pagerduty_vendor.foo.id}"
}

// Generic integration
resource "pagerduty_service_integration" "foo" {
  name    = "bar"
  type = "generic_events_api_inbound_integration"
  service = "${pagerduty_service.foo.id}"
}
```