### PR TITLE
Changes to address #12552

### DIFF
--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -326,31 +326,3 @@ func ignoreCaseDiffSuppressFunc(k, old, new string, d *schema.ResourceData) bool
 func ignoreCaseStateFunc(val interface{}) string {
 	return strings.ToLower(val.(string))
 }
-
-func userDataStateFunc(v interface{}) string {
-	switch s := v.(type) {
-	case string:
-		s = base64Encode(s)
-		hash := sha1.Sum([]byte(s))
-		return hex.EncodeToString(hash[:])
-	default:
-		return ""
-	}
-}
-
-// Base64Encode encodes data if the input isn't already encoded using
-// base64.StdEncoding.EncodeToString. If the input is already base64 encoded,
-// return the original input unchanged.
-func base64Encode(data string) string {
-	// Check whether the data is already Base64 encoded; don't double-encode
-	if isBase64Encoded(data) {
-		return data
-	}
-	// data has not been encoded encode and return
-	return base64.StdEncoding.EncodeToString([]byte(data))
-}
-
-func isBase64Encoded(data string) bool {
-	_, err := base64.StdEncoding.DecodeString(data)
-	return err == nil
-}

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -1,9 +1,6 @@
 package azurerm
 
 import (
-	"crypto/sha1"
-	"encoding/base64"
-	"encoding/hex"
 	"fmt"
 	"log"
 	"reflect"

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -292,6 +292,9 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"admin_password": {
 							Type:     schema.TypeString,
 							Required: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								return true
+							},
 						},
 
 						"custom_data": {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -295,10 +295,8 @@ func resourceArmVirtualMachine() *schema.Resource {
 						},
 
 						"custom_data": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							Computed:  true,
-							StateFunc: userDataStateFunc,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -1038,7 +1038,6 @@ func expandAzureRmVirtualMachineOsProfile(d *schema.ResourceData) (*compute.OSPr
 	}
 
 	if v := osProfile["custom_data"].(string); v != "" {
-		v = base64Encode(v)
 		profile.CustomData = &v
 	}
 

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -92,9 +92,8 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 						},
 
 						"custom_data": {
-							Type:      schema.TypeString,
-							Optional:  true,
-							StateFunc: userDataStateFunc,
+							Type:     schema.TypeString,
+							Optional: true,
 						},
 					},
 				},
@@ -873,7 +872,6 @@ func expandAzureRMVirtualMachineScaleSetsOsProfile(d *schema.ResourceData) (*com
 	}
 
 	if customData != "" {
-		customData = base64Encode(customData)
 		osProfile.CustomData = &customData
 	}
 


### PR DESCRIPTION
The documentation for the Azure API clearly says that the use should provide a base64 encoded string. This is reflected in the provider documentation for a virtual machine.

Change from a computed value to a straight encoded string.
Reference Issue #12552 