### PR TITLE
provider/aws: output the task definition name when errors occur

### DIFF
--- a/builtin/providers/aws/data_source_aws_ecs_task_definition.go
+++ b/builtin/providers/aws/data_source_aws_ecs_task_definition.go
@@ -51,7 +51,7 @@ func dataSourceAwsEcsTaskDefinitionRead(d *schema.ResourceData, meta interface{}
 	})
 
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed getting task definition %s %q", err, d.Get("task_definition").(string))
 	}
 
 	taskDefinition := *desc.TaskDefinition


### PR DESCRIPTION
before:

    * data.aws_ecs_task_definition.task: ClientException: Unable to describe task definition.
        status code: 400, request id: ace827be-06a7-11e7-9670-c3345178283b


after:

    * data.aws_ecs_task_definition.task: Failed getting task definition ClientException: Unable to describe task definition.
        status code: 400, request id: e1e3296a-06a9-11e7-8aed-fb4787197f0e "my_task"