### PR TITLE
provider/aws: Rename 'timeout' to 'build_timeout' for Codebuild

### DIFF
--- a/builtin/providers/aws/resource_aws_codebuild_project.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project.go
@@ -164,6 +164,12 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validateAwsCodeBuildTimeout,
+				Removed:      "This field has been removed. Please use build_timeout instead",
+			},
+			"build_timeout": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ValidateFunc: validateAwsCodeBuildTimeout,
 			},
 			"tags": tagsSchema(),
 		},
@@ -196,7 +202,7 @@ func resourceAwsCodeBuildProjectCreate(d *schema.ResourceData, meta interface{})
 		params.ServiceRole = aws.String(v.(string))
 	}
 
-	if v, ok := d.GetOk("timeout"); ok {
+	if v, ok := d.GetOk("build_timeout"); ok {
 		params.TimeoutInMinutes = aws.Int64(int64(v.(int)))
 	}
 
@@ -373,7 +379,7 @@ func resourceAwsCodeBuildProjectRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("encryption_key", project.EncryptionKey)
 	d.Set("name", project.Name)
 	d.Set("service_role", project.ServiceRole)
-	d.Set("timeout", project.TimeoutInMinutes)
+	d.Set("build_timeout", project.TimeoutInMinutes)
 
 	if err := d.Set("tags", tagsToMapCodeBuild(project.Tags)); err != nil {
 		return err
@@ -416,8 +422,8 @@ func resourceAwsCodeBuildProjectUpdate(d *schema.ResourceData, meta interface{})
 		params.ServiceRole = aws.String(d.Get("service_role").(string))
 	}
 
-	if d.HasChange("timeout") {
-		params.TimeoutInMinutes = aws.Int64(int64(d.Get("timeout").(int)))
+	if d.HasChange("build_timeout") {
+		params.TimeoutInMinutes = aws.Int64(int64(d.Get("build_timeout").(int)))
 	}
 
 	// The documentation clearly says "The replacement set of tags for this build project."

--- a/builtin/providers/aws/resource_aws_codebuild_project_migrate.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project_migrate.go
@@ -1,0 +1,36 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsCodebuildMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Codebuild State v0; migrating to v1")
+		return migrateCodebuildStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateCodebuildStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	if is.Attributes["timeout"] != "" {
+		is.Attributes["build_timeout"] = strings.TrimSpace(is.Attributes["timeout"])
+	}
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/aws/resource_aws_codebuild_project_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project_migrate_test.go
@@ -1,0 +1,53 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSCodebuildMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			ID:           "tf-testing-file",
+			Attributes: map[string]string{
+				"description": "some description",
+				"timeout":     "5",
+			},
+			Expected: "5",
+		},
+		"v0_2": {
+			StateVersion: 0,
+			ID:           "tf-testing-file",
+			Attributes: map[string]string{
+				"description":   "some description",
+				"build_timeout": "5",
+			},
+			Expected: "5",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsCodebuildMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.Attributes["build_timeout"] != tc.Expected {
+			t.Fatalf("Bad build_timeout migration: %s\n\n expected: %s", is.Attributes["build_timeout"], tc.Expected)
+		}
+	}
+}

--- a/builtin/providers/aws/resource_aws_codebuild_project_test.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project_test.go
@@ -342,7 +342,7 @@ resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
 resource "aws_codebuild_project" "foo" {
   name         = "test-project-%s"
   description  = "test_codebuild_project"
-  timeout      = "5"
+  build_timeout      = "5"
 	service_role = "${aws_iam_role.codebuild_role.arn}"
 
 	artifacts {
@@ -429,7 +429,7 @@ resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
 resource "aws_codebuild_project" "foo" {
   name         = "test-project-%s"
   description  = "test_codebuild_project"
-  timeout      = "5"
+  build_timeout      = "5"
 	service_role = "${aws_iam_role.codebuild_role.arn}"
 
 	artifacts {

--- a/website/source/docs/providers/aws/r/codebuild_project.html.markdown
+++ b/website/source/docs/providers/aws/r/codebuild_project.html.markdown
@@ -66,7 +66,7 @@ resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
 resource "aws_codebuild_project" "foo" {
   name         = "test-project"
   description  = "test_codebuild_project"
-  timeout      = "5"
+  build_timeout      = "5"
   service_role = "${aws_iam_role.codebuild_role.arn}"
 
   artifacts {
@@ -108,7 +108,7 @@ The following arguments are supported:
 * `description` - (Optional) A short description of the project.
 * `encryption_key` - (Optional) The AWS Key Management Service (AWS KMS) customer master key (CMK) to be used for encrypting the build project's build output artifacts.
 * `service_role` - (Optional) The Amazon Resource Name (ARN) of the AWS Identity and Access Management (IAM) role that enables AWS CodeBuild to interact with dependent AWS services on behalf of the AWS account.
-* `timeout` - (Optional) How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
+* `build_timeout` - (Optional) How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. The default is 60 minutes.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `artifacts` - (Required) Information about the project's build output artifacts. Artifact blocks are documented below.
 * `environment` - (Required) Information about the project's build environment. Environment blocks are documented below.


### PR DESCRIPTION
Step one of a fix to attribute collision between `aws_codebuild` and `helper/schema/resource_timeout`. 

Both Codebuild and the new Timeouts feature have a root level name of `timeout`, which was causing a panic in Terraform. Guarding against the panic has been fixed in https://github.com/hashicorp/terraform/commit/aa3677cd896809718f26d066216ded14673a7961. 

This PR renames `aws_codebuild`'s argument of `timeout` to `build_timeout`, to further distinguish and just give a better name to what the argument does. 

This is a BACKWARDS INCOMPATIBILITY however the `aws_codebuild` resource was just released, and I felt the impact minimal. The only thing required is to update the configuration name from `timeout` to `build_timeout` in the configuration, that while is breaking, is much clearer in the intent. 


------

This is intended for the `v0.9` release branch only