### PR TITLE
provider/google: fix container instance group URLs

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -13,6 +13,10 @@ import (
 	"google.golang.org/api/googleapi"
 )
 
+var (
+	instanceGroupManagerURL = regexp.MustCompile("^https://www.googleapis.com/compute/v1/projects/([a-z][a-z0-9-]{5}(?:[-a-z0-9]{0,23}[a-z0-9])?)/zones/([a-z0-9-]*)/instanceGroupManagers/([^/]*)")
+)
+
 func resourceContainerCluster() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceContainerClusterCreate,
@@ -474,7 +478,28 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("network", d.Get("network").(string))
 	d.Set("subnetwork", cluster.Subnetwork)
 	d.Set("node_config", flattenClusterNodeConfig(cluster.NodeConfig))
-	d.Set("instance_group_urls", cluster.InstanceGroupUrls)
+
+	// container engine's API currently mistakenly returns the instance group manager's
+	// URL instead of the instance group's URL in its responses. This shim detects that
+	// error, and corrects it, by fetching the instance group manager URL and retrieving
+	// the instance group manager, then using that to look up the instance group URL, which
+	// is then substituted.
+	//
+	// This should be removed when the API response is fixed.
+	instanceGroupURLs := make([]string, 0, len(cluster.InstanceGroupUrls))
+	for _, u := range cluster.InstanceGroupUrls {
+		if !instanceGroupManagerURL.MatchString(u) {
+			instanceGroupURLs = append(instanceGroupURLs, u)
+			continue
+		}
+		matches := instanceGroupManagerURL.FindStringSubmatch(u)
+		instanceGroupManager, err := config.clientCompute.InstanceGroupManagers.Get(matches[1], matches[2], matches[3]).Do()
+		if err != nil {
+			return fmt.Errorf("Error reading instance group manager returned as an instance group URL: %s", err)
+		}
+		instanceGroupURLs = append(instanceGroupURLs, instanceGroupManager.InstanceGroup)
+	}
+	d.Set("instance_group_urls", instanceGroupURLs)
 
 	return nil
 }


### PR DESCRIPTION
Google Container Engine's cluster API returned instance group manager
URLs when it meant to return instance group URLs. See #4336 for details
about the bug.

While this is undeniably an upstream problem, this PR:

* detects the error, meaning it will work as expected when the API is
  fixed.
* corrects the error by requesting the instance group manager, then
  retrieving its instance group URL, and using that instead.
* adds a test that exercises the error and the solution, to ensure it is
  functioning properly.

Unit test without fix:

```
=== RUN   TestAccContainerCluster_backend
--- FAIL: TestAccContainerCluster_backend (303.57s)
        testing.go:265: Step 0 error: Error applying: 1 error(s) occurred:

                * google_compute_backend_service.my-backend-service: 1 error(s) occurred:

                * google_compute_backend_service.my-backend-service: Error creating backend service: googleapi: Error 400: Invalid value for field 'resource.backends[0].group': 'https://www.googleapis.com/compute/v1/projects/hc-terraform-testing/zones/us-central1-c/instanceGroupManagers/gke-terraform-test-evnwj-default-pool-68b6a1a7-grp'. The value is not a valid resourceView nor instanceGroup URL., invalid
FAIL
```

Unit test with fix:

```
=== RUN   TestAccContainerCluster_backend
--- PASS: TestAccContainerCluster_backend (298.37s)
```