### PR TITLE
Don't reuse the ResourceProvider between tests

### DIFF
--- a/builtin/providers/azurerm/data_source_arm_client_config_test.go
+++ b/builtin/providers/azurerm/data_source_arm_client_config_test.go
@@ -14,8 +14,8 @@ func TestAccAzureRMClientConfig_basic(t *testing.T) {
 	subscriptionId := os.Getenv("ARM_SUBSCRIPTION_ID")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccCheckArmClientConfig_basic,

--- a/builtin/providers/azurerm/import_arm_availability_set_test.go
+++ b/builtin/providers/azurerm/import_arm_availability_set_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMAvailabilitySet_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/import_arm_cdn_endpoint_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMCdnEndpoint_importWithTags(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTags, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_cdn_profile_test.go
+++ b/builtin/providers/azurerm/import_arm_cdn_profile_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMCdnProfile_importWithTags(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMCdnProfile_withTags, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMCdnProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_container_registry_test.go
+++ b/builtin/providers/azurerm/import_arm_container_registry_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMContainerRegistry_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerRegistry_basic, ri, rs, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerRegistryDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -42,9 +42,9 @@ func TestAccAzureRMContainerRegistry_importComplete(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerRegistry_complete, ri, rs, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerRegistryDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_a_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_a_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsARecord_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsARecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_aaaa_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_aaaa_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsAAAARecord_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsAAAARecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsAAAARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsAAAARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_cname_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_cname_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsCNameRecord_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsCNameRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsCNameRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsCNameRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_mx_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_mx_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsMxRecord_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsMxRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsMxRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsMxRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_ns_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_ns_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsNsRecord_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsNsRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsNsRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsNsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_srv_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_srv_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsSrvRecord_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsSrvRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsSrvRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsSrvRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_txt_record_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_txt_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsTxtRecord_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsTxtRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsTxtRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsTxtRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_dns_zone_test.go
+++ b/builtin/providers/azurerm/import_arm_dns_zone_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsZone_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsZone_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsZoneDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_eventhub_authorization_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_eventhub_authorization_rule_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMEventHubAuthorizationRule_importListen(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_listen, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -40,9 +40,9 @@ func TestAccAzureRMEventHubAuthorizationRule_importSend(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_send, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -64,9 +64,9 @@ func TestAccAzureRMEventHubAuthorizationRule_importReadWrite(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_readwrite, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -88,9 +88,9 @@ func TestAccAzureRMEventHubAuthorizationRule_importManage(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_manage, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_eventhub_consumer_group_test.go
+++ b/builtin/providers/azurerm/import_arm_eventhub_consumer_group_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMEventHubConsumerGroup_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_basic, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubConsumerGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubConsumerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -40,9 +40,9 @@ func TestAccAzureRMEventHubConsumerGroup_importComplete(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_complete, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubConsumerGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubConsumerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_eventhub_namespace_test.go
+++ b/builtin/providers/azurerm/import_arm_eventhub_namespace_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMEventHubNamespace_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubNamespace_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubNamespaceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_eventhub_test.go
+++ b/builtin/providers/azurerm/import_arm_eventhub_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMEventHub_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHub_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_key_vault_test.go
+++ b/builtin/providers/azurerm/import_arm_key_vault_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMKeyVault_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMKeyVault_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMKeyVaultDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMKeyVaultDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_loadbalancer_backend_address_pool_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_backend_address_pool_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_importBasic(t *testing.T) {
 	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName),

--- a/builtin/providers/azurerm/import_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_nat_pool_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMLoadBalancerNatPool_importBasic(t *testing.T) {
 	natPoolName := fmt.Sprintf("NatPool-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),

--- a/builtin/providers/azurerm/import_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_nat_rule_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMLoadBalancerNatRule_importBasic(t *testing.T) {
 	natRuleName := fmt.Sprintf("NatRule-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),

--- a/builtin/providers/azurerm/import_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_probe_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMLoadBalancerProbe_importBasic(t *testing.T) {
 	probeName := fmt.Sprintf("probe-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),

--- a/builtin/providers/azurerm/import_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_rule_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMLoadBalancerRule_importBasic(t *testing.T) {
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),

--- a/builtin/providers/azurerm/import_arm_loadbalancer_test.go
+++ b/builtin/providers/azurerm/import_arm_loadbalancer_test.go
@@ -11,9 +11,9 @@ func TestAccAzureRMLoadBalancer_importBasic(t *testing.T) {
 	resourceName := "azurerm_lb.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMLoadBalancer_basic(acctest.RandInt()),

--- a/builtin/providers/azurerm/import_arm_local_network_gateway_test.go
+++ b/builtin/providers/azurerm/import_arm_local_network_gateway_test.go
@@ -10,9 +10,9 @@ func TestAccAzureRMLocalNetworkGateway_importBasic(t *testing.T) {
 	resourceName := "azurerm_local_network_gateway.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLocalNetworkGatewayDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMLocalNetworkGatewayConfig_basic,

--- a/builtin/providers/azurerm/import_arm_network_security_group_test.go
+++ b/builtin/providers/azurerm/import_arm_network_security_group_test.go
@@ -12,9 +12,9 @@ func TestAccAzureRMNetworkSecurityGroup_importBasic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMNetworkSecurityGroup_basic(rInt),

--- a/builtin/providers/azurerm/import_arm_network_security_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_network_security_rule_test.go
@@ -12,9 +12,9 @@ func TestAccAzureRMNetworkSecurityRule_importBasic(t *testing.T) {
 	resourceName := "azurerm_network_security_rule.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityRuleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccAzureRMNetworkSecurityRule_basic(rInt),

--- a/builtin/providers/azurerm/import_arm_public_ip_test.go
+++ b/builtin/providers/azurerm/import_arm_public_ip_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMPublicIpStatic_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_resource_group_test.go
+++ b/builtin/providers/azurerm/import_arm_resource_group_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMResourceGroup_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMResourceGroup_basic, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_route_table_test.go
+++ b/builtin/providers/azurerm/import_arm_route_table_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMRouteTable_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRouteTable_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_route_test.go
+++ b/builtin/providers/azurerm/import_arm_route_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMRoute_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRoute_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_servicebus_namespace_test.go
+++ b/builtin/providers/azurerm/import_arm_servicebus_namespace_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMServiceBusNamespace_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusNamespaceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_servicebus_subscription_test.go
+++ b/builtin/providers/azurerm/import_arm_servicebus_subscription_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMServiceBusSubscription_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMServiceBusSubscription_basic, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusSubscriptionDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusSubscriptionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_servicebus_topic_test.go
+++ b/builtin/providers/azurerm/import_arm_servicebus_topic_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMServiceBusTopic_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_sql_firewall_rule_test.go
+++ b/builtin/providers/azurerm/import_arm_sql_firewall_rule_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMSqlFirewallRule_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSqlFirewallRule_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlFirewallRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlFirewallRuleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_sql_server_test.go
+++ b/builtin/providers/azurerm/import_arm_sql_server_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMSqlServer_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSqlServer_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlServerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlServerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_storage_account_test.go
+++ b/builtin/providers/azurerm/import_arm_storage_account_test.go
@@ -17,9 +17,9 @@ func TestAccAzureRMStorageAccount_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageAccount_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_subnet_test.go
+++ b/builtin/providers/azurerm/import_arm_subnet_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMSubnet_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSubnetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_traffic_manager_endpoint_test.go
+++ b/builtin/providers/azurerm/import_arm_traffic_manager_endpoint_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMTrafficManagerEndpoint_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basic, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_traffic_manager_profile_test.go
+++ b/builtin/providers/azurerm/import_arm_traffic_manager_profile_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMTrafficManagerProfile_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_performance, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_virtual_machine_extension_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_machine_extension_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMVirtualMachineExtension_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualMachineExtension_basic, ri, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineExtensionDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineExtensionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_machine_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMVirtualMachine_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_virtual_network_peering_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_network_peering_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMVirtualNetworkPeering_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualNetworkPeering_basic, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkPeeringDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkPeeringDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/import_arm_virtual_network_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_network_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMVirtualNetwork_importBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualNetwork_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_availability_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_availability_set_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMAvailabilitySet_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -40,9 +40,9 @@ func TestAccAzureRMAvailabilitySet_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -67,9 +67,9 @@ func TestAccAzureRMAvailabilitySet_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withUpdatedTags, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -104,9 +104,9 @@ func TestAccAzureRMAvailabilitySet_withDomainCounts(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVAvailabilitySet_withDomainCounts, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMAvailabilitySetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMAvailabilitySetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_endpoint_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMCdnEndpoint_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -34,9 +34,9 @@ func TestAccAzureRMCdnEndpoint_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMCdnEndpoint_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -56,9 +56,9 @@ func TestAccAzureRMCdnEndpoint_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMCdnEndpoint_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMCdnEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMCdnEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
+++ b/builtin/providers/azurerm/resource_arm_cdn_profile_test.go
@@ -56,9 +56,9 @@ func TestAccAzureRMCdnProfile_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMCdnProfile_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMCdnProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -77,9 +77,9 @@ func TestAccAzureRMCdnProfile_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMCdnProfile_withTagsUpdate, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMCdnProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMCdnProfileDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_container_registry_test.go
+++ b/builtin/providers/azurerm/resource_arm_container_registry_test.go
@@ -72,9 +72,9 @@ func TestAccAzureRMContainerRegistry_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerRegistry_basic, ri, rs, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerRegistryDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -92,9 +92,9 @@ func TestAccAzureRMContainerRegistry_complete(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerRegistry_complete, ri, rs, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerRegistryDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerRegistryDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_container_service_test.go
+++ b/builtin/providers/azurerm/resource_arm_container_service_test.go
@@ -80,9 +80,9 @@ func TestAccAzureRMContainerService_dcosBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerService_dcosBasic, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerServiceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerServiceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -99,9 +99,9 @@ func TestAccAzureRMContainerService_kubernetesBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerService_kubernetesBasic, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerServiceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerServiceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -118,9 +118,9 @@ func TestAccAzureRMContainerService_kubernetesComplete(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerService_kubernetesComplete, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerServiceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerServiceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -137,9 +137,9 @@ func TestAccAzureRMContainerService_swarmBasic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMContainerService_swarmBasic, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMContainerServiceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMContainerServiceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_dns_a_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_a_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsARecord_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsARecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMDnsARecord_updateRecords(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsARecord_updateRecords, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -66,9 +66,9 @@ func TestAccAzureRMDnsARecord_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsARecord_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_dns_aaaa_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_aaaa_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsAAAARecord_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsAAAARecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsAAAARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsAAAARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMDnsAAAARecord_updateRecords(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsAAAARecord_updateRecords, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsAAAARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsAAAARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -66,9 +66,9 @@ func TestAccAzureRMDnsAAAARecord_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsAAAARecord_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsAAAARecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsAAAARecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_dns_cname_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_cname_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsCNameRecord_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsCNameRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsCNameRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsCNameRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -34,9 +34,9 @@ func TestAccAzureRMDnsCNameRecord_subdomain(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsCNameRecord_subdomain, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsCNameRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsCNameRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -56,9 +56,9 @@ func TestAccAzureRMDnsCNameRecord_updateRecords(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsCNameRecord_updateRecords, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsCNameRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsCNameRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -83,9 +83,9 @@ func TestAccAzureRMDnsCNameRecord_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsCNameRecord_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsCNameRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsCNameRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_dns_mx_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_mx_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsMxRecord_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsMxRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsMxRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsMxRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMDnsMxRecord_updateRecords(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsMxRecord_updateRecords, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsMxRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsMxRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -66,9 +66,9 @@ func TestAccAzureRMDnsMxRecord_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsMxRecord_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsMxRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsMxRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_dns_ns_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_ns_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsNsRecord_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsNsRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsNsRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsNsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMDnsNsRecord_updateRecords(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsNsRecord_updateRecords, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsNsRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsNsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -66,9 +66,9 @@ func TestAccAzureRMDnsNsRecord_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsNsRecord_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsNsRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsNsRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_dns_srv_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_srv_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsSrvRecord_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsSrvRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsSrvRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsSrvRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMDnsSrvRecord_updateRecords(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsSrvRecord_updateRecords, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsSrvRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsSrvRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -66,9 +66,9 @@ func TestAccAzureRMDnsSrvRecord_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsSrvRecord_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsSrvRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsSrvRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_dns_txt_record_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_txt_record_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsTxtRecord_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsTxtRecord_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsTxtRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsTxtRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMDnsTxtRecord_updateRecords(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsTxtRecord_updateRecords, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsTxtRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsTxtRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -66,9 +66,9 @@ func TestAccAzureRMDnsTxtRecord_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsTxtRecord_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsTxtRecordDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsTxtRecordDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_dns_zone_test.go
+++ b/builtin/providers/azurerm/resource_arm_dns_zone_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMDnsZone_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMDnsZone_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsZoneDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMDnsZone_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMDnsZone_withTagsUupdate, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMDnsZoneDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMDnsZoneDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_eventhub_authorization_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_authorization_rule_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMEventHubAuthorizationRule_listen(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_listen, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -34,9 +34,9 @@ func TestAccAzureRMEventHubAuthorizationRule_send(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_send, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -53,9 +53,9 @@ func TestAccAzureRMEventHubAuthorizationRule_readwrite(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_readwrite, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -72,9 +72,9 @@ func TestAccAzureRMEventHubAuthorizationRule_manage(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubAuthorizationRule_manage, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubAuthorizationRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubAuthorizationRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_eventhub_consumer_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_consumer_group_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMEventHubConsumerGroup_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_basic, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubConsumerGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubConsumerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -36,9 +36,9 @@ func TestAccAzureRMEventHubConsumerGroup_complete(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubConsumerGroup_complete, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubConsumerGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubConsumerGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_eventhub_namespace_test.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_namespace_test.go
@@ -85,9 +85,9 @@ func TestAccAzureRMEventHubNamespace_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubNamespace_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -105,9 +105,9 @@ func TestAccAzureRMEventHubNamespace_standard(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubNamespace_standard, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -124,9 +124,9 @@ func TestAccAzureRMEventHubNamespace_readDefaultKeys(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHubNamespace_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubNamespaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubNamespaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_eventhub_test.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_test.go
@@ -100,9 +100,9 @@ func TestAccAzureRMEventHub_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHub_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -120,9 +120,9 @@ func TestAccAzureRMEventHub_standard(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMEventHub_standard, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMEventHubDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMEventHubDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_key_vault_test.go
+++ b/builtin/providers/azurerm/resource_arm_key_vault_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMKeyVault_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMKeyVault_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMKeyVaultDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMKeyVaultDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMKeyVault_update(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMKeyVault_update, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMKeyVaultDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMKeyVaultDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_backend_address_pool_test.go
@@ -22,9 +22,9 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_basic(t *testing.T) {
 		subscriptionID, ri, ri, addressPoolName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName),
@@ -45,9 +45,9 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_removal(t *testing.T) {
 	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerBackEndAddressPool_removal(ri),
@@ -70,9 +70,9 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_reapply(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName),
@@ -100,9 +100,9 @@ func TestAccAzureRMLoadBalancerBackEndAddressPool_disappears(t *testing.T) {
 	addressPoolName := fmt.Sprintf("%d-address-pool", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerBackEndAddressPool_basic(ri, addressPoolName),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_pool_test.go
@@ -22,9 +22,9 @@ func TestAccAzureRMLoadBalancerNatPool_basic(t *testing.T) {
 		subscriptionID, ri, ri, natPoolName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
@@ -45,9 +45,9 @@ func TestAccAzureRMLoadBalancerNatPool_removal(t *testing.T) {
 	natPoolName := fmt.Sprintf("NatPool-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
@@ -74,9 +74,9 @@ func TestAccAzureRMLoadBalancerNatPool_update(t *testing.T) {
 	natPool2Name := fmt.Sprintf("NatPool-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatPool_multiplePools(ri, natPoolName, natPool2Name),
@@ -110,9 +110,9 @@ func TestAccAzureRMLoadBalancerNatPool_reapply(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),
@@ -140,9 +140,9 @@ func TestAccAzureRMLoadBalancerNatPool_disappears(t *testing.T) {
 	natPoolName := fmt.Sprintf("NatPool-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatPool_basic(ri, natPoolName),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_nat_rule_test.go
@@ -22,9 +22,9 @@ func TestAccAzureRMLoadBalancerNatRule_basic(t *testing.T) {
 		subscriptionID, ri, ri, natRuleName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
@@ -45,9 +45,9 @@ func TestAccAzureRMLoadBalancerNatRule_removal(t *testing.T) {
 	natRuleName := fmt.Sprintf("NatRule-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
@@ -74,9 +74,9 @@ func TestAccAzureRMLoadBalancerNatRule_update(t *testing.T) {
 	natRule2Name := fmt.Sprintf("NatRule-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatRule_multipleRules(ri, natRuleName, natRule2Name),
@@ -112,9 +112,9 @@ func TestAccAzureRMLoadBalancerNatRule_reapply(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),
@@ -142,9 +142,9 @@ func TestAccAzureRMLoadBalancerNatRule_disappears(t *testing.T) {
 	natRuleName := fmt.Sprintf("NatRule-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerNatRule_basic(ri, natRuleName),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_probe_test.go
@@ -22,9 +22,9 @@ func TestAccAzureRMLoadBalancerProbe_basic(t *testing.T) {
 		subscriptionID, ri, ri, probeName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
@@ -45,9 +45,9 @@ func TestAccAzureRMLoadBalancerProbe_removal(t *testing.T) {
 	probeName := fmt.Sprintf("probe-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
@@ -74,9 +74,9 @@ func TestAccAzureRMLoadBalancerProbe_update(t *testing.T) {
 	probe2Name := fmt.Sprintf("probe-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerProbe_multipleProbes(ri, probeName, probe2Name),
@@ -106,9 +106,9 @@ func TestAccAzureRMLoadBalancerProbe_updateProtocol(t *testing.T) {
 	probeName := fmt.Sprintf("probe-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerProbe_updateProtocolBefore(ri, probeName),
@@ -140,9 +140,9 @@ func TestAccAzureRMLoadBalancerProbe_reapply(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),
@@ -170,9 +170,9 @@ func TestAccAzureRMLoadBalancerProbe_disappears(t *testing.T) {
 	probeName := fmt.Sprintf("probe-%d", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerProbe_basic(ri, probeName),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_rule_test.go
@@ -78,9 +78,9 @@ func TestAccAzureRMLoadBalancerRule_basic(t *testing.T) {
 		subscriptionID, ri, ri, lbRuleName)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
@@ -101,9 +101,9 @@ func TestAccAzureRMLoadBalancerRule_removal(t *testing.T) {
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
@@ -132,9 +132,9 @@ func TestAccAzureRMLoadBalancerRule_inconsistentReads(t *testing.T) {
 	probeName := fmt.Sprintf("LbProbe-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerRule_inconsistentRead(ri, backendPoolName, probeName, lbRuleName),
@@ -165,9 +165,9 @@ func TestAccAzureRMLoadBalancerRule_update(t *testing.T) {
 		subscriptionID, ri, ri, lbRule2Name)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerRule_multipleRules(ri, lbRuleName, lbRule2Name),
@@ -207,9 +207,9 @@ func TestAccAzureRMLoadBalancerRule_reapply(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),
@@ -237,9 +237,9 @@ func TestAccAzureRMLoadBalancerRule_disappears(t *testing.T) {
 	lbRuleName := fmt.Sprintf("LbRule-%s", acctest.RandStringFromCharSet(8, acctest.CharSetAlpha))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancerRule_basic(ri, lbRuleName),

--- a/builtin/providers/azurerm/resource_arm_loadbalancer_test.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer_test.go
@@ -52,9 +52,9 @@ func TestAccAzureRMLoadBalancer_basic(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancer_basic(ri),
@@ -71,9 +71,9 @@ func TestAccAzureRMLoadBalancer_frontEndConfig(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancer_frontEndConfig(ri),
@@ -100,9 +100,9 @@ func TestAccAzureRMLoadBalancer_tags(t *testing.T) {
 	ri := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLoadBalancerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLoadBalancerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLoadBalancer_basic(ri),

--- a/builtin/providers/azurerm/resource_arm_local_network_gateway_test.go
+++ b/builtin/providers/azurerm/resource_arm_local_network_gateway_test.go
@@ -13,9 +13,9 @@ func TestAccAzureRMLocalNetworkGateway_basic(t *testing.T) {
 	name := "azurerm_local_network_gateway.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLocalNetworkGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLocalNetworkGatewayConfig_basic,
@@ -33,9 +33,9 @@ func TestAccAzureRMLocalNetworkGateway_disappears(t *testing.T) {
 	name := "azurerm_local_network_gateway.test"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMLocalNetworkGatewayDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMLocalNetworkGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMLocalNetworkGatewayConfig_basic,

--- a/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_interface_card_test.go
@@ -13,9 +13,9 @@ import (
 func TestAccAzureRMNetworkInterface_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkInterface_basic(rInt),
@@ -30,9 +30,9 @@ func TestAccAzureRMNetworkInterface_basic(t *testing.T) {
 func TestAccAzureRMNetworkInterface_disappears(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkInterface_basic(rInt),
@@ -49,9 +49,9 @@ func TestAccAzureRMNetworkInterface_disappears(t *testing.T) {
 func TestAccAzureRMNetworkInterface_enableIPForwarding(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkInterface_ipForwarding(rInt),
@@ -68,9 +68,9 @@ func TestAccAzureRMNetworkInterface_enableIPForwarding(t *testing.T) {
 func TestAccAzureRMNetworkInterface_multipleLoadBalancers(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkInterface_multipleLoadBalancers(rInt),
@@ -86,9 +86,9 @@ func TestAccAzureRMNetworkInterface_multipleLoadBalancers(t *testing.T) {
 func TestAccAzureRMNetworkInterface_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkInterfaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkInterfaceDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkInterface_withTags(rInt),

--- a/builtin/providers/azurerm/resource_arm_network_security_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group_test.go
@@ -13,9 +13,9 @@ import (
 func TestAccAzureRMNetworkSecurityGroup_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkSecurityGroup_basic(rInt),
@@ -30,9 +30,9 @@ func TestAccAzureRMNetworkSecurityGroup_basic(t *testing.T) {
 func TestAccAzureRMNetworkSecurityGroup_disappears(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkSecurityGroup_basic(rInt),
@@ -49,9 +49,9 @@ func TestAccAzureRMNetworkSecurityGroup_disappears(t *testing.T) {
 func TestAccAzureRMNetworkSecurityGroup_withTags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkSecurityGroup_withTags(rInt),
@@ -83,9 +83,9 @@ func TestAccAzureRMNetworkSecurityGroup_withTags(t *testing.T) {
 func TestAccAzureRMNetworkSecurityGroup_addingExtraRules(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityGroupDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkSecurityGroup_basic(rInt),

--- a/builtin/providers/azurerm/resource_arm_network_security_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_rule_test.go
@@ -13,9 +13,9 @@ import (
 func TestAccAzureRMNetworkSecurityRule_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkSecurityRule_basic(rInt),
@@ -31,9 +31,9 @@ func TestAccAzureRMNetworkSecurityRule_disappears(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkSecurityRule_basic(rInt),
@@ -51,9 +51,9 @@ func TestAccAzureRMNetworkSecurityRule_addingRules(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMNetworkSecurityRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMNetworkSecurityRuleDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAzureRMNetworkSecurityRule_updateBasic(rInt),

--- a/builtin/providers/azurerm/resource_arm_public_ip_test.go
+++ b/builtin/providers/azurerm/resource_arm_public_ip_test.go
@@ -84,9 +84,9 @@ func TestAccAzureRMPublicIpStatic_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -104,9 +104,9 @@ func TestAccAzureRMPublicIpStatic_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVPublicIpStatic_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -126,9 +126,9 @@ func TestAccAzureRMPublicIpStatic_idleTimeout(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVPublicIpStatic_idleTimeout, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -152,9 +152,9 @@ func TestAccAzureRMPublicIpStatic_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_withTagsUpdate, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -190,9 +190,9 @@ func TestAccAzureRMPublicIpStatic_update(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMVPublicIpStatic_update, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -219,9 +219,9 @@ func TestAccAzureRMPublicIpDynamic_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVPublicIpDynamic_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMPublicIpDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMPublicIpDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_redis_cache_test.go
+++ b/builtin/providers/azurerm/resource_arm_redis_cache_test.go
@@ -114,9 +114,9 @@ func TestAccAzureRMRedisCache_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRedisCache_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRedisCacheDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -133,9 +133,9 @@ func TestAccAzureRMRedisCache_standard(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRedisCache_standard, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRedisCacheDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -152,9 +152,9 @@ func TestAccAzureRMRedisCache_premium(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRedisCache_premium, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRedisCacheDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -171,9 +171,9 @@ func TestAccAzureRMRedisCache_premiumSharded(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRedisCache_premiumSharded, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRedisCacheDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRedisCacheDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_resource_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_resource_group_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMResourceGroup_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMResourceGroup_basic, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -34,9 +34,9 @@ func TestAccAzureRMResourceGroup_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMResourceGroup_basic, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -56,9 +56,9 @@ func TestAccAzureRMResourceGroup_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMResourceGroup_withTagsUpdated, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMResourceGroupDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMResourceGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_route_table_test.go
+++ b/builtin/providers/azurerm/resource_arm_route_table_test.go
@@ -64,9 +64,9 @@ func TestAccAzureRMRouteTable_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRouteTable_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -84,9 +84,9 @@ func TestAccAzureRMRouteTable_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRouteTable_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -107,9 +107,9 @@ func TestAccAzureRMRouteTable_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMRouteTable_withTagsUpdate, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -145,9 +145,9 @@ func TestAccAzureRMRouteTable_multipleRoutes(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMRouteTable_multipleRoutes, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteTableDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteTableDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_route_test.go
+++ b/builtin/providers/azurerm/resource_arm_route_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMRoute_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRoute_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -36,9 +36,9 @@ func TestAccAzureRMRoute_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMRoute_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -59,9 +59,9 @@ func TestAccAzureRMRoute_multipleRoutes(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMRoute_multipleRoutes, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMRouteDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMRouteDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_search_service_test.go
+++ b/builtin/providers/azurerm/resource_arm_search_service_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMSearchService_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSearchService_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSearchServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -37,9 +37,9 @@ func TestAccAzureRMSearchService_updateReplicaCountAndTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMSearchService_updated, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSearchServiceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSearchServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_namespace_test.go
@@ -81,9 +81,9 @@ func TestAccAzureRMServiceBusNamespace_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusNamespaceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -100,9 +100,9 @@ func TestAccAzureRMServiceBusNamespace_readDefaultKeys(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMServiceBusNamespace_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusNamespaceDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusNamespaceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_subscription_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMServiceBusSubscription_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMServiceBusSubscription_basic, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMServiceBusSubscription_update(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMServiceBusSubscription_update, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -62,9 +62,9 @@ func TestAccAzureRMServiceBusSubscription_updateRequiresSession(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMServiceBusSubscription_updateRequiresSession, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMServiceBusTopic_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMServiceBusTopic_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMServiceBusTopic_update(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_update, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -64,9 +64,9 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningStandard(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enablePartitioningStandard, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -94,9 +94,9 @@ func TestAccAzureRMServiceBusTopic_enablePartitioningPremium(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enablePartitioningPremium, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -123,9 +123,9 @@ func TestAccAzureRMServiceBusTopic_enableDuplicateDetection(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMServiceBusTopic_enableDuplicateDetection, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMServiceBusTopicDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMServiceBusTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_sql_database_test.go
+++ b/builtin/providers/azurerm/resource_arm_sql_database_test.go
@@ -51,9 +51,9 @@ func TestAccAzureRMSqlDatabase_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSqlDatabase_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -71,9 +71,9 @@ func TestAccAzureRMSqlDatabase_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMSqlDatabase_withTagsUpdate, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -100,9 +100,9 @@ func TestAccAzureRMSqlDatabase_datawarehouse(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSqlDatabase_datawarehouse, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlDatabaseDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlDatabaseDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_sql_firewall_rule_test.go
+++ b/builtin/providers/azurerm/resource_arm_sql_firewall_rule_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMSqlFirewallRule_basic(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMSqlFirewallRule_withUpdates, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlFirewallRuleDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlFirewallRuleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_sql_server_test.go
+++ b/builtin/providers/azurerm/resource_arm_sql_server_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMSqlServer_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSqlServer_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlServerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlServerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -35,9 +35,9 @@ func TestAccAzureRMSqlServer_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMSqlServer_withTagsUpdated, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSqlServerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSqlServerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_storage_account_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_account_test.go
@@ -57,9 +57,9 @@ func TestAccAzureRMStorageAccount_basic(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMStorageAccount_update, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -90,9 +90,9 @@ func TestAccAzureRMStorageAccount_disappears(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMStorageAccount_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -116,9 +116,9 @@ func TestAccAzureRMStorageAccount_blobEncryption(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMStorageAccount_blobEncryptionDisabled, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -146,9 +146,9 @@ func TestAccAzureRMStorageAccount_blobStorageWithUpdate(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMStorageAccount_blobStorageUpdate, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageAccountDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageAccountDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_storage_blob_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_blob_test.go
@@ -149,9 +149,9 @@ func TestAccAzureRMStorageBlob_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageBlob_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -169,9 +169,9 @@ func TestAccAzureRMStorageBlob_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageBlob_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -206,9 +206,9 @@ func TestAccAzureRMStorageBlobBlock_source(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageBlobBlock_source, ri, rs1, sourceBlob.Name())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -265,9 +265,9 @@ func TestAccAzureRMStorageBlobPage_source(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageBlobPage_source, ri, rs1, sourceBlob.Name())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -300,9 +300,9 @@ func TestAccAzureRMStorageBlob_source_uri(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageBlob_source_uri, ri, rs1, sourceBlob.Name())
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageBlobDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageBlobDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_storage_container_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_container_test.go
@@ -20,9 +20,9 @@ func TestAccAzureRMStorageContainer_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageContainer_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageContainerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageContainerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -42,9 +42,9 @@ func TestAccAzureRMStorageContainer_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageContainer_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageContainerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageContainerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -66,9 +66,9 @@ func TestAccAzureRMStorageContainer_root(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageContainer_root, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageContainerDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageContainerDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_storage_queue_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_queue_test.go
@@ -57,9 +57,9 @@ func TestAccAzureRMStorageQueue_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageQueue_basic, ri, rs, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageQueueDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageQueueDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_storage_share_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_share_test.go
@@ -20,9 +20,9 @@ func TestAccAzureRMStorageShare_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageShare_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageShareDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageShareDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -42,9 +42,9 @@ func TestAccAzureRMStorageShare_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageShare_basic, ri, rs)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageShareDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageShareDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_storage_table_test.go
+++ b/builtin/providers/azurerm/resource_arm_storage_table_test.go
@@ -20,9 +20,9 @@ func TestAccAzureRMStorageTable_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageTable_basic, ri, rs, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageTableDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -42,9 +42,9 @@ func TestAccAzureRMStorageTable_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMStorageTable_basic, ri, rs, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMStorageTableDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMStorageTableDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSubnetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -36,9 +36,9 @@ func TestAccAzureRMSubnet_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMSubnetDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_template_deployment_test.go
+++ b/builtin/providers/azurerm/resource_arm_template_deployment_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMTemplateDeployment_basic(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_basicExample, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTemplateDeploymentDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTemplateDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -33,9 +33,9 @@ func TestAccAzureRMTemplateDeployment_disappears(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_basicExample, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTemplateDeploymentDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTemplateDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -53,9 +53,9 @@ func TestAccAzureRMTemplateDeployment_withParams(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_withParams, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTemplateDeploymentDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTemplateDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -72,9 +72,9 @@ func TestAccAzureRMTemplateDeployment_withError(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMTemplateDeployment_withError, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTemplateDeploymentDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTemplateDeploymentDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config:      config,

--- a/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint_test.go
+++ b/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMTrafficManagerEndpoint_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basic, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -38,9 +38,9 @@ func TestAccAzureRMTrafficManagerEndpoint_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basic, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -63,9 +63,9 @@ func TestAccAzureRMTrafficManagerEndpoint_basicDisableExternal(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_basicDisableExternal, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -96,9 +96,9 @@ func TestAccAzureRMTrafficManagerEndpoint_updateWeight(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_updateWeight, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -129,9 +129,9 @@ func TestAccAzureRMTrafficManagerEndpoint_updatePriority(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_updatePriority, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -160,9 +160,9 @@ func TestAccAzureRMTrafficManagerEndpoint_nestedEndpoints(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMTrafficManagerEndpoint_nestedEndpoints, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerEndpointDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerEndpointDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_traffic_manager_profile_test.go
+++ b/builtin/providers/azurerm/resource_arm_traffic_manager_profile_test.go
@@ -18,9 +18,9 @@ func TestAccAzureRMTrafficManagerProfile_weighted(t *testing.T) {
 	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -41,9 +41,9 @@ func TestAccAzureRMTrafficManagerProfile_performance(t *testing.T) {
 	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -64,9 +64,9 @@ func TestAccAzureRMTrafficManagerProfile_priority(t *testing.T) {
 	fqdn := fmt.Sprintf("acctesttmp%d.trafficmanager.net", ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -86,9 +86,9 @@ func TestAccAzureRMTrafficManagerProfile_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMTrafficManagerProfile_withTagsUpdated, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMTrafficManagerProfileDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMTrafficManagerProfileDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_extension_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_extension_test.go
@@ -18,9 +18,9 @@ func TestAccAzureRMVirtualMachineExtension_basic(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachineExtension_basicUpdate, ri, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineExtensionDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineExtensionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -45,9 +45,9 @@ func TestAccAzureRMVirtualMachineExtension_concurrent(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualMachineExtension_concurrent, ri, ri, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineExtensionDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineExtensionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -67,9 +67,9 @@ func TestAccAzureRMVirtualMachineExtension_linuxDiagnostics(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualMachineExtension_linuxDiagnostics, ri, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineExtensionDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineExtensionDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -14,9 +14,9 @@ func TestAccAzureRMVirtualMachineScaleSet_basicLinux(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basicLinux, ri, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineScaleSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -32,9 +32,9 @@ func TestAccAzureRMVirtualMachineScaleSet_basicLinux_disappears(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basicLinux, ri, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineScaleSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -52,9 +52,9 @@ func TestAccAzureRMVirtualMachineScaleSet_loadBalancer(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSetLoadbalancerTemplate, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineScaleSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -71,9 +71,9 @@ func TestAccAzureRMVirtualMachineScaleSet_overprovision(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSetOverprovisionTemplate, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineScaleSetDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -17,9 +17,9 @@ func TestAccAzureRMVirtualMachine_basicLinuxMachine(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -36,9 +36,9 @@ func TestAccAzureRMVirtualMachine_basicLinuxMachine_disappears(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -58,9 +58,9 @@ func TestAccAzureRMVirtualMachine_withDataDisk(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_withDataDisk, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -79,9 +79,9 @@ func TestAccAzureRMVirtualMachine_tags(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineUpdated, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -119,9 +119,9 @@ func TestAccAzureRMVirtualMachine_updateMachineSize(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_updatedLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -148,9 +148,9 @@ func TestAccAzureRMVirtualMachine_basicWindowsMachine(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_basicWindowsMachine, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -167,9 +167,9 @@ func TestAccAzureRMVirtualMachine_windowsUnattendedConfig(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_windowsUnattendedConfig, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -186,9 +186,9 @@ func TestAccAzureRMVirtualMachine_diagnosticsProfile(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_diagnosticsProfile, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -205,9 +205,9 @@ func TestAccAzureRMVirtualMachine_winRMConfig(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_winRMConfig, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -225,9 +225,9 @@ func TestAccAzureRMVirtualMachine_deleteVHDOptOut(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_withDataDisk, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineDeleteVM, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -252,9 +252,9 @@ func TestAccAzureRMVirtualMachine_deleteVHDOptIn(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisksBefore, ri, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineDestroyDisksAfter, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -280,9 +280,9 @@ func TestAccAzureRMVirtualMachine_ChangeComputerName(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_machineNameBeforeUpdate, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_updateMachineName, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -310,9 +310,9 @@ func TestAccAzureRMVirtualMachine_ChangeAvailbilitySet(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_withAvailabilitySet, ri, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_updateAvailabilitySet, ri, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -340,9 +340,9 @@ func TestAccAzureRMVirtualMachine_changeStorageImageReference(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineStorageImageBefore, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineStorageImageAfter, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -370,9 +370,9 @@ func TestAccAzureRMVirtualMachine_changeOSDiskVhdUri(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachine, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_basicLinuxMachineWithOSDiskVhdUriChanged, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,
@@ -398,9 +398,9 @@ func TestAccAzureRMVirtualMachine_plan(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_plan, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -418,9 +418,9 @@ func TestAccAzureRMVirtualMachine_changeSSHKey(t *testing.T) {
 	preConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_linuxMachineWithSSH, ri, ri, ri, ri, ri, ri, ri)
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualMachine_linuxMachineWithSSHRemoved, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: preConfig,
@@ -566,9 +566,9 @@ func TestAccAzureRMVirtualMachine_windowsLicenseType(t *testing.T) {
 	ri := acctest.RandInt()
 	config := fmt.Sprintf(testAccAzureRMVirtualMachine_windowsLicenseType, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualMachineDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: config,

--- a/builtin/providers/azurerm/resource_arm_virtual_network_peering_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network_peering_test.go
@@ -15,9 +15,9 @@ func TestAccAzureRMVirtualNetworkPeering_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualNetworkPeering_basic, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkPeeringDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkPeeringDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -39,9 +39,9 @@ func TestAccAzureRMVirtualNetworkPeering_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualNetworkPeering_basic, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkPeeringDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkPeeringDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -66,9 +66,9 @@ func TestAccAzureRMVirtualNetworkPeering_update(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualNetworkPeering_basicUpdate, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkPeeringDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkPeeringDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/builtin/providers/azurerm/resource_arm_virtual_network_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network_test.go
@@ -16,9 +16,9 @@ func TestAccAzureRMVirtualNetwork_basic(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualNetwork_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -36,9 +36,9 @@ func TestAccAzureRMVirtualNetwork_disappears(t *testing.T) {
 	config := fmt.Sprintf(testAccAzureRMVirtualNetwork_basic, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: config,
@@ -59,9 +59,9 @@ func TestAccAzureRMVirtualNetwork_withTags(t *testing.T) {
 	postConfig := fmt.Sprintf(testAccAzureRMVirtualNetwork_withTagsUpdated, ri, ri)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMVirtualNetworkDestroy,
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: testAccProviders,
+		CheckDestroy:      testCheckAzureRMVirtualNetworkDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: preConfig,

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -138,6 +138,13 @@ func (p *Provider) Stop() error {
 	return nil
 }
 
+// StopTestReset resets tha StopContext for tests.
+// This should not be called outside of unit tests, and not while any other
+// test are being executed.
+func (p *Provider) StopContextTestReset() {
+	p.stopInit()
+}
+
 // Input implementation of terraform.ResourceProvider interface.
 func (p *Provider) Input(
 	input terraform.UIInput,


### PR DESCRIPTION
[DO NOT MERGE]

This is testing out an idea that requires a change to helper/schema, which should be done through another PR.

The arm provider was configured once in the test init, but if the StopContext was ever canceled any further tests would fail.  Using a ResourceProviderFactory ensures that the arm provider is re-configured between tests.