### PR TITLE
Give keys and values map functions an option to disable lexical sorting of keys

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -951,17 +951,31 @@ func interpolationFuncElement() ast.Function {
 // keys of map types within a Terraform configuration.
 func interpolationFuncKeys(vs map[string]ast.Variable) ast.Function {
 	return ast.Function{
-		ArgTypes:   []ast.Type{ast.TypeMap},
-		ReturnType: ast.TypeList,
+		ArgTypes:     []ast.Type{ast.TypeMap},
+		ReturnType:   ast.TypeList,
+		Variadic:     true,
+		VariadicType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
+			sortValue := "true"
+			if len(args) > 1 {
+				sortValue = args[1].(string)
+			} else if len(args) > 2 {
+				return "", fmt.Errorf("keys() takes no more than two arguments")
+			}
+			if sortValue != "true" && sortValue != "false" {
+				return "", fmt.Errorf("keys() \"sort\" parameter, if provided, must be \"true\" or \"false\"")
+			}
 			mapVar := args[0].(map[string]ast.Variable)
+
 			keys := make([]string, 0)
 
 			for k, _ := range mapVar {
 				keys = append(keys, k)
 			}
 
-			sort.Strings(keys)
+			if sortValue == "true" {
+				sort.Strings(keys)
+			}
 
 			// Keys are guaranteed to be strings
 			return stringSliceToVariableValue(keys), nil
@@ -970,12 +984,23 @@ func interpolationFuncKeys(vs map[string]ast.Variable) ast.Function {
 }
 
 // interpolationFuncValues implements the "values" function that yields a list of
-// keys of map types within a Terraform configuration.
+// values of map types within a Terraform configuration.
 func interpolationFuncValues(vs map[string]ast.Variable) ast.Function {
 	return ast.Function{
-		ArgTypes:   []ast.Type{ast.TypeMap},
-		ReturnType: ast.TypeList,
+		ArgTypes:     []ast.Type{ast.TypeMap},
+		ReturnType:   ast.TypeList,
+		Variadic:     true,
+		VariadicType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
+			sortValue := "true"
+			if len(args) > 1 {
+				sortValue = args[1].(string)
+			} else if len(args) > 2 {
+				return "", fmt.Errorf("values() takes no more than two arguments")
+			}
+			if sortValue != "true" && sortValue != "false" {
+				return "", fmt.Errorf("values() \"sort\" parameter, if provided, must be \"true\" or \"false\"")
+			}
 			mapVar := args[0].(map[string]ast.Variable)
 			keys := make([]string, 0)
 
@@ -983,7 +1008,9 @@ func interpolationFuncValues(vs map[string]ast.Variable) ast.Function {
 				keys = append(keys, k)
 			}
 
-			sort.Strings(keys)
+			if sortValue == "true" {
+				sort.Strings(keys)
+			}
 
 			values := make([]string, len(keys))
 			for index, key := range keys {

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1654,6 +1654,57 @@ func TestInterpolateFuncKeyValOrder(t *testing.T) {
 	})
 }
 
+// Confirm that keys return in original order, and values return in their original
+// order which depends upon key ordering being unchanged
+func TestInterpolateFuncKeyValUnsortedOrder(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.foo": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"D": ast.Variable{
+						Value: "2",
+						Type:  ast.TypeString,
+					},
+					"C": ast.Variable{
+						Value: "Y",
+						Type:  ast.TypeString,
+					},
+					"A": ast.Variable{
+						Value: "X",
+						Type:  ast.TypeString,
+					},
+					"10": ast.Variable{
+						Value: "Z",
+						Type:  ast.TypeString,
+					},
+					"1": ast.Variable{
+						Value: "4",
+						Type:  ast.TypeString,
+					},
+					"3": ast.Variable{
+						Value: "W",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${keys(var.foo, "false")}`,
+				[]interface{}{"D", "C", "A", "10", "1", "3"},
+				false,
+			},
+
+			{
+				`${values(var.foo, "false")}`,
+				[]interface{}{"2", "Y", "X", "Z", "4", "W"},
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncValues(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Vars: map[string]ast.Variable{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -230,7 +230,8 @@ The supported built-in functions are:
     Note that if the item is a string, the return value includes the double
     quotes.
 
-  * `keys(map)` - Returns a lexically sorted list of the map keys.
+  * `keys(map, [sort])` - Returns a list of the map keys, lexically sorted by default.
+      The `sort` parameter can be set to "false" to disable sorting.
 
   * `length(list)` - Returns the number of members in a given list or map, or the number of characters in a given string.
       * `${length(split(",", "a,b,c"))}` = 3
@@ -324,9 +325,10 @@ The supported built-in functions are:
 
   * `uuid()` - Returns a UUID string in RFC 4122 v4 format. This string will change with every invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the [`ignore_changes`](/docs/configuration/resources.html#ignore-changes) lifecycle attribute.
 
-  * `values(map)` - Returns a list of the map values, in the order of the keys
-    returned by the `keys` function. This function only works on flat maps and
-    will return an error for maps that include nested lists or maps.
+  * `values(map, [sort])` - Returns a list of the map values, by default in the order of the keys
+    returned by the `keys` function. If the `sort` parameters is set to "false", the values will be
+    in the order of the keys returned by the `keys` function when the associated `sort` parameter is set to "false".
+    This function only works on flat maps and will return an error for maps that include nested lists or maps.
 
   * `zipmap(list, list)` - Creates a map from a list of keys and a list of
       values. The keys must all be of type string, and the length of the lists


### PR DESCRIPTION
This is an alternative option for https://github.com/hashicorp/terraform/pull/12598