### PR TITLE
provider/google: datasource subnetwork and network

### DIFF
--- a/builtin/providers/google/data_source_google_compute_network.go
+++ b/builtin/providers/google/data_source_google_compute_network.go
@@ -1,0 +1,71 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/googleapi"
+)
+
+func dataSourceGoogleComputeNetwork() *schema.Resource {
+	return &schema.Resource{
+		Read:   dataSourceGoogleComputeNetworkRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"gateway_ipv4": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ipv4_range": &schema.Schema{
+				Type:       schema.TypeString,
+				Computed: true,
+			},
+
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+
+
+func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	network, err := config.clientCompute.Networks.Get(
+		project, d.Get("name").(string)).Do()
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			// The resource doesn't exist anymore
+
+			return fmt.Errorf("Network Not Found")
+		}
+
+		return fmt.Errorf("Error reading network: %s", err)
+	}
+
+
+	d.Set("gateway_ipv4", network.GatewayIPv4)
+	d.Set("self_link", network.SelfLink)
+	d.Set("description", network.Description)
+	d.Set("ipv4_range", network.IPv4Range)
+	d.SetId(network.Name)
+	return nil
+}

--- a/builtin/providers/google/data_source_google_compute_network.go
+++ b/builtin/providers/google/data_source_google_compute_network.go
@@ -40,6 +40,7 @@ func dataSourceGoogleComputeNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"subnetworks_self_links": {
 				Type:     schema.TypeList,
 				Computed: true,

--- a/builtin/providers/google/data_source_google_compute_network.go
+++ b/builtin/providers/google/data_source_google_compute_network.go
@@ -27,15 +27,11 @@ func dataSourceGoogleComputeNetwork() *schema.Resource {
 				Computed: true,
 			},
 
-			"ipv4_range": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -63,7 +59,7 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			// The resource doesn't exist anymore
 
-			return fmt.Errorf("Network Not Found")
+			return fmt.Errorf("Network Not Found : %s", d.Get("name"))
 		}
 
 		return fmt.Errorf("Error reading network: %s", err)
@@ -71,7 +67,6 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 	d.Set("gateway_ipv4", network.GatewayIPv4)
 	d.Set("self_link", network.SelfLink)
 	d.Set("description", network.Description)
-	d.Set("ipv4_range", network.IPv4Range)
 	d.Set("subnetworks_self_links", network.Subnetworks)
 	d.SetId(network.Name)
 	return nil

--- a/builtin/providers/google/data_source_google_compute_network.go
+++ b/builtin/providers/google/data_source_google_compute_network.go
@@ -9,7 +9,7 @@ import (
 
 func dataSourceGoogleComputeNetwork() *schema.Resource {
 	return &schema.Resource{
-		Read:   dataSourceGoogleComputeNetworkRead,
+		Read: dataSourceGoogleComputeNetworkRead,
 
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
@@ -28,7 +28,7 @@ func dataSourceGoogleComputeNetwork() *schema.Resource {
 			},
 
 			"ipv4_range": &schema.Schema{
-				Type:       schema.TypeString,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 
@@ -36,11 +36,18 @@ func dataSourceGoogleComputeNetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"subnetworks_self_links": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
-
-
 
 func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
@@ -60,12 +67,11 @@ func dataSourceGoogleComputeNetworkRead(d *schema.ResourceData, meta interface{}
 
 		return fmt.Errorf("Error reading network: %s", err)
 	}
-
-
 	d.Set("gateway_ipv4", network.GatewayIPv4)
 	d.Set("self_link", network.SelfLink)
 	d.Set("description", network.Description)
 	d.Set("ipv4_range", network.IPv4Range)
+	d.Set("subnetworks_self_links", network.Subnetworks)
 	d.SetId(network.Name)
 	return nil
 }

--- a/builtin/providers/google/data_source_google_compute_network_test.go
+++ b/builtin/providers/google/data_source_google_compute_network_test.go
@@ -22,43 +22,37 @@ func TestAccDataSourceGoogleNetwork(t *testing.T) {
 	})
 }
 
-func testAccDataSourceGoogleNetworkCheck(name string, network_name string) resource.TestCheckFunc {
+func testAccDataSourceGoogleNetworkCheck(data_source_name string, resource_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		ds, ok := s.RootModule().Resources[data_source_name]
 		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
+			return fmt.Errorf("root module has no resource called %s", data_source_name)
 		}
 
-		networkOrigin, ok := s.RootModule().Resources[network_name]
+		rs, ok := s.RootModule().Resources[resource_name]
 		if !ok {
-			return fmt.Errorf("can't find google_compute_network.foobar in state")
+			return fmt.Errorf("can't find %s in state", resource_name)
 		}
 
-		attr := rs.Primary.Attributes
-
-		if attr["id"] != networkOrigin.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"id is %s; want %s",
-				attr["id"],
-				networkOrigin.Primary.Attributes["id"],
-			)
+		ds_attr := ds.Primary.Attributes
+		rs_attr := rs.Primary.Attributes
+		network_attrs_to_test := []string{
+			"id",
+			"self_link",
+			"name",
+			"description",
 		}
 
-		if attr["self_link"] != networkOrigin.Primary.Attributes["self_link"] {
-			return fmt.Errorf(
-				"self_link is %s; want %s",
-				attr["self_link"],
-				networkOrigin.Primary.Attributes["self_link"],
-			)
+		for _, attr_to_check := range network_attrs_to_test {
+			if ds_attr[attr_to_check] != rs_attr[attr_to_check] {
+				return fmt.Errorf(
+					"%s is %s; want %s",
+					attr_to_check,
+					ds_attr[attr_to_check],
+					rs_attr[attr_to_check],
+				)
+			}
 		}
-
-		if attr["name"] != networkOrigin.Primary.Attributes["name"] {
-			return fmt.Errorf("bad name %s", attr["name"])
-		}
-		if attr["description"] != networkOrigin.Primary.Attributes["description"] {
-			return fmt.Errorf("bad description %s", attr["description"])
-		}
-
 		return nil
 	}
 }

--- a/builtin/providers/google/data_source_google_compute_network_test.go
+++ b/builtin/providers/google/data_source_google_compute_network_test.go
@@ -15,21 +15,21 @@ func TestAccDataSourceGoogleNetwork(t *testing.T) {
 			resource.TestStep{
 				Config: TestAccDataSourceGoogleNetworkConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceGoogleNetworktCheck("data.google_compute_network.my_network"),
+					testAccDataSourceGoogleNetworkCheck("data.google_compute_network.my_network", "google_compute_network.foobar"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceGoogleNetworktCheck(name string) resource.TestCheckFunc {
+func testAccDataSourceGoogleNetworkCheck(name string, network_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("root module has no resource called %s", name)
 		}
 
-		networkOrigin, ok := s.RootModule().Resources["google_compute_network.foobar"]
+		networkOrigin, ok := s.RootModule().Resources[network_name]
 		if !ok {
 			return fmt.Errorf("can't find google_compute_network.foobar in state")
 		}
@@ -52,10 +52,10 @@ func testAccDataSourceGoogleNetworktCheck(name string) resource.TestCheckFunc {
 			)
 		}
 
-		if attr["name"] != "network-test" {
+		if attr["name"] != networkOrigin.Primary.Attributes["name"] {
 			return fmt.Errorf("bad name %s", attr["name"])
 		}
-		if attr["description"] != "my-description" {
+		if attr["description"] != networkOrigin.Primary.Attributes["description"] {
 			return fmt.Errorf("bad description %s", attr["description"])
 		}
 

--- a/builtin/providers/google/data_source_google_compute_network_test.go
+++ b/builtin/providers/google/data_source_google_compute_network_test.go
@@ -2,10 +2,9 @@ package google
 
 import (
 	"fmt"
-	"testing"
-
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
+	"testing"
 )
 
 func TestAccDataSourceGoogleNetwork(t *testing.T) {
@@ -17,7 +16,6 @@ func TestAccDataSourceGoogleNetwork(t *testing.T) {
 				Config: TestAccDataSourceGoogleNetworkConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceGoogleNetworktCheck("data.google_compute_network.my_network"),
-
 				),
 			},
 		},
@@ -35,7 +33,6 @@ func testAccDataSourceGoogleNetworktCheck(name string) resource.TestCheckFunc {
 		if !ok {
 			return fmt.Errorf("can't find google_compute_network.foobar in state")
 		}
-
 
 		attr := rs.Primary.Attributes
 
@@ -61,10 +58,10 @@ func testAccDataSourceGoogleNetworktCheck(name string) resource.TestCheckFunc {
 		if attr["description"] != "my-description" {
 			return fmt.Errorf("bad description %s", attr["description"])
 		}
+
 		return nil
 	}
 }
-
 
 var TestAccDataSourceGoogleNetworkConfig = `
 resource "google_compute_network" "foobar" {

--- a/builtin/providers/google/data_source_google_compute_network_test.go
+++ b/builtin/providers/google/data_source_google_compute_network_test.go
@@ -1,0 +1,77 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceGoogleNetwork(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: TestAccDataSourceGoogleNetworkConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGoogleNetworktCheck("data.google_compute_network.my_network"),
+
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleNetworktCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		networkOrigin, ok := s.RootModule().Resources["google_compute_network.foobar"]
+		if !ok {
+			return fmt.Errorf("can't find google_compute_network.foobar in state")
+		}
+
+
+		attr := rs.Primary.Attributes
+
+		if attr["id"] != networkOrigin.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				attr["id"],
+				networkOrigin.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["self_link"] != networkOrigin.Primary.Attributes["self_link"] {
+			return fmt.Errorf(
+				"self_link is %s; want %s",
+				attr["self_link"],
+				networkOrigin.Primary.Attributes["self_link"],
+			)
+		}
+
+		if attr["name"] != "network-test" {
+			return fmt.Errorf("bad name %s", attr["name"])
+		}
+		if attr["description"] != "my-description" {
+			return fmt.Errorf("bad description %s", attr["description"])
+		}
+		return nil
+	}
+}
+
+
+var TestAccDataSourceGoogleNetworkConfig = `
+resource "google_compute_network" "foobar" {
+	name = "network-test"
+	description = "my-description"
+}
+
+data "google_compute_network" "my_network" {
+	name = "${google_compute_network.foobar.name}"
+}`

--- a/builtin/providers/google/data_source_google_compute_subnetwork.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork.go
@@ -1,0 +1,86 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"google.golang.org/api/googleapi"
+)
+
+func dataSourceGoogleComputeSubnetwork() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGoogleComputeSubnetworkRead,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"ip_cidr_range": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"network_self_link": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gateway_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"region": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+	region, err := getRegion(d, config)
+	if err != nil {
+		return err
+	}
+
+	subnetwork, err := config.clientCompute.Subnetworks.Get(
+		project, region, d.Get("name").(string)).Do()
+	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			// The resource doesn't exist anymore
+
+			return fmt.Errorf("Subnetwork Not Found")
+		}
+
+		return fmt.Errorf("Error reading Subnetwork: %s", err)
+	}
+
+	d.Set("ip_cidr_range", subnetwork.IpCidrRange)
+	d.Set("self_link", subnetwork.SelfLink)
+	d.Set("description", subnetwork.Description)
+	d.Set("gateway_address", subnetwork.GatewayAddress)
+	d.Set("network_self_link", subnetwork.Network)
+
+	//To put subnet id see resource compute subnetnetwork details
+	subnetwork.Region = region
+	d.SetId(createSubnetID(subnetwork))
+	return nil
+}

--- a/builtin/providers/google/data_source_google_compute_subnetwork.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork.go
@@ -41,6 +41,7 @@ func dataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -79,7 +80,7 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	d.Set("gateway_address", subnetwork.GatewayAddress)
 	d.Set("network", subnetwork.Network)
 
-	//To put subnet id see resource compute subnetnetwork details
+	//Subnet id creation is defined in resource_compute_subnetwork.go
 	subnetwork.Region = region
 	d.SetId(createSubnetID(subnetwork))
 	return nil

--- a/builtin/providers/google/data_source_google_compute_subnetwork.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork.go
@@ -29,7 +29,7 @@ func dataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"network_self_link": &schema.Schema{
+			"network": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -77,7 +77,7 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	d.Set("self_link", subnetwork.SelfLink)
 	d.Set("description", subnetwork.Description)
 	d.Set("gateway_address", subnetwork.GatewayAddress)
-	d.Set("network_self_link", subnetwork.Network)
+	d.Set("network", subnetwork.Network)
 
 	//To put subnet id see resource compute subnetnetwork details
 	subnetwork.Region = region

--- a/builtin/providers/google/data_source_google_compute_subnetwork_test.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork_test.go
@@ -16,20 +16,20 @@ func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
 			resource.TestStep{
 				Config: TestAccDataSourceGoogleSubnetworkConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceGoogleSubnetworktCheck("data.google_compute_subnetwork.my_subnetwork"),
+					testAccDataSourceGoogleSubnetworkCheck("data.google_compute_subnetwork.my_subnetwork", "google_compute_subnetwork.foobar"),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceGoogleSubnetworktCheck(name string) resource.TestCheckFunc {
+func testAccDataSourceGoogleSubnetworkCheck(name string, subnetwork_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
 			return fmt.Errorf("root module has no resource called %s", name)
 		}
-		network, ok := s.RootModule().Resources["google_compute_network.foobar"]
+		network, ok := s.RootModule().Resources[subnetwork_name]
 		if !ok {
 			return fmt.Errorf("can't find google_compute_network.foobar in state")
 		}
@@ -57,18 +57,18 @@ func testAccDataSourceGoogleSubnetworktCheck(name string) resource.TestCheckFunc
 			)
 		}
 
-		if attr["name"] != "subnetwork-test" {
+		if attr["name"] != subnetworkOrigin.Primary.Attributes["name"] {
 			return fmt.Errorf("bad name %s", attr["name"])
 		}
 
-		if attr["ip_cidr_range"] != "10.0.0.0/24" {
+		if attr["ip_cidr_range"] != subnetworkOrigin.Primary.Attributes["ip_cidr_range"] {
 			return fmt.Errorf("bad ip_cidr_range %s", attr["ip_cidr_range"])
 		}
-		if attr["network_self_link"] != network.Primary.Attributes["self_link"] {
-			return fmt.Errorf("bad network_name %s", attr["network_self_link"])
+		if attr["network"] != network.Primary.Attributes["network"] {
+			return fmt.Errorf("bad network_name %s", attr["network"])
 		}
 
-		if attr["description"] != "my-description" {
+		if attr["description"] != subnetworkOrigin.Primary.Attributes["description"] {
 			return fmt.Errorf("bad description %s", attr["description"])
 		}
 		return nil

--- a/builtin/providers/google/data_source_google_compute_subnetwork_test.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork_test.go
@@ -1,0 +1,94 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: TestAccDataSourceGoogleSubnetworkConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGoogleSubnetworktCheck("data.google_compute_subnetwork.my_subnetwork"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGoogleSubnetworktCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+		network, ok := s.RootModule().Resources["google_compute_network.foobar"]
+		if !ok {
+			return fmt.Errorf("can't find google_compute_network.foobar in state")
+		}
+
+		subnetworkOrigin, ok := s.RootModule().Resources["google_compute_subnetwork.foobar"]
+		if !ok {
+			return fmt.Errorf("can't find google_compute_subnetwork.foobar in state")
+		}
+
+		attr := rs.Primary.Attributes
+
+		if attr["id"] != subnetworkOrigin.Primary.Attributes["id"] {
+			return fmt.Errorf(
+				"id is %s; want %s",
+				attr["id"],
+				subnetworkOrigin.Primary.Attributes["id"],
+			)
+		}
+
+		if attr["self_link"] != subnetworkOrigin.Primary.Attributes["self_link"] {
+			return fmt.Errorf(
+				"self_link is %s; want %s",
+				attr["self_link"],
+				subnetworkOrigin.Primary.Attributes["self_link"],
+			)
+		}
+
+		if attr["name"] != "subnetwork-test" {
+			return fmt.Errorf("bad name %s", attr["name"])
+		}
+
+		if attr["ip_cidr_range"] != "10.0.0.0/24" {
+			return fmt.Errorf("bad ip_cidr_range %s", attr["ip_cidr_range"])
+		}
+		if attr["network_self_link"] != network.Primary.Attributes["self_link"] {
+			return fmt.Errorf("bad network_name %s", attr["network_self_link"])
+		}
+
+		if attr["description"] != "my-description" {
+			return fmt.Errorf("bad description %s", attr["description"])
+		}
+		return nil
+	}
+}
+
+var TestAccDataSourceGoogleSubnetworkConfig = `
+
+resource "google_compute_network" "foobar" {
+	name = "network-test"
+	description = "my-description"
+}
+resource "google_compute_subnetwork" "foobar" {
+	name = "subnetwork-test"
+	description = "my-description"
+	ip_cidr_range = "10.0.0.0/24"
+	network  = "${google_compute_network.foobar.self_link}"
+}
+
+data "google_compute_subnetwork" "my_subnetwork" {
+	name = "${google_compute_subnetwork.foobar.name}"
+}
+`

--- a/builtin/providers/google/data_source_google_compute_subnetwork_test.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork_test.go
@@ -23,54 +23,41 @@ func TestAccDataSourceGoogleSubnetwork(t *testing.T) {
 	})
 }
 
-func testAccDataSourceGoogleSubnetworkCheck(name string, subnetwork_name string) resource.TestCheckFunc {
+func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		ds, ok := s.RootModule().Resources[data_source_name]
 		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
+			return fmt.Errorf("root module has no resource called %s", data_source_name)
 		}
-		network, ok := s.RootModule().Resources[subnetwork_name]
+
+		rs, ok := s.RootModule().Resources[resource_name]
 		if !ok {
-			return fmt.Errorf("can't find google_compute_network.foobar in state")
+			return fmt.Errorf("can't find %s in state", resource_name)
 		}
 
-		subnetworkOrigin, ok := s.RootModule().Resources["google_compute_subnetwork.foobar"]
-		if !ok {
-			return fmt.Errorf("can't find google_compute_subnetwork.foobar in state")
+		ds_attr := ds.Primary.Attributes
+		rs_attr := rs.Primary.Attributes
+
+		subnetwork_attrs_to_test := []string{
+			"id",
+			"self_link",
+			"name",
+			"description",
+			"ip_cidr_range",
+			"network",
 		}
 
-		attr := rs.Primary.Attributes
-
-		if attr["id"] != subnetworkOrigin.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"id is %s; want %s",
-				attr["id"],
-				subnetworkOrigin.Primary.Attributes["id"],
-			)
+		for _, attr_to_check := range subnetwork_attrs_to_test {
+			if ds_attr[attr_to_check] != rs_attr[attr_to_check] {
+				return fmt.Errorf(
+					"%s is %s; want %s",
+					attr_to_check,
+					ds_attr[attr_to_check],
+					rs_attr[attr_to_check],
+				)
+			}
 		}
 
-		if attr["self_link"] != subnetworkOrigin.Primary.Attributes["self_link"] {
-			return fmt.Errorf(
-				"self_link is %s; want %s",
-				attr["self_link"],
-				subnetworkOrigin.Primary.Attributes["self_link"],
-			)
-		}
-
-		if attr["name"] != subnetworkOrigin.Primary.Attributes["name"] {
-			return fmt.Errorf("bad name %s", attr["name"])
-		}
-
-		if attr["ip_cidr_range"] != subnetworkOrigin.Primary.Attributes["ip_cidr_range"] {
-			return fmt.Errorf("bad ip_cidr_range %s", attr["ip_cidr_range"])
-		}
-		if attr["network"] != network.Primary.Attributes["network"] {
-			return fmt.Errorf("bad network_name %s", attr["network"])
-		}
-
-		if attr["description"] != subnetworkOrigin.Primary.Attributes["description"] {
-			return fmt.Errorf("bad description %s", attr["description"])
-		}
 		return nil
 	}
 }

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -50,6 +50,7 @@ func Provider() terraform.ResourceProvider {
 		DataSourcesMap: map[string]*schema.Resource{
 			"google_iam_policy":    dataSourceGoogleIamPolicy(),
 			"google_compute_zones": dataSourceGoogleComputeZones(),
+			"google_compute_network": dataSourceGoogleComputeNetwork(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -51,6 +51,7 @@ func Provider() terraform.ResourceProvider {
 			"google_iam_policy":    dataSourceGoogleIamPolicy(),
 			"google_compute_zones": dataSourceGoogleComputeZones(),
 			"google_compute_network": dataSourceGoogleComputeNetwork(),
+			"google_compute_subnetwork": dataSourceGoogleComputeSubnetwork(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -48,9 +48,9 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"google_iam_policy":    dataSourceGoogleIamPolicy(),
-			"google_compute_zones": dataSourceGoogleComputeZones(),
-			"google_compute_network": dataSourceGoogleComputeNetwork(),
+			"google_iam_policy":         dataSourceGoogleIamPolicy(),
+			"google_compute_zones":      dataSourceGoogleComputeZones(),
+			"google_compute_network":    dataSourceGoogleComputeNetwork(),
 			"google_compute_subnetwork": dataSourceGoogleComputeSubnetwork(),
 		},
 

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -48,10 +48,10 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"google_iam_policy":         dataSourceGoogleIamPolicy(),
-			"google_compute_zones":      dataSourceGoogleComputeZones(),
 			"google_compute_network":    dataSourceGoogleComputeNetwork(),
 			"google_compute_subnetwork": dataSourceGoogleComputeSubnetwork(),
+			"google_compute_zones":      dataSourceGoogleComputeZones(),
+			"google_iam_policy":         dataSourceGoogleIamPolicy(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
@@ -39,11 +39,8 @@ In addition to the arguments listed above, the following attributes are exported
 
 * `description` - Description of this network.
 
-* `ip_v4_range` - (DEPRECATED) The IPv4 address range that machines in this network
-   are assigned to, represented as a CIDR block..
-
 * `gateway_ipv4` - The IP address of the gateway.
 
-* `subnetworks_self_links` - the list of subnetworks which belongs to the network
+* `subnetworks_self_links` - the list of subnetworks which belong to the network
 
 * `self_link` - The URI of the resource.

--- a/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_network"
-sidebar_current: "docs-google-compute-network"
+sidebar_current: "docs-google-datasource-compute-etwork"
 description: |-
   Get a network within GCE.
 ---

--- a/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
@@ -1,20 +1,20 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_network"
-sidebar_current: "docs-google-datasource-compute-etwork"
+sidebar_current: "docs-google-datasource-compute-network"
 description: |-
   Get a network within GCE.
 ---
 
 # google\_compute\_network
 
-Get a network within GCE from his name.
+Get a network within GCE from its name.
 
 ## Example Usage
 
-```js
+```tf
 datasource "google_compute_network" "my-network" {
-  name          = "default-us-east1"
+  name = "default-us-east1"
 }
 ```
 
@@ -32,8 +32,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are
-exported:
+In addition to the arguments listed above, the following attributes are exported:
 
 * `network` - The network name or resource link to the parent
     network of this network. 

--- a/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
@@ -13,7 +13,7 @@ Get a network within GCE from its name.
 ## Example Usage
 
 ```tf
-datasource "google_compute_network" "my-network" {
+data "google_compute_network" "my-network" {
   name = "default-us-east1"
 }
 ```

--- a/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_network.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "google"
+page_title: "Google: google_compute_network"
+sidebar_current: "docs-google-compute-network"
+description: |-
+  Get a network within GCE.
+---
+
+# google\_compute\_network
+
+Get a network within GCE from his name.
+
+## Example Usage
+
+```js
+datasource "google_compute_network" "my-network" {
+  name          = "default-us-east1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the network.
+    
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `network` - The network name or resource link to the parent
+    network of this network. 
+
+* `description` - Description of this network.
+
+* `ip_v4_range` - (DEPRECATED) The IPv4 address range that machines in this network
+   are assigned to, represented as a CIDR block..
+
+* `gateway_ipv4` - The IP address of the gateway.
+
+* `subnetworks_self_links` - the list of subnetworks which belongs to the network
+
+* `self_link` - The URI of the resource.

--- a/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "google"
 page_title: "Google: google_compute_subnetwork"
-sidebar_current: "docs-google-compute-subnetwork"
+sidebar_current: "docs-google-datasource-compute-subnetwork"
 description: |-
   Get a subnetwork within GCE.
 ---

--- a/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
@@ -1,0 +1,51 @@
+---
+layout: "google"
+page_title: "Google: google_compute_subnetwork"
+sidebar_current: "docs-google-compute-subnetwork"
+description: |-
+  Get a subnetwork within GCE.
+---
+
+# google\_compute\_subnetwork
+
+Get a subnetwork within GCE from his name and region.
+
+## Example Usage
+
+```js
+datasource "google_compute_subnetwork" "my-subnetwork" {
+  name          = "default-us-east1"
+  region        = "us-east1"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - The name of the subnetwork.
+
+- - -
+
+* `project` - (Optional) The project in which the resource belongs. If it
+    is not provided, the provider project is used.
+
+* `region` - (Optional) The region this subnetwork has been created in. If
+    unspecified, this defaults to the region configured in the provider.
+
+## Attributes Reference
+
+In addition to the arguments listed above, the following computed attributes are
+exported:
+
+* `network` - The network name or resource link to the parent
+    network of this subnetwork. 
+
+* `description` - Description of this subnetwork.
+
+* `ip_cidr_range` - The IP address range that machines in this
+    network are assigned to, represented as a CIDR block.
+
+* `gateway_address` - The IP address of the gateway.
+
+* `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
@@ -13,7 +13,7 @@ Get a subnetwork within GCE from its name and region.
 ## Example Usage
 
 ```tf
-datasource "google_compute_subnetwork" "my-subnetwork" {
+data "google_compute_subnetwork" "my-subnetwork" {
   name   = "default-us-east1"
   region = "us-east1"
 }

--- a/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
@@ -8,14 +8,14 @@ description: |-
 
 # google\_compute\_subnetwork
 
-Get a subnetwork within GCE from his name and region.
+Get a subnetwork within GCE from its name and region.
 
 ## Example Usage
 
-```js
+```tf
 datasource "google_compute_subnetwork" "my-subnetwork" {
-  name          = "default-us-east1"
-  region        = "us-east1"
+  name   = "default-us-east1"
+  region = "us-east1"
 }
 ```
 
@@ -35,8 +35,7 @@ The following arguments are supported:
 
 ## Attributes Reference
 
-In addition to the arguments listed above, the following computed attributes are
-exported:
+In addition to the arguments listed above, the following attributes are exported:
 
 * `network` - The network name or resource link to the parent
     network of this subnetwork. 

--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -19,6 +19,12 @@
       <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
       <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
       </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
+        <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
+      </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-subnetwork") %>>
+        <a href="/docs/providers/google/d/datasource_compute_subnetwork.html">google_compute_subnetwork</a>
+      </li>
     </ul>
     </li>
 

--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -16,14 +16,14 @@
       <li<%= sidebar_current("docs-google-datasource-compute-zones") %>>
       <a href="/docs/providers/google/d/google_compute_zones.html">google_compute_zones</a>
       </li>
-      <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
-      <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
-      </li>
       <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-compute-subnetwork") %>>
         <a href="/docs/providers/google/d/datasource_compute_subnetwork.html">google_compute_subnetwork</a>
+      </li>
+      <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
+      <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>
       </li>
     </ul>
     </li>

--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -13,14 +13,14 @@
     <li<%= sidebar_current("docs-google-datasource") %>>
     <a href="#">Google Cloud Platform Data Sources</a>
     <ul class="nav nav-visible">
-      <li<%= sidebar_current("docs-google-datasource-compute-zones") %>>
-      <a href="/docs/providers/google/d/google_compute_zones.html">google_compute_zones</a>
-      </li>
       <li<%= sidebar_current("docs-google-datasource-compute-network") %>>
         <a href="/docs/providers/google/d/datasource_compute_network.html">google_compute_network</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-compute-subnetwork") %>>
         <a href="/docs/providers/google/d/datasource_compute_subnetwork.html">google_compute_subnetwork</a>
+      </li>
+      <li<%= sidebar_current("docs-google-datasource-compute-zones") %>>
+      <a href="/docs/providers/google/d/google_compute_zones.html">google_compute_zones</a>
       </li>
       <li<%= sidebar_current("docs-google-datasource-iam-policy") %>>
       <a href="/docs/providers/google/d/google_iam_policy.html">google_iam_policy</a>


### PR DESCRIPTION
Hi,

This PR adds `google_compute_subnetwork` and `google_compute_network`.

Thanks for your review :)

```
TF_ACC=true go test -v github.com/hashicorp/terraform/builtin/providers/google -run ^TestAccDataSourceGoogleNetwork$
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	0.016s

TF_ACC=true go test -v github.com/hashicorp/terraform/builtin/providers/google -run TestAccDataSourceGoogleSubnetwork
=== RUN   TestAccDataSourceGoogleSubnetwork
--- PASS: TestAccDataSourceGoogleSubnetwork (86.76s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	86.777s
```