### PR TITLE
provider/pagerduty: Remove deprecated name_regex field 

### DIFF
--- a/builtin/providers/pagerduty/data_source_pagerduty_vendor.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_vendor.go
@@ -15,16 +15,13 @@ func dataSourcePagerDutyVendor() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name_regex": {
-				Type:          schema.TypeString,
-				Optional:      true,
-				Deprecated:    "Use field name instead",
-				ConflictsWith: []string{"name"},
+				Type:     schema.TypeString,
+				Optional: true,
+				Removed:  "Use `name` instead. This attribute will be removed in a future version",
 			},
 			"name": {
-				Type:          schema.TypeString,
-				Computed:      true,
-				Optional:      true,
-				ConflictsWith: []string{"name_regex"},
+				Type:     schema.TypeString,
+				Required: true,
 			},
 			"type": {
 				Type:     schema.TypeString,
@@ -36,19 +33,6 @@ func dataSourcePagerDutyVendor() *schema.Resource {
 
 func dataSourcePagerDutyVendorRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*pagerduty.Client)
-
-	// Check if we're doing a normal or legacy lookup
-	_, ok := d.GetOk("name")
-	_, legacyOk := d.GetOk("name_regex")
-
-	if !ok && !legacyOk {
-		return fmt.Errorf("Either name or name_regex must be set")
-	}
-
-	// If name_regex is set, we're doing a legacy lookup
-	if legacyOk {
-		return dataSourcePagerDutyVendorLegacyRead(d, meta)
-	}
 
 	log.Printf("[INFO] Reading PagerDuty vendor")
 
@@ -81,53 +65,6 @@ func dataSourcePagerDutyVendorRead(d *schema.ResourceData, meta interface{}) err
 	d.SetId(found.ID)
 	d.Set("name", found.Name)
 	d.Set("type", found.GenericServiceType)
-
-	return nil
-}
-
-func dataSourcePagerDutyVendorLegacyRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*pagerduty.Client)
-
-	log.Printf("[INFO] Reading PagerDuty vendor (legacy)")
-
-	resp, err := getVendors(client)
-
-	if err != nil {
-		return err
-	}
-
-	r := regexp.MustCompile("(?i)" + d.Get("name_regex").(string))
-
-	var vendors []pagerduty.Vendor
-	var vendorNames []string
-
-	for _, v := range resp {
-		if r.MatchString(v.Name) {
-			vendors = append(vendors, v)
-			vendorNames = append(vendorNames, v.Name)
-		}
-	}
-
-	if len(vendors) == 0 {
-		return fmt.Errorf("Unable to locate any vendor using the regex string: %s", r.String())
-	} else if len(vendors) > 1 {
-		return fmt.Errorf("Your query returned more than one result using the regex string: %#v. Found vendors: %#v", r.String(), vendorNames)
-	}
-
-	vendor := vendors[0]
-
-	genericServiceType := vendor.GenericServiceType
-
-	switch {
-	case genericServiceType == "email":
-		genericServiceType = "generic_email_inbound_integration"
-	case genericServiceType == "api":
-		genericServiceType = "generic_events_api_inbound_integration"
-	}
-
-	d.SetId(vendor.ID)
-	d.Set("name", vendor.Name)
-	d.Set("type", genericServiceType)
 
 	return nil
 }

--- a/builtin/providers/pagerduty/util.go
+++ b/builtin/providers/pagerduty/util.go
@@ -3,7 +3,6 @@ package pagerduty
 import (
 	"fmt"
 
-	pagerduty "github.com/PagerDuty/go-pagerduty"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -24,45 +23,4 @@ func validateValueFunc(values []string) schema.SchemaValidateFunc {
 		}
 		return
 	}
-}
-
-// getVendors retrieves all PagerDuty vendors and returns a list of []pagerduty.Vendor
-func getVendors(client *pagerduty.Client) ([]pagerduty.Vendor, error) {
-	var offset uint
-	var totalCount int
-	var vendors []pagerduty.Vendor
-
-	for {
-		o := &pagerduty.ListVendorOptions{
-			APIListObject: pagerduty.APIListObject{
-				Limit:  100,
-				Total:  1,
-				Offset: offset,
-			},
-		}
-
-		resp, err := client.ListVendors(*o)
-
-		if err != nil {
-			return nil, err
-		}
-
-		for _, v := range resp.Vendors {
-			totalCount++
-			vendors = append(vendors, v)
-		}
-
-		rOffset := uint(resp.Offset)
-		returnedCount := uint(len(resp.Vendors))
-		rTotal := uint(resp.Total)
-
-		if resp.More && uint(totalCount) != uint(rTotal) {
-			offset = returnedCount + rOffset
-			continue
-		}
-
-		break
-	}
-
-	return vendors, nil
 }


### PR DESCRIPTION
This PR removes the deprecated field `name_regex` as well as the old behaviour of looking up vendors.

Existing configurations using the `name_regex` field will render:

```bash
1 error(s) occurred:

* data.pagerduty_vendor.test: "name_regex": [REMOVED] Use `name` instead. This attribute will be removed in a future version
```

Not sure if this is the best way to proceed so any feedback is more than welcome :)