### PR TITLE
provider/google: add location to storage tests.

### DIFF
--- a/builtin/providers/google/resource_storage_bucket_test.go
+++ b/builtin/providers/google/resource_storage_bucket_test.go
@@ -68,7 +68,7 @@ func TestAccStorageStorageClass(t *testing.T) {
 		CheckDestroy: testAccGoogleStorageDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "MULTI_REGIONAL"),
+				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "MULTI_REGIONAL", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName),
@@ -77,7 +77,7 @@ func TestAccStorageStorageClass(t *testing.T) {
 				),
 			},
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "NEARLINE"),
+				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "NEARLINE", ""),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName),
@@ -86,12 +86,14 @@ func TestAccStorageStorageClass(t *testing.T) {
 				),
 			},
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "REGIONAL"),
+				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "REGIONAL", "us-central1"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudStorageBucketExists(
 						"google_storage_bucket.bucket", bucketName),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "storage_class", "REGIONAL"),
+					resource.TestCheckResourceAttr(
+						"google_storage_bucket.bucket", "location", "us-central1"),
 				),
 			},
 		},
@@ -266,11 +268,16 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName)
 }
 
-func testGoogleStorageBucketsReaderStorageClass(bucketName string, storageClass string) string {
+func testGoogleStorageBucketsReaderStorageClass(bucketName, storageClass, location string) string {
+	var locationBlock string
+	if location != "" {
+		locationBlock = fmt.Sprintf(`
+	location = "%s"`, location)
+	}
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
-	storage_class = "%s"
+	storage_class = "%s"%s
 }
-`, bucketName, storageClass)
+`, bucketName, storageClass, locationBlock)
 }


### PR DESCRIPTION
Add location to storage tests that need it, which fixes the failing
TestAccStorageStorageClass test.

Test before patch:

```
=== RUN   TestAccStorageStorageClass
Error creating bucket tf-test-acc-bucket-1345402779410348481: googleapi: Error 400: The combination of locationConstraint and storageClass you provided is not supported for your project, invalid--- FAIL: TestAccStorageStorageClass (5.18s)
        testing.go:265: Step 2 error: Error applying: 1 error(s) occurred:

                * google_storage_bucket.bucket: 1 error(s) occurred:

                * google_storage_bucket.bucket: googleapi: Error 400: The combination of locationConstraint and storageClass you provided is not supported for your project, invalid
FAIL
```

Test after patch:

```
=== RUN   TestAccStorageStorageClass
--- PASS: TestAccStorageStorageClass (7.72s)
PASS
```