### PR TITLE
provider/aws: Add timestamps to final snapshot

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -211,8 +211,15 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"timestamp_final_snapshot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"timestamp_final_snapshot_format": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "20060102-150405",
 			},
 
 			"skip_final_snapshot": {
@@ -804,9 +811,9 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 
 	if skipFinalSnapshot == false {
 		if name, present := d.GetOk("final_snapshot_identifier"); present {
-			if timestamp, present := d.GetOk("timestamp_final_snapshot"); present {
+			if d.Get("timestamp_final_snapshot").(bool) {
 				t := time.Now()
-				opts.FinalDBSnapshotIdentifier = aws.String(name.(string) + "-" + t.Format(timestamp.(string)))
+				opts.FinalDBSnapshotIdentifier = aws.String(name.(string) + "-" + t.Format(d.Get("timestamp_final_snapshot_format").(string)))
 			} else {
 				opts.FinalDBSnapshotIdentifier = aws.String(name.(string))
 			}

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -210,6 +210,11 @@ func resourceAwsDbInstance() *schema.Resource {
 				},
 			},
 
+			"timestamp_final_snapshot": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"skip_final_snapshot": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -799,7 +804,12 @@ func resourceAwsDbInstanceDelete(d *schema.ResourceData, meta interface{}) error
 
 	if skipFinalSnapshot == false {
 		if name, present := d.GetOk("final_snapshot_identifier"); present {
-			opts.FinalDBSnapshotIdentifier = aws.String(name.(string))
+			if timestamp, present := d.GetOk("timestamp_final_snapshot"); present {
+				t := time.Now()
+				opts.FinalDBSnapshotIdentifier = aws.String(name.(string) + "-" + t.Format(timestamp.(string)))
+			} else {
+				opts.FinalDBSnapshotIdentifier = aws.String(name.(string))
+			}
 		} else {
 			return fmt.Errorf("DB Instance FinalSnapshotIdentifier is required when a final snapshot is required")
 		}

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -864,7 +864,8 @@ resource "aws_db_instance" "snapshot-timestamp" {
   skip_final_snapshot = false
   copy_tags_to_snapshot = true
   final_snapshot_identifier = "foobarbaz-test-terraform-final-snapshot-%d"
-  timestamp_final_snapshot = "20060102"
+  timestamp_final_snapshot = true
+  timestamp_final_snapshot_format = "20060102"
 
 	backup_retention_period = 0
   apply_immediately = true

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -186,8 +186,15 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 			},
 
 			"timestamp_final_snapshot": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"timestamp_final_snapshot_format": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "20060102-150405",
 			},
 
 			"skip_final_snapshot": {
@@ -775,9 +782,9 @@ func resourceAwsRedshiftClusterDelete(d *schema.ResourceData, meta interface{}) 
 
 	if skipFinalSnapshot == false {
 		if name, present := d.GetOk("final_snapshot_identifier"); present {
-			if timestamp, present := d.GetOk("timestamp_final_snapshot"); present {
+			if d.Get("timestamp_final_snapshot").(bool) {
 				t := time.Now()
-				deleteOpts.FinalClusterSnapshotIdentifier = aws.String(name.(string) + "-" + t.Format(timestamp.(string)))
+				deleteOpts.FinalClusterSnapshotIdentifier = aws.String(name.(string) + "-" + t.Format(d.Get("timestamp_final_snapshot_format").(string)))
 			} else {
 				deleteOpts.FinalClusterSnapshotIdentifier = aws.String(name.(string))
 			}

--- a/builtin/providers/aws/resource_aws_redshift_cluster.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster.go
@@ -185,6 +185,11 @@ func resourceAwsRedshiftCluster() *schema.Resource {
 				ValidateFunc: validateRedshiftClusterFinalSnapshotIdentifier,
 			},
 
+			"timestamp_final_snapshot": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+
 			"skip_final_snapshot": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -770,7 +775,12 @@ func resourceAwsRedshiftClusterDelete(d *schema.ResourceData, meta interface{}) 
 
 	if skipFinalSnapshot == false {
 		if name, present := d.GetOk("final_snapshot_identifier"); present {
-			deleteOpts.FinalClusterSnapshotIdentifier = aws.String(name.(string))
+			if timestamp, present := d.GetOk("timestamp_final_snapshot"); present {
+				t := time.Now()
+				deleteOpts.FinalClusterSnapshotIdentifier = aws.String(name.(string) + "-" + t.Format(timestamp.(string)))
+			} else {
+				deleteOpts.FinalClusterSnapshotIdentifier = aws.String(name.(string))
+			}
 		} else {
 			return fmt.Errorf("Redshift Cluster Instance FinalSnapshotIdentifier is required when a final snapshot is required")
 		}

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -61,7 +61,8 @@ The following arguments are supported:
     when this DB instance is deleted. If omitted, no final snapshot will be
     made.
 * `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from `final_snapshot_identifier`. Default is `false`.
-* `timestamp_final_snapshot` - (Optional) Append "-<timestamp>" to final DB snapshot using the provided [go time Format](https://golang.org/pkg/time/#Time.Format)
+* `timestamp_final_snapshot` - (Optional, boolean) Append "-<timestamp>" to final DB snapshot with the default timestamp format ("20060102-150405")
+* `timestamp_final_snapshot_format` - (Optional) format the "-<timestamp>" using the provided [go time Format](https://golang.org/pkg/time/#Time.Format)
 * `copy_tags_to_snapshot` – (Optional, boolean) On delete, copy all Instance `tags` to
 the final snapshot (if `final_snapshot_identifier` is specified). Default
 `false`

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -61,6 +61,7 @@ The following arguments are supported:
     when this DB instance is deleted. If omitted, no final snapshot will be
     made.
 * `skip_final_snapshot` - (Optional) Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from `final_snapshot_identifier`. Default is `false`.
+* `timestamp_final_snapshot` - (Optional) Append "-<timestamp>" to final DB snapshot using the provided [go time Format](https://golang.org/pkg/time/#Time.Format)
 * `copy_tags_to_snapshot` – (Optional, boolean) On delete, copy all Instance `tags` to
 the final snapshot (if `final_snapshot_identifier` is specified). Default
 `false`

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -59,7 +59,8 @@ string.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true.
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
 * `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is true.
-* `timestamp_final_snapshot` - (Optional) Append "-<timestamp>" to final DB snapshot using the provided [go time Format](https://golang.org/pkg/time/#Time.Format)
+* `timestamp_final_snapshot` - (Optional, boolean) Append "-<timestamp>" to final DB snapshot with the default timestamp format ("20060102-150405")
+* `timestamp_final_snapshot_format` - (Optional) format the "-<timestamp>" using the provided [go time Format](https://golang.org/pkg/time/#Time.Format)
 * `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.
 * `snapshot_identifier` - (Optional) The name of the snapshot from which to create the new cluster.
 * `snapshot_cluster_identifier` - (Optional) The name of the cluster the source snapshot was created from.

--- a/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/redshift_cluster.html.markdown
@@ -59,6 +59,7 @@ string.
 * `kms_key_id` - (Optional) The ARN for the KMS encryption key. When specifying `kms_key_id`, `encrypted` needs to be set to true.
 * `elastic_ip` - (Optional) The Elastic IP (EIP) address for the cluster.
 * `skip_final_snapshot` - (Optional) Determines whether a final snapshot of the cluster is created before Amazon Redshift deletes the cluster. If true , a final cluster snapshot is not created. If false , a final cluster snapshot is created before the cluster is deleted. Default is true.
+* `timestamp_final_snapshot` - (Optional) Append "-<timestamp>" to final DB snapshot using the provided [go time Format](https://golang.org/pkg/time/#Time.Format)
 * `final_snapshot_identifier` - (Optional) The identifier of the final snapshot that is to be created immediately before deleting the cluster. If this parameter is provided, `skip_final_snapshot` must be false.
 * `snapshot_identifier` - (Optional) The name of the snapshot from which to create the new cluster.
 * `snapshot_cluster_identifier` - (Optional) The name of the cluster the source snapshot was created from.


### PR DESCRIPTION
tl;dr: add a `timestamp_final_snapshot` parameter to `aws_db_instance` and `aws_redshift_cluster`. When deleting the instance this generates a snapshot named `<final_snapshot_identifier>-<timestamp>`

Example: generates a snapshot called mydb-20170210-083019

    resource "aws_db_instance" "default" {
      allocated_storage    = 10
      engine               = "mysql"
      instance_class       = "db.t1.micro"
      name                 = "mydb"
      username             = "foofoofoo"
      password             = "barbarbar"
      db_subnet_group_name = "mydb_subnet_group"
      parameter_group_name = "default.mysql5.6"
      final_snapshot_identifier = "mydb"
      timestamp_final_snapshot = "20060102-150405"
    }

My team have been encountering the following error intermittently the past couple of weeks:
    4 error(s) occurred:
    
    * aws_db_instance.default: DBSnapshotAlreadyExists: Cannot create the snapshot because a snapshot with the identifier finalsnapshotcifull-service-mysql already exists.
        status code: 400, request id: 456a579a-ee6a-11e6-a5b8-cdbcbd0418d6

We've also been encountering these with redshift clusters now that I've started to use them:
    
    * aws_redshift_cluster.redshift-cluster: [ERROR] Error deleting Redshift Cluster (bentest): ClusterSnapshotAlreadyExists: Cannot create the snapshot because a snapshot with the identifier bentest-final-snapshot already exists.

To help mitigate the issue we had been appending a `md5(timestamp())` to the final_snapshot_identifier parameter of aws_db_instance, but this was causing some less than optimal behavior when running terraform apply against the same environment repeatedly, not to mention the fact that the snapshot name wasn't particularly readable.

To mitigate the issue I decided it would be useful to have a real timestamp appended to the snapshot identifier. It uses a [golang time Format](https://golang.org/pkg/time/#Time.Format) string to determine the formatting.