### PR TITLE
nested lists in variables panic during validation

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -201,6 +201,12 @@ func TestConfigValidate_table(t *testing.T) {
 			true,
 			"cannot contain interp",
 		},
+		{
+			"nested types in variable default",
+			"validate-var-nested",
+			true,
+			"ERROR",
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -204,8 +204,8 @@ func TestConfigValidate_table(t *testing.T) {
 		{
 			"nested types in variable default",
 			"validate-var-nested",
-			true,
-			"ERROR",
+			false,
+			"",
 		},
 	}
 

--- a/config/interpolate_walk.go
+++ b/config/interpolate_walk.go
@@ -206,6 +206,12 @@ func (w *interpolationWalker) Primitive(v reflect.Value) error {
 }
 
 func (w *interpolationWalker) replaceCurrent(v reflect.Value) {
+	// if we don't have at least 2 values, we're not going to find a map, but
+	// we could panic.
+	if len(w.cs) < 2 {
+		return
+	}
+
 	c := w.cs[len(w.cs)-2]
 	switch c.Kind() {
 	case reflect.Map:

--- a/config/test-fixtures/validate-var-nested/main.tf
+++ b/config/test-fixtures/validate-var-nested/main.tf
@@ -1,0 +1,6 @@
+variable "foo" {
+  default = [["foo", "bar"]]
+}
+variable "bar" {
+  default = [{foo = "bar"}]
+}


### PR DESCRIPTION
Verify that we have enough containers in the stack to look for a map in
replaceCurrent.

This won't guarantee that nested containers work in all cases (they don't), but we shouldn't panic when validating the config. 

Fixes #12450