### PR TITLE
Implement filter function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -65,6 +65,7 @@ func Funcs() map[string]ast.Function {
 		"distinct":     interpolationFuncDistinct(),
 		"element":      interpolationFuncElement(),
 		"file":         interpolationFuncFile(),
+		"filter":       interpolationFuncFilter(),
 		"floor":        interpolationFuncFloor(),
 		"format":       interpolationFuncFormat(),
 		"formatlist":   interpolationFuncFormatList(),
@@ -638,6 +639,44 @@ func appendIfMissing(slice []string, element string) []string {
 		}
 	}
 	return append(slice, element)
+}
+
+// interpolationFuncFilter implements the "filter" function that
+// removes elements from a list
+func interpolationFuncFilter() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeList, ast.TypeList, ast.TypeString},
+		ReturnType: ast.TypeList,
+		Callback: func(args []interface{}) (interface{}, error) {
+			var list []string
+
+			argument, _ := args[0].([]ast.Variable)
+			keys, _ := args[1].([]ast.Variable)
+			searchkey, _ := args[2].(string)
+
+			if len(argument) != len(keys) {
+				return nil, fmt.Errorf("length of lists should be equal")
+			}
+
+			for i, element := range argument {
+				if element.Type != ast.TypeString {
+					return nil, fmt.Errorf(
+						"only works for flat lists, this list contains elements of %s",
+						element.Type.Printable())
+				}
+				if keys[i].Type != ast.TypeString {
+					return nil, fmt.Errorf(
+						"only works for flat lists, this list contains elements of %s",
+						keys[i].Type.Printable())
+				}
+				if keys[i].Value.(string) == searchkey {
+					list = append(list, element.Value.(string))
+				}
+			}
+
+			return stringSliceToVariableValue(list), nil
+		},
+	}
 }
 
 // interpolationFuncJoin implements the "join" function that allows

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -883,6 +883,43 @@ func TestInterpolateFuncDistinct(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncFilter(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			// normal usage
+			{
+				`${filter(list("a", "b", "c"), list("ref1", "ref2", "ref3"), "ref2")}`,
+				[]interface{}{"b"},
+				false,
+			},
+			// zero case
+			{
+				`${filter(list(), list(), "nope")}`,
+				[]interface{}{},
+				false,
+			},
+			// non-string list is an error
+			{
+				`${filter(list(list("a"), list("a")), list("a"), "a")}`,
+				nil,
+				true,
+			},
+			// non-string keys list is an error
+			{
+				`${filter(list("a"), list(list("a"), list("a")), "a")}`,
+				nil,
+				true,
+			},
+			// lists of different length is an error
+			{
+				`${filter(list("a"), list("a", "b"), "a")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncFile(t *testing.T) {
 	tf, err := ioutil.TempFile("", "tf")
 	if err != nil {

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -196,6 +196,14 @@ The supported built-in functions are:
       module, you generally want to make the path relative to the module base,
       like this: `file("${path.module}/file")`.
 
+  * `filter(list, keys, searchkey)` - For two lists `list` and `keys` of
+      equal length, returns all elements from `list` where the corresponding
+      element from `keys` is equal to `searchkey`.  E.g.
+      `filter(aws_instance.example.*.id,
+      aws_instance.example.*.availability_zone, "us-west-2a")` will return a
+      list of the instance IDs of the `aws_instance.example` instances in
+      `"us-west-2a"`.
+
   * `floor(float)` - Returns the greatest integer value less than or equal to
       the argument.
 


### PR DESCRIPTION
This change adds an interpolation function `filter()` that allows selecting only the elements of a list that match given criteria. An example use is given in the documentation: After creating several instances spread out across several availability zones (using `count = <some number>` and `zone = "${element(var.some_list_of_zones, count.index)}"`), create lists of only the instances in this set that are in a particular zone.