### PR TITLE
Add specific and independent unsortedkeys and unsortedvalues functions

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -970,7 +970,7 @@ func interpolationFuncKeys(vs map[string]ast.Variable) ast.Function {
 }
 
 // interpolationFuncValues implements the "values" function that yields a list of
-// keys of map types within a Terraform configuration.
+// values of map types within a Terraform configuration.
 func interpolationFuncValues(vs map[string]ast.Variable) ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeMap},
@@ -1003,6 +1003,60 @@ func interpolationFuncValues(vs map[string]ast.Variable) ast.Function {
 			return variable.Value, nil
 		},
 	}
+}
+
+// interpolationFuncUnsortedKeys implements the "unsortedkeys" function that yields a list of
+// keys of map types within a Terraform configuration without lexically sorting them.
+func interpolationFuncUnsortedKeys(vs map[string]ast.Variable) ast.Function {
+        return ast.Function{
+                ArgTypes:   []ast.Type{ast.TypeMap},
+                ReturnType: ast.TypeList,
+                Callback: func(args []interface{}) (interface{}, error) {
+                        mapVar := args[0].(map[string]ast.Variable)
+                        keys := make([]string, 0)
+
+                        for k, _ := range mapVar {
+                                keys = append(keys, k)
+                        }
+
+                        // Keys are guaranteed to be strings
+                        return stringSliceToVariableValue(keys), nil
+                },
+        }
+}
+
+// interpolationFuncUnsortedValues implements the "unsortedvalues" function that yields a list of
+// values of map types within a Terraform configuration without sorting them by their respective keys.
+func interpolationFuncUnsortedValues(vs map[string]ast.Variable) ast.Function {
+        return ast.Function{
+                ArgTypes:   []ast.Type{ast.TypeMap},
+                ReturnType: ast.TypeList,
+                Callback: func(args []interface{}) (interface{}, error) {
+                        mapVar := args[0].(map[string]ast.Variable)
+                        keys := make([]string, 0)
+
+                        for k, _ := range mapVar {
+                                keys = append(keys, k)
+                        }
+
+                        values := make([]string, len(keys))
+                        for index, key := range keys {
+                                if value, ok := mapVar[key].Value.(string); ok {
+                                        values[index] = value
+                                } else {
+                                        return "", fmt.Errorf("values(): %q has element with bad type %s",
+                                                key, mapVar[key].Type)
+                                }
+                        }
+
+                        variable, err := hil.InterfaceToVariable(values)
+                        if err != nil {
+                                return nil, err
+                        }
+
+                        return variable.Value, nil
+                },
+        }
 }
 
 // interpolationFuncBase64Encode implements the "base64encode" function that

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1713,6 +1713,168 @@ func TestInterpolateFuncValues(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncUnsortedKeys(t *testing.T) {
+        testFunction(t, testFunctionConfig{
+                Vars: map[string]ast.Variable{
+                        "var.foo": ast.Variable{
+                                Type: ast.TypeMap,
+                                Value: map[string]ast.Variable{
+                                        "bar": ast.Variable{
+                                                Value: "baz",
+                                                Type:  ast.TypeString,
+                                        },
+                                        "qux": ast.Variable{
+                                                Value: "quack",
+                                                Type:  ast.TypeString,
+                                        },
+                                },
+                        },
+                        "var.str": ast.Variable{
+                                Value: "astring",
+                                Type:  ast.TypeString,
+                        },
+                },
+                Cases: []testFunctionCase{
+                        {
+                                `${unsortedkeys(var.foo)}`,
+                                []interface{}{"bar", "qux"},
+                                false,
+                        },
+
+                        // Invalid key
+                        {
+                                `${unsortedkeys(var.not)}`,
+                                nil,
+                                true,
+                        },
+
+                        // Too many args
+                        {
+                                `${unsortedkeys(var.foo, "bar")}`,
+                                nil,
+                                true,
+                        },
+
+                        // Not a map
+                        {
+                                `${unsortedkeys(var.str)}`,
+                                nil,
+                                true,
+                        },
+                },
+        })
+}
+
+// Confirm that keys return in original order, and values return in their original
+// order which depends upon key ordering being unchanged
+func TestInterpolateFuncKeyValUnsortedOrder(t *testing.T) {
+        testFunction(t, testFunctionConfig{
+                Vars: map[string]ast.Variable{
+                        "var.foo": ast.Variable{
+                                Type: ast.TypeMap,
+                                Value: map[string]ast.Variable{
+                                        "D": ast.Variable{
+                                                Value: "2",
+                                                Type:  ast.TypeString,
+                                        },
+                                        "C": ast.Variable{
+                                                Value: "Y",
+                                                Type:  ast.TypeString,
+                                        },
+                                        "A": ast.Variable{
+                                                Value: "X",
+                                                Type:  ast.TypeString,
+                                        },
+                                        "10": ast.Variable{
+                                                Value: "Z",
+                                                Type:  ast.TypeString,
+                                        },
+                                        "1": ast.Variable{
+                                                Value: "4",
+                                                Type:  ast.TypeString,
+                                        },
+                                        "3": ast.Variable{
+                                                Value: "W",
+                                                Type:  ast.TypeString,
+                                        },
+                                },
+                        },
+                },
+                Cases: []testFunctionCase{
+                        {
+                                `${keys(var.foo)}`,
+                                []interface{}{"D", "C", "A", "10", "1", "3"},
+                                false,
+                        },
+
+                        {
+                                `${values(var.foo)}`,
+                                []interface{}{"2", "Y", "X", "Z", "4", "W"},
+                                false,
+                        },
+                },
+        })
+}
+
+func TestInterpolateFuncUnsortedValues(t *testing.T) {
+        testFunction(t, testFunctionConfig{
+                Vars: map[string]ast.Variable{
+                        "var.foo": ast.Variable{
+                                Type: ast.TypeMap,
+                                Value: map[string]ast.Variable{
+                                        "bar": ast.Variable{
+                                                Value: "quack",
+                                                Type:  ast.TypeString,
+                                        },
+                                        "qux": ast.Variable{
+                                                Value: "baz",
+                                                Type:  ast.TypeString,
+                                        },
+                                },
+                        },
+                        "var.str": ast.Variable{
+                                Value: "astring",
+                                Type:  ast.TypeString,
+                        },
+                },
+                Cases: []testFunctionCase{
+                        {
+                                `${unsortedvalues(var.foo)}`,
+                                []interface{}{"quack", "baz"},
+                                false,
+                        },
+
+                        // Invalid key
+                        {
+                                `${unsortedvalues(var.not)}`,
+                                nil,
+                                true,
+                        },
+
+                        // Too many args
+                        {
+                                `${unsortedvalues(var.foo, "bar")}`,
+                                nil,
+                                true,
+                        },
+
+                        // Not a map
+                        {
+                                `${unsortedvalues(var.str)}`,
+                                nil,
+                                true,
+                        },
+
+                        // Map of lists
+                        {
+                                `${unsortedvalues(map("one", list()))}`,
+                                nil,
+                                true,
+                        },
+                },
+        })
+}
+
 func interfaceToVariableSwallowError(input interface{}) ast.Variable {
 	variable, _ := hil.InterfaceToVariable(input)
 	return variable

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -325,6 +325,8 @@ func langEvalConfig(vs map[string]ast.Variable) *hil.EvalConfig {
 	funcMap["lookup"] = interpolationFuncLookup(vs)
 	funcMap["keys"] = interpolationFuncKeys(vs)
 	funcMap["values"] = interpolationFuncValues(vs)
+	funcMap["unsortedkeys"] = interpolationFuncUnsortedKeys(vs)
+	funcMap["unsortedvalues"] = interpolationFuncUnsortedValues(vs)
 
 	return &hil.EvalConfig{
 		GlobalScope: &ast.BasicScope{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -320,6 +320,12 @@ The supported built-in functions are:
 
   * `trimspace(string)` - Returns a copy of the string with all leading and trailing white spaces removed.
 
+  * `unsortedkeys(map)` - Returns a list of the map keys in their original order.
+
+  * `unsortedvalues(map)` - Returns a list of the map values, in their original order
+    (specifically the the order of the keys returned by the `unsortedkeys` function).
+    This function only works on flat maps and will return an error for maps that include nested lists or maps.
+
   * `upper(string)` - Returns a copy of the string with all Unicode letters mapped to their upper case.
 
   * `uuid()` - Returns a UUID string in RFC 4122 v4 format. This string will change with every invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the [`ignore_changes`](/docs/configuration/resources.html#ignore-changes) lifecycle attribute.


### PR DESCRIPTION
For retrieving keys and values from maps without any lexical sorting. This prevents recreation of swathes of resources when using count to generate many resources based on the contents of a map. You have control to ensure that adding a new entry to the end of the map will not cause the whole count association to shift.