### PR TITLE
provider/aws: Ignore whitespace in json diff for aws_dms_replication_task options

### DIFF
--- a/builtin/providers/aws/diff_suppress_funcs.go
+++ b/builtin/providers/aws/diff_suppress_funcs.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"bytes"
+	"encoding/json"
 	"log"
 	"strings"
 
@@ -41,4 +43,18 @@ func suppressAwsDbEngineVersionDiffs(k, old, new string, d *schema.ResourceData)
 
 	// Throw a diff by default
 	return false
+}
+
+func suppressEquivalentJsonDiffs(k, old, new string, d *schema.ResourceData) bool {
+	ob := bytes.NewBufferString("")
+	if err := json.Compact(ob, []byte(old)); err != nil {
+		return false
+	}
+
+	nb := bytes.NewBufferString("")
+	if err := json.Compact(nb, []byte(new)); err != nil {
+		return false
+	}
+
+	return jsonBytesEqual(ob.Bytes(), nb.Bytes())
 }

--- a/builtin/providers/aws/diff_suppress_funcs_test.go
+++ b/builtin/providers/aws/diff_suppress_funcs_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func TestSuppressEquivalentJsonDiffsWhitespaceAndNoWhitespace(t *testing.T) {
+	d := new(schema.ResourceData)
+
+	noWhitespace := `{"test":"test"}`
+	whitespace := `
+{
+  "test": "test"
+}`
+
+	if !suppressEquivalentJsonDiffs("", noWhitespace, whitespace, d) {
+		t.Errorf("Expected suppressEquivalentJsonDiffs to return true for %s == %s", noWhitespace, whitespace)
+	}
+
+	noWhitespaceDiff := `{"test":"test"}`
+	whitespaceDiff := `
+{
+  "test": "tested"
+}`
+
+	if suppressEquivalentJsonDiffs("", noWhitespaceDiff, whitespaceDiff, d) {
+		t.Errorf("Expected suppressEquivalentJsonDiffs to return false for %s == %s", noWhitespaceDiff, whitespaceDiff)
+	}
+}

--- a/builtin/providers/aws/resource_aws_dms_replication_task.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_task.go
@@ -57,9 +57,10 @@ func resourceAwsDmsReplicationTask() *schema.Resource {
 				ValidateFunc: validateDmsReplicationTaskId,
 			},
 			"replication_task_settings": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validateJsonString,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 			},
 			"source_endpoint_arn": {
 				Type:         schema.TypeString,
@@ -68,9 +69,10 @@ func resourceAwsDmsReplicationTask() *schema.Resource {
 				ValidateFunc: validateArn,
 			},
 			"table_mappings": {
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validateJsonString,
+				Type:             schema.TypeString,
+				Required:         true,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
 			},
 			"tags": {
 				Type:     schema.TypeMap,

--- a/builtin/providers/aws/utils.go
+++ b/builtin/providers/aws/utils.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"encoding/base64"
+	"encoding/json"
+	"reflect"
 	"regexp"
 )
 
@@ -23,4 +25,18 @@ func isBase64Encoded(data []byte) bool {
 
 func looksLikeJsonString(s interface{}) bool {
 	return regexp.MustCompile(`^\s*{`).MatchString(s.(string))
+}
+
+func jsonBytesEqual(b1, b2 []byte) bool {
+	var o1 interface{}
+	if err := json.Unmarshal(b1, &o1); err != nil {
+		return false
+	}
+
+	var o2 interface{}
+	if err := json.Unmarshal(b2, &o2); err != nil {
+		return false
+	}
+
+	return reflect.DeepEqual(o1, o2)
 }

--- a/builtin/providers/aws/utils_test.go
+++ b/builtin/providers/aws/utils_test.go
@@ -32,3 +32,41 @@ func TestLooksLikeJsonString(t *testing.T) {
 		t.Errorf("Expected looksLikeJson to return false for %s", doesNotLookLikeJson)
 	}
 }
+
+func TestJsonBytesEqualQuotedAndUnquoted(t *testing.T) {
+	unquoted := `{"test": "test"}`
+	quoted := "{\"test\": \"test\"}"
+
+	if !jsonBytesEqual([]byte(unquoted), []byte(quoted)) {
+		t.Errorf("Expected jsonBytesEqual to return true for %s == %s", unquoted, quoted)
+	}
+
+	unquotedDiff := `{"test": "test"}`
+	quotedDiff := "{\"test\": \"tested\"}"
+
+	if jsonBytesEqual([]byte(unquotedDiff), []byte(quotedDiff)) {
+		t.Errorf("Expected jsonBytesEqual to return false for %s == %s", unquotedDiff, quotedDiff)
+	}
+}
+
+func TestJsonBytesEqualWhitespaceAndNoWhitespace(t *testing.T) {
+	noWhitespace := `{"test":"test"}`
+	whitespace := `
+{
+  "test": "test"
+}`
+
+	if !jsonBytesEqual([]byte(noWhitespace), []byte(whitespace)) {
+		t.Errorf("Expected jsonBytesEqual to return true for %s == %s", noWhitespace, whitespace)
+	}
+
+	noWhitespaceDiff := `{"test":"test"}`
+	whitespaceDiff := `
+{
+  "test": "tested"
+}`
+
+	if jsonBytesEqual([]byte(noWhitespaceDiff), []byte(whitespaceDiff)) {
+		t.Errorf("Expected jsonBytesEqual to return false for %s == %s", noWhitespaceDiff, whitespaceDiff)
+	}
+}


### PR DESCRIPTION
Fixes #12378 