### PR TITLE
provider/aws: Only send iops when creating io1 devices. Fix docs

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -1030,10 +1030,15 @@ func readBlockDeviceMappingsFromConfig(
 
 			if v, ok := bd["volume_type"].(string); ok && v != "" {
 				ebs.VolumeType = aws.String(v)
-			}
-
-			if v, ok := bd["iops"].(int); ok && v > 0 {
-				ebs.Iops = aws.Int64(int64(v))
+				if "io1" == strings.ToLower(v) {
+					// Condition: This parameter is required for requests to create io1
+					// volumes; it is not used in requests to create gp2, st1, sc1, or
+					// standard volumes.
+					// See: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsBlockDevice.html
+					if v, ok := bd["iops"].(int); ok && v > 0 {
+						ebs.Iops = aws.Int64(int64(v))
+					}
+				}
 			}
 
 			blockDevices = append(blockDevices, &ec2.BlockDeviceMapping{

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -1060,7 +1060,6 @@ resource "aws_instance" "foo" {
 	root_block_device {
 		volume_type = "gp2"
 		volume_size = 11
-		iops = 330
 	}
 }
 `

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -102,7 +102,8 @@ The `root_block_device` mapping supports the following:
 * `volume_size` - (Optional) The size of the volume in gigabytes.
 * `iops` - (Optional) The amount of provisioned
   [IOPS](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ebs-io-characteristics.html).
-  This must be set with a `volume_type` of `"io1"`.
+  This is only valid for `volume_type` of `"io1"`, and must be specified if
+  using that type
 * `delete_on_termination` - (Optional) Whether the volume should be destroyed
   on instance termination (Default: `true`).
 


### PR DESCRIPTION
I think https://github.com/hashicorp/terraform/pull/11619 revealed a "bug" in our tests where `iops` were being specified in a `gp2` volume. Because the `root_block_device` hash was always zero (it couldn't be changed), we failed to detect this.

Fixes `TestAccAWSInstance_GP2IopsDevice` test error:

```
------- Stdout: -------
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- FAIL: TestAccAWSInstance_GP2IopsDevice (168.38s)
    testing.go:265: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_instance.foo
          associate_public_ip_address:               "true" => "<computed>"
          availability_zone:                         "us-west-2c" => "<computed>"
          ebs_block_device.#:                        "0" => "<computed>"
          ephemeral_block_device.#:                  "0" => "<computed>""
          root_block_device.#:                       "1" => "1"
          root_block_device.0.delete_on_termination: "true" => "true"
          root_block_device.0.iops:                  "100" => "330" (forces new resource)
```


Test runs:

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_GP2IopsDevice -timeout 120m
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (59.02s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	59.051s
```
```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_blockDevices -timeout 120m
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (85.59s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	85.613s
```