### PR TITLE
Fix error message in Azure state backend

### DIFF
--- a/state/remote/azure.go
+++ b/state/remote/azure.go
@@ -35,7 +35,7 @@ func azureFactory(conf map[string]string) (Client, error) {
 	if !ok {
 		resourceGroupName, ok := conf["resource_group_name"]
 		if !ok {
-			return nil, fmt.Errorf("missing 'resource_group' configuration")
+			return nil, fmt.Errorf("missing 'resource_group_name' configuration")
 		}
 
 		var err error


### PR DESCRIPTION
The error led me to try adding `resource_group` but the code wanted `resource_group_name`. This fixes the error message to match the code.
