### PR TITLE
provider/statuscake: use default status code list when updating test

### DIFF
--- a/builtin/providers/statuscake/resource_statuscaketest.go
+++ b/builtin/providers/statuscake/resource_statuscaketest.go
@@ -193,5 +193,13 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	if v, ok := d.GetOk("port"); ok {
 		test.Port = v.(int)
 	}
+
+	defaultStatusCodes := "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +
+		"408, 410, 413, 444, 429, 494, 495, 496, 499, 500, 501, 502, 503, " +
+		"504, 505, 506, 507, 508, 509, 510, 511, 521, 522, 523, 524, 520, " +
+		"598, 599"
+
+	test.StatusCodes = defaultStatusCodes
+
 	return test
 }


### PR DESCRIPTION
This PR fixes an issue whenever a StatusCake test is updated which would clear the list of status codes considered as errors.

According to the StatusCake API documentation (https://github.com/DreamItGetIT/statuscake/blob/master/tests.go#L93), when updating a test definition the `StatusCodes` definition is always updated. Since currently there's no support for setting the list of status codes in terraform this would replace the list with an empty list.

This PR fixes the issue by always providing the default list of status codes when updating a test.
