### PR TITLE
provider/aws: Add the IPV6 cidr block to the vpc datasource

### DIFF
--- a/builtin/providers/aws/data_source_aws_vpc.go
+++ b/builtin/providers/aws/data_source_aws_vpc.go
@@ -14,19 +14,19 @@ func dataSourceAwsVpc() *schema.Resource {
 		Read: dataSourceAwsVpcRead,
 
 		Schema: map[string]*schema.Schema{
-			"cidr_block": &schema.Schema{
+			"cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"dhcp_options_id": &schema.Schema{
+			"dhcp_options_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"default": &schema.Schema{
+			"default": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Computed: true,
@@ -34,18 +34,28 @@ func dataSourceAwsVpc() *schema.Resource {
 
 			"filter": ec2CustomFiltersSchema(),
 
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"instance_tenancy": &schema.Schema{
+			"instance_tenancy": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"state": &schema.Schema{
+			"ipv6_cidr_block": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"ipv6_association_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"state": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -116,6 +126,11 @@ func dataSourceAwsVpcRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("default", vpc.IsDefault)
 	d.Set("state", vpc.State)
 	d.Set("tags", tagsToMap(vpc.Tags))
+
+	if vpc.Ipv6CidrBlockAssociationSet != nil {
+		d.Set("ipv6_association_id", vpc.Ipv6CidrBlockAssociationSet[0].AssociationId)
+		d.Set("ipv6_cidr_block", vpc.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock)
+	}
 
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_vpc_test.go
+++ b/builtin/providers/aws/data_source_aws_vpc_test.go
@@ -13,13 +13,32 @@ func TestAccDataSourceAwsVpc_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsVpcConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_id"),
 					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_cidr"),
 					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_tag"),
 					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_filter"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsVpc_ipv6Associated(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsVpcConfigIpv6,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsVpcCheck("data.aws_vpc.by_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_vpc.by_id", "ipv6_association_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_vpc.by_id", "ipv6_cidr_block"),
 				),
 			},
 		},
@@ -58,6 +77,25 @@ func testAccDataSourceAwsVpcCheck(name string) resource.TestCheckFunc {
 		return nil
 	}
 }
+
+const testAccDataSourceAwsVpcConfigIpv6 = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "172.16.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags {
+    Name = "terraform-testacc-vpc-data-source"
+  }
+}
+
+data "aws_vpc" "by_id" {
+  id = "${aws_vpc.test.id}"
+}
+`
 
 const testAccDataSourceAwsVpcConfig = `
 provider "aws" {

--- a/website/source/docs/providers/aws/d/vpc.html.markdown
+++ b/website/source/docs/providers/aws/d/vpc.html.markdown
@@ -77,3 +77,7 @@ The following attribute is additionally exported:
 
 * `instance_tenancy` - The allowed tenancy of instances launched into the
   selected VPC. May be any of `"default"`, `"dedicated"`, or `"host"`.
+
+* `ipv6_association_id` - The association ID for the IPv6 CIDR block.
+
+* `ipv6_cidr_block` - The IPv6 CIDR block.


### PR DESCRIPTION
Fixes: #12526

```
% make testacc TEST=./builtin/providers/aws  TESTARGS='-run=TestAccDataSourceAwsVpc_ipv6Associated'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/08 17:42:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v
-run=TestAccDataSourceAwsVpc_ipv6Associated -timeout 120m
=== RUN   TestAccDataSourceAwsVpc_ipv6Associated
--- PASS: TestAccDataSourceAwsVpc_ipv6Associated (71.33s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws71.366s
```