### PR TITLE
provider/pagerduty: Improve errors

### DIFF
--- a/vendor/github.com/PagerDuty/go-pagerduty/client.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/client.go
@@ -37,9 +37,9 @@ type APIReference struct {
 }
 
 type errorObject struct {
-	Code   int      `json:"code,omitempty"`
-	Mesage string   `json:"message,omitempty"`
-	Errors []string `json:"errors,omitempty"`
+	Code    int         `json:"code,omitempty"`
+	Message string      `json:"message,omitempty"`
+	Errors  interface{} `json:"errors,omitempty"`
 }
 
 // Client wraps http client

--- a/vendor/github.com/PagerDuty/go-pagerduty/maintenance_window.go
+++ b/vendor/github.com/PagerDuty/go-pagerduty/maintenance_window.go
@@ -9,13 +9,13 @@ import (
 // MaintenanceWindow is used to temporarily disable one or more services for a set period of time.
 type MaintenanceWindow struct {
 	APIObject
-	SequenceNumber uint   `json:"sequence_number,omitempty"`
-	StartTime      string `json:"start_time"`
-	EndTime        string `json:"end_time"`
-	Description    string
-	Services       []APIObject
-	Teams          []APIListObject
-	CreatedBy      APIListObject `json:"created_by"`
+	SequenceNumber uint            `json:"sequence_number,omitempty"`
+	StartTime      string          `json:"start_time"`
+	EndTime        string          `json:"end_time"`
+	Description    string          `json:"description"`
+	Services       []APIObject     `json:"services"`
+	Teams          []APIListObject `json:"teams"`
+	CreatedBy      APIListObject   `json:"created_by"`
 }
 
 // ListMaintenanceWindowsResponse is the data structur returned from calling the ListMaintenanceWindows API endpoint.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -381,10 +381,10 @@
 			"revisionTime": "2016-11-03T18:56:17Z"
 		},
 		{
-			"checksumSHA1": "ibs+ylGiQibNx5GeZlCKx7A/zH8=",
+			"checksumSHA1": "iysTPYhDNP3x2reGLTMgNHw+iL0=",
 			"path": "github.com/PagerDuty/go-pagerduty",
-			"revision": "fcea06d066d768bf90755d1071dd444c6abff524",
-			"revisionTime": "2017-03-01T18:59:23Z"
+			"revision": "cc53abe550274c2dec666e7f44cefc9ee10e429d",
+			"revisionTime": "2017-03-09T00:45:39Z"
 		},
 		{
 			"checksumSHA1": "NX4v3cbkXAJxFlrncqT9yEUBuoA=",


### PR DESCRIPTION
This PR should resolve the issue described in: https://github.com/hashicorp/terraform/issues/11135.

Previously when receiving an error from the PagerDuty API the client library couldn't decode the JSON response thus making it very difficult for the user to know what actually went wrong. 
With this fix in place, we should now be able to see what actually went wrong.

Previously:
```bash
* pagerduty_schedule.my_schedule: Response did not contain formatted error: Could not decode JSON response: json: cannot unmarshal object into Go value of type []string. HTTP response code: 400. Raw response: &{Status:400 Bad Request StatusCode:400 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Access-Control-Allow-Methods:[GET, POST, PUT, DELETE, OPTIONS] Access-Control-Allow-Origin:[*] Access-Control-Allow-Headers:[Authorization, Content-Type] X-Ua-Compatible:[IE=Edge,chrome=1] Date:[Tue, 10 Jan 2017 18:51:55 GMT] Connection:[keep-alive] Status:[400 Bad Request] Access-Control-Max-Age:[1728000] Cache-Control:[no-cache] X-Request-Id:[70b9b14be473c73684a3c69e478671f0] Server:[nginx] Content-Type:[application/json; charset=utf-8]] Body:0xc4204edc40 ContentLength:-1 TransferEncoding:[chunked] Close:false Uncompressed:false Trailer:map[] Request:0xc4205e7860 TLS:0xc4201b56b0}
```

With the fix in place:
```bash
* pagerduty_schedule.my_schedule: Failed call API endpoint. HTTP response code: 400. Error: &{3001 Invalid Schedule map[rotation_layers.weekly_restrictions.duration_seconds:[Please use a shorter duration or just turn the recurrence off.]]}
```