### PR TITLE
provider/openstack: Set Availability Zone in Instances

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -29,6 +29,8 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeV2InstanceExists("openstack_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_instance_v2.instance_1", "availability_zone", "nova"),
 				),
 			},
 		},

--- a/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/results.go
+++ b/vendor/github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones/results.go
@@ -1,0 +1,12 @@
+package availabilityzones
+
+// ServerExt is an extension to the base Server object
+type ServerExt struct {
+	// AvailabilityZone is the availabilty zone the server is in.
+	AvailabilityZone string `json:"OS-EXT-AZ:availability_zone"`
+}
+
+// UnmarshalJSON to override default
+func (r *ServerExt) UnmarshalJSON(b []byte) error {
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1531,6 +1531,12 @@
 			"revisionTime": "2017-03-10T01:59:53Z"
 		},
 		{
+			"checksumSHA1": "y49Ur726Juznj85+23ZgqMvehgg=",
+			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/availabilityzones",
+			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",
+			"revisionTime": "2017-03-10T01:59:53Z"
+		},
+		{
 			"checksumSHA1": "w2wHF5eEBE89ZYlkS9GAJsSIq9U=",
 			"path": "github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/bootfromvolume",
 			"revision": "0f64da0e36de86a0ca1a8f2fc1b0570a0d3f7504",


### PR DESCRIPTION
This configures the openstack_compute_instance_v2 resource
to set the Availability Zone of the instance resource.

For #9979