### PR TITLE
provider/aws: Support the ability to enable / disable ipv6 support in VPC

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_test.go
@@ -46,7 +46,7 @@ func TestAccAWSVpc_enableIpv6(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccVpcConfigIpv6Enabled,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckVpcExists("aws_vpc.foo", &vpc),
 					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
 					resource.TestCheckResourceAttr(
@@ -55,6 +55,34 @@ func TestAccAWSVpc_enableIpv6(t *testing.T) {
 						"aws_vpc.foo", "ipv6_association_id"),
 					resource.TestCheckResourceAttrSet(
 						"aws_vpc.foo", "ipv6_cidr_block"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "true"),
+				),
+			},
+			{
+				Config: testAccVpcConfigIpv6Disabled,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVpcExists("aws_vpc.foo", &vpc),
+					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "false"),
+				),
+			},
+			{
+				Config: testAccVpcConfigIpv6Enabled,
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckVpcExists("aws_vpc.foo", &vpc),
+					testAccCheckVpcCidr(&vpc, "10.1.0.0/16"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.foo", "cidr_block", "10.1.0.0/16"),
+					resource.TestCheckResourceAttrSet(
+						"aws_vpc.foo", "ipv6_association_id"),
+					resource.TestCheckResourceAttrSet(
+						"aws_vpc.foo", "ipv6_cidr_block"),
+					resource.TestCheckResourceAttr(
+						"aws_vpc.foo", "assign_generated_ipv6_cidr_block", "true"),
 				),
 			},
 		},
@@ -280,6 +308,12 @@ const testAccVpcConfigIpv6Enabled = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.1.0.0/16"
 	assign_generated_ipv6_cidr_block = true
+}
+`
+
+const testAccVpcConfigIpv6Disabled = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
 }
 `
 


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpc_' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/28 15:49:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpc_ -timeout 120m
=== RUN   TestAccAWSVpc_importBasic
--- PASS: TestAccAWSVpc_importBasic (102.01s)
=== RUN   TestAccAWSVpc_basic
--- PASS: TestAccAWSVpc_basic (63.75s)
=== RUN   TestAccAWSVpc_enableIpv6
--- PASS: TestAccAWSVpc_enableIpv6 (231.41s)
=== RUN   TestAccAWSVpc_dedicatedTenancy
--- PASS: TestAccAWSVpc_dedicatedTenancy (66.65s)
=== RUN   TestAccAWSVpc_tags
--- PASS: TestAccAWSVpc_tags (130.26s)
=== RUN   TestAccAWSVpc_update
--- PASS: TestAccAWSVpc_update (120.21s)
=== RUN   TestAccAWSVpc_bothDnsOptionsSet
--- PASS: TestAccAWSVpc_bothDnsOptionsSet (50.10s)
=== RUN   TestAccAWSVpc_DisabledDnsSupport
--- PASS: TestAccAWSVpc_DisabledDnsSupport (67.47s)
=== RUN   TestAccAWSVpc_classiclinkOptionSet
--- PASS: TestAccAWSVpc_classiclinkOptionSet (64.57s)
PASS
ok	github.com/hashicorp/terraform/builtin/providers/aws	896.464s
```