### PR TITLE
Skip tag operations on cloudwatch logs in govcloud partition.

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_group.go
@@ -91,11 +91,13 @@ func resourceAwsCloudWatchLogGroupRead(d *schema.ResourceData, meta interface{})
 		d.Set("retention_in_days", lg.RetentionInDays)
 	}
 
-	tags, err := flattenCloudWatchTags(d, conn)
-	if err != nil {
-		return err
+	if meta.(*AWSClient).partition != "aws-us-gov" {
+		tags, err := flattenCloudWatchTags(d, conn)
+		if err != nil {
+			return err
+		}
+		d.Set("tags", tags)
 	}
-	d.Set("tags", tags)
 
 	return nil
 }
@@ -152,7 +154,7 @@ func resourceAwsCloudWatchLogGroupUpdate(d *schema.ResourceData, meta interface{
 		}
 	}
 
-	if d.HasChange("tags") {
+	if meta.(*AWSClient).partition != "aws-us-gov" && d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tags")
 		o := oraw.(map[string]interface{})
 		n := nraw.(map[string]interface{})


### PR DESCRIPTION
AWS GovCloud doesn't support tag operations on cloudwatch log groups:

```
± aws logs list-tags-log-group --log-group-name some-log-group
An error occurred (UnknownOperationException) when calling the ListTagsLogGroup operation:

± aws logs tag-log-group --log-group-name some-log-group --tags Name=test
An error occurred (UnknownOperationException) when calling the TagLogGroup operation:
```

This patch skips adding, removing, and listing tags on cloudwatch log groups when the partition is `aws-us-gov`.

cc @LinuxBozo