### PR TITLE
Makefile: restore test check deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ plugin-dev: generate
 	mv $(GOPATH)/bin/$(PLUGIN) $(GOPATH)/bin/terraform-$(PLUGIN)
 
 # test runs the unit tests
-test:# fmtcheck errcheck generate
+test: fmtcheck errcheck generate
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
 		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4


### PR DESCRIPTION
https://github.com/hashicorp/terraform/commit/f4ca79d7b76c0ef9b64960328d43b87b6f79b4ee removed some dependency checks to `make test`, and we've had some minor things slip through the cracks as a result. This PR restores those additional checks.

cc @mitchellh