### PR TITLE
terraform: run Gosched in test so other goroutines run

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -1812,7 +1813,9 @@ func TestContext2Apply_cancelBlock(t *testing.T) {
 		close(applyCh)
 
 		for !ctx.sh.Stopped() {
-			// Wait for stop to be called
+			// Wait for stop to be called. We call Gosched here so that
+			// the other goroutines can always be scheduled to set Stopped.
+			runtime.Gosched()
 		}
 
 		// Sleep


### PR DESCRIPTION
Starting with Go 1.8 betas, we've periodically received SIGQUITs on our
tests in Travis. The stack trace looks like this:

https://gist.github.com/mitchellh/abf09b0980f8ea01269f8d9d6133884d

The tests are timing out! This is a test that hasn't been touched really
in a very long time and has always passed. I've **reproduced this
locally** by setting `GOMAXPROCS=1` and running the test. By yielding
the scheduler in the hot loop, it now passes almost instantly every
time.

My only theory is that in Go 1.8 the scheduler changed in some way
that it now sometimes doesn't schedule the other goroutine. This
is not in any way a bug in Go, of course, it is just old behavior we
depended on. Gosched fixes this.

Perhaps the test can be written in a different way, but this gets tests
passing and I think will fix our periodic errors.