### PR TITLE
provider/aws: fix aws_route53_zone force_destroy behavior

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone.go
+++ b/builtin/providers/aws/resource_aws_route53_zone.go
@@ -300,7 +300,7 @@ func deleteAllRecordsInHostedZoneId(hostedZoneId, hostedZoneName string, conn *r
 		changes := make([]*route53.Change, 0)
 		// 100 items per page returned by default
 		for _, set := range sets {
-			if *set.Name == hostedZoneName+"." && (*set.Type == "NS" || *set.Type == "SOA") {
+			if strings.TrimSuffix(*set.Name, ".") == strings.TrimSuffix(hostedZoneName, ".") && (*set.Type == "NS" || *set.Type == "SOA") {
 				// Zone NS & SOA records cannot be deleted
 				continue
 			}

--- a/builtin/providers/aws/resource_aws_route53_zone_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_test.go
@@ -414,7 +414,7 @@ resource "aws_route53_zone" "main" {
 
 const testAccRoute53ZoneConfig_forceDestroy = `
 resource "aws_route53_zone" "destroyable" {
-	name = "terraform.io"
+	name = "terraform.io."
 	force_destroy = true
 }
 `


### PR DESCRIPTION
The conditional to ignore the deletion of NS and SOA records can fail to
match if the hostedZoneName already ends with a ".". When that happens,
terraform tries to delete those records which is not supported by AWS
and results in a 400 bad request. This fixes the conditional so that it
will work whether or not hostedZoneName ends with a ".".

fixes #12407