### PR TITLE
aws/provider: redshift cluster exercise invalid password char path

### DIFF
--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -566,6 +566,10 @@ func TestResourceAWSRedshiftClusterMasterPasswordValidation(t *testing.T) {
 			Value:    "1Testing",
 			ErrCount: 0,
 		},
+		{
+			Value:    "Testing@",
+			ErrCount: 1,
+		},
 	}
 
 	for _, tc := range cases {

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -567,7 +567,7 @@ func TestResourceAWSRedshiftClusterMasterPasswordValidation(t *testing.T) {
 			ErrCount: 0,
 		},
 		{
-			Value:    "Testing@",
+			Value:    "1Testing@",
 			ErrCount: 1,
 		},
 	}


### PR DESCRIPTION
A quick test of the invalid password character code branch.