### PR TITLE
Add schema.Provider.TestReset to reset StopContext between tests

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -22,8 +22,9 @@ import (
 
 const TestEnvVar = "TF_ACC"
 
-// TestProvider is implemented by scheme.Provider to allow resetting the
-// provider state between tests.
+// TestProvider can be implemented by any ResourceProvider to provide custom
+// reset functionality at the start of an acceptance test.
+// The helper/schema Provider implements this interface.
 type TestProvider interface {
 	TestReset() error
 }

--- a/helper/schema/provider_test.go
+++ b/helper/schema/provider_test.go
@@ -381,3 +381,29 @@ func TestProviderStop_stopFirst(t *testing.T) {
 		t.Fatal("should be stopped")
 	}
 }
+
+func TestProviderReset(t *testing.T) {
+	var p Provider
+	stopCtx := p.StopContext()
+	p.MetaReset = func() error {
+		stopCtx = p.StopContext()
+		return nil
+	}
+
+	// cancel the current context
+	p.Stop()
+
+	if err := p.TestReset(); err != nil {
+		t.Fatal(err)
+	}
+
+	// the first context should have been replaced
+	if err := stopCtx.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	// we should not get a canceled context here either
+	if err := p.StopContext().Err(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -56,6 +56,8 @@ type MockResourceProvider struct {
 	ReadDataDiffFn                 func(*InstanceInfo, *ResourceConfig) (*InstanceDiff, error)
 	ReadDataDiffReturn             *InstanceDiff
 	ReadDataDiffReturnError        error
+	TestResetCalled                bool
+	TestResetError                 error
 	StopCalled                     bool
 	StopFn                         func() error
 	StopReturnError                error
@@ -142,6 +144,14 @@ func (p *MockResourceProvider) Configure(c *ResourceConfig) error {
 	}
 
 	return p.ConfigureReturnError
+}
+
+func (p *MockResourceProvider) TestReset() error {
+	p.Lock()
+	defer p.Unlock()
+
+	p.TestResetCalled = true
+	return p.TestResetError
 }
 
 func (p *MockResourceProvider) Stop() error {

--- a/terraform/resource_provider_mock.go
+++ b/terraform/resource_provider_mock.go
@@ -56,8 +56,6 @@ type MockResourceProvider struct {
 	ReadDataDiffFn                 func(*InstanceInfo, *ResourceConfig) (*InstanceDiff, error)
 	ReadDataDiffReturn             *InstanceDiff
 	ReadDataDiffReturnError        error
-	TestResetCalled                bool
-	TestResetError                 error
 	StopCalled                     bool
 	StopFn                         func() error
 	StopReturnError                error
@@ -144,14 +142,6 @@ func (p *MockResourceProvider) Configure(c *ResourceConfig) error {
 	}
 
 	return p.ConfigureReturnError
-}
-
-func (p *MockResourceProvider) TestReset() error {
-	p.Lock()
-	defer p.Unlock()
-
-	p.TestResetCalled = true
-	return p.TestResetError
 }
 
 func (p *MockResourceProvider) Stop() error {


### PR DESCRIPTION
In normal operation, a provider is only created once and only ever canceled once, but in testing a ResourceProvider may be initialized and reused throughout multiple tests. 

This poses a problem when `Stop()` has been called on a provider and the StopContext has been used by the provider. 

This adds a `TestReset` method to `schema.Provider` to reset its internal state, currently only consisting of the internal Context. `Provider.TestReset` will then call Provider.MetaReset if it's not nil, which can be used to reset any state stored in the meta interface value which is especially important if it stored a StopContext value. 

The TestReset method will be automatically called after PreCheck in resource.Test.