### PR TITLE
provider/aws: Fix spurious aws_spot_fleet_request diffs

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -2,9 +2,6 @@ package aws
 
 import (
 	"bytes"
-	"crypto/sha1"
-	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"strconv"
@@ -215,8 +212,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 							StateFunc: func(v interface{}) string {
 								switch v.(type) {
 								case string:
-									hash := sha1.Sum([]byte(v.(string)))
-									return hex.EncodeToString(hash[:])
+									return userDataHashSum(v.(string))
 								default:
 									return ""
 								}
@@ -325,8 +321,7 @@ func buildSpotFleetLaunchSpecification(d map[string]interface{}, meta interface{
 	}
 
 	if v, ok := d["user_data"]; ok {
-		opts.UserData = aws.String(
-			base64Encode([]byte(v.(string))))
+		opts.UserData = aws.String(base64Encode([]byte(v.(string))))
 	}
 
 	if v, ok := d["key_name"]; ok {
@@ -771,10 +766,7 @@ func launchSpecToMap(l *ec2.SpotFleetLaunchSpecification, rootDevName *string) m
 	}
 
 	if l.UserData != nil {
-		ud_dec, err := base64.StdEncoding.DecodeString(aws.StringValue(l.UserData))
-		if err == nil {
-			m["user_data"] = string(ud_dec)
-		}
+		m["user_data"] = userDataHashSum(aws.StringValue(l.UserData))
 	}
 
 	if l.KeyName != nil {
@@ -1013,7 +1005,6 @@ func hashLaunchSpecification(v interface{}) int {
 	}
 	buf.WriteString(fmt.Sprintf("%s-", m["instance_type"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["spot_price"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["user_data"].(string)))
 	return hashcode.String(buf.String())
 }
 

--- a/builtin/providers/aws/resource_aws_spot_fleet_request.go
+++ b/builtin/providers/aws/resource_aws_spot_fleet_request.go
@@ -168,6 +168,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 						"ebs_optimized": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"iam_instance_profile": &schema.Schema{
 							Type:     schema.TypeString,
@@ -194,6 +195,7 @@ func resourceAwsSpotFleetRequest() *schema.Resource {
 						"monitoring": &schema.Schema{
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"placement_group": &schema.Schema{
 							Type:     schema.TypeString,


### PR DESCRIPTION
This fixes the following issues:
- [x] The default value for `launch_specification.monitoring` was `""`, which got translated to `false` by AWS, generating a spurious diff
- [x] The default value for `launch_specification.ebs_optimized` was `""`, which got translated to `false` by AWS, generating a spurious diff
- [x] `launch_specification.vpc_security_group_ids` were not read back from AWS, generating a spurious diff
- [x] `launch_specification.vpc_security_group_ids` were not handled properly when setting 'associate_public_ip_address = true'
- [x] `launch_specification.user_data` was not handled consistently (sometimes hashed, sometimes not), generating a spurious diff

I also cleaned up some dead code handling a `security_groups` property since there is no way for the user to define it.

@stack72 it seems you've been reviewing spot fleet related PRs, so tagging you here.

One final note: it may be a good idea to reuse the same hash function for root/ebs/ephemeral volumes across this resource, `aws_instance` and `aws_launch_configuration`?