### PR TITLE
document update: terraform get -u flag doesn't work

### DIFF
--- a/website/source/intro/getting-started/modules.html.md
+++ b/website/source/intro/getting-started/modules.html.md
@@ -83,7 +83,7 @@ $ terraform get
 
 This command will download the modules if they haven't been already.
 By default, the command will not check for updates, so it is safe (and fast)
-to run multiple times. You can use the `-u` flag to check and download
+to run multiple times. You can use the `-update` flag to check and download
 updates.
 
 ## Planning and Apply Modules


### PR DESCRIPTION
The -u flag didn't work for me and based on documentation should be -update, which did work.  Makes getting started docs more accurate.