### PR TITLE
provider/aws: Update spot instance request to store new ipv6

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -266,6 +266,29 @@ func readInstance(d *schema.ResourceData, meta interface{}) error {
 		if err := readBlockDevices(d, instance, conn); err != nil {
 			return err
 		}
+
+		var ipv6Addresses []string
+		if len(instance.NetworkInterfaces) > 0 {
+			for _, ni := range instance.NetworkInterfaces {
+				if *ni.Attachment.DeviceIndex == 0 {
+					d.Set("subnet_id", ni.SubnetId)
+					d.Set("network_interface_id", ni.NetworkInterfaceId)
+					d.Set("associate_public_ip_address", ni.Association != nil)
+					d.Set("ipv6_address_count", len(ni.Ipv6Addresses))
+
+					for _, address := range ni.Ipv6Addresses {
+						ipv6Addresses = append(ipv6Addresses, *address.Ipv6Address)
+					}
+				}
+			}
+		} else {
+			d.Set("subnet_id", instance.SubnetId)
+			d.Set("network_interface_id", "")
+		}
+
+		if err := d.Set("ipv6_addresses", ipv6Addresses); err != nil {
+			log.Printf("[WARN] Error setting ipv6_addresses for AWS Spot Instance (%s): %s", d.Id(), err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Read and save the new `ipv6` information for Spot Instance Requests

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSpotInstanceRequest_ -timeout 120m
=== RUN   TestAccAWSSpotInstanceRequest_basic
--- PASS: TestAccAWSSpotInstanceRequest_basic (126.28s)
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (85.03s)
=== RUN   TestAccAWSSpotInstanceRequest_vpc
--- PASS: TestAccAWSSpotInstanceRequest_vpc (104.87s)
=== RUN   TestAccAWSSpotInstanceRequest_SubnetAndSG
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSG (87.19s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    403.411s

```