### PR TITLE
Updated README.md to use Go 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ All documentation is available on the [Terraform website](http://www.terraform.i
 Developing Terraform
 --------------------
 
-If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.7+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
+If you wish to work on Terraform itself or any of its built-in providers, you'll first need [Go](http://www.golang.org) installed on your machine (version 1.8+ is *required*). Alternatively, you can use the Vagrantfile in the root of this repo to stand up a virtual machine with the appropriate dev tooling already set up for you.
 
 For local dev first make sure Go is properly installed, including setting up a [GOPATH](http://golang.org/doc/code.html#GOPATH). You will also need to add `$GOPATH/bin` to your `$PATH`.
 


### PR DESCRIPTION
As per the 1.8 Go release and also @mitchellh's [comment](https://github.com/hashicorp/terraform/issues/12556#issuecomment-285351240), local Terraform developments should use Go 1.8 rather than 1.7 :)

