### PR TITLE
Bug Fix: Terraform crashes during azurerm_container_service provisioning

### DIFF
--- a/builtin/providers/azurerm/resource_arm_container_service.go
+++ b/builtin/providers/azurerm/resource_arm_container_service.go
@@ -360,7 +360,7 @@ func flattenAzureRmContainerServiceLinuxProfile(profile containerservice.LinuxPr
 	}
 
 	values["admin_username"] = *profile.AdminUsername
-	values["ssh_key"] = &sshKeys
+	values["ssh_key"] = sshKeys
 	profiles.Add(values)
 
 	return profiles

--- a/builtin/providers/azurerm/resource_arm_container_service_test.go
+++ b/builtin/providers/azurerm/resource_arm_container_service_test.go
@@ -154,7 +154,7 @@ func TestAccAzureRMContainerService_swarmBasic(t *testing.T) {
 var testAccAzureRMContainerService_dcosBasic = `
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "West US"
+  location = "East US"
 }
 
 resource "azurerm_container_service" "test" {
@@ -235,7 +235,7 @@ resource "azurerm_container_service" "test" {
 var testAccAzureRMContainerService_kubernetesComplete = `
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "West US"
+  location = "East US"
 }
 
 resource "azurerm_container_service" "test" {
@@ -282,7 +282,7 @@ resource "azurerm_container_service" "test" {
 var testAccAzureRMContainerService_swarmBasic = `
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "West US"
+  location = "East US"
 }
 
 resource "azurerm_container_service" "test" {

--- a/builtin/providers/azurerm/resource_arm_container_service_test.go
+++ b/builtin/providers/azurerm/resource_arm_container_service_test.go
@@ -192,7 +192,7 @@ resource "azurerm_container_service" "test" {
 var testAccAzureRMContainerService_kubernetesBasic = `
 resource "azurerm_resource_group" "test" {
   name     = "acctestRG-%d"
-  location = "West US"
+  location = "East US"
 }
 
 resource "azurerm_container_service" "test" {


### PR DESCRIPTION
Fixed pointer to pointer referencing issue causing crash while provisioning azurerm_container_service  (#12510).

Also updated tests to use East US region since resources required for tests were not available in West US. All container service tests are now passing.