### PR TITLE
report all errors from module validation

### DIFF
--- a/config/module/test-fixtures/validate-required-var/child/main.tf
+++ b/config/module/test-fixtures/validate-required-var/child/main.tf
@@ -1,1 +1,2 @@
 variable "memory" {}
+variable "feature" {}

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -410,8 +410,17 @@ func TestTreeValidate_requiredChildVar(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	if err := tree.Validate(); err == nil {
+	err := tree.Validate()
+	if err == nil {
 		t.Fatal("should error")
+	}
+
+	// ensure both variables are mentioned in the output
+	errMsg := err.Error()
+	for _, v := range []string{"feature", "memory"} {
+		if !strings.Contains(errMsg, v) {
+			t.Fatalf("no mention of missing variable %q", v)
+		}
 	}
 }
 


### PR DESCRIPTION
It can be tedious fixing a new module with many errors when Terraform
only outputs the first random error it encounters.

Accumulate all errors from validation, and format them for the user.

Example output of multiple variables missing in modules:


```
  module root:
    module mod: required variable in_a not set
    module mod: required variable in_b not set
    module mod: required variable in_c not set
  module mod.root:
    module mod2: required variable in2_c not set
    module mod2: required variable in2_a not set
    module mod2: required variable in2_b not set
```