### PR TITLE
provider/aws: Add support for ACM certificates to api_gateway_domain_name

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -21,33 +21,41 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 
+			//According to AWS Documentation, ACM will be the only way to add certificates
+			//to ApiGateway DomainNames. When this happens, we will be deprecating all certificate methods
+			//except certificate_arn. We are not quite sure when this will happen.
 			"certificate_body": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
 			},
 
 			"certificate_chain": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
 			},
 
 			"certificate_name": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 			},
 
 			"certificate_private_key": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
 			},
 
 			"domain_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+			},
+
+			"certificate_arn": {
+				Type:     schema.TypeString,
+				Optional: true,
 			},
 
 			"cloudfront_domain_name": {
@@ -72,13 +80,31 @@ func resourceAwsApiGatewayDomainNameCreate(d *schema.ResourceData, meta interfac
 	conn := meta.(*AWSClient).apigateway
 	log.Printf("[DEBUG] Creating API Gateway Domain Name")
 
-	domainName, err := conn.CreateDomainName(&apigateway.CreateDomainNameInput{
-		CertificateBody:       aws.String(d.Get("certificate_body").(string)),
-		CertificateChain:      aws.String(d.Get("certificate_chain").(string)),
-		CertificateName:       aws.String(d.Get("certificate_name").(string)),
-		CertificatePrivateKey: aws.String(d.Get("certificate_private_key").(string)),
-		DomainName:            aws.String(d.Get("domain_name").(string)),
-	})
+	params := &apigateway.CreateDomainNameInput{
+		DomainName: aws.String(d.Get("domain_name").(string)),
+	}
+
+	if v, ok := d.GetOk("certificate_arn"); ok {
+		params.CertificateArn = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("certificate_name"); ok {
+		params.CertificateName = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("certificate_body"); ok {
+		params.CertificateBody = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("certificate_chain"); ok {
+		params.CertificateChain = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("certificate_private_key"); ok {
+		params.CertificatePrivateKey = aws.String(v.(string))
+	}
+
+	domainName, err := conn.CreateDomainName(params)
 	if err != nil {
 		return fmt.Errorf("Error creating API Gateway Domain Name: %s", err)
 	}
@@ -113,6 +139,7 @@ func resourceAwsApiGatewayDomainNameRead(d *schema.ResourceData, meta interface{
 	}
 	d.Set("cloudfront_domain_name", domainName.DistributionDomainName)
 	d.Set("domain_name", domainName.DomainName)
+	d.Set("certificate_arn", domainName.CertificateArn)
 
 	return nil
 }
@@ -128,6 +155,14 @@ func resourceAwsApiGatewayDomainNameUpdateOperations(d *schema.ResourceData) []*
 		})
 	}
 
+	if d.HasChange("certificate_arn") {
+		operations = append(operations, &apigateway.PatchOperation{
+			Op:    aws.String("replace"),
+			Path:  aws.String("/certificateArn"),
+			Value: aws.String(d.Get("certificate_arn").(string)),
+		})
+	}
+
 	return operations
 }
 
@@ -139,6 +174,7 @@ func resourceAwsApiGatewayDomainNameUpdate(d *schema.ResourceData, meta interfac
 		DomainName:      aws.String(d.Id()),
 		PatchOperations: resourceAwsApiGatewayDomainNameUpdateOperations(d),
 	})
+
 	if err != nil {
 		return err
 	}

--- a/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
@@ -55,15 +55,16 @@ resource "aws_route53_record" "example" {
 The following arguments are supported:
 
 * `domain_name` - (Required) The fully-qualified domain name to register
-* `certificate_name` - (Required) The unique name to use when registering this
+* `certificate_name` - (Optional) The unique name to use when registering this
   cert as an IAM server certificate
-* `certificate_body` - (Required) The certificate issued for the domain name
+* `certificate_body` - (Optional) The certificate issued for the domain name
   being registered, in PEM format
-* `certificate_chain` - (Required) The certificate for the CA that issued the
+* `certificate_chain` - (Optional) The certificate for the CA that issued the
   certificate, along with any intermediate CA certificates required to
   create an unbroken chain to a certificate trusted by the intended API clients.
-* `certificate_private_key` - (Required) The private key associated with the
+* `certificate_private_key` - (Optional) The private key associated with the
   domain certificate given in `certificate_body`.
+* `certificate_arn` - (Optional) The ARN for an AWS-managed certificate.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #12566

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayDomainName_'         ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/10 19:32:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAPIGatewayDomainName_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayDomainName_basic
--- PASS: TestAccAWSAPIGatewayDomainName_basic (54.06s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	54.091s
```

Unfortunately, due to ACM not being automatable, we can't add a test for this!