### PR TITLE
Don't append unique id to custom reference name

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_health_check.go
+++ b/builtin/providers/aws/resource_aws_route53_health_check.go
@@ -273,7 +273,7 @@ func resourceAwsRoute53HealthCheckCreate(d *schema.ResourceData, meta interface{
 
 	callerRef := resource.UniqueId()
 	if v, ok := d.GetOk("reference_name"); ok {
-		callerRef = fmt.Sprintf("%s-%s", v.(string), callerRef)
+		callerRef = fmt.Sprintf("%s", v.(string))
 	}
 
 	input := &route53.CreateHealthCheckInput{


### PR DESCRIPTION
This caused some confusion as the 64 char limit of the reference name is easily reached as `terraform-01000000000000000000000000` is appended to the reference name (36 chars).