### PR TITLE
Updates heroku-go to the latest revision

### DIFF
--- a/builtin/providers/heroku/resource_heroku_addon_test.go
+++ b/builtin/providers/heroku/resource_heroku_addon_test.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func TestAccHerokuAddon_Basic(t *testing.T) {
-	var addon heroku.Addon
+	var addon heroku.AddOnInfoResult
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -19,7 +20,7 @@ func TestAccHerokuAddon_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckHerokuAddonConfig_basic(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
@@ -38,7 +39,7 @@ func TestAccHerokuAddon_Basic(t *testing.T) {
 
 // GH-198
 func TestAccHerokuAddon_noPlan(t *testing.T) {
-	var addon heroku.Addon
+	var addon heroku.AddOnInfoResult
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -46,7 +47,7 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckHerokuAddonDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckHerokuAddonConfig_no_plan(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
@@ -57,7 +58,7 @@ func TestAccHerokuAddon_noPlan(t *testing.T) {
 						"heroku_addon.foobar", "plan", "memcachier"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckHerokuAddonConfig_no_plan(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuAddonExists("heroku_addon.foobar", &addon),
@@ -80,7 +81,7 @@ func testAccCheckHerokuAddonDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.AddonInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		_, err := client.AddOnInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err == nil {
 			return fmt.Errorf("Addon still exists")
@@ -90,7 +91,7 @@ func testAccCheckHerokuAddonDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuAddonAttributes(addon *heroku.Addon, n string) resource.TestCheckFunc {
+func testAccCheckHerokuAddonAttributes(addon *heroku.AddOnInfoResult, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if addon.Plan.Name != n {
@@ -101,7 +102,7 @@ func testAccCheckHerokuAddonAttributes(addon *heroku.Addon, n string) resource.T
 	}
 }
 
-func testAccCheckHerokuAddonExists(n string, addon *heroku.Addon) resource.TestCheckFunc {
+func testAccCheckHerokuAddonExists(n string, addon *heroku.AddOnInfoResult) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -115,7 +116,7 @@ func testAccCheckHerokuAddonExists(n string, addon *heroku.Addon) resource.TestC
 
 		client := testAccProvider.Meta().(*heroku.Service)
 
-		foundAddon, err := client.AddonInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		foundAddon, err := client.AddOnInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/builtin/providers/heroku/resource_heroku_app.go
+++ b/builtin/providers/heroku/resource_heroku_app.go
@@ -1,11 +1,12 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"log"
 
 	"github.com/cyberdelia/heroku-go/v3"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -38,7 +39,7 @@ func (a *application) Update() error {
 	var err error
 
 	if !a.Organization {
-		app, err := a.Client.AppInfo(a.Id)
+		app, err := a.Client.AppInfo(context.TODO(), a.Id)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
@@ -50,7 +51,7 @@ func (a *application) Update() error {
 			a.App.WebURL = app.WebURL
 		}
 	} else {
-		app, err := a.Client.OrganizationAppInfo(a.Id)
+		app, err := a.Client.OrganizationAppInfo(context.TODO(), a.Id)
 		if err != nil {
 			errs = append(errs, err)
 		} else {
@@ -90,25 +91,25 @@ func resourceHerokuApp() *schema.Resource {
 		Delete: resourceHerokuAppDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"region": &schema.Schema{
+			"region": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"stack": &schema.Schema{
+			"stack": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 				ForceNew: true,
 			},
 
-			"config_vars": &schema.Schema{
+			"config_vars": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Schema{
@@ -116,43 +117,43 @@ func resourceHerokuApp() *schema.Resource {
 				},
 			},
 
-			"all_config_vars": &schema.Schema{
+			"all_config_vars": {
 				Type:     schema.TypeMap,
 				Computed: true,
 			},
 
-			"git_url": &schema.Schema{
+			"git_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"web_url": &schema.Schema{
+			"web_url": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"heroku_hostname": &schema.Schema{
+			"heroku_hostname": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"organization": &schema.Schema{
+			"organization": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"locked": &schema.Schema{
+						"locked": {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
 
-						"personal": &schema.Schema{
+						"personal": {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
@@ -199,7 +200,7 @@ func resourceHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] Creating Heroku app...")
-	a, err := client.AppCreate(opts)
+	a, err := client.AppCreate(context.TODO(), opts)
 	if err != nil {
 		return err
 	}
@@ -263,7 +264,7 @@ func resourceHerokuOrgAppCreate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[DEBUG] Creating Heroku app...")
-	a, err := client.OrganizationAppCreate(opts)
+	a, err := client.OrganizationAppCreate(context.TODO(), opts)
 	if err != nil {
 		return err
 	}
@@ -287,7 +288,7 @@ func resourceHerokuAppRead(d *schema.ResourceData, meta interface{}) error {
 	configVars := make(map[string]string)
 	care := make(map[string]struct{})
 	for _, v := range d.Get("config_vars").([]interface{}) {
-		for k, _ := range v.(map[string]interface{}) {
+		for k := range v.(map[string]interface{}) {
 			care[k] = struct{}{}
 		}
 	}
@@ -347,7 +348,7 @@ func resourceHerokuAppUpdate(d *schema.ResourceData, meta interface{}) error {
 			Name: &v,
 		}
 
-		renamedApp, err := client.AppUpdate(d.Id(), opts)
+		renamedApp, err := client.AppUpdate(context.TODO(), d.Id(), opts)
 		if err != nil {
 			return err
 		}
@@ -380,7 +381,7 @@ func resourceHerokuAppDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	log.Printf("[INFO] Deleting App: %s", d.Id())
-	err := client.AppDelete(d.Id())
+	_, err := client.AppDelete(context.TODO(), d.Id())
 	if err != nil {
 		return fmt.Errorf("Error deleting App: %s", err)
 	}
@@ -402,13 +403,20 @@ func resourceHerokuAppRetrieve(id string, organization bool, client *heroku.Serv
 }
 
 func retrieveConfigVars(id string, client *heroku.Service) (map[string]string, error) {
-	vars, err := client.ConfigVarInfo(id)
+	vars, err := client.ConfigVarInfoForApp(context.TODO(), id)
 
 	if err != nil {
 		return nil, err
 	}
 
-	return vars, nil
+	nonNullVars := map[string]string{}
+	for k, v := range vars {
+		if v != nil {
+			nonNullVars[k] = *v
+		}
+	}
+
+	return nonNullVars, nil
 }
 
 // Updates the config vars for from an expanded configuration.
@@ -421,7 +429,7 @@ func updateConfigVars(
 
 	for _, v := range o {
 		if v != nil {
-			for k, _ := range v.(map[string]interface{}) {
+			for k := range v.(map[string]interface{}) {
 				vars[k] = nil
 			}
 		}
@@ -436,7 +444,7 @@ func updateConfigVars(
 	}
 
 	log.Printf("[INFO] Updating config vars: *%#v", vars)
-	if _, err := client.ConfigVarUpdate(id, vars); err != nil {
+	if _, err := client.ConfigVarUpdate(context.TODO(), id, vars); err != nil {
 		return fmt.Errorf("Error updating config vars: %s", err)
 	}
 

--- a/builtin/providers/heroku/resource_heroku_cert.go
+++ b/builtin/providers/heroku/resource_heroku_cert.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -16,28 +17,28 @@ func resourceHerokuCert() *schema.Resource {
 		Delete: resourceHerokuCertDelete,
 
 		Schema: map[string]*schema.Schema{
-			"app": &schema.Schema{
+			"app": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"certificate_chain": &schema.Schema{
+			"certificate_chain": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"private_key": &schema.Schema{
+			"private_key": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"cname": &schema.Schema{
+			"cname": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -56,7 +57,7 @@ func resourceHerokuCertCreate(d *schema.ResourceData, meta interface{}) error {
 		PrivateKey:       d.Get("private_key").(string)}
 
 	log.Printf("[DEBUG] SSL Certificate create configuration: %#v, %#v", app, opts)
-	a, err := client.SSLEndpointCreate(app, opts)
+	a, err := client.SSLEndpointCreate(context.TODO(), app, opts)
 	if err != nil {
 		return fmt.Errorf("Error creating SSL endpoint: %s", err)
 	}
@@ -92,7 +93,7 @@ func resourceHerokuCertUpdate(d *schema.ResourceData, meta interface{}) error {
 		preprocess := true
 		rollback := false
 		ad, err := client.SSLEndpointUpdate(
-			app, d.Id(), heroku.SSLEndpointUpdateOpts{
+			context.TODO(), app, d.Id(), heroku.SSLEndpointUpdateOpts{
 				CertificateChain: d.Get("certificate_chain").(*string),
 				Preprocess:       &preprocess,
 				PrivateKey:       d.Get("private_key").(*string),
@@ -114,7 +115,7 @@ func resourceHerokuCertDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting SSL Cert: %s", d.Id())
 
 	// Destroy the app
-	err := client.SSLEndpointDelete(d.Get("app").(string), d.Id())
+	_, err := client.SSLEndpointDelete(context.TODO(), d.Get("app").(string), d.Id())
 	if err != nil {
 		return fmt.Errorf("Error deleting SSL Cert: %s", err)
 	}
@@ -123,8 +124,8 @@ func resourceHerokuCertDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceHerokuSSLCertRetrieve(app string, id string, client *heroku.Service) (*heroku.SSLEndpoint, error) {
-	addon, err := client.SSLEndpointInfo(app, id)
+func resourceHerokuSSLCertRetrieve(app string, id string, client *heroku.Service) (*heroku.SSLEndpointInfoResult, error) {
+	addon, err := client.SSLEndpointInfo(context.TODO(), app, id)
 
 	if err != nil {
 		return nil, fmt.Errorf("Error retrieving SSL Cert: %s", err)

--- a/builtin/providers/heroku/resource_heroku_cert_test.go
+++ b/builtin/providers/heroku/resource_heroku_cert_test.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -13,7 +14,7 @@ import (
 )
 
 func TestAccHerokuCert_Basic(t *testing.T) {
-	var endpoint heroku.SSLEndpoint
+	var endpoint heroku.SSLEndpointInfoResult
 	wd, _ := os.Getwd()
 	certificateChainFile := wd + "/test-fixtures/terraform.cert"
 	certificateChainBytes, _ := ioutil.ReadFile(certificateChainFile)
@@ -43,7 +44,7 @@ func TestAccHerokuCert_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckHerokuCertDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckHerokuCertConfig_basic,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuCertExists("heroku_cert.ssl_certificate", &endpoint),
@@ -65,7 +66,7 @@ func testAccCheckHerokuCertDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.SSLEndpointInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		_, err := client.SSLEndpointInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err == nil {
 			return fmt.Errorf("Cerfificate still exists")
@@ -75,7 +76,7 @@ func testAccCheckHerokuCertDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuCertificateChain(endpoint *heroku.SSLEndpoint, chain string) resource.TestCheckFunc {
+func testAccCheckHerokuCertificateChain(endpoint *heroku.SSLEndpointInfoResult, chain string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if endpoint.CertificateChain != chain {
@@ -86,7 +87,7 @@ func testAccCheckHerokuCertificateChain(endpoint *heroku.SSLEndpoint, chain stri
 	}
 }
 
-func testAccCheckHerokuCertExists(n string, endpoint *heroku.SSLEndpoint) resource.TestCheckFunc {
+func testAccCheckHerokuCertExists(n string, endpoint *heroku.SSLEndpointInfoResult) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -100,7 +101,7 @@ func testAccCheckHerokuCertExists(n string, endpoint *heroku.SSLEndpoint) resour
 
 		client := testAccProvider.Meta().(*heroku.Service)
 
-		foundEndpoint, err := client.SSLEndpointInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		foundEndpoint, err := client.SSLEndpointInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/builtin/providers/heroku/resource_heroku_domain.go
+++ b/builtin/providers/heroku/resource_heroku_domain.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -15,19 +16,19 @@ func resourceHerokuDomain() *schema.Resource {
 		Delete: resourceHerokuDomainDelete,
 
 		Schema: map[string]*schema.Schema{
-			"hostname": &schema.Schema{
+			"hostname": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"app": &schema.Schema{
+			"app": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"cname": &schema.Schema{
+			"cname": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -43,7 +44,7 @@ func resourceHerokuDomainCreate(d *schema.ResourceData, meta interface{}) error 
 
 	log.Printf("[DEBUG] Domain create configuration: %#v, %#v", app, hostname)
 
-	do, err := client.DomainCreate(app, heroku.DomainCreateOpts{Hostname: hostname})
+	do, err := client.DomainCreate(context.TODO(), app, heroku.DomainCreateOpts{Hostname: hostname})
 	if err != nil {
 		return err
 	}
@@ -62,7 +63,7 @@ func resourceHerokuDomainDelete(d *schema.ResourceData, meta interface{}) error 
 	log.Printf("[INFO] Deleting Domain: %s", d.Id())
 
 	// Destroy the domain
-	err := client.DomainDelete(d.Get("app").(string), d.Id())
+	_, err := client.DomainDelete(context.TODO(), d.Get("app").(string), d.Id())
 	if err != nil {
 		return fmt.Errorf("Error deleting domain: %s", err)
 	}
@@ -74,7 +75,7 @@ func resourceHerokuDomainRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
 	app := d.Get("app").(string)
-	do, err := client.DomainInfo(app, d.Id())
+	do, err := client.DomainInfo(context.TODO(), app, d.Id())
 	if err != nil {
 		return fmt.Errorf("Error retrieving domain: %s", err)
 	}

--- a/builtin/providers/heroku/resource_heroku_domain_test.go
+++ b/builtin/providers/heroku/resource_heroku_domain_test.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func TestAccHerokuDomain_Basic(t *testing.T) {
-	var domain heroku.Domain
+	var domain heroku.DomainInfoResult
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -19,7 +20,7 @@ func TestAccHerokuDomain_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckHerokuDomainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckHerokuDomainConfig_basic(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDomainExists("heroku_domain.foobar", &domain),
@@ -45,7 +46,7 @@ func testAccCheckHerokuDomainDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.DomainInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		_, err := client.DomainInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err == nil {
 			return fmt.Errorf("Domain still exists")
@@ -55,7 +56,7 @@ func testAccCheckHerokuDomainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuDomainAttributes(Domain *heroku.Domain) resource.TestCheckFunc {
+func testAccCheckHerokuDomainAttributes(Domain *heroku.DomainInfoResult) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if Domain.Hostname != "terraform.example.com" {
@@ -66,7 +67,7 @@ func testAccCheckHerokuDomainAttributes(Domain *heroku.Domain) resource.TestChec
 	}
 }
 
-func testAccCheckHerokuDomainExists(n string, Domain *heroku.Domain) resource.TestCheckFunc {
+func testAccCheckHerokuDomainExists(n string, Domain *heroku.DomainInfoResult) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -80,7 +81,7 @@ func testAccCheckHerokuDomainExists(n string, Domain *heroku.Domain) resource.Te
 
 		client := testAccProvider.Meta().(*heroku.Service)
 
-		foundDomain, err := client.DomainInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		foundDomain, err := client.DomainInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/builtin/providers/heroku/resource_heroku_drain.go
+++ b/builtin/providers/heroku/resource_heroku_drain.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -18,19 +19,19 @@ func resourceHerokuDrain() *schema.Resource {
 		Delete: resourceHerokuDrainDelete,
 
 		Schema: map[string]*schema.Schema{
-			"url": &schema.Schema{
+			"url": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"app": &schema.Schema{
+			"app": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"token": &schema.Schema{
+			"token": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -48,9 +49,9 @@ func resourceHerokuDrainCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Drain create configuration: %#v, %#v", app, url)
 
-	var dr *heroku.LogDrain
+	var dr *heroku.LogDrainCreateResult
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
-		d, err := client.LogDrainCreate(app, heroku.LogDrainCreateOpts{URL: url})
+		d, err := client.LogDrainCreate(context.TODO(), app, heroku.LogDrainCreateOpts{URL: url})
 		if err != nil {
 			if strings.Contains(err.Error(), retryableError) {
 				return resource.RetryableError(err)
@@ -78,7 +79,7 @@ func resourceHerokuDrainDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting drain: %s", d.Id())
 
 	// Destroy the drain
-	err := client.LogDrainDelete(d.Get("app").(string), d.Id())
+	_, err := client.LogDrainDelete(context.TODO(), d.Get("app").(string), d.Id())
 	if err != nil {
 		return fmt.Errorf("Error deleting drain: %s", err)
 	}
@@ -89,7 +90,7 @@ func resourceHerokuDrainDelete(d *schema.ResourceData, meta interface{}) error {
 func resourceHerokuDrainRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
-	dr, err := client.LogDrainInfo(d.Get("app").(string), d.Id())
+	dr, err := client.LogDrainInfo(context.TODO(), d.Get("app").(string), d.Id())
 	if err != nil {
 		return fmt.Errorf("Error retrieving drain: %s", err)
 	}

--- a/builtin/providers/heroku/resource_heroku_drain_test.go
+++ b/builtin/providers/heroku/resource_heroku_drain_test.go
@@ -1,6 +1,7 @@
 package heroku
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -11,7 +12,7 @@ import (
 )
 
 func TestAccHerokuDrain_Basic(t *testing.T) {
-	var drain heroku.LogDrain
+	var drain heroku.LogDrainInfoResult
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -19,7 +20,7 @@ func TestAccHerokuDrain_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckHerokuDrainDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckHerokuDrainConfig_basic(appName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuDrainExists("heroku_drain.foobar", &drain),
@@ -42,7 +43,7 @@ func testAccCheckHerokuDrainDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.LogDrainInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		_, err := client.LogDrainInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err == nil {
 			return fmt.Errorf("Drain still exists")
@@ -52,7 +53,7 @@ func testAccCheckHerokuDrainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuDrainAttributes(Drain *heroku.LogDrain) resource.TestCheckFunc {
+func testAccCheckHerokuDrainAttributes(Drain *heroku.LogDrainInfoResult) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if Drain.URL != "syslog://terraform.example.com:1234" {
@@ -67,7 +68,7 @@ func testAccCheckHerokuDrainAttributes(Drain *heroku.LogDrain) resource.TestChec
 	}
 }
 
-func testAccCheckHerokuDrainExists(n string, Drain *heroku.LogDrain) resource.TestCheckFunc {
+func testAccCheckHerokuDrainExists(n string, Drain *heroku.LogDrainInfoResult) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -81,7 +82,7 @@ func testAccCheckHerokuDrainExists(n string, Drain *heroku.LogDrain) resource.Te
 
 		client := testAccProvider.Meta().(*heroku.Service)
 
-		foundDrain, err := client.LogDrainInfo(rs.Primary.Attributes["app"], rs.Primary.ID)
+		foundDrain, err := client.LogDrainInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
@@ -12,6 +12,7 @@ package heroku
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,17 +20,20 @@ import (
 	"reflect"
 	"runtime"
 	"time"
+
+	"github.com/google/go-querystring/query"
 )
 
 const (
 	Version          = "v3"
-	DefaultAPIURL    = "https://api.heroku.com"
 	DefaultUserAgent = "heroku/" + Version + " (" + runtime.GOOS + "; " + runtime.GOARCH + ")"
+	DefaultURL       = "https://api.heroku.com"
 )
 
 // Service represents your API.
 type Service struct {
 	client *http.Client
+	URL    string
 }
 
 // NewService creates a Service using the given, if none is provided
@@ -40,11 +44,12 @@ func NewService(c *http.Client) *Service {
 	}
 	return &Service{
 		client: c,
+		URL:    DefaultURL,
 	}
 }
 
 // NewRequest generates an HTTP request, but does not perform the request.
-func (s *Service) NewRequest(method, path string, body interface{}) (*http.Request, error) {
+func (s *Service) NewRequest(ctx context.Context, method, path string, body interface{}, q interface{}) (*http.Request, error) {
 	var ctype string
 	var rbody io.Reader
 	switch t := body.(type) {
@@ -71,9 +76,21 @@ func (s *Service) NewRequest(method, path string, body interface{}) (*http.Reque
 		rbody = bytes.NewReader(j)
 		ctype = "application/json"
 	}
-	req, err := http.NewRequest(method, DefaultAPIURL+path, rbody)
+	req, err := http.NewRequest(method, s.URL+path, rbody)
 	if err != nil {
 		return nil, err
+	}
+	req = req.WithContext(ctx)
+	if q != nil {
+		v, err := query.Values(q)
+		if err != nil {
+			return nil, err
+		}
+		query := v.Encode()
+		if req.URL.RawQuery != "" && query != "" {
+			req.URL.RawQuery += "&"
+		}
+		req.URL.RawQuery += query
 	}
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", DefaultUserAgent)
@@ -84,8 +101,8 @@ func (s *Service) NewRequest(method, path string, body interface{}) (*http.Reque
 }
 
 // Do sends a request and decodes the response into v.
-func (s *Service) Do(v interface{}, method, path string, body interface{}, lr *ListRange) error {
-	req, err := s.NewRequest(method, path, body)
+func (s *Service) Do(ctx context.Context, v interface{}, method, path string, body interface{}, q interface{}, lr *ListRange) error {
+	req, err := s.NewRequest(ctx, method, path, body, q)
 	if err != nil {
 		return err
 	}
@@ -108,28 +125,28 @@ func (s *Service) Do(v interface{}, method, path string, body interface{}, lr *L
 }
 
 // Get sends a GET request and decodes the response into v.
-func (s *Service) Get(v interface{}, path string, lr *ListRange) error {
-	return s.Do(v, "GET", path, nil, lr)
+func (s *Service) Get(ctx context.Context, v interface{}, path string, query interface{}, lr *ListRange) error {
+	return s.Do(ctx, v, "GET", path, nil, query, lr)
 }
 
 // Patch sends a Path request and decodes the response into v.
-func (s *Service) Patch(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PATCH", path, body, nil)
+func (s *Service) Patch(ctx context.Context, v interface{}, path string, body interface{}) error {
+	return s.Do(ctx, v, "PATCH", path, body, nil, nil)
 }
 
 // Post sends a POST request and decodes the response into v.
-func (s *Service) Post(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "POST", path, body, nil)
+func (s *Service) Post(ctx context.Context, v interface{}, path string, body interface{}) error {
+	return s.Do(ctx, v, "POST", path, body, nil, nil)
 }
 
 // Put sends a PUT request and decodes the response into v.
-func (s *Service) Put(v interface{}, path string, body interface{}) error {
-	return s.Do(v, "PUT", path, body, nil)
+func (s *Service) Put(ctx context.Context, v interface{}, path string, body interface{}) error {
+	return s.Do(ctx, v, "PUT", path, body, nil, nil)
 }
 
 // Delete sends a DELETE request.
-func (s *Service) Delete(path string) error {
-	return s.Do(nil, "DELETE", path, nil, nil)
+func (s *Service) Delete(ctx context.Context, v interface{}, path string) error {
+	return s.Do(ctx, v, "DELETE", path, nil, nil, nil)
 }
 
 // ListRange describes a range.
@@ -151,11 +168,11 @@ func (lr *ListRange) SetHeader(req *http.Request) {
 	if lr.Max != 0 {
 		hdrval += fmt.Sprintf("; max=%d", lr.Max)
 		if lr.Descending {
-			hdrval += ", "
+			hdrval += "; "
 		}
 	}
 	if lr.Descending {
-		hdrval += ", order=desc"
+		hdrval += "order=desc"
 	}
 	req.Header.Set("Range", hdrval)
 	return
@@ -192,299 +209,1352 @@ func String(v string) *string {
 // An account represents an individual signed up to use the Heroku
 // platform.
 type Account struct {
-	AllowTracking bool      `json:"allow_tracking"` // whether to allow third party web activity tracking
-	Beta          bool      `json:"beta"`           // whether allowed to utilize beta Heroku features
-	CreatedAt     time.Time `json:"created_at"`     // when account was created
-	Email         string    `json:"email"`          // unique email address of account
-	ID            string    `json:"id"`             // unique identifier of an account
-	LastLogin     time.Time `json:"last_login"`     // when account last authorized with Heroku
-	Name          *string   `json:"name"`           // full name of the account owner
-	UpdatedAt     time.Time `json:"updated_at"`     // when account was updated
-	Verified      bool      `json:"verified"`       // whether account has been verified with billing information
+	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
+	Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
+	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
+	DefaultOrganization *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"default_organization" url:"default_organization,key"` // organization selected by default
+	DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
+	Email            string     `json:"email" url:"email,key"`                 // unique email address of account
+	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
+	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
+	IdentityProvider *struct {
+		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
+		Organization struct {
+			Name string `json:"name" url:"name,key"` // unique name of organization
+		} `json:"organization" url:"organization,key"`
+	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
+	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
+	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
+	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
+	SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
+	TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
+	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
+	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
+}
+type AccountInfoResult struct {
+	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
+	Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
+	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
+	DefaultOrganization *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"default_organization" url:"default_organization,key"` // organization selected by default
+	DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
+	Email            string     `json:"email" url:"email,key"`                 // unique email address of account
+	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
+	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
+	IdentityProvider *struct {
+		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
+		Organization struct {
+			Name string `json:"name" url:"name,key"` // unique name of organization
+		} `json:"organization" url:"organization,key"`
+	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
+	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
+	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
+	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
+	SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
+	TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
+	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
+	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
 }
 
 // Info for account.
-func (s *Service) AccountInfo() (*Account, error) {
-	var account Account
-	return &account, s.Get(&account, fmt.Sprintf("/account"), nil)
+func (s *Service) AccountInfo(ctx context.Context) (*AccountInfoResult, error) {
+	var account AccountInfoResult
+	return &account, s.Get(ctx, &account, fmt.Sprintf("/account"), nil, nil)
 }
 
 type AccountUpdateOpts struct {
-	AllowTracking *bool   `json:"allow_tracking,omitempty"` // whether to allow third party web activity tracking
-	Beta          *bool   `json:"beta,omitempty"`           // whether allowed to utilize beta Heroku features
-	Name          *string `json:"name,omitempty"`           // full name of the account owner
-	Password      string  `json:"password"`                 // current password on the account
+	AllowTracking *bool   `json:"allow_tracking,omitempty" url:"allow_tracking,omitempty,key"` // whether to allow third party web activity tracking
+	Beta          *bool   `json:"beta,omitempty" url:"beta,omitempty,key"`                     // whether allowed to utilize beta Heroku features
+	Name          *string `json:"name,omitempty" url:"name,omitempty,key"`                     // full name of the account owner
+}
+type AccountUpdateResult struct {
+	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
+	Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
+	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
+	DefaultOrganization *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"default_organization" url:"default_organization,key"` // organization selected by default
+	DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
+	Email            string     `json:"email" url:"email,key"`                 // unique email address of account
+	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
+	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
+	IdentityProvider *struct {
+		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
+		Organization struct {
+			Name string `json:"name" url:"name,key"` // unique name of organization
+		} `json:"organization" url:"organization,key"`
+	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
+	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
+	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
+	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
+	SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
+	TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
+	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
+	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
 }
 
 // Update account.
-func (s *Service) AccountUpdate(o struct {
-	AllowTracking *bool   `json:"allow_tracking,omitempty"` // whether to allow third party web activity tracking
-	Beta          *bool   `json:"beta,omitempty"`           // whether allowed to utilize beta Heroku features
-	Name          *string `json:"name,omitempty"`           // full name of the account owner
-	Password      string  `json:"password"`                 // current password on the account
-}) (*Account, error) {
-	var account Account
-	return &account, s.Patch(&account, fmt.Sprintf("/account"), o)
+func (s *Service) AccountUpdate(ctx context.Context, o AccountUpdateOpts) (*AccountUpdateResult, error) {
+	var account AccountUpdateResult
+	return &account, s.Patch(ctx, &account, fmt.Sprintf("/account"), o)
 }
 
-type AccountChangeEmailOpts struct {
-	Email    string `json:"email"`    // unique email address of account
-	Password string `json:"password"` // current password on the account
+type AccountDeleteResult struct {
+	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
+	Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
+	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
+	DefaultOrganization *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"default_organization" url:"default_organization,key"` // organization selected by default
+	DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
+	Email            string     `json:"email" url:"email,key"`                 // unique email address of account
+	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
+	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
+	IdentityProvider *struct {
+		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
+		Organization struct {
+			Name string `json:"name" url:"name,key"` // unique name of organization
+		} `json:"organization" url:"organization,key"`
+	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
+	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
+	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
+	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
+	SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
+	TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
+	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
+	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
 }
 
-// Change Email for account.
-func (s *Service) AccountChangeEmail(o struct {
-	Email    string `json:"email"`    // unique email address of account
-	Password string `json:"password"` // current password on the account
-}) (*Account, error) {
-	var account Account
-	return &account, s.Patch(&account, fmt.Sprintf("/account"), o)
-}
-
-type AccountChangePasswordOpts struct {
-	NewPassword string `json:"new_password"` // the new password for the account when changing the password
-	Password    string `json:"password"`     // current password on the account
-}
-
-// Change Password for account.
-func (s *Service) AccountChangePassword(o struct {
-	NewPassword string `json:"new_password"` // the new password for the account when changing the password
-	Password    string `json:"password"`     // current password on the account
-}) (*Account, error) {
-	var account Account
-	return &account, s.Patch(&account, fmt.Sprintf("/account"), o)
+// Delete account. Note that this action cannot be undone.
+func (s *Service) AccountDelete(ctx context.Context) (*AccountDeleteResult, error) {
+	var account AccountDeleteResult
+	return &account, s.Delete(ctx, &account, fmt.Sprintf("/account"))
 }
 
 // An account feature represents a Heroku labs capability that can be
 // enabled or disabled for an account on Heroku.
 type AccountFeature struct {
-	CreatedAt   time.Time `json:"created_at"`  // when account feature was created
-	Description string    `json:"description"` // description of account feature
-	DocURL      string    `json:"doc_url"`     // documentation URL of account feature
-	Enabled     bool      `json:"enabled"`     // whether or not account feature has been enabled
-	ID          string    `json:"id"`          // unique identifier of account feature
-	Name        string    `json:"name"`        // unique name of account feature
-	State       string    `json:"state"`       // state of account feature
-	UpdatedAt   time.Time `json:"updated_at"`  // when account feature was updated
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
+	Description string    `json:"description" url:"description,key"` // description of account feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
+	State       string    `json:"state" url:"state,key"`             // state of account feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+}
+type AccountFeatureInfoResult struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
+	Description string    `json:"description" url:"description,key"` // description of account feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
+	State       string    `json:"state" url:"state,key"`             // state of account feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
 }
 
 // Info for an existing account feature.
-func (s *Service) AccountFeatureInfo(accountFeatureIdentity string) (*AccountFeature, error) {
-	var accountFeature AccountFeature
-	return &accountFeature, s.Get(&accountFeature, fmt.Sprintf("/account/features/%v", accountFeatureIdentity), nil)
+func (s *Service) AccountFeatureInfo(ctx context.Context, accountFeatureIdentity string) (*AccountFeatureInfoResult, error) {
+	var accountFeature AccountFeatureInfoResult
+	return &accountFeature, s.Get(ctx, &accountFeature, fmt.Sprintf("/account/features/%v", accountFeatureIdentity), nil, nil)
+}
+
+type AccountFeatureListResult []struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
+	Description string    `json:"description" url:"description,key"` // description of account feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
+	State       string    `json:"state" url:"state,key"`             // state of account feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
 }
 
 // List existing account features.
-func (s *Service) AccountFeatureList(lr *ListRange) ([]*AccountFeature, error) {
-	var accountFeatureList []*AccountFeature
-	return accountFeatureList, s.Get(&accountFeatureList, fmt.Sprintf("/account/features"), lr)
+func (s *Service) AccountFeatureList(ctx context.Context, lr *ListRange) (AccountFeatureListResult, error) {
+	var accountFeature AccountFeatureListResult
+	return accountFeature, s.Get(ctx, &accountFeature, fmt.Sprintf("/account/features"), nil, lr)
 }
 
 type AccountFeatureUpdateOpts struct {
-	Enabled bool `json:"enabled"` // whether or not account feature has been enabled
+	Enabled bool `json:"enabled" url:"enabled,key"` // whether or not account feature has been enabled
+}
+type AccountFeatureUpdateResult struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
+	Description string    `json:"description" url:"description,key"` // description of account feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
+	State       string    `json:"state" url:"state,key"`             // state of account feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
 }
 
 // Update an existing account feature.
-func (s *Service) AccountFeatureUpdate(accountFeatureIdentity string, o struct {
-	Enabled bool `json:"enabled"` // whether or not account feature has been enabled
-}) (*AccountFeature, error) {
-	var accountFeature AccountFeature
-	return &accountFeature, s.Patch(&accountFeature, fmt.Sprintf("/account/features/%v", accountFeatureIdentity), o)
+func (s *Service) AccountFeatureUpdate(ctx context.Context, accountFeatureIdentity string, o AccountFeatureUpdateOpts) (*AccountFeatureUpdateResult, error) {
+	var accountFeature AccountFeatureUpdateResult
+	return &accountFeature, s.Patch(ctx, &accountFeature, fmt.Sprintf("/account/features/%v", accountFeatureIdentity), o)
 }
 
-// Add-ons represent add-ons that have been provisioned for an app.
-type Addon struct {
+// Add-ons represent add-ons that have been provisioned and attached to
+// one or more apps.
+type AddOn struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
 	AddonService struct {
-		ID   string `json:"id"`   // unique identifier of this addon-service
-		Name string `json:"name"` // unique name of this addon-service
-	} `json:"addon_service"` // identity of add-on service
-	ConfigVars []string  `json:"config_vars"` // config vars associated with this application
-	CreatedAt  time.Time `json:"created_at"`  // when add-on was updated
-	ID         string    `json:"id"`          // unique identifier of add-on
-	Name       string    `json:"name"`        // name of the add-on unique within its app
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
 	Plan       struct {
-		ID   string `json:"id"`   // unique identifier of this plan
-		Name string `json:"name"` // unique name of this plan
-	} `json:"plan"` // identity of add-on plan
-	ProviderID string    `json:"provider_id"` // id of this add-on with its provider
-	UpdatedAt  time.Time `json:"updated_at"`  // when add-on was updated
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
 }
-type AddonCreateOpts struct {
-	Config *map[string]string `json:"config,omitempty"` // custom add-on provisioning options
-	Plan   string             `json:"plan"`             // unique identifier of this plan
+type AddOnCreateOpts struct {
+	Attachment *struct{}          `json:"attachment,omitempty" url:"attachment,omitempty,key"` // name for add-on's initial attachment
+	Config     *map[string]string `json:"config,omitempty" url:"config,omitempty,key"`         // custom add-on provisioning options
+	Plan       string             `json:"plan" url:"plan,key"`                                 // unique identifier of this plan
+}
+type AddOnCreateResult struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
 }
 
 // Create a new add-on.
-func (s *Service) AddonCreate(appIdentity string, o struct {
-	Config *map[string]string `json:"config,omitempty"` // custom add-on provisioning options
-	Plan   string             `json:"plan"`             // unique identifier of this plan
-}) (*Addon, error) {
-	var addon Addon
-	return &addon, s.Post(&addon, fmt.Sprintf("/apps/%v/addons", appIdentity), o)
+func (s *Service) AddOnCreate(ctx context.Context, appIdentity string, o AddOnCreateOpts) (*AddOnCreateResult, error) {
+	var addOn AddOnCreateResult
+	return &addOn, s.Post(ctx, &addOn, fmt.Sprintf("/apps/%v/addons", appIdentity), o)
+}
+
+type AddOnDeleteResult struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
 }
 
 // Delete an existing add-on.
-func (s *Service) AddonDelete(appIdentity string, addonIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addonIdentity))
+func (s *Service) AddOnDelete(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOnDeleteResult, error) {
+	var addOn AddOnDeleteResult
+	return &addOn, s.Delete(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity))
+}
+
+type AddOnInfoResult struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
 }
 
 // Info for an existing add-on.
-func (s *Service) AddonInfo(appIdentity string, addonIdentity string) (*Addon, error) {
-	var addon Addon
-	return &addon, s.Get(&addon, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addonIdentity), nil)
+func (s *Service) AddOnInfo(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOnInfoResult, error) {
+	var addOn AddOnInfoResult
+	return &addOn, s.Get(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity), nil, nil)
 }
 
-// List existing add-ons.
-func (s *Service) AddonList(appIdentity string, lr *ListRange) ([]*Addon, error) {
-	var addonList []*Addon
-	return addonList, s.Get(&addonList, fmt.Sprintf("/apps/%v/addons", appIdentity), lr)
+type AddOnListResult []struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
 }
 
-type AddonUpdateOpts struct {
-	Plan string `json:"plan"` // unique identifier of this plan
+// List all existing add-ons.
+func (s *Service) AddOnList(ctx context.Context, lr *ListRange) (AddOnListResult, error) {
+	var addOn AddOnListResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/addons"), nil, lr)
+}
+
+type AddOnListByUserResult []struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+}
+
+// List all existing add-ons a user has access to
+func (s *Service) AddOnListByUser(ctx context.Context, accountIdentity string, lr *ListRange) (AddOnListByUserResult, error) {
+	var addOn AddOnListByUserResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/users/%v/addons", accountIdentity), nil, lr)
+}
+
+type AddOnListByAppResult []struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+}
+
+// List existing add-ons for an app.
+func (s *Service) AddOnListByApp(ctx context.Context, appIdentity string, lr *ListRange) (AddOnListByAppResult, error) {
+	var addOn AddOnListByAppResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/apps/%v/addons", appIdentity), nil, lr)
+}
+
+type AddOnUpdateOpts struct {
+	Plan string `json:"plan" url:"plan,key"` // unique identifier of this plan
 }
 
 // Change add-on plan. Some add-ons may not support changing plans. In
 // that case, an error will be returned.
-func (s *Service) AddonUpdate(appIdentity string, addonIdentity string, o struct {
-	Plan string `json:"plan"` // unique identifier of this plan
-}) (*Addon, error) {
-	var addon Addon
-	return &addon, s.Patch(&addon, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addonIdentity), o)
+func (s *Service) AddOnUpdate(ctx context.Context, appIdentity string, addOnIdentity string, o AddOnUpdateOpts) (*AddOn, error) {
+	var addOn AddOn
+	return &addOn, s.Patch(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity), o)
+}
+
+// Add-on Actions are lifecycle operations for add-on provisioning and
+// deprovisioning. They allow whitelisted add-on providers to
+// (de)provision add-ons in the background and then report back when
+// (de)provisioning is complete.
+type AddOnAction struct{}
+type AddOnActionCreateProvisionResult struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+}
+
+// Mark an add-on as provisioned for use.
+func (s *Service) AddOnActionCreateProvision(ctx context.Context, addOnIdentity string) (*AddOnActionCreateProvisionResult, error) {
+	var addOnAction AddOnActionCreateProvisionResult
+	return &addOnAction, s.Post(ctx, &addOnAction, fmt.Sprintf("/addons/%v/actions/provision", addOnIdentity), nil)
+}
+
+type AddOnActionCreateDeprovisionResult struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+}
+
+// Mark an add-on as deprovisioned.
+func (s *Service) AddOnActionCreateDeprovision(ctx context.Context, addOnIdentity string) (*AddOnActionCreateDeprovisionResult, error) {
+	var addOnAction AddOnActionCreateDeprovisionResult
+	return &addOnAction, s.Post(ctx, &addOnAction, fmt.Sprintf("/addons/%v/actions/deprovision", addOnIdentity), nil)
+}
+
+// An add-on attachment represents a connection between an app and an
+// add-on that it has been given access to.
+type AddOnAttachment struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+type AddOnAttachmentCreateOpts struct {
+	Addon string `json:"addon" url:"addon,key"`                     // unique identifier of add-on
+	App   string `json:"app" url:"app,key"`                         // unique identifier of app
+	Force *bool  `json:"force,omitempty" url:"force,omitempty,key"` // whether or not to allow existing attachment with same name to be
+	// replaced
+	Name *string `json:"name,omitempty" url:"name,omitempty,key"` // unique name for this add-on attachment to this app
+}
+type AddOnAttachmentCreateResult struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+
+// Create a new add-on attachment.
+func (s *Service) AddOnAttachmentCreate(ctx context.Context, o AddOnAttachmentCreateOpts) (*AddOnAttachmentCreateResult, error) {
+	var addOnAttachment AddOnAttachmentCreateResult
+	return &addOnAttachment, s.Post(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments"), o)
+}
+
+type AddOnAttachmentDeleteResult struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+
+// Delete an existing add-on attachment.
+func (s *Service) AddOnAttachmentDelete(ctx context.Context, addOnAttachmentIdentity string) (*AddOnAttachmentDeleteResult, error) {
+	var addOnAttachment AddOnAttachmentDeleteResult
+	return &addOnAttachment, s.Delete(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments/%v", addOnAttachmentIdentity))
+}
+
+type AddOnAttachmentInfoResult struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+
+// Info for existing add-on attachment.
+func (s *Service) AddOnAttachmentInfo(ctx context.Context, addOnAttachmentIdentity string) (*AddOnAttachmentInfoResult, error) {
+	var addOnAttachment AddOnAttachmentInfoResult
+	return &addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments/%v", addOnAttachmentIdentity), nil, nil)
+}
+
+type AddOnAttachmentListResult []struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+
+// List existing add-on attachments.
+func (s *Service) AddOnAttachmentList(ctx context.Context, lr *ListRange) (AddOnAttachmentListResult, error) {
+	var addOnAttachment AddOnAttachmentListResult
+	return addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments"), nil, lr)
+}
+
+type AddOnAttachmentListByAddOnResult []struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+
+// List existing add-on attachments for an add-on.
+func (s *Service) AddOnAttachmentListByAddOn(ctx context.Context, addOnIdentity string, lr *ListRange) (AddOnAttachmentListByAddOnResult, error) {
+	var addOnAttachment AddOnAttachmentListByAddOnResult
+	return addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/addons/%v/addon-attachments", addOnIdentity), nil, lr)
+}
+
+type AddOnAttachmentListByAppResult []struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+
+// List existing add-on attachments for an app.
+func (s *Service) AddOnAttachmentListByApp(ctx context.Context, appIdentity string, lr *ListRange) (AddOnAttachmentListByAppResult, error) {
+	var addOnAttachment AddOnAttachmentListByAppResult
+	return addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/apps/%v/addon-attachments", appIdentity), nil, lr)
+}
+
+type AddOnAttachmentInfoByAppResult struct {
+	Addon struct {
+		App struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of app
+			Name string `json:"name" url:"name,key"` // unique name of app
+		} `json:"app" url:"app,key"` // billing application associated with this add-on
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+		Plan struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+			Name string `json:"name" url:"name,key"` // unique name of this plan
+		} `json:"plan" url:"plan,key"` // identity of add-on plan
+	} `json:"addon" url:"addon,key"` // identity of add-on
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application that is attached to add-on
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
+	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
+	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+}
+
+// Info for existing add-on attachment for an app.
+func (s *Service) AddOnAttachmentInfoByApp(ctx context.Context, appIdentity string, addOnAttachmentScopedIdentity string) (*AddOnAttachmentInfoByAppResult, error) {
+	var addOnAttachment AddOnAttachmentInfoByAppResult
+	return &addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/apps/%v/addon-attachments/%v", appIdentity, addOnAttachmentScopedIdentity), nil, nil)
+}
+
+// Configuration of an Add-on
+type AddOnConfig struct {
+	Name  string  `json:"name" url:"name,key"`   // unique name of the config
+	Value *string `json:"value" url:"value,key"` // value of the config
+}
+type AddOnConfigListResult []struct {
+	Name  string  `json:"name" url:"name,key"`   // unique name of the config
+	Value *string `json:"value" url:"value,key"` // value of the config
+}
+
+// Get an add-on's config. Accessible by customers with access and by
+// the add-on partner providing this add-on.
+func (s *Service) AddOnConfigList(ctx context.Context, addOnIdentity string, lr *ListRange) (AddOnConfigListResult, error) {
+	var addOnConfig AddOnConfigListResult
+	return addOnConfig, s.Get(ctx, &addOnConfig, fmt.Sprintf("/addons/%v/config", addOnIdentity), nil, lr)
+}
+
+type AddOnConfigUpdateOpts struct {
+	Config *[]*struct {
+		Name  *string `json:"name,omitempty" url:"name,omitempty,key"`   // unique name of the config
+		Value *string `json:"value,omitempty" url:"value,omitempty,key"` // value of the config
+	} `json:"config,omitempty" url:"config,omitempty,key"`
+}
+type AddOnConfigUpdateResult []struct {
+	Name  string  `json:"name" url:"name,key"`   // unique name of the config
+	Value *string `json:"value" url:"value,key"` // value of the config
+}
+
+// Update an add-on's config. Can only be accessed by the add-on partner
+// providing this add-on.
+func (s *Service) AddOnConfigUpdate(ctx context.Context, addOnIdentity string, o AddOnConfigUpdateOpts) (AddOnConfigUpdateResult, error) {
+	var addOnConfig AddOnConfigUpdateResult
+	return addOnConfig, s.Patch(ctx, &addOnConfig, fmt.Sprintf("/addons/%v/config", addOnIdentity), o)
+}
+
+// Add-on Plan Actions are Provider functionality for specific add-on
+// installations
+type AddOnPlanAction struct {
+	Action        string `json:"action" url:"action,key"`                 // identifier of the action to take that is sent via SSO
+	ID            string `json:"id" url:"id,key"`                         // a unique identifier
+	Label         string `json:"label" url:"label,key"`                   // the display text shown in Dashboard
+	RequiresOwner bool   `json:"requires_owner" url:"requires_owner,key"` // if the action requires the user to own the app
+	URL           string `json:"url" url:"url,key"`                       // absolute URL to use instead of an action
+}
+
+// Add-on region capabilities represent the relationship between an
+// Add-on Service and a specific Region. Only Beta and GA add-ons are
+// returned by these endpoints.
+type AddOnRegionCapability struct {
+	AddonService struct {
+		CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
+		CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
+		HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
+		ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
+		Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
+		State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
+		SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
+		// add-on at the same time
+		SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
+		// app
+		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
+	} `json:"addon_service" url:"addon_service,key"` // Add-on services represent add-ons that may be provisioned for apps.
+	// Endpoints under add-on services can be accessed without
+	// authentication.
+	ID     string `json:"id" url:"id,key"` // unique identifier of this add-on-region-capability
+	Region struct {
+		Country        string    `json:"country" url:"country,key"`                 // country where the region exists
+		CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
+		Description    string    `json:"description" url:"description,key"`         // description of region
+		ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
+		Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
+		Name           string    `json:"name" url:"name,key"`                       // unique name of region
+		PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
+		Provider       struct {
+			Name   string `json:"name" url:"name,key"`     // name of provider
+			Region string `json:"region" url:"region,key"` // region name used by provider
+		} `json:"provider" url:"provider,key"` // provider of underlying substrate
+		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
+	} `json:"region" url:"region,key"` // A region represents a geographic location in which your application
+	// may run.
+	SupportsPrivateNetworking bool `json:"supports_private_networking" url:"supports_private_networking,key"` // whether the add-on can be installed to a Space
+}
+type AddOnRegionCapabilityListResult []struct {
+	AddonService struct {
+		CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
+		CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
+		HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
+		ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
+		Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
+		State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
+		SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
+		// add-on at the same time
+		SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
+		// app
+		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
+	} `json:"addon_service" url:"addon_service,key"` // Add-on services represent add-ons that may be provisioned for apps.
+	// Endpoints under add-on services can be accessed without
+	// authentication.
+	ID     string `json:"id" url:"id,key"` // unique identifier of this add-on-region-capability
+	Region struct {
+		Country        string    `json:"country" url:"country,key"`                 // country where the region exists
+		CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
+		Description    string    `json:"description" url:"description,key"`         // description of region
+		ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
+		Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
+		Name           string    `json:"name" url:"name,key"`                       // unique name of region
+		PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
+		Provider       struct {
+			Name   string `json:"name" url:"name,key"`     // name of provider
+			Region string `json:"region" url:"region,key"` // region name used by provider
+		} `json:"provider" url:"provider,key"` // provider of underlying substrate
+		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
+	} `json:"region" url:"region,key"` // A region represents a geographic location in which your application
+	// may run.
+	SupportsPrivateNetworking bool `json:"supports_private_networking" url:"supports_private_networking,key"` // whether the add-on can be installed to a Space
+}
+
+// List all existing add-on region capabilities.
+func (s *Service) AddOnRegionCapabilityList(ctx context.Context, lr *ListRange) (AddOnRegionCapabilityListResult, error) {
+	var addOnRegionCapability AddOnRegionCapabilityListResult
+	return addOnRegionCapability, s.Get(ctx, &addOnRegionCapability, fmt.Sprintf("/addon-region-capabilities"), nil, lr)
+}
+
+type AddOnRegionCapabilityListByAddOnServiceResult []struct {
+	AddonService struct {
+		CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
+		CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
+		HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
+		ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
+		Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
+		State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
+		SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
+		// add-on at the same time
+		SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
+		// app
+		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
+	} `json:"addon_service" url:"addon_service,key"` // Add-on services represent add-ons that may be provisioned for apps.
+	// Endpoints under add-on services can be accessed without
+	// authentication.
+	ID     string `json:"id" url:"id,key"` // unique identifier of this add-on-region-capability
+	Region struct {
+		Country        string    `json:"country" url:"country,key"`                 // country where the region exists
+		CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
+		Description    string    `json:"description" url:"description,key"`         // description of region
+		ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
+		Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
+		Name           string    `json:"name" url:"name,key"`                       // unique name of region
+		PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
+		Provider       struct {
+			Name   string `json:"name" url:"name,key"`     // name of provider
+			Region string `json:"region" url:"region,key"` // region name used by provider
+		} `json:"provider" url:"provider,key"` // provider of underlying substrate
+		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
+	} `json:"region" url:"region,key"` // A region represents a geographic location in which your application
+	// may run.
+	SupportsPrivateNetworking bool `json:"supports_private_networking" url:"supports_private_networking,key"` // whether the add-on can be installed to a Space
+}
+
+// List existing add-on region capabilities for an add-on-service
+func (s *Service) AddOnRegionCapabilityListByAddOnService(ctx context.Context, addOnServiceIdentity string, lr *ListRange) (AddOnRegionCapabilityListByAddOnServiceResult, error) {
+	var addOnRegionCapability AddOnRegionCapabilityListByAddOnServiceResult
+	return addOnRegionCapability, s.Get(ctx, &addOnRegionCapability, fmt.Sprintf("/addon-services/%v/region-capabilities", addOnServiceIdentity), nil, lr)
 }
 
 // Add-on services represent add-ons that may be provisioned for apps.
 // Endpoints under add-on services can be accessed without
 // authentication.
-type AddonService struct {
-	CreatedAt time.Time `json:"created_at"` // when addon-service was created
-	ID        string    `json:"id"`         // unique identifier of this addon-service
-	Name      string    `json:"name"`       // unique name of this addon-service
-	UpdatedAt time.Time `json:"updated_at"` // when addon-service was updated
+type AddOnService struct {
+	CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
+	CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
+	HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
+	ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
+	Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
+	State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
+	SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
+	// add-on at the same time
+	SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
+	// app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
+}
+type AddOnServiceInfoResult struct {
+	CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
+	CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
+	HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
+	ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
+	Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
+	State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
+	SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
+	// add-on at the same time
+	SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
+	// app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
 }
 
-// Info for existing addon-service.
-func (s *Service) AddonServiceInfo(addonServiceIdentity string) (*AddonService, error) {
-	var addonService AddonService
-	return &addonService, s.Get(&addonService, fmt.Sprintf("/addon-services/%v", addonServiceIdentity), nil)
+// Info for existing add-on-service.
+func (s *Service) AddOnServiceInfo(ctx context.Context, addOnServiceIdentity string) (*AddOnServiceInfoResult, error) {
+	var addOnService AddOnServiceInfoResult
+	return &addOnService, s.Get(ctx, &addOnService, fmt.Sprintf("/addon-services/%v", addOnServiceIdentity), nil, nil)
 }
 
-// List existing addon-services.
-func (s *Service) AddonServiceList(lr *ListRange) ([]*AddonService, error) {
-	var addonServiceList []*AddonService
-	return addonServiceList, s.Get(&addonServiceList, fmt.Sprintf("/addon-services"), lr)
+type AddOnServiceListResult []struct {
+	CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
+	CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
+	HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
+	ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
+	Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
+	State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
+	SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
+	// add-on at the same time
+	SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
+	// app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
+}
+
+// List existing add-on-services.
+func (s *Service) AddOnServiceList(ctx context.Context, lr *ListRange) (AddOnServiceListResult, error) {
+	var addOnService AddOnServiceListResult
+	return addOnService, s.Get(ctx, &addOnService, fmt.Sprintf("/addon-services"), nil, lr)
 }
 
 // An app represents the program that you would like to deploy and run
 // on Heroku.
 type App struct {
-	ArchivedAt                   *time.Time `json:"archived_at"`                    // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at"`                     // when app was created
-	GitURL                       string     `json:"git_url"`                        // git repo URL of app
-	ID                           string     `json:"id"`                             // unique identifier of app
-	Maintenance                  bool       `json:"maintenance"`                    // maintenance status of app
-	Name                         string     `json:"name"`                           // unique name of app
-	Owner                        struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"owner"` // identity of app owner
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // identity of organization
+	Owner struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
 	Region struct {
-		ID   string `json:"id"`   // unique identifier of region
-		Name string `json:"name"` // unique name of region
-	} `json:"region"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at"` // when app was released
-	RepoSize   *int       `json:"repo_size"`   // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size"`   // slug size in bytes of app
-	Stack      struct {
-		ID   string `json:"id"`   // unique identifier of stack
-		Name string `json:"name"` // unique name of stack
-	} `json:"stack"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at"` // when app was updated
-	WebURL    string    `json:"web_url"`    // web URL of app
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID     string `json:"id" url:"id,key"`         // unique identifier of space
+		Name   string `json:"name" url:"name,key"`     // unique name of space
+		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 type AppCreateOpts struct {
-	Name   *string `json:"name,omitempty"`   // unique name of app
-	Region *string `json:"region,omitempty"` // unique identifier of region
-	Stack  *string `json:"stack,omitempty"`  // unique name of stack
+	Name   *string `json:"name,omitempty" url:"name,omitempty,key"`     // unique name of app
+	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
+	Stack  *string `json:"stack,omitempty" url:"stack,omitempty,key"`   // unique name of stack
+}
+type AppCreateResult struct {
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // identity of organization
+	Owner struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID     string `json:"id" url:"id,key"`         // unique identifier of space
+		Name   string `json:"name" url:"name,key"`     // unique name of space
+		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // Create a new app.
-func (s *Service) AppCreate(o struct {
-	Name   *string `json:"name,omitempty"`   // unique name of app
-	Region *string `json:"region,omitempty"` // unique identifier of region
-	Stack  *string `json:"stack,omitempty"`  // unique name of stack
-}) (*App, error) {
-	var app App
-	return &app, s.Post(&app, fmt.Sprintf("/apps"), o)
+func (s *Service) AppCreate(ctx context.Context, o AppCreateOpts) (*AppCreateResult, error) {
+	var app AppCreateResult
+	return &app, s.Post(ctx, &app, fmt.Sprintf("/apps"), o)
+}
+
+type AppDeleteResult struct {
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // identity of organization
+	Owner struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID     string `json:"id" url:"id,key"`         // unique identifier of space
+		Name   string `json:"name" url:"name,key"`     // unique name of space
+		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // Delete an existing app.
-func (s *Service) AppDelete(appIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v", appIdentity))
+func (s *Service) AppDelete(ctx context.Context, appIdentity string) (*AppDeleteResult, error) {
+	var app AppDeleteResult
+	return &app, s.Delete(ctx, &app, fmt.Sprintf("/apps/%v", appIdentity))
+}
+
+type AppInfoResult struct {
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // identity of organization
+	Owner struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID     string `json:"id" url:"id,key"`         // unique identifier of space
+		Name   string `json:"name" url:"name,key"`     // unique name of space
+		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // Info for existing app.
-func (s *Service) AppInfo(appIdentity string) (*App, error) {
-	var app App
-	return &app, s.Get(&app, fmt.Sprintf("/apps/%v", appIdentity), nil)
+func (s *Service) AppInfo(ctx context.Context, appIdentity string) (*AppInfoResult, error) {
+	var app AppInfoResult
+	return &app, s.Get(ctx, &app, fmt.Sprintf("/apps/%v", appIdentity), nil, nil)
+}
+
+type AppListResult []struct {
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // identity of organization
+	Owner struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID     string `json:"id" url:"id,key"`         // unique identifier of space
+		Name   string `json:"name" url:"name,key"`     // unique name of space
+		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // List existing apps.
-func (s *Service) AppList(lr *ListRange) ([]*App, error) {
-	var appList []*App
-	return appList, s.Get(&appList, fmt.Sprintf("/apps"), lr)
+func (s *Service) AppList(ctx context.Context, lr *ListRange) (AppListResult, error) {
+	var app AppListResult
+	return app, s.Get(ctx, &app, fmt.Sprintf("/apps"), nil, lr)
+}
+
+type AppListOwnedAndCollaboratedResult []struct {
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // identity of organization
+	Owner struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID     string `json:"id" url:"id,key"`         // unique identifier of space
+		Name   string `json:"name" url:"name,key"`     // unique name of space
+		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
+}
+
+// List owned and collaborated apps (excludes organization apps).
+func (s *Service) AppListOwnedAndCollaborated(ctx context.Context, accountIdentity string, lr *ListRange) (AppListOwnedAndCollaboratedResult, error) {
+	var app AppListOwnedAndCollaboratedResult
+	return app, s.Get(ctx, &app, fmt.Sprintf("/users/%v/apps", accountIdentity), nil, lr)
 }
 
 type AppUpdateOpts struct {
-	Maintenance *bool   `json:"maintenance,omitempty"` // maintenance status of app
-	Name        *string `json:"name,omitempty"`        // unique name of app
+	BuildStack  *string `json:"build_stack,omitempty" url:"build_stack,omitempty,key"` // unique name of stack
+	Maintenance *bool   `json:"maintenance,omitempty" url:"maintenance,omitempty,key"` // maintenance status of app
+	Name        *string `json:"name,omitempty" url:"name,omitempty,key"`               // unique name of app
+}
+type AppUpdateResult struct {
+	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
+	BuildStack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
+	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // identity of organization
+	Owner struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID     string `json:"id" url:"id,key"`         // unique identifier of space
+		Name   string `json:"name" url:"name,key"`     // unique name of space
+		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // Update an existing app.
-func (s *Service) AppUpdate(appIdentity string, o struct {
-	Maintenance *bool   `json:"maintenance,omitempty"` // maintenance status of app
-	Name        *string `json:"name,omitempty"`        // unique name of app
-}) (*App, error) {
-	var app App
-	return &app, s.Patch(&app, fmt.Sprintf("/apps/%v", appIdentity), o)
+func (s *Service) AppUpdate(ctx context.Context, appIdentity string, o AppUpdateOpts) (*AppUpdateResult, error) {
+	var app AppUpdateResult
+	return &app, s.Patch(ctx, &app, fmt.Sprintf("/apps/%v", appIdentity), o)
 }
 
 // An app feature represents a Heroku labs capability that can be
 // enabled or disabled for an app on Heroku.
 type AppFeature struct {
-	CreatedAt   time.Time `json:"created_at"`  // when app feature was created
-	Description string    `json:"description"` // description of app feature
-	DocURL      string    `json:"doc_url"`     // documentation URL of app feature
-	Enabled     bool      `json:"enabled"`     // whether or not app feature has been enabled
-	ID          string    `json:"id"`          // unique identifier of app feature
-	Name        string    `json:"name"`        // unique name of app feature
-	State       string    `json:"state"`       // state of app feature
-	UpdatedAt   time.Time `json:"updated_at"`  // when app feature was updated
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
+	Description string    `json:"description" url:"description,key"` // description of app feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
+	State       string    `json:"state" url:"state,key"`             // state of app feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
+}
+type AppFeatureInfoResult struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
+	Description string    `json:"description" url:"description,key"` // description of app feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
+	State       string    `json:"state" url:"state,key"`             // state of app feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
 }
 
 // Info for an existing app feature.
-func (s *Service) AppFeatureInfo(appIdentity string, appFeatureIdentity string) (*AppFeature, error) {
-	var appFeature AppFeature
-	return &appFeature, s.Get(&appFeature, fmt.Sprintf("/apps/%v/features/%v", appIdentity, appFeatureIdentity), nil)
+func (s *Service) AppFeatureInfo(ctx context.Context, appIdentity string, appFeatureIdentity string) (*AppFeatureInfoResult, error) {
+	var appFeature AppFeatureInfoResult
+	return &appFeature, s.Get(ctx, &appFeature, fmt.Sprintf("/apps/%v/features/%v", appIdentity, appFeatureIdentity), nil, nil)
+}
+
+type AppFeatureListResult []struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
+	Description string    `json:"description" url:"description,key"` // description of app feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
+	State       string    `json:"state" url:"state,key"`             // state of app feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
 }
 
 // List existing app features.
-func (s *Service) AppFeatureList(appIdentity string, lr *ListRange) ([]*AppFeature, error) {
-	var appFeatureList []*AppFeature
-	return appFeatureList, s.Get(&appFeatureList, fmt.Sprintf("/apps/%v/features", appIdentity), lr)
+func (s *Service) AppFeatureList(ctx context.Context, appIdentity string, lr *ListRange) (AppFeatureListResult, error) {
+	var appFeature AppFeatureListResult
+	return appFeature, s.Get(ctx, &appFeature, fmt.Sprintf("/apps/%v/features", appIdentity), nil, lr)
 }
 
 type AppFeatureUpdateOpts struct {
-	Enabled bool `json:"enabled"` // whether or not app feature has been enabled
+	Enabled bool `json:"enabled" url:"enabled,key"` // whether or not app feature has been enabled
+}
+type AppFeatureUpdateResult struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
+	Description string    `json:"description" url:"description,key"` // description of app feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
+	State       string    `json:"state" url:"state,key"`             // state of app feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
 }
 
 // Update an existing app feature.
-func (s *Service) AppFeatureUpdate(appIdentity string, appFeatureIdentity string, o struct {
-	Enabled bool `json:"enabled"` // whether or not app feature has been enabled
-}) (*AppFeature, error) {
-	var appFeature AppFeature
-	return &appFeature, s.Patch(&appFeature, fmt.Sprintf("/apps/%v/features/%v", appIdentity, appFeatureIdentity), o)
+func (s *Service) AppFeatureUpdate(ctx context.Context, appIdentity string, appFeatureIdentity string, o AppFeatureUpdateOpts) (*AppFeatureUpdateResult, error) {
+	var appFeature AppFeatureUpdateResult
+	return &appFeature, s.Patch(ctx, &appFeature, fmt.Sprintf("/apps/%v/features/%v", appIdentity, appFeatureIdentity), o)
+}
+
+// App formation set describes the combination of process types with
+// their quantities and sizes as well as application process tier
+type AppFormationSet struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app being described by the formation-set
+	Description string    `json:"description" url:"description,key"`   // a string representation of the formation set
+	ProcessTier string    `json:"process_tier" url:"process_tier,key"` // application process tier
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`     // last time fomation-set was updated
 }
 
 // An app setup represents an app on Heroku that is setup using an
@@ -492,385 +1562,1161 @@ func (s *Service) AppFeatureUpdate(appIdentity string, appFeatureIdentity string
 // file.
 type AppSetup struct {
 	App struct {
-		ID   string `json:"id"`   // unique identifier of app
-		Name string `json:"name"` // unique name of app
-	} `json:"app"` // identity of app
-	Build struct {
-		ID     string `json:"id"`     // unique identifier of build
-		Status string `json:"status"` // status of build
-	} `json:"build"` // identity and status of build
-	CreatedAt      time.Time `json:"created_at"`      // when app setup was created
-	FailureMessage *string   `json:"failure_message"` // reason that app setup has failed
-	ID             string    `json:"id"`              // unique identifier of app setup
-	ManifestErrors []string  `json:"manifest_errors"` // errors associated with invalid app.json manifest file
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app
+	Build *struct {
+		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
+		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+		// stream is available as either `text/plain` or `text/event-stream`.
+		// Clients should be prepared to handle disconnects and can resume the
+		// stream by sending a `Range` header (for `text/plain`) or a
+		// `Last-Event-Id` header (for `text/event-stream`).
+		Status string `json:"status" url:"status,key"` // status of build
+	} `json:"build" url:"build,key"` // identity and status of build
+	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when app setup was created
+	FailureMessage *string   `json:"failure_message" url:"failure_message,key"` // reason that app setup has failed
+	ID             string    `json:"id" url:"id,key"`                           // unique identifier of app setup
+	ManifestErrors []string  `json:"manifest_errors" url:"manifest_errors,key"` // errors associated with invalid app.json manifest file
 	Postdeploy     *struct {
-		ExitCode int    `json:"exit_code"` // The exit code of the postdeploy script
-		Output   string `json:"output"`    // output of the postdeploy script
-	} `json:"postdeploy"` // result of postdeploy script
-	ResolvedSuccessURL *string   `json:"resolved_success_url"` // fully qualified success url
-	Status             string    `json:"status"`               // the overall status of app setup
-	UpdatedAt          time.Time `json:"updated_at"`           // when app setup was updated
+		ExitCode int    `json:"exit_code" url:"exit_code,key"` // The exit code of the postdeploy script
+		Output   string `json:"output" url:"output,key"`       // output of the postdeploy script
+	} `json:"postdeploy" url:"postdeploy,key"` // result of postdeploy script
+	ResolvedSuccessURL *string   `json:"resolved_success_url" url:"resolved_success_url,key"` // fully qualified success url
+	Status             string    `json:"status" url:"status,key"`                             // the overall status of app setup
+	UpdatedAt          time.Time `json:"updated_at" url:"updated_at,key"`                     // when app setup was updated
 }
 type AppSetupCreateOpts struct {
 	App *struct {
-		Locked       *bool   `json:"locked,omitempty"`       // are other organization members forbidden from joining this app.
-		Name         *string `json:"name,omitempty"`         // unique name of app
-		Organization *string `json:"organization,omitempty"` // unique name of organization
-		Personal     *bool   `json:"personal,omitempty"`     // force creation of the app in the user account even if a default org
+		Locked       *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`             // are other organization members forbidden from joining this app.
+		Name         *string `json:"name,omitempty" url:"name,omitempty,key"`                 // unique name of app
+		Organization *string `json:"organization,omitempty" url:"organization,omitempty,key"` // unique name of organization
+		Personal     *bool   `json:"personal,omitempty" url:"personal,omitempty,key"`         // force creation of the app in the user account even if a default org
 		// is set.
-		Region *string `json:"region,omitempty"` // unique name of region
-		Stack  *string `json:"stack,omitempty"`  // unique name of stack
-	} `json:"app,omitempty"` // optional parameters for created app
+		Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique name of region
+		Space  *string `json:"space,omitempty" url:"space,omitempty,key"`   // unique name of space
+		Stack  *string `json:"stack,omitempty" url:"stack,omitempty,key"`   // unique name of stack
+	} `json:"app,omitempty" url:"app,omitempty,key"` // optional parameters for created app
 	Overrides *struct {
-		Env *map[string]string `json:"env,omitempty"` // overrides of the env specified in the app.json manifest file
-	} `json:"overrides,omitempty"` // overrides of keys in the app.json manifest file
+		Buildpacks *[]*struct {
+			URL *string `json:"url,omitempty" url:"url,omitempty,key"` // location of the buildpack
+		} `json:"buildpacks,omitempty" url:"buildpacks,omitempty,key"` // overrides the buildpacks specified in the app.json manifest file
+		Env *map[string]string `json:"env,omitempty" url:"env,omitempty,key"` // overrides of the env specified in the app.json manifest file
+	} `json:"overrides,omitempty" url:"overrides,omitempty,key"` // overrides of keys in the app.json manifest file
 	SourceBlob struct {
-		URL *string `json:"url,omitempty"` // URL of gzipped tarball of source code containing app.json manifest
+		Checksum *string `json:"checksum,omitempty" url:"checksum,omitempty,key"` // an optional checksum of the gzipped tarball for verifying its
+		// integrity
+		URL *string `json:"url,omitempty" url:"url,omitempty,key"` // URL of gzipped tarball of source code containing app.json manifest
 		// file
-	} `json:"source_blob"` // gzipped tarball of source code containing app.json manifest file
+		Version *string `json:"version,omitempty" url:"version,omitempty,key"` // Version of the gzipped tarball.
+	} `json:"source_blob" url:"source_blob,key"` // gzipped tarball of source code containing app.json manifest file
+}
+type AppSetupCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app
+	Build *struct {
+		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
+		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+		// stream is available as either `text/plain` or `text/event-stream`.
+		// Clients should be prepared to handle disconnects and can resume the
+		// stream by sending a `Range` header (for `text/plain`) or a
+		// `Last-Event-Id` header (for `text/event-stream`).
+		Status string `json:"status" url:"status,key"` // status of build
+	} `json:"build" url:"build,key"` // identity and status of build
+	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when app setup was created
+	FailureMessage *string   `json:"failure_message" url:"failure_message,key"` // reason that app setup has failed
+	ID             string    `json:"id" url:"id,key"`                           // unique identifier of app setup
+	ManifestErrors []string  `json:"manifest_errors" url:"manifest_errors,key"` // errors associated with invalid app.json manifest file
+	Postdeploy     *struct {
+		ExitCode int    `json:"exit_code" url:"exit_code,key"` // The exit code of the postdeploy script
+		Output   string `json:"output" url:"output,key"`       // output of the postdeploy script
+	} `json:"postdeploy" url:"postdeploy,key"` // result of postdeploy script
+	ResolvedSuccessURL *string   `json:"resolved_success_url" url:"resolved_success_url,key"` // fully qualified success url
+	Status             string    `json:"status" url:"status,key"`                             // the overall status of app setup
+	UpdatedAt          time.Time `json:"updated_at" url:"updated_at,key"`                     // when app setup was updated
 }
 
 // Create a new app setup from a gzipped tar archive containing an
 // app.json manifest file.
-func (s *Service) AppSetupCreate(o struct {
-	App *struct {
-		Locked       *bool   `json:"locked,omitempty"`       // are other organization members forbidden from joining this app.
-		Name         *string `json:"name,omitempty"`         // unique name of app
-		Organization *string `json:"organization,omitempty"` // unique name of organization
-		Personal     *bool   `json:"personal,omitempty"`     // force creation of the app in the user account even if a default org
-		// is set.
-		Region *string `json:"region,omitempty"` // unique name of region
-		Stack  *string `json:"stack,omitempty"`  // unique name of stack
-	} `json:"app,omitempty"` // optional parameters for created app
-	Overrides *struct {
-		Env *map[string]string `json:"env,omitempty"` // overrides of the env specified in the app.json manifest file
-	} `json:"overrides,omitempty"` // overrides of keys in the app.json manifest file
-	SourceBlob struct {
-		URL *string `json:"url,omitempty"` // URL of gzipped tarball of source code containing app.json manifest
-		// file
-	} `json:"source_blob"` // gzipped tarball of source code containing app.json manifest file
-}) (*AppSetup, error) {
-	var appSetup AppSetup
-	return &appSetup, s.Post(&appSetup, fmt.Sprintf("/app-setups"), o)
+func (s *Service) AppSetupCreate(ctx context.Context, o AppSetupCreateOpts) (*AppSetupCreateResult, error) {
+	var appSetup AppSetupCreateResult
+	return &appSetup, s.Post(ctx, &appSetup, fmt.Sprintf("/app-setups"), o)
+}
+
+type AppSetupInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // identity of app
+	Build *struct {
+		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
+		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+		// stream is available as either `text/plain` or `text/event-stream`.
+		// Clients should be prepared to handle disconnects and can resume the
+		// stream by sending a `Range` header (for `text/plain`) or a
+		// `Last-Event-Id` header (for `text/event-stream`).
+		Status string `json:"status" url:"status,key"` // status of build
+	} `json:"build" url:"build,key"` // identity and status of build
+	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when app setup was created
+	FailureMessage *string   `json:"failure_message" url:"failure_message,key"` // reason that app setup has failed
+	ID             string    `json:"id" url:"id,key"`                           // unique identifier of app setup
+	ManifestErrors []string  `json:"manifest_errors" url:"manifest_errors,key"` // errors associated with invalid app.json manifest file
+	Postdeploy     *struct {
+		ExitCode int    `json:"exit_code" url:"exit_code,key"` // The exit code of the postdeploy script
+		Output   string `json:"output" url:"output,key"`       // output of the postdeploy script
+	} `json:"postdeploy" url:"postdeploy,key"` // result of postdeploy script
+	ResolvedSuccessURL *string   `json:"resolved_success_url" url:"resolved_success_url,key"` // fully qualified success url
+	Status             string    `json:"status" url:"status,key"`                             // the overall status of app setup
+	UpdatedAt          time.Time `json:"updated_at" url:"updated_at,key"`                     // when app setup was updated
 }
 
 // Get the status of an app setup.
-func (s *Service) AppSetupInfo(appSetupIdentity string) (*AppSetup, error) {
-	var appSetup AppSetup
-	return &appSetup, s.Get(&appSetup, fmt.Sprintf("/app-setups/%v", appSetupIdentity), nil)
+func (s *Service) AppSetupInfo(ctx context.Context, appSetupIdentity string) (*AppSetupInfoResult, error) {
+	var appSetup AppSetupInfoResult
+	return &appSetup, s.Get(ctx, &appSetup, fmt.Sprintf("/app-setups/%v", appSetupIdentity), nil, nil)
 }
 
 // An app transfer represents a two party interaction for transferring
 // ownership of an app.
 type AppTransfer struct {
 	App struct {
-		ID   string `json:"id"`   // unique identifier of app
-		Name string `json:"name"` // unique name of app
-	} `json:"app"` // app involved in the transfer
-	CreatedAt time.Time `json:"created_at"` // when app transfer was created
-	ID        string    `json:"id"`         // unique identifier of app transfer
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the transfer
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
 	Owner     struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"owner"` // identity of the owner of the transfer
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
 	Recipient struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"recipient"` // identity of the recipient of the transfer
-	State     string    `json:"state"`      // the current state of an app transfer
-	UpdatedAt time.Time `json:"updated_at"` // when app transfer was updated
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
+	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
 type AppTransferCreateOpts struct {
-	App       string `json:"app"`       // unique identifier of app
-	Recipient string `json:"recipient"` // unique email address of account
+	App       string `json:"app" url:"app,key"`                           // unique identifier of app
+	Recipient string `json:"recipient" url:"recipient,key"`               // unique email address of account
+	Silent    *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email notification when transferring apps
+}
+type AppTransferCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the transfer
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
+	Owner     struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
+	Recipient struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
+	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
 
 // Create a new app transfer.
-func (s *Service) AppTransferCreate(o struct {
-	App       string `json:"app"`       // unique identifier of app
-	Recipient string `json:"recipient"` // unique email address of account
-}) (*AppTransfer, error) {
-	var appTransfer AppTransfer
-	return &appTransfer, s.Post(&appTransfer, fmt.Sprintf("/account/app-transfers"), o)
+func (s *Service) AppTransferCreate(ctx context.Context, o AppTransferCreateOpts) (*AppTransferCreateResult, error) {
+	var appTransfer AppTransferCreateResult
+	return &appTransfer, s.Post(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers"), o)
+}
+
+type AppTransferDeleteResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the transfer
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
+	Owner     struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
+	Recipient struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
+	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
 
 // Delete an existing app transfer
-func (s *Service) AppTransferDelete(appTransferIdentity string) error {
-	return s.Delete(fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity))
+func (s *Service) AppTransferDelete(ctx context.Context, appTransferIdentity string) (*AppTransferDeleteResult, error) {
+	var appTransfer AppTransferDeleteResult
+	return &appTransfer, s.Delete(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity))
+}
+
+type AppTransferInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the transfer
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
+	Owner     struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
+	Recipient struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
+	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
 
 // Info for existing app transfer.
-func (s *Service) AppTransferInfo(appTransferIdentity string) (*AppTransfer, error) {
-	var appTransfer AppTransfer
-	return &appTransfer, s.Get(&appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity), nil)
+func (s *Service) AppTransferInfo(ctx context.Context, appTransferIdentity string) (*AppTransferInfoResult, error) {
+	var appTransfer AppTransferInfoResult
+	return &appTransfer, s.Get(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity), nil, nil)
+}
+
+type AppTransferListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the transfer
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
+	Owner     struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
+	Recipient struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
+	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
 
 // List existing apps transfers.
-func (s *Service) AppTransferList(lr *ListRange) ([]*AppTransfer, error) {
-	var appTransferList []*AppTransfer
-	return appTransferList, s.Get(&appTransferList, fmt.Sprintf("/account/app-transfers"), lr)
+func (s *Service) AppTransferList(ctx context.Context, lr *ListRange) (AppTransferListResult, error) {
+	var appTransfer AppTransferListResult
+	return appTransfer, s.Get(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers"), nil, lr)
 }
 
 type AppTransferUpdateOpts struct {
-	State string `json:"state"` // the current state of an app transfer
+	State string `json:"state" url:"state,key"` // the current state of an app transfer
+}
+type AppTransferUpdateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the transfer
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
+	Owner     struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
+	Recipient struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
+	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
 }
 
 // Update an existing app transfer.
-func (s *Service) AppTransferUpdate(appTransferIdentity string, o struct {
-	State string `json:"state"` // the current state of an app transfer
-}) (*AppTransfer, error) {
-	var appTransfer AppTransfer
-	return &appTransfer, s.Patch(&appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity), o)
+func (s *Service) AppTransferUpdate(ctx context.Context, appTransferIdentity string, o AppTransferUpdateOpts) (*AppTransferUpdateResult, error) {
+	var appTransfer AppTransferUpdateResult
+	return &appTransfer, s.Patch(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity), o)
 }
 
 // A build represents the process of transforming a code tarball into a
 // slug
 type Build struct {
-	CreatedAt time.Time `json:"created_at"` // when build was created
-	ID        string    `json:"id"`         // unique identifier of build
-	Slug      *struct {
-		ID string `json:"id"` // unique identifier of slug
-	} `json:"slug"` // slug created by this build
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app that the build belongs to
+	Buildpacks *[]struct {
+		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpacks" url:"buildpacks,key"` // buildpacks executed for this build, in order
+	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when build was created
+	ID              string    `json:"id" url:"id,key"`                               // unique identifier of build
+	OutputStreamURL string    `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+	// stream is available as either `text/plain` or `text/event-stream`.
+	// Clients should be prepared to handle disconnects and can resume the
+	// stream by sending a `Range` header (for `text/plain`) or a
+	// `Last-Event-Id` header (for `text/event-stream`).
+	Release *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of release
+	} `json:"release" url:"release,key"` // release resulting from the build
+	Slug *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug created by this build
 	SourceBlob struct {
-		URL string `json:"url"` // URL where gzipped tar archive of source code for build was
+		Checksum *string `json:"checksum" url:"checksum,key"` // an optional checksum of the gzipped tarball for verifying its
+		// integrity
+		URL string `json:"url" url:"url,key"` // URL where gzipped tar archive of source code for build was
 		// downloaded.
-		Version *string `json:"version"` // Version of the gzipped tarball.
-	} `json:"source_blob"` // location of gzipped tarball of source code used to create build
-	Status    string    `json:"status"`     // status of build
-	UpdatedAt time.Time `json:"updated_at"` // when build was updated
+		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
+	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
+	Status    string    `json:"status" url:"status,key"`         // status of build
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
 	User      struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"user"` // user that started the build
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that started the build
 }
 type BuildCreateOpts struct {
+	Buildpacks *[]*struct {
+		URL *string `json:"url,omitempty" url:"url,omitempty,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpacks,omitempty" url:"buildpacks,omitempty,key"` // buildpacks executed for this build, in order
 	SourceBlob struct {
-		URL *string `json:"url,omitempty"` // URL where gzipped tar archive of source code for build was
+		Checksum *string `json:"checksum,omitempty" url:"checksum,omitempty,key"` // an optional checksum of the gzipped tarball for verifying its
+		// integrity
+		URL *string `json:"url,omitempty" url:"url,omitempty,key"` // URL where gzipped tar archive of source code for build was
 		// downloaded.
-		Version *string `json:"version,omitempty"` // Version of the gzipped tarball.
-	} `json:"source_blob"` // location of gzipped tarball of source code used to create build
+		Version *string `json:"version,omitempty" url:"version,omitempty,key"` // Version of the gzipped tarball.
+	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
+}
+type BuildCreateResult struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app that the build belongs to
+	Buildpacks *[]struct {
+		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpacks" url:"buildpacks,key"` // buildpacks executed for this build, in order
+	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when build was created
+	ID              string    `json:"id" url:"id,key"`                               // unique identifier of build
+	OutputStreamURL string    `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+	// stream is available as either `text/plain` or `text/event-stream`.
+	// Clients should be prepared to handle disconnects and can resume the
+	// stream by sending a `Range` header (for `text/plain`) or a
+	// `Last-Event-Id` header (for `text/event-stream`).
+	Release *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of release
+	} `json:"release" url:"release,key"` // release resulting from the build
+	Slug *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug created by this build
+	SourceBlob struct {
+		Checksum *string `json:"checksum" url:"checksum,key"` // an optional checksum of the gzipped tarball for verifying its
+		// integrity
+		URL string `json:"url" url:"url,key"` // URL where gzipped tar archive of source code for build was
+		// downloaded.
+		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
+	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
+	Status    string    `json:"status" url:"status,key"`         // status of build
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that started the build
 }
 
 // Create a new build.
-func (s *Service) BuildCreate(appIdentity string, o struct {
+func (s *Service) BuildCreate(ctx context.Context, appIdentity string, o BuildCreateOpts) (*BuildCreateResult, error) {
+	var build BuildCreateResult
+	return &build, s.Post(ctx, &build, fmt.Sprintf("/apps/%v/builds", appIdentity), o)
+}
+
+type BuildInfoResult struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app that the build belongs to
+	Buildpacks *[]struct {
+		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpacks" url:"buildpacks,key"` // buildpacks executed for this build, in order
+	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when build was created
+	ID              string    `json:"id" url:"id,key"`                               // unique identifier of build
+	OutputStreamURL string    `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+	// stream is available as either `text/plain` or `text/event-stream`.
+	// Clients should be prepared to handle disconnects and can resume the
+	// stream by sending a `Range` header (for `text/plain`) or a
+	// `Last-Event-Id` header (for `text/event-stream`).
+	Release *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of release
+	} `json:"release" url:"release,key"` // release resulting from the build
+	Slug *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug created by this build
 	SourceBlob struct {
-		URL *string `json:"url,omitempty"` // URL where gzipped tar archive of source code for build was
+		Checksum *string `json:"checksum" url:"checksum,key"` // an optional checksum of the gzipped tarball for verifying its
+		// integrity
+		URL string `json:"url" url:"url,key"` // URL where gzipped tar archive of source code for build was
 		// downloaded.
-		Version *string `json:"version,omitempty"` // Version of the gzipped tarball.
-	} `json:"source_blob"` // location of gzipped tarball of source code used to create build
-}) (*Build, error) {
-	var build Build
-	return &build, s.Post(&build, fmt.Sprintf("/apps/%v/builds", appIdentity), o)
+		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
+	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
+	Status    string    `json:"status" url:"status,key"`         // status of build
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that started the build
 }
 
 // Info for existing build.
-func (s *Service) BuildInfo(appIdentity string, buildIdentity string) (*Build, error) {
-	var build Build
-	return &build, s.Get(&build, fmt.Sprintf("/apps/%v/builds/%v", appIdentity, buildIdentity), nil)
+func (s *Service) BuildInfo(ctx context.Context, appIdentity string, buildIdentity string) (*BuildInfoResult, error) {
+	var build BuildInfoResult
+	return &build, s.Get(ctx, &build, fmt.Sprintf("/apps/%v/builds/%v", appIdentity, buildIdentity), nil, nil)
+}
+
+type BuildListResult []struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app that the build belongs to
+	Buildpacks *[]struct {
+		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpacks" url:"buildpacks,key"` // buildpacks executed for this build, in order
+	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when build was created
+	ID              string    `json:"id" url:"id,key"`                               // unique identifier of build
+	OutputStreamURL string    `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+	// stream is available as either `text/plain` or `text/event-stream`.
+	// Clients should be prepared to handle disconnects and can resume the
+	// stream by sending a `Range` header (for `text/plain`) or a
+	// `Last-Event-Id` header (for `text/event-stream`).
+	Release *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of release
+	} `json:"release" url:"release,key"` // release resulting from the build
+	Slug *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug created by this build
+	SourceBlob struct {
+		Checksum *string `json:"checksum" url:"checksum,key"` // an optional checksum of the gzipped tarball for verifying its
+		// integrity
+		URL string `json:"url" url:"url,key"` // URL where gzipped tar archive of source code for build was
+		// downloaded.
+		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
+	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
+	Status    string    `json:"status" url:"status,key"`         // status of build
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that started the build
 }
 
 // List existing build.
-func (s *Service) BuildList(appIdentity string, lr *ListRange) ([]*Build, error) {
-	var buildList []*Build
-	return buildList, s.Get(&buildList, fmt.Sprintf("/apps/%v/builds", appIdentity), lr)
+func (s *Service) BuildList(ctx context.Context, appIdentity string, lr *ListRange) (BuildListResult, error) {
+	var build BuildListResult
+	return build, s.Get(ctx, &build, fmt.Sprintf("/apps/%v/builds", appIdentity), nil, lr)
 }
 
 // A build result contains the output from a build.
 type BuildResult struct {
 	Build struct {
-		ID     string `json:"id"`     // unique identifier of build
-		Status string `json:"status"` // status of build
-	} `json:"build"` // identity of build
-	ExitCode float64 `json:"exit_code"` // status from the build
+		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
+		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+		// stream is available as either `text/plain` or `text/event-stream`.
+		// Clients should be prepared to handle disconnects and can resume the
+		// stream by sending a `Range` header (for `text/plain`) or a
+		// `Last-Event-Id` header (for `text/event-stream`).
+		Status string `json:"status" url:"status,key"` // status of build
+	} `json:"build" url:"build,key"` // identity of build
+	ExitCode float64 `json:"exit_code" url:"exit_code,key"` // status from the build
 	Lines    []struct {
-		Line   string `json:"line"`   // A line of output from the build.
-		Stream string `json:"stream"` // The output stream where the line was sent.
-	} `json:"lines"` // A list of all the lines of a build's output.
+		Line   string `json:"line" url:"line,key"`     // A line of output from the build.
+		Stream string `json:"stream" url:"stream,key"` // The output stream where the line was sent.
+	} `json:"lines" url:"lines,key"` // A list of all the lines of a build's output. This has been replaced
+	// by the `output_stream_url` attribute on the build resource.
+}
+type BuildResultInfoResult struct {
+	Build struct {
+		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
+		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
+		// stream is available as either `text/plain` or `text/event-stream`.
+		// Clients should be prepared to handle disconnects and can resume the
+		// stream by sending a `Range` header (for `text/plain`) or a
+		// `Last-Event-Id` header (for `text/event-stream`).
+		Status string `json:"status" url:"status,key"` // status of build
+	} `json:"build" url:"build,key"` // identity of build
+	ExitCode float64 `json:"exit_code" url:"exit_code,key"` // status from the build
+	Lines    []struct {
+		Line   string `json:"line" url:"line,key"`     // A line of output from the build.
+		Stream string `json:"stream" url:"stream,key"` // The output stream where the line was sent.
+	} `json:"lines" url:"lines,key"` // A list of all the lines of a build's output. This has been replaced
+	// by the `output_stream_url` attribute on the build resource.
 }
 
 // Info for existing result.
-func (s *Service) BuildResultInfo(appIdentity string, buildIdentity string) (*BuildResult, error) {
-	var buildResult BuildResult
-	return &buildResult, s.Get(&buildResult, fmt.Sprintf("/apps/%v/builds/%v/result", appIdentity, buildIdentity), nil)
+func (s *Service) BuildResultInfo(ctx context.Context, appIdentity string, buildIdentity string) (*BuildResultInfoResult, error) {
+	var buildResult BuildResultInfoResult
+	return &buildResult, s.Get(ctx, &buildResult, fmt.Sprintf("/apps/%v/builds/%v/result", appIdentity, buildIdentity), nil, nil)
+}
+
+// A buildpack installation represents a buildpack that will be run
+// against an app.
+type BuildpackInstallation struct {
+	Buildpack struct {
+		Name string `json:"name" url:"name,key"` // either the shorthand name (heroku official buildpacks) or url
+		// (unofficial buildpacks) of the buildpack for the app
+		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpack" url:"buildpack,key"` // buildpack
+	Ordinal int `json:"ordinal" url:"ordinal,key"` // determines the order in which the buildpacks will execute
+}
+type BuildpackInstallationUpdateOpts struct {
+	Updates []struct {
+		Buildpack string `json:"buildpack" url:"buildpack,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"updates" url:"updates,key"` // The buildpack attribute can accept a name, a url, or a urn.
+}
+type BuildpackInstallationUpdateResult []struct {
+	Buildpack struct {
+		Name string `json:"name" url:"name,key"` // either the shorthand name (heroku official buildpacks) or url
+		// (unofficial buildpacks) of the buildpack for the app
+		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpack" url:"buildpack,key"` // buildpack
+	Ordinal int `json:"ordinal" url:"ordinal,key"` // determines the order in which the buildpacks will execute
+}
+
+// Update an app's buildpack installations.
+func (s *Service) BuildpackInstallationUpdate(ctx context.Context, appIdentity string, o BuildpackInstallationUpdateOpts) (BuildpackInstallationUpdateResult, error) {
+	var buildpackInstallation BuildpackInstallationUpdateResult
+	return buildpackInstallation, s.Put(ctx, &buildpackInstallation, fmt.Sprintf("/apps/%v/buildpack-installations", appIdentity), o)
+}
+
+type BuildpackInstallationListResult []struct {
+	Buildpack struct {
+		Name string `json:"name" url:"name,key"` // either the shorthand name (heroku official buildpacks) or url
+		// (unofficial buildpacks) of the buildpack for the app
+		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
+		// buildpacks) or an internal urn (heroku official buildpacks).
+	} `json:"buildpack" url:"buildpack,key"` // buildpack
+	Ordinal int `json:"ordinal" url:"ordinal,key"` // determines the order in which the buildpacks will execute
+}
+
+// List an app's existing buildpack installations.
+func (s *Service) BuildpackInstallationList(ctx context.Context, appIdentity string, lr *ListRange) (BuildpackInstallationListResult, error) {
+	var buildpackInstallation BuildpackInstallationListResult
+	return buildpackInstallation, s.Get(ctx, &buildpackInstallation, fmt.Sprintf("/apps/%v/buildpack-installations", appIdentity), nil, lr)
 }
 
 // A collaborator represents an account that has been given access to an
 // app on Heroku.
 type Collaborator struct {
-	CreatedAt time.Time `json:"created_at"` // when collaborator was created
-	ID        string    `json:"id"`         // unique identifier of collaborator
-	UpdatedAt time.Time `json:"updated_at"` // when collaborator was updated
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+	} `json:"permissions" url:"permissions,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
 	User      struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"user"` // identity of collaborated account
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 type CollaboratorCreateOpts struct {
-	Silent *bool  `json:"silent,omitempty"` // whether to suppress email invitation when creating collaborator
-	User   string `json:"user"`             // unique email address of account
+	Silent *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email invitation when creating collaborator
+	User   string `json:"user" url:"user,key"`                         // unique email address of account
+}
+type CollaboratorCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+	} `json:"permissions" url:"permissions,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // Create a new collaborator.
-func (s *Service) CollaboratorCreate(appIdentity string, o struct {
-	Silent *bool  `json:"silent,omitempty"` // whether to suppress email invitation when creating collaborator
-	User   string `json:"user"`             // unique email address of account
-}) (*Collaborator, error) {
-	var collaborator Collaborator
-	return &collaborator, s.Post(&collaborator, fmt.Sprintf("/apps/%v/collaborators", appIdentity), o)
+func (s *Service) CollaboratorCreate(ctx context.Context, appIdentity string, o CollaboratorCreateOpts) (*CollaboratorCreateResult, error) {
+	var collaborator CollaboratorCreateResult
+	return &collaborator, s.Post(ctx, &collaborator, fmt.Sprintf("/apps/%v/collaborators", appIdentity), o)
+}
+
+type CollaboratorDeleteResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+	} `json:"permissions" url:"permissions,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // Delete an existing collaborator.
-func (s *Service) CollaboratorDelete(appIdentity string, collaboratorIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v/collaborators/%v", appIdentity, collaboratorIdentity))
+func (s *Service) CollaboratorDelete(ctx context.Context, appIdentity string, collaboratorIdentity string) (*CollaboratorDeleteResult, error) {
+	var collaborator CollaboratorDeleteResult
+	return &collaborator, s.Delete(ctx, &collaborator, fmt.Sprintf("/apps/%v/collaborators/%v", appIdentity, collaboratorIdentity))
+}
+
+type CollaboratorInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+	} `json:"permissions" url:"permissions,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // Info for existing collaborator.
-func (s *Service) CollaboratorInfo(appIdentity string, collaboratorIdentity string) (*Collaborator, error) {
-	var collaborator Collaborator
-	return &collaborator, s.Get(&collaborator, fmt.Sprintf("/apps/%v/collaborators/%v", appIdentity, collaboratorIdentity), nil)
+func (s *Service) CollaboratorInfo(ctx context.Context, appIdentity string, collaboratorIdentity string) (*CollaboratorInfoResult, error) {
+	var collaborator CollaboratorInfoResult
+	return &collaborator, s.Get(ctx, &collaborator, fmt.Sprintf("/apps/%v/collaborators/%v", appIdentity, collaboratorIdentity), nil, nil)
+}
+
+type CollaboratorListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+	} `json:"permissions" url:"permissions,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // List existing collaborators.
-func (s *Service) CollaboratorList(appIdentity string, lr *ListRange) ([]*Collaborator, error) {
-	var collaboratorList []*Collaborator
-	return collaboratorList, s.Get(&collaboratorList, fmt.Sprintf("/apps/%v/collaborators", appIdentity), lr)
+func (s *Service) CollaboratorList(ctx context.Context, appIdentity string, lr *ListRange) (CollaboratorListResult, error) {
+	var collaborator CollaboratorListResult
+	return collaborator, s.Get(ctx, &collaborator, fmt.Sprintf("/apps/%v/collaborators", appIdentity), nil, lr)
 }
 
 // Config Vars allow you to manage the configuration information
 // provided to an app on Heroku.
 type ConfigVar map[string]string
+type ConfigVarInfoForAppResult map[string]*string
 
 // Get config-vars for app.
-func (s *Service) ConfigVarInfo(appIdentity string) (map[string]string, error) {
-	var configVar ConfigVar
-	return configVar, s.Get(&configVar, fmt.Sprintf("/apps/%v/config-vars", appIdentity), nil)
+func (s *Service) ConfigVarInfoForApp(ctx context.Context, appIdentity string) (ConfigVarInfoForAppResult, error) {
+	var configVar ConfigVarInfoForAppResult
+	return configVar, s.Get(ctx, &configVar, fmt.Sprintf("/apps/%v/config-vars", appIdentity), nil, nil)
 }
 
-type ConfigVarUpdateOpts map[string]*string
+type ConfigVarInfoForAppReleaseResult map[string]*string
+
+// Get config-vars for a release.
+func (s *Service) ConfigVarInfoForAppRelease(ctx context.Context, appIdentity string, releaseIdentity string) (ConfigVarInfoForAppReleaseResult, error) {
+	var configVar ConfigVarInfoForAppReleaseResult
+	return configVar, s.Get(ctx, &configVar, fmt.Sprintf("/apps/%v/releases/%v/config-vars", appIdentity, releaseIdentity), nil, nil)
+}
+
+type ConfigVarUpdateResult map[string]*string
 
 // Update config-vars for app. You can update existing config-vars by
-// setting them again, and remove by setting it to `NULL`.
-func (s *Service) ConfigVarUpdate(appIdentity string, o map[string]*string) (map[string]string, error) {
-	var configVar ConfigVar
-	return configVar, s.Patch(&configVar, fmt.Sprintf("/apps/%v/config-vars", appIdentity), o)
+// setting them again, and remove by setting it to `null`.
+func (s *Service) ConfigVarUpdate(ctx context.Context, appIdentity string, o map[string]*string) (ConfigVarUpdateResult, error) {
+	var configVar ConfigVarUpdateResult
+	return configVar, s.Patch(ctx, &configVar, fmt.Sprintf("/apps/%v/config-vars", appIdentity), o)
 }
 
 // A credit represents value that will be used up before further charges
 // are assigned to an account.
 type Credit struct {
-	Amount    float64   `json:"amount"`     // total value of credit in cents
-	Balance   float64   `json:"balance"`    // remaining value of credit in cents
-	CreatedAt time.Time `json:"created_at"` // when credit was created
-	ExpiresAt time.Time `json:"expires_at"` // when credit will expire
-	ID        string    `json:"id"`         // unique identifier of credit
-	Title     string    `json:"title"`      // a name for credit
-	UpdatedAt time.Time `json:"updated_at"` // when credit was updated
+	Amount    float64   `json:"amount" url:"amount,key"`         // total value of credit in cents
+	Balance   float64   `json:"balance" url:"balance,key"`       // remaining value of credit in cents
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when credit was created
+	ExpiresAt time.Time `json:"expires_at" url:"expires_at,key"` // when credit will expire
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of credit
+	Title     string    `json:"title" url:"title,key"`           // a name for credit
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
+}
+type CreditCreateOpts struct {
+	Code1 *string `json:"code1,omitempty" url:"code1,omitempty,key"` // first code from a discount card
+	Code2 *string `json:"code2,omitempty" url:"code2,omitempty,key"` // second code from a discount card
+}
+type CreditCreateResult struct {
+	Amount    float64   `json:"amount" url:"amount,key"`         // total value of credit in cents
+	Balance   float64   `json:"balance" url:"balance,key"`       // remaining value of credit in cents
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when credit was created
+	ExpiresAt time.Time `json:"expires_at" url:"expires_at,key"` // when credit will expire
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of credit
+	Title     string    `json:"title" url:"title,key"`           // a name for credit
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
+}
+
+// Create a new credit.
+func (s *Service) CreditCreate(ctx context.Context, o CreditCreateOpts) (*CreditCreateResult, error) {
+	var credit CreditCreateResult
+	return &credit, s.Post(ctx, &credit, fmt.Sprintf("/account/credits"), o)
+}
+
+type CreditInfoResult struct {
+	Amount    float64   `json:"amount" url:"amount,key"`         // total value of credit in cents
+	Balance   float64   `json:"balance" url:"balance,key"`       // remaining value of credit in cents
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when credit was created
+	ExpiresAt time.Time `json:"expires_at" url:"expires_at,key"` // when credit will expire
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of credit
+	Title     string    `json:"title" url:"title,key"`           // a name for credit
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
 }
 
 // Info for existing credit.
-func (s *Service) CreditInfo(creditIdentity string) (*Credit, error) {
-	var credit Credit
-	return &credit, s.Get(&credit, fmt.Sprintf("/account/credits/%v", creditIdentity), nil)
+func (s *Service) CreditInfo(ctx context.Context, creditIdentity string) (*CreditInfoResult, error) {
+	var credit CreditInfoResult
+	return &credit, s.Get(ctx, &credit, fmt.Sprintf("/account/credits/%v", creditIdentity), nil, nil)
+}
+
+type CreditListResult []struct {
+	Amount    float64   `json:"amount" url:"amount,key"`         // total value of credit in cents
+	Balance   float64   `json:"balance" url:"balance,key"`       // remaining value of credit in cents
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when credit was created
+	ExpiresAt time.Time `json:"expires_at" url:"expires_at,key"` // when credit will expire
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of credit
+	Title     string    `json:"title" url:"title,key"`           // a name for credit
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
 }
 
 // List existing credits.
-func (s *Service) CreditList(lr *ListRange) ([]*Credit, error) {
-	var creditList []*Credit
-	return creditList, s.Get(&creditList, fmt.Sprintf("/account/credits"), lr)
+func (s *Service) CreditList(ctx context.Context, lr *ListRange) (CreditListResult, error) {
+	var credit CreditListResult
+	return credit, s.Get(ctx, &credit, fmt.Sprintf("/account/credits"), nil, lr)
 }
 
 // Domains define what web routes should be routed to an app on Heroku.
 type Domain struct {
-	CreatedAt time.Time `json:"created_at"` // when domain was created
-	Hostname  string    `json:"hostname"`   // full hostname
-	ID        string    `json:"id"`         // unique identifier of this domain
-	UpdatedAt time.Time `json:"updated_at"` // when domain was updated
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app that owns the domain
+	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
+	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
+	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
+	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
 }
 type DomainCreateOpts struct {
-	Hostname string `json:"hostname"` // full hostname
+	Hostname string `json:"hostname" url:"hostname,key"` // full hostname
+}
+type DomainCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app that owns the domain
+	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
+	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
+	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
+	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
 }
 
 // Create a new domain.
-func (s *Service) DomainCreate(appIdentity string, o struct {
-	Hostname string `json:"hostname"` // full hostname
-}) (*Domain, error) {
-	var domain Domain
-	return &domain, s.Post(&domain, fmt.Sprintf("/apps/%v/domains", appIdentity), o)
+func (s *Service) DomainCreate(ctx context.Context, appIdentity string, o DomainCreateOpts) (*DomainCreateResult, error) {
+	var domain DomainCreateResult
+	return &domain, s.Post(ctx, &domain, fmt.Sprintf("/apps/%v/domains", appIdentity), o)
+}
+
+type DomainDeleteResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app that owns the domain
+	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
+	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
+	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
+	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
 }
 
 // Delete an existing domain
-func (s *Service) DomainDelete(appIdentity string, domainIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v/domains/%v", appIdentity, domainIdentity))
+func (s *Service) DomainDelete(ctx context.Context, appIdentity string, domainIdentity string) (*DomainDeleteResult, error) {
+	var domain DomainDeleteResult
+	return &domain, s.Delete(ctx, &domain, fmt.Sprintf("/apps/%v/domains/%v", appIdentity, domainIdentity))
+}
+
+type DomainInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app that owns the domain
+	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
+	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
+	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
+	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
 }
 
 // Info for existing domain.
-func (s *Service) DomainInfo(appIdentity string, domainIdentity string) (*Domain, error) {
-	var domain Domain
-	return &domain, s.Get(&domain, fmt.Sprintf("/apps/%v/domains/%v", appIdentity, domainIdentity), nil)
+func (s *Service) DomainInfo(ctx context.Context, appIdentity string, domainIdentity string) (*DomainInfoResult, error) {
+	var domain DomainInfoResult
+	return &domain, s.Get(ctx, &domain, fmt.Sprintf("/apps/%v/domains/%v", appIdentity, domainIdentity), nil, nil)
+}
+
+type DomainListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app that owns the domain
+	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
+	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
+	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
+	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
 }
 
 // List existing domains.
-func (s *Service) DomainList(appIdentity string, lr *ListRange) ([]*Domain, error) {
-	var domainList []*Domain
-	return domainList, s.Get(&domainList, fmt.Sprintf("/apps/%v/domains", appIdentity), lr)
+func (s *Service) DomainList(ctx context.Context, appIdentity string, lr *ListRange) (DomainListResult, error) {
+	var domain DomainListResult
+	return domain, s.Get(ctx, &domain, fmt.Sprintf("/apps/%v/domains", appIdentity), nil, lr)
 }
 
-// Dynos encapsulate running processes of an app on Heroku.
+// Dynos encapsulate running processes of an app on Heroku. Detailed
+// information about dyno sizes can be found at:
+// [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.h
+// eroku.com/articles/dyno-types).
 type Dyno struct {
-	AttachURL *string `json:"attach_url"` // a URL to stream output from for attached processes or null for
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	AttachURL *string `json:"attach_url" url:"attach_url,key"` // a URL to stream output from for attached processes or null for
 	// non-attached processes
-	Command   string    `json:"command"`    // command used to start this process
-	CreatedAt time.Time `json:"created_at"` // when dyno was created
-	ID        string    `json:"id"`         // unique identifier of this dyno
-	Name      string    `json:"name"`       // the name of this process on this dyno
+	Command   string    `json:"command" url:"command,key"`       // command used to start this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when dyno was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this dyno
+	Name      string    `json:"name" url:"name,key"`             // the name of this process on this dyno
 	Release   struct {
-		ID      string `json:"id"`      // unique identifier of release
-		Version int    `json:"version"` // unique version assigned to the release
-	} `json:"release"` // app release of the dyno
-	Size  string `json:"size"`  // dyno size (default: "1X")
-	State string `json:"state"` // current status of process (either: crashed, down, idle, starting, or
+		ID      string `json:"id" url:"id,key"`           // unique identifier of release
+		Version int    `json:"version" url:"version,key"` // unique version assigned to the release
+	} `json:"release" url:"release,key"` // app release of the dyno
+	Size  string `json:"size" url:"size,key"`   // dyno size (default: "standard-1X")
+	State string `json:"state" url:"state,key"` // current status of process (either: crashed, down, idle, starting, or
 	// up)
-	Type      string    `json:"type"`       // type of process
-	UpdatedAt time.Time `json:"updated_at"` // when process last changed state
+	Type      string    `json:"type" url:"type,key"`             // type of process
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
 }
 type DynoCreateOpts struct {
-	Attach  *bool              `json:"attach,omitempty"` // whether to stream output or not
-	Command string             `json:"command"`          // command used to start this process
-	Env     *map[string]string `json:"env,omitempty"`    // custom environment to add to the dyno config vars
-	Size    *string            `json:"size,omitempty"`   // dyno size (default: "1X")
+	Attach     *bool              `json:"attach,omitempty" url:"attach,omitempty,key"`             // whether to stream output or not
+	Command    string             `json:"command" url:"command,key"`                               // command used to start this process
+	Env        *map[string]string `json:"env,omitempty" url:"env,omitempty,key"`                   // custom environment to add to the dyno config vars
+	ForceNoTty *bool              `json:"force_no_tty,omitempty" url:"force_no_tty,omitempty,key"` // force an attached one-off dyno to not run in a tty
+	Size       *string            `json:"size,omitempty" url:"size,omitempty,key"`                 // dyno size (default: "standard-1X")
+	TimeToLive *int               `json:"time_to_live,omitempty" url:"time_to_live,omitempty,key"` // seconds until dyno expires, after which it will soon be killed
+	Type       *string            `json:"type,omitempty" url:"type,omitempty,key"`                 // type of process
+}
+type DynoCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	AttachURL *string `json:"attach_url" url:"attach_url,key"` // a URL to stream output from for attached processes or null for
+	// non-attached processes
+	Command   string    `json:"command" url:"command,key"`       // command used to start this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when dyno was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this dyno
+	Name      string    `json:"name" url:"name,key"`             // the name of this process on this dyno
+	Release   struct {
+		ID      string `json:"id" url:"id,key"`           // unique identifier of release
+		Version int    `json:"version" url:"version,key"` // unique version assigned to the release
+	} `json:"release" url:"release,key"` // app release of the dyno
+	Size  string `json:"size" url:"size,key"`   // dyno size (default: "standard-1X")
+	State string `json:"state" url:"state,key"` // current status of process (either: crashed, down, idle, starting, or
+	// up)
+	Type      string    `json:"type" url:"type,key"`             // type of process
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
 }
 
 // Create a new dyno.
-func (s *Service) DynoCreate(appIdentity string, o struct {
-	Attach  *bool              `json:"attach,omitempty"` // whether to stream output or not
-	Command string             `json:"command"`          // command used to start this process
-	Env     *map[string]string `json:"env,omitempty"`    // custom environment to add to the dyno config vars
-	Size    *string            `json:"size,omitempty"`   // dyno size (default: "1X")
-}) (*Dyno, error) {
-	var dyno Dyno
-	return &dyno, s.Post(&dyno, fmt.Sprintf("/apps/%v/dynos", appIdentity), o)
+func (s *Service) DynoCreate(ctx context.Context, appIdentity string, o DynoCreateOpts) (*DynoCreateResult, error) {
+	var dyno DynoCreateResult
+	return &dyno, s.Post(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos", appIdentity), o)
 }
+
+type DynoRestartResult struct{}
 
 // Restart dyno.
-func (s *Service) DynoRestart(appIdentity string, dynoIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v/dynos/%v", appIdentity, dynoIdentity))
+func (s *Service) DynoRestart(ctx context.Context, appIdentity string, dynoIdentity string) (DynoRestartResult, error) {
+	var dyno DynoRestartResult
+	return dyno, s.Delete(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos/%v", appIdentity, dynoIdentity))
 }
 
-// Restart all dynos
-func (s *Service) DynoRestartAll(appIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v/dynos", appIdentity))
+type DynoRestartAllResult struct{}
+
+// Restart all dynos.
+func (s *Service) DynoRestartAll(ctx context.Context, appIdentity string) (DynoRestartAllResult, error) {
+	var dyno DynoRestartAllResult
+	return dyno, s.Delete(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos", appIdentity))
+}
+
+type DynoStopResult struct{}
+
+// Stop dyno.
+func (s *Service) DynoStop(ctx context.Context, appIdentity string, dynoIdentity string) (DynoStopResult, error) {
+	var dyno DynoStopResult
+	return dyno, s.Post(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos/%v/actions/stop", appIdentity, dynoIdentity), nil)
+}
+
+type DynoInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	AttachURL *string `json:"attach_url" url:"attach_url,key"` // a URL to stream output from for attached processes or null for
+	// non-attached processes
+	Command   string    `json:"command" url:"command,key"`       // command used to start this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when dyno was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this dyno
+	Name      string    `json:"name" url:"name,key"`             // the name of this process on this dyno
+	Release   struct {
+		ID      string `json:"id" url:"id,key"`           // unique identifier of release
+		Version int    `json:"version" url:"version,key"` // unique version assigned to the release
+	} `json:"release" url:"release,key"` // app release of the dyno
+	Size  string `json:"size" url:"size,key"`   // dyno size (default: "standard-1X")
+	State string `json:"state" url:"state,key"` // current status of process (either: crashed, down, idle, starting, or
+	// up)
+	Type      string    `json:"type" url:"type,key"`             // type of process
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
 }
 
 // Info for existing dyno.
-func (s *Service) DynoInfo(appIdentity string, dynoIdentity string) (*Dyno, error) {
-	var dyno Dyno
-	return &dyno, s.Get(&dyno, fmt.Sprintf("/apps/%v/dynos/%v", appIdentity, dynoIdentity), nil)
+func (s *Service) DynoInfo(ctx context.Context, appIdentity string, dynoIdentity string) (*DynoInfoResult, error) {
+	var dyno DynoInfoResult
+	return &dyno, s.Get(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos/%v", appIdentity, dynoIdentity), nil, nil)
+}
+
+type DynoListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	AttachURL *string `json:"attach_url" url:"attach_url,key"` // a URL to stream output from for attached processes or null for
+	// non-attached processes
+	Command   string    `json:"command" url:"command,key"`       // command used to start this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when dyno was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this dyno
+	Name      string    `json:"name" url:"name,key"`             // the name of this process on this dyno
+	Release   struct {
+		ID      string `json:"id" url:"id,key"`           // unique identifier of release
+		Version int    `json:"version" url:"version,key"` // unique version assigned to the release
+	} `json:"release" url:"release,key"` // app release of the dyno
+	Size  string `json:"size" url:"size,key"`   // dyno size (default: "standard-1X")
+	State string `json:"state" url:"state,key"` // current status of process (either: crashed, down, idle, starting, or
+	// up)
+	Type      string    `json:"type" url:"type,key"`             // type of process
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
 }
 
 // List existing dynos.
-func (s *Service) DynoList(appIdentity string, lr *ListRange) ([]*Dyno, error) {
-	var dynoList []*Dyno
-	return dynoList, s.Get(&dynoList, fmt.Sprintf("/apps/%v/dynos", appIdentity), lr)
+func (s *Service) DynoList(ctx context.Context, appIdentity string, lr *ListRange) (DynoListResult, error) {
+	var dyno DynoListResult
+	return dyno, s.Get(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos", appIdentity), nil, lr)
+}
+
+// Dyno sizes are the values and details of sizes that can be assigned
+// to dynos. This information can also be found at :
+// [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.h
+// eroku.com/articles/dyno-types).
+type DynoSize struct {
+	Compute          int       `json:"compute" url:"compute,key"`                       // minimum vCPUs, non-dedicated may get more depending on load
+	Cost             *struct{} `json:"cost" url:"cost,key"`                             // price information for this dyno size
+	Dedicated        bool      `json:"dedicated" url:"dedicated,key"`                   // whether this dyno will be dedicated to one user
+	DynoUnits        int       `json:"dyno_units" url:"dyno_units,key"`                 // unit of consumption for Heroku Enterprise customers
+	ID               string    `json:"id" url:"id,key"`                                 // unique identifier of this dyno size
+	Memory           float64   `json:"memory" url:"memory,key"`                         // amount of RAM in GB
+	Name             string    `json:"name" url:"name,key"`                             // the name of this dyno-size
+	PrivateSpaceOnly bool      `json:"private_space_only" url:"private_space_only,key"` // whether this dyno can only be provisioned in a private space
+}
+type DynoSizeInfoResult struct {
+	Compute          int       `json:"compute" url:"compute,key"`                       // minimum vCPUs, non-dedicated may get more depending on load
+	Cost             *struct{} `json:"cost" url:"cost,key"`                             // price information for this dyno size
+	Dedicated        bool      `json:"dedicated" url:"dedicated,key"`                   // whether this dyno will be dedicated to one user
+	DynoUnits        int       `json:"dyno_units" url:"dyno_units,key"`                 // unit of consumption for Heroku Enterprise customers
+	ID               string    `json:"id" url:"id,key"`                                 // unique identifier of this dyno size
+	Memory           float64   `json:"memory" url:"memory,key"`                         // amount of RAM in GB
+	Name             string    `json:"name" url:"name,key"`                             // the name of this dyno-size
+	PrivateSpaceOnly bool      `json:"private_space_only" url:"private_space_only,key"` // whether this dyno can only be provisioned in a private space
+}
+
+// Info for existing dyno size.
+func (s *Service) DynoSizeInfo(ctx context.Context, dynoSizeIdentity string) (*DynoSizeInfoResult, error) {
+	var dynoSize DynoSizeInfoResult
+	return &dynoSize, s.Get(ctx, &dynoSize, fmt.Sprintf("/dyno-sizes/%v", dynoSizeIdentity), nil, nil)
+}
+
+type DynoSizeListResult []struct {
+	Compute          int       `json:"compute" url:"compute,key"`                       // minimum vCPUs, non-dedicated may get more depending on load
+	Cost             *struct{} `json:"cost" url:"cost,key"`                             // price information for this dyno size
+	Dedicated        bool      `json:"dedicated" url:"dedicated,key"`                   // whether this dyno will be dedicated to one user
+	DynoUnits        int       `json:"dyno_units" url:"dyno_units,key"`                 // unit of consumption for Heroku Enterprise customers
+	ID               string    `json:"id" url:"id,key"`                                 // unique identifier of this dyno size
+	Memory           float64   `json:"memory" url:"memory,key"`                         // amount of RAM in GB
+	Name             string    `json:"name" url:"name,key"`                             // the name of this dyno-size
+	PrivateSpaceOnly bool      `json:"private_space_only" url:"private_space_only,key"` // whether this dyno can only be provisioned in a private space
+}
+
+// List existing dyno sizes.
+func (s *Service) DynoSizeList(ctx context.Context, lr *ListRange) (DynoSizeListResult, error) {
+	var dynoSize DynoSizeListResult
+	return dynoSize, s.Get(ctx, &dynoSize, fmt.Sprintf("/dyno-sizes"), nil, lr)
+}
+
+// An event represents an action performed on another API resource.
+type Event struct {
+	Action string `json:"action" url:"action,key"` // the operation performed on the resource
+	Actor  struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"actor" url:"actor,key"` // user that performed the operation
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when the event was created
+	Data      struct {
+		AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
+		Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
+		CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
+		DefaultOrganization *struct {
+			ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+			Name string `json:"name" url:"name,key"` // unique name of organization
+		} `json:"default_organization" url:"default_organization,key"` // organization selected by default
+		DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
+		Email            string     `json:"email" url:"email,key"`                 // unique email address of account
+		Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
+		ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
+		IdentityProvider *struct {
+			ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
+			Organization struct {
+				Name string `json:"name" url:"name,key"` // unique name of organization
+			} `json:"organization" url:"organization,key"`
+		} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
+		LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
+		Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
+		SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
+		SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
+		TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
+		UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
+		Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
+	} `json:"data" url:"data,key"` // An account represents an individual signed up to use the Heroku
+	// platform.
+	ID           string     `json:"id" url:"id,key"`                       // unique identifier of an event
+	PreviousData struct{}   `json:"previous_data" url:"previous_data,key"` // data fields that were changed during update with previous values
+	PublishedAt  *time.Time `json:"published_at" url:"published_at,key"`   // when the event was published
+	Resource     string     `json:"resource" url:"resource,key"`           // the type of resource affected
+	Sequence     *string    `json:"sequence" url:"sequence,key"`           // a numeric string representing the event's sequence
+	UpdatedAt    time.Time  `json:"updated_at" url:"updated_at,key"`       // when the event was updated (same as created)
+	Version      string     `json:"version" url:"version,key"`             // the event's API version string
+}
+
+// A failed event represents a failure of an action performed on another
+// API resource.
+type FailedEvent struct {
+	Action   string  `json:"action" url:"action,key"`     // The attempted operation performed on the resource.
+	Code     *int    `json:"code" url:"code,key"`         // An HTTP status code.
+	ErrorID  *string `json:"error_id" url:"error_id,key"` // ID of error raised.
+	Message  string  `json:"message" url:"message,key"`   // A detailed error message.
+	Method   string  `json:"method" url:"method,key"`     // The HTTP method type of the failed action.
+	Path     string  `json:"path" url:"path,key"`         // The path of the attempted operation.
+	Resource *struct {
+		ID   string `json:"id" url:"id,key"`     // Unique identifier of a resource.
+		Name string `json:"name" url:"name,key"` // the type of resource affected
+	} `json:"resource" url:"resource,key"` // The related resource of the failed action.
+}
+
+// Filters are special endpoints to allow for API consumers to specify a
+// subset of resources to consume in order to reduce the number of
+// requests that are performed.  Each filter endpoint endpoint is
+// responsible for determining its supported request format.  The
+// endpoints are over POST in order to handle large request bodies
+// without hitting request uri query length limitations, but the
+// requests themselves are idempotent and will not have side effects.
+type FilterApps struct{}
+type FilterAppsAppsOpts struct {
+	In *struct {
+		ID *[]*string `json:"id,omitempty" url:"id,omitempty,key"`
+	} `json:"in,omitempty" url:"in,omitempty,key"`
+}
+type FilterAppsAppsResult []struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
+	Owner *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
+}
+
+// Request an apps list filtered by app id.
+func (s *Service) FilterAppsApps(ctx context.Context, o FilterAppsAppsOpts) (FilterAppsAppsResult, error) {
+	var filterApps FilterAppsAppsResult
+	return filterApps, s.Post(ctx, &filterApps, fmt.Sprintf("/filters/apps"), o)
 }
 
 // The formation of processes that should be maintained for an app.
@@ -879,176 +2725,580 @@ func (s *Service) DynoList(appIdentity string, lr *ListRange) ([]*Dyno, error) {
 // `process_types` attribute for the [slug](#slug) currently released on
 // an app.
 type Formation struct {
-	Command   string    `json:"command"`    // command to use to launch this process
-	CreatedAt time.Time `json:"created_at"` // when process type was created
-	ID        string    `json:"id"`         // unique identifier of this process type
-	Quantity  int       `json:"quantity"`   // number of processes to maintain
-	Size      string    `json:"size"`       // dyno size (default: "1X")
-	Type      string    `json:"type"`       // type of process to maintain
-	UpdatedAt time.Time `json:"updated_at"` // when dyno type was updated
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
+	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
+	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
+	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
+}
+type FormationInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
+	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
+	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
+	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
 }
 
 // Info for a process type
-func (s *Service) FormationInfo(appIdentity string, formationIdentity string) (*Formation, error) {
-	var formation Formation
-	return &formation, s.Get(&formation, fmt.Sprintf("/apps/%v/formation/%v", appIdentity, formationIdentity), nil)
+func (s *Service) FormationInfo(ctx context.Context, appIdentity string, formationIdentity string) (*FormationInfoResult, error) {
+	var formation FormationInfoResult
+	return &formation, s.Get(ctx, &formation, fmt.Sprintf("/apps/%v/formation/%v", appIdentity, formationIdentity), nil, nil)
+}
+
+type FormationListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
+	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
+	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
+	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
 }
 
 // List process type formation
-func (s *Service) FormationList(appIdentity string, lr *ListRange) ([]*Formation, error) {
-	var formationList []*Formation
-	return formationList, s.Get(&formationList, fmt.Sprintf("/apps/%v/formation", appIdentity), lr)
+func (s *Service) FormationList(ctx context.Context, appIdentity string, lr *ListRange) (FormationListResult, error) {
+	var formation FormationListResult
+	return formation, s.Get(ctx, &formation, fmt.Sprintf("/apps/%v/formation", appIdentity), nil, lr)
 }
 
 type FormationBatchUpdateOpts struct {
 	Updates []struct {
-		Process  string  `json:"process"`            // unique identifier of this process type
-		Quantity *int    `json:"quantity,omitempty"` // number of processes to maintain
-		Size     *string `json:"size,omitempty"`     // dyno size (default: "1X")
-	} `json:"updates"` // Array with formation updates. Each element must have "process", the
-	// id or name of the process type to be updated, and can optionally
-	// update its "quantity" or "size".
+		Quantity *int    `json:"quantity,omitempty" url:"quantity,omitempty,key"` // number of processes to maintain
+		Size     *string `json:"size,omitempty" url:"size,omitempty,key"`         // dyno size (default: "standard-1X")
+		Type     string  `json:"type" url:"type,key"`                             // type of process to maintain
+	} `json:"updates" url:"updates,key"` // Array with formation updates. Each element must have "type", the id
+	// or name of the process type to be updated, and can optionally update
+	// its "quantity" or "size".
+}
+type FormationBatchUpdateResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
+	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
+	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
+	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
 }
 
 // Batch update process types
-func (s *Service) FormationBatchUpdate(appIdentity string, o struct {
-	Updates []struct {
-		Process  string  `json:"process"`            // unique identifier of this process type
-		Quantity *int    `json:"quantity,omitempty"` // number of processes to maintain
-		Size     *string `json:"size,omitempty"`     // dyno size (default: "1X")
-	} `json:"updates"` // Array with formation updates. Each element must have "process", the
-	// id or name of the process type to be updated, and can optionally
-	// update its "quantity" or "size".
-}) (*Formation, error) {
-	var formation Formation
-	return &formation, s.Patch(&formation, fmt.Sprintf("/apps/%v/formation", appIdentity), o)
+func (s *Service) FormationBatchUpdate(ctx context.Context, appIdentity string, o FormationBatchUpdateOpts) (FormationBatchUpdateResult, error) {
+	var formation FormationBatchUpdateResult
+	return formation, s.Patch(ctx, &formation, fmt.Sprintf("/apps/%v/formation", appIdentity), o)
 }
 
 type FormationUpdateOpts struct {
-	Quantity *int    `json:"quantity,omitempty"` // number of processes to maintain
-	Size     *string `json:"size,omitempty"`     // dyno size (default: "1X")
+	Quantity *int    `json:"quantity,omitempty" url:"quantity,omitempty,key"` // number of processes to maintain
+	Size     *string `json:"size,omitempty" url:"size,omitempty,key"`         // dyno size (default: "standard-1X")
+}
+type FormationUpdateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app formation belongs to
+	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
+	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
+	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
+	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
 }
 
 // Update process type
-func (s *Service) FormationUpdate(appIdentity string, formationIdentity string, o struct {
-	Quantity *int    `json:"quantity,omitempty"` // number of processes to maintain
-	Size     *string `json:"size,omitempty"`     // dyno size (default: "1X")
-}) (*Formation, error) {
-	var formation Formation
-	return &formation, s.Patch(&formation, fmt.Sprintf("/apps/%v/formation/%v", appIdentity, formationIdentity), o)
+func (s *Service) FormationUpdate(ctx context.Context, appIdentity string, formationIdentity string, o FormationUpdateOpts) (*FormationUpdateResult, error) {
+	var formation FormationUpdateResult
+	return &formation, s.Patch(ctx, &formation, fmt.Sprintf("/apps/%v/formation/%v", appIdentity, formationIdentity), o)
+}
+
+// Identity Providers represent the SAML configuration of an
+// Organization.
+type IdentityProvider struct {
+	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
+	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
+	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
+	Organization *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
+	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
+	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
+}
+type IdentityProviderListResult []struct {
+	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
+	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
+	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
+	Organization *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
+	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
+	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
+}
+
+// Get a list of an organization's Identity Providers
+func (s *Service) IdentityProviderList(ctx context.Context, organizationName string, lr *ListRange) (IdentityProviderListResult, error) {
+	var identityProvider IdentityProviderListResult
+	return identityProvider, s.Get(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers", organizationName), nil, lr)
+}
+
+type IdentityProviderCreateOpts struct {
+	Certificate  string  `json:"certificate" url:"certificate,key"`                           // raw contents of the public certificate (eg: .crt or .pem file)
+	EntityID     string  `json:"entity_id" url:"entity_id,key"`                               // URL identifier provided by the identity provider
+	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
+	SsoTargetURL string  `json:"sso_target_url" url:"sso_target_url,key"`                     // single sign on URL for this identity provider
+}
+type IdentityProviderCreateResult struct {
+	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
+	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
+	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
+	Organization *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
+	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
+	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
+}
+
+// Create an Identity Provider for an organization
+func (s *Service) IdentityProviderCreate(ctx context.Context, organizationName string, o IdentityProviderCreateOpts) (*IdentityProviderCreateResult, error) {
+	var identityProvider IdentityProviderCreateResult
+	return &identityProvider, s.Post(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers", organizationName), o)
+}
+
+type IdentityProviderUpdateOpts struct {
+	Certificate  *string `json:"certificate,omitempty" url:"certificate,omitempty,key"`       // raw contents of the public certificate (eg: .crt or .pem file)
+	EntityID     *string `json:"entity_id,omitempty" url:"entity_id,omitempty,key"`           // URL identifier provided by the identity provider
+	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
+	SsoTargetURL *string `json:"sso_target_url,omitempty" url:"sso_target_url,omitempty,key"` // single sign on URL for this identity provider
+}
+type IdentityProviderUpdateResult struct {
+	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
+	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
+	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
+	Organization *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
+	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
+	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
+}
+
+// Update an organization's Identity Provider
+func (s *Service) IdentityProviderUpdate(ctx context.Context, organizationName string, identityProviderID string, o IdentityProviderUpdateOpts) (*IdentityProviderUpdateResult, error) {
+	var identityProvider IdentityProviderUpdateResult
+	return &identityProvider, s.Patch(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers/%v", organizationName, identityProviderID), o)
+}
+
+type IdentityProviderDeleteResult struct {
+	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
+	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
+	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
+	Organization *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
+	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
+	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
+}
+
+// Delete an organization's Identity Provider
+func (s *Service) IdentityProviderDelete(ctx context.Context, organizationName string, identityProviderID string) (*IdentityProviderDeleteResult, error) {
+	var identityProvider IdentityProviderDeleteResult
+	return &identityProvider, s.Delete(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers/%v", organizationName, identityProviderID))
+}
+
+// An inbound-ruleset is a collection of rules that specify what hosts
+// can or cannot connect to an application.
+type InboundRuleset struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when inbound-ruleset was created
+	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an inbound-ruleset
+	Rules     []struct {
+		Action string `json:"action" url:"action,key"` // states whether the connection is allowed or denied
+		Source string `json:"source" url:"source,key"` // is the request’s source in CIDR notation
+	} `json:"rules" url:"rules,key"`
+}
+type InboundRulesetInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when inbound-ruleset was created
+	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an inbound-ruleset
+	Rules     []struct {
+		Action string `json:"action" url:"action,key"` // states whether the connection is allowed or denied
+		Source string `json:"source" url:"source,key"` // is the request’s source in CIDR notation
+	} `json:"rules" url:"rules,key"`
+}
+
+// Current inbound ruleset for a space
+func (s *Service) InboundRulesetInfo(ctx context.Context, spaceIdentity string) (*InboundRulesetInfoResult, error) {
+	var inboundRuleset InboundRulesetInfoResult
+	return &inboundRuleset, s.Get(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-ruleset", spaceIdentity), nil, nil)
+}
+
+type InboundRulesetListResult []struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when inbound-ruleset was created
+	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an inbound-ruleset
+	Rules     []struct {
+		Action string `json:"action" url:"action,key"` // states whether the connection is allowed or denied
+		Source string `json:"source" url:"source,key"` // is the request’s source in CIDR notation
+	} `json:"rules" url:"rules,key"`
+}
+
+// List all inbound rulesets for a space
+func (s *Service) InboundRulesetList(ctx context.Context, spaceIdentity string, lr *ListRange) (InboundRulesetListResult, error) {
+	var inboundRuleset InboundRulesetListResult
+	return inboundRuleset, s.Get(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-rulesets", spaceIdentity), nil, lr)
+}
+
+type InboundRulesetCreateOpts struct {
+	Rules *[]*struct {
+		Action string `json:"action" url:"action,key"` // states whether the connection is allowed or denied
+		Source string `json:"source" url:"source,key"` // is the request’s source in CIDR notation
+	} `json:"rules,omitempty" url:"rules,omitempty,key"`
+}
+
+// Create a new inbound ruleset
+func (s *Service) InboundRulesetCreate(ctx context.Context, spaceIdentity string, o InboundRulesetCreateOpts) (*InboundRuleset, error) {
+	var inboundRuleset InboundRuleset
+	return &inboundRuleset, s.Put(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-ruleset", spaceIdentity), o)
+}
+
+// An invitation represents an invite sent to a user to use the Heroku
+// platform.
+type Invitation struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"`
+	VerificationRequired bool `json:"verification_required" url:"verification_required,key"` // if the invitation requires verification
+}
+
+// Info for invitation.
+func (s *Service) InvitationInfo(ctx context.Context, invitationIdentity string) (*Invitation, error) {
+	var invitation Invitation
+	return &invitation, s.Get(ctx, &invitation, fmt.Sprintf("/invitations/%v", invitationIdentity), nil, nil)
+}
+
+type InvitationCreateOpts struct {
+	Email string  `json:"email" url:"email,key"` // unique email address of account
+	Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+}
+
+// Invite a user.
+func (s *Service) InvitationCreate(ctx context.Context, o InvitationCreateOpts) (*Invitation, error) {
+	var invitation Invitation
+	return &invitation, s.Post(ctx, &invitation, fmt.Sprintf("/invitations"), o)
+}
+
+type InvitationSendVerificationCodeOpts struct {
+	Method      *string `json:"method,omitempty" url:"method,omitempty,key"` // Transport used to send verification code
+	PhoneNumber string  `json:"phone_number" url:"phone_number,key"`         // Phone number to send verification code
+}
+
+// Send a verification code for an invitation via SMS/phone call.
+func (s *Service) InvitationSendVerificationCode(ctx context.Context, invitationIdentity string, o InvitationSendVerificationCodeOpts) (*Invitation, error) {
+	var invitation Invitation
+	return &invitation, s.Post(ctx, &invitation, fmt.Sprintf("/invitations/%v/actions/send-verification", invitationIdentity), o)
+}
+
+type InvitationVerifyOpts struct {
+	VerificationCode string `json:"verification_code" url:"verification_code,key"` // Value used to verify invitation
+}
+
+// Verify an invitation using a verification code.
+func (s *Service) InvitationVerify(ctx context.Context, invitationIdentity string, o InvitationVerifyOpts) (*Invitation, error) {
+	var invitation Invitation
+	return &invitation, s.Post(ctx, &invitation, fmt.Sprintf("/invitations/%v/actions/verify", invitationIdentity), o)
+}
+
+type InvitationFinalizeOpts struct {
+	Password             string `json:"password" url:"password,key"`                                         // current password on the account
+	PasswordConfirmation string `json:"password_confirmation" url:"password_confirmation,key"`               // current password on the account
+	ReceiveNewsletter    *bool  `json:"receive_newsletter,omitempty" url:"receive_newsletter,omitempty,key"` // whether this user should receive a newsletter or not
+}
+
+// Finalize Invitation and Create Account.
+func (s *Service) InvitationFinalize(ctx context.Context, invitationIdentity string, o InvitationFinalizeOpts) (*Invitation, error) {
+	var invitation Invitation
+	return &invitation, s.Patch(ctx, &invitation, fmt.Sprintf("/invitations/%v", invitationIdentity), o)
+}
+
+// An invoice is an itemized bill of goods for an account which includes
+// pricing and charges.
+type Invoice struct {
+	ChargesTotal float64   `json:"charges_total" url:"charges_total,key"` // total charges on this invoice
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`       // when invoice was created
+	CreditsTotal float64   `json:"credits_total" url:"credits_total,key"` // total credits on this invoice
+	ID           string    `json:"id" url:"id,key"`                       // unique identifier of this invoice
+	Number       int       `json:"number" url:"number,key"`               // human readable invoice number
+	PeriodEnd    string    `json:"period_end" url:"period_end,key"`       // the ending date that the invoice covers
+	PeriodStart  string    `json:"period_start" url:"period_start,key"`   // the starting date that this invoice covers
+	State        int       `json:"state" url:"state,key"`                 // payment status for this invoice (pending, successful, failed)
+	Total        float64   `json:"total" url:"total,key"`                 // combined total of charges and credits on this invoice
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when invoice was updated
+}
+type InvoiceInfoResult struct {
+	ChargesTotal float64   `json:"charges_total" url:"charges_total,key"` // total charges on this invoice
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`       // when invoice was created
+	CreditsTotal float64   `json:"credits_total" url:"credits_total,key"` // total credits on this invoice
+	ID           string    `json:"id" url:"id,key"`                       // unique identifier of this invoice
+	Number       int       `json:"number" url:"number,key"`               // human readable invoice number
+	PeriodEnd    string    `json:"period_end" url:"period_end,key"`       // the ending date that the invoice covers
+	PeriodStart  string    `json:"period_start" url:"period_start,key"`   // the starting date that this invoice covers
+	State        int       `json:"state" url:"state,key"`                 // payment status for this invoice (pending, successful, failed)
+	Total        float64   `json:"total" url:"total,key"`                 // combined total of charges and credits on this invoice
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when invoice was updated
+}
+
+// Info for existing invoice.
+func (s *Service) InvoiceInfo(ctx context.Context, invoiceIdentity int) (*InvoiceInfoResult, error) {
+	var invoice InvoiceInfoResult
+	return &invoice, s.Get(ctx, &invoice, fmt.Sprintf("/account/invoices/%v", invoiceIdentity), nil, nil)
+}
+
+type InvoiceListResult []struct {
+	ChargesTotal float64   `json:"charges_total" url:"charges_total,key"` // total charges on this invoice
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`       // when invoice was created
+	CreditsTotal float64   `json:"credits_total" url:"credits_total,key"` // total credits on this invoice
+	ID           string    `json:"id" url:"id,key"`                       // unique identifier of this invoice
+	Number       int       `json:"number" url:"number,key"`               // human readable invoice number
+	PeriodEnd    string    `json:"period_end" url:"period_end,key"`       // the ending date that the invoice covers
+	PeriodStart  string    `json:"period_start" url:"period_start,key"`   // the starting date that this invoice covers
+	State        int       `json:"state" url:"state,key"`                 // payment status for this invoice (pending, successful, failed)
+	Total        float64   `json:"total" url:"total,key"`                 // combined total of charges and credits on this invoice
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when invoice was updated
+}
+
+// List existing invoices.
+func (s *Service) InvoiceList(ctx context.Context, lr *ListRange) (InvoiceListResult, error) {
+	var invoice InvoiceListResult
+	return invoice, s.Get(ctx, &invoice, fmt.Sprintf("/account/invoices"), nil, lr)
+}
+
+// An invoice address represents the address that should be listed on an
+// invoice.
+type InvoiceAddress struct {
+	Address1          string `json:"address_1" url:"address_1,key"`                     // invoice street address line 1
+	Address2          string `json:"address_2" url:"address_2,key"`                     // invoice street address line 2
+	City              string `json:"city" url:"city,key"`                               // invoice city
+	Country           string `json:"country" url:"country,key"`                         // country
+	HerokuID          string `json:"heroku_id" url:"heroku_id,key"`                     // heroku_id identifier reference
+	Other             string `json:"other" url:"other,key"`                             // metadata / additional information to go on invoice
+	PostalCode        string `json:"postal_code" url:"postal_code,key"`                 // invoice zip code
+	State             string `json:"state" url:"state,key"`                             // invoice state
+	UseInvoiceAddress bool   `json:"use_invoice_address" url:"use_invoice_address,key"` // flag to use the invoice address for an account or not
+}
+
+// Retrieve existing invoice address.
+func (s *Service) InvoiceAddressInfo(ctx context.Context) (*InvoiceAddress, error) {
+	var invoiceAddress InvoiceAddress
+	return &invoiceAddress, s.Get(ctx, &invoiceAddress, fmt.Sprintf("/account/invoice-address"), nil, nil)
+}
+
+type InvoiceAddressUpdateOpts struct {
+	Address1          *string `json:"address_1,omitempty" url:"address_1,omitempty,key"`                     // invoice street address line 1
+	Address2          *string `json:"address_2,omitempty" url:"address_2,omitempty,key"`                     // invoice street address line 2
+	City              *string `json:"city,omitempty" url:"city,omitempty,key"`                               // invoice city
+	Country           *string `json:"country,omitempty" url:"country,omitempty,key"`                         // country
+	Other             *string `json:"other,omitempty" url:"other,omitempty,key"`                             // metadata / additional information to go on invoice
+	PostalCode        *string `json:"postal_code,omitempty" url:"postal_code,omitempty,key"`                 // invoice zip code
+	State             *string `json:"state,omitempty" url:"state,omitempty,key"`                             // invoice state
+	UseInvoiceAddress *bool   `json:"use_invoice_address,omitempty" url:"use_invoice_address,omitempty,key"` // flag to use the invoice address for an account or not
+}
+
+// Update invoice address for an account.
+func (s *Service) InvoiceAddressUpdate(ctx context.Context, o InvoiceAddressUpdateOpts) (*InvoiceAddress, error) {
+	var invoiceAddress InvoiceAddress
+	return &invoiceAddress, s.Put(ctx, &invoiceAddress, fmt.Sprintf("/account/invoice-address"), o)
 }
 
 // Keys represent public SSH keys associated with an account and are
 // used to authorize accounts as they are performing git operations.
 type Key struct {
-	Comment     string    `json:"comment"`     // comment on the key
-	CreatedAt   time.Time `json:"created_at"`  // when key was created
-	Email       string    `json:"email"`       // deprecated. Please refer to 'comment' instead
-	Fingerprint string    `json:"fingerprint"` // a unique identifying string based on contents
-	ID          string    `json:"id"`          // unique identifier of this key
-	PublicKey   string    `json:"public_key"`  // full public_key as uploaded
-	UpdatedAt   time.Time `json:"updated_at"`  // when key was updated
+	Comment     string    `json:"comment" url:"comment,key"`         // comment on the key
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when key was created
+	Email       string    `json:"email" url:"email,key"`             // deprecated. Please refer to 'comment' instead
+	Fingerprint string    `json:"fingerprint" url:"fingerprint,key"` // a unique identifying string based on contents
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of this key
+	PublicKey   string    `json:"public_key" url:"public_key,key"`   // full public_key as uploaded
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when key was updated
 }
-type KeyCreateOpts struct {
-	PublicKey string `json:"public_key"` // full public_key as uploaded
-}
-
-// Create a new key.
-func (s *Service) KeyCreate(o struct {
-	PublicKey string `json:"public_key"` // full public_key as uploaded
-}) (*Key, error) {
-	var key Key
-	return &key, s.Post(&key, fmt.Sprintf("/account/keys"), o)
-}
-
-// Delete an existing key
-func (s *Service) KeyDelete(keyIdentity string) error {
-	return s.Delete(fmt.Sprintf("/account/keys/%v", keyIdentity))
+type KeyInfoResult struct {
+	Comment     string    `json:"comment" url:"comment,key"`         // comment on the key
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when key was created
+	Email       string    `json:"email" url:"email,key"`             // deprecated. Please refer to 'comment' instead
+	Fingerprint string    `json:"fingerprint" url:"fingerprint,key"` // a unique identifying string based on contents
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of this key
+	PublicKey   string    `json:"public_key" url:"public_key,key"`   // full public_key as uploaded
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when key was updated
 }
 
 // Info for existing key.
-func (s *Service) KeyInfo(keyIdentity string) (*Key, error) {
-	var key Key
-	return &key, s.Get(&key, fmt.Sprintf("/account/keys/%v", keyIdentity), nil)
+func (s *Service) KeyInfo(ctx context.Context, keyIdentity string) (*KeyInfoResult, error) {
+	var key KeyInfoResult
+	return &key, s.Get(ctx, &key, fmt.Sprintf("/account/keys/%v", keyIdentity), nil, nil)
+}
+
+type KeyListResult []struct {
+	Comment     string    `json:"comment" url:"comment,key"`         // comment on the key
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when key was created
+	Email       string    `json:"email" url:"email,key"`             // deprecated. Please refer to 'comment' instead
+	Fingerprint string    `json:"fingerprint" url:"fingerprint,key"` // a unique identifying string based on contents
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of this key
+	PublicKey   string    `json:"public_key" url:"public_key,key"`   // full public_key as uploaded
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when key was updated
 }
 
 // List existing keys.
-func (s *Service) KeyList(lr *ListRange) ([]*Key, error) {
-	var keyList []*Key
-	return keyList, s.Get(&keyList, fmt.Sprintf("/account/keys"), lr)
+func (s *Service) KeyList(ctx context.Context, lr *ListRange) (KeyListResult, error) {
+	var key KeyListResult
+	return key, s.Get(ctx, &key, fmt.Sprintf("/account/keys"), nil, lr)
 }
 
-// [Log
-// drains](https://devcenter.heroku.com/articles/logging#syslog-drains)
+// [Log drains](https://devcenter.heroku.com/articles/log-drains)
 // provide a way to forward your Heroku logs to an external syslog
 // server for long-term archiving. This external service must be
 // configured to receive syslog packets from Heroku, whereupon its URL
-// can be added to an app using this API. Some addons will add a log
+// can be added to an app using this API. Some add-ons will add a log
 // drain when they are provisioned to an app. These drains can only be
 // removed by removing the add-on.
 type LogDrain struct {
 	Addon *struct {
-		ID string `json:"id"` // unique identifier of add-on
-	} `json:"addon"` // addon that created the drain
-	CreatedAt time.Time `json:"created_at"` // when log drain was created
-	ID        string    `json:"id"`         // unique identifier of this log drain
-	Token     string    `json:"token"`      // token associated with the log drain
-	UpdatedAt time.Time `json:"updated_at"` // when log drain was updated
-	URL       string    `json:"url"`        // url associated with the log drain
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // add-on that created the drain
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
+	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
+	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
 type LogDrainCreateOpts struct {
-	URL string `json:"url"` // url associated with the log drain
+	URL string `json:"url" url:"url,key"` // url associated with the log drain
+}
+type LogDrainCreateResult struct {
+	Addon *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // add-on that created the drain
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
+	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
+	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
 
 // Create a new log drain.
-func (s *Service) LogDrainCreate(appIdentity string, o struct {
-	URL string `json:"url"` // url associated with the log drain
-}) (*LogDrain, error) {
-	var logDrain LogDrain
-	return &logDrain, s.Post(&logDrain, fmt.Sprintf("/apps/%v/log-drains", appIdentity), o)
+func (s *Service) LogDrainCreate(ctx context.Context, appIdentity string, o LogDrainCreateOpts) (*LogDrainCreateResult, error) {
+	var logDrain LogDrainCreateResult
+	return &logDrain, s.Post(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains", appIdentity), o)
+}
+
+type LogDrainDeleteResult struct {
+	Addon *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // add-on that created the drain
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
+	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
+	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
 
 // Delete an existing log drain. Log drains added by add-ons can only be
 // removed by removing the add-on.
-func (s *Service) LogDrainDelete(appIdentity string, logDrainIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v/log-drains/%v", appIdentity, logDrainIdentity))
+func (s *Service) LogDrainDelete(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrainDeleteResult, error) {
+	var logDrain LogDrainDeleteResult
+	return &logDrain, s.Delete(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains/%v", appIdentity, logDrainQueryIdentity))
+}
+
+type LogDrainInfoResult struct {
+	Addon *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // add-on that created the drain
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
+	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
+	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
 
 // Info for existing log drain.
-func (s *Service) LogDrainInfo(appIdentity string, logDrainIdentity string) (*LogDrain, error) {
-	var logDrain LogDrain
-	return &logDrain, s.Get(&logDrain, fmt.Sprintf("/apps/%v/log-drains/%v", appIdentity, logDrainIdentity), nil)
+func (s *Service) LogDrainInfo(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrainInfoResult, error) {
+	var logDrain LogDrainInfoResult
+	return &logDrain, s.Get(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains/%v", appIdentity, logDrainQueryIdentity), nil, nil)
+}
+
+type LogDrainListResult []struct {
+	Addon *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
+		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
+	} `json:"addon" url:"addon,key"` // add-on that created the drain
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
+	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
+	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
 
 // List existing log drains.
-func (s *Service) LogDrainList(appIdentity string, lr *ListRange) ([]*LogDrain, error) {
-	var logDrainList []*LogDrain
-	return logDrainList, s.Get(&logDrainList, fmt.Sprintf("/apps/%v/log-drains", appIdentity), lr)
+func (s *Service) LogDrainList(ctx context.Context, appIdentity string, lr *ListRange) (LogDrainListResult, error) {
+	var logDrain LogDrainListResult
+	return logDrain, s.Get(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains", appIdentity), nil, lr)
 }
 
 // A log session is a reference to the http based log stream for an app.
 type LogSession struct {
-	CreatedAt  time.Time `json:"created_at"`  // when log connection was created
-	ID         string    `json:"id"`          // unique identifier of this log session
-	LogplexURL string    `json:"logplex_url"` // URL for log streaming session
-	UpdatedAt  time.Time `json:"updated_at"`  // when log session was updated
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when log connection was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of this log session
+	LogplexURL string    `json:"logplex_url" url:"logplex_url,key"` // URL for log streaming session
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when log session was updated
 }
 type LogSessionCreateOpts struct {
-	Dyno   *string `json:"dyno,omitempty"`   // dyno to limit results to
-	Lines  *int    `json:"lines,omitempty"`  // number of log lines to stream at once
-	Source *string `json:"source,omitempty"` // log source to limit results to
-	Tail   *bool   `json:"tail,omitempty"`   // whether to stream ongoing logs
+	Dyno   *string `json:"dyno,omitempty" url:"dyno,omitempty,key"`     // dyno to limit results to
+	Lines  *int    `json:"lines,omitempty" url:"lines,omitempty,key"`   // number of log lines to stream at once
+	Source *string `json:"source,omitempty" url:"source,omitempty,key"` // log source to limit results to
+	Tail   *bool   `json:"tail,omitempty" url:"tail,omitempty,key"`     // whether to stream ongoing logs
+}
+type LogSessionCreateResult struct {
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when log connection was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of this log session
+	LogplexURL string    `json:"logplex_url" url:"logplex_url,key"` // URL for log streaming session
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when log session was updated
 }
 
 // Create a new log session.
-func (s *Service) LogSessionCreate(appIdentity string, o struct {
-	Dyno   *string `json:"dyno,omitempty"`   // dyno to limit results to
-	Lines  *int    `json:"lines,omitempty"`  // number of log lines to stream at once
-	Source *string `json:"source,omitempty"` // log source to limit results to
-	Tail   *bool   `json:"tail,omitempty"`   // whether to stream ongoing logs
-}) (*LogSession, error) {
-	var logSession LogSession
-	return &logSession, s.Post(&logSession, fmt.Sprintf("/apps/%v/log-sessions", appIdentity), o)
+func (s *Service) LogSessionCreate(ctx context.Context, appIdentity string, o LogSessionCreateOpts) (*LogSessionCreateResult, error) {
+	var logSession LogSessionCreateResult
+	return &logSession, s.Post(ctx, &logSession, fmt.Sprintf("/apps/%v/log-sessions", appIdentity), o)
 }
 
 // OAuth authorizations represent clients that a Heroku user has
@@ -1057,67 +3307,243 @@ func (s *Service) LogSessionCreate(appIdentity string, o struct {
 // documentation](https://devcenter.heroku.com/articles/oauth)
 type OAuthAuthorization struct {
 	AccessToken *struct {
-		ExpiresIn *int `json:"expires_in"` // seconds until OAuth token expires; may be `null` for tokens with
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
 		// indefinite lifetime
-		ID    string `json:"id"`    // unique identifier of OAuth token
-		Token string `json:"token"` // contents of the token to be used for authorization
-	} `json:"access_token"` // access token for this authorization
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // access token for this authorization
 	Client *struct {
-		ID          string `json:"id"`           // unique identifier of this OAuth client
-		Name        string `json:"name"`         // OAuth client name
-		RedirectURI string `json:"redirect_uri"` // endpoint for redirection after authorization with OAuth client
-	} `json:"client"` // identifier of the client that obtained this authorization, if any
-	CreatedAt time.Time `json:"created_at"` // when OAuth authorization was created
+		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
+		Name        string `json:"name" url:"name,key"`                 // OAuth client name
+		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
+	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
 	Grant     *struct {
-		Code      string `json:"code"`       // grant code received from OAuth web application authorization
-		ExpiresIn int    `json:"expires_in"` // seconds until OAuth grant expires
-		ID        string `json:"id"`         // unique identifier of OAuth grant
-	} `json:"grant"` // this authorization's grant
-	ID           string `json:"id"` // unique identifier of OAuth authorization
+		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
+		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
+	} `json:"grant" url:"grant,key"` // this authorization's grant
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
 	RefreshToken *struct {
-		ExpiresIn *int `json:"expires_in"` // seconds until OAuth token expires; may be `null` for tokens with
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
 		// indefinite lifetime
-		ID    string `json:"id"`    // unique identifier of OAuth token
-		Token string `json:"token"` // contents of the token to be used for authorization
-	} `json:"refresh_token"` // refresh token for this authorization
-	Scope     []string  `json:"scope"`      // The scope of access OAuth authorization allows
-	UpdatedAt time.Time `json:"updated_at"` // when OAuth authorization was updated
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
+	User      struct {
+		Email    string  `json:"email" url:"email,key"`         // unique email address of account
+		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
+		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
 }
 type OAuthAuthorizationCreateOpts struct {
-	Client      *string `json:"client,omitempty"`      // unique identifier of this OAuth client
-	Description *string `json:"description,omitempty"` // human-friendly description of this OAuth authorization
-	ExpiresIn   *int    `json:"expires_in,omitempty"`  // seconds until OAuth token expires; may be `null` for tokens with
+	Client      *string `json:"client,omitempty" url:"client,omitempty,key"`           // unique identifier of this OAuth client
+	Description *string `json:"description,omitempty" url:"description,omitempty,key"` // human-friendly description of this OAuth authorization
+	ExpiresIn   *int    `json:"expires_in,omitempty" url:"expires_in,omitempty,key"`   // seconds until OAuth token expires; may be `null` for tokens with
 	// indefinite lifetime
-	Scope []string `json:"scope"` // The scope of access OAuth authorization allows
+	Scope []string `json:"scope" url:"scope,key"` // The scope of access OAuth authorization allows
+}
+type OAuthAuthorizationCreateResult struct {
+	AccessToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // access token for this authorization
+	Client *struct {
+		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
+		Name        string `json:"name" url:"name,key"`                 // OAuth client name
+		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
+	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
+	Grant     *struct {
+		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
+		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
+	} `json:"grant" url:"grant,key"` // this authorization's grant
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	RefreshToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
+	User      struct {
+		Email    string  `json:"email" url:"email,key"`         // unique email address of account
+		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
+		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
 }
 
 // Create a new OAuth authorization.
-func (s *Service) OAuthAuthorizationCreate(o struct {
-	Client      *string `json:"client,omitempty"`      // unique identifier of this OAuth client
-	Description *string `json:"description,omitempty"` // human-friendly description of this OAuth authorization
-	ExpiresIn   *int    `json:"expires_in,omitempty"`  // seconds until OAuth token expires; may be `null` for tokens with
-	// indefinite lifetime
-	Scope []string `json:"scope"` // The scope of access OAuth authorization allows
-}) (*OAuthAuthorization, error) {
-	var oauthAuthorization OAuthAuthorization
-	return &oauthAuthorization, s.Post(&oauthAuthorization, fmt.Sprintf("/oauth/authorizations"), o)
+func (s *Service) OAuthAuthorizationCreate(ctx context.Context, o OAuthAuthorizationCreateOpts) (*OAuthAuthorizationCreateResult, error) {
+	var oauthAuthorization OAuthAuthorizationCreateResult
+	return &oauthAuthorization, s.Post(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations"), o)
+}
+
+type OAuthAuthorizationDeleteResult struct {
+	AccessToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // access token for this authorization
+	Client *struct {
+		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
+		Name        string `json:"name" url:"name,key"`                 // OAuth client name
+		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
+	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
+	Grant     *struct {
+		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
+		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
+	} `json:"grant" url:"grant,key"` // this authorization's grant
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	RefreshToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
+	User      struct {
+		Email    string  `json:"email" url:"email,key"`         // unique email address of account
+		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
+		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
 }
 
 // Delete OAuth authorization.
-func (s *Service) OAuthAuthorizationDelete(oauthAuthorizationIdentity string) error {
-	return s.Delete(fmt.Sprintf("/oauth/authorizations/%v", oauthAuthorizationIdentity))
+func (s *Service) OAuthAuthorizationDelete(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorizationDeleteResult, error) {
+	var oauthAuthorization OAuthAuthorizationDeleteResult
+	return &oauthAuthorization, s.Delete(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations/%v", oauthAuthorizationIdentity))
+}
+
+type OAuthAuthorizationInfoResult struct {
+	AccessToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // access token for this authorization
+	Client *struct {
+		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
+		Name        string `json:"name" url:"name,key"`                 // OAuth client name
+		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
+	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
+	Grant     *struct {
+		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
+		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
+	} `json:"grant" url:"grant,key"` // this authorization's grant
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	RefreshToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
+	User      struct {
+		Email    string  `json:"email" url:"email,key"`         // unique email address of account
+		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
+		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
 }
 
 // Info for an OAuth authorization.
-func (s *Service) OAuthAuthorizationInfo(oauthAuthorizationIdentity string) (*OAuthAuthorization, error) {
-	var oauthAuthorization OAuthAuthorization
-	return &oauthAuthorization, s.Get(&oauthAuthorization, fmt.Sprintf("/oauth/authorizations/%v", oauthAuthorizationIdentity), nil)
+func (s *Service) OAuthAuthorizationInfo(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorizationInfoResult, error) {
+	var oauthAuthorization OAuthAuthorizationInfoResult
+	return &oauthAuthorization, s.Get(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations/%v", oauthAuthorizationIdentity), nil, nil)
+}
+
+type OAuthAuthorizationListResult []struct {
+	AccessToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // access token for this authorization
+	Client *struct {
+		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
+		Name        string `json:"name" url:"name,key"`                 // OAuth client name
+		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
+	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
+	Grant     *struct {
+		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
+		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
+	} `json:"grant" url:"grant,key"` // this authorization's grant
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	RefreshToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
+	User      struct {
+		Email    string  `json:"email" url:"email,key"`         // unique email address of account
+		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
+		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
 }
 
 // List OAuth authorizations.
-func (s *Service) OAuthAuthorizationList(lr *ListRange) ([]*OAuthAuthorization, error) {
-	var oauthAuthorizationList []*OAuthAuthorization
-	return oauthAuthorizationList, s.Get(&oauthAuthorizationList, fmt.Sprintf("/oauth/authorizations"), lr)
+func (s *Service) OAuthAuthorizationList(ctx context.Context, lr *ListRange) (OAuthAuthorizationListResult, error) {
+	var oauthAuthorization OAuthAuthorizationListResult
+	return oauthAuthorization, s.Get(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations"), nil, lr)
+}
+
+type OAuthAuthorizationRegenerateResult struct {
+	AccessToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // access token for this authorization
+	Client *struct {
+		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
+		Name        string `json:"name" url:"name,key"`                 // OAuth client name
+		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
+	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
+	Grant     *struct {
+		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
+		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
+	} `json:"grant" url:"grant,key"` // this authorization's grant
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	RefreshToken *struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
+	User      struct {
+		Email    string  `json:"email" url:"email,key"`         // unique email address of account
+		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
+		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
+}
+
+// Regenerate OAuth tokens. This endpoint is only available to direct
+// authorizations or privileged OAuth clients.
+func (s *Service) OAuthAuthorizationRegenerate(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorizationRegenerateResult, error) {
+	var oauthAuthorization OAuthAuthorizationRegenerateResult
+	return &oauthAuthorization, s.Post(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations/%v/actions/regenerate-tokens", oauthAuthorizationIdentity), nil)
 }
 
 // OAuth clients are applications that Heroku users can authorize to
@@ -1125,57 +3551,106 @@ func (s *Service) OAuthAuthorizationList(lr *ListRange) ([]*OAuthAuthorization, 
 // information please refer to the [Heroku OAuth
 // documentation](https://devcenter.heroku.com/articles/oauth).
 type OAuthClient struct {
-	CreatedAt         time.Time `json:"created_at"`         // when OAuth client was created
-	ID                string    `json:"id"`                 // unique identifier of this OAuth client
-	IgnoresDelinquent *bool     `json:"ignores_delinquent"` // whether the client is still operable given a delinquent account
-	Name              string    `json:"name"`               // OAuth client name
-	RedirectURI       string    `json:"redirect_uri"`       // endpoint for redirection after authorization with OAuth client
-	Secret            string    `json:"secret"`             // secret used to obtain OAuth authorizations under this client
-	UpdatedAt         time.Time `json:"updated_at"`         // when OAuth client was updated
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
+	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
+	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
+	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
+	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
+	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
 }
 type OAuthClientCreateOpts struct {
-	Name        string `json:"name"`         // OAuth client name
-	RedirectURI string `json:"redirect_uri"` // endpoint for redirection after authorization with OAuth client
+	Name        string `json:"name" url:"name,key"`                 // OAuth client name
+	RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
+}
+type OAuthClientCreateResult struct {
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
+	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
+	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
+	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
+	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
+	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
 }
 
 // Create a new OAuth client.
-func (s *Service) OAuthClientCreate(o struct {
-	Name        string `json:"name"`         // OAuth client name
-	RedirectURI string `json:"redirect_uri"` // endpoint for redirection after authorization with OAuth client
-}) (*OAuthClient, error) {
-	var oauthClient OAuthClient
-	return &oauthClient, s.Post(&oauthClient, fmt.Sprintf("/oauth/clients"), o)
+func (s *Service) OAuthClientCreate(ctx context.Context, o OAuthClientCreateOpts) (*OAuthClientCreateResult, error) {
+	var oauthClient OAuthClientCreateResult
+	return &oauthClient, s.Post(ctx, &oauthClient, fmt.Sprintf("/oauth/clients"), o)
+}
+
+type OAuthClientDeleteResult struct {
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
+	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
+	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
+	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
+	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
+	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
 }
 
 // Delete OAuth client.
-func (s *Service) OAuthClientDelete(oauthClientIdentity string) error {
-	return s.Delete(fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity))
+func (s *Service) OAuthClientDelete(ctx context.Context, oauthClientIdentity string) (*OAuthClientDeleteResult, error) {
+	var oauthClient OAuthClientDeleteResult
+	return &oauthClient, s.Delete(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity))
 }
 
 // Info for an OAuth client
-func (s *Service) OAuthClientInfo(oauthClientIdentity string) (*OAuthClient, error) {
+func (s *Service) OAuthClientInfo(ctx context.Context, oauthClientIdentity string) (*OAuthClient, error) {
 	var oauthClient OAuthClient
-	return &oauthClient, s.Get(&oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity), nil)
+	return &oauthClient, s.Get(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity), nil, nil)
+}
+
+type OAuthClientListResult []struct {
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
+	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
+	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
+	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
+	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
+	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
 }
 
 // List OAuth clients
-func (s *Service) OAuthClientList(lr *ListRange) ([]*OAuthClient, error) {
-	var oauthClientList []*OAuthClient
-	return oauthClientList, s.Get(&oauthClientList, fmt.Sprintf("/oauth/clients"), lr)
+func (s *Service) OAuthClientList(ctx context.Context, lr *ListRange) (OAuthClientListResult, error) {
+	var oauthClient OAuthClientListResult
+	return oauthClient, s.Get(ctx, &oauthClient, fmt.Sprintf("/oauth/clients"), nil, lr)
 }
 
 type OAuthClientUpdateOpts struct {
-	Name        *string `json:"name,omitempty"`         // OAuth client name
-	RedirectURI *string `json:"redirect_uri,omitempty"` // endpoint for redirection after authorization with OAuth client
+	Name        *string `json:"name,omitempty" url:"name,omitempty,key"`                 // OAuth client name
+	RedirectURI *string `json:"redirect_uri,omitempty" url:"redirect_uri,omitempty,key"` // endpoint for redirection after authorization with OAuth client
+}
+type OAuthClientUpdateResult struct {
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
+	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
+	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
+	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
+	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
+	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
 }
 
 // Update OAuth client
-func (s *Service) OAuthClientUpdate(oauthClientIdentity string, o struct {
-	Name        *string `json:"name,omitempty"`         // OAuth client name
-	RedirectURI *string `json:"redirect_uri,omitempty"` // endpoint for redirection after authorization with OAuth client
-}) (*OAuthClient, error) {
-	var oauthClient OAuthClient
-	return &oauthClient, s.Patch(&oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity), o)
+func (s *Service) OAuthClientUpdate(ctx context.Context, oauthClientIdentity string, o OAuthClientUpdateOpts) (*OAuthClientUpdateResult, error) {
+	var oauthClient OAuthClientUpdateResult
+	return &oauthClient, s.Patch(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity), o)
+}
+
+type OAuthClientRotateCredentialsResult struct {
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
+	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
+	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
+	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
+	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
+	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
+}
+
+// Rotate credentials for an OAuth client
+func (s *Service) OAuthClientRotateCredentials(ctx context.Context, oauthClientIdentity string) (*OAuthClientRotateCredentialsResult, error) {
+	var oauthClient OAuthClientRotateCredentialsResult
+	return &oauthClient, s.Post(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v/actions/rotate-credentials", oauthClientIdentity), nil)
 }
 
 // OAuth grants are used to obtain authorizations on behalf of a user.
@@ -1189,546 +3664,2603 @@ type OAuthGrant struct{}
 // documentation](https://devcenter.heroku.com/articles/oauth)
 type OAuthToken struct {
 	AccessToken struct {
-		ExpiresIn *int `json:"expires_in"` // seconds until OAuth token expires; may be `null` for tokens with
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
 		// indefinite lifetime
-		ID    string `json:"id"`    // unique identifier of OAuth token
-		Token string `json:"token"` // contents of the token to be used for authorization
-	} `json:"access_token"` // current access token
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // current access token
 	Authorization struct {
-		ID string `json:"id"` // unique identifier of OAuth authorization
-	} `json:"authorization"` // authorization for this set of tokens
+		ID string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	} `json:"authorization" url:"authorization,key"` // authorization for this set of tokens
 	Client *struct {
-		Secret string `json:"secret"` // secret used to obtain OAuth authorizations under this client
-	} `json:"client"` // OAuth client secret used to obtain token
-	CreatedAt time.Time `json:"created_at"` // when OAuth token was created
+		Secret string `json:"secret" url:"secret,key"` // secret used to obtain OAuth authorizations under this client
+	} `json:"client" url:"client,key"` // OAuth client secret used to obtain token
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth token was created
 	Grant     struct {
-		Code string `json:"code"` // grant code received from OAuth web application authorization
-		Type string `json:"type"` // type of grant requested, one of `authorization_code` or
+		Code string `json:"code" url:"code,key"` // grant code received from OAuth web application authorization
+		Type string `json:"type" url:"type,key"` // type of grant requested, one of `authorization_code` or
 		// `refresh_token`
-	} `json:"grant"` // grant used on the underlying authorization
-	ID           string `json:"id"` // unique identifier of OAuth token
+	} `json:"grant" url:"grant,key"` // grant used on the underlying authorization
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth token
 	RefreshToken struct {
-		ExpiresIn *int `json:"expires_in"` // seconds until OAuth token expires; may be `null` for tokens with
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
 		// indefinite lifetime
-		ID    string `json:"id"`    // unique identifier of OAuth token
-		Token string `json:"token"` // contents of the token to be used for authorization
-	} `json:"refresh_token"` // refresh token for this authorization
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
 	Session struct {
-		ID string `json:"id"` // unique identifier of OAuth token
-	} `json:"session"` // OAuth session using this token
-	UpdatedAt time.Time `json:"updated_at"` // when OAuth token was updated
+		ID string `json:"id" url:"id,key"` // unique identifier of OAuth token
+	} `json:"session" url:"session,key"` // OAuth session using this token
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth token was updated
 	User      struct {
-		ID string `json:"id"` // unique identifier of an account
-	} `json:"user"` // Reference to the user associated with this token
+		ID string `json:"id" url:"id,key"` // unique identifier of an account
+	} `json:"user" url:"user,key"` // Reference to the user associated with this token
 }
 type OAuthTokenCreateOpts struct {
 	Client struct {
-		Secret *string `json:"secret,omitempty"` // secret used to obtain OAuth authorizations under this client
-	} `json:"client"`
+		Secret *string `json:"secret,omitempty" url:"secret,omitempty,key"` // secret used to obtain OAuth authorizations under this client
+	} `json:"client" url:"client,key"`
 	Grant struct {
-		Code *string `json:"code,omitempty"` // grant code received from OAuth web application authorization
-		Type *string `json:"type,omitempty"` // type of grant requested, one of `authorization_code` or
+		Code *string `json:"code,omitempty" url:"code,omitempty,key"` // grant code received from OAuth web application authorization
+		Type *string `json:"type,omitempty" url:"type,omitempty,key"` // type of grant requested, one of `authorization_code` or
 		// `refresh_token`
-	} `json:"grant"`
+	} `json:"grant" url:"grant,key"`
 	RefreshToken struct {
-		Token *string `json:"token,omitempty"` // contents of the token to be used for authorization
-	} `json:"refresh_token"`
+		Token *string `json:"token,omitempty" url:"token,omitempty,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"`
+}
+type OAuthTokenCreateResult struct {
+	AccessToken struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // current access token
+	Authorization struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	} `json:"authorization" url:"authorization,key"` // authorization for this set of tokens
+	Client *struct {
+		Secret string `json:"secret" url:"secret,key"` // secret used to obtain OAuth authorizations under this client
+	} `json:"client" url:"client,key"` // OAuth client secret used to obtain token
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth token was created
+	Grant     struct {
+		Code string `json:"code" url:"code,key"` // grant code received from OAuth web application authorization
+		Type string `json:"type" url:"type,key"` // type of grant requested, one of `authorization_code` or
+		// `refresh_token`
+	} `json:"grant" url:"grant,key"` // grant used on the underlying authorization
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth token
+	RefreshToken struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Session struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of OAuth token
+	} `json:"session" url:"session,key"` // OAuth session using this token
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth token was updated
+	User      struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of an account
+	} `json:"user" url:"user,key"` // Reference to the user associated with this token
 }
 
 // Create a new OAuth token.
-func (s *Service) OAuthTokenCreate(o struct {
-	Client struct {
-		Secret *string `json:"secret,omitempty"` // secret used to obtain OAuth authorizations under this client
-	} `json:"client"`
-	Grant struct {
-		Code *string `json:"code,omitempty"` // grant code received from OAuth web application authorization
-		Type *string `json:"type,omitempty"` // type of grant requested, one of `authorization_code` or
+func (s *Service) OAuthTokenCreate(ctx context.Context, o OAuthTokenCreateOpts) (*OAuthTokenCreateResult, error) {
+	var oauthToken OAuthTokenCreateResult
+	return &oauthToken, s.Post(ctx, &oauthToken, fmt.Sprintf("/oauth/tokens"), o)
+}
+
+type OAuthTokenDeleteResult struct {
+	AccessToken struct {
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"access_token" url:"access_token,key"` // current access token
+	Authorization struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
+	} `json:"authorization" url:"authorization,key"` // authorization for this set of tokens
+	Client *struct {
+		Secret string `json:"secret" url:"secret,key"` // secret used to obtain OAuth authorizations under this client
+	} `json:"client" url:"client,key"` // OAuth client secret used to obtain token
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth token was created
+	Grant     struct {
+		Code string `json:"code" url:"code,key"` // grant code received from OAuth web application authorization
+		Type string `json:"type" url:"type,key"` // type of grant requested, one of `authorization_code` or
 		// `refresh_token`
-	} `json:"grant"`
+	} `json:"grant" url:"grant,key"` // grant used on the underlying authorization
+	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth token
 	RefreshToken struct {
-		Token *string `json:"token,omitempty"` // contents of the token to be used for authorization
-	} `json:"refresh_token"`
-}) (*OAuthToken, error) {
-	var oauthToken OAuthToken
-	return &oauthToken, s.Post(&oauthToken, fmt.Sprintf("/oauth/tokens"), o)
+		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
+		// indefinite lifetime
+		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
+		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
+	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
+	Session struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of OAuth token
+	} `json:"session" url:"session,key"` // OAuth session using this token
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth token was updated
+	User      struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of an account
+	} `json:"user" url:"user,key"` // Reference to the user associated with this token
+}
+
+// Revoke OAuth access token.
+func (s *Service) OAuthTokenDelete(ctx context.Context, oauthTokenIdentity string) (*OAuthTokenDeleteResult, error) {
+	var oauthToken OAuthTokenDeleteResult
+	return &oauthToken, s.Delete(ctx, &oauthToken, fmt.Sprintf("/oauth/tokens/%v", oauthTokenIdentity))
 }
 
 // Organizations allow you to manage access to a shared group of
 // applications across your development team.
 type Organization struct {
-	CreditCardCollections bool   `json:"credit_card_collections"` // whether charges incurred by the org are paid by credit card.
-	Default               bool   `json:"default"`                 // whether to use this organization when none is specified
-	Name                  string `json:"name"`                    // unique name of organization
-	ProvisionedLicenses   bool   `json:"provisioned_licenses"`    // whether the org is provisioned licenses by salesforce.
-	Role                  string `json:"role"`                    // role in the organization
+	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
+	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
+	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
+	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
+	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
+	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
+	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
+	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
+	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
+	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
+}
+type OrganizationListResult []struct {
+	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
+	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
+	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
+	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
+	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
+	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
+	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
+	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
+	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
+	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
 }
 
 // List organizations in which you are a member.
-func (s *Service) OrganizationList(lr *ListRange) ([]*Organization, error) {
-	var organizationList []*Organization
-	return organizationList, s.Get(&organizationList, fmt.Sprintf("/organizations"), lr)
+func (s *Service) OrganizationList(ctx context.Context, lr *ListRange) (OrganizationListResult, error) {
+	var organization OrganizationListResult
+	return organization, s.Get(ctx, &organization, fmt.Sprintf("/organizations"), nil, lr)
+}
+
+// Info for an organization.
+func (s *Service) OrganizationInfo(ctx context.Context, organizationIdentity string) (*Organization, error) {
+	var organization Organization
+	return &organization, s.Get(ctx, &organization, fmt.Sprintf("/organizations/%v", organizationIdentity), nil, nil)
 }
 
 type OrganizationUpdateOpts struct {
-	Default *bool `json:"default,omitempty"` // whether to use this organization when none is specified
+	Default *bool   `json:"default,omitempty" url:"default,omitempty,key"` // whether to use this organization when none is specified
+	Name    *string `json:"name,omitempty" url:"name,omitempty,key"`       // unique name of organization
+}
+type OrganizationUpdateResult struct {
+	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
+	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
+	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
+	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
+	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
+	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
+	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
+	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
+	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
+	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
 }
 
-// Set or unset the organization as your default organization.
-func (s *Service) OrganizationUpdate(organizationIdentity string, o struct {
-	Default *bool `json:"default,omitempty"` // whether to use this organization when none is specified
-}) (*Organization, error) {
-	var organization Organization
-	return &organization, s.Patch(&organization, fmt.Sprintf("/organizations/%v", organizationIdentity), o)
+// Update organization properties.
+func (s *Service) OrganizationUpdate(ctx context.Context, organizationIdentity string, o OrganizationUpdateOpts) (*OrganizationUpdateResult, error) {
+	var organization OrganizationUpdateResult
+	return &organization, s.Patch(ctx, &organization, fmt.Sprintf("/organizations/%v", organizationIdentity), o)
+}
+
+type OrganizationCreateOpts struct {
+	Address1        *string `json:"address_1,omitempty" url:"address_1,omitempty,key"`               // street address line 1
+	Address2        *string `json:"address_2,omitempty" url:"address_2,omitempty,key"`               // street address line 2
+	CardNumber      *string `json:"card_number,omitempty" url:"card_number,omitempty,key"`           // encrypted card number of payment method
+	City            *string `json:"city,omitempty" url:"city,omitempty,key"`                         // city
+	Country         *string `json:"country,omitempty" url:"country,omitempty,key"`                   // country
+	Cvv             *string `json:"cvv,omitempty" url:"cvv,omitempty,key"`                           // card verification value
+	ExpirationMonth *string `json:"expiration_month,omitempty" url:"expiration_month,omitempty,key"` // expiration month
+	ExpirationYear  *string `json:"expiration_year,omitempty" url:"expiration_year,omitempty,key"`   // expiration year
+	FirstName       *string `json:"first_name,omitempty" url:"first_name,omitempty,key"`             // the first name for payment method
+	LastName        *string `json:"last_name,omitempty" url:"last_name,omitempty,key"`               // the last name for payment method
+	Name            string  `json:"name" url:"name,key"`                                             // unique name of organization
+	Other           *string `json:"other,omitempty" url:"other,omitempty,key"`                       // metadata
+	PostalCode      *string `json:"postal_code,omitempty" url:"postal_code,omitempty,key"`           // postal code
+	State           *string `json:"state,omitempty" url:"state,omitempty,key"`                       // state
+}
+type OrganizationCreateResult struct {
+	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
+	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
+	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
+	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
+	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
+	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
+	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
+	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
+	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
+	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
+}
+
+// Create a new organization.
+func (s *Service) OrganizationCreate(ctx context.Context, o OrganizationCreateOpts) (*OrganizationCreateResult, error) {
+	var organization OrganizationCreateResult
+	return &organization, s.Post(ctx, &organization, fmt.Sprintf("/organizations"), o)
+}
+
+type OrganizationDeleteResult struct {
+	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
+	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
+	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
+	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
+	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
+	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
+	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
+	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
+	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
+	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
+}
+
+// Delete an existing organization.
+func (s *Service) OrganizationDelete(ctx context.Context, organizationIdentity string) (*OrganizationDeleteResult, error) {
+	var organization OrganizationDeleteResult
+	return &organization, s.Delete(ctx, &organization, fmt.Sprintf("/organizations/%v", organizationIdentity))
+}
+
+// A list of add-ons the Organization uses across all apps
+type OrganizationAddOn struct{}
+type OrganizationAddOnListForOrganizationResult []struct {
+	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // billing application associated with this add-on
+	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
+	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
+	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
+	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
+	Plan       struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
+		Name string `json:"name" url:"name,key"` // unique name of this plan
+	} `json:"plan" url:"plan,key"` // identity of add-on plan
+	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
+	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
+	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
+	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+}
+
+// List add-ons used across all Organization apps
+func (s *Service) OrganizationAddOnListForOrganization(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationAddOnListForOrganizationResult, error) {
+	var organizationAddOn OrganizationAddOnListForOrganizationResult
+	return organizationAddOn, s.Get(ctx, &organizationAddOn, fmt.Sprintf("/organizations/%v/addons", organizationIdentity), nil, lr)
 }
 
 // An organization app encapsulates the organization specific
 // functionality of Heroku apps.
 type OrganizationApp struct {
-	ArchivedAt                   *time.Time `json:"archived_at"`                    // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at"`                     // when app was created
-	GitURL                       string     `json:"git_url"`                        // git repo URL of app
-	ID                           string     `json:"id"`                             // unique identifier of app
-	Joined                       bool       `json:"joined"`                         // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked"`                         // are other organization members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance"`                    // maintenance status of app
-	Name                         string     `json:"name"`                           // unique name of app
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
 	Organization                 *struct {
-		Name string `json:"name"` // unique name of organization
-	} `json:"organization"` // organization that owns this app
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
 	Owner *struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"owner"` // identity of app owner
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
 	Region struct {
-		ID   string `json:"id"`   // unique identifier of region
-		Name string `json:"name"` // unique name of region
-	} `json:"region"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at"` // when app was released
-	RepoSize   *int       `json:"repo_size"`   // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size"`   // slug size in bytes of app
-	Stack      struct {
-		ID   string `json:"id"`   // unique identifier of stack
-		Name string `json:"name"` // unique name of stack
-	} `json:"stack"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at"` // when app was updated
-	WebURL    string    `json:"web_url"`    // web URL of app
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 type OrganizationAppCreateOpts struct {
-	Locked       *bool   `json:"locked,omitempty"`       // are other organization members forbidden from joining this app.
-	Name         *string `json:"name,omitempty"`         // unique name of app
-	Organization *string `json:"organization,omitempty"` // unique name of organization
-	Personal     *bool   `json:"personal,omitempty"`     // force creation of the app in the user account even if a default org
+	Locked       *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`             // are other organization members forbidden from joining this app.
+	Name         *string `json:"name,omitempty" url:"name,omitempty,key"`                 // unique name of app
+	Organization *string `json:"organization,omitempty" url:"organization,omitempty,key"` // unique name of organization
+	Personal     *bool   `json:"personal,omitempty" url:"personal,omitempty,key"`         // force creation of the app in the user account even if a default org
 	// is set.
-	Region *string `json:"region,omitempty"` // unique name of region
-	Stack  *string `json:"stack,omitempty"`  // unique name of stack
+	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique name of region
+	Space  *string `json:"space,omitempty" url:"space,omitempty,key"`   // unique name of space
+	Stack  *string `json:"stack,omitempty" url:"stack,omitempty,key"`   // unique name of stack
 }
 
 // Create a new app in the specified organization, in the default
 // organization if unspecified,  or in personal account, if default
 // organization is not set.
-func (s *Service) OrganizationAppCreate(o struct {
-	Locked       *bool   `json:"locked,omitempty"`       // are other organization members forbidden from joining this app.
-	Name         *string `json:"name,omitempty"`         // unique name of app
-	Organization *string `json:"organization,omitempty"` // unique name of organization
-	Personal     *bool   `json:"personal,omitempty"`     // force creation of the app in the user account even if a default org
-	// is set.
-	Region *string `json:"region,omitempty"` // unique name of region
-	Stack  *string `json:"stack,omitempty"`  // unique name of stack
-}) (*OrganizationApp, error) {
+func (s *Service) OrganizationAppCreate(ctx context.Context, o OrganizationAppCreateOpts) (*OrganizationApp, error) {
 	var organizationApp OrganizationApp
-	return &organizationApp, s.Post(&organizationApp, fmt.Sprintf("/organizations/apps"), o)
+	return &organizationApp, s.Post(ctx, &organizationApp, fmt.Sprintf("/organizations/apps"), o)
+}
+
+type OrganizationAppListResult []struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
+	Owner *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // List apps in the default organization, or in personal account, if
 // default organization is not set.
-func (s *Service) OrganizationAppList(lr *ListRange) ([]*OrganizationApp, error) {
-	var organizationAppList []*OrganizationApp
-	return organizationAppList, s.Get(&organizationAppList, fmt.Sprintf("/organizations/apps"), lr)
+func (s *Service) OrganizationAppList(ctx context.Context, lr *ListRange) (OrganizationAppListResult, error) {
+	var organizationApp OrganizationAppListResult
+	return organizationApp, s.Get(ctx, &organizationApp, fmt.Sprintf("/organizations/apps"), nil, lr)
+}
+
+type OrganizationAppListForOrganizationResult []struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
+	Owner *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // List organization apps.
-func (s *Service) OrganizationAppListForOrganization(organizationIdentity string, lr *ListRange) ([]*OrganizationApp, error) {
-	var organizationAppList []*OrganizationApp
-	return organizationAppList, s.Get(&organizationAppList, fmt.Sprintf("/organizations/%v/apps", organizationIdentity), lr)
+func (s *Service) OrganizationAppListForOrganization(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationAppListForOrganizationResult, error) {
+	var organizationApp OrganizationAppListForOrganizationResult
+	return organizationApp, s.Get(ctx, &organizationApp, fmt.Sprintf("/organizations/%v/apps", organizationIdentity), nil, lr)
 }
 
 // Info for an organization app.
-func (s *Service) OrganizationAppInfo(organizationAppIdentity string) (*OrganizationApp, error) {
+func (s *Service) OrganizationAppInfo(ctx context.Context, organizationAppIdentity string) (*OrganizationApp, error) {
 	var organizationApp OrganizationApp
-	return &organizationApp, s.Get(&organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), nil)
+	return &organizationApp, s.Get(ctx, &organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), nil, nil)
 }
 
 type OrganizationAppUpdateLockedOpts struct {
-	Locked bool `json:"locked"` // are other organization members forbidden from joining this app.
+	Locked bool `json:"locked" url:"locked,key"` // are other organization members forbidden from joining this app.
+}
+type OrganizationAppUpdateLockedResult struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
+	Owner *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // Lock or unlock an organization app.
-func (s *Service) OrganizationAppUpdateLocked(organizationAppIdentity string, o struct {
-	Locked bool `json:"locked"` // are other organization members forbidden from joining this app.
-}) (*OrganizationApp, error) {
-	var organizationApp OrganizationApp
-	return &organizationApp, s.Patch(&organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
+func (s *Service) OrganizationAppUpdateLocked(ctx context.Context, organizationAppIdentity string, o OrganizationAppUpdateLockedOpts) (*OrganizationAppUpdateLockedResult, error) {
+	var organizationApp OrganizationAppUpdateLockedResult
+	return &organizationApp, s.Patch(ctx, &organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
 }
 
 type OrganizationAppTransferToAccountOpts struct {
-	Owner string `json:"owner"` // unique email address of account
+	Owner string `json:"owner" url:"owner,key"` // unique email address of account
 }
 
 // Transfer an existing organization app to another Heroku account.
-func (s *Service) OrganizationAppTransferToAccount(organizationAppIdentity string, o struct {
-	Owner string `json:"owner"` // unique email address of account
-}) (*OrganizationApp, error) {
+func (s *Service) OrganizationAppTransferToAccount(ctx context.Context, organizationAppIdentity string, o OrganizationAppTransferToAccountOpts) (*OrganizationApp, error) {
 	var organizationApp OrganizationApp
-	return &organizationApp, s.Patch(&organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
+	return &organizationApp, s.Patch(ctx, &organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
 }
 
 type OrganizationAppTransferToOrganizationOpts struct {
-	Owner string `json:"owner"` // unique name of organization
+	Owner string `json:"owner" url:"owner,key"` // unique name of organization
+}
+type OrganizationAppTransferToOrganizationResult struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
+	Owner *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
 
 // Transfer an existing organization app to another organization.
-func (s *Service) OrganizationAppTransferToOrganization(organizationAppIdentity string, o struct {
-	Owner string `json:"owner"` // unique name of organization
-}) (*OrganizationApp, error) {
-	var organizationApp OrganizationApp
-	return &organizationApp, s.Patch(&organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
+func (s *Service) OrganizationAppTransferToOrganization(ctx context.Context, organizationAppIdentity string, o OrganizationAppTransferToOrganizationOpts) (*OrganizationAppTransferToOrganizationResult, error) {
+	var organizationApp OrganizationAppTransferToOrganizationResult
+	return &organizationApp, s.Patch(ctx, &organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
 }
 
 // An organization collaborator represents an account that has been
 // given access to an organization app on Heroku.
 type OrganizationAppCollaborator struct {
-	CreatedAt time.Time `json:"created_at"` // when collaborator was created
-	ID        string    `json:"id"`         // unique identifier of collaborator
-	Role      string    `json:"role"`       // role in the organization
-	UpdatedAt time.Time `json:"updated_at"` // when collaborator was updated
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
 	User      struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"user"` // identity of collaborated account
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 type OrganizationAppCollaboratorCreateOpts struct {
-	Silent *bool  `json:"silent,omitempty"` // whether to suppress email invitation when creating collaborator
-	User   string `json:"user"`             // unique email address of account
+	Silent *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email invitation when creating collaborator
+	User   string `json:"user" url:"user,key"`                         // unique email address of account
+}
+type OrganizationAppCollaboratorCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // Create a new collaborator on an organization app. Use this endpoint
 // instead of the `/apps/{app_id_or_name}/collaborator` endpoint when
-// you want the collaborator to be granted [privileges]
-// (https://devcenter.heroku.com/articles/org-users-access#roles)
-// according to their role in the organization.
-func (s *Service) OrganizationAppCollaboratorCreate(appIdentity string, o struct {
-	Silent *bool  `json:"silent,omitempty"` // whether to suppress email invitation when creating collaborator
-	User   string `json:"user"`             // unique email address of account
-}) (*OrganizationAppCollaborator, error) {
-	var organizationAppCollaborator OrganizationAppCollaborator
-	return &organizationAppCollaborator, s.Post(&organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators", appIdentity), o)
+// you want the collaborator to be granted [permissions]
+// (https://devcenter.heroku.com/articles/org-users-access#roles-and-app-
+// permissions) according to their role in the organization.
+func (s *Service) OrganizationAppCollaboratorCreate(ctx context.Context, appIdentity string, o OrganizationAppCollaboratorCreateOpts) (*OrganizationAppCollaboratorCreateResult, error) {
+	var organizationAppCollaborator OrganizationAppCollaboratorCreateResult
+	return &organizationAppCollaborator, s.Post(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators", appIdentity), o)
+}
+
+type OrganizationAppCollaboratorDeleteResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // Delete an existing collaborator from an organization app.
-func (s *Service) OrganizationAppCollaboratorDelete(organizationAppIdentity string, organizationAppCollaboratorIdentity string) error {
-	return s.Delete(fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity))
+func (s *Service) OrganizationAppCollaboratorDelete(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaboratorDeleteResult, error) {
+	var organizationAppCollaborator OrganizationAppCollaboratorDeleteResult
+	return &organizationAppCollaborator, s.Delete(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity))
+}
+
+type OrganizationAppCollaboratorInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // Info for a collaborator on an organization app.
-func (s *Service) OrganizationAppCollaboratorInfo(organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaborator, error) {
-	var organizationAppCollaborator OrganizationAppCollaborator
-	return &organizationAppCollaborator, s.Get(&organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity), nil)
+func (s *Service) OrganizationAppCollaboratorInfo(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaboratorInfoResult, error) {
+	var organizationAppCollaborator OrganizationAppCollaboratorInfoResult
+	return &organizationAppCollaborator, s.Get(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity), nil, nil)
+}
+
+type OrganizationAppCollaboratorUpdateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
+}
+
+// Update an existing collaborator from an organization app.
+func (s *Service) OrganizationAppCollaboratorUpdate(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaboratorUpdateResult, error) {
+	var organizationAppCollaborator OrganizationAppCollaboratorUpdateResult
+	return &organizationAppCollaborator, s.Patch(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity), nil)
+}
+
+type OrganizationAppCollaboratorListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 
 // List collaborators on an organization app.
-func (s *Service) OrganizationAppCollaboratorList(organizationAppIdentity string, lr *ListRange) ([]*OrganizationAppCollaborator, error) {
-	var organizationAppCollaboratorList []*OrganizationAppCollaborator
-	return organizationAppCollaboratorList, s.Get(&organizationAppCollaboratorList, fmt.Sprintf("/organizations/apps/%v/collaborators", organizationAppIdentity), lr)
+func (s *Service) OrganizationAppCollaboratorList(ctx context.Context, organizationAppIdentity string, lr *ListRange) (OrganizationAppCollaboratorListResult, error) {
+	var organizationAppCollaborator OrganizationAppCollaboratorListResult
+	return organizationAppCollaborator, s.Get(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators", organizationAppIdentity), nil, lr)
+}
+
+// An organization app permission is a behavior that is assigned to a
+// user in an organization app.
+type OrganizationAppPermission struct {
+	Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+	Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+}
+type OrganizationAppPermissionListResult []struct {
+	Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+	Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+}
+
+// Lists permissions available to organizations.
+func (s *Service) OrganizationAppPermissionList(ctx context.Context, lr *ListRange) (OrganizationAppPermissionListResult, error) {
+	var organizationAppPermission OrganizationAppPermissionListResult
+	return organizationAppPermission, s.Get(ctx, &organizationAppPermission, fmt.Sprintf("/organizations/permissions"), nil, lr)
+}
+
+// An organization feature represents a feature enabled on an
+// organization account.
+type OrganizationFeature struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
+	Description string    `json:"description" url:"description,key"` // description of account feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
+	State       string    `json:"state" url:"state,key"`             // state of account feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+}
+type OrganizationFeatureInfoResult struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
+	Description string    `json:"description" url:"description,key"` // description of account feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
+	State       string    `json:"state" url:"state,key"`             // state of account feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+}
+
+// Info for an existing account feature.
+func (s *Service) OrganizationFeatureInfo(ctx context.Context, organizationIdentity string, organizationFeatureIdentity string) (*OrganizationFeatureInfoResult, error) {
+	var organizationFeature OrganizationFeatureInfoResult
+	return &organizationFeature, s.Get(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features/%v", organizationIdentity, organizationFeatureIdentity), nil, nil)
+}
+
+type OrganizationFeatureListResult []struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
+	Description string    `json:"description" url:"description,key"` // description of account feature
+	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
+	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
+	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
+	State       string    `json:"state" url:"state,key"`             // state of account feature
+	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+}
+
+// List existing organization features.
+func (s *Service) OrganizationFeatureList(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationFeatureListResult, error) {
+	var organizationFeature OrganizationFeatureListResult
+	return organizationFeature, s.Get(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features", organizationIdentity), nil, lr)
+}
+
+// An organization invitation represents an invite to an organization.
+type OrganizationInvitation struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
+	ID        string    `json:"id" url:"id,key"`                 // Unique identifier of an invitation
+	InvitedBy struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"invited_by" url:"invited_by,key"`
+	Organization struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when invitation was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"`
+}
+type OrganizationInvitationListResult []struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
+	ID        string    `json:"id" url:"id,key"`                 // Unique identifier of an invitation
+	InvitedBy struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"invited_by" url:"invited_by,key"`
+	Organization struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when invitation was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"`
+}
+
+// Get a list of an organization's Identity Providers
+func (s *Service) OrganizationInvitationList(ctx context.Context, organizationName string, lr *ListRange) (OrganizationInvitationListResult, error) {
+	var organizationInvitation OrganizationInvitationListResult
+	return organizationInvitation, s.Get(ctx, &organizationInvitation, fmt.Sprintf("/organizations/%v/invitations", organizationName), nil, lr)
+}
+
+type OrganizationInvitationCreateOpts struct {
+	Email string  `json:"email" url:"email,key"` // unique email address of account
+	Role  *string `json:"role" url:"role,key"`   // role in the organization
+}
+
+// Create Organization Invitation
+func (s *Service) OrganizationInvitationCreate(ctx context.Context, organizationIdentity string, o OrganizationInvitationCreateOpts) (*OrganizationInvitation, error) {
+	var organizationInvitation OrganizationInvitation
+	return &organizationInvitation, s.Put(ctx, &organizationInvitation, fmt.Sprintf("/organizations/%v/invitations", organizationIdentity), o)
+}
+
+// Revoke an organization invitation.
+func (s *Service) OrganizationInvitationRevoke(ctx context.Context, organizationIdentity string, organizationInvitationIdentity string) (*OrganizationInvitation, error) {
+	var organizationInvitation OrganizationInvitation
+	return &organizationInvitation, s.Delete(ctx, &organizationInvitation, fmt.Sprintf("/organizations/%v/invitations/%v", organizationIdentity, organizationInvitationIdentity))
+}
+
+type OrganizationInvitationGetResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
+	ID        string    `json:"id" url:"id,key"`                 // Unique identifier of an invitation
+	InvitedBy struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"invited_by" url:"invited_by,key"`
+	Organization struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"`
+	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when invitation was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"`
+}
+
+// Get an invitation by its token
+func (s *Service) OrganizationInvitationGet(ctx context.Context, organizationInvitationToken string, lr *ListRange) (*OrganizationInvitationGetResult, error) {
+	var organizationInvitation OrganizationInvitationGetResult
+	return &organizationInvitation, s.Get(ctx, &organizationInvitation, fmt.Sprintf("/organizations/invitations/%v", organizationInvitationToken), nil, lr)
+}
+
+type OrganizationInvitationAcceptResult struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
+	// authentication enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
+}
+
+// Accept Organization Invitation
+func (s *Service) OrganizationInvitationAccept(ctx context.Context, organizationInvitationToken string) (*OrganizationInvitationAcceptResult, error) {
+	var organizationInvitation OrganizationInvitationAcceptResult
+	return &organizationInvitation, s.Post(ctx, &organizationInvitation, fmt.Sprintf("/organizations/invitations/%v/accept", organizationInvitationToken), nil)
+}
+
+// An organization invoice is an itemized bill of goods for an
+// organization which includes pricing and charges.
+type OrganizationInvoice struct {
+	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
+	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
+	CreditsTotal      int       `json:"credits_total" url:"credits_total,key"`             // total credits on this invoice
+	DatabaseTotal     int       `json:"database_total" url:"database_total,key"`           // total database charges on this invoice
+	DynoUnits         float64   `json:"dyno_units" url:"dyno_units,key"`                   // The total amount of dyno units consumed across dyno types.
+	ID                string    `json:"id" url:"id,key"`                                   // unique identifier of this invoice
+	Number            int       `json:"number" url:"number,key"`                           // human readable invoice number
+	PaymentStatus     string    `json:"payment_status" url:"payment_status,key"`           // Status of the invoice payment.
+	PeriodEnd         string    `json:"period_end" url:"period_end,key"`                   // the ending date that the invoice covers
+	PeriodStart       string    `json:"period_start" url:"period_start,key"`               // the starting date that this invoice covers
+	PlatformTotal     int       `json:"platform_total" url:"platform_total,key"`           // total platform charges on this invoice
+	State             int       `json:"state" url:"state,key"`                             // payment status for this invoice (pending, successful, failed)
+	Total             int       `json:"total" url:"total,key"`                             // combined total of charges and credits on this invoice
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                   // when invoice was updated
+	WeightedDynoHours float64   `json:"weighted_dyno_hours" url:"weighted_dyno_hours,key"` // The total amount of hours consumed across dyno types.
+}
+type OrganizationInvoiceInfoResult struct {
+	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
+	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
+	CreditsTotal      int       `json:"credits_total" url:"credits_total,key"`             // total credits on this invoice
+	DatabaseTotal     int       `json:"database_total" url:"database_total,key"`           // total database charges on this invoice
+	DynoUnits         float64   `json:"dyno_units" url:"dyno_units,key"`                   // The total amount of dyno units consumed across dyno types.
+	ID                string    `json:"id" url:"id,key"`                                   // unique identifier of this invoice
+	Number            int       `json:"number" url:"number,key"`                           // human readable invoice number
+	PaymentStatus     string    `json:"payment_status" url:"payment_status,key"`           // Status of the invoice payment.
+	PeriodEnd         string    `json:"period_end" url:"period_end,key"`                   // the ending date that the invoice covers
+	PeriodStart       string    `json:"period_start" url:"period_start,key"`               // the starting date that this invoice covers
+	PlatformTotal     int       `json:"platform_total" url:"platform_total,key"`           // total platform charges on this invoice
+	State             int       `json:"state" url:"state,key"`                             // payment status for this invoice (pending, successful, failed)
+	Total             int       `json:"total" url:"total,key"`                             // combined total of charges and credits on this invoice
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                   // when invoice was updated
+	WeightedDynoHours float64   `json:"weighted_dyno_hours" url:"weighted_dyno_hours,key"` // The total amount of hours consumed across dyno types.
+}
+
+// Info for existing invoice.
+func (s *Service) OrganizationInvoiceInfo(ctx context.Context, organizationIdentity string, organizationInvoiceIdentity int) (*OrganizationInvoiceInfoResult, error) {
+	var organizationInvoice OrganizationInvoiceInfoResult
+	return &organizationInvoice, s.Get(ctx, &organizationInvoice, fmt.Sprintf("/organizations/%v/invoices/%v", organizationIdentity, organizationInvoiceIdentity), nil, nil)
+}
+
+type OrganizationInvoiceListResult []struct {
+	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
+	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
+	CreditsTotal      int       `json:"credits_total" url:"credits_total,key"`             // total credits on this invoice
+	DatabaseTotal     int       `json:"database_total" url:"database_total,key"`           // total database charges on this invoice
+	DynoUnits         float64   `json:"dyno_units" url:"dyno_units,key"`                   // The total amount of dyno units consumed across dyno types.
+	ID                string    `json:"id" url:"id,key"`                                   // unique identifier of this invoice
+	Number            int       `json:"number" url:"number,key"`                           // human readable invoice number
+	PaymentStatus     string    `json:"payment_status" url:"payment_status,key"`           // Status of the invoice payment.
+	PeriodEnd         string    `json:"period_end" url:"period_end,key"`                   // the ending date that the invoice covers
+	PeriodStart       string    `json:"period_start" url:"period_start,key"`               // the starting date that this invoice covers
+	PlatformTotal     int       `json:"platform_total" url:"platform_total,key"`           // total platform charges on this invoice
+	State             int       `json:"state" url:"state,key"`                             // payment status for this invoice (pending, successful, failed)
+	Total             int       `json:"total" url:"total,key"`                             // combined total of charges and credits on this invoice
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                   // when invoice was updated
+	WeightedDynoHours float64   `json:"weighted_dyno_hours" url:"weighted_dyno_hours,key"` // The total amount of hours consumed across dyno types.
+}
+
+// List existing invoices.
+func (s *Service) OrganizationInvoiceList(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationInvoiceListResult, error) {
+	var organizationInvoice OrganizationInvoiceListResult
+	return organizationInvoice, s.Get(ctx, &organizationInvoice, fmt.Sprintf("/organizations/%v/invoices", organizationIdentity), nil, lr)
 }
 
 // An organization member is an individual with access to an
 // organization.
 type OrganizationMember struct {
-	CreatedAt time.Time `json:"created_at"` // when organization-member was created
-	Email     string    `json:"email"`      // email address of the organization member
-	Role      string    `json:"role"`       // role in the organization
-	UpdatedAt time.Time `json:"updated_at"` // when organization-member was updated
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
+	// authentication enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
 }
 type OrganizationMemberCreateOrUpdateOpts struct {
-	Email string `json:"email"` // email address of the organization member
-	Role  string `json:"role"`  // role in the organization
+	Email     string  `json:"email" url:"email,key"`                             // email address of the organization member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the organization
+}
+type OrganizationMemberCreateOrUpdateResult struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
+	// authentication enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
 }
 
 // Create a new organization member, or update their role.
-func (s *Service) OrganizationMemberCreateOrUpdate(organizationIdentity string, o struct {
-	Email string `json:"email"` // email address of the organization member
-	Role  string `json:"role"`  // role in the organization
-}) (*OrganizationMember, error) {
-	var organizationMember OrganizationMember
-	return &organizationMember, s.Put(&organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), o)
+func (s *Service) OrganizationMemberCreateOrUpdate(ctx context.Context, organizationIdentity string, o OrganizationMemberCreateOrUpdateOpts) (*OrganizationMemberCreateOrUpdateResult, error) {
+	var organizationMember OrganizationMemberCreateOrUpdateResult
+	return &organizationMember, s.Put(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), o)
+}
+
+type OrganizationMemberCreateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the organization member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the organization
+}
+type OrganizationMemberCreateResult struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
+	// authentication enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
+}
+
+// Create a new organization member.
+func (s *Service) OrganizationMemberCreate(ctx context.Context, organizationIdentity string, o OrganizationMemberCreateOpts) (*OrganizationMemberCreateResult, error) {
+	var organizationMember OrganizationMemberCreateResult
+	return &organizationMember, s.Post(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), o)
+}
+
+type OrganizationMemberUpdateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the organization member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the organization
+}
+type OrganizationMemberUpdateResult struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
+	// authentication enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
+}
+
+// Update an organization member.
+func (s *Service) OrganizationMemberUpdate(ctx context.Context, organizationIdentity string, o OrganizationMemberUpdateOpts) (*OrganizationMemberUpdateResult, error) {
+	var organizationMember OrganizationMemberUpdateResult
+	return &organizationMember, s.Patch(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), o)
+}
+
+type OrganizationMemberDeleteResult struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
+	// authentication enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
 }
 
 // Remove a member from the organization.
-func (s *Service) OrganizationMemberDelete(organizationIdentity string, organizationMemberIdentity string) error {
-	return s.Delete(fmt.Sprintf("/organizations/%v/members/%v", organizationIdentity, organizationMemberIdentity))
+func (s *Service) OrganizationMemberDelete(ctx context.Context, organizationIdentity string, organizationMemberIdentity string) (*OrganizationMemberDeleteResult, error) {
+	var organizationMember OrganizationMemberDeleteResult
+	return &organizationMember, s.Delete(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members/%v", organizationIdentity, organizationMemberIdentity))
+}
+
+type OrganizationMemberListResult []struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
+	// authentication enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
 }
 
 // List members of the organization.
-func (s *Service) OrganizationMemberList(organizationIdentity string, lr *ListRange) ([]*OrganizationMember, error) {
-	var organizationMemberList []*OrganizationMember
-	return organizationMemberList, s.Get(&organizationMemberList, fmt.Sprintf("/organizations/%v/members", organizationIdentity), lr)
+func (s *Service) OrganizationMemberList(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationMemberListResult, error) {
+	var organizationMember OrganizationMemberListResult
+	return organizationMember, s.Get(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), nil, lr)
+}
+
+// Tracks an organization's preferences
+type OrganizationPreferences struct {
+	DefaultPermission *string `json:"default-permission" url:"default-permission,key"` // The default permission used when adding new members to the
+	// organization
+	WhitelistingEnabled *bool `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+type OrganizationPreferencesListResult struct {
+	DefaultPermission *string `json:"default-permission" url:"default-permission,key"` // The default permission used when adding new members to the
+	// organization
+	WhitelistingEnabled *bool `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+
+// Retrieve Organization Preferences
+func (s *Service) OrganizationPreferencesList(ctx context.Context, organizationPreferencesIdentity string) (*OrganizationPreferencesListResult, error) {
+	var organizationPreferences OrganizationPreferencesListResult
+	return &organizationPreferences, s.Get(ctx, &organizationPreferences, fmt.Sprintf("/organizations/%v/preferences", organizationPreferencesIdentity), nil, nil)
+}
+
+type OrganizationPreferencesUpdateOpts struct {
+	WhitelistingEnabled *bool `json:"whitelisting-enabled,omitempty" url:"whitelisting-enabled,omitempty,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+type OrganizationPreferencesUpdateResult struct {
+	DefaultPermission *string `json:"default-permission" url:"default-permission,key"` // The default permission used when adding new members to the
+	// organization
+	WhitelistingEnabled *bool `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+
+// Update Organization Preferences
+func (s *Service) OrganizationPreferencesUpdate(ctx context.Context, organizationPreferencesIdentity string, o OrganizationPreferencesUpdateOpts) (*OrganizationPreferencesUpdateResult, error) {
+	var organizationPreferences OrganizationPreferencesUpdateResult
+	return &organizationPreferences, s.Patch(ctx, &organizationPreferences, fmt.Sprintf("/organizations/%v/preferences", organizationPreferencesIdentity), o)
+}
+
+// An outbound-ruleset is a collection of rules that specify what hosts
+// Dynos are allowed to communicate with.
+type OutboundRuleset struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when outbound-ruleset was created
+	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an outbound-ruleset
+	Rules     []struct {
+		FromPort int    `json:"from_port" url:"from_port,key"` // an endpoint of communication in an operating system.
+		Protocol string `json:"protocol" url:"protocol,key"`   // formal standards and policies comprised of rules, procedures and
+		// formats that define communication between two or more devices over a
+		// network
+		Target string `json:"target" url:"target,key"`   // is the target destination in CIDR notation
+		ToPort int    `json:"to_port" url:"to_port,key"` // an endpoint of communication in an operating system.
+	} `json:"rules" url:"rules,key"`
+}
+type OutboundRulesetInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when outbound-ruleset was created
+	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an outbound-ruleset
+	Rules     []struct {
+		FromPort int    `json:"from_port" url:"from_port,key"` // an endpoint of communication in an operating system.
+		Protocol string `json:"protocol" url:"protocol,key"`   // formal standards and policies comprised of rules, procedures and
+		// formats that define communication between two or more devices over a
+		// network
+		Target string `json:"target" url:"target,key"`   // is the target destination in CIDR notation
+		ToPort int    `json:"to_port" url:"to_port,key"` // an endpoint of communication in an operating system.
+	} `json:"rules" url:"rules,key"`
+}
+
+// Current outbound ruleset for a space
+func (s *Service) OutboundRulesetInfo(ctx context.Context, spaceIdentity string) (*OutboundRulesetInfoResult, error) {
+	var outboundRuleset OutboundRulesetInfoResult
+	return &outboundRuleset, s.Get(ctx, &outboundRuleset, fmt.Sprintf("/spaces/%v/outbound-ruleset", spaceIdentity), nil, nil)
+}
+
+type OutboundRulesetListResult []struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when outbound-ruleset was created
+	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an outbound-ruleset
+	Rules     []struct {
+		FromPort int    `json:"from_port" url:"from_port,key"` // an endpoint of communication in an operating system.
+		Protocol string `json:"protocol" url:"protocol,key"`   // formal standards and policies comprised of rules, procedures and
+		// formats that define communication between two or more devices over a
+		// network
+		Target string `json:"target" url:"target,key"`   // is the target destination in CIDR notation
+		ToPort int    `json:"to_port" url:"to_port,key"` // an endpoint of communication in an operating system.
+	} `json:"rules" url:"rules,key"`
+}
+
+// List all Outbound Rulesets for a space
+func (s *Service) OutboundRulesetList(ctx context.Context, spaceIdentity string, lr *ListRange) (OutboundRulesetListResult, error) {
+	var outboundRuleset OutboundRulesetListResult
+	return outboundRuleset, s.Get(ctx, &outboundRuleset, fmt.Sprintf("/spaces/%v/outbound-rulesets", spaceIdentity), nil, lr)
+}
+
+type OutboundRulesetCreateOpts struct {
+	Rules *[]*struct {
+		FromPort int    `json:"from_port" url:"from_port,key"` // an endpoint of communication in an operating system.
+		Protocol string `json:"protocol" url:"protocol,key"`   // formal standards and policies comprised of rules, procedures and
+		// formats that define communication between two or more devices over a
+		// network
+		Target string `json:"target" url:"target,key"`   // is the target destination in CIDR notation
+		ToPort int    `json:"to_port" url:"to_port,key"` // an endpoint of communication in an operating system.
+	} `json:"rules,omitempty" url:"rules,omitempty,key"`
+}
+
+// Create a new outbound ruleset
+func (s *Service) OutboundRulesetCreate(ctx context.Context, spaceIdentity string, o OutboundRulesetCreateOpts) (*OutboundRuleset, error) {
+	var outboundRuleset OutboundRuleset
+	return &outboundRuleset, s.Put(ctx, &outboundRuleset, fmt.Sprintf("/spaces/%v/outbound-ruleset", spaceIdentity), o)
+}
+
+// A password reset represents a in-process password reset attempt.
+type PasswordReset struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when password reset was created
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"`
+}
+type PasswordResetResetPasswordOpts struct {
+	Email *string `json:"email,omitempty" url:"email,omitempty,key"` // unique email address of account
+}
+
+// Reset account's password. This will send a reset password link to the
+// user's email address.
+func (s *Service) PasswordResetResetPassword(ctx context.Context, o PasswordResetResetPasswordOpts) (*PasswordReset, error) {
+	var passwordReset PasswordReset
+	return &passwordReset, s.Post(ctx, &passwordReset, fmt.Sprintf("/password-resets"), o)
+}
+
+type PasswordResetCompleteResetPasswordOpts struct {
+	Password             *string `json:"password,omitempty" url:"password,omitempty,key"`                           // current password on the account
+	PasswordConfirmation *string `json:"password_confirmation,omitempty" url:"password_confirmation,omitempty,key"` // confirmation of the new password
+}
+
+// Complete password reset.
+func (s *Service) PasswordResetCompleteResetPassword(ctx context.Context, passwordResetResetPasswordToken string, o PasswordResetCompleteResetPasswordOpts) (*PasswordReset, error) {
+	var passwordReset PasswordReset
+	return &passwordReset, s.Post(ctx, &passwordReset, fmt.Sprintf("/password-resets/%v/actions/finalize", passwordResetResetPasswordToken), o)
+}
+
+// A pipeline allows grouping of apps into different stages.
+type Pipeline struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
+	Name      string    `json:"name" url:"name,key"`             // name of pipeline
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
+}
+type PipelineCreateOpts struct {
+	Name string `json:"name" url:"name,key"` // name of pipeline
+}
+type PipelineCreateResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
+	Name      string    `json:"name" url:"name,key"`             // name of pipeline
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
+}
+
+// Create a new pipeline.
+func (s *Service) PipelineCreate(ctx context.Context, o PipelineCreateOpts) (*PipelineCreateResult, error) {
+	var pipeline PipelineCreateResult
+	return &pipeline, s.Post(ctx, &pipeline, fmt.Sprintf("/pipelines"), o)
+}
+
+type PipelineInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
+	Name      string    `json:"name" url:"name,key"`             // name of pipeline
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
+}
+
+// Info for existing pipeline.
+func (s *Service) PipelineInfo(ctx context.Context, pipelineIdentity string) (*PipelineInfoResult, error) {
+	var pipeline PipelineInfoResult
+	return &pipeline, s.Get(ctx, &pipeline, fmt.Sprintf("/pipelines/%v", pipelineIdentity), nil, nil)
+}
+
+type PipelineDeleteResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
+	Name      string    `json:"name" url:"name,key"`             // name of pipeline
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
+}
+
+// Delete an existing pipeline.
+func (s *Service) PipelineDelete(ctx context.Context, pipelineID string) (*PipelineDeleteResult, error) {
+	var pipeline PipelineDeleteResult
+	return &pipeline, s.Delete(ctx, &pipeline, fmt.Sprintf("/pipelines/%v", pipelineID))
+}
+
+type PipelineUpdateOpts struct {
+	Name *string `json:"name,omitempty" url:"name,omitempty,key"` // name of pipeline
+}
+type PipelineUpdateResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
+	Name      string    `json:"name" url:"name,key"`             // name of pipeline
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
+}
+
+// Update an existing pipeline.
+func (s *Service) PipelineUpdate(ctx context.Context, pipelineID string, o PipelineUpdateOpts) (*PipelineUpdateResult, error) {
+	var pipeline PipelineUpdateResult
+	return &pipeline, s.Patch(ctx, &pipeline, fmt.Sprintf("/pipelines/%v", pipelineID), o)
+}
+
+type PipelineListResult []struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
+	Name      string    `json:"name" url:"name,key"`             // name of pipeline
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
+}
+
+// List existing pipelines.
+func (s *Service) PipelineList(ctx context.Context, lr *ListRange) (PipelineListResult, error) {
+	var pipeline PipelineListResult
+	return pipeline, s.Get(ctx, &pipeline, fmt.Sprintf("/pipelines"), nil, lr)
+}
+
+// Information about an app's coupling to a pipeline
+type PipelineCoupling struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
+	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
+}
+type PipelineCouplingListResult []struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
+	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
+}
+
+// List couplings for a pipeline
+func (s *Service) PipelineCouplingList(ctx context.Context, pipelineID string, lr *ListRange) (PipelineCouplingListResult, error) {
+	var pipelineCoupling PipelineCouplingListResult
+	return pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/pipelines/%v/pipeline-couplings", pipelineID), nil, lr)
+}
+
+type PipelineCouplingCreateOpts struct {
+	App      string `json:"app" url:"app,key"`           // unique identifier of app
+	Pipeline string `json:"pipeline" url:"pipeline,key"` // unique identifier of pipeline
+	Stage    string `json:"stage" url:"stage,key"`       // target pipeline stage
+}
+type PipelineCouplingCreateResult struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
+	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
+}
+
+// Create a new pipeline coupling.
+func (s *Service) PipelineCouplingCreate(ctx context.Context, o PipelineCouplingCreateOpts) (*PipelineCouplingCreateResult, error) {
+	var pipelineCoupling PipelineCouplingCreateResult
+	return &pipelineCoupling, s.Post(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings"), o)
+}
+
+type PipelineCouplingInfoResult struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
+	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
+}
+
+// Info for an existing pipeline coupling.
+func (s *Service) PipelineCouplingInfo(ctx context.Context, pipelineCouplingIdentity string) (*PipelineCouplingInfoResult, error) {
+	var pipelineCoupling PipelineCouplingInfoResult
+	return &pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings/%v", pipelineCouplingIdentity), nil, nil)
+}
+
+type PipelineCouplingDeleteResult struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
+	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
+}
+
+// Delete an existing pipeline coupling.
+func (s *Service) PipelineCouplingDelete(ctx context.Context, pipelineCouplingIdentity string) (*PipelineCouplingDeleteResult, error) {
+	var pipelineCoupling PipelineCouplingDeleteResult
+	return &pipelineCoupling, s.Delete(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings/%v", pipelineCouplingIdentity))
+}
+
+type PipelineCouplingUpdateOpts struct {
+	Stage *string `json:"stage,omitempty" url:"stage,omitempty,key"` // target pipeline stage
+}
+type PipelineCouplingUpdateResult struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
+	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
+}
+
+// Update an existing pipeline coupling.
+func (s *Service) PipelineCouplingUpdate(ctx context.Context, pipelineCouplingIdentity string, o PipelineCouplingUpdateOpts) (*PipelineCouplingUpdateResult, error) {
+	var pipelineCoupling PipelineCouplingUpdateResult
+	return &pipelineCoupling, s.Patch(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings/%v", pipelineCouplingIdentity), o)
+}
+
+// Promotions allow you to move code from an app in a pipeline to all
+// targets
+type PipelinePromotion struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when promotion was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of promotion
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // the pipeline which the promotion belongs to
+	Source struct {
+		App struct {
+			ID string `json:"id" url:"id,key"` // unique identifier of app
+		} `json:"app" url:"app,key"` // the app which was promoted from
+		Release struct {
+			ID string `json:"id" url:"id,key"` // unique identifier of release
+		} `json:"release" url:"release,key"` // the release used to promoted from
+	} `json:"source" url:"source,key"` // the app being promoted from
+	Status    string     `json:"status" url:"status,key"`         // status of promotion
+	UpdatedAt *time.Time `json:"updated_at" url:"updated_at,key"` // when promotion was updated
+}
+type PipelinePromotionCreateOpts struct {
+	Pipeline struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the promotion
+	Source struct {
+		App *struct {
+			ID *string `json:"id,omitempty" url:"id,omitempty,key"` // unique identifier of app
+		} `json:"app,omitempty" url:"app,omitempty,key"` // the app which was promoted from
+	} `json:"source" url:"source,key"` // the app being promoted from
+	Targets []struct {
+		App *struct {
+			ID *string `json:"id,omitempty" url:"id,omitempty,key"` // unique identifier of app
+		} `json:"app,omitempty" url:"app,omitempty,key"` // the app is being promoted to
+	} `json:"targets" url:"targets,key"`
+}
+
+// Create a new promotion.
+func (s *Service) PipelinePromotionCreate(ctx context.Context, o PipelinePromotionCreateOpts) (*PipelinePromotion, error) {
+	var pipelinePromotion PipelinePromotion
+	return &pipelinePromotion, s.Post(ctx, &pipelinePromotion, fmt.Sprintf("/pipeline-promotions"), o)
+}
+
+type PipelinePromotionInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when promotion was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of promotion
+	Pipeline  struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
+	} `json:"pipeline" url:"pipeline,key"` // the pipeline which the promotion belongs to
+	Source struct {
+		App struct {
+			ID string `json:"id" url:"id,key"` // unique identifier of app
+		} `json:"app" url:"app,key"` // the app which was promoted from
+		Release struct {
+			ID string `json:"id" url:"id,key"` // unique identifier of release
+		} `json:"release" url:"release,key"` // the release used to promoted from
+	} `json:"source" url:"source,key"` // the app being promoted from
+	Status    string     `json:"status" url:"status,key"`         // status of promotion
+	UpdatedAt *time.Time `json:"updated_at" url:"updated_at,key"` // when promotion was updated
+}
+
+// Info for existing pipeline promotion.
+func (s *Service) PipelinePromotionInfo(ctx context.Context, pipelinePromotionIdentity string) (*PipelinePromotionInfoResult, error) {
+	var pipelinePromotion PipelinePromotionInfoResult
+	return &pipelinePromotion, s.Get(ctx, &pipelinePromotion, fmt.Sprintf("/pipeline-promotions/%v", pipelinePromotionIdentity), nil, nil)
+}
+
+// Promotion targets represent an individual app being promoted to
+type PipelinePromotionTarget struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // the app which was promoted to
+	ErrorMessage      *string `json:"error_message" url:"error_message,key"` // an error message for why the promotion failed
+	ID                string  `json:"id" url:"id,key"`                       // unique identifier of promotion target
+	PipelinePromotion struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of promotion
+	} `json:"pipeline_promotion" url:"pipeline_promotion,key"` // the promotion which the target belongs to
+	Release *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of release
+	} `json:"release" url:"release,key"` // the release which was created on the target app
+	Status string `json:"status" url:"status,key"` // status of promotion
+}
+type PipelinePromotionTargetListResult []struct {
+	App struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of app
+	} `json:"app" url:"app,key"` // the app which was promoted to
+	ErrorMessage      *string `json:"error_message" url:"error_message,key"` // an error message for why the promotion failed
+	ID                string  `json:"id" url:"id,key"`                       // unique identifier of promotion target
+	PipelinePromotion struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of promotion
+	} `json:"pipeline_promotion" url:"pipeline_promotion,key"` // the promotion which the target belongs to
+	Release *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of release
+	} `json:"release" url:"release,key"` // the release which was created on the target app
+	Status string `json:"status" url:"status,key"` // status of promotion
+}
+
+// List promotion targets belonging to an existing promotion.
+func (s *Service) PipelinePromotionTargetList(ctx context.Context, pipelinePromotionID string, lr *ListRange) (PipelinePromotionTargetListResult, error) {
+	var pipelinePromotionTarget PipelinePromotionTargetListResult
+	return pipelinePromotionTarget, s.Get(ctx, &pipelinePromotionTarget, fmt.Sprintf("/pipeline-promotions/%v/promotion-targets", pipelinePromotionID), nil, lr)
 }
 
 // Plans represent different configurations of add-ons that may be added
 // to apps. Endpoints under add-on services can be accessed without
 // authentication.
 type Plan struct {
-	CreatedAt   time.Time `json:"created_at"`  // when plan was created
-	Default     bool      `json:"default"`     // whether this plan is the default for its addon service
-	Description string    `json:"description"` // description of plan
-	ID          string    `json:"id"`          // unique identifier of this plan
-	Name        string    `json:"name"`        // unique name of this plan
-	Price       struct {
-		Cents int    `json:"cents"` // price in cents per unit of plan
-		Unit  string `json:"unit"`  // unit of price for plan
-	} `json:"price"` // price
-	State     string    `json:"state"`      // release status for plan
-	UpdatedAt time.Time `json:"updated_at"` // when plan was updated
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	Compliance                       *[]string `json:"compliance" url:"compliance,key"`                                                   // the compliance regimes applied to an add-on plan
+	CreatedAt                        time.Time `json:"created_at" url:"created_at,key"`                                                   // when plan was created
+	Default                          bool      `json:"default" url:"default,key"`                                                         // whether this plan is the default for its add-on service
+	Description                      string    `json:"description" url:"description,key"`                                                 // description of plan
+	HumanName                        string    `json:"human_name" url:"human_name,key"`                                                   // human readable name of the add-on plan
+	ID                               string    `json:"id" url:"id,key"`                                                                   // unique identifier of this plan
+	InstallableInsidePrivateNetwork  bool      `json:"installable_inside_private_network" url:"installable_inside_private_network,key"`   // whether this plan is installable to a Private Spaces app
+	InstallableOutsidePrivateNetwork bool      `json:"installable_outside_private_network" url:"installable_outside_private_network,key"` // whether this plan is installable to a Common Runtime app
+	Name                             string    `json:"name" url:"name,key"`                                                               // unique name of this plan
+	Price                            struct {
+		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
+		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
+	} `json:"price" url:"price,key"` // price
+	SpaceDefault bool      `json:"space_default" url:"space_default,key"` // whether this plan is the default for apps in Private Spaces
+	State        string    `json:"state" url:"state,key"`                 // release status for plan
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when plan was updated
+	Visible      bool      `json:"visible" url:"visible,key"`             // whether this plan is publicly visible
+}
+type PlanInfoResult struct {
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	Compliance                       *[]string `json:"compliance" url:"compliance,key"`                                                   // the compliance regimes applied to an add-on plan
+	CreatedAt                        time.Time `json:"created_at" url:"created_at,key"`                                                   // when plan was created
+	Default                          bool      `json:"default" url:"default,key"`                                                         // whether this plan is the default for its add-on service
+	Description                      string    `json:"description" url:"description,key"`                                                 // description of plan
+	HumanName                        string    `json:"human_name" url:"human_name,key"`                                                   // human readable name of the add-on plan
+	ID                               string    `json:"id" url:"id,key"`                                                                   // unique identifier of this plan
+	InstallableInsidePrivateNetwork  bool      `json:"installable_inside_private_network" url:"installable_inside_private_network,key"`   // whether this plan is installable to a Private Spaces app
+	InstallableOutsidePrivateNetwork bool      `json:"installable_outside_private_network" url:"installable_outside_private_network,key"` // whether this plan is installable to a Common Runtime app
+	Name                             string    `json:"name" url:"name,key"`                                                               // unique name of this plan
+	Price                            struct {
+		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
+		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
+	} `json:"price" url:"price,key"` // price
+	SpaceDefault bool      `json:"space_default" url:"space_default,key"` // whether this plan is the default for apps in Private Spaces
+	State        string    `json:"state" url:"state,key"`                 // release status for plan
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when plan was updated
+	Visible      bool      `json:"visible" url:"visible,key"`             // whether this plan is publicly visible
 }
 
 // Info for existing plan.
-func (s *Service) PlanInfo(addonServiceIdentity string, planIdentity string) (*Plan, error) {
-	var plan Plan
-	return &plan, s.Get(&plan, fmt.Sprintf("/addon-services/%v/plans/%v", addonServiceIdentity, planIdentity), nil)
+func (s *Service) PlanInfo(ctx context.Context, addOnServiceIdentity string, planIdentity string) (*PlanInfoResult, error) {
+	var plan PlanInfoResult
+	return &plan, s.Get(ctx, &plan, fmt.Sprintf("/addon-services/%v/plans/%v", addOnServiceIdentity, planIdentity), nil, nil)
+}
+
+type PlanListResult []struct {
+	AddonService struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
+		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
+	Compliance                       *[]string `json:"compliance" url:"compliance,key"`                                                   // the compliance regimes applied to an add-on plan
+	CreatedAt                        time.Time `json:"created_at" url:"created_at,key"`                                                   // when plan was created
+	Default                          bool      `json:"default" url:"default,key"`                                                         // whether this plan is the default for its add-on service
+	Description                      string    `json:"description" url:"description,key"`                                                 // description of plan
+	HumanName                        string    `json:"human_name" url:"human_name,key"`                                                   // human readable name of the add-on plan
+	ID                               string    `json:"id" url:"id,key"`                                                                   // unique identifier of this plan
+	InstallableInsidePrivateNetwork  bool      `json:"installable_inside_private_network" url:"installable_inside_private_network,key"`   // whether this plan is installable to a Private Spaces app
+	InstallableOutsidePrivateNetwork bool      `json:"installable_outside_private_network" url:"installable_outside_private_network,key"` // whether this plan is installable to a Common Runtime app
+	Name                             string    `json:"name" url:"name,key"`                                                               // unique name of this plan
+	Price                            struct {
+		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
+		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
+	} `json:"price" url:"price,key"` // price
+	SpaceDefault bool      `json:"space_default" url:"space_default,key"` // whether this plan is the default for apps in Private Spaces
+	State        string    `json:"state" url:"state,key"`                 // release status for plan
+	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when plan was updated
+	Visible      bool      `json:"visible" url:"visible,key"`             // whether this plan is publicly visible
 }
 
 // List existing plans.
-func (s *Service) PlanList(addonServiceIdentity string, lr *ListRange) ([]*Plan, error) {
-	var planList []*Plan
-	return planList, s.Get(&planList, fmt.Sprintf("/addon-services/%v/plans", addonServiceIdentity), lr)
+func (s *Service) PlanList(ctx context.Context, addOnServiceIdentity string, lr *ListRange) (PlanListResult, error) {
+	var plan PlanListResult
+	return plan, s.Get(ctx, &plan, fmt.Sprintf("/addon-services/%v/plans", addOnServiceIdentity), nil, lr)
 }
 
 // Rate Limit represents the number of request tokens each account
 // holds. Requests to this endpoint do not count towards the rate limit.
 type RateLimit struct {
-	Remaining int `json:"remaining"` // allowed requests remaining in current interval
+	Remaining int `json:"remaining" url:"remaining,key"` // allowed requests remaining in current interval
+}
+type RateLimitInfoResult struct {
+	Remaining int `json:"remaining" url:"remaining,key"` // allowed requests remaining in current interval
 }
 
 // Info for rate limits.
-func (s *Service) RateLimitInfo() (*RateLimit, error) {
-	var rateLimit RateLimit
-	return &rateLimit, s.Get(&rateLimit, fmt.Sprintf("/account/rate-limits"), nil)
+func (s *Service) RateLimitInfo(ctx context.Context) (*RateLimitInfoResult, error) {
+	var rateLimit RateLimitInfoResult
+	return &rateLimit, s.Get(ctx, &rateLimit, fmt.Sprintf("/account/rate-limits"), nil, nil)
 }
 
 // A region represents a geographic location in which your application
 // may run.
 type Region struct {
-	CreatedAt   time.Time `json:"created_at"`  // when region was created
-	Description string    `json:"description"` // description of region
-	ID          string    `json:"id"`          // unique identifier of region
-	Name        string    `json:"name"`        // unique name of region
-	UpdatedAt   time.Time `json:"updated_at"`  // when region was updated
+	Country        string    `json:"country" url:"country,key"`                 // country where the region exists
+	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
+	Description    string    `json:"description" url:"description,key"`         // description of region
+	ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
+	Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
+	Name           string    `json:"name" url:"name,key"`                       // unique name of region
+	PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
+	Provider       struct {
+		Name   string `json:"name" url:"name,key"`     // name of provider
+		Region string `json:"region" url:"region,key"` // region name used by provider
+	} `json:"provider" url:"provider,key"` // provider of underlying substrate
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
+}
+type RegionInfoResult struct {
+	Country        string    `json:"country" url:"country,key"`                 // country where the region exists
+	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
+	Description    string    `json:"description" url:"description,key"`         // description of region
+	ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
+	Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
+	Name           string    `json:"name" url:"name,key"`                       // unique name of region
+	PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
+	Provider       struct {
+		Name   string `json:"name" url:"name,key"`     // name of provider
+		Region string `json:"region" url:"region,key"` // region name used by provider
+	} `json:"provider" url:"provider,key"` // provider of underlying substrate
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
 }
 
 // Info for existing region.
-func (s *Service) RegionInfo(regionIdentity string) (*Region, error) {
-	var region Region
-	return &region, s.Get(&region, fmt.Sprintf("/regions/%v", regionIdentity), nil)
+func (s *Service) RegionInfo(ctx context.Context, regionIdentity string) (*RegionInfoResult, error) {
+	var region RegionInfoResult
+	return &region, s.Get(ctx, &region, fmt.Sprintf("/regions/%v", regionIdentity), nil, nil)
+}
+
+type RegionListResult []struct {
+	Country        string    `json:"country" url:"country,key"`                 // country where the region exists
+	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
+	Description    string    `json:"description" url:"description,key"`         // description of region
+	ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
+	Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
+	Name           string    `json:"name" url:"name,key"`                       // unique name of region
+	PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
+	Provider       struct {
+		Name   string `json:"name" url:"name,key"`     // name of provider
+		Region string `json:"region" url:"region,key"` // region name used by provider
+	} `json:"provider" url:"provider,key"` // provider of underlying substrate
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
 }
 
 // List existing regions.
-func (s *Service) RegionList(lr *ListRange) ([]*Region, error) {
-	var regionList []*Region
-	return regionList, s.Get(&regionList, fmt.Sprintf("/regions"), lr)
+func (s *Service) RegionList(ctx context.Context, lr *ListRange) (RegionListResult, error) {
+	var region RegionListResult
+	return region, s.Get(ctx, &region, fmt.Sprintf("/regions"), nil, lr)
 }
 
 // A release represents a combination of code, config vars and add-ons
 // for an app on Heroku.
 type Release struct {
-	CreatedAt   time.Time `json:"created_at"`  // when release was created
-	Description string    `json:"description"` // description of changes in this release
-	ID          string    `json:"id"`          // unique identifier of release
+	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
+	App            struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the release
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
+	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
+	Description string    `json:"description" url:"description,key"` // description of changes in this release
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
 	Slug        *struct {
-		ID string `json:"id"` // unique identifier of slug
-	} `json:"slug"` // slug running in this release
-	UpdatedAt time.Time `json:"updated_at"` // when release was updated
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug running in this release
+	Status    string    `json:"status" url:"status,key"`         // current status of the release
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
 	User      struct {
-		Email string `json:"email"` // unique email address of account
-		ID    string `json:"id"`    // unique identifier of an account
-	} `json:"user"` // user that created the release
-	Version int `json:"version"` // unique version assigned to the release
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that created the release
+	Version int `json:"version" url:"version,key"` // unique version assigned to the release
+}
+type ReleaseInfoResult struct {
+	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
+	App            struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the release
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
+	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
+	Description string    `json:"description" url:"description,key"` // description of changes in this release
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
+	Slug        *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug running in this release
+	Status    string    `json:"status" url:"status,key"`         // current status of the release
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that created the release
+	Version int `json:"version" url:"version,key"` // unique version assigned to the release
 }
 
 // Info for existing release.
-func (s *Service) ReleaseInfo(appIdentity string, releaseIdentity string) (*Release, error) {
-	var release Release
-	return &release, s.Get(&release, fmt.Sprintf("/apps/%v/releases/%v", appIdentity, releaseIdentity), nil)
+func (s *Service) ReleaseInfo(ctx context.Context, appIdentity string, releaseIdentity string) (*ReleaseInfoResult, error) {
+	var release ReleaseInfoResult
+	return &release, s.Get(ctx, &release, fmt.Sprintf("/apps/%v/releases/%v", appIdentity, releaseIdentity), nil, nil)
+}
+
+type ReleaseListResult []struct {
+	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
+	App            struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the release
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
+	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
+	Description string    `json:"description" url:"description,key"` // description of changes in this release
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
+	Slug        *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug running in this release
+	Status    string    `json:"status" url:"status,key"`         // current status of the release
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that created the release
+	Version int `json:"version" url:"version,key"` // unique version assigned to the release
 }
 
 // List existing releases.
-func (s *Service) ReleaseList(appIdentity string, lr *ListRange) ([]*Release, error) {
-	var releaseList []*Release
-	return releaseList, s.Get(&releaseList, fmt.Sprintf("/apps/%v/releases", appIdentity), lr)
+func (s *Service) ReleaseList(ctx context.Context, appIdentity string, lr *ListRange) (ReleaseListResult, error) {
+	var release ReleaseListResult
+	return release, s.Get(ctx, &release, fmt.Sprintf("/apps/%v/releases", appIdentity), nil, lr)
 }
 
 type ReleaseCreateOpts struct {
-	Description *string `json:"description,omitempty"` // description of changes in this release
-	Slug        string  `json:"slug"`                  // unique identifier of slug
+	Description *string `json:"description,omitempty" url:"description,omitempty,key"` // description of changes in this release
+	Slug        string  `json:"slug" url:"slug,key"`                                   // unique identifier of slug
+}
+type ReleaseCreateResult struct {
+	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
+	App            struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the release
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
+	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
+	Description string    `json:"description" url:"description,key"` // description of changes in this release
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
+	Slug        *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug running in this release
+	Status    string    `json:"status" url:"status,key"`         // current status of the release
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that created the release
+	Version int `json:"version" url:"version,key"` // unique version assigned to the release
 }
 
-// Create new release. The API cannot be used to create releases on
-// Bamboo apps.
-func (s *Service) ReleaseCreate(appIdentity string, o struct {
-	Description *string `json:"description,omitempty"` // description of changes in this release
-	Slug        string  `json:"slug"`                  // unique identifier of slug
-}) (*Release, error) {
-	var release Release
-	return &release, s.Post(&release, fmt.Sprintf("/apps/%v/releases", appIdentity), o)
+// Create new release.
+func (s *Service) ReleaseCreate(ctx context.Context, appIdentity string, o ReleaseCreateOpts) (*ReleaseCreateResult, error) {
+	var release ReleaseCreateResult
+	return &release, s.Post(ctx, &release, fmt.Sprintf("/apps/%v/releases", appIdentity), o)
 }
 
 type ReleaseRollbackOpts struct {
-	Release string `json:"release"` // unique identifier of release
+	Release string `json:"release" url:"release,key"` // unique identifier of release
+}
+type ReleaseRollbackResult struct {
+	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
+	App            struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app involved in the release
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
+	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
+	Description string    `json:"description" url:"description,key"` // description of changes in this release
+	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
+	Slug        *struct {
+		ID string `json:"id" url:"id,key"` // unique identifier of slug
+	} `json:"slug" url:"slug,key"` // slug running in this release
+	Status    string    `json:"status" url:"status,key"`         // current status of the release
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // user that created the release
+	Version int `json:"version" url:"version,key"` // unique version assigned to the release
 }
 
 // Rollback to an existing release.
-func (s *Service) ReleaseRollback(appIdentity string, o struct {
-	Release string `json:"release"` // unique identifier of release
-}) (*Release, error) {
-	var release Release
-	return &release, s.Post(&release, fmt.Sprintf("/apps/%v/releases", appIdentity), o)
+func (s *Service) ReleaseRollback(ctx context.Context, appIdentity string, o ReleaseRollbackOpts) (*ReleaseRollbackResult, error) {
+	var release ReleaseRollbackResult
+	return &release, s.Post(ctx, &release, fmt.Sprintf("/apps/%v/releases", appIdentity), o)
 }
 
 // A slug is a snapshot of your application code that is ready to run on
 // the platform.
 type Slug struct {
 	Blob struct {
-		Method string `json:"method"` // method to be used to interact with the slug blob
-		URL    string `json:"url"`    // URL to interact with the slug blob
-	} `json:"blob"` // pointer to the url where clients can fetch or store the actual
+		Method string `json:"method" url:"method,key"` // method to be used to interact with the slug blob
+		URL    string `json:"url" url:"url,key"`       // URL to interact with the slug blob
+	} `json:"blob" url:"blob,key"` // pointer to the url where clients can fetch or store the actual
 	// release binary
-	BuildpackProvidedDescription *string `json:"buildpack_provided_description"` // description from buildpack of slug
-	Commit                       *string `json:"commit"`                         // identification of the code with your version control system (eg: SHA
+	BuildpackProvidedDescription *string `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of slug
+	Checksum                     *string `json:"checksum" url:"checksum,key"`                                             // an optional checksum of the slug for verifying its integrity
+	Commit                       *string `json:"commit" url:"commit,key"`                                                 // identification of the code with your version control system (eg: SHA
 	// of the git HEAD)
-	CreatedAt    time.Time         `json:"created_at"`    // when slug was created
-	ID           string            `json:"id"`            // unique identifier of slug
-	ProcessTypes map[string]string `json:"process_types"` // hash mapping process type names to their respective command
-	Size         *int              `json:"size"`          // size of slug, in bytes
-	UpdatedAt    time.Time         `json:"updated_at"`    // when slug was updated
+	CommitDescription *string           `json:"commit_description" url:"commit_description,key"` // an optional description of the provided commit
+	CreatedAt         time.Time         `json:"created_at" url:"created_at,key"`                 // when slug was created
+	ID                string            `json:"id" url:"id,key"`                                 // unique identifier of slug
+	ProcessTypes      map[string]string `json:"process_types" url:"process_types,key"`           // hash mapping process type names to their respective command
+	Size              *int              `json:"size" url:"size,key"`                             // size of slug, in bytes
+	Stack             struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of slug stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when slug was updated
+}
+type SlugInfoResult struct {
+	Blob struct {
+		Method string `json:"method" url:"method,key"` // method to be used to interact with the slug blob
+		URL    string `json:"url" url:"url,key"`       // URL to interact with the slug blob
+	} `json:"blob" url:"blob,key"` // pointer to the url where clients can fetch or store the actual
+	// release binary
+	BuildpackProvidedDescription *string `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of slug
+	Checksum                     *string `json:"checksum" url:"checksum,key"`                                             // an optional checksum of the slug for verifying its integrity
+	Commit                       *string `json:"commit" url:"commit,key"`                                                 // identification of the code with your version control system (eg: SHA
+	// of the git HEAD)
+	CommitDescription *string           `json:"commit_description" url:"commit_description,key"` // an optional description of the provided commit
+	CreatedAt         time.Time         `json:"created_at" url:"created_at,key"`                 // when slug was created
+	ID                string            `json:"id" url:"id,key"`                                 // unique identifier of slug
+	ProcessTypes      map[string]string `json:"process_types" url:"process_types,key"`           // hash mapping process type names to their respective command
+	Size              *int              `json:"size" url:"size,key"`                             // size of slug, in bytes
+	Stack             struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of slug stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when slug was updated
 }
 
 // Info for existing slug.
-func (s *Service) SlugInfo(appIdentity string, slugIdentity string) (*Slug, error) {
-	var slug Slug
-	return &slug, s.Get(&slug, fmt.Sprintf("/apps/%v/slugs/%v", appIdentity, slugIdentity), nil)
+func (s *Service) SlugInfo(ctx context.Context, appIdentity string, slugIdentity string) (*SlugInfoResult, error) {
+	var slug SlugInfoResult
+	return &slug, s.Get(ctx, &slug, fmt.Sprintf("/apps/%v/slugs/%v", appIdentity, slugIdentity), nil, nil)
 }
 
 type SlugCreateOpts struct {
-	BuildpackProvidedDescription *string `json:"buildpack_provided_description,omitempty"` // description from buildpack of slug
-	Commit                       *string `json:"commit,omitempty"`                         // identification of the code with your version control system (eg: SHA
+	BuildpackProvidedDescription *string `json:"buildpack_provided_description,omitempty" url:"buildpack_provided_description,omitempty,key"` // description from buildpack of slug
+	Checksum                     *string `json:"checksum,omitempty" url:"checksum,omitempty,key"`                                             // an optional checksum of the slug for verifying its integrity
+	Commit                       *string `json:"commit,omitempty" url:"commit,omitempty,key"`                                                 // identification of the code with your version control system (eg: SHA
 	// of the git HEAD)
-	ProcessTypes map[string]string `json:"process_types"` // hash mapping process type names to their respective command
+	CommitDescription *string           `json:"commit_description,omitempty" url:"commit_description,omitempty,key"` // an optional description of the provided commit
+	ProcessTypes      map[string]string `json:"process_types" url:"process_types,key"`                               // hash mapping process type names to their respective command
+	Stack             *string           `json:"stack,omitempty" url:"stack,omitempty,key"`                           // unique name of stack
+}
+type SlugCreateResult struct {
+	Blob struct {
+		Method string `json:"method" url:"method,key"` // method to be used to interact with the slug blob
+		URL    string `json:"url" url:"url,key"`       // URL to interact with the slug blob
+	} `json:"blob" url:"blob,key"` // pointer to the url where clients can fetch or store the actual
+	// release binary
+	BuildpackProvidedDescription *string `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of slug
+	Checksum                     *string `json:"checksum" url:"checksum,key"`                                             // an optional checksum of the slug for verifying its integrity
+	Commit                       *string `json:"commit" url:"commit,key"`                                                 // identification of the code with your version control system (eg: SHA
+	// of the git HEAD)
+	CommitDescription *string           `json:"commit_description" url:"commit_description,key"` // an optional description of the provided commit
+	CreatedAt         time.Time         `json:"created_at" url:"created_at,key"`                 // when slug was created
+	ID                string            `json:"id" url:"id,key"`                                 // unique identifier of slug
+	ProcessTypes      map[string]string `json:"process_types" url:"process_types,key"`           // hash mapping process type names to their respective command
+	Size              *int              `json:"size" url:"size,key"`                             // size of slug, in bytes
+	Stack             struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of slug stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when slug was updated
 }
 
 // Create a new slug. For more information please refer to [Deploying
 // Slugs using the Platform
 // API](https://devcenter.heroku.com/articles/platform-api-deploying-slug
-// s?preview=1).
-func (s *Service) SlugCreate(appIdentity string, o struct {
-	BuildpackProvidedDescription *string `json:"buildpack_provided_description,omitempty"` // description from buildpack of slug
-	Commit                       *string `json:"commit,omitempty"`                         // identification of the code with your version control system (eg: SHA
-	// of the git HEAD)
-	ProcessTypes map[string]string `json:"process_types"` // hash mapping process type names to their respective command
-}) (*Slug, error) {
-	var slug Slug
-	return &slug, s.Post(&slug, fmt.Sprintf("/apps/%v/slugs", appIdentity), o)
+// s).
+func (s *Service) SlugCreate(ctx context.Context, appIdentity string, o SlugCreateOpts) (*SlugCreateResult, error) {
+	var slug SlugCreateResult
+	return &slug, s.Post(ctx, &slug, fmt.Sprintf("/apps/%v/slugs", appIdentity), o)
+}
+
+// SMS numbers are used for recovery on accounts with two-factor
+// authentication enabled.
+type SmsNumber struct {
+	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
+}
+type SmsNumberSMSNumberResult struct {
+	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
+}
+
+// Recover an account using an SMS recovery code
+func (s *Service) SmsNumberSMSNumber(ctx context.Context, accountIdentity string) (*SmsNumberSMSNumberResult, error) {
+	var smsNumber SmsNumberSMSNumberResult
+	return &smsNumber, s.Get(ctx, &smsNumber, fmt.Sprintf("/users/%v/sms-number", accountIdentity), nil, nil)
+}
+
+type SmsNumberRecoverResult struct {
+	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
+}
+
+// Recover an account using an SMS recovery code
+func (s *Service) SmsNumberRecover(ctx context.Context, accountIdentity string) (*SmsNumberRecoverResult, error) {
+	var smsNumber SmsNumberRecoverResult
+	return &smsNumber, s.Post(ctx, &smsNumber, fmt.Sprintf("/users/%v/sms-number/actions/recover", accountIdentity), nil)
+}
+
+type SmsNumberConfirmResult struct {
+	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
+}
+
+// Confirm an SMS number change with a confirmation code
+func (s *Service) SmsNumberConfirm(ctx context.Context, accountIdentity string) (*SmsNumberConfirmResult, error) {
+	var smsNumber SmsNumberConfirmResult
+	return &smsNumber, s.Post(ctx, &smsNumber, fmt.Sprintf("/users/%v/sms-number/actions/confirm", accountIdentity), nil)
+}
+
+// SNI Endpoint is a public address serving a custom SSL cert for HTTPS
+// traffic, using the SNI TLS extension, to a Heroku app.
+type SniEndpoint struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
+	// app
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
+	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
+}
+type SniEndpointCreateOpts struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	PrivateKey       string `json:"private_key" url:"private_key,key"`             // contents of the private key (eg .key file)
+}
+type SniEndpointCreateResult struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
+	// app
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
+	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
+}
+
+// Create a new SNI endpoint.
+func (s *Service) SniEndpointCreate(ctx context.Context, appIdentity string, o SniEndpointCreateOpts) (*SniEndpointCreateResult, error) {
+	var sniEndpoint SniEndpointCreateResult
+	return &sniEndpoint, s.Post(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints", appIdentity), o)
+}
+
+type SniEndpointDeleteResult struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
+	// app
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
+	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
+}
+
+// Delete existing SNI endpoint.
+func (s *Service) SniEndpointDelete(ctx context.Context, appIdentity string, sniEndpointIdentity string) (*SniEndpointDeleteResult, error) {
+	var sniEndpoint SniEndpointDeleteResult
+	return &sniEndpoint, s.Delete(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints/%v", appIdentity, sniEndpointIdentity))
+}
+
+type SniEndpointInfoResult struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
+	// app
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
+	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
+}
+
+// Info for existing SNI endpoint.
+func (s *Service) SniEndpointInfo(ctx context.Context, appIdentity string, sniEndpointIdentity string) (*SniEndpointInfoResult, error) {
+	var sniEndpoint SniEndpointInfoResult
+	return &sniEndpoint, s.Get(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints/%v", appIdentity, sniEndpointIdentity), nil, nil)
+}
+
+type SniEndpointListResult []struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
+	// app
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
+	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
+}
+
+// List existing SNI endpoints.
+func (s *Service) SniEndpointList(ctx context.Context, appIdentity string, lr *ListRange) (SniEndpointListResult, error) {
+	var sniEndpoint SniEndpointListResult
+	return sniEndpoint, s.Get(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints", appIdentity), nil, lr)
+}
+
+type SniEndpointUpdateOpts struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	PrivateKey       string `json:"private_key" url:"private_key,key"`             // contents of the private key (eg .key file)
+}
+type SniEndpointUpdateResult struct {
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
+	// app
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
+	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
+}
+
+// Update an existing SNI endpoint.
+func (s *Service) SniEndpointUpdate(ctx context.Context, appIdentity string, sniEndpointIdentity string, o SniEndpointUpdateOpts) (*SniEndpointUpdateResult, error) {
+	var sniEndpoint SniEndpointUpdateResult
+	return &sniEndpoint, s.Patch(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints/%v", appIdentity, sniEndpointIdentity), o)
+}
+
+// A source is a location for uploading and downloading an application's
+// source code.
+type Source struct {
+	SourceBlob struct {
+		GetURL string `json:"get_url" url:"get_url,key"` // URL to download the source
+		PutURL string `json:"put_url" url:"put_url,key"` // URL to upload the source
+	} `json:"source_blob" url:"source_blob,key"` // pointer to the URL where clients can fetch or store the source
+}
+type SourceCreateResult struct {
+	SourceBlob struct {
+		GetURL string `json:"get_url" url:"get_url,key"` // URL to download the source
+		PutURL string `json:"put_url" url:"put_url,key"` // URL to upload the source
+	} `json:"source_blob" url:"source_blob,key"` // pointer to the URL where clients can fetch or store the source
+}
+
+// Create URLs for uploading and downloading source.
+func (s *Service) SourceCreate(ctx context.Context) (*SourceCreateResult, error) {
+	var source SourceCreateResult
+	return &source, s.Post(ctx, &source, fmt.Sprintf("/sources"), nil)
+}
+
+type SourceCreateDeprecatedResult struct {
+	SourceBlob struct {
+		GetURL string `json:"get_url" url:"get_url,key"` // URL to download the source
+		PutURL string `json:"put_url" url:"put_url,key"` // URL to upload the source
+	} `json:"source_blob" url:"source_blob,key"` // pointer to the URL where clients can fetch or store the source
+}
+
+// Create URLs for uploading and downloading source. Deprecated in favor
+// of `POST /sources`
+func (s *Service) SourceCreateDeprecated(ctx context.Context, appIdentity string) (*SourceCreateDeprecatedResult, error) {
+	var source SourceCreateDeprecatedResult
+	return &source, s.Post(ctx, &source, fmt.Sprintf("/apps/%v/sources", appIdentity), nil)
+}
+
+// A space is an isolated, highly available, secure app execution
+// environments, running in the modern VPC substrate.
+type Space struct {
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Name         string    `json:"name" url:"name,key"`             // unique name of space
+	Organization struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this space
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of space region
+	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
+	State     string    `json:"state" url:"state,key"`           // availability of this space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+}
+type SpaceListResult []struct {
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Name         string    `json:"name" url:"name,key"`             // unique name of space
+	Organization struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this space
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of space region
+	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
+	State     string    `json:"state" url:"state,key"`           // availability of this space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+}
+
+// List existing spaces.
+func (s *Service) SpaceList(ctx context.Context, lr *ListRange) (SpaceListResult, error) {
+	var space SpaceListResult
+	return space, s.Get(ctx, &space, fmt.Sprintf("/spaces"), nil, lr)
+}
+
+type SpaceInfoResult struct {
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Name         string    `json:"name" url:"name,key"`             // unique name of space
+	Organization struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this space
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of space region
+	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
+	State     string    `json:"state" url:"state,key"`           // availability of this space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+}
+
+// Info for existing space.
+func (s *Service) SpaceInfo(ctx context.Context, spaceIdentity string) (*SpaceInfoResult, error) {
+	var space SpaceInfoResult
+	return &space, s.Get(ctx, &space, fmt.Sprintf("/spaces/%v", spaceIdentity), nil, nil)
+}
+
+type SpaceUpdateOpts struct {
+	Name *string `json:"name,omitempty" url:"name,omitempty,key"` // unique name of space
+}
+type SpaceUpdateResult struct {
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Name         string    `json:"name" url:"name,key"`             // unique name of space
+	Organization struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this space
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of space region
+	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
+	State     string    `json:"state" url:"state,key"`           // availability of this space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+}
+
+// Update an existing space.
+func (s *Service) SpaceUpdate(ctx context.Context, spaceIdentity string, o SpaceUpdateOpts) (*SpaceUpdateResult, error) {
+	var space SpaceUpdateResult
+	return &space, s.Patch(ctx, &space, fmt.Sprintf("/spaces/%v", spaceIdentity), o)
+}
+
+type SpaceDeleteResult struct {
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Name         string    `json:"name" url:"name,key"`             // unique name of space
+	Organization struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this space
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of space region
+	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
+	State     string    `json:"state" url:"state,key"`           // availability of this space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+}
+
+// Delete an existing space.
+func (s *Service) SpaceDelete(ctx context.Context, spaceIdentity string) (*SpaceDeleteResult, error) {
+	var space SpaceDeleteResult
+	return &space, s.Delete(ctx, &space, fmt.Sprintf("/spaces/%v", spaceIdentity))
+}
+
+type SpaceCreateOpts struct {
+	Name         string  `json:"name" url:"name,key"`                         // unique name of space
+	Organization string  `json:"organization" url:"organization,key"`         // unique name of organization
+	Region       *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
+	Shield       *bool   `json:"shield,omitempty" url:"shield,omitempty,key"` // true if this space has shield enabled
+}
+type SpaceCreateResult struct {
+	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Name         string    `json:"name" url:"name,key"`             // unique name of space
+	Organization struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this space
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of space region
+	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
+	State     string    `json:"state" url:"state,key"`           // availability of this space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+}
+
+// Create a new space.
+func (s *Service) SpaceCreate(ctx context.Context, o SpaceCreateOpts) (*SpaceCreateResult, error) {
+	var space SpaceCreateResult
+	return &space, s.Post(ctx, &space, fmt.Sprintf("/spaces"), o)
+}
+
+// Space access represents the permissions a particular user has on a
+// particular space.
+type SpaceAppAccess struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"`
+		Name        string `json:"name" url:"name,key"`
+	} `json:"permissions" url:"permissions,key"` // user space permissions
+	Space struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"space" url:"space,key"` // space user belongs to
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of user account
+}
+type SpaceAppAccessInfoResult struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"`
+		Name        string `json:"name" url:"name,key"`
+	} `json:"permissions" url:"permissions,key"` // user space permissions
+	Space struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"space" url:"space,key"` // space user belongs to
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of user account
+}
+
+// List permissions for a given user on a given space.
+func (s *Service) SpaceAppAccessInfo(ctx context.Context, spaceIdentity string, accountIdentity string) (*SpaceAppAccessInfoResult, error) {
+	var spaceAppAccess SpaceAppAccessInfoResult
+	return &spaceAppAccess, s.Get(ctx, &spaceAppAccess, fmt.Sprintf("/spaces/%v/members/%v", spaceIdentity, accountIdentity), nil, nil)
+}
+
+type SpaceAppAccessUpdateOpts struct {
+	Permissions *[]*struct {
+		Name *string `json:"name,omitempty" url:"name,omitempty,key"`
+	} `json:"permissions,omitempty" url:"permissions,omitempty,key"`
+}
+type SpaceAppAccessUpdateResult struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"`
+		Name        string `json:"name" url:"name,key"`
+	} `json:"permissions" url:"permissions,key"` // user space permissions
+	Space struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"space" url:"space,key"` // space user belongs to
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of user account
+}
+
+// Update an existing user's set of permissions on a space.
+func (s *Service) SpaceAppAccessUpdate(ctx context.Context, spaceIdentity string, accountIdentity string, o SpaceAppAccessUpdateOpts) (*SpaceAppAccessUpdateResult, error) {
+	var spaceAppAccess SpaceAppAccessUpdateResult
+	return &spaceAppAccess, s.Patch(ctx, &spaceAppAccess, fmt.Sprintf("/spaces/%v/members/%v", spaceIdentity, accountIdentity), o)
+}
+
+type SpaceAppAccessListResult []struct {
+	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when space was created
+	ID          string    `json:"id" url:"id,key"`                 // unique identifier of space
+	Permissions []struct {
+		Description string `json:"description" url:"description,key"`
+		Name        string `json:"name" url:"name,key"`
+	} `json:"permissions" url:"permissions,key"` // user space permissions
+	Space struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"space" url:"space,key"` // space user belongs to
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
+	User      struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of user account
+}
+
+// List all users and their permissions on a space.
+func (s *Service) SpaceAppAccessList(ctx context.Context, spaceIdentity string, lr *ListRange) (SpaceAppAccessListResult, error) {
+	var spaceAppAccess SpaceAppAccessListResult
+	return spaceAppAccess, s.Get(ctx, &spaceAppAccess, fmt.Sprintf("/spaces/%v/members", spaceIdentity), nil, lr)
+}
+
+// Network address translation (NAT) for stable outbound IP addresses
+// from a space
+type SpaceNat struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when network address translation for a space was created
+	Sources   []string  `json:"sources" url:"sources,key"`       // potential IPs from which outbound network traffic will originate
+	State     string    `json:"state" url:"state,key"`           // availability of network address translation for a space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when network address translation for a space was updated
+}
+type SpaceNatInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when network address translation for a space was created
+	Sources   []string  `json:"sources" url:"sources,key"`       // potential IPs from which outbound network traffic will originate
+	State     string    `json:"state" url:"state,key"`           // availability of network address translation for a space
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when network address translation for a space was updated
+}
+
+// Current state of network address translation for a space.
+func (s *Service) SpaceNatInfo(ctx context.Context, spaceIdentity string) (*SpaceNatInfoResult, error) {
+	var spaceNat SpaceNatInfoResult
+	return &spaceNat, s.Get(ctx, &spaceNat, fmt.Sprintf("/spaces/%v/nat", spaceIdentity), nil, nil)
 }
 
 // [SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is
 // a public address serving custom SSL cert for HTTPS traffic to a
-// Heroku app. Note that an app must have the `ssl:endpoint` addon
+// Heroku app. Note that an app must have the `ssl:endpoint` add-on
 // installed before it can provision an SSL Endpoint using these APIs.
 type SSLEndpoint struct {
-	CertificateChain string    `json:"certificate_chain"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string    `json:"cname"`             // canonical name record, the address to point a domain at
-	CreatedAt        time.Time `json:"created_at"`        // when endpoint was created
-	ID               string    `json:"id"`                // unique identifier of this SSL endpoint
-	Name             string    `json:"name"`              // unique name for SSL endpoint
-	UpdatedAt        time.Time `json:"updated_at"`        // when endpoint was updated
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
+	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
+	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
+	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
+	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
+	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
 }
 type SSLEndpointCreateOpts struct {
-	CertificateChain string `json:"certificate_chain"`    // raw contents of the public certificate chain (eg: .crt or .pem file)
-	Preprocess       *bool  `json:"preprocess,omitempty"` // allow Heroku to modify an uploaded public certificate chain if deemed
+	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"`       // raw contents of the public certificate chain (eg: .crt or .pem file)
+	Preprocess       *bool  `json:"preprocess,omitempty" url:"preprocess,omitempty,key"` // allow Heroku to modify an uploaded public certificate chain if deemed
 	// advantageous by adding missing intermediaries, stripping unnecessary
 	// ones, etc.
-	PrivateKey string `json:"private_key"` // contents of the private key (eg .key file)
+	PrivateKey string `json:"private_key" url:"private_key,key"` // contents of the private key (eg .key file)
+}
+type SSLEndpointCreateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
+	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
+	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
+	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
+	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
+	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
 }
 
 // Create a new SSL endpoint.
-func (s *Service) SSLEndpointCreate(appIdentity string, o struct {
-	CertificateChain string `json:"certificate_chain"`    // raw contents of the public certificate chain (eg: .crt or .pem file)
-	Preprocess       *bool  `json:"preprocess,omitempty"` // allow Heroku to modify an uploaded public certificate chain if deemed
-	// advantageous by adding missing intermediaries, stripping unnecessary
-	// ones, etc.
-	PrivateKey string `json:"private_key"` // contents of the private key (eg .key file)
-}) (*SSLEndpoint, error) {
-	var sslEndpoint SSLEndpoint
-	return &sslEndpoint, s.Post(&sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints", appIdentity), o)
+func (s *Service) SSLEndpointCreate(ctx context.Context, appIdentity string, o SSLEndpointCreateOpts) (*SSLEndpointCreateResult, error) {
+	var sslEndpoint SSLEndpointCreateResult
+	return &sslEndpoint, s.Post(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints", appIdentity), o)
+}
+
+type SSLEndpointDeleteResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
+	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
+	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
+	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
+	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
+	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
 }
 
 // Delete existing SSL endpoint.
-func (s *Service) SSLEndpointDelete(appIdentity string, sslEndpointIdentity string) error {
-	return s.Delete(fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity))
+func (s *Service) SSLEndpointDelete(ctx context.Context, appIdentity string, sslEndpointIdentity string) (*SSLEndpointDeleteResult, error) {
+	var sslEndpoint SSLEndpointDeleteResult
+	return &sslEndpoint, s.Delete(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity))
+}
+
+type SSLEndpointInfoResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
+	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
+	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
+	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
+	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
+	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
 }
 
 // Info for existing SSL endpoint.
-func (s *Service) SSLEndpointInfo(appIdentity string, sslEndpointIdentity string) (*SSLEndpoint, error) {
-	var sslEndpoint SSLEndpoint
-	return &sslEndpoint, s.Get(&sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity), nil)
+func (s *Service) SSLEndpointInfo(ctx context.Context, appIdentity string, sslEndpointIdentity string) (*SSLEndpointInfoResult, error) {
+	var sslEndpoint SSLEndpointInfoResult
+	return &sslEndpoint, s.Get(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity), nil, nil)
+}
+
+type SSLEndpointListResult []struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
+	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
+	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
+	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
+	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
+	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
 }
 
 // List existing SSL endpoints.
-func (s *Service) SSLEndpointList(appIdentity string, lr *ListRange) ([]*SSLEndpoint, error) {
-	var sslEndpointList []*SSLEndpoint
-	return sslEndpointList, s.Get(&sslEndpointList, fmt.Sprintf("/apps/%v/ssl-endpoints", appIdentity), lr)
+func (s *Service) SSLEndpointList(ctx context.Context, appIdentity string, lr *ListRange) (SSLEndpointListResult, error) {
+	var sslEndpoint SSLEndpointListResult
+	return sslEndpoint, s.Get(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints", appIdentity), nil, lr)
 }
 
 type SSLEndpointUpdateOpts struct {
-	CertificateChain *string `json:"certificate_chain,omitempty"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	Preprocess       *bool   `json:"preprocess,omitempty"`        // allow Heroku to modify an uploaded public certificate chain if deemed
+	CertificateChain *string `json:"certificate_chain,omitempty" url:"certificate_chain,omitempty,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	Preprocess       *bool   `json:"preprocess,omitempty" url:"preprocess,omitempty,key"`               // allow Heroku to modify an uploaded public certificate chain if deemed
 	// advantageous by adding missing intermediaries, stripping unnecessary
 	// ones, etc.
-	PrivateKey *string `json:"private_key,omitempty"` // contents of the private key (eg .key file)
-	Rollback   *bool   `json:"rollback,omitempty"`    // indicates that a rollback should be performed
+	PrivateKey *string `json:"private_key,omitempty" url:"private_key,omitempty,key"` // contents of the private key (eg .key file)
+	Rollback   *bool   `json:"rollback,omitempty" url:"rollback,omitempty,key"`       // indicates that a rollback should be performed
+}
+type SSLEndpointUpdateResult struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
+	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
+	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
+	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
+	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
+	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
+	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
 }
 
 // Update an existing SSL endpoint.
-func (s *Service) SSLEndpointUpdate(appIdentity string, sslEndpointIdentity string, o struct {
-	CertificateChain *string `json:"certificate_chain,omitempty"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	Preprocess       *bool   `json:"preprocess,omitempty"`        // allow Heroku to modify an uploaded public certificate chain if deemed
-	// advantageous by adding missing intermediaries, stripping unnecessary
-	// ones, etc.
-	PrivateKey *string `json:"private_key,omitempty"` // contents of the private key (eg .key file)
-	Rollback   *bool   `json:"rollback,omitempty"`    // indicates that a rollback should be performed
-}) (*SSLEndpoint, error) {
-	var sslEndpoint SSLEndpoint
-	return &sslEndpoint, s.Patch(&sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity), o)
+func (s *Service) SSLEndpointUpdate(ctx context.Context, appIdentity string, sslEndpointIdentity string, o SSLEndpointUpdateOpts) (*SSLEndpointUpdateResult, error) {
+	var sslEndpoint SSLEndpointUpdateResult
+	return &sslEndpoint, s.Patch(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity), o)
 }
 
 // Stacks are the different application execution environments available
 // in the Heroku platform.
 type Stack struct {
-	CreatedAt time.Time `json:"created_at"` // when stack was introduced
-	ID        string    `json:"id"`         // unique identifier of stack
-	Name      string    `json:"name"`       // unique name of stack
-	State     string    `json:"state"`      // availability of this stack: beta, deprecated or public
-	UpdatedAt time.Time `json:"updated_at"` // when stack was last modified
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when stack was introduced
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of stack
+	Name      string    `json:"name" url:"name,key"`             // unique name of stack
+	State     string    `json:"state" url:"state,key"`           // availability of this stack: beta, deprecated or public
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when stack was last modified
+}
+type StackInfoResult struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when stack was introduced
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of stack
+	Name      string    `json:"name" url:"name,key"`             // unique name of stack
+	State     string    `json:"state" url:"state,key"`           // availability of this stack: beta, deprecated or public
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when stack was last modified
 }
 
 // Stack info.
-func (s *Service) StackInfo(stackIdentity string) (*Stack, error) {
-	var stack Stack
-	return &stack, s.Get(&stack, fmt.Sprintf("/stacks/%v", stackIdentity), nil)
+func (s *Service) StackInfo(ctx context.Context, stackIdentity string) (*StackInfoResult, error) {
+	var stack StackInfoResult
+	return &stack, s.Get(ctx, &stack, fmt.Sprintf("/stacks/%v", stackIdentity), nil, nil)
+}
+
+type StackListResult []struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when stack was introduced
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of stack
+	Name      string    `json:"name" url:"name,key"`             // unique name of stack
+	State     string    `json:"state" url:"state,key"`           // availability of this stack: beta, deprecated or public
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when stack was last modified
 }
 
 // List available stacks.
-func (s *Service) StackList(lr *ListRange) ([]*Stack, error) {
-	var stackList []*Stack
-	return stackList, s.Get(&stackList, fmt.Sprintf("/stacks"), lr)
+func (s *Service) StackList(ctx context.Context, lr *ListRange) (StackListResult, error) {
+	var stack StackListResult
+	return stack, s.Get(ctx, &stack, fmt.Sprintf("/stacks"), nil, lr)
 }
 
+// Tracks a user's preferences and message dismissals
+type UserPreferences struct {
+	DefaultOrganization        *string `json:"default-organization" url:"default-organization,key"`                   // User's default organization
+	DismissedGettingStarted    *bool   `json:"dismissed-getting-started" url:"dismissed-getting-started,key"`         // Whether the user has dismissed the getting started banner
+	DismissedGithubBanner      *bool   `json:"dismissed-github-banner" url:"dismissed-github-banner,key"`             // Whether the user has dismissed the GitHub link banner
+	DismissedOrgAccessControls *bool   `json:"dismissed-org-access-controls" url:"dismissed-org-access-controls,key"` // Whether the user has dismissed the Organization Access Controls
+	// banner
+	DismissedOrgWizardNotification *bool `json:"dismissed-org-wizard-notification" url:"dismissed-org-wizard-notification,key"` // Whether the user has dismissed the Organization Wizard
+	DismissedPipelinesBanner       *bool `json:"dismissed-pipelines-banner" url:"dismissed-pipelines-banner,key"`               // Whether the user has dismissed the Pipelines banner
+	DismissedPipelinesGithubBanner *bool `json:"dismissed-pipelines-github-banner" url:"dismissed-pipelines-github-banner,key"` // Whether the user has dismissed the GitHub banner on a pipeline
+	// overview
+	DismissedPipelinesGithubBanners *[]string `json:"dismissed-pipelines-github-banners" url:"dismissed-pipelines-github-banners,key"` // Which pipeline uuids the user has dismissed the GitHub banner for
+	DismissedSmsBanner              *bool     `json:"dismissed-sms-banner" url:"dismissed-sms-banner,key"`                             // Whether the user has dismissed the 2FA SMS banner
+	Timezone                        *string   `json:"timezone" url:"timezone,key"`                                                     // User's default timezone
+}
+type UserPreferencesListResult struct {
+	DefaultOrganization        *string `json:"default-organization" url:"default-organization,key"`                   // User's default organization
+	DismissedGettingStarted    *bool   `json:"dismissed-getting-started" url:"dismissed-getting-started,key"`         // Whether the user has dismissed the getting started banner
+	DismissedGithubBanner      *bool   `json:"dismissed-github-banner" url:"dismissed-github-banner,key"`             // Whether the user has dismissed the GitHub link banner
+	DismissedOrgAccessControls *bool   `json:"dismissed-org-access-controls" url:"dismissed-org-access-controls,key"` // Whether the user has dismissed the Organization Access Controls
+	// banner
+	DismissedOrgWizardNotification *bool `json:"dismissed-org-wizard-notification" url:"dismissed-org-wizard-notification,key"` // Whether the user has dismissed the Organization Wizard
+	DismissedPipelinesBanner       *bool `json:"dismissed-pipelines-banner" url:"dismissed-pipelines-banner,key"`               // Whether the user has dismissed the Pipelines banner
+	DismissedPipelinesGithubBanner *bool `json:"dismissed-pipelines-github-banner" url:"dismissed-pipelines-github-banner,key"` // Whether the user has dismissed the GitHub banner on a pipeline
+	// overview
+	DismissedPipelinesGithubBanners *[]string `json:"dismissed-pipelines-github-banners" url:"dismissed-pipelines-github-banners,key"` // Which pipeline uuids the user has dismissed the GitHub banner for
+	DismissedSmsBanner              *bool     `json:"dismissed-sms-banner" url:"dismissed-sms-banner,key"`                             // Whether the user has dismissed the 2FA SMS banner
+	Timezone                        *string   `json:"timezone" url:"timezone,key"`                                                     // User's default timezone
+}
+
+// Retrieve User Preferences
+func (s *Service) UserPreferencesList(ctx context.Context, userPreferencesIdentity string) (*UserPreferencesListResult, error) {
+	var userPreferences UserPreferencesListResult
+	return &userPreferences, s.Get(ctx, &userPreferences, fmt.Sprintf("/users/%v/preferences", userPreferencesIdentity), nil, nil)
+}
+
+type UserPreferencesUpdateOpts struct {
+	DefaultOrganization        *string `json:"default-organization,omitempty" url:"default-organization,omitempty,key"`                   // User's default organization
+	DismissedGettingStarted    *bool   `json:"dismissed-getting-started,omitempty" url:"dismissed-getting-started,omitempty,key"`         // Whether the user has dismissed the getting started banner
+	DismissedGithubBanner      *bool   `json:"dismissed-github-banner,omitempty" url:"dismissed-github-banner,omitempty,key"`             // Whether the user has dismissed the GitHub link banner
+	DismissedOrgAccessControls *bool   `json:"dismissed-org-access-controls,omitempty" url:"dismissed-org-access-controls,omitempty,key"` // Whether the user has dismissed the Organization Access Controls
+	// banner
+	DismissedOrgWizardNotification *bool `json:"dismissed-org-wizard-notification,omitempty" url:"dismissed-org-wizard-notification,omitempty,key"` // Whether the user has dismissed the Organization Wizard
+	DismissedPipelinesBanner       *bool `json:"dismissed-pipelines-banner,omitempty" url:"dismissed-pipelines-banner,omitempty,key"`               // Whether the user has dismissed the Pipelines banner
+	DismissedPipelinesGithubBanner *bool `json:"dismissed-pipelines-github-banner,omitempty" url:"dismissed-pipelines-github-banner,omitempty,key"` // Whether the user has dismissed the GitHub banner on a pipeline
+	// overview
+	DismissedPipelinesGithubBanners *[]*string `json:"dismissed-pipelines-github-banners,omitempty" url:"dismissed-pipelines-github-banners,omitempty,key"` // Which pipeline uuids the user has dismissed the GitHub banner for
+	DismissedSmsBanner              *bool      `json:"dismissed-sms-banner,omitempty" url:"dismissed-sms-banner,omitempty,key"`                             // Whether the user has dismissed the 2FA SMS banner
+	Timezone                        *string    `json:"timezone,omitempty" url:"timezone,omitempty,key"`                                                     // User's default timezone
+}
+type UserPreferencesUpdateResult struct {
+	DefaultOrganization        *string `json:"default-organization" url:"default-organization,key"`                   // User's default organization
+	DismissedGettingStarted    *bool   `json:"dismissed-getting-started" url:"dismissed-getting-started,key"`         // Whether the user has dismissed the getting started banner
+	DismissedGithubBanner      *bool   `json:"dismissed-github-banner" url:"dismissed-github-banner,key"`             // Whether the user has dismissed the GitHub link banner
+	DismissedOrgAccessControls *bool   `json:"dismissed-org-access-controls" url:"dismissed-org-access-controls,key"` // Whether the user has dismissed the Organization Access Controls
+	// banner
+	DismissedOrgWizardNotification *bool `json:"dismissed-org-wizard-notification" url:"dismissed-org-wizard-notification,key"` // Whether the user has dismissed the Organization Wizard
+	DismissedPipelinesBanner       *bool `json:"dismissed-pipelines-banner" url:"dismissed-pipelines-banner,key"`               // Whether the user has dismissed the Pipelines banner
+	DismissedPipelinesGithubBanner *bool `json:"dismissed-pipelines-github-banner" url:"dismissed-pipelines-github-banner,key"` // Whether the user has dismissed the GitHub banner on a pipeline
+	// overview
+	DismissedPipelinesGithubBanners *[]string `json:"dismissed-pipelines-github-banners" url:"dismissed-pipelines-github-banners,key"` // Which pipeline uuids the user has dismissed the GitHub banner for
+	DismissedSmsBanner              *bool     `json:"dismissed-sms-banner" url:"dismissed-sms-banner,key"`                             // Whether the user has dismissed the 2FA SMS banner
+	Timezone                        *string   `json:"timezone" url:"timezone,key"`                                                     // User's default timezone
+}
+
+// Update User Preferences
+func (s *Service) UserPreferencesUpdate(ctx context.Context, userPreferencesIdentity string, o UserPreferencesUpdateOpts) (*UserPreferencesUpdateResult, error) {
+	var userPreferences UserPreferencesUpdateResult
+	return &userPreferences, s.Patch(ctx, &userPreferences, fmt.Sprintf("/users/%v/preferences", userPreferencesIdentity), o)
+}
+
+// Entities that have been whitelisted to be used by an Organization
+type WhitelistedAddOnService struct {
+	AddedAt time.Time `json:"added_at" url:"added_at,key"` // when the add-on service was whitelisted
+	AddedBy struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"added_by" url:"added_by,key"` // the user which whitelisted the Add-on Service
+	AddonService struct {
+		HumanName string `json:"human_name" url:"human_name,key"` // human-readable name of the add-on service provider
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of this add-on-service
+		Name      string `json:"name" url:"name,key"`             // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
+	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
+}
+type WhitelistedAddOnServiceListResult []struct {
+	AddedAt time.Time `json:"added_at" url:"added_at,key"` // when the add-on service was whitelisted
+	AddedBy struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"added_by" url:"added_by,key"` // the user which whitelisted the Add-on Service
+	AddonService struct {
+		HumanName string `json:"human_name" url:"human_name,key"` // human-readable name of the add-on service provider
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of this add-on-service
+		Name      string `json:"name" url:"name,key"`             // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
+	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
+}
+
+// List all whitelisted Add-on Services for an Organization
+func (s *Service) WhitelistedAddOnServiceList(ctx context.Context, organizationIdentity string, lr *ListRange) (WhitelistedAddOnServiceListResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceListResult
+	return whitelistedAddOnService, s.Get(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services", organizationIdentity), nil, lr)
+}
+
+type WhitelistedAddOnServiceCreateOpts struct {
+	AddonService *string `json:"addon_service,omitempty" url:"addon_service,omitempty,key"` // name of the Add-on to whitelist
+}
+type WhitelistedAddOnServiceCreateResult []struct {
+	AddedAt time.Time `json:"added_at" url:"added_at,key"` // when the add-on service was whitelisted
+	AddedBy struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"added_by" url:"added_by,key"` // the user which whitelisted the Add-on Service
+	AddonService struct {
+		HumanName string `json:"human_name" url:"human_name,key"` // human-readable name of the add-on service provider
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of this add-on-service
+		Name      string `json:"name" url:"name,key"`             // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
+	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
+}
+
+// Whitelist an Add-on Service
+func (s *Service) WhitelistedAddOnServiceCreate(ctx context.Context, organizationIdentity string, o WhitelistedAddOnServiceCreateOpts) (WhitelistedAddOnServiceCreateResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceCreateResult
+	return whitelistedAddOnService, s.Post(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services", organizationIdentity), o)
+}
+
+type WhitelistedAddOnServiceDeleteResult struct {
+	AddedAt time.Time `json:"added_at" url:"added_at,key"` // when the add-on service was whitelisted
+	AddedBy struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"added_by" url:"added_by,key"` // the user which whitelisted the Add-on Service
+	AddonService struct {
+		HumanName string `json:"human_name" url:"human_name,key"` // human-readable name of the add-on service provider
+		ID        string `json:"id" url:"id,key"`                 // unique identifier of this add-on-service
+		Name      string `json:"name" url:"name,key"`             // unique name of this add-on-service
+	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
+	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
+}
+
+// Remove a whitelisted entity
+func (s *Service) WhitelistedAddOnServiceDelete(ctx context.Context, organizationIdentity string, whitelistedAddOnServiceIdentity string) (*WhitelistedAddOnServiceDeleteResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceDeleteResult
+	return &whitelistedAddOnService, s.Delete(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services/%v", organizationIdentity, whitelistedAddOnServiceIdentity))
+}

--- a/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
@@ -1,5 +1,8 @@
 {
   "$schema": "http://interagent.github.io/interagent-hyper-schema",
+  "type": [
+    "object"
+  ],
   "definitions": {
     "account-feature": {
       "description": "An account feature represents a Heroku labs capability that can be enabled or disabled for an account on Heroku.",
@@ -212,6 +215,14 @@
             "string"
           ]
         },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "id": {
           "description": "unique identifier of an account",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
@@ -228,6 +239,9 @@
             },
             {
               "$ref": "#/definitions/account/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/account/definitions/self"
             }
           ]
         },
@@ -237,7 +251,8 @@
           "format": "date-time",
           "readOnly": true,
           "type": [
-            "string"
+            "string",
+            "null"
           ]
         },
         "name": {
@@ -249,20 +264,60 @@
             "null"
           ]
         },
-        "new_password": {
-          "description": "the new password for the account when changing the password",
-          "example": "newpassword",
-          "readOnly": true,
-          "type": [
-            "string"
-          ]
-        },
         "password": {
           "description": "current password on the account",
           "example": "currentpassword",
           "readOnly": true,
           "type": [
             "string"
+          ]
+        },
+        "self": {
+          "description": "Implicit reference to currently authorized user",
+          "enum": [
+            "~"
+          ],
+          "example": "~",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "sms_number": {
+          "description": "SMS number of account",
+          "example": "+1 ***-***-1234",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "suspended_at": {
+          "description": "when account was suspended",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "delinquent_at": {
+          "description": "when account became delinquent",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "two_factor_authentication": {
+          "description": "whether two-factor auth is enabled on the account",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
           ]
         },
         "updated_at": {
@@ -310,14 +365,8 @@
               },
               "name": {
                 "$ref": "#/definitions/account/definitions/name"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
               }
             },
-            "required": [
-              "password"
-            ],
             "type": [
               "object"
             ]
@@ -328,47 +377,42 @@
           "title": "Update"
         },
         {
-          "description": "Change Email for account.",
+          "description": "Delete account. Note that this action cannot be undone.",
           "href": "/account",
-          "method": "PATCH",
-          "rel": "update",
-          "schema": {
-            "properties": {
-              "email": {
-                "$ref": "#/definitions/account/definitions/email"
-              },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
-              }
-            },
-            "required": [
-              "password",
-              "email"
-            ],
-            "type": [
-              "object"
-            ]
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/account"
           },
-          "title": "Change Email"
+          "title": "Delete"
         },
         {
-          "description": "Change Password for account.",
-          "href": "/account",
+          "description": "Info for account.",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update account.",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
           "schema": {
             "properties": {
-              "new_password": {
-                "$ref": "#/definitions/account/definitions/new_password"
+              "allow_tracking": {
+                "$ref": "#/definitions/account/definitions/allow_tracking"
               },
-              "password": {
-                "$ref": "#/definitions/account/definitions/password"
+              "beta": {
+                "$ref": "#/definitions/account/definitions/beta"
+              },
+              "name": {
+                "$ref": "#/definitions/account/definitions/name"
               }
             },
-            "required": [
-              "new_password",
-              "password"
-            ],
             "type": [
               "object"
             ]
@@ -376,7 +420,17 @@
           "targetSchema": {
             "$ref": "#/definitions/account"
           },
-          "title": "Change Password"
+          "title": "Update"
+        },
+        {
+          "description": "Delete account. Note that this action cannot be undone.",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/account"
+          },
+          "title": "Delete"
         }
       ],
       "properties": {
@@ -392,8 +446,33 @@
         "email": {
           "$ref": "#/definitions/account/definitions/email"
         },
+        "federated": {
+          "$ref": "#/definitions/account/definitions/federated"
+        },
         "id": {
           "$ref": "#/definitions/account/definitions/id"
+        },
+        "identity_provider": {
+          "description": "Identity Provider details for federated users.",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/identity-provider/definitions/id"
+            },
+            "organization": {
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "name": {
+                  "$ref": "#/definitions/organization/definitions/name"
+                }
+              }
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
         },
         "last_login": {
           "$ref": "#/definitions/account/definitions/last_login"
@@ -401,15 +480,608 @@
         "name": {
           "$ref": "#/definitions/account/definitions/name"
         },
+        "sms_number": {
+          "$ref": "#/definitions/account/definitions/sms_number"
+        },
+        "suspended_at": {
+          "$ref": "#/definitions/account/definitions/suspended_at"
+        },
+        "delinquent_at": {
+          "$ref": "#/definitions/account/definitions/delinquent_at"
+        },
+        "two_factor_authentication": {
+          "$ref": "#/definitions/account/definitions/two_factor_authentication"
+        },
         "updated_at": {
           "$ref": "#/definitions/account/definitions/updated_at"
         },
         "verified": {
           "$ref": "#/definitions/account/definitions/verified"
+        },
+        "default_organization": {
+          "description": "organization selected by default",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/organization/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
         }
       }
     },
-    "addon-service": {
+    "add-on-action": {
+      "description": "Add-on Actions are lifecycle operations for add-on provisioning and deprovisioning. They allow whitelisted add-on providers to (de)provision add-ons in the background and then report back when (de)provisioning is complete.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Action",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+      },
+      "links": [
+        {
+          "description": "Mark an add-on as provisioned for use.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/provision",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Create - Provision"
+        },
+        {
+          "description": "Mark an add-on as deprovisioned.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/actions/deprovision",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Create - Deprovision"
+        }
+      ],
+      "properties": {
+      }
+    },
+    "add-on-attachment": {
+      "description": "An add-on attachment represents a connection between an app and an add-on that it has been given access to.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Attachment",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when add-on attachment was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this add-on attachment",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "force": {
+          "default": false,
+          "description": "whether or not to allow existing attachment with same name to be replaced",
+          "example": false,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
+            }
+          ]
+        },
+        "scopedIdentity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on-attachment/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/add-on-attachment/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name for this add-on attachment to this app",
+          "example": "DATABASE",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when add-on attachment was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "web_url": {
+          "description": "URL for logging into web interface of add-on in attached app context",
+          "example": "https://postgres.heroku.com/databases/01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uri",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new add-on attachment.",
+          "href": "/addon-attachments",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "addon": {
+                "$ref": "#/definitions/add-on/definitions/identity"
+              },
+              "app": {
+                "$ref": "#/definitions/app/definitions/identity"
+              },
+              "force": {
+                "$ref": "#/definitions/add-on-attachment/definitions/force"
+              },
+              "name": {
+                "$ref": "#/definitions/add-on-attachment/definitions/name"
+              }
+            },
+            "required": [
+              "addon",
+              "app"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing add-on attachment.",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing add-on attachment.",
+          "href": "/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing add-on attachments.",
+          "href": "/addon-attachments",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List existing add-on attachments for an add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/addon-attachments",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by Add-on"
+        },
+        {
+          "description": "List existing add-on attachments for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by App"
+        },
+        {
+          "description": "Info for existing add-on attachment for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addon-attachments/{(%23%2Fdefinitions%2Fadd-on-attachment%2Fdefinitions%2FscopedIdentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on-attachment"
+          },
+          "title": "Info by App"
+        }
+      ],
+      "properties": {
+        "addon": {
+          "description": "identity of add-on",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on/definitions/name"
+            },
+            "app": {
+              "description": "billing application associated with this add-on",
+              "type": [
+                "object"
+              ],
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/app/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/app/definitions/name"
+                }
+              },
+              "strictProperties": true
+            },
+            "plan": {
+              "description": "identity of add-on plan",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/plan/definitions/id"
+                },
+                "name": {
+                  "$ref": "#/definitions/plan/definitions/name"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "id",
+            "name",
+            "app"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "app": {
+          "description": "application that is attached to add-on",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/add-on-attachment/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/add-on-attachment/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/add-on-attachment/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/add-on-attachment/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/add-on-attachment/definitions/web_url"
+        }
+      }
+    },
+    "add-on-config": {
+      "description": "Configuration of an Add-on",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Config",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/add-on-config/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of the config",
+          "example": "FOO",
+          "type": [
+            "string"
+          ]
+        },
+        "value": {
+          "description": "value of the config",
+          "example": "bar",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get an add-on's config. Accessible by customers with access and by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-config"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an add-on's config. Can only be accessed by the add-on partner providing this add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}/config",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "config": {
+                "items": {
+                  "$ref": "#/definitions/add-on-config"
+                },
+                "type": [
+                  "array"
+                ]
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "type": [
+              "array"
+            ],
+            "items": {
+              "$ref": "#/definitions/add-on-config"
+            }
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/add-on-config/definitions/name"
+        },
+        "value": {
+          "$ref": "#/definitions/add-on-config/definitions/value"
+        }
+      }
+    },
+    "add-on-plan-action": {
+      "description": "Add-on Plan Actions are Provider functionality for specific add-on installations",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Plan Action",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "a unique identifier",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "description": "the display text shown in Dashboard",
+          "example": "Example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "action": {
+          "description": "identifier of the action to take that is sent via SSO",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "url": {
+          "description": "absolute URL to use instead of an action",
+          "example": "http://example.com?resource_id=:resource_id",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "requires_owner": {
+          "description": "if the action requires the user to own the app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/id"
+        },
+        "label": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/label"
+        },
+        "action": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/action"
+        },
+        "url": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/url"
+        },
+        "requires_owner": {
+          "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
+        }
+      }
+    },
+    "add-on-region-capability": {
+      "description": "Add-on region capabilities represent the relationship between an Add-on Service and a specific Region. Only Beta and GA add-ons are returned by these endpoints.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Add-on Region Capability",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of this add-on-region-capability",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "supports_private_networking": {
+          "description": "whether the add-on can be installed to a Space",
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
+        }
+      },
+      "links": [
+        {
+          "description": "List all existing add-on region capabilities.",
+          "href": "/addon-region-capabilities",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-region-capability"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List existing add-on region capabilities for an add-on-service",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/region-capabilities",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-region-capability"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by Add-on Service"
+        },
+        {
+          "description": "List existing add-on region capabilities for a region.",
+          "href": "/regions/{(%23%2Fdefinitions%2Fregion%2Fdefinitions%2Fidentity)}/addon-region-capabilities",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on-region-capability"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/add-on-region-capability/definitions/id"
+        },
+        "supports_private_networking": {
+          "$ref": "#/definitions/add-on-region-capability/definitions/supports_private_networking"
+        },
+        "addon_service": {
+          "$ref": "#/definitions/add-on-service"
+        },
+        "region": {
+          "$ref": "#/definitions/region"
+        }
+      }
+    },
+    "add-on-service": {
       "description": "Add-on services represent add-ons that may be provisioned for apps. Endpoints under add-on services can be accessed without authentication.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
@@ -419,8 +1091,17 @@
         "object"
       ],
       "definitions": {
+        "cli_plugin_name": {
+          "description": "npm package name of the add-on service's Heroku CLI plugin",
+          "example": "heroku-papertrail",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "created_at": {
-          "description": "when addon-service was created",
+          "description": "when add-on-service was created",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -428,8 +1109,16 @@
             "string"
           ]
         },
+        "human_name": {
+          "description": "human-readable name of the add-on service provider",
+          "example": "Heroku Postgres",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "id": {
-          "description": "unique identifier of this addon-service",
+          "description": "unique identifier of this add-on-service",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
           "format": "uuid",
           "readOnly": true,
@@ -440,23 +1129,55 @@
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           ]
         },
         "name": {
-          "description": "unique name of this addon-service",
+          "description": "unique name of this add-on-service",
           "example": "heroku-postgresql",
           "readOnly": true,
           "type": [
             "string"
           ]
         },
+        "state": {
+          "description": "release status for add-on service",
+          "enum": [
+            "alpha",
+            "beta",
+            "ga",
+            "shutdown"
+          ],
+          "example": "ga",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "supports_multiple_installations": {
+          "default": false,
+          "description": "whether or not apps can have access to more than one instance of this add-on at the same time",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "supports_sharing": {
+          "default": false,
+          "description": "whether or not apps can have access to add-ons billed to a different app",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "updated_at": {
-          "description": "when addon-service was updated",
+          "description": "when add-on-service was updated",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -467,23 +1188,23 @@
       },
       "links": [
         {
-          "description": "Info for existing addon-service.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}",
+          "description": "Info for existing add-on-service.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon-service"
+            "$ref": "#/definitions/add-on-service"
           },
           "title": "Info"
         },
         {
-          "description": "List existing addon-services.",
+          "description": "List existing add-on-services.",
           "href": "/addon-services",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon-service"
+              "$ref": "#/definitions/add-on-service"
             },
             "type": [
               "array"
@@ -493,22 +1214,37 @@
         }
       ],
       "properties": {
+        "cli_plugin_name": {
+          "$ref": "#/definitions/add-on-service/definitions/cli_plugin_name"
+        },
         "created_at": {
-          "$ref": "#/definitions/addon-service/definitions/created_at"
+          "$ref": "#/definitions/add-on-service/definitions/created_at"
+        },
+        "human_name": {
+          "$ref": "#/definitions/add-on-service/definitions/human_name"
         },
         "id": {
-          "$ref": "#/definitions/addon-service/definitions/id"
+          "$ref": "#/definitions/add-on-service/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon-service/definitions/name"
+          "$ref": "#/definitions/add-on-service/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/add-on-service/definitions/state"
+        },
+        "supports_multiple_installations": {
+          "$ref": "#/definitions/add-on-service/definitions/supports_multiple_installations"
+        },
+        "supports_sharing": {
+          "$ref": "#/definitions/add-on-service/definitions/supports_sharing"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon-service/definitions/updated_at"
+          "$ref": "#/definitions/add-on-service/definitions/updated_at"
         }
       }
     },
-    "addon": {
-      "description": "Add-ons represent add-ons that have been provisioned for an app.",
+    "add-on": {
+      "description": "Add-ons represent add-ons that have been provisioned and attached to one or more apps.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
       "strictProperties": true,
@@ -517,8 +1253,37 @@
         "object"
       ],
       "definitions": {
+        "actions": {
+          "description": "provider actions for this specific add-on",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ]
+          },
+          "readOnly": true,
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/id"
+            },
+            "label": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/label"
+            },
+            "action": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/action"
+            },
+            "url": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/url"
+            },
+            "requires_owner": {
+              "$ref": "#/definitions/add-on-plan-action/definitions/requires_owner"
+            }
+          }
+        },
         "config_vars": {
-          "description": "config vars associated with this application",
+          "description": "config vars exposed to the owning app by this add-on",
           "example": [
             "FOO",
             "BAZ"
@@ -534,7 +1299,7 @@
           ]
         },
         "created_at": {
-          "description": "when add-on was updated",
+          "description": "when add-on was created",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -554,17 +1319,17 @@
         "identity": {
           "anyOf": [
             {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
             },
             {
-              "$ref": "#/definitions/addon/definitions/name"
+              "$ref": "#/definitions/add-on/definitions/name"
             }
           ]
         },
         "name": {
-          "description": "name of the add-on unique within its app",
-          "example": "heroku-postgresql-teal",
-          "pattern": "^[a-z][a-z0-9-]+$",
+          "description": "globally unique name of the add-on",
+          "example": "acme-inc-primary-database",
+          "pattern": "^[a-zA-Z][A-Za-z0-9_-]+$",
           "readOnly": true,
           "type": [
             "string"
@@ -572,7 +1337,20 @@
         },
         "provider_id": {
           "description": "id of this add-on with its provider",
-          "example": "app123@heroku.com",
+          "example": "abcd1234",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state in the add-on's lifecycle",
+          "enum": [
+            "provisioning",
+            "provisioned",
+            "deprovisioned"
+          ],
+          "example": "provisioned",
           "readOnly": true,
           "type": [
             "string"
@@ -586,6 +1364,16 @@
           "type": [
             "string"
           ]
+        },
+        "web_url": {
+          "description": "URL for logging into web interface of add-on (e.g. a dashboard)",
+          "example": "https://postgres.heroku.com/databases/01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uri",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
         }
       },
       "links": [
@@ -596,6 +1384,18 @@
           "rel": "create",
           "schema": {
             "properties": {
+              "attachment": {
+                "description": "name for add-on's initial attachment",
+                "example": {
+                  "name": "DATABASE_FOLLOWER"
+                },
+                "name": {
+                  "$ref": "#/definitions/add-on-attachment/definitions/name"
+                },
+                "type": [
+                  "object"
+                ]
+              },
               "config": {
                 "additionalProperties": false,
                 "description": "custom add-on provisioning options",
@@ -625,38 +1425,38 @@
             ]
           },
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Create"
         },
         {
           "description": "Delete an existing add-on.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Delete"
         },
         {
           "description": "Info for an existing add-on.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/addon"
+            "$ref": "#/definitions/add-on"
           },
           "title": "Info"
         },
         {
-          "description": "List existing add-ons.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons",
+          "description": "List all existing add-ons.",
+          "href": "/addons",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/addon"
+              "$ref": "#/definitions/add-on"
             },
             "type": [
               "array"
@@ -665,8 +1465,48 @@
           "title": "List"
         },
         {
+          "description": "Info for an existing add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all existing add-ons a user has access to",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by User"
+        },
+        {
+          "description": "List existing add-ons for an app.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List by App"
+        },
+        {
           "description": "Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Faddon%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
           "schema": {
@@ -686,14 +1526,17 @@
         }
       ],
       "properties": {
+        "actions": {
+          "$ref": "#/definitions/add-on/definitions/actions"
+        },
         "addon_service": {
           "description": "identity of add-on service",
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon-service/definitions/id"
+              "$ref": "#/definitions/add-on-service/definitions/id"
             },
             "name": {
-              "$ref": "#/definitions/addon-service/definitions/name"
+              "$ref": "#/definitions/add-on-service/definitions/name"
             }
           },
           "strictProperties": true,
@@ -701,17 +1544,32 @@
             "object"
           ]
         },
+        "app": {
+          "description": "billing application associated with this add-on",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true
+        },
         "config_vars": {
-          "$ref": "#/definitions/addon/definitions/config_vars"
+          "$ref": "#/definitions/add-on/definitions/config_vars"
         },
         "created_at": {
-          "$ref": "#/definitions/addon/definitions/created_at"
+          "$ref": "#/definitions/add-on/definitions/created_at"
         },
         "id": {
-          "$ref": "#/definitions/addon/definitions/id"
+          "$ref": "#/definitions/add-on/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/addon/definitions/name"
+          "$ref": "#/definitions/add-on/definitions/name"
         },
         "plan": {
           "description": "identity of add-on plan",
@@ -729,10 +1587,16 @@
           ]
         },
         "provider_id": {
-          "$ref": "#/definitions/addon/definitions/provider_id"
+          "$ref": "#/definitions/add-on/definitions/provider_id"
+        },
+        "state": {
+          "$ref": "#/definitions/add-on/definitions/state"
         },
         "updated_at": {
-          "$ref": "#/definitions/addon/definitions/updated_at"
+          "$ref": "#/definitions/add-on/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/add-on/definitions/web_url"
         }
       }
     },
@@ -901,6 +1765,64 @@
         }
       }
     },
+    "app-formation-set": {
+      "description": "App formation set describes the combination of process types with their quantities and sizes as well as application process tier",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Application Formation Set",
+      "type": [
+        "object"
+      ],
+      "properties": {
+        "description": {
+          "description": "a string representation of the formation set",
+          "example": "web@2:Standard-2X worker@3:Performance-M",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "process_tier": {
+          "description": "application process tier",
+          "enum": [
+            "production",
+            "traditional",
+            "free",
+            "hobby",
+            "private"
+          ],
+          "example": "production",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "app": {
+          "description": "app being described by the formation-set",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "description": "last time fomation-set was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      }
+    },
     "app-setup": {
       "description": "An app setup represents an app on Heroku that is setup using an environment, addons, and scripts described in an app.json manifest file.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -927,6 +1849,21 @@
             }
           ]
         },
+        "buildpack_override": {
+          "description": "a buildpack override",
+          "properties": {
+            "url": {
+              "description": "location of the buildpack",
+              "example": "https://example.com/buildpack.tgz",
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
         "created_at": {
           "description": "when app setup was created",
           "example": "2012-01-01T12:00:00Z",
@@ -947,7 +1884,7 @@
         },
         "status": {
           "description": "the overall status of app setup",
-          "example": "succeeded",
+          "example": "failed",
           "enum": [
             "failed",
             "pending",
@@ -960,7 +1897,7 @@
         },
         "resolved_success_url": {
           "description": "fully qualified success url",
-          "example": "http://example.herokuapp.com/welcome",
+          "example": "https://example.herokuapp.com/welcome",
           "readOnly": true,
           "type": [
             "string",
@@ -989,6 +1926,58 @@
           },
           "type": [
             "array"
+          ]
+        },
+        "overrides": {
+          "description": "overrides of keys in the app.json manifest file",
+          "example": {
+            "buildpacks": [
+              {
+                "url": "https://example.com/buildpack.tgz"
+              }
+            ],
+            "env": {
+              "FOO": "bar",
+              "BAZ": "qux"
+            }
+          },
+          "properties": {
+            "buildpacks": {
+              "description": "overrides the buildpacks specified in the app.json manifest file",
+              "example": [
+                {
+                  "url": "https://example.com/buildpack.tgz"
+                }
+              ],
+              "items": {
+                "$ref": "#/definitions/app-setup/definitions/buildpack_override"
+              },
+              "type": [
+                "array"
+              ]
+            },
+            "env": {
+              "description": "overrides of the env specified in the app.json manifest file",
+              "example": {
+                "FOO": "bar",
+                "BAZ": "qux"
+              },
+              "readOnly": true,
+              "additionalProperties": false,
+              "patternProperties": {
+                "^\\w+$": {
+                  "type": [
+                    "string"
+                  ]
+                }
+              },
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "type": [
+            "object"
           ]
         },
         "postdeploy": {
@@ -1053,6 +2042,7 @@
           "description": "identity and status of build",
           "strictProperties": true,
           "type": [
+            "null",
             "object"
           ],
           "properties": {
@@ -1061,6 +2051,9 @@
             },
             "status": {
               "$ref": "#/definitions/build/definitions/status"
+            },
+            "output_stream_url": {
+              "$ref": "#/definitions/build/definitions/output_stream_url"
             }
           }
         },
@@ -1107,6 +2100,9 @@
                   "region": {
                     "$ref": "#/definitions/region/definitions/name"
                   },
+                  "space": {
+                    "$ref": "#/definitions/space/definitions/name"
+                  },
                   "stack": {
                     "$ref": "#/definitions/stack/definitions/name"
                   }
@@ -1117,14 +2113,31 @@
               },
               "source_blob": {
                 "description": "gzipped tarball of source code containing app.json manifest file",
-                "example": "https://example.com/source.tgz?token=xyz",
                 "properties": {
+                  "checksum": {
+                    "description": "an optional checksum of the gzipped tarball for verifying its integrity",
+                    "example": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                    "readOnly": true,
+                    "type": [
+                      "null",
+                      "string"
+                    ]
+                  },
                   "url": {
                     "description": "URL of gzipped tarball of source code containing app.json manifest file",
                     "example": "https://example.com/source.tgz?token=xyz",
                     "readOnly": true,
                     "type": [
                       "string"
+                    ]
+                  },
+                  "version": {
+                    "description": "Version of the gzipped tarball.",
+                    "example": "v1.3.0",
+                    "readOnly": true,
+                    "type": [
+                      "string",
+                      "null"
                     ]
                   }
                 },
@@ -1133,37 +2146,7 @@
                 ]
               },
               "overrides": {
-                "description": "overrides of keys in the app.json manifest file",
-                "example": {
-                  "env": {
-                    "FOO": "bar",
-                    "BAZ": "qux"
-                  }
-                },
-                "properties": {
-                  "env": {
-                    "description": "overrides of the env specified in the app.json manifest file",
-                    "example": {
-                      "FOO": "bar",
-                      "BAZ": "qux"
-                    },
-                    "readOnly": true,
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^\\w+$": {
-                        "type": [
-                          "string"
-                        ]
-                      }
-                    },
-                    "type": [
-                      "object"
-                    ]
-                  }
-                },
-                "type": [
-                  "object"
-                ]
+                "$ref": "#/definitions/app-setup/definitions/overrides"
               }
             }
           },
@@ -1221,6 +2204,15 @@
             }
           ]
         },
+        "silent": {
+          "default": false,
+          "description": "whether to suppress email notification when transferring apps",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "state": {
           "description": "the current state of an app transfer",
           "enum": [
@@ -1257,6 +2249,9 @@
               },
               "recipient": {
                 "$ref": "#/definitions/account/definitions/identity"
+              },
+              "silent": {
+                "$ref": "#/definitions/app-transfer/definitions/silent"
               }
             },
             "required": [
@@ -1430,8 +2425,8 @@
         },
         "git_url": {
           "description": "git repo URL of app",
-          "example": "git@heroku.com:example.git",
-          "pattern": "^git@heroku\\.com:[a-z][a-z0-9-]{3,30}\\.git$",
+          "example": "https://git.heroku.com/example.git",
+          "pattern": "^https://git\\.heroku\\.com/[a-z][a-z0-9-]{2,29}\\.git$",
           "readOnly": true,
           "type": [
             "string"
@@ -1468,7 +2463,7 @@
         "name": {
           "description": "unique name of app",
           "example": "example",
-          "pattern": "^[a-z][a-z0-9-]{3,30}$",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
           "readOnly": false,
           "type": [
             "string"
@@ -1516,12 +2511,21 @@
         },
         "web_url": {
           "description": "web URL of app",
-          "example": "http://example.herokuapp.com/",
+          "example": "https://example.herokuapp.com/",
           "format": "uri",
-          "pattern": "^http://[a-z][a-z0-9-]{3,30}\\.herokuapp\\.com/$",
+          "pattern": "^https?://[a-z][a-z0-9-]{3,30}\\.herokuapp\\.com/$",
           "readOnly": true,
           "type": [
             "string"
+          ]
+        },
+        "acm": {
+          "description": "ACM status of this app",
+          "default": false,
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
           ]
         }
       },
@@ -1593,12 +2597,35 @@
           "title": "List"
         },
         {
+          "description": "List owned and collaborated apps (excludes organization apps).",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "ranges": [
+            "id",
+            "name",
+            "updated_at"
+          ],
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List Owned and Collaborated"
+        },
+        {
           "description": "Update an existing app.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
           "schema": {
             "properties": {
+              "build_stack": {
+                "$ref": "#/definitions/stack/definitions/identity"
+              },
               "maintenance": {
                 "$ref": "#/definitions/app/definitions/maintenance"
               },
@@ -1622,6 +2649,21 @@
         },
         "buildpack_provided_description": {
           "$ref": "#/definitions/app/definitions/buildpack_provided_description"
+        },
+        "build_stack": {
+          "description": "identity of the stack that will be used for new builds",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
         },
         "created_at": {
           "$ref": "#/definitions/app/definitions/created_at"
@@ -1653,6 +2695,21 @@
             "object"
           ]
         },
+        "organization": {
+          "description": "identity of organization",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/organization/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
         "region": {
           "description": "identity of app region",
           "properties": {
@@ -1676,6 +2733,24 @@
         },
         "slug_size": {
           "$ref": "#/definitions/app/definitions/slug_size"
+        },
+        "space": {
+          "description": "identity of space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/space/definitions/name"
+            },
+            "shield": {
+              "$ref": "#/definitions/space/definitions/shield"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
         },
         "stack": {
           "description": "identity of app stack",
@@ -1702,9 +2777,10 @@
     },
     "build-result": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "deactivate_on": "2016-10-01",
       "description": "A build result contains the output from a build.",
       "title": "Heroku Build API - Build Result",
-      "stability": "production",
+      "stability": "deprecation",
       "strictProperties": true,
       "type": [
         "object"
@@ -1784,6 +2860,9 @@
             },
             "status": {
               "$ref": "#/definitions/build/definitions/status"
+            },
+            "output_stream_url": {
+              "$ref": "#/definitions/build/definitions/output_stream_url"
             }
           },
           "type": [
@@ -1800,7 +2879,7 @@
           "items": {
             "$ref": "#/definitions/build-result/definitions/line"
           },
-          "description": "A list of all the lines of a build's output.",
+          "description": "A list of all the lines of a build's output. This has been replaced by the `output_stream_url` attribute on the build resource.",
           "example": [
             {
               "line": "-----> Ruby app detected\n",
@@ -1820,6 +2899,24 @@
         "object"
       ],
       "definitions": {
+        "buildpacks": {
+          "description": "buildpacks executed for this build, in order",
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "description": "Buildpack to execute in a build",
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "url": {
+                "$ref": "#/definitions/buildpack-installation/definitions/url"
+              }
+            }
+          }
+        },
         "created_at": {
           "description": "when build was created",
           "example": "2012-01-01T12:00:00Z",
@@ -1845,9 +2942,52 @@
             }
           ]
         },
+        "output_stream_url": {
+          "description": "Build process output will be available from this URL as a stream. The stream is available as either `text/plain` or `text/event-stream`. Clients should be prepared to handle disconnects and can resume the stream by sending a `Range` header (for `text/plain`) or a `Last-Event-Id` header (for `text/event-stream`).",
+          "example": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "release": {
+          "description": "release resulting from the build",
+          "strictProperties": true,
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/release/definitions/id"
+            }
+          },
+          "example": {
+            "id": "01234567-89ab-cdef-0123-456789abcdef"
+          },
+          "readOnly": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "definitions": {
+            "id": {
+              "description": "unique identifier of release",
+              "example": "01234567-89ab-cdef-0123-456789abcdef",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
         "source_blob": {
           "description": "location of gzipped tarball of source code used to create build",
           "properties": {
+            "checksum": {
+              "description": "an optional checksum of the gzipped tarball for verifying its integrity",
+              "example": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "readOnly": true,
+              "type": [
+                "null",
+                "string"
+              ]
+            },
             "url": {
               "description": "URL where gzipped tar archive of source code for build was downloaded.",
               "example": "https://example.com/source.tgz?token=xyz",
@@ -1905,6 +3045,9 @@
               "object"
             ],
             "properties": {
+              "buildpacks": {
+                "$ref": "#/definitions/build/definitions/buildpacks"
+              },
               "source_blob": {
                 "$ref": "#/definitions/build/definitions/source_blob"
               }
@@ -1949,14 +3092,35 @@
         }
       ],
       "properties": {
+        "app": {
+          "description": "app that the build belongs to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "buildpacks": {
+          "$ref": "#/definitions/build/definitions/buildpacks"
+        },
         "created_at": {
           "$ref": "#/definitions/build/definitions/created_at"
         },
         "id": {
           "$ref": "#/definitions/build/definitions/id"
         },
+        "output_stream_url": {
+          "$ref": "#/definitions/build/definitions/output_stream_url"
+        },
         "source_blob": {
           "$ref": "#/definitions/build/definitions/source_blob"
+        },
+        "release": {
+          "$ref": "#/definitions/build/definitions/release"
         },
         "slug": {
           "description": "slug created by this build",
@@ -1994,11 +3158,140 @@
         }
       }
     },
-    "collaborator": {
-      "description": "A collaborator represents an account that has been given access to an app on Heroku.",
+    "buildpack-installation": {
+      "description": "A buildpack installation represents a buildpack that will be run against an app.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
       "strictProperties": true,
+      "title": "Heroku Platform API - Buildpack Installations",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "ordinal": {
+          "description": "determines the order in which the buildpacks will execute",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "update": {
+          "additionalProperties": false,
+          "description": "Properties to update a buildpack installation",
+          "properties": {
+            "buildpack": {
+              "$ref": "#/definitions/buildpack-installation/definitions/url"
+            }
+          },
+          "readOnly": false,
+          "required": [
+            "buildpack"
+          ],
+          "type": [
+            "object"
+          ]
+        },
+        "url": {
+          "description": "location of the buildpack for the app. Either a url (unofficial buildpacks) or an internal urn (heroku official buildpacks).",
+          "example": "https://github.com/heroku/heroku-buildpack-ruby",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "name": {
+          "description": "either the shorthand name (heroku official buildpacks) or url (unofficial buildpacks) of the buildpack for the app",
+          "example": "heroku/ruby",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Update an app's buildpack installations.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/buildpack-installations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "updates": {
+                "description": "The buildpack attribute can accept a name, a url, or a urn.",
+                "items": {
+                  "$ref": "#/definitions/buildpack-installation/definitions/update"
+                },
+                "type": [
+                  "array"
+                ]
+              }
+            },
+            "required": [
+              "updates"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/buildpack-installation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List an app's existing buildpack installations.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/buildpack-installations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/buildpack-installation"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "ordinal": {
+          "$ref": "#/definitions/buildpack-installation/definitions/ordinal"
+        },
+        "buildpack": {
+          "description": "buildpack",
+          "properties": {
+            "url": {
+              "$ref": "#/definitions/buildpack-installation/definitions/url"
+            },
+            "name": {
+              "$ref": "#/definitions/buildpack-installation/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "collaborator": {
+      "description": "A collaborator represents an account that has been given access to an app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "additionalProperties": false,
+      "required": [
+        "app",
+        "created_at",
+        "id",
+        "updated_at",
+        "user"
+      ],
+      "stability": "production",
       "title": "Heroku Platform API - Collaborator",
       "type": [
         "object"
@@ -2124,11 +3417,37 @@
         }
       ],
       "properties": {
+        "app": {
+          "description": "app collaborator belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
         "created_at": {
           "$ref": "#/definitions/collaborator/definitions/created_at"
         },
         "id": {
           "$ref": "#/definitions/collaborator/definitions/id"
+        },
+        "permissions": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/organization-app-permission"
+          }
+        },
+        "role": {
+          "$ref": "#/definitions/organization/definitions/role"
         },
         "updated_at": {
           "$ref": "#/definitions/collaborator/definitions/updated_at"
@@ -2138,6 +3457,9 @@
           "properties": {
             "email": {
               "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
             },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
@@ -2189,16 +3511,26 @@
           "targetSchema": {
             "$ref": "#/definitions/config-var/definitions/config_vars"
           },
-          "title": "Info"
+          "title": "Info for App"
         },
         {
-          "description": "Update config-vars for app. You can update existing config-vars by setting them again, and remove by setting it to `NULL`.",
+          "description": "Get config-vars for a release.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases/{(%23%2Fdefinitions%2Frelease%2Fdefinitions%2Fidentity)}/config-vars",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/config-var/definitions/config_vars"
+          },
+          "title": "Info for App Release"
+        },
+        {
+          "description": "Update config-vars for app. You can update existing config-vars by setting them again, and remove by setting it to `null`.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/config-vars",
           "method": "PATCH",
           "rel": "update",
           "schema": {
             "additionalProperties": false,
-            "description": "hash of config changes – update values or delete by seting it to NULL",
+            "description": "hash of config changes – update values or delete by seting it to `null`",
             "example": {
               "FOO": "bar",
               "BAZ": "qux"
@@ -2282,7 +3614,11 @@
           ]
         },
         "identity": {
-          "$ref": "#/definitions/credit/definitions/id"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/credit/definitions/id"
+            }
+          ]
         },
         "title": {
           "description": "a name for credit",
@@ -2301,6 +3637,37 @@
         }
       },
       "links": [
+        {
+          "description": "Create a new credit.",
+          "href": "/account/credits",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "code1": {
+                "description": "first code from a discount card",
+                "example": "012abc",
+                "type": [
+                  "string"
+                ]
+              },
+              "code2": {
+                "description": "second code from a discount card",
+                "example": "012abc",
+                "type": [
+                  "string"
+                ]
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/credit"
+          },
+          "title": "Create"
+        },
         {
           "description": "Info for existing credit.",
           "href": "/account/credits/{(%23%2Fdefinitions%2Fcredit%2Fdefinitions%2Fidentity)}",
@@ -2370,9 +3737,27 @@
             "string"
           ]
         },
+        "cname": {
+          "description": "canonical name record, the address to point a domain at",
+          "example": "example.herokudns.com",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "status": {
+          "description": "status of this record's cname",
+          "example": "pending",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "hostname": {
           "description": "full hostname",
           "example": "subdomain.example.com",
+          "format": "uri",
           "readOnly": true,
           "type": [
             "string"
@@ -2395,6 +3780,18 @@
             {
               "$ref": "#/definitions/domain/definitions/hostname"
             }
+          ]
+        },
+        "kind": {
+          "description": "type of domain name",
+          "enum": [
+            "heroku",
+            "custom"
+          ],
+          "example": "custom",
+          "readOnly": true,
+          "type": [
+            "string"
           ]
         },
         "updated_at": {
@@ -2468,6 +3865,23 @@
         }
       ],
       "properties": {
+        "app": {
+          "description": "app that owns the domain",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "cname": {
+          "$ref": "#/definitions/domain/definitions/cname"
+        },
         "created_at": {
           "$ref": "#/definitions/domain/definitions/created_at"
         },
@@ -2477,13 +3891,177 @@
         "id": {
           "$ref": "#/definitions/domain/definitions/id"
         },
+        "kind": {
+          "$ref": "#/definitions/domain/definitions/kind"
+        },
         "updated_at": {
           "$ref": "#/definitions/domain/definitions/updated_at"
+        },
+        "status": {
+          "$ref": "#/definitions/domain/definitions/status"
+        }
+      }
+    },
+    "dyno-size": {
+      "description": "Dyno sizes are the values and details of sizes that can be assigned to dynos. This information can also be found at : [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Dyno Size",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "compute": {
+          "description": "minimum vCPUs, non-dedicated may get more depending on load",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dedicated": {
+          "description": "whether this dyno will be dedicated to one user",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this dyno size",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/dyno-size/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/dyno-size/definitions/name"
+            }
+          ]
+        },
+        "memory": {
+          "description": "amount of RAM in GB",
+          "example": 0.5,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "name": {
+          "description": "the name of this dyno-size",
+          "example": "free",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "cost": {
+          "description": "price information for this dyno size",
+          "readOnly": true,
+          "type": [
+            "null",
+            "object"
+          ],
+          "definitions": {
+            "cents": {
+              "description": "price in cents per unit time",
+              "example": 0,
+              "readOnly": true,
+              "type": [
+                "integer"
+              ]
+            },
+            "unit": {
+              "description": "unit of price for dyno",
+              "readOnly": true,
+              "example": "month",
+              "type": [
+                "string"
+              ]
+            }
+          }
+        },
+        "dyno_units": {
+          "description": "unit of consumption for Heroku Enterprise customers",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "private_space_only": {
+          "description": "whether this dyno can only be provisioned in a private space",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing dyno size.",
+          "href": "/dyno-sizes/{(%23%2Fdefinitions%2Fdyno-size%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/dyno-size"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing dyno sizes.",
+          "href": "/dyno-sizes",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/dyno-size"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "compute": {
+          "$ref": "#/definitions/dyno-size/definitions/compute"
+        },
+        "cost": {
+          "$ref": "#/definitions/dyno-size/definitions/cost"
+        },
+        "dedicated": {
+          "$ref": "#/definitions/dyno-size/definitions/dedicated"
+        },
+        "dyno_units": {
+          "$ref": "#/definitions/dyno-size/definitions/dyno_units"
+        },
+        "id": {
+          "$ref": "#/definitions/dyno-size/definitions/id"
+        },
+        "memory": {
+          "$ref": "#/definitions/dyno-size/definitions/memory"
+        },
+        "name": {
+          "$ref": "#/definitions/dyno-size/definitions/name"
+        },
+        "private_space_only": {
+          "$ref": "#/definitions/dyno-size/definitions/private_space_only"
         }
       }
     },
     "dyno": {
-      "description": "Dynos encapsulate running processes of an app on Heroku.",
+      "description": "Dynos encapsulate running processes of an app on Heroku. Detailed information about dyno sizes can be found at: [https://devcenter.heroku.com/articles/dyno-types](https://devcenter.heroku.com/articles/dyno-types).",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
       "strictProperties": true,
@@ -2573,9 +4151,18 @@
             "string"
           ]
         },
+        "force_no_tty": {
+          "description": "force an attached one-off dyno to not run in a tty",
+          "example": null,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "size": {
-          "description": "dyno size (default: \"1X\")",
-          "example": "1X",
+          "description": "dyno size (default: \"standard-1X\")",
+          "example": "standard-1X",
           "readOnly": false,
           "type": [
             "string"
@@ -2592,9 +4179,17 @@
         "type": {
           "description": "type of process",
           "example": "run",
-          "readOnly": true,
+          "readOnly": false,
           "type": [
             "string"
+          ]
+        },
+        "time_to_live": {
+          "description": "seconds until dyno expires, after which it will soon be killed",
+          "example": 1800,
+          "readOnly": false,
+          "type": [
+            "integer"
           ]
         },
         "updated_at": {
@@ -2624,8 +4219,17 @@
               "env": {
                 "$ref": "#/definitions/dyno/definitions/env"
               },
+              "force_no_tty": {
+                "$ref": "#/definitions/dyno/definitions/force_no_tty"
+              },
               "size": {
                 "$ref": "#/definitions/dyno/definitions/size"
+              },
+              "type": {
+                "$ref": "#/definitions/dyno/definitions/type"
+              },
+              "time_to_live": {
+                "$ref": "#/definitions/dyno/definitions/time_to_live"
               }
             },
             "required": [
@@ -2654,7 +4258,7 @@
           "title": "Restart"
         },
         {
-          "description": "Restart all dynos",
+          "description": "Restart all dynos.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos",
           "method": "DELETE",
           "rel": "empty",
@@ -2665,6 +4269,19 @@
             ]
           },
           "title": "Restart all"
+        },
+        {
+          "description": "Stop dyno.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/dynos/{(%23%2Fdefinitions%2Fdyno%2Fdefinitions%2Fidentity)}/actions/stop",
+          "method": "POST",
+          "rel": "empty",
+          "targetSchema": {
+            "additionalPoperties": false,
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Stop"
         },
         {
           "description": "Info for existing dyno.",
@@ -2723,6 +4340,20 @@
             "object"
           ]
         },
+        "app": {
+          "description": "app formation belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
         "size": {
           "$ref": "#/definitions/dyno/definitions/size"
         },
@@ -2736,6 +4367,429 @@
           "$ref": "#/definitions/dyno/definitions/updated_at"
         }
       }
+    },
+    "event": {
+      "description": "An event represents an action performed on another API resource.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Event",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "action": {
+          "description": "the operation performed on the resource",
+          "enum": [
+            "create",
+            "destroy",
+            "update"
+          ],
+          "example": "create",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when the event was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "data": {
+          "description": "the serialized resource affected by the event",
+          "example": {
+          },
+          "anyOf": [
+            {
+              "$ref": "#/definitions/account"
+            },
+            {
+              "$ref": "#/definitions/add-on"
+            },
+            {
+              "$ref": "#/definitions/add-on-attachment"
+            },
+            {
+              "$ref": "#/definitions/app"
+            },
+            {
+              "$ref": "#/definitions/app-formation-set"
+            },
+            {
+              "$ref": "#/definitions/app-setup"
+            },
+            {
+              "$ref": "#/definitions/app-transfer"
+            },
+            {
+              "$ref": "#/definitions/build"
+            },
+            {
+              "$ref": "#/definitions/collaborator"
+            },
+            {
+              "$ref": "#/definitions/domain"
+            },
+            {
+              "$ref": "#/definitions/dyno"
+            },
+            {
+              "$ref": "#/definitions/failed-event"
+            },
+            {
+              "$ref": "#/definitions/formation"
+            },
+            {
+              "$ref": "#/definitions/inbound-ruleset"
+            },
+            {
+              "$ref": "#/definitions/organization"
+            },
+            {
+              "$ref": "#/definitions/release"
+            },
+            {
+              "$ref": "#/definitions/space"
+            }
+          ],
+          "readOnly": true,
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an event",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/event/definitions/id"
+            }
+          ]
+        },
+        "published_at": {
+          "description": "when the event was published",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "resource": {
+          "description": "the type of resource affected",
+          "enum": [
+            "addon",
+            "addon-attachment",
+            "app",
+            "app-setup",
+            "app-transfer",
+            "build",
+            "collaborator",
+            "domain",
+            "dyno",
+            "failed-event",
+            "formation",
+            "formation-set",
+            "inbound-ruleset",
+            "organization",
+            "release",
+            "space",
+            "user"
+          ],
+          "example": "app",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "sequence": {
+          "description": "a numeric string representing the event's sequence",
+          "example": "1234567890",
+          "pattern": "^[0-9]{1,128}$",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the event was updated (same as created)",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "version": {
+          "description": "the event's API version string",
+          "example": "application/vnd.heroku+json; version=3",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/event/definitions/action"
+        },
+        "actor": {
+          "description": "user that performed the operation",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/event/definitions/created_at"
+        },
+        "data": {
+          "$ref": "#/definitions/event/definitions/data"
+        },
+        "id": {
+          "$ref": "#/definitions/event/definitions/id"
+        },
+        "previous_data": {
+          "description": "data fields that were changed during update with previous values",
+          "type": [
+            "object"
+          ]
+        },
+        "published_at": {
+          "$ref": "#/definitions/event/definitions/published_at"
+        },
+        "resource": {
+          "$ref": "#/definitions/event/definitions/resource"
+        },
+        "sequence": {
+          "$ref": "#/definitions/event/definitions/sequence"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/event/definitions/updated_at"
+        },
+        "version": {
+          "$ref": "#/definitions/event/definitions/version"
+        }
+      }
+    },
+    "failed-event": {
+      "description": "A failed event represents a failure of an action performed on another API resource.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Failed Event",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "action": {
+          "description": "The attempted operation performed on the resource.",
+          "enum": [
+            "create",
+            "destroy",
+            "update",
+            "unknown"
+          ],
+          "example": "create",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "error_id": {
+          "description": "ID of error raised.",
+          "example": "rate_limit",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "message": {
+          "description": "A detailed error message.",
+          "example": "Your account reached the API rate limit\nPlease wait a few minutes before making new requests",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "method": {
+          "description": "The HTTP method type of the failed action.",
+          "enum": [
+            "DELETE",
+            "GET",
+            "HEAD",
+            "OPTIONS",
+            "PATCH",
+            "POST",
+            "PUT"
+          ],
+          "example": "POST",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "code": {
+          "description": "An HTTP status code.",
+          "example": 404,
+          "readOnly": true,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/event/definitions/id"
+            }
+          ]
+        },
+        "path": {
+          "description": "The path of the attempted operation.",
+          "example": "/apps/my-app",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "resource_id": {
+          "description": "Unique identifier of a resource.",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+      ],
+      "properties": {
+        "action": {
+          "$ref": "#/definitions/failed-event/definitions/action"
+        },
+        "code": {
+          "$ref": "#/definitions/failed-event/definitions/code"
+        },
+        "error_id": {
+          "$ref": "#/definitions/failed-event/definitions/error_id"
+        },
+        "message": {
+          "$ref": "#/definitions/failed-event/definitions/message"
+        },
+        "method": {
+          "$ref": "#/definitions/failed-event/definitions/method"
+        },
+        "path": {
+          "$ref": "#/definitions/failed-event/definitions/path"
+        },
+        "resource": {
+          "description": "The related resource of the failed action.",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/failed-event/definitions/resource_id"
+            },
+            "name": {
+              "$ref": "#/definitions/event/definitions/resource"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object",
+            "null"
+          ]
+        }
+      }
+    },
+    "filter-apps": {
+      "description": "Filters are special endpoints to allow for API consumers to specify a subset of resources to consume in order to reduce the number of requests that are performed.  Each filter endpoint endpoint is responsible for determining its supported request format.  The endpoints are over POST in order to handle large request bodies without hitting request uri query length limitations, but the requests themselves are idempotent and will not have side effects.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "title": "Heroku Platform API - Filters",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "filter": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "in": {
+              "$ref": "#/definitions/filter-apps/definitions/in"
+            }
+          }
+        },
+        "in": {
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/filter-apps/definitions/id"
+            }
+          }
+        },
+        "id": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/app/definitions/id"
+          }
+        }
+      },
+      "links": [
+        {
+          "description": "Request an apps list filtered by app id.",
+          "title": "Apps",
+          "href": "/filters/apps",
+          "method": "POST",
+          "ranges": [
+            "id",
+            "name",
+            "updated_at"
+          ],
+          "rel": "instances",
+          "schema": {
+            "$ref": "#/definitions/filter-apps/definitions/filter"
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-app"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        }
+      ]
     },
     "formation": {
       "description": "The formation of processes that should be maintained for an app. Update the formation to scale processes or change dyno sizes. Available process type names and commands are defined by the `process_types` attribute for the [slug](#slug) currently released on an app.",
@@ -2792,8 +4846,8 @@
           ]
         },
         "size": {
-          "description": "dyno size (default: \"1X\")",
-          "example": "1X",
+          "description": "dyno size (default: \"standard-1X\")",
+          "example": "standard-1X",
           "readOnly": false,
           "type": [
             "string"
@@ -2803,6 +4857,7 @@
           "description": "type of process to maintain",
           "example": "web",
           "readOnly": true,
+          "pattern": "^[-\\w]{1,128}$",
           "type": [
             "string"
           ]
@@ -2820,19 +4875,19 @@
           "additionalProperties": false,
           "description": "Properties to update a process type",
           "properties": {
-            "process": {
-              "$ref": "#/definitions/formation/definitions/identity"
-            },
             "quantity": {
               "$ref": "#/definitions/formation/definitions/quantity"
             },
             "size": {
               "$ref": "#/definitions/formation/definitions/size"
+            },
+            "type": {
+              "$ref": "#/definitions/formation/definitions/type"
             }
           },
           "readOnly": false,
           "required": [
-            "process"
+            "type"
           ],
           "type": [
             "object"
@@ -2879,14 +4934,7 @@
                 "items": {
                   "$ref": "#/definitions/formation/definitions/update"
                 },
-                "description": "Array with formation updates. Each element must have \"process\", the id or name of the process type to be updated, and can optionally update its \"quantity\" or \"size\".",
-                "example": [
-                  {
-                    "process": "web",
-                    "quantity": 1,
-                    "size": "2X"
-                  }
-                ]
+                "description": "Array with formation updates. Each element must have \"type\", the id or name of the process type to be updated, and can optionally update its \"quantity\" or \"size\"."
               }
             },
             "required": [
@@ -2934,6 +4982,20 @@
         }
       ],
       "properties": {
+        "app": {
+          "description": "app formation belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
         "command": {
           "$ref": "#/definitions/formation/definitions/command"
         },
@@ -2954,6 +5016,880 @@
         },
         "updated_at": {
           "$ref": "#/definitions/formation/definitions/updated_at"
+        }
+      }
+    },
+    "identity-provider": {
+      "description": "Identity Providers represent the SAML configuration of an Organization.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Identity Provider",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "certificate": {
+          "description": "raw contents of the public certificate (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when provider record was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "entity_id": {
+          "description": "URL identifier provided by the identity provider",
+          "example": "https://customer-domain.idp.com",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this identity provider",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "slo_target_url": {
+          "description": "single log out URL for this identity provider",
+          "example": "https://example.com/idp/logout",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "sso_target_url": {
+          "description": "single sign on URL for this identity provider",
+          "example": "https://example.com/idp/login",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the identity provider record was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of an organization's Identity Providers",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/identity-provider"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create an Identity Provider for an organization",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "required": [
+              "certificate",
+              "sso_target_url",
+              "entity_id"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update an organization's Identity Provider",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete an organization's Identity Provider",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "certificate": {
+          "$ref": "#/definitions/identity-provider/definitions/certificate"
+        },
+        "created_at": {
+          "$ref": "#/definitions/identity-provider/definitions/created_at"
+        },
+        "entity_id": {
+          "$ref": "#/definitions/identity-provider/definitions/entity_id"
+        },
+        "id": {
+          "$ref": "#/definitions/identity-provider/definitions/id"
+        },
+        "slo_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+        },
+        "sso_target_url": {
+          "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+        },
+        "organization": {
+          "description": "organization associated with this identity provider",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/identity-provider/definitions/updated_at"
+        }
+      }
+    },
+    "inbound-ruleset": {
+      "description": "An inbound-ruleset is a collection of rules that specify what hosts can or cannot connect to an application.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Inbound Ruleset",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "action": {
+          "description": "states whether the connection is allowed or denied",
+          "example": "allow",
+          "readOnly": false,
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "allow",
+            "deny"
+          ]
+        },
+        "source": {
+          "description": "is the request’s source in CIDR notation",
+          "example": "1.1.1.1/1",
+          "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when inbound-ruleset was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an inbound-ruleset",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/inbound-ruleset/definitions/id"
+            }
+          ]
+        },
+        "rule": {
+          "description": "the combination of an IP address in CIDR notation and whether to allow or deny it's traffic.",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "action": {
+              "$ref": "#/definitions/inbound-ruleset/definitions/action"
+            },
+            "source": {
+              "$ref": "#/definitions/inbound-ruleset/definitions/source"
+            }
+          },
+          "required": [
+            "source",
+            "action"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Current inbound ruleset for a space",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-ruleset",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/inbound-ruleset"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Info on an existing Inbound Ruleset",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-rulesets/{(%23%2Fdefinitions%2Finbound-ruleset%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/inbound-ruleset"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all inbound rulesets for a space",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-rulesets",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/inbound-ruleset"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create a new inbound ruleset",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/inbound-ruleset",
+          "method": "PUT",
+          "rel": "create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "rules": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/inbound-ruleset/definitions/rule"
+                }
+              }
+            }
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/inbound-ruleset/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/inbound-ruleset/definitions/created_at"
+        },
+        "rules": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/inbound-ruleset/definitions/rule"
+          }
+        },
+        "created_by": {
+          "$ref": "#/definitions/account/definitions/email"
+        }
+      }
+    },
+    "invitation": {
+      "description": "An invitation represents an invite sent to a user to use the Heroku platform.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Invitation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when invitation was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/invitation/definitions/token"
+            }
+          ]
+        },
+        "receive_newsletter": {
+          "description": "whether this user should receive a newsletter or not",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "verification_required": {
+          "description": "if the invitation requires verification",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "token": {
+          "description": "Unique identifier of an invitation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "phone_number": {
+          "description": "Phone number to send verification code",
+          "example": "+1 123-123-1234",
+          "type": [
+            "string"
+          ]
+        },
+        "method": {
+          "description": "Transport used to send verification code",
+          "example": "sms",
+          "default": "sms",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "call",
+            "sms"
+          ]
+        },
+        "verification_code": {
+          "description": "Value used to verify invitation",
+          "example": "123456",
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for invitation.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "Invite a user.",
+          "href": "/invitations",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "name": {
+                "$ref": "#/definitions/account/definitions/name"
+              }
+            },
+            "required": [
+              "email",
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Send a verification code for an invitation via SMS/phone call.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/send-verification",
+          "method": "POST",
+          "rel": "empty",
+          "schema": {
+            "properties": {
+              "phone_number": {
+                "$ref": "#/definitions/invitation/definitions/phone_number"
+              },
+              "method": {
+                "$ref": "#/definitions/invitation/definitions/method"
+              }
+            },
+            "required": [
+              "phone_number"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Send Verification Code"
+        },
+        {
+          "description": "Verify an invitation using a verification code.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}/actions/verify",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "verification_code": {
+                "$ref": "#/definitions/invitation/definitions/verification_code"
+              }
+            },
+            "required": [
+              "verification_code"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Verify"
+        },
+        {
+          "description": "Finalize Invitation and Create Account.",
+          "href": "/invitations/{(%23%2Fdefinitions%2Finvitation%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "password": {
+                "$ref": "#/definitions/account/definitions/password"
+              },
+              "password_confirmation": {
+                "$ref": "#/definitions/account/definitions/password"
+              },
+              "receive_newsletter": {
+                "$ref": "#/definitions/invitation/definitions/receive_newsletter"
+              }
+            },
+            "required": [
+              "password",
+              "password_confirmation"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Finalize"
+        }
+      ],
+      "properties": {
+        "verification_required": {
+          "$ref": "#/definitions/invitation/definitions/verification_required"
+        },
+        "created_at": {
+          "$ref": "#/definitions/invitation/definitions/created_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "invoice-address": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An invoice address represents the address that should be listed on an invoice.",
+      "title": "Heroku Vault API - Invoice Address",
+      "stability": "development",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "address_1": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice street address line 1",
+          "example": "40 Hickory Blvd."
+        },
+        "address_2": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice street address line 2",
+          "example": "Suite 300"
+        },
+        "city": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice city",
+          "example": "Seattle"
+        },
+        "country": {
+          "type": [
+            "string"
+          ],
+          "description": "country",
+          "example": "US"
+        },
+        "heroku_id": {
+          "type": [
+            "string"
+          ],
+          "description": "heroku_id identifier reference",
+          "example": "user930223902@heroku.com",
+          "readOnly": true
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/invoice-address/definitions/heroku_id"
+            }
+          ]
+        },
+        "other": {
+          "type": [
+            "string"
+          ],
+          "description": "metadata / additional information to go on invoice",
+          "example": "Company ABC Inc. VAT 903820"
+        },
+        "postal_code": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice zip code",
+          "example": "98101"
+        },
+        "state": {
+          "type": [
+            "string"
+          ],
+          "description": "invoice state",
+          "example": "WA"
+        },
+        "use_invoice_address": {
+          "type": [
+            "boolean"
+          ],
+          "description": "flag to use the invoice address for an account or not",
+          "example": true,
+          "default": false
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve existing invoice address.",
+          "href": "/account/invoice-address",
+          "method": "GET",
+          "rel": "self",
+          "title": "info"
+        },
+        {
+          "description": "Update invoice address for an account.",
+          "href": "/account/invoice-address",
+          "method": "PUT",
+          "rel": "self",
+          "title": "update",
+          "schema": {
+            "properties": {
+              "address_1": {
+                "$ref": "#/definitions/invoice-address/definitions/address_1"
+              },
+              "address_2": {
+                "$ref": "#/definitions/invoice-address/definitions/address_2"
+              },
+              "city": {
+                "$ref": "#/definitions/invoice-address/definitions/city"
+              },
+              "country": {
+                "$ref": "#/definitions/invoice-address/definitions/country"
+              },
+              "other": {
+                "$ref": "#/definitions/invoice-address/definitions/other"
+              },
+              "postal_code": {
+                "$ref": "#/definitions/invoice-address/definitions/postal_code"
+              },
+              "state": {
+                "$ref": "#/definitions/invoice-address/definitions/state"
+              },
+              "use_invoice_address": {
+                "$ref": "#/definitions/invoice-address/definitions/use_invoice_address"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          }
+        }
+      ],
+      "properties": {
+        "address_1": {
+          "$ref": "#/definitions/invoice-address/definitions/address_1"
+        },
+        "address_2": {
+          "$ref": "#/definitions/invoice-address/definitions/address_2"
+        },
+        "city": {
+          "$ref": "#/definitions/invoice-address/definitions/city"
+        },
+        "country": {
+          "$ref": "#/definitions/invoice-address/definitions/country"
+        },
+        "heroku_id": {
+          "$ref": "#/definitions/invoice-address/definitions/identity"
+        },
+        "other": {
+          "$ref": "#/definitions/invoice-address/definitions/other"
+        },
+        "postal_code": {
+          "$ref": "#/definitions/invoice-address/definitions/postal_code"
+        },
+        "state": {
+          "$ref": "#/definitions/invoice-address/definitions/state"
+        },
+        "use_invoice_address": {
+          "$ref": "#/definitions/invoice-address/definitions/use_invoice_address"
+        }
+      }
+    },
+    "invoice": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An invoice is an itemized bill of goods for an account which includes pricing and charges.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Invoice",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "charges_total": {
+          "description": "total charges on this invoice",
+          "example": 100.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "created_at": {
+          "description": "when invoice was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credits_total": {
+          "description": "total credits on this invoice",
+          "example": 100.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this invoice",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/invoice/definitions/number"
+            }
+          ]
+        },
+        "number": {
+          "description": "human readable invoice number",
+          "example": 9403943,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "period_end": {
+          "description": "the ending date that the invoice covers",
+          "example": "01/31/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "period_start": {
+          "description": "the starting date that this invoice covers",
+          "example": "01/01/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "payment status for this invoice (pending, successful, failed)",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "total": {
+          "description": "combined total of charges and credits on this invoice",
+          "example": 100.0,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "updated_at": {
+          "description": "when invoice was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing invoice.",
+          "href": "/account/invoices/{(%23%2Fdefinitions%2Finvoice%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/invoice"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing invoices.",
+          "href": "/account/invoices",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/invoice"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "charges_total": {
+          "$ref": "#/definitions/invoice/definitions/charges_total"
+        },
+        "created_at": {
+          "$ref": "#/definitions/invoice/definitions/created_at"
+        },
+        "credits_total": {
+          "$ref": "#/definitions/invoice/definitions/credits_total"
+        },
+        "id": {
+          "$ref": "#/definitions/invoice/definitions/id"
+        },
+        "number": {
+          "$ref": "#/definitions/invoice/definitions/number"
+        },
+        "period_end": {
+          "$ref": "#/definitions/invoice/definitions/period_end"
+        },
+        "period_start": {
+          "$ref": "#/definitions/invoice/definitions/period_start"
+        },
+        "state": {
+          "$ref": "#/definitions/invoice/definitions/state"
+        },
+        "total": {
+          "$ref": "#/definitions/invoice/definitions/total"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/invoice/definitions/updated_at"
         }
       }
     },
@@ -3040,50 +5976,12 @@
       },
       "links": [
         {
-          "description": "Create a new key.",
-          "href": "/account/keys",
-          "method": "POST",
-          "rel": "create",
-          "schema": {
-            "properties": {
-              "public_key": {
-                "$ref": "#/definitions/key/definitions/public_key"
-              }
-            },
-            "required": [
-              "public_key"
-            ],
-            "type": [
-              "object"
-            ]
-          },
-          "targetSchema": {
-            "$ref": "#/definitions/key"
-          },
-          "title": "Create"
-        },
-        {
-          "description": "Delete an existing key",
-          "href": "/account/keys/{(%23%2Fdefinitions%2Fkey%2Fdefinitions%2Fidentity)}",
-          "method": "DELETE",
-          "rel": "destroy",
-          "targetSchema": {
-            "$ref": "#/definitions/key"
-          },
-          "title": "Delete"
-        },
-        {
           "description": "Info for existing key.",
           "href": "/account/keys/{(%23%2Fdefinitions%2Fkey%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/key"
-            },
-            "type": [
-              "array"
-            ]
+            "$ref": "#/definitions/key"
           },
           "title": "Info"
         },
@@ -3092,6 +5990,14 @@
           "href": "/account/keys",
           "method": "GET",
           "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/key"
+            },
+            "type": [
+              "array"
+            ]
+          },
           "title": "List"
         }
       ],
@@ -3120,7 +6026,7 @@
       }
     },
     "log-drain": {
-      "description": "[Log drains](https://devcenter.heroku.com/articles/logging#syslog-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some addons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.",
+      "description": "[Log drains](https://devcenter.heroku.com/articles/log-drains) provide a way to forward your Heroku logs to an external syslog server for long-term archiving. This external service must be configured to receive syslog packets from Heroku, whereupon its URL can be added to an app using this API. Some add-ons will add a log drain when they are provisioned to an app. These drains can only be removed by removing the add-on.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "production",
       "strictProperties": true,
@@ -3130,11 +6036,17 @@
       ],
       "definitions": {
         "addon": {
-          "description": "addon that created the drain",
-          "example": "example",
+          "description": "add-on that created the drain",
+          "example": {
+            "id": "01234567-89ab-cdef-0123-456789abcdef",
+            "name": "singing-swiftly-1242"
+          },
           "properties": {
             "id": {
-              "$ref": "#/definitions/addon/definitions/id"
+              "$ref": "#/definitions/add-on/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on/definitions/name"
             }
           },
           "readOnly": true,
@@ -3161,11 +6073,21 @@
             "string"
           ]
         },
-        "identity": {
+        "query_identity": {
           "anyOf": [
             {
               "$ref": "#/definitions/log-drain/definitions/id"
             },
+            {
+              "$ref": "#/definitions/log-drain/definitions/url"
+            },
+            {
+              "$ref": "#/definitions/log-drain/definitions/token"
+            }
+          ]
+        },
+        "identity": {
+          "anyOf": [
             {
               "$ref": "#/definitions/log-drain/definitions/url"
             }
@@ -3223,7 +6145,7 @@
         },
         {
           "description": "Delete an existing log drain. Log drains added by add-ons can only be removed by removing the add-on.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fquery_identity)}",
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
@@ -3233,7 +6155,7 @@
         },
         {
           "description": "Info for existing log drain.",
-          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fidentity)}",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/log-drains/{(%23%2Fdefinitions%2Flog-drain%2Fdefinitions%2Fquery_identity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
@@ -3544,6 +6466,16 @@
             ]
           },
           "title": "List"
+        },
+        {
+          "description": "Regenerate OAuth tokens. This endpoint is only available to direct authorizations or privileged OAuth clients.",
+          "href": "/oauth/authorizations/{(%23%2Fdefinitions%2Foauth-authorization%2Fdefinitions%2Fidentity)}/actions/regenerate-tokens",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-authorization"
+          },
+          "title": "Regenerate"
         }
       ],
       "properties": {
@@ -3632,6 +6564,24 @@
         },
         "updated_at": {
           "$ref": "#/definitions/oauth-authorization/definitions/updated_at"
+        },
+        "user": {
+          "description": "authenticated user associated with this authorization",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "full_name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
         }
       }
     },
@@ -3795,6 +6745,16 @@
             "$ref": "#/definitions/oauth-client"
           },
           "title": "Update"
+        },
+        {
+          "description": "Rotate credentials for an OAuth client",
+          "href": "/oauth/clients/{(%23%2Fdefinitions%2Foauth-client%2Fdefinitions%2Fidentity)}/actions/rotate-credentials",
+          "method": "POST",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-client"
+          },
+          "title": "Rotate Credentials"
         }
       ],
       "properties": {
@@ -3994,6 +6954,16 @@
             "$ref": "#/definitions/oauth-token"
           },
           "title": "Create"
+        },
+        {
+          "description": "Revoke OAuth access token.",
+          "href": "/oauth/tokens/{(%23%2Fdefinitions%2Foauth-token%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/oauth-token"
+          },
+          "title": "Delete"
         }
       ],
       "properties": {
@@ -4108,11 +7078,36 @@
         }
       }
     },
+    "organization-add-on": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A list of add-ons the Organization uses across all apps",
+      "stability": "production",
+      "title": "Heroku Platform API - Organization Add-on",
+      "type": [
+        "object"
+      ],
+      "links": [
+        {
+          "description": "List add-ons used across all Organization apps",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List For Organization"
+        }
+      ]
+    },
     "organization-app-collaborator": {
       "description": "An organization collaborator represents an account that has been given access to an organization app on Heroku.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
-      "strictProperties": true,
       "title": "Heroku Platform API - Organization App Collaborator",
       "type": [
         "object"
@@ -4128,7 +7123,7 @@
       },
       "links": [
         {
-          "description": "Create a new collaborator on an organization app. Use this endpoint instead of the `/apps/{app_id_or_name}/collaborator` endpoint when you want the collaborator to be granted [privileges] (https://devcenter.heroku.com/articles/org-users-access#roles) according to their role in the organization.",
+          "description": "Create a new collaborator on an organization app. Use this endpoint instead of the `/apps/{app_id_or_name}/collaborator` endpoint when you want the collaborator to be granted [permissions] (https://devcenter.heroku.com/articles/org-users-access#roles-and-app-permissions) according to their role in the organization.",
           "href": "/organizations/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators",
           "method": "POST",
           "rel": "create",
@@ -4149,7 +7144,7 @@
             ]
           },
           "targetSchema": {
-            "$ref": "#/definitions/collaborator"
+            "$ref": "#/definitions/organization-app-collaborator"
           },
           "title": "Create"
         },
@@ -4159,7 +7154,7 @@
           "method": "DELETE",
           "rel": "destroy",
           "targetSchema": {
-            "$ref": "#/definitions/collaborator"
+            "$ref": "#/definitions/organization-app-collaborator"
           },
           "title": "Delete"
         },
@@ -4169,9 +7164,19 @@
           "method": "GET",
           "rel": "self",
           "targetSchema": {
-            "$ref": "#/definitions/collaborator"
+            "$ref": "#/definitions/organization-app-collaborator"
           },
           "title": "Info"
+        },
+        {
+          "description": "Update an existing collaborator from an organization app.",
+          "href": "/organizations/apps/{(%23%2Fdefinitions%2Forganization-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Forganization-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-app-collaborator"
+          },
+          "title": "Update"
         },
         {
           "description": "List collaborators on an organization app.",
@@ -4180,7 +7185,7 @@
           "rel": "instances",
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/collaborator"
+              "$ref": "#/definitions/organization-app-collaborator"
             },
             "type": [
               "array"
@@ -4190,6 +7195,21 @@
         }
       ],
       "properties": {
+        "app": {
+          "description": "app collaborator belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
         "created_at": {
           "$ref": "#/definitions/collaborator/definitions/created_at"
         },
@@ -4207,6 +7227,9 @@
           "properties": {
             "email": {
               "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
             },
             "id": {
               "$ref": "#/definitions/account/definitions/id"
@@ -4282,6 +7305,9 @@
               },
               "region": {
                 "$ref": "#/definitions/region/definitions/name"
+              },
+              "space": {
+                "$ref": "#/definitions/space/definitions/name"
               },
               "stack": {
                 "$ref": "#/definitions/stack/definitions/name"
@@ -4475,6 +7501,21 @@
         "slug_size": {
           "$ref": "#/definitions/app/definitions/slug_size"
         },
+        "space": {
+          "description": "identity of space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/space/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
         "stack": {
           "description": "identity of app stack",
           "properties": {
@@ -4497,18 +7538,577 @@
         }
       }
     },
+    "organization-feature": {
+      "description": "An organization feature represents a feature enabled on an organization account.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when organization feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of organization feature",
+          "example": "Causes account to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of organization feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not account feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of organization feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/organization-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of organization feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of organization feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when organization feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing account feature.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Forganization-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing organization features.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/account-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/account-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/account-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/account-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/account-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/account-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/account-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/account-feature/definitions/updated_at"
+        }
+      }
+    },
+    "organization-invitation": {
+      "description": "An organization invitation represents an invite to an organization.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Invitation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when invitation was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-invitation/definitions/id"
+            }
+          ]
+        },
+        "id": {
+          "description": "Unique identifier of an invitation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "token": {
+          "description": "Special token for invitation",
+          "example": "614ae25aa2d4802096cd7c18625b526c",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when invitation was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of an organization's Identity Providers",
+          "title": "List",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fname)}/invitations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-invitation"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        },
+        {
+          "description": "Create Organization Invitation",
+          "title": "Create",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invitations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          }
+        },
+        {
+          "description": "Revoke an organization invitation.",
+          "title": "Revoke",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "self"
+        },
+        {
+          "description": "Get an invitation by its token",
+          "title": "Get",
+          "href": "/organizations/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Ftoken)}",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-invitation"
+          }
+        },
+        {
+          "description": "Accept Organization Invitation",
+          "title": "Accept",
+          "href": "/organizations/invitations/{(%23%2Fdefinitions%2Forganization-invitation%2Fdefinitions%2Ftoken)}/accept",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          }
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/organization-invitation/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/organization-invitation/definitions/id"
+        },
+        "invited_by": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "organization": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/organization/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "role": {
+          "$ref": "#/definitions/organization/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/organization-invitation/definitions/updated_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "organization-invoice": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Invoice",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons_total": {
+          "description": "total add-ons charges in on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "database_total": {
+          "description": "total database charges on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "charges_total": {
+          "description": "total charges on this invoice",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "created_at": {
+          "description": "when invoice was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credits_total": {
+          "description": "total credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dyno_units": {
+          "description": "The total amount of dyno units consumed across dyno types.",
+          "example": 1.92,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this invoice",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-invoice/definitions/number"
+            }
+          ]
+        },
+        "number": {
+          "description": "human readable invoice number",
+          "example": 9403943,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "payment_status": {
+          "description": "Status of the invoice payment.",
+          "example": "Paid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "platform_total": {
+          "description": "total platform charges on this invoice",
+          "example": 50000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "period_end": {
+          "description": "the ending date that the invoice covers",
+          "example": "01/31/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "period_start": {
+          "description": "the starting date that this invoice covers",
+          "example": "01/01/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "payment status for this invoice (pending, successful, failed)",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "total": {
+          "description": "combined total of charges and credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "updated_at": {
+          "description": "when invoice was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "weighted_dyno_hours": {
+          "description": "The total amount of hours consumed across dyno types.",
+          "example": 1488,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing invoice.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invoices/{(%23%2Fdefinitions%2Forganization-invoice%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-invoice"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing invoices.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/invoices",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-invoice"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "addons_total": {
+          "$ref": "#/definitions/organization-invoice/definitions/addons_total"
+        },
+        "database_total": {
+          "$ref": "#/definitions/organization-invoice/definitions/database_total"
+        },
+        "charges_total": {
+          "$ref": "#/definitions/organization-invoice/definitions/charges_total"
+        },
+        "created_at": {
+          "$ref": "#/definitions/organization-invoice/definitions/created_at"
+        },
+        "credits_total": {
+          "$ref": "#/definitions/organization-invoice/definitions/credits_total"
+        },
+        "dyno_units": {
+          "$ref": "#/definitions/organization-invoice/definitions/dyno_units"
+        },
+        "id": {
+          "$ref": "#/definitions/organization-invoice/definitions/id"
+        },
+        "number": {
+          "$ref": "#/definitions/organization-invoice/definitions/number"
+        },
+        "payment_status": {
+          "$ref": "#/definitions/organization-invoice/definitions/payment_status"
+        },
+        "period_end": {
+          "$ref": "#/definitions/organization-invoice/definitions/period_end"
+        },
+        "period_start": {
+          "$ref": "#/definitions/organization-invoice/definitions/period_start"
+        },
+        "platform_total": {
+          "$ref": "#/definitions/organization-invoice/definitions/platform_total"
+        },
+        "state": {
+          "$ref": "#/definitions/organization-invoice/definitions/state"
+        },
+        "total": {
+          "$ref": "#/definitions/organization-invoice/definitions/total"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/organization-invoice/definitions/updated_at"
+        },
+        "weighted_dyno_hours": {
+          "$ref": "#/definitions/organization-invoice/definitions/weighted_dyno_hours"
+        }
+      }
+    },
     "organization-member": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "description": "An organization member is an individual with access to an organization.",
       "stability": "prototype",
-      "strictProperties": true,
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "email",
+        "federated",
+        "updated_at"
+      ],
       "title": "Heroku Platform API - Organization Member",
       "type": [
         "object"
       ],
       "definitions": {
         "created_at": {
-          "description": "when organization-member was created",
+          "description": "when the membership record was created",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -4524,15 +8124,52 @@
             "string"
           ]
         },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of organization member",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "identity": {
           "anyOf": [
             {
               "$ref": "#/definitions/organization-member/definitions/email"
+            },
+            {
+              "$ref": "#/definitions/organization-member/definitions/id"
             }
           ]
         },
+        "name": {
+          "description": "full name of the organization member",
+          "example": "Tina Edmonds",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "two_factor_authentication": {
+          "description": "whether the Enterprise organization member has two factor authentication enabled",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
         "updated_at": {
-          "description": "when organization-member was updated",
+          "description": "when the membership record was updated",
           "example": "2012-01-01T12:00:00Z",
           "format": "date-time",
           "readOnly": true,
@@ -4552,6 +8189,9 @@
               "email": {
                 "$ref": "#/definitions/organization-member/definitions/email"
               },
+              "federated": {
+                "$ref": "#/definitions/organization-member/definitions/federated"
+              },
               "role": {
                 "$ref": "#/definitions/organization/definitions/role"
               }
@@ -4570,6 +8210,66 @@
           "title": "Create or Update"
         },
         {
+          "description": "Create a new organization member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/organization-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/organization-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update an organization member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/organization-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/organization-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/organization/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-member"
+          },
+          "title": "update"
+        },
+        {
           "description": "Remove a member from the organization.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Forganization-member%2Fdefinitions%2Fidentity)}",
           "method": "DELETE",
@@ -4583,10 +8283,28 @@
           "description": "List members of the organization.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members",
           "method": "GET",
+          "ranges": [
+            "email"
+          ],
           "rel": "instances",
           "targetSchema": {
             "items": {
               "$ref": "#/definitions/organization-member"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List the apps of a member.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Forganization-member%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-app"
             },
             "type": [
               "array"
@@ -4602,11 +8320,117 @@
         "email": {
           "$ref": "#/definitions/organization-member/definitions/email"
         },
+        "federated": {
+          "$ref": "#/definitions/organization-member/definitions/federated"
+        },
+        "id": {
+          "$ref": "#/definitions/organization-member/definitions/id"
+        },
         "role": {
           "$ref": "#/definitions/organization/definitions/role"
         },
+        "two_factor_authentication": {
+          "$ref": "#/definitions/organization-member/definitions/two_factor_authentication"
+        },
         "updated_at": {
           "$ref": "#/definitions/organization-member/definitions/updated_at"
+        },
+        "user": {
+          "description": "user information for the membership",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "organization-preferences": {
+      "description": "Tracks an organization's preferences",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Organization Preferences",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "default-permission": {
+          "description": "The default permission used when adding new members to the organization",
+          "example": "member",
+          "readOnly": false,
+          "enum": [
+            "admin",
+            "member",
+            "viewer",
+            null
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/organization/definitions/identity"
+        },
+        "whitelisting-enabled": {
+          "description": "Whether whitelisting rules should be applied to add-on installations",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve Organization Preferences",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/organization-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update Organization Preferences",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "whitelisting-enabled": {
+                "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "default-permission": {
+          "$ref": "#/definitions/organization-preferences/definitions/default-permission"
+        },
+        "whitelisting-enabled": {
+          "$ref": "#/definitions/organization-preferences/definitions/whitelisting-enabled"
         }
       }
     },
@@ -4620,9 +8444,18 @@
         "object"
       ],
       "definitions": {
+        "created_at": {
+          "description": "when the organization was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "credit_card_collections": {
           "description": "whether charges incurred by the org are paid by credit card.",
-          "example": "true",
+          "example": true,
           "readOnly": true,
           "type": [
             "boolean"
@@ -4630,17 +8463,129 @@
         },
         "default": {
           "description": "whether to use this organization when none is specified",
-          "example": "true",
+          "example": true,
           "readOnly": false,
           "type": [
             "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of organization",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
           ]
         },
         "identity": {
           "anyOf": [
             {
               "$ref": "#/definitions/organization/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/organization/definitions/id"
             }
+          ]
+        },
+        "address_1": {
+          "type": [
+            "string"
+          ],
+          "description": "street address line 1",
+          "example": "40 Hickory Lane"
+        },
+        "address_2": {
+          "type": [
+            "string"
+          ],
+          "description": "street address line 2",
+          "example": "Suite 103"
+        },
+        "card_number": {
+          "type": [
+            "string"
+          ],
+          "description": "encrypted card number of payment method",
+          "example": "encrypted-card-number"
+        },
+        "city": {
+          "type": [
+            "string"
+          ],
+          "description": "city",
+          "example": "San Francisco"
+        },
+        "country": {
+          "type": [
+            "string"
+          ],
+          "description": "country",
+          "example": "US"
+        },
+        "cvv": {
+          "type": [
+            "string"
+          ],
+          "description": "card verification value",
+          "example": "123"
+        },
+        "expiration_month": {
+          "type": [
+            "string"
+          ],
+          "description": "expiration month",
+          "example": "11"
+        },
+        "expiration_year": {
+          "type": [
+            "string"
+          ],
+          "description": "expiration year",
+          "example": "2014"
+        },
+        "first_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the first name for payment method",
+          "example": "Jason"
+        },
+        "last_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the last name for payment method",
+          "example": "Walker"
+        },
+        "other": {
+          "type": [
+            "string"
+          ],
+          "description": "metadata",
+          "example": "Additional information for payment method"
+        },
+        "postal_code": {
+          "type": [
+            "string"
+          ],
+          "description": "postal code",
+          "example": "90210"
+        },
+        "state": {
+          "type": [
+            "string"
+          ],
+          "description": "state",
+          "example": "CA"
+        },
+        "membership_limit": {
+          "description": "upper limit of members allowed in an organization.",
+          "example": 25,
+          "readOnly": true,
+          "type": [
+            "number",
+            "null"
           ]
         },
         "name": {
@@ -4653,7 +8598,7 @@
         },
         "provisioned_licenses": {
           "description": "whether the org is provisioned licenses by salesforce.",
-          "example": "true",
+          "example": true,
           "readOnly": true,
           "type": [
             "boolean"
@@ -4663,10 +8608,34 @@
           "description": "role in the organization",
           "enum": [
             "admin",
+            "collaborator",
             "member",
-            "collaborator"
+            "owner",
+            null
           ],
           "example": "admin",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "type": {
+          "description": "type of organization.",
+          "example": "team",
+          "enum": [
+            "enterprise",
+            "team"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the organization was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
           "readOnly": true,
           "type": [
             "string"
@@ -4690,7 +8659,14 @@
           "title": "List"
         },
         {
-          "description": "Set or unset the organization as your default organization.",
+          "description": "Info for an organization.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "Update organization properties.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
@@ -4698,6 +8674,9 @@
             "properties": {
               "default": {
                 "$ref": "#/definitions/organization/definitions/default"
+              },
+              "name": {
+                "$ref": "#/definitions/organization/definitions/name"
               }
             },
             "type": [
@@ -4708,14 +8687,95 @@
             "$ref": "#/definitions/organization"
           },
           "title": "Update"
+        },
+        {
+          "description": "Create a new organization.",
+          "href": "/organizations",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/organization/definitions/name"
+              },
+              "address_1": {
+                "$ref": "#/definitions/organization/definitions/address_1"
+              },
+              "address_2": {
+                "$ref": "#/definitions/organization/definitions/address_2"
+              },
+              "card_number": {
+                "$ref": "#/definitions/organization/definitions/card_number"
+              },
+              "city": {
+                "$ref": "#/definitions/organization/definitions/city"
+              },
+              "country": {
+                "$ref": "#/definitions/organization/definitions/country"
+              },
+              "cvv": {
+                "$ref": "#/definitions/organization/definitions/cvv"
+              },
+              "expiration_month": {
+                "$ref": "#/definitions/organization/definitions/expiration_month"
+              },
+              "expiration_year": {
+                "$ref": "#/definitions/organization/definitions/expiration_year"
+              },
+              "first_name": {
+                "$ref": "#/definitions/organization/definitions/first_name"
+              },
+              "last_name": {
+                "$ref": "#/definitions/organization/definitions/last_name"
+              },
+              "other": {
+                "$ref": "#/definitions/organization/definitions/other"
+              },
+              "postal_code": {
+                "$ref": "#/definitions/organization/definitions/postal_code"
+              },
+              "state": {
+                "$ref": "#/definitions/organization/definitions/state"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing organization.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/organization"
+          },
+          "title": "Delete"
         }
       ],
       "properties": {
+        "id": {
+          "$ref": "#/definitions/organization/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/organization/definitions/created_at"
+        },
         "credit_card_collections": {
           "$ref": "#/definitions/organization/definitions/credit_card_collections"
         },
         "default": {
           "$ref": "#/definitions/organization/definitions/default"
+        },
+        "membership_limit": {
+          "$ref": "#/definitions/organization/definitions/membership_limit"
         },
         "name": {
           "$ref": "#/definitions/organization/definitions/name"
@@ -4725,6 +8785,1017 @@
         },
         "role": {
           "$ref": "#/definitions/organization/definitions/role"
+        },
+        "type": {
+          "$ref": "#/definitions/organization/definitions/type"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/organization/definitions/updated_at"
+        }
+      }
+    },
+    "outbound-ruleset": {
+      "description": "An outbound-ruleset is a collection of rules that specify what hosts Dynos are allowed to communicate with. ",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Outbound Ruleset",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "target": {
+          "description": "is the target destination in CIDR notation",
+          "example": "1.1.1.1/1",
+          "pattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/([0-9]|[1-2][0-9]|3[0-2]))$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when outbound-ruleset was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an outbound-ruleset",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "port": {
+          "description": "an endpoint of communication in an operating system.",
+          "example": 80,
+          "readOnly": false,
+          "type": [
+            "integer"
+          ]
+        },
+        "protocol": {
+          "description": "formal standards and policies comprised of rules, procedures and formats that define communication between two or more devices over a network",
+          "example": "tcp",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/outbound-ruleset/definitions/id"
+            }
+          ]
+        },
+        "rule": {
+          "description": "the combination of an IP address in CIDR notation, a from_port, to_port and protocol.",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "target": {
+              "$ref": "#/definitions/outbound-ruleset/definitions/target"
+            },
+            "from_port": {
+              "$ref": "#/definitions/outbound-ruleset/definitions/port"
+            },
+            "to_port": {
+              "$ref": "#/definitions/outbound-ruleset/definitions/port"
+            },
+            "protocol": {
+              "$ref": "#/definitions/outbound-ruleset/definitions/protocol"
+            }
+          },
+          "required": [
+            "target",
+            "from_port",
+            "to_port",
+            "protocol"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Current outbound ruleset for a space",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/outbound-ruleset",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/outbound-ruleset"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Info on an existing Outbound Ruleset",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/outbound-rulesets/{(%23%2Fdefinitions%2Foutbound-ruleset%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/outbound-ruleset"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List all Outbound Rulesets for a space",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/outbound-rulesets",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/outbound-ruleset"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create a new outbound ruleset",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/outbound-ruleset",
+          "method": "PUT",
+          "rel": "create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "rules": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/outbound-ruleset/definitions/rule"
+                }
+              }
+            }
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/outbound-ruleset/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/outbound-ruleset/definitions/created_at"
+        },
+        "rules": {
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/outbound-ruleset/definitions/rule"
+          }
+        },
+        "created_by": {
+          "$ref": "#/definitions/account/definitions/email"
+        }
+      }
+    },
+    "password-reset": {
+      "description": "A password reset represents a in-process password reset attempt.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - PasswordReset",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when password reset was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/account/definitions/email"
+            }
+          ]
+        },
+        "password_confirmation": {
+          "description": "confirmation of the new password",
+          "example": "newpassword",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "reset_password_token": {
+          "description": "unique identifier of a password reset attempt",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Reset account's password. This will send a reset password link to the user's email address.",
+          "href": "/password-resets",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Reset Password"
+        },
+        {
+          "description": "Complete password reset.",
+          "href": "/password-resets/{(%23%2Fdefinitions%2Fpassword-reset%2Fdefinitions%2Freset_password_token)}/actions/finalize",
+          "method": "POST",
+          "rel": "self",
+          "schema": {
+            "properties": {
+              "password": {
+                "$ref": "#/definitions/account/definitions/password"
+              },
+              "password_confirmation": {
+                "$ref": "#/definitions/password-reset/definitions/password_confirmation"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Complete Reset Password"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/password-reset/definitions/created_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "organization-app-permission": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An organization app permission is a behavior that is assigned to a user in an organization app.",
+      "stability": "prototype",
+      "title": "Heroku Platform API - Organization App Permission",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/organization-app-permission/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "The name of the app permission.",
+          "example": "view",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "A description of what the app permission allows.",
+          "example": "Can manage config, deploy, run commands and restart the app.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Lists permissions available to organizations.",
+          "href": "/organizations/permissions",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/organization-app-permission"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/organization-app-permission/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/organization-app-permission/definitions/description"
+        }
+      }
+    },
+    "pipeline-coupling": {
+      "description": "Information about an app's coupling to a pipeline",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "title": "Heroku Platform API - Pipeline Coupling",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when pipeline coupling was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of pipeline coupling",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline-coupling/definitions/id"
+            }
+          ]
+        },
+        "stage": {
+          "description": "target pipeline stage",
+          "example": "production",
+          "enum": [
+            "test",
+            "review",
+            "development",
+            "staging",
+            "production"
+          ],
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when pipeline coupling was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List couplings for a pipeline",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}/pipeline-couplings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-coupling"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List pipeline couplings.",
+          "href": "/pipeline-couplings",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-coupling"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Create a new pipeline coupling.",
+          "href": "/pipeline-couplings",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "app": {
+                "$ref": "#/definitions/app/definitions/identity"
+              },
+              "pipeline": {
+                "$ref": "#/definitions/pipeline/definitions/id"
+              },
+              "stage": {
+                "$ref": "#/definitions/pipeline-coupling/definitions/stage"
+              }
+            },
+            "required": [
+              "app",
+              "pipeline",
+              "stage"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for an existing pipeline coupling.",
+          "href": "/pipeline-couplings/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Delete an existing pipeline coupling.",
+          "href": "/pipeline-couplings/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "delete",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Update an existing pipeline coupling.",
+          "href": "/pipeline-couplings/{(%23%2Fdefinitions%2Fpipeline-coupling%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "stage": {
+                "$ref": "#/definitions/pipeline-coupling/definitions/stage"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Info for an existing pipeline coupling.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/pipeline-couplings",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-coupling"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app involved in the pipeline coupling",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/id"
+        },
+        "pipeline": {
+          "description": "pipeline involved in the coupling",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "stage": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/stage"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/pipeline-coupling/definitions/updated_at"
+        }
+      }
+    },
+    "pipeline-promotion-target": {
+      "description": "Promotion targets represent an individual app being promoted to",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Promotion Target",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "error_message": {
+          "description": "an error message for why the promotion failed",
+          "example": "User does not have access to that app",
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of promotion target",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline-promotion-target/definitions/id"
+            }
+          ]
+        },
+        "status": {
+          "description": "status of promotion",
+          "example": "pending",
+          "readOnly": true,
+          "enum": [
+            "pending",
+            "succeeded",
+            "failed"
+          ],
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List promotion targets belonging to an existing promotion.",
+          "href": "/pipeline-promotions/{(%23%2Fdefinitions%2Fpipeline-promotion%2Fdefinitions%2Fid)}/promotion-targets",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/pipeline-promotion-target"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "the app which was promoted to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "error_message": {
+          "$ref": "#/definitions/pipeline-promotion-target/definitions/error_message"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline-promotion-target/definitions/id"
+        },
+        "pipeline_promotion": {
+          "description": "the promotion which the target belongs to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline-promotion/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "release": {
+          "description": "the release which was created on the target app",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/release/definitions/id"
+            }
+          },
+          "type": [
+            "object",
+            "null"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/pipeline-promotion-target/definitions/status"
+        }
+      }
+    },
+    "pipeline-promotion": {
+      "description": "Promotions allow you to move code from an app in a pipeline to all targets",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline Promotion",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when promotion was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of promotion",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "readOnly": true,
+          "format": "uuid",
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline-promotion/definitions/id"
+            }
+          ]
+        },
+        "status": {
+          "description": "status of promotion",
+          "example": "pending",
+          "readOnly": true,
+          "enum": [
+            "pending",
+            "completed"
+          ],
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when promotion was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new promotion.",
+          "href": "/pipeline-promotions",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "pipeline": {
+                "description": "pipeline involved in the promotion",
+                "properties": {
+                  "id": {
+                    "$ref": "#/definitions/pipeline/definitions/id"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "type": [
+                  "object"
+                ]
+              },
+              "source": {
+                "description": "the app being promoted from",
+                "type": [
+                  "object"
+                ],
+                "properties": {
+                  "app": {
+                    "description": "the app which was promoted from",
+                    "properties": {
+                      "id": {
+                        "$ref": "#/definitions/app/definitions/id"
+                      }
+                    },
+                    "strictProperties": true,
+                    "type": [
+                      "object"
+                    ]
+                  }
+                }
+              },
+              "targets": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "app": {
+                      "description": "the app is being promoted to",
+                      "properties": {
+                        "id": {
+                          "$ref": "#/definitions/app/definitions/id"
+                        }
+                      },
+                      "strictProperties": true,
+                      "type": [
+                        "object"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "required": [
+              "pipeline",
+              "source",
+              "targets"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing pipeline promotion.",
+          "href": "/pipeline-promotions/{(%23%2Fdefinitions%2Fpipeline-promotion%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline-promotion"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/id"
+        },
+        "pipeline": {
+          "description": "the pipeline which the promotion belongs to",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "source": {
+          "description": "the app being promoted from",
+          "properties": {
+            "app": {
+              "description": "the app which was promoted from",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/app/definitions/id"
+                }
+              },
+              "strictProperties": true,
+              "type": [
+                "object"
+              ]
+            },
+            "release": {
+              "description": "the release used to promoted from",
+              "properties": {
+                "id": {
+                  "$ref": "#/definitions/release/definitions/id"
+                }
+              },
+              "type": [
+                "object"
+              ]
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "status": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/status"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/pipeline-promotion/definitions/updated_at"
+        }
+      }
+    },
+    "pipeline": {
+      "description": "A pipeline allows grouping of apps into different stages.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Pipeline",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when pipeline was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of pipeline",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/pipeline/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/pipeline/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "name of pipeline",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when pipeline was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new pipeline.",
+          "href": "/pipelines",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/pipeline/definitions/name"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Info for existing pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Delete an existing pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "delete",
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Update an existing pipeline.",
+          "href": "/pipelines/{(%23%2Fdefinitions%2Fpipeline%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/pipeline/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/pipeline"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List existing pipelines.",
+          "href": "/pipelines",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "type": [
+              "array"
+            ],
+            "items": {
+              "$ref": "#/definitions/pipeline"
+            }
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/pipeline/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/pipeline/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/pipeline/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/pipeline/definitions/updated_at"
         }
       }
     },
@@ -4747,8 +9818,22 @@
             "string"
           ]
         },
+        "compliance": {
+          "description": "the compliance regimes applied to an add-on plan",
+          "example": [
+            "HIPAA"
+          ],
+          "readOnly": false,
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/regime"
+          }
+        },
         "default": {
-          "description": "whether this plan is the default for its addon service",
+          "description": "whether this plan is the default for its add-on service",
           "example": false,
           "readOnly": true,
           "type": [
@@ -4763,6 +9848,14 @@
             "string"
           ]
         },
+        "human_name": {
+          "description": "human readable name of the add-on plan",
+          "example": "Dev",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "id": {
           "description": "unique identifier of this plan",
           "example": "01234567-89ab-cdef-0123-456789abcdef",
@@ -4770,6 +9863,22 @@
           "readOnly": true,
           "type": [
             "string"
+          ]
+        },
+        "installable_inside_private_network": {
+          "description": "whether this plan is installable to a Private Spaces app",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "installable_outside_private_network": {
+          "description": "whether this plan is installable to a Common Runtime app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
           ]
         },
         "identity": {
@@ -4790,6 +9899,18 @@
             "string"
           ]
         },
+        "regime": {
+          "description": "compliance requirements an add-on plan must adhere to",
+          "readOnly": true,
+          "example": "HIPAA",
+          "type": [
+            "string"
+          ],
+          "enum": [
+            "HIPAA",
+            "PCI"
+          ]
+        },
         "cents": {
           "description": "price in cents per unit of plan",
           "example": 0,
@@ -4804,6 +9925,14 @@
           "readOnly": true,
           "type": [
             "string"
+          ]
+        },
+        "space_default": {
+          "description": "whether this plan is the default for apps in Private Spaces",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
           ]
         },
         "state": {
@@ -4822,12 +9951,20 @@
           "type": [
             "string"
           ]
+        },
+        "visible": {
+          "description": "whether this plan is publicly visible",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
         }
       },
       "links": [
         {
           "description": "Info for existing plan.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
@@ -4837,7 +9974,7 @@
         },
         {
           "description": "List existing plans.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Faddon-service%2Fdefinitions%2Fidentity)}/plans",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans",
           "method": "GET",
           "rel": "instances",
           "targetSchema": {
@@ -4852,8 +9989,26 @@
         }
       ],
       "properties": {
+        "addon_service": {
+          "description": "identity of add-on service",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on-service/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on-service/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
         "created_at": {
           "$ref": "#/definitions/plan/definitions/created_at"
+        },
+        "compliance": {
+          "$ref": "#/definitions/plan/definitions/compliance"
         },
         "default": {
           "$ref": "#/definitions/plan/definitions/default"
@@ -4861,8 +10016,17 @@
         "description": {
           "$ref": "#/definitions/plan/definitions/description"
         },
+        "human_name": {
+          "$ref": "#/definitions/plan/definitions/human_name"
+        },
         "id": {
           "$ref": "#/definitions/plan/definitions/id"
+        },
+        "installable_inside_private_network": {
+          "$ref": "#/definitions/plan/definitions/installable_inside_private_network"
+        },
+        "installable_outside_private_network": {
+          "$ref": "#/definitions/plan/definitions/installable_outside_private_network"
         },
         "name": {
           "$ref": "#/definitions/plan/definitions/name"
@@ -4882,11 +10046,17 @@
             "object"
           ]
         },
+        "space_default": {
+          "$ref": "#/definitions/plan/definitions/space_default"
+        },
         "state": {
           "$ref": "#/definitions/plan/definitions/state"
         },
         "updated_at": {
           "$ref": "#/definitions/plan/definitions/updated_at"
+        },
+        "visible": {
+          "$ref": "#/definitions/plan/definitions/visible"
         }
       }
     },
@@ -4939,6 +10109,14 @@
         "object"
       ],
       "definitions": {
+        "country": {
+          "description": "country where the region exists",
+          "example": "United States",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "created_at": {
           "description": "when region was created",
           "example": "2012-01-01T12:00:00Z",
@@ -4975,6 +10153,14 @@
             }
           ]
         },
+        "locale": {
+          "description": "area in the country where the region exists",
+          "example": "Virginia",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
         "name": {
           "description": "unique name of region",
           "example": "us",
@@ -4982,6 +10168,39 @@
           "type": [
             "string"
           ]
+        },
+        "private_capable": {
+          "description": "whether or not region is available for creating a Private Space",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "provider": {
+          "description": "provider of underlying substrate",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "name": {
+              "description": "name of provider",
+              "example": "amazon-web-services",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            },
+            "region": {
+              "description": "region name used by provider",
+              "example": "us-east-1",
+              "readOnly": true,
+              "type": [
+                "string"
+              ]
+            }
+          },
+          "readOnly": true
         },
         "updated_at": {
           "description": "when region was updated",
@@ -5021,6 +10240,9 @@
         }
       ],
       "properties": {
+        "country": {
+          "$ref": "#/definitions/region/definitions/country"
+        },
         "created_at": {
           "$ref": "#/definitions/region/definitions/created_at"
         },
@@ -5030,8 +10252,17 @@
         "id": {
           "$ref": "#/definitions/region/definitions/id"
         },
+        "locale": {
+          "$ref": "#/definitions/region/definitions/locale"
+        },
         "name": {
           "$ref": "#/definitions/region/definitions/name"
+        },
+        "private_capable": {
+          "$ref": "#/definitions/region/definitions/private_capable"
+        },
+        "provider": {
+          "$ref": "#/definitions/region/definitions/provider"
         },
         "updated_at": {
           "$ref": "#/definitions/region/definitions/updated_at"
@@ -5060,6 +10291,19 @@
         "description": {
           "description": "description of changes in this release",
           "example": "Added new feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "status": {
+          "description": "current status of the release",
+          "enum": [
+            "failed",
+            "pending",
+            "succeeded"
+          ],
+          "example": "succeeded",
           "readOnly": true,
           "type": [
             "string"
@@ -5100,6 +10344,14 @@
           "type": [
             "integer"
           ]
+        },
+        "current": {
+          "description": "indicates this release as being the current one for the app",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
         }
       },
       "links": [
@@ -5129,7 +10381,7 @@
           "title": "List"
         },
         {
-          "description": "Create new release. The API cannot be used to create releases on Bamboo apps.",
+          "description": "Create new release.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/releases",
           "method": "POST",
           "rel": "create",
@@ -5179,6 +10431,29 @@
         }
       ],
       "properties": {
+        "addon_plan_names": {
+          "description": "add-on plans installed on the app for this release",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/plan/definitions/name"
+          }
+        },
+        "app": {
+          "description": "app involved in the release",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
         "created_at": {
           "$ref": "#/definitions/release/definitions/created_at"
         },
@@ -5204,6 +10479,9 @@
             "null"
           ]
         },
+        "status": {
+          "$ref": "#/definitions/release/definitions/status"
+        },
         "user": {
           "description": "user that created the release",
           "properties": {
@@ -5221,6 +10499,9 @@
         },
         "version": {
           "$ref": "#/definitions/release/definitions/version"
+        },
+        "current": {
+          "$ref": "#/definitions/release/definitions/current"
         }
       }
     },
@@ -5243,9 +10524,27 @@
             "string"
           ]
         },
+        "checksum": {
+          "description": "an optional checksum of the slug for verifying its integrity",
+          "example": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "commit": {
           "description": "identification of the code with your version control system (eg: SHA of the git HEAD)",
           "example": "60883d9e8947a57e04dc9124f25df004866a2051",
+          "readOnly": false,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "commit_description": {
+          "description": "an optional description of the provided commit",
+          "example": "fixed a bug with API documentation",
           "readOnly": false,
           "type": [
             "null",
@@ -5292,7 +10591,7 @@
             "web": "./bin/web -p $PORT"
           },
           "patternProperties": {
-            "^\\w+$": {
+            "^[-\\w]{1,128}$": {
               "type": [
                 "string"
               ]
@@ -5343,7 +10642,7 @@
           "title": "Info"
         },
         {
-          "description": "Create a new slug. For more information please refer to [Deploying Slugs using the Platform API](https://devcenter.heroku.com/articles/platform-api-deploying-slugs?preview=1).",
+          "description": "Create a new slug. For more information please refer to [Deploying Slugs using the Platform API](https://devcenter.heroku.com/articles/platform-api-deploying-slugs).",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/slugs",
           "method": "POST",
           "rel": "create",
@@ -5352,11 +10651,20 @@
               "buildpack_provided_description": {
                 "$ref": "#/definitions/slug/definitions/buildpack_provided_description"
               },
+              "checksum": {
+                "$ref": "#/definitions/slug/definitions/checksum"
+              },
               "commit": {
                 "$ref": "#/definitions/slug/definitions/commit"
               },
+              "commit_description": {
+                "$ref": "#/definitions/slug/definitions/commit_description"
+              },
               "process_types": {
                 "$ref": "#/definitions/slug/definitions/process_types"
+              },
+              "stack": {
+                "$ref": "#/definitions/stack/definitions/identity"
               }
             },
             "required": [
@@ -5367,7 +10675,28 @@
             ]
           },
           "targetSchema": {
-            "$ref": "#/definitions/slug"
+            "$ref": "#/definitions/slug",
+            "example": {
+              "blob": {
+                "method": "PUT",
+                "url": "https://api.heroku.com/slugs/1234.tgz"
+              },
+              "buildpack_provided_description": "Ruby/Rack",
+              "checksum": "SHA256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+              "commit": "60883d9e8947a57e04dc9124f25df004866a2051",
+              "commit_description": "fixed a bug with API documentation",
+              "created_at": "2012-01-01T12:00:00Z",
+              "id": "01234567-89ab-cdef-0123-456789abcdef",
+              "process_types": {
+                "web": "./bin/web -p $PORT"
+              },
+              "size": 2048,
+              "stack": {
+                "id": "01234567-89ab-cdef-0123-456789abcdef",
+                "name": "cedar-14"
+              },
+              "updated_at": "2012-01-01T12:00:00Z"
+            }
           },
           "title": "Create"
         }
@@ -5391,8 +10720,14 @@
         "buildpack_provided_description": {
           "$ref": "#/definitions/slug/definitions/buildpack_provided_description"
         },
+        "checksum": {
+          "$ref": "#/definitions/slug/definitions/checksum"
+        },
         "commit": {
           "$ref": "#/definitions/slug/definitions/commit"
+        },
+        "commit_description": {
+          "$ref": "#/definitions/slug/definitions/commit_description"
         },
         "created_at": {
           "$ref": "#/definitions/slug/definitions/created_at"
@@ -5406,13 +10741,795 @@
         "size": {
           "$ref": "#/definitions/slug/definitions/size"
         },
+        "stack": {
+          "description": "identity of slug stack",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
         "updated_at": {
           "$ref": "#/definitions/slug/definitions/updated_at"
         }
       }
     },
+    "sms-number": {
+      "description": "SMS numbers are used for recovery on accounts with two-factor authentication enabled.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - SMS Number",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "sms_number": {
+          "$ref": "#/definitions/account/definitions/sms_number"
+        }
+      },
+      "links": [
+        {
+          "description": "Recover an account using an SMS recovery code",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/sms-number",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sms-number"
+          },
+          "title": "SMS Number"
+        },
+        {
+          "description": "Recover an account using an SMS recovery code",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/sms-number/actions/recover",
+          "method": "POST",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sms-number"
+          },
+          "title": "Recover"
+        },
+        {
+          "description": "Confirm an SMS number change with a confirmation code",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/sms-number/actions/confirm",
+          "method": "POST",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sms-number"
+          },
+          "title": "Confirm"
+        }
+      ],
+      "properties": {
+        "sms_number": {
+          "$ref": "#/definitions/account/definitions/sms_number"
+        }
+      }
+    },
+    "sni-endpoint": {
+      "description": "SNI Endpoint is a public address serving a custom SSL cert for HTTPS traffic, using the SNI TLS extension, to a Heroku app.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "title": "Heroku Platform API - SNI Endpoint",
+      "stability": "development",
+      "strictProperties": true,
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "certificate_chain": {
+          "description": "raw contents of the public certificate chain (eg: .crt or .pem file)",
+          "example": "-----BEGIN CERTIFICATE----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "cname": {
+          "description": "deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this app",
+          "example": "example.herokussl.com",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "created_at": {
+          "description": "when endpoint was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this SNI endpoint",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/sni-endpoint/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name for SNI endpoint",
+          "example": "example",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "private_key": {
+          "description": "contents of the private key (eg .key file)",
+          "example": "-----BEGIN RSA PRIVATE KEY----- ...",
+          "readOnly": false,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when SNI endpoint was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing SNI endpoints.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/sni-endpoint"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update an existing SNI endpoint.",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sni-endpoints/{(%23%2Fdefinitions%2Fsni-endpoint%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate_chain": {
+                "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+              },
+              "private_key": {
+                "$ref": "#/definitions/sni-endpoint/definitions/private_key"
+              }
+            },
+            "required": [
+              "certificate_chain",
+              "private_key"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/sni-endpoint"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "certificate_chain": {
+          "$ref": "#/definitions/sni-endpoint/definitions/certificate_chain"
+        },
+        "cname": {
+          "$ref": "#/definitions/sni-endpoint/definitions/cname"
+        },
+        "created_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/sni-endpoint/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/sni-endpoint/definitions/name"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/sni-endpoint/definitions/updated_at"
+        }
+      }
+    },
+    "source": {
+      "description": "A source is a location for uploading and downloading an application's source code.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Source",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "get_url": {
+          "description": "URL to download the source",
+          "example": "https://api.heroku.com/sources/1234.tgz",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "put_url": {
+          "description": "URL to upload the source",
+          "example": "https://api.heroku.com/sources/1234.tgz",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create URLs for uploading and downloading source.",
+          "href": "/sources",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/source"
+          },
+          "title": "Create"
+        },
+        {
+          "deactivate_on": "2017-08-01",
+          "description": "Create URLs for uploading and downloading source. Deprecated in favor of `POST /sources`",
+          "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/sources",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/source"
+          },
+          "title": "Create - Deprecated"
+        }
+      ],
+      "properties": {
+        "source_blob": {
+          "description": "pointer to the URL where clients can fetch or store the source",
+          "properties": {
+            "get_url": {
+              "$ref": "#/definitions/source/definitions/get_url"
+            },
+            "put_url": {
+              "$ref": "#/definitions/source/definitions/put_url"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "space-app-access": {
+      "description": "Space access represents the permissions a particular user has on a particular space.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "title": "Heroku Platform API - Space Access",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "id": {
+          "description": "unique identifier of the space a user has permissions on",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/space-app-access/definitions/id"
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List permissions for a given user on a given space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/space-app-access"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing user's set of permissions on a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "type": [
+                    "object"
+                  ],
+                  "properties": {
+                    "name": {
+                      "type": [
+                        "string"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/space-app-access"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List all users and their permissions on a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/members",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/space-app-access"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "space": {
+          "description": "space user belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/space/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/space/definitions/id"
+        },
+        "permissions": {
+          "description": "user space permissions",
+          "type": [
+            "array"
+          ],
+          "items": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "description": {
+                "type": [
+                  "string"
+                ]
+              },
+              "name": {
+                "type": [
+                  "string"
+                ]
+              }
+            }
+          }
+        },
+        "updated_at": {
+          "$ref": "#/definitions/space/definitions/updated_at"
+        },
+        "user": {
+          "description": "identity of user account",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "space-nat": {
+      "description": "Network address translation (NAT) for stable outbound IP addresses from a space",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Space Network Address Translation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when network address translation for a space was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "ip_v4_address": {
+          "example": "123.123.123.123",
+          "format": "ipv4",
+          "pattern": "^(([01]?\\d?\\d|2[0-4]\\d|25[0-5])\\.){3}([01]?\\d?\\d|2[0-4]\\d|25[0-5])$",
+          "type": [
+            "string"
+          ]
+        },
+        "sources": {
+          "description": "potential IPs from which outbound network traffic will originate",
+          "readOnly": true,
+          "type": [
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/space-nat/definitions/ip_v4_address"
+          }
+        },
+        "state": {
+          "description": "availability of network address translation for a space",
+          "enum": [
+            "disabled",
+            "updating",
+            "enabled"
+          ],
+          "example": "enabled",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when network address translation for a space was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Current state of network address translation for a space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}/nat",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/space-nat"
+          },
+          "title": "Info"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/space-nat/definitions/created_at"
+        },
+        "sources": {
+          "$ref": "#/definitions/space-nat/definitions/sources"
+        },
+        "state": {
+          "$ref": "#/definitions/space-nat/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/space-nat/definitions/updated_at"
+        }
+      }
+    },
+    "space": {
+      "description": "A space is an isolated, highly available, secure app execution environments, running in the modern VPC substrate.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Space",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when space was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of space",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/space/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of space",
+          "example": "nasa",
+          "readOnly": false,
+          "pattern": "^[a-z0-9](?:[a-z0-9]|-(?!-))+[a-z0-9]$",
+          "type": [
+            "string"
+          ]
+        },
+        "shield": {
+          "description": "true if this space has shield enabled",
+          "readOnly": true,
+          "example": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "state": {
+          "description": "availability of this space",
+          "enum": [
+            "allocating",
+            "allocated",
+            "deleting"
+          ],
+          "example": "allocated",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when space was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List existing spaces.",
+          "href": "/spaces",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/space"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for existing space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/space/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Delete an existing space.",
+          "href": "/spaces/{(%23%2Fdefinitions%2Fspace%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Create a new space.",
+          "href": "/spaces",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/space/definitions/name"
+              },
+              "organization": {
+                "$ref": "#/definitions/organization/definitions/name"
+              },
+              "region": {
+                "$ref": "#/definitions/region/definitions/identity"
+              },
+              "shield": {
+                "$ref": "#/definitions/space/definitions/shield"
+              }
+            },
+            "required": [
+              "name",
+              "organization"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/space"
+          },
+          "title": "Create"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/space/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/space/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/space/definitions/name"
+        },
+        "organization": {
+          "description": "organization that owns this space",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "region": {
+          "description": "identity of space region",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/region/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/region/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "shield": {
+          "$ref": "#/definitions/space/definitions/shield"
+        },
+        "state": {
+          "$ref": "#/definitions/space/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/space/definitions/updated_at"
+        }
+      }
+    },
     "ssl-endpoint": {
-      "description": "[SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` addon installed before it can provision an SSL Endpoint using these APIs.",
+      "description": "[SSL Endpoint](https://devcenter.heroku.com/articles/ssl-endpoint) is a public address serving custom SSL cert for HTTPS traffic to a Heroku app. Note that an app must have the `ssl:endpoint` add-on installed before it can provision an SSL Endpoint using these APIs.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "title": "Heroku Platform API - SSL Endpoint",
       "stability": "production",
@@ -5468,7 +11585,7 @@
         "name": {
           "description": "unique name for SSL endpoint",
           "example": "example",
-          "pattern": "^[a-z][a-z0-9-]{3,30}$",
+          "pattern": "^[a-z][a-z0-9-]{2,29}$",
           "readOnly": true,
           "type": [
             "string"
@@ -5607,6 +11724,21 @@
         }
       ],
       "properties": {
+        "app": {
+          "description": "application associated with this ssl-endpoint",
+          "type": [
+            "object"
+          ],
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          },
+          "strictProperties": true
+        },
         "certificate_chain": {
           "$ref": "#/definitions/ssl-endpoint/definitions/certificate_chain"
         },
@@ -5667,7 +11799,7 @@
         },
         "name": {
           "description": "unique name of stack",
-          "example": "cedar",
+          "example": "cedar-14",
           "readOnly": true,
           "type": [
             "string"
@@ -5735,6 +11867,373 @@
           "$ref": "#/definitions/stack/definitions/updated_at"
         }
       }
+    },
+    "user-preferences": {
+      "description": "Tracks a user's preferences and message dismissals",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "production",
+      "strictProperties": true,
+      "title": "Heroku Platform API - User Preferences",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/user-preferences/definitions/self"
+            }
+          ]
+        },
+        "self": {
+          "description": "Implicit reference to currently authorized user",
+          "enum": [
+            "~"
+          ],
+          "example": "~",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "timezone": {
+          "description": "User's default timezone",
+          "example": "UTC",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "default-organization": {
+          "description": "User's default organization",
+          "example": "sushi-inc",
+          "readOnly": false,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dismissed-github-banner": {
+          "description": "Whether the user has dismissed the GitHub link banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-getting-started": {
+          "description": "Whether the user has dismissed the getting started banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-org-access-controls": {
+          "description": "Whether the user has dismissed the Organization Access Controls banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-org-wizard-notification": {
+          "description": "Whether the user has dismissed the Organization Wizard",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-pipelines-banner": {
+          "description": "Whether the user has dismissed the Pipelines banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-pipelines-github-banner": {
+          "description": "Whether the user has dismissed the GitHub banner on a pipeline overview",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "dismissed-pipelines-github-banners": {
+          "description": "Which pipeline uuids the user has dismissed the GitHub banner for",
+          "example": [
+            "96c68759-f310-4910-9867-e0b062064098"
+          ],
+          "readOnly": false,
+          "type": [
+            "null",
+            "array"
+          ],
+          "items": {
+            "$ref": "#/definitions/pipeline/definitions/id"
+          }
+        },
+        "dismissed-sms-banner": {
+          "description": "Whether the user has dismissed the 2FA SMS banner",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve User Preferences",
+          "href": "/users/{(%23%2Fdefinitions%2Fuser-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/user-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update User Preferences",
+          "href": "/users/{(%23%2Fdefinitions%2Fuser-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "timezone": {
+                "$ref": "#/definitions/user-preferences/definitions/timezone"
+              },
+              "default-organization": {
+                "$ref": "#/definitions/user-preferences/definitions/default-organization"
+              },
+              "dismissed-github-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-github-banner"
+              },
+              "dismissed-getting-started": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-getting-started"
+              },
+              "dismissed-org-access-controls": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-org-access-controls"
+              },
+              "dismissed-org-wizard-notification": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-org-wizard-notification"
+              },
+              "dismissed-pipelines-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-banner"
+              },
+              "dismissed-pipelines-github-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banner"
+              },
+              "dismissed-pipelines-github-banners": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banners"
+              },
+              "dismissed-sms-banner": {
+                "$ref": "#/definitions/user-preferences/definitions/dismissed-sms-banner"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/user-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "timezone": {
+          "$ref": "#/definitions/user-preferences/definitions/timezone"
+        },
+        "default-organization": {
+          "$ref": "#/definitions/user-preferences/definitions/default-organization"
+        },
+        "dismissed-github-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-github-banner"
+        },
+        "dismissed-getting-started": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-getting-started"
+        },
+        "dismissed-org-access-controls": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-org-access-controls"
+        },
+        "dismissed-org-wizard-notification": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-org-wizard-notification"
+        },
+        "dismissed-pipelines-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-banner"
+        },
+        "dismissed-pipelines-github-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banner"
+        },
+        "dismissed-pipelines-github-banners": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-pipelines-github-banners"
+        },
+        "dismissed-sms-banner": {
+          "$ref": "#/definitions/user-preferences/definitions/dismissed-sms-banner"
+        }
+      }
+    },
+    "whitelisted-add-on-service": {
+      "description": "Entities that have been whitelisted to be used by an Organization",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "prototype",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Whitelisted Entity",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "added_at": {
+          "description": "when the add-on service was whitelisted",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "added_by": {
+          "description": "the user which whitelisted the Add-on Service",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "readOnly": true,
+          "type": [
+            "object"
+          ]
+        },
+        "addon_service": {
+          "description": "the Add-on Service whitelisted for use",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/add-on-service/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/add-on-service/definitions/name"
+            },
+            "human_name": {
+              "$ref": "#/definitions/add-on-service/definitions/human_name"
+            }
+          },
+          "readOnly": true,
+          "type": [
+            "object"
+          ]
+        },
+        "id": {
+          "description": "unique identifier for this whitelisting entity",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/whitelisted-add-on-service/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/add-on-service/definitions/name"
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List all whitelisted Add-on Services for an Organization",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/whitelisted-addon-services",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/whitelisted-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Whitelist an Add-on Service",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/whitelisted-addon-services",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "addon_service": {
+                "description": "name of the Add-on to whitelist",
+                "example": "heroku-postgresql",
+                "type": [
+                  "string"
+                ]
+              }
+            }
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/whitelisted-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Remove a whitelisted entity",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/whitelisted-addon-services/{(%23%2Fdefinitions%2Fwhitelisted-add-on-service%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/whitelisted-add-on-service"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "added_at": {
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/added_at"
+        },
+        "added_by": {
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/added_by"
+        },
+        "addon_service": {
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/addon_service"
+        },
+        "id": {
+          "$ref": "#/definitions/whitelisted-add-on-service/definitions/id"
+        }
+      }
     }
   },
   "properties": {
@@ -5744,14 +12243,32 @@
     "account": {
       "$ref": "#/definitions/account"
     },
-    "addon-service": {
-      "$ref": "#/definitions/addon-service"
+    "add-on-action": {
+      "$ref": "#/definitions/add-on-action"
     },
-    "addon": {
-      "$ref": "#/definitions/addon"
+    "add-on-attachment": {
+      "$ref": "#/definitions/add-on-attachment"
+    },
+    "add-on-config": {
+      "$ref": "#/definitions/add-on-config"
+    },
+    "add-on-plan-action": {
+      "$ref": "#/definitions/add-on-plan-action"
+    },
+    "add-on-region-capability": {
+      "$ref": "#/definitions/add-on-region-capability"
+    },
+    "add-on-service": {
+      "$ref": "#/definitions/add-on-service"
+    },
+    "add-on": {
+      "$ref": "#/definitions/add-on"
     },
     "app-feature": {
       "$ref": "#/definitions/app-feature"
+    },
+    "app-formation-set": {
+      "$ref": "#/definitions/app-formation-set"
     },
     "app-setup": {
       "$ref": "#/definitions/app-setup"
@@ -5768,6 +12285,9 @@
     "build": {
       "$ref": "#/definitions/build"
     },
+    "buildpack-installation": {
+      "$ref": "#/definitions/buildpack-installation"
+    },
     "collaborator": {
       "$ref": "#/definitions/collaborator"
     },
@@ -5780,11 +12300,38 @@
     "domain": {
       "$ref": "#/definitions/domain"
     },
+    "dyno-size": {
+      "$ref": "#/definitions/dyno-size"
+    },
     "dyno": {
       "$ref": "#/definitions/dyno"
     },
+    "event": {
+      "$ref": "#/definitions/event"
+    },
+    "failed-event": {
+      "$ref": "#/definitions/failed-event"
+    },
+    "filter-apps": {
+      "$ref": "#/definitions/filter-apps"
+    },
     "formation": {
       "$ref": "#/definitions/formation"
+    },
+    "identity-provider": {
+      "$ref": "#/definitions/identity-provider"
+    },
+    "inbound-ruleset": {
+      "$ref": "#/definitions/inbound-ruleset"
+    },
+    "invitation": {
+      "$ref": "#/definitions/invitation"
+    },
+    "invoice-address": {
+      "$ref": "#/definitions/invoice-address"
+    },
+    "invoice": {
+      "$ref": "#/definitions/invoice"
     },
     "key": {
       "$ref": "#/definitions/key"
@@ -5807,17 +12354,53 @@
     "oauth-token": {
       "$ref": "#/definitions/oauth-token"
     },
+    "organization-add-on": {
+      "$ref": "#/definitions/organization-add-on"
+    },
     "organization-app-collaborator": {
       "$ref": "#/definitions/organization-app-collaborator"
     },
     "organization-app": {
       "$ref": "#/definitions/organization-app"
     },
+    "organization-feature": {
+      "$ref": "#/definitions/organization-feature"
+    },
+    "organization-invitation": {
+      "$ref": "#/definitions/organization-invitation"
+    },
+    "organization-invoice": {
+      "$ref": "#/definitions/organization-invoice"
+    },
     "organization-member": {
       "$ref": "#/definitions/organization-member"
     },
+    "organization-preferences": {
+      "$ref": "#/definitions/organization-preferences"
+    },
     "organization": {
       "$ref": "#/definitions/organization"
+    },
+    "outbound-ruleset": {
+      "$ref": "#/definitions/outbound-ruleset"
+    },
+    "password-reset": {
+      "$ref": "#/definitions/password-reset"
+    },
+    "organization-app-permission": {
+      "$ref": "#/definitions/organization-app-permission"
+    },
+    "pipeline-coupling": {
+      "$ref": "#/definitions/pipeline-coupling"
+    },
+    "pipeline-promotion-target": {
+      "$ref": "#/definitions/pipeline-promotion-target"
+    },
+    "pipeline-promotion": {
+      "$ref": "#/definitions/pipeline-promotion"
+    },
+    "pipeline": {
+      "$ref": "#/definitions/pipeline"
     },
     "plan": {
       "$ref": "#/definitions/plan"
@@ -5834,16 +12417,37 @@
     "slug": {
       "$ref": "#/definitions/slug"
     },
+    "sms-number": {
+      "$ref": "#/definitions/sms-number"
+    },
+    "sni-endpoint": {
+      "$ref": "#/definitions/sni-endpoint"
+    },
+    "source": {
+      "$ref": "#/definitions/source"
+    },
+    "space-app-access": {
+      "$ref": "#/definitions/space-app-access"
+    },
+    "space-nat": {
+      "$ref": "#/definitions/space-nat"
+    },
+    "space": {
+      "$ref": "#/definitions/space"
+    },
     "ssl-endpoint": {
       "$ref": "#/definitions/ssl-endpoint"
     },
     "stack": {
       "$ref": "#/definitions/stack"
+    },
+    "user-preferences": {
+      "$ref": "#/definitions/user-preferences"
+    },
+    "whitelisted-add-on-service": {
+      "$ref": "#/definitions/whitelisted-add-on-service"
     }
   },
-  "type": [
-    "object"
-  ],
   "description": "The platform API empowers developers to automate, extend and combine Heroku with other services.",
   "id": "http://api.heroku.com/schema#",
   "links": [

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1262,9 +1262,10 @@
 			"revisionTime": "2016-07-14T17:28:59Z"
 		},
 		{
-			"checksumSHA1": "+LNqBN6tG7kPK8t4EIoNxk+VTvg=",
+			"checksumSHA1": "cSJrzeVJLa9x2xoVqrJLz2Y+l0Y=",
 			"path": "github.com/cyberdelia/heroku-go/v3",
-			"revision": "81c5afa1abcf69cc18ccc24fa3716b5a455c9208"
+			"revision": "58deda4c1fb0b4803387b29dc916c21887b81954",
+			"revisionTime": "2017-03-06T18:52:00Z"
 		},
 		{
 			"checksumSHA1": "/5cvgU+J4l7EhMXTK76KaCAfOuU=",


### PR DESCRIPTION
After many years of [being broken](https://github.com/interagent/schematic/issues/29), schematic and heroku-go can [generate the Heroku API again](https://github.com/interagent/schematic/pull/39) :tada:

But the generated code looks a bit different now and also requires passing a `context.Context` as the first argument.

This PR does not introduce any functionality, but does update the library to the latest revision. It will, however, open the door to implementing long-requested functionality like [pipelines](https://github.com/hashicorp/terraform/issues/11326) and [spaces](https://github.com/hashicorp/terraform/issues/7059).