### PR TITLE
provider/azurerm: Allow blob copy between storage accounts

### DIFF
--- a/builtin/providers/azurerm/resource_arm_storage_blob.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob.go
@@ -205,7 +205,7 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Source storage account %q not found", sourceAccount)
 		}
 
-		sourceUri, err = sourceBlobClient.GetBlobSASURI(sourceContainer, sourceBlob, time.Now().Add(10*time.Minute), "r")
+		sourceUri, err = sourceBlobClient.GetBlobSASURI(sourceContainer, sourceBlob, time.Now().Add(60*time.Minute), "r")
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/azurerm/resource_arm_storage_blob.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 
+	"time"
+
 	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -58,16 +60,52 @@ func resourceArmStorageBlob() *schema.Resource {
 				ValidateFunc: validateArmStorageBlobSize,
 			},
 			"source": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				ForceNew:      true,
-				ConflictsWith: []string{"source_uri"},
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"source_uri",
+					"source_resource_group_name",
+					"source_storage_account_name",
+					"source_storage_container_name",
+					"source_blob_name",
+				},
 			},
 			"source_uri": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				ConflictsWith: []string{
+					"source",
+					"source_resource_group_name",
+					"source_storage_account_name",
+					"source_storage_container_name",
+					"source_blob_name",
+				},
+			},
+			"source_resource_group_name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				ForceNew:      true,
-				ConflictsWith: []string{"source"},
+				ConflictsWith: []string{"source", "source_uri"},
+			},
+			"source_storage_account_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"source", "source_uri"},
+			},
+			"source_storage_container_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"source", "source_uri"},
+			},
+			"source_blob_name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"source", "source_uri"},
 			},
 			"url": {
 				Type:     schema.TypeString,
@@ -152,8 +190,27 @@ func resourceArmStorageBlobCreate(d *schema.ResourceData, meta interface{}) erro
 	blobType := d.Get("type").(string)
 	cont := d.Get("storage_container_name").(string)
 	sourceUri := d.Get("source_uri").(string)
+	sourceResourceGroup := d.Get("source_resource_group_name").(string)
+	sourceAccount := d.Get("source_storage_account_name").(string)
+	sourceContainer := d.Get("source_storage_container_name").(string)
+	sourceBlob := d.Get("source_blob_name").(string)
 
 	log.Printf("[INFO] Creating blob %q in storage account %q", name, storageAccountName)
+	if sourceBlob != "" {
+		sourceBlobClient, exists, err := armClient.getBlobStorageClientForStorageAccount(sourceResourceGroup, sourceAccount)
+		if err != nil {
+			return err
+		}
+		if !exists {
+			return fmt.Errorf("Source storage account %q not found", sourceAccount)
+		}
+
+		sourceUri, err = sourceBlobClient.GetBlobSASURI(sourceContainer, sourceBlob, time.Now().Add(10*time.Minute), "r")
+		if err != nil {
+			return err
+		}
+	}
+
 	if sourceUri != "" {
 		if err := blobClient.CopyBlob(cont, name, sourceUri); err != nil {
 			return fmt.Errorf("Error creating storage blob on Azure: %s", err)

--- a/website/source/docs/providers/azurerm/r/storage_blob.html.markdown
+++ b/website/source/docs/providers/azurerm/r/storage_blob.html.markdown
@@ -72,6 +72,14 @@ The following arguments are supported:
 
 * `attempts` - (Optional) The number of attempts to make per page or block when uploading. Defaults to `1`.
 
+* `source_resource_group_name` - (Optional) The resource group name of the source blob if the source blob is not publically accessible. Cannot be defined if `source` or `source_uri` is specified.
+
+* `source_storage_account_name` - (Optional) The storage account name of the source blob if the source blob is not publically accessible. Cannot be defined if `source` or `source_uri` is specified.
+
+* `source_storage_container_name` - (Optional) The storage container name of the source blob if the source blob is not publically accessible. Cannot be defined if `source` or `source_uri` is specified.
+
+* `source_blob_name` - (Optional) The name of the source blob if the source blob is not publically accessible. Cannot be defined if `source` or `source_uri` is specified.
+
 ## Attributes Reference
 
 The following attributes are exported in addition to the arguments listed above:


### PR DESCRIPTION
Currently, unless the blob is publically accessible, specifying the source_uri in the azurerm_storage_blob resource does not work. This change allows the source for a blob to be in any storage account to which the service principal has access.

Side node: I'm still having some issues with acceptance tests running correctly when creating storage accounts. I did validate this change however against our production subscription and it worked as designed.