### PR TITLE
Don't display plan diffs with only data reads

### DIFF
--- a/backend/local/backend_plan.go
+++ b/backend/local/backend_plan.go
@@ -102,8 +102,15 @@ func (b *Local) opPlan(
 		return
 	}
 
-	// Record state
-	runningOp.PlanEmpty = plan.Diff.Empty()
+	// the hook counts and EmptyExceptData have to match in order to hide
+	// diff output.
+	anyChanges := (countHook.ToAdd +
+		countHook.ToRemoveAndAdd +
+		countHook.ToChange +
+		countHook.ToRemove +
+		countHook.ToRemoveAndAdd)
+
+	runningOp.PlanEmpty = plan.Diff.EmptyExceptData() && anyChanges == 0
 
 	// Save the plan to disk
 	if path := op.PlanOutPath; path != "" {
@@ -124,7 +131,7 @@ func (b *Local) opPlan(
 
 	// Perform some output tasks if we have a CLI to output to.
 	if b.CLI != nil {
-		if plan.Diff.Empty() {
+		if runningOp.PlanEmpty {
 			b.CLI.Output(b.Colorize().Color(strings.TrimSpace(planNoChanges)))
 			return
 		}

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -109,6 +109,29 @@ func (d *Diff) Empty() bool {
 	return true
 }
 
+// EmptyExceptData returns true if the only changes in the diff are data
+// sources.  Since data sources are read-only, there's no reason to output a
+// diff only containing data source reads.
+func (d *Diff) EmptyExceptData() bool {
+	if d.Empty() {
+		return true
+	}
+
+	for _, m := range d.Modules {
+		if m.Empty() {
+			continue
+		}
+
+		for res, diff := range m.Resources {
+			if !strings.HasPrefix(res, "data.") && !diff.Empty() {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
 // Equal compares two diffs for exact equality.
 //
 // This is different from the Same comparison that is supported which

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -292,6 +292,47 @@ func TestModuleDiff_Empty(t *testing.T) {
 	}
 }
 
+func TestDiff_EmptyExceptData(t *testing.T) {
+	modDiff := new(ModuleDiff)
+	diff := Diff{
+		Modules: []*ModuleDiff{modDiff},
+	}
+
+	if !diff.EmptyExceptData() {
+		t.Fatal("should be empty")
+	}
+
+	modDiff.Resources = map[string]*InstanceDiff{
+		"nodeA": &InstanceDiff{},
+	}
+
+	if !diff.EmptyExceptData() {
+		t.Fatal("should be empty")
+	}
+
+	modDiff.Resources["data.nodeB"] = &InstanceDiff{
+		Attributes: map[string]*ResourceAttrDiff{
+			"foo": &ResourceAttrDiff{
+				Old:         "foo",
+				New:         "<computed>",
+				NewComputed: true,
+				Type:        2,
+			},
+		},
+	}
+
+	if !diff.EmptyExceptData() {
+		t.Fatal("should be empty except for data.foo")
+	}
+
+	modDiff.Resources["nodeA"].Attributes = nil
+	modDiff.Resources["nodeA"].Destroy = true
+
+	if diff.EmptyExceptData() {
+		t.Fatal("should not be empty")
+	}
+}
+
 func TestModuleDiff_String(t *testing.T) {
 	diff := &ModuleDiff{
 		Resources: map[string]*InstanceDiff{


### PR DESCRIPTION
If the only action in a plan is to read data, possibly because the data
source depends on a value to be computed, we don't need to display that
in the plan output.

The add change and destroy counts must also be 0 to supress output.
These should match the plan diff, but check them as an added failsafe.

Possible fix for issues like #11806?  