### PR TITLE
provider/datadog: Update to datadog_monitor still used d.GetOk

### DIFF
--- a/builtin/providers/datadog/resource_datadog_monitor.go
+++ b/builtin/providers/datadog/resource_datadog_monitor.go
@@ -324,7 +324,9 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	o := datadog.Options{
-		NotifyNoData: datadog.Bool(d.Get("notify_no_data").(bool)),
+		NotifyNoData:      datadog.Bool(d.Get("notify_no_data").(bool)),
+		RequireFullWindow: datadog.Bool(d.Get("require_full_window").(bool)),
+		IncludeTags:       datadog.Bool(d.Get("include_tags").(bool)),
 	}
 	if attr, ok := d.GetOk("thresholds"); ok {
 		thresholds := attr.(map[string]interface{})
@@ -340,9 +342,6 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 		}
 	}
 
-	if attr, ok := d.GetOk("notify_no_data"); ok {
-		o.SetNotifyNoData(attr.(bool))
-	}
 	if attr, ok := d.GetOk("new_host_delay"); ok {
 		o.SetNewHostDelay(attr.(int))
 	}
@@ -368,12 +367,6 @@ func resourceDatadogMonitorUpdate(d *schema.ResourceData, meta interface{}) erro
 			s[k], _ = strconv.Atoi(v.(string))
 		}
 		o.Silenced = s
-	}
-	if attr, ok := d.GetOk("include_tags"); ok {
-		o.SetIncludeTags(attr.(bool))
-	}
-	if attr, ok := d.GetOk("require_full_window"); ok {
-		o.SetRequireFullWindow(attr.(bool))
 	}
 	if attr, ok := d.GetOk("locked"); ok {
 		o.SetLocked(attr.(bool))

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -23,12 +23,13 @@ import (
 	datadogprovider "github.com/hashicorp/terraform/builtin/providers/datadog"
 	digitaloceanprovider "github.com/hashicorp/terraform/builtin/providers/digitalocean"
 	dmeprovider "github.com/hashicorp/terraform/builtin/providers/dme"
-	dnsprovider "github.com/hashicorp/terraform/builtin/providers/dns"
 	dnsimpleprovider "github.com/hashicorp/terraform/builtin/providers/dnsimple"
+	dnsprovider "github.com/hashicorp/terraform/builtin/providers/dns"
 	dockerprovider "github.com/hashicorp/terraform/builtin/providers/docker"
 	dynprovider "github.com/hashicorp/terraform/builtin/providers/dyn"
 	externalprovider "github.com/hashicorp/terraform/builtin/providers/external"
 	fastlyprovider "github.com/hashicorp/terraform/builtin/providers/fastly"
+	fileprovisioner "github.com/hashicorp/terraform/builtin/provisioners/file"
 	githubprovider "github.com/hashicorp/terraform/builtin/providers/github"
 	googleprovider "github.com/hashicorp/terraform/builtin/providers/google"
 	grafanaprovider "github.com/hashicorp/terraform/builtin/providers/grafana"
@@ -37,6 +38,7 @@ import (
 	ignitionprovider "github.com/hashicorp/terraform/builtin/providers/ignition"
 	influxdbprovider "github.com/hashicorp/terraform/builtin/providers/influxdb"
 	libratoprovider "github.com/hashicorp/terraform/builtin/providers/librato"
+	localexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/local-exec"
 	logentriesprovider "github.com/hashicorp/terraform/builtin/providers/logentries"
 	mailgunprovider "github.com/hashicorp/terraform/builtin/providers/mailgun"
 	mysqlprovider "github.com/hashicorp/terraform/builtin/providers/mysql"
@@ -54,6 +56,7 @@ import (
 	rabbitmqprovider "github.com/hashicorp/terraform/builtin/providers/rabbitmq"
 	rancherprovider "github.com/hashicorp/terraform/builtin/providers/rancher"
 	randomprovider "github.com/hashicorp/terraform/builtin/providers/random"
+	remoteexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
 	rundeckprovider "github.com/hashicorp/terraform/builtin/providers/rundeck"
 	scalewayprovider "github.com/hashicorp/terraform/builtin/providers/scaleway"
 	softlayerprovider "github.com/hashicorp/terraform/builtin/providers/softlayer"
@@ -68,9 +71,6 @@ import (
 	vaultprovider "github.com/hashicorp/terraform/builtin/providers/vault"
 	vcdprovider "github.com/hashicorp/terraform/builtin/providers/vcd"
 	vsphereprovider "github.com/hashicorp/terraform/builtin/providers/vsphere"
-	fileprovisioner "github.com/hashicorp/terraform/builtin/provisioners/file"
-	localexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/local-exec"
-	remoteexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
 
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
@@ -80,74 +80,76 @@ import (
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
-	"alicloud":     alicloudprovider.Provider,
-	"archive":      archiveprovider.Provider,
-	"arukas":       arukasprovider.Provider,
-	"atlas":        atlasprovider.Provider,
-	"aws":          awsprovider.Provider,
-	"azure":        azureprovider.Provider,
-	"azurerm":      azurermprovider.Provider,
-	"bitbucket":    bitbucketprovider.Provider,
-	"chef":         chefprovider.Provider,
-	"clc":          clcprovider.Provider,
+	"alicloud":   alicloudprovider.Provider,
+	"archive":   archiveprovider.Provider,
+	"arukas":   arukasprovider.Provider,
+	"atlas":   atlasprovider.Provider,
+	"aws":   awsprovider.Provider,
+	"azure":   azureprovider.Provider,
+	"azurerm":   azurermprovider.Provider,
+	"bitbucket":   bitbucketprovider.Provider,
+	"chef":   chefprovider.Provider,
+	"clc":   clcprovider.Provider,
 	"cloudflare":   cloudflareprovider.Provider,
 	"cloudstack":   cloudstackprovider.Provider,
-	"cobbler":      cobblerprovider.Provider,
-	"consul":       consulprovider.Provider,
-	"datadog":      datadogprovider.Provider,
-	"digitalocean": digitaloceanprovider.Provider,
-	"dme":          dmeprovider.Provider,
-	"dns":          dnsprovider.Provider,
-	"dnsimple":     dnsimpleprovider.Provider,
-	"docker":       dockerprovider.Provider,
-	"dyn":          dynprovider.Provider,
-	"external":     externalprovider.Provider,
-	"fastly":       fastlyprovider.Provider,
-	"github":       githubprovider.Provider,
-	"google":       googleprovider.Provider,
-	"grafana":      grafanaprovider.Provider,
-	"heroku":       herokuprovider.Provider,
-	"icinga2":      icinga2provider.Provider,
-	"ignition":     ignitionprovider.Provider,
-	"influxdb":     influxdbprovider.Provider,
-	"librato":      libratoprovider.Provider,
+	"cobbler":   cobblerprovider.Provider,
+	"consul":   consulprovider.Provider,
+	"datadog":   datadogprovider.Provider,
+	"digitalocean":   digitaloceanprovider.Provider,
+	"dme":   dmeprovider.Provider,
+	"dns":   dnsprovider.Provider,
+	"dnsimple":   dnsimpleprovider.Provider,
+	"docker":   dockerprovider.Provider,
+	"dyn":   dynprovider.Provider,
+	"external":   externalprovider.Provider,
+	"fastly":   fastlyprovider.Provider,
+	"github":   githubprovider.Provider,
+	"google":   googleprovider.Provider,
+	"grafana":   grafanaprovider.Provider,
+	"heroku":   herokuprovider.Provider,
+	"icinga2":   icinga2provider.Provider,
+	"ignition":   ignitionprovider.Provider,
+	"influxdb":   influxdbprovider.Provider,
+	"librato":   libratoprovider.Provider,
 	"logentries":   logentriesprovider.Provider,
-	"mailgun":      mailgunprovider.Provider,
-	"mysql":        mysqlprovider.Provider,
-	"newrelic":     newrelicprovider.Provider,
-	"nomad":        nomadprovider.Provider,
-	"ns1":          ns1provider.Provider,
-	"null":         nullprovider.Provider,
-	"openstack":    openstackprovider.Provider,
-	"opsgenie":     opsgenieprovider.Provider,
-	"packet":       packetprovider.Provider,
-	"pagerduty":    pagerdutyprovider.Provider,
+	"mailgun":   mailgunprovider.Provider,
+	"mysql":   mysqlprovider.Provider,
+	"newrelic":   newrelicprovider.Provider,
+	"nomad":   nomadprovider.Provider,
+	"ns1":   ns1provider.Provider,
+	"null":   nullprovider.Provider,
+	"openstack":   openstackprovider.Provider,
+	"opsgenie":   opsgenieprovider.Provider,
+	"packet":   packetprovider.Provider,
+	"pagerduty":   pagerdutyprovider.Provider,
 	"postgresql":   postgresqlprovider.Provider,
-	"powerdns":     powerdnsprovider.Provider,
-	"profitbricks": profitbricksprovider.Provider,
-	"rabbitmq":     rabbitmqprovider.Provider,
-	"rancher":      rancherprovider.Provider,
-	"random":       randomprovider.Provider,
-	"rundeck":      rundeckprovider.Provider,
-	"scaleway":     scalewayprovider.Provider,
-	"softlayer":    softlayerprovider.Provider,
-	"spotinst":     spotinstprovider.Provider,
+	"powerdns":   powerdnsprovider.Provider,
+	"profitbricks":   profitbricksprovider.Provider,
+	"rabbitmq":   rabbitmqprovider.Provider,
+	"rancher":   rancherprovider.Provider,
+	"random":   randomprovider.Provider,
+	"rundeck":   rundeckprovider.Provider,
+	"scaleway":   scalewayprovider.Provider,
+	"softlayer":   softlayerprovider.Provider,
+	"spotinst":   spotinstprovider.Provider,
 	"statuscake":   statuscakeprovider.Provider,
-	"template":     templateprovider.Provider,
-	"terraform":    terraformprovider.Provider,
-	"test":         testprovider.Provider,
-	"tls":          tlsprovider.Provider,
-	"triton":       tritonprovider.Provider,
-	"ultradns":     ultradnsprovider.Provider,
-	"vault":        vaultprovider.Provider,
-	"vcd":          vcdprovider.Provider,
-	"vsphere":      vsphereprovider.Provider,
+	"template":   templateprovider.Provider,
+	"terraform":   terraformprovider.Provider,
+	"test":   testprovider.Provider,
+	"tls":   tlsprovider.Provider,
+	"triton":   tritonprovider.Provider,
+	"ultradns":   ultradnsprovider.Provider,
+	"vault":   vaultprovider.Provider,
+	"vcd":   vcdprovider.Provider,
+	"vsphere":   vsphereprovider.Provider,
+
 }
 
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{
-	"file":        fileprovisioner.Provisioner,
-	"local-exec":  localexecprovisioner.Provisioner,
-	"remote-exec": remoteexecprovisioner.Provisioner,
+	"file":   fileprovisioner.Provisioner,
+	"local-exec":   localexecprovisioner.Provisioner,
+	"remote-exec":   remoteexecprovisioner.Provisioner,
+
 }
 
 func init() {
@@ -155,3 +157,4 @@ func init() {
 	// built-in provisioners.
 	InternalProvisioners["chef"] = func() terraform.ResourceProvisioner { return new(chefprovisioner.ResourceProvisioner) }
 }
+


### PR DESCRIPTION
Fixes: #12494

The Create was changed to use the default and not d.GetOk - the update
wasn't - this was causing issues when trying to update to a false value

```
% make testacc TEST=./builtin/providers/datadog
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/07 16:20:54 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/datadog -v  -timeout 120m
=== RUN   TestDatadogMonitor_import
--- PASS: TestDatadogMonitor_import (4.77s)
=== RUN   TestDatadogUser_import
--- PASS: TestDatadogUser_import (6.23s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDatadogMonitor_Basic
--- PASS: TestAccDatadogMonitor_Basic (3.83s)
=== RUN   TestAccDatadogMonitor_BasicNoTreshold
--- PASS: TestAccDatadogMonitor_BasicNoTreshold (4.92s)
=== RUN   TestAccDatadogMonitor_Updated
--- PASS: TestAccDatadogMonitor_Updated (5.88s)
=== RUN   TestAccDatadogMonitor_TrimWhitespace
--- PASS: TestAccDatadogMonitor_TrimWhitespace (3.23s)
=== RUN   TestAccDatadogMonitor_Basic_float_int
--- PASS: TestAccDatadogMonitor_Basic_float_int (5.73s)
=== RUN   TestAccDatadogTimeboard_update
--- PASS: TestAccDatadogTimeboard_update (8.86s)
=== RUN   TestValidateAggregatorMethod
--- PASS: TestValidateAggregatorMethod (0.00s)
=== RUN   TestAccDatadogUser_Updated
--- PASS: TestAccDatadogUser_Updated (6.05s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/datadog	49.506s
```