### PR TITLE
provider/aws: Default build_timeout to 60, matching docs, update tests

### DIFF
--- a/builtin/providers/aws/resource_aws_codebuild_project.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project.go
@@ -169,6 +169,7 @@ func resourceAwsCodeBuildProject() *schema.Resource {
 			"build_timeout": {
 				Type:         schema.TypeInt,
 				Optional:     true,
+				Default:      "60",
 				ValidateFunc: validateAwsCodeBuildTimeout,
 			},
 			"tags": tagsSchema(),

--- a/builtin/providers/aws/resource_aws_codebuild_project_test.go
+++ b/builtin/providers/aws/resource_aws_codebuild_project_test.go
@@ -25,19 +25,51 @@ func TestAccAWSCodeBuildProject_basic(t *testing.T) {
 				Config: testAccAWSCodeBuildProjectConfig_basic(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codebuild_project.foo", "build_timeout", "5"),
 				),
 			},
 			{
 				Config: testAccAWSCodeBuildProjectConfig_basicUpdated(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codebuild_project.foo", "build_timeout", "50"),
 				),
 			},
 		},
 	})
 }
 
-func TestAccAWSCodeBuildProject_artifactsTypeValidation(t *testing.T) {
+func TestAccAWSCodeBuildProject_default_build_timeout(t *testing.T) {
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodeBuildProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCodeBuildProjectConfig_default_timeout(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codebuild_project.foo", "build_timeout", "60"),
+				),
+			},
+			{
+				Config: testAccAWSCodeBuildProjectConfig_basicUpdated(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodeBuildProjectExists("aws_codebuild_project.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_codebuild_project.foo", "build_timeout", "50"),
+				),
+			},
+		},
+	})
+}
+
+func TestAWSCodeBuildProject_artifactsTypeValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -57,7 +89,7 @@ func TestAccAWSCodeBuildProject_artifactsTypeValidation(t *testing.T) {
 	}
 }
 
-func TestAccAWSCodeBuildProject_artifactsNamespaceTypeValidation(t *testing.T) {
+func TestAWSCodeBuildProject_artifactsNamespaceTypeValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -94,7 +126,7 @@ func longTestData() string {
 	}, data)
 }
 
-func TestAccAWSCodeBuildProject_nameValidation(t *testing.T) {
+func TestAWSCodeBuildProject_nameValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -115,7 +147,7 @@ func TestAccAWSCodeBuildProject_nameValidation(t *testing.T) {
 	}
 }
 
-func TestAccAWSCodeBuildProject_descriptionValidation(t *testing.T) {
+func TestAWSCodeBuildProject_descriptionValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -133,7 +165,7 @@ func TestAccAWSCodeBuildProject_descriptionValidation(t *testing.T) {
 	}
 }
 
-func TestAccAWSCodeBuildProject_environmentComputeTypeValidation(t *testing.T) {
+func TestAWSCodeBuildProject_environmentComputeTypeValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -153,7 +185,7 @@ func TestAccAWSCodeBuildProject_environmentComputeTypeValidation(t *testing.T) {
 	}
 }
 
-func TestAccAWSCodeBuildProject_environmentTypeValidation(t *testing.T) {
+func TestAWSCodeBuildProject_environmentTypeValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -171,7 +203,7 @@ func TestAccAWSCodeBuildProject_environmentTypeValidation(t *testing.T) {
 	}
 }
 
-func TestAccAWSCodeBuildProject_sourceTypeValidation(t *testing.T) {
+func TestAWSCodeBuildProject_sourceTypeValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -192,7 +224,7 @@ func TestAccAWSCodeBuildProject_sourceTypeValidation(t *testing.T) {
 	}
 }
 
-func TestAccAWSCodeBuildProject_sourceAuthTypeValidation(t *testing.T) {
+func TestAWSCodeBuildProject_sourceAuthTypeValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
 		ErrCount int
@@ -210,7 +242,7 @@ func TestAccAWSCodeBuildProject_sourceAuthTypeValidation(t *testing.T) {
 	}
 }
 
-func TestAccAWSCodeBuildProject_timeoutValidation(t *testing.T) {
+func TestAWSCodeBuildProject_timeoutValidation(t *testing.T) {
 	cases := []struct {
 		Value    int
 		ErrCount int
@@ -429,7 +461,94 @@ resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
 resource "aws_codebuild_project" "foo" {
   name         = "test-project-%s"
   description  = "test_codebuild_project"
-  build_timeout      = "5"
+  build_timeout      = "50"
+	service_role = "${aws_iam_role.codebuild_role.arn}"
+
+	artifacts {
+		type = "NO_ARTIFACTS"
+	}
+
+  environment {
+    compute_type = "BUILD_GENERAL1_SMALL"
+    image        = "2"
+    type         = "LINUX_CONTAINER"
+
+		environment_variable = {
+			"name"  = "SOME_OTHERKEY"
+			"value" = "SOME_OTHERVALUE"
+		}
+  }
+
+  source {
+    auth {
+      type = "OAUTH"
+    }
+
+    type     = "GITHUB"
+    location = "https://github.com/mitchellh/packer.git"
+  }
+
+  tags {
+    "Environment" = "Test"
+  }
+}
+`, rName, rName, rName, rName)
+}
+
+func testAccAWSCodeBuildProjectConfig_default_timeout(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "codebuild_role" {
+  name = "codebuild-role-%s"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "codebuild_policy" {
+    name        = "codebuild-policy-%s"
+    path        = "/service-role/"
+    description = "Policy used in trust relationship with CodeBuild"
+    policy      = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_policy_attachment" "codebuild_policy_attachment" {
+  name       = "codebuild-policy-attachment-%s"
+  policy_arn = "${aws_iam_policy.codebuild_policy.arn}"
+  roles      = ["${aws_iam_role.codebuild_role.id}"]
+}
+
+resource "aws_codebuild_project" "foo" {
+  name         = "test-project-%s"
+  description  = "test_codebuild_project"
+
 	service_role = "${aws_iam_role.codebuild_role.arn}"
 
 	artifacts {


### PR DESCRIPTION
`aws_codebuild_project` should have a default of `60` for the `timeout` (now `build_timeout`) attribute, as documented, but we didn't actually have the default in there before.

This caused update issue when the `build_timeout` argument wasn't specified (it's optional).

I also add a new ACC test for this, and renamed some of the exiting ones because they were actually Unit tests. 