### PR TITLE
Add specific and independent unsortedkeys and unsortedvalues functions

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1588,7 +1588,7 @@ func TestInterpolateFuncKeys(t *testing.T) {
 
 			// Too many args
 			{
-				`${keys(var.foo, "bar")}`,
+				`${keys(var.foo, "false", "bar")}`,
 				nil,
 				true,
 			},
@@ -1706,6 +1706,168 @@ func TestInterpolateFuncValues(t *testing.T) {
 			// Map of lists
 			{
 				`${values(map("one", list()))}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncUnsortedKeys(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.foo": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: "baz",
+						Type:  ast.TypeString,
+					},
+					"qux": ast.Variable{
+						Value: "quack",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+			"var.str": ast.Variable{
+				Value: "astring",
+				Type:  ast.TypeString,
+			},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${unsortedkeys(var.foo)}`,
+				[]interface{}{"bar", "qux"},
+				false,
+			},
+
+			// Invalid key
+			{
+				`${unsortedkeys(var.not)}`,
+				nil,
+				true,
+			},
+
+			// Too many args
+			{
+				`${unsortedkeys(var.foo, "bar")}`,
+				nil,
+				true,
+			},
+
+			// Not a map
+			{
+				`${unsortedkeys(var.str)}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
+// Confirm that keys return in original order, and values return in their original
+// order which depends upon key ordering being unchanged
+func TestInterpolateFuncUnsortedKeyValOrder(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.foo": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"D": ast.Variable{
+						Value: "2",
+						Type:  ast.TypeString,
+					},
+					"C": ast.Variable{
+						Value: "Y",
+						Type:  ast.TypeString,
+					},
+					"A": ast.Variable{
+						Value: "X",
+						Type:  ast.TypeString,
+					},
+					"10": ast.Variable{
+						Value: "Z",
+						Type:  ast.TypeString,
+					},
+					"1": ast.Variable{
+						Value: "4",
+						Type:  ast.TypeString,
+					},
+					"3": ast.Variable{
+						Value: "W",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${unsortedkeys(var.foo)}`,
+				[]interface{}{"D", "C", "A", "10", "1", "3"},
+				false,
+			},
+
+			{
+				`${unsortedvalues(var.foo)}`,
+				[]interface{}{"2", "Y", "X", "Z", "4", "W"},
+				false,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncUnsortedValues(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.foo": ast.Variable{
+				Type: ast.TypeMap,
+				Value: map[string]ast.Variable{
+					"bar": ast.Variable{
+						Value: "quack",
+						Type:  ast.TypeString,
+					},
+					"qux": ast.Variable{
+						Value: "baz",
+						Type:  ast.TypeString,
+					},
+				},
+			},
+			"var.str": ast.Variable{
+				Value: "astring",
+				Type:  ast.TypeString,
+			},
+		},
+		Cases: []testFunctionCase{
+			{
+				`${unsortedvalues(var.foo)}`,
+				[]interface{}{"quack", "baz"},
+				false,
+			},
+
+			// Invalid key
+			{
+				`${unsortedvalues(var.not)}`,
+				nil,
+				true,
+			},
+
+			// Too many args
+			{
+				`${unsortedvalues(var.foo, "bar")}`,
+				nil,
+				true,
+			},
+
+			// Not a map
+			{
+				`${unsortedvalues(var.str)}`,
+				nil,
+				true,
+			},
+
+			// Map of lists
+			{
+				`${unsortedvalues(map("one", list()))}`,
 				nil,
 				true,
 			},

--- a/config/raw_config.go
+++ b/config/raw_config.go
@@ -325,6 +325,8 @@ func langEvalConfig(vs map[string]ast.Variable) *hil.EvalConfig {
 	funcMap["lookup"] = interpolationFuncLookup(vs)
 	funcMap["keys"] = interpolationFuncKeys(vs)
 	funcMap["values"] = interpolationFuncValues(vs)
+	funcMap["unsortedkeys"] = interpolationFuncUnsortedKeys(vs)
+	funcMap["unsortedvalues"] = interpolationFuncUnsortedValues(vs)
 
 	return &hil.EvalConfig{
 		GlobalScope: &ast.BasicScope{

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -320,6 +320,12 @@ The supported built-in functions are:
 
   * `trimspace(string)` - Returns a copy of the string with all leading and trailing white spaces removed.
 
+  * `unsortedkeys(map)` - Returns a list of the map keys in their original order.
+
+  * `unsortedvalues(map)` - Returns a list of the map values, in their original order
+    (specifically the the order of the keys returned by the `unsortedkeys` function).
+    This function only works on flat maps and will return an error for maps that include nested lists or maps.
+
   * `upper(string)` - Returns a copy of the string with all Unicode letters mapped to their upper case.
 
   * `uuid()` - Returns a UUID string in RFC 4122 v4 format. This string will change with every invocation of the function, so in order to prevent diffs on every plan & apply, it must be used with the [`ignore_changes`](/docs/configuration/resources.html#ignore-changes) lifecycle attribute.


### PR DESCRIPTION
For retrieving keys and values from maps without any lexical sorting. This prevents recreation of swathes of resources when using count to generate many resources based on the contents of a map.

This is an alternative option for https://github.com/hashicorp/terraform/pull/12597