### PR TITLE
provider/aws: catch invalid lambda function timeout in plan

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -83,9 +83,10 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				ValidateFunc: validateRuntime,
 			},
 			"timeout": {
-				Type:     schema.TypeInt,
-				Optional: true,
-				Default:  3,
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      3,
+				ValidateFunc: validateTimeout,
 			},
 			"publish": {
 				Type:     schema.TypeBool,
@@ -583,6 +584,17 @@ func validateRuntime(v interface{}, k string) (ws []string, errors []error) {
 		errors = append(errors, fmt.Errorf(
 			"%s has reached end of life since October 2016 and has been deprecated in favor of %s.",
 			runtime, lambda.RuntimeNodejs43))
+	}
+	return
+}
+
+func validateTimeout(v interface{}, k string) (ws []string, errors []error) {
+	timeout := v.(int)
+
+	if timeout > 300 {
+		errors = append(errors, fmt.Errorf(
+			"Lambda timeout can't exceed 300. Currently set to %d.",
+			timeout))
 	}
 	return
 }


### PR DESCRIPTION
Encountered the following error after a terraform apply failed:

    * aws_lambda_function.LambdaFunction: Error modifying Lambda Function Configuration cifull1-Redshift-Persistence: ValidationException: 1 validation error detected: Value '600' at 'timeout' failed to satisfy constraint: Member must have value less than or equal to 300
	status code: 400, request id: e8d3f902-05d8-11e7-9dff-9b2b32ac011c

This patch adds a validator to the timeout value to ensure it is under during 300 during plan.