### PR TITLE
provider/aws: Refresh iam saml provider from state on 404

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_saml_provider.go
+++ b/builtin/providers/aws/resource_aws_iam_saml_provider.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"regexp"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -70,6 +72,11 @@ func resourceAwsIamSamlProviderRead(d *schema.ResourceData, meta interface{}) er
 	}
 	out, err := iamconn.GetSAMLProvider(input)
 	if err != nil {
+		if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+			log.Printf("[WARN] IAM SAML Provider %q not found.", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes: #12599

Before this patch:

```
% terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_iam_saml_provider.salesforce: Refreshing state... (ID: arn:aws:i...rce-test)
Error refreshing state: 1 error(s) occurred:

* aws_iam_saml_provider.salesforce: aws_iam_saml_provider.salesforce: NoSuchEntity: Manifest not found for arn arn:aws:iam::187416307283:saml-provider/tf-salesforce-test
	status code: 404, request id: fc32c7f8-0631-11e7-8e1f-29a8c10edf64
```

After this patch:

```
% terraform plan                                                                                  ✚ ✭
[WARN] /Users/stacko/Code/go/bin/terraform-provider-aws overrides an internal plugin for aws-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_iam_saml_provider.salesforce: Refreshing state... (ID: arn:aws:i...rce-test)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ aws_iam_saml_provider.salesforce
    arn:                    "<computed>"
    name:                   "tf-salesforce-test"
```