### PR TITLE
provider/google: ignore expanded v collapsed policies in diff

### DIFF
--- a/builtin/providers/google/resource_google_project_iam_policy.go
+++ b/builtin/providers/google/resource_google_project_iam_policy.go
@@ -373,6 +373,8 @@ func jsonPolicyDiffSuppress(k, old, new string, d *schema.ResourceData) bool {
 		log.Printf("[ERROR] Could not unmarshal new policy %s: %v", new, err)
 		return false
 	}
+	oldPolicy.Bindings = mergeBindings(oldPolicy.Bindings)
+	newPolicy.Bindings = mergeBindings(newPolicy.Bindings)
 	if newPolicy.Etag != oldPolicy.Etag {
 		return false
 	}

--- a/builtin/providers/google/resource_google_project_iam_policy_test.go
+++ b/builtin/providers/google/resource_google_project_iam_policy_test.go
@@ -633,8 +633,8 @@ func testAccGoogleProjectAssociatePolicyBasic(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
-	name = "%s"
-	org_id = "%s"
+    name = "%s"
+    org_id = "%s"
 }
 resource "google_project_iam_policy" "acceptance" {
     project = "${google_project.acceptance.id}"
@@ -662,8 +662,8 @@ func testAccGoogleProject_create(pid, name, org string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
-	name = "%s"
-	org_id = "%s"
+    name = "%s"
+    org_id = "%s"
 }`, pid, name, org)
 }
 
@@ -671,9 +671,9 @@ func testAccGoogleProject_createBilling(pid, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "acceptance" {
     project_id = "%s"
-	name = "%s"
-	org_id = "%s"
-	billing_account = "%s"
+    name = "%s"
+    org_id = "%s"
+    billing_account = "%s"
 }`, pid, name, org, billing)
 }
 
@@ -692,16 +692,16 @@ resource "google_project_iam_policy" "acceptance" {
 data "google_iam_policy" "expanded" {
     binding {
         role = "roles/viewer"
-	members = [
-	    "user:paddy@carvers.co",
-	]
+        members = [
+            "user:paddy@carvers.co",
+        ]
     }
     
     binding {
         role = "roles/viewer"
-	members = [
-	    "user:paddy@hashicorp.com",
-	]
+        members = [
+            "user:paddy@hashicorp.com",
+        ]
     }
 }`, pid, name, org)
 }

--- a/builtin/providers/google/resource_google_project_iam_policy_test.go
+++ b/builtin/providers/google/resource_google_project_iam_policy_test.go
@@ -254,7 +254,24 @@ func TestAccGoogleProjectIamPolicy_basic(t *testing.T) {
 	})
 }
 
-func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes, pid string) resource.TestCheckFunc {
+// Test that a non-collapsed IAM policy doesn't perpetually diff
+func TestAccGoogleProjectIamPolicy_expanded(t *testing.T) {
+	pid := "terraform-" + acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccGoogleProjectAssociatePolicyExpanded(pid, pname, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGoogleProjectIamPolicyExists("google_project_iam_policy.acceptance", "data.google_iam_policy.expanded", pid),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGoogleProjectIamPolicyExists(projectRes, policyRes, pid string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		// Get the project resource
 		project, ok := s.RootModule().Resources[projectRes]
@@ -290,10 +307,55 @@ func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes, pid strin
 		}
 
 		// The bindings in both policies should be identical
+		projectP.Bindings = mergeBindings(projectP.Bindings)
+		policyP.Bindings = mergeBindings(policyP.Bindings)
 		sort.Sort(sortableBindings(projectP.Bindings))
 		sort.Sort(sortableBindings(policyP.Bindings))
 		if !reflect.DeepEqual(derefBindings(projectP.Bindings), derefBindings(policyP.Bindings)) {
 			return fmt.Errorf("Project and data source policies do not match: project policy is %+v, data resource policy is  %+v", derefBindings(projectP.Bindings), derefBindings(policyP.Bindings))
+		}
+		return nil
+	}
+}
+
+func testAccCheckGoogleProjectIamPolicyIsMerged(projectRes, policyRes, pid string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Get the project resource
+		project, ok := s.RootModule().Resources[projectRes]
+		if !ok {
+			return fmt.Errorf("Not found: %s", projectRes)
+		}
+		// The project ID should match the config's project ID
+		if project.Primary.ID != pid {
+			return fmt.Errorf("Expected project %q to match ID %q in state", pid, project.Primary.ID)
+		}
+
+		err := testAccCheckGoogleProjectIamPolicyExists(projectRes, policyRes, pid)(s)
+		if err != nil {
+			return err
+		}
+
+		var projectP, policyP cloudresourcemanager.Policy
+		// The project should have a policy
+		ps, ok := project.Primary.Attributes["policy_data"]
+		if !ok {
+			return fmt.Errorf("Project resource %q did not have a 'policy_data' attribute. Attributes were %#v", project.Primary.Attributes["id"], project.Primary.Attributes)
+		}
+		if err := json.Unmarshal([]byte(ps), &projectP); err != nil {
+			return fmt.Errorf("Could not unmarshal %s:\n: %v", ps, err)
+		}
+
+		// The data policy resource should have a policy
+		policy, ok := s.RootModule().Resources[policyRes]
+		if !ok {
+			return fmt.Errorf("Not found: %s", policyRes)
+		}
+		ps, ok = policy.Primary.Attributes["policy_data"]
+		if !ok {
+			return fmt.Errorf("Data policy resource %q did not have a 'policy_data' attribute. Attributes were %#v", policy.Primary.Attributes["id"], project.Primary.Attributes)
+		}
+		if err := json.Unmarshal([]byte(ps), &policyP); err != nil {
+			return err
 		}
 
 		// Merge the project policy in Terraform state with the policy the project had before the config was applied
@@ -633,4 +695,33 @@ resource "google_project" "acceptance" {
 	org_id = "%s"
 	billing_account = "%s"
 }`, pid, name, org, billing)
+}
+
+func testAccGoogleProjectAssociatePolicyExpanded(pid, name, org string) string {
+	return fmt.Sprintf(`
+resource "google_project" "acceptance" {
+    project_id = "%s"
+    name = "%s"
+    org_id = "%s"
+}
+resource "google_project_iam_policy" "acceptance" {
+    project = "${google_project.acceptance.id}"
+    policy_data = "${data.google_iam_policy.expanded.policy_data}"
+    authoritative = false
+}
+data "google_iam_policy" "expanded" {
+    binding {
+        role = "roles/viewer"
+	members = [
+	    "user:paddy@carvers.co",
+	]
+    }
+    
+    binding {
+        role = "roles/viewer"
+	members = [
+	    "user:paddy@hashicorp.com",
+	]
+    }
+}`, pid, name, org)
 }


### PR DESCRIPTION
When comparing the config and state for google_project_iam_policy,
always merge the bindings down to a common representation, to avoid a
perpetual diff.

Fixes #11763.

I also added a test to ensure the fix worked. Output of the test without the fix in place:

```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/02 13:59:46 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccGoogleProjectIamPolicy_expanded -timeout 120m
=== RUN   TestAccGoogleProjectIamPolicy_expanded
--- FAIL: TestAccGoogleProjectIamPolicy_expanded (20.58s)
        testing.go:265: Step 0 error: After applying this step, the plan was not empty:

                DIFF:

                UPDATE: google_project_iam_policy.acceptance
                  policy_data: "{\"bindings\":[{\"members\":[\"user:paddy@carvers.co\",\"user:paddy@hashicorp.com\"],\"role\":\"roles/viewer\"}]}" => "{\"bindings\":[{\"members\":[\"user:paddy@hashicorp.com\"],\"role\":\"roles/viewer\"},{\"members\":[\"user:paddy@carvers.co\"],\"role\":\"roles/viewer\"}]}"

                STATE:

                data.google_iam_policy.expanded:
                  ID = 1322415602
                  binding.# = 2
                  binding.1102091722.members.# = 1
                  binding.1102091722.members.2912398366 = user:paddy@hashicorp.com
                  binding.1102091722.role = roles/viewer
                  binding.4049261743.members.# = 1
                  binding.4049261743.members.360503667 = user:paddy@carvers.co
                  binding.4049261743.role = roles/viewer
                  policy_data = {"bindings":[{"members":["user:paddy@hashicorp.com"],"role":"roles/viewer"},{"members":["user:paddy@carvers.co"],"role":"roles/viewer"}]}
                google_project.acceptance:
                  ID = terraform-pjewz40hq3
                  name = Terraform Acceptance Tests
                  number = 609045719484
                  org_id = 622235425790
                  project_id = terraform-pjewz40hq3
                google_project_iam_policy.acceptance:
                  ID = terraform-pjewz40hq3
                  authoritative = false
                  etag = BwVJxo1shsw=
                  policy_data = {"bindings":[{"members":["user:paddy@carvers.co","user:paddy@hashicorp.com"],"role":"roles/viewer"}]}
                  project = terraform-pjewz40hq3
                  restore_policy = {"bindings":[{"members":["serviceAccount:terraform-acceptance-tests@hc-terraform-testing.iam.gserviceaccount.com"],"role":"roles/owner"}],"etag":"BwVJxo0AAQ4=","version":1}

                  Dependencies:
                    google_project.acceptance
                    data.google_iam_policy.expanded
FAIL
exit status 1
FAIL    github.com/hashicorp/terraform/builtin/providers/google 20.584s
Makefile:48: recipe for target 'testacc' failed
make: *** [testacc] Error 1
```

Output after fix:

```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/02 14:00:32 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccGoogleProjectIamPolicy_expanded -timeout 120m
=== RUN   TestAccGoogleProjectIamPolicy_expanded
--- PASS: TestAccGoogleProjectIamPolicy_expanded (19.65s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/google 19.659s
```