### PR TITLE
Add aws_emr_cluster documentation clarifications

### DIFF
--- a/website/source/docs/providers/aws/r/emr_cluster.html.md
+++ b/website/source/docs/providers/aws/r/emr_cluster.html.md
@@ -71,13 +71,13 @@ The following arguments are supported:
 * `core_instance_count` - (Optional) Number of Amazon EC2 instances used to execute the job flow. EMR will use one node as the cluster's master node and use the remainder of the nodes (`core_instance_count`-1) as core nodes. Default `1`
 * `log_uri` - (Optional) S3 bucket to write the log files of the job flow. If a value
 	is not provided, logs are not created
-* `applications` - (Optional) A list of applications for the cluster. Valid values are: `Flink`, `Hadoop`, `Hive`, `Mahout`, `Pig`, and `Spark`. Case insensitive
+* `applications` - (Optional) A list of applications for the cluster. Values are passed directly to the AWS API, valid values varies with EMR release, examples include: `Flink`, `Ganglia`, `Hadoop`, `Hive`, `Mahout`, `Pig`, and `Spark`. Case insensitive
 * `termination_protection` - (Optional) Switch on/off termination protection (default is off) 
 * `keep_job_flow_alive_when_no_steps` - (Optional) Switch on/off run cluster with no steps or when all steps are complete (default is on)
 * `ec2_attributes` - (Optional) Attributes for the EC2 instances running the job
 flow. Defined below
 * `bootstrap_action` - (Optional) List of bootstrap actions that will be run before Hadoop is started on
-	the cluster nodes. Defined below
+	the cluster nodes. Order of actions is not guaranteed. Defined below
 * `configurations` - (Optional) List of configurations supplied for the EMR cluster you are creating
 * `visible_to_all_users` - (Optional) Whether the job flow is visible to all IAM users of the AWS account associated with the job flow. Default `true`
 * `tags` - (Optional) list of tags to apply to the EMR Cluster


### PR DESCRIPTION
In the documentation for aws_emr_cluster it specifies a small list of valid actions, terraform is not validating these, and they are passed directly to the aws api. The actual list of valid actions varies depending on which emr version you specify.

I've also included a clarification to make it clear bootstrap actions order is not guaranteed. It is when created through the AWS console, but since they are stored in a Set internally in terraform the order specified in the resource is not guaranteed to be passed as-is to the api. I think this behaviour would be better changed so order is guaranteed but at least for now this documentation change reflects reality. It took me some experimentation to find this out so I thought it would be better to make it clear up front.

This applies to the current version of terraform (0.8.8).