### PR TITLE
provider/aws: Add support to set iam_role_arn on cloudformation Stack

### DIFF
--- a/builtin/providers/aws/data_source_aws_cloudformation_stack.go
+++ b/builtin/providers/aws/data_source_aws_cloudformation_stack.go
@@ -58,6 +58,10 @@ func dataSourceAwsCloudFormationStack() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"iam_role_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"tags": {
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -86,6 +90,7 @@ func dataSourceAwsCloudFormationStackRead(d *schema.ResourceData, meta interface
 	d.Set("description", stack.Description)
 	d.Set("disable_rollback", stack.DisableRollback)
 	d.Set("timeout_in_minutes", stack.TimeoutInMinutes)
+	d.Set("iam_role_arn", stack.RoleARN)
 
 	if len(stack.NotificationARNs) > 0 {
 		d.Set("notification_arns", schema.NewSet(schema.HashString, flattenStringList(stack.NotificationARNs)))

--- a/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
@@ -20,7 +20,7 @@ func TestAccAWSCloudFormation_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.network", &stack),
@@ -38,7 +38,7 @@ func TestAccAWSCloudFormation_yaml(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_yaml,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.yaml", &stack),
@@ -56,7 +56,7 @@ func TestAccAWSCloudFormation_defaultParams(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_defaultParams,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.asg-demo", &stack),
@@ -75,7 +75,7 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
@@ -93,7 +93,7 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "timeout_in_minutes", "10"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies_modified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
@@ -124,13 +124,13 @@ func TestAccAWSCloudFormation_withParams(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_withParams,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_withParams_modified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
@@ -149,13 +149,13 @@ func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_templateUrl_withParams,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_templateUrl_withParams_modified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
@@ -173,7 +173,7 @@ func TestAccAWSCloudFormation_withUrl_withParams_withYaml(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFormationConfig_templateUrl_withParams_withYaml,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params-and-yaml", &stack),

--- a/website/source/docs/providers/aws/d/cloudformation_stack.html.markdown
+++ b/website/source/docs/providers/aws/d/cloudformation_stack.html.markdown
@@ -47,4 +47,5 @@ The following attributes are exported:
 * `parameters` - A map of parameters that specify input parameters for the stack.
 * `tags` - A map of tags associated with this stack.
 * `template_body` - Structure containing the template body.
+* `iam_role_arn` - The ARN of the IAM role used to create the stack.
 * `timeout_in_minutes` - The amount of time that can pass before the stack status becomes `CREATE_FAILED`

--- a/website/source/docs/providers/aws/r/cloudformation_stack.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudformation_stack.html.markdown
@@ -65,6 +65,7 @@ The following arguments are supported:
 * `policy_url` - (Optional) Location of a file containing the stack policy.
   Conflicts w/ `policy_body`.
 * `tags` - (Optional) A list of tags to associate with this stack.
+* `iam_role_arn` - (Optional) The ARN of an IAM role that AWS CloudFormation assumes to create the stack. If you don't specify a value, AWS CloudFormation uses the role that was previously associated with the stack. If no role is available, AWS CloudFormation uses a temporary session that is generated from your user credentials.
 * `timeout_in_minutes` - (Optional) The amount of time that can pass before the stack status becomes `CREATE_FAILED`.
 
 ## Attributes Reference


### PR DESCRIPTION
Fixes: #11266

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudFormation_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/09 01:39:16 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudFormation_basic -timeout 120m
=== RUN   TestAccAWSCloudFormation_basic
--- PASS: TestAccAWSCloudFormation_basic (89.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	89.416s
```