### PR TITLE
provider/aws: Prevent aws_dms_replication_task panic

### DIFF
--- a/builtin/providers/aws/resource_aws_dms_replication_task.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_task.go
@@ -27,7 +27,7 @@ func resourceAwsDmsReplicationTask() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"cdc_start_time": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 				// Requires a Unix timestamp in seconds. Example 1484346880
 			},


### PR DESCRIPTION
Fixes: #12506

When a replication_task cdc_start_time was specified as an int, it was
causing a panic as the conversion to a Unix timestampe was expecting a
string

It's important to know that the schema was incorrect here - the strip was required for the Parse of the time not an int

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAwsDmsReplicationTaskBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/08 22:55:29 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAwsDmsReplicationTaskBasic -timeout 120m
=== RUN   TestAccAwsDmsReplicationTaskBasic
--- PASS: TestAccAwsDmsReplicationTaskBasic (1089.77s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1089.802s
```