### PR TITLE
Add note for terraform remote config

### DIFF
--- a/website/source/intro/getting-started/remote.html.markdown
+++ b/website/source/intro/getting-started/remote.html.markdown
@@ -48,6 +48,8 @@ $ terraform remote config -backend-config="name=ATLAS_USERNAME/getting-started"
 
 Replace `ATLAS_USERNAME` with your Atlas username.
 
+**Note:** This action requires either a Terraform Enterprise account or you need to sign up Terraform Enterprise Free-Trial (1 month).
+
 Before you [push](/docs/commands/push.html) your Terraform configuration to Atlas you'll need to start a local version control system with at least one commit. Here is an example using `git`.
 
 ```


### PR DESCRIPTION
Added note on required account type for successfully running "terraform remote config" command given in this guide.