### PR TITLE
missing args assignment after parsing flags

### DIFF
--- a/command/env_command_test.go
+++ b/command/env_command_test.go
@@ -64,6 +64,16 @@ func TestEnv_createAndList(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
+	// make sure a vars file doesn't interfere
+	err := ioutil.WriteFile(
+		DefaultVarsFilename,
+		[]byte(`foo = "bar"`),
+		0644,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	newCmd := &EnvNewCommand{}
 
 	envs := []string{"test_a", "test_b", "test_c"}

--- a/command/env_list.go
+++ b/command/env_list.go
@@ -19,6 +19,7 @@ func (c *EnvListCommand) Run(args []string) int {
 		return 1
 	}
 
+	args = cmdFlags.Args()
 	configPath, err := ModulePath(args)
 	if err != nil {
 		c.Ui.Error(err.Error())


### PR DESCRIPTION
`env list` was missing the args re-assignment after parsing the flags.
This is only a problem if the variables are automatically populated
as arguments from a tfvars file.

Fixes #12423