### PR TITLE
mysql: Avoid crash on un-interpolated provider cfg

### DIFF
--- a/builtin/providers/mysql/provider.go
+++ b/builtin/providers/mysql/provider.go
@@ -72,7 +72,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	var endpoint = d.Get("endpoint").(string)
 
 	proto := "tcp"
-	if endpoint[0] == '/' {
+	if len(endpoint) > 0 && endpoint[0] == '/' {
 		proto = "unix"
 	}
 


### PR DESCRIPTION
### How to reproduce

```hcl
provider "aws" {
  region = "us-east-1"
}

resource "aws_db_instance" "default" {
  allocated_storage    = 10
  engine               = "mysql"
  engine_version       = "5.6.17"
  instance_class       = "db.t1.micro"
  name                 = "mydb"
  username             = "foo"
  password             = "bar"
  db_subnet_group_name = "my_database_subnet_group"
  parameter_group_name = "default.mysql5.6"
}

provider "mysql" {
    endpoint = "${aws_db_instance.default.endpoint}"
    username = "${aws_db_instance.default.username}"
    password = "${aws_db_instance.default.password}"
}

resource "mysql_database" "app" {
    name = "my_awesome_app"
}
```
```
$ terraform plan
```
```
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

Error running plan: 1 error(s) occurred:

* provider.mysql: unexpected EOF
panic: runtime error: index out of range
2017/03/02 22:36:01 [DEBUG] plugin: terraform:
2017/03/02 22:36:01 [DEBUG] plugin: terraform: goroutine 53 [running]:
2017/03/02 22:36:01 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/mysql.providerConfigure(0xc4201149a0, 0xc4201149a0, 0xc4201812f0, 0xc420187880, 0x0)
2017/03/02 22:36:01 [DEBUG] plugin: terraform: 	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/builtin/providers/mysql/provider.go:75 +0x39b
2017/03/02 22:36:01 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*Provider).Configure(0xc4200a23c0, 0xc4201812f0, 0x0, 0x0)
2017/03/02 22:36:01 [DEBUG] plugin: terraform: 	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/provider.go:193 +0xed
2017/03/02 22:36:01 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Configure(0xc42007a1e0, 0xc4201812f0, 0xc42007c220, 0x0, 0x0)
2017/03/02 22:36:01 [DEBUG] plugin: terraform: 	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/plugin/resource_provider.go:478 +0x42
2017/03/02 22:36:01 [DEBUG] plugin: terraform: reflect.Value.call(0xc420400ae0, 0xc42007c020, 0x13, 0x4c53ac6, 0x4, 0xc420042f20, 0x3, 0x3, 0x0, 0x0, ...)
2017/03/02 22:36:01 [DEBUG] plugin: terraform: 	/usr/local/Cellar/go/1.8/libexec/src/reflect/value.go:434 +0x91f
2017/03/02 22:36:01 [DEBUG] plugin: terraform: reflect.Value.Call(0xc420400ae0, 0xc42007c020, 0x13, 0xc420027f20, 0x3, 0x3, 0x0, 0x0, 0x0)
2017/03/02 22:36:01 [DEBUG] plugin: terraform: 	/usr/local/Cellar/go/1.8/libexec/src/reflect/value.go:302 +0xa4
2017/03/02 22:36:01 [DEBUG] plugin: terraform: net/rpc.(*service).call(0xc42023e180, 0xc42023e040, 0xc4202281c0, 0xc42009a200, 0xc420186040, 0x4932ee0, 0xc4201812f0, 0x16, 0x404da40, 0xc42007c220, ...)
2017/03/02 22:36:01 [DEBUG] plugin: terraform: 	/usr/local/Cellar/go/1.8/libexec/src/net/rpc/server.go:387 +0x144
2017/03/02 22:36:01 [DEBUG] plugin: terraform: created by net/rpc.(*Server).ServeCodec
2017/03/02 22:36:01 [DEBUG] plugin: terraform: 	/usr/local/Cellar/go/1.8/libexec/src/net/rpc/server.go:481 +0x404
2017/03/02 22:36:01 [ERROR] root: eval: *terraform.EvalConfigProvider, err: unexpected EOF
2017/03/02 22:36:01 [ERROR] root: eval: *terraform.EvalSequence, err: unexpected EOF
2017/03/02 22:36:01 [ERROR] root: eval: *terraform.EvalOpFilter, err: unexpected EOF
2017/03/02 22:36:01 [ERROR] root: eval: *terraform.EvalSequence, err: unexpected EOF
2017/03/02 22:36:01 [TRACE] [walkPlan] Exiting eval tree: provider.mysql
2017/03/02 22:36:01 [DEBUG] dag/walk: upstream errored, not walking "mysql_database.app"
2017/03/02 22:36:01 [WARN] plugin: error closing client during Kill: connection is shut down
2017/03/02 22:36:01 [DEBUG] plugin: waiting for all plugin processes to complete...
2017/03/02 22:36:01 [DEBUG] plugin: /Users/radeksimko/gopath/bin/terraform: plugin process exited
2017/03/02 22:36:01 [DEBUG] plugin: terraform: aws-provider (internal) 2017/03/02 22:36:01 [DEBUG] plugin: waiting for all plugin processes to complete...
2017/03/02 22:36:01 [DEBUG] plugin: /Users/radeksimko/gopath/bin/terraform: plugin process exited
```

The cross-provider dependency and fact that it doesn't work is part of a different issue I'll file separately, but I think it's reasonable to at least avoid this crash.