### PR TITLE
helper/schema: Rename Timeout resource block to Timeouts

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -622,6 +622,10 @@ resource "aws_db_instance" "bar" {
 	backup_retention_period = 0
 
 	parameter_group_name = "default.mysql5.6"
+
+	timeouts {
+		create = "30m"
+	}
 }`
 
 var testAccAWSDBInstanceConfigKmsKeyId = `

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -156,7 +156,7 @@ func TestResourceDiff_Timeout_diff(t *testing.T) {
 	raw, err := config.NewRawConfig(
 		map[string]interface{}{
 			"foo": 42,
-			"timeout": []map[string]interface{}{
+			"timeouts": []map[string]interface{}{
 				map[string]interface{}{
 					"create": "2h",
 				}},

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -10,6 +10,7 @@ import (
 )
 
 const TimeoutKey = "e2bfb730-ecaa-11e6-8f88-34363bc7c4c0"
+const TimeoutsConfigKey = "timeouts"
 
 const (
 	TimeoutCreate  = "create"
@@ -60,7 +61,7 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig)
 		*t = *raw.(*ResourceTimeout)
 	}
 
-	if raw, ok := c.Config["timeouts"]; ok {
+	if raw, ok := c.Config[TimeoutsConfigKey]; ok {
 		if configTimeouts, ok := raw.([]map[string]interface{}); ok {
 			for _, timeoutValues := range configTimeouts {
 				// loop through each Timeout given in the configuration and validate they

--- a/helper/schema/resource_timeout.go
+++ b/helper/schema/resource_timeout.go
@@ -60,7 +60,7 @@ func (t *ResourceTimeout) ConfigDecode(s *Resource, c *terraform.ResourceConfig)
 		*t = *raw.(*ResourceTimeout)
 	}
 
-	if raw, ok := c.Config["timeout"]; ok {
+	if raw, ok := c.Config["timeouts"]; ok {
 		if configTimeouts, ok := raw.([]map[string]interface{}); ok {
 			for _, timeoutValues := range configTimeouts {
 				// loop through each Timeout given in the configuration and validate they

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -63,8 +63,8 @@ func TestResourceTimeout_ConfigDecode_badkey(t *testing.T) {
 
 			raw, err := config.NewRawConfig(
 				map[string]interface{}{
-					"foo":      "bar",
-					"timeouts": c.Config,
+					"foo":             "bar",
+					TimeoutsConfigKey: c.Config,
 				})
 			if err != nil {
 				t.Fatalf("err: %s", err)
@@ -104,7 +104,7 @@ func TestResourceTimeout_ConfigDecode(t *testing.T) {
 	raw, err := config.NewRawConfig(
 		map[string]interface{}{
 			"foo": "bar",
-			"timeouts": []map[string]interface{}{
+			TimeoutsConfigKey: []map[string]interface{}{
 				map[string]interface{}{
 					"create": "2m",
 				},

--- a/helper/schema/resource_timeout_test.go
+++ b/helper/schema/resource_timeout_test.go
@@ -63,8 +63,8 @@ func TestResourceTimeout_ConfigDecode_badkey(t *testing.T) {
 
 			raw, err := config.NewRawConfig(
 				map[string]interface{}{
-					"foo":     "bar",
-					"timeout": c.Config,
+					"foo":      "bar",
+					"timeouts": c.Config,
 				})
 			if err != nil {
 				t.Fatalf("err: %s", err)
@@ -104,7 +104,7 @@ func TestResourceTimeout_ConfigDecode(t *testing.T) {
 	raw, err := config.NewRawConfig(
 		map[string]interface{}{
 			"foo": "bar",
-			"timeout": []map[string]interface{}{
+			"timeouts": []map[string]interface{}{
 				map[string]interface{}{
 					"create": "2m",
 				},

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1327,7 +1327,7 @@ func (m schemaMap) validateObject(
 	if m, ok := raw.(map[string]interface{}); ok {
 		for subk, _ := range m {
 			if _, ok := schema[subk]; !ok {
-				if subk == "timeouts" {
+				if subk == TimeoutsConfigKey {
 					continue
 				}
 				es = append(es, fmt.Errorf(

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1327,7 +1327,7 @@ func (m schemaMap) validateObject(
 	if m, ok := raw.(map[string]interface{}); ok {
 		for subk, _ := range m {
 			if _, ok := schema[subk]; !ok {
-				if subk == "timeout" {
+				if subk == "timeouts" {
 					continue
 				}
 				es = append(es, fmt.Errorf(

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4785,7 +4785,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 			},
 
 			Config: map[string]interface{}{
-				"timeouts": "bar",
+				TimeoutsConfigKey: "bar",
 			},
 
 			Err: false,

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -4774,7 +4774,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Err: false,
 		},
 
-		"special timeout field": {
+		"special timeouts field": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -4785,7 +4785,7 @@ func TestSchemaMap_Validate(t *testing.T) {
 			},
 
 			Config: map[string]interface{}{
-				"timeout": "bar",
+				"timeouts": "bar",
 			},
 
 			Err: false,

--- a/website/source/docs/configuration/resources.html.md
+++ b/website/source/docs/configuration/resources.html.md
@@ -102,7 +102,7 @@ wildcard (e.g. `"rout*"`) is **not** supported.
 
 ### Timeouts
 
-Individual Resources may provide a `timeout` block to enable users to configure the
+Individual Resources may provide a `timeouts` block to enable users to configure the
 amount of time a specific operation is allowed to take before being considered
 an error. For example, the 
 [aws_db_instance](/docs/providers/aws/r/db_instance.html#timeouts) 
@@ -122,7 +122,7 @@ resource "aws_db_instance" "timeout_example" {
   name                 = "mydb"
   [...]
 
-  timeout {
+  timeouts {
     create = "60m"
     delete = "2h"
   }


### PR DESCRIPTION
Pluralize configuration argument name to better represent that there is
one block for many timeouts. Also adds a `timeouts` block into the `db_instance` basic test, just to have them present in an acceptance test.


Example:
```
resource "example" "name" {
  name = "thing"

  timeout {
    create = "10m"
    update = "5m"
  }
}
```

Becomes:

```
resource "example" "name" {
  name = "thing"

  timeouts {
    create = "10m"
    update = "5m"
  }
}
```

This is a follow up change to the following:

- https://github.com/hashicorp/terraform/commit/aa3677cd896809718f26d066216ded14673a7961
- https://github.com/hashicorp/terraform/pull/12503

cc @mitchellh 

------

This is intended for `v0.9` only, as Timeouts were not back ported to `v0.8.x` series 