### PR TITLE
command: Fix crash caused by empty state (data source PostApply)

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -129,8 +129,9 @@ func (h *UiHook) PreApply(
 		attrString = "\n  " + attrString
 	}
 
-	var stateIdSuffix string
-	if s.ID != "" {
+	var stateId, stateIdSuffix string
+	if s != nil && s.ID != "" {
+		stateId = s.ID
 		stateIdSuffix = fmt.Sprintf(" (ID: %s)", truncateId(s.ID, maxIdLen))
 	}
 
@@ -142,7 +143,7 @@ func (h *UiHook) PreApply(
 		attrString)))
 
 	// Set a timer to show an operation is still happening
-	time.AfterFunc(periodicUiTimer, func() { h.stillApplying(id, s.ID) })
+	time.AfterFunc(periodicUiTimer, func() { h.stillApplying(id, stateId) })
 
 	return terraform.HookActionContinue, nil
 }
@@ -200,7 +201,7 @@ func (h *UiHook) PostApply(
 	h.l.Unlock()
 
 	var stateIdSuffix string
-	if s.ID != "" {
+	if s != nil && s.ID != "" {
 		stateIdSuffix = fmt.Sprintf(" (ID: %s)", truncateId(s.ID, maxIdLen))
 	}
 


### PR DESCRIPTION
Apparently I didn't test https://github.com/hashicorp/terraform/pull/12261 thoroughly on data sources. 😢 

cc @mitchellh This should be reviewed & merged prior to the next release.

```
data.google_compute_zones.available: Destroying... (ID: 2017-03-0...0000 UTC)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x4693629]

goroutine 489 [running]:
github.com/hashicorp/terraform/command.(*UiHook).PostApply(0xc4201c41e0, 0xc420017b30, 0x0, 0x0, 0x0, 0x18, 0xc4204e3360, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/command/hook_ui.go:203 +0x119
github.com/hashicorp/terraform/terraform.(*EvalApplyPost).Eval.func1(0x7d8e300, 0xc4201c41e0, 0xed049efa6, 0xc420278000, 0x2c)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval_apply.go:142 +0x5b
github.com/hashicorp/terraform/terraform.(*BuiltinEvalContext).Hook(0xc42014d0a0, 0xc4204e3360, 0x2c, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval_context_builtin.go:61 +0x6c
github.com/hashicorp/terraform/terraform.(*EvalApplyPost).Eval(0xc4204e2b00, 0x7d8fd80, 0xc42014d0a0, 0x2, 0x2, 0x56aa7fd, 0x4)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval_apply.go:143 +0xa7
github.com/hashicorp/terraform/terraform.EvalRaw(0x7d5da80, 0xc4204e2b00, 0x7d8fd80, 0xc42014d0a0, 0x5331c40, 0x0, 0x0, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval.go:53 +0x175
github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc4204e2b60, 0x7d8fd80, 0xc42014d0a0, 0x2, 0x2, 0x56aa7fd, 0x4)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0xc1
github.com/hashicorp/terraform/terraform.EvalRaw(0x7d5e380, 0xc4204e2b60, 0x7d8fd80, 0xc42014d0a0, 0x2b, 0x0, 0x0, 0x2b)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval.go:53 +0x175
github.com/hashicorp/terraform/terraform.(*EvalOpFilter).Eval(0xc4204a7f50, 0x7d8fd80, 0xc42014d0a0, 0x2, 0x2, 0x56aa7fd, 0x4)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval_filter_operation.go:37 +0x4c
github.com/hashicorp/terraform/terraform.EvalRaw(0x7d5e140, 0xc4204a7f50, 0x7d8fd80, 0xc42014d0a0, 0x4d7bb40, 0xc4201bd11c, 0x4afdc80, 0xc4201bd140)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval.go:53 +0x175
github.com/hashicorp/terraform/terraform.Eval(0x7d5e140, 0xc4204a7f50, 0x7d8fd80, 0xc42014d0a0, 0xc4204a7f50, 0x7d5e140, 0xc4204a7f50, 0xc42068e340)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x5524ac0, 0xc42000c570, 0x0, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/graph.go:126 +0xd4d
github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc42096ed90, 0x5524ac0, 0xc42000c570, 0xc420554240)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/dag/walk.go:387 +0x392
created by github.com/hashicorp/terraform/dag.(*Walker).Update
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/dag/walk.go:310 +0x9ca
```

### Repro case & test plan

```hcl
provider "google" {
...
}

data "google_compute_zones" "available" {}
```
```
terraform apply && terraform destroy -force
```