### PR TITLE
provider/openstack: Change Port fixed_ip to a Set

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -80,7 +80,7 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Computed: true,
 			},
 			"fixed_ip": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				ForceNew: false,
 				Computed: true,
@@ -304,7 +304,7 @@ func resourcePortSecurityGroupsV2(d *schema.ResourceData) []string {
 }
 
 func resourcePortFixedIpsV2(d *schema.ResourceData) interface{} {
-	rawIP := d.Get("fixed_ip").([]interface{})
+	rawIP := d.Get("fixed_ip").(*schema.Set).List()
 
 	if len(rawIP) == 0 {
 		return nil

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
@@ -80,6 +80,28 @@ func TestAccNetworkingV2Port_allowedAddressPairs(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Port_multipleFixedIPs(t *testing.T) {
+	var network networks.Network
+	var port ports.Port
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Port_multipleFixedIPs,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2PortDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -244,6 +266,41 @@ resource "openstack_networking_port_v2" "instance_port" {
   allowed_address_pairs {
     ip_address = "${openstack_networking_port_v2.vrrp_port_2.fixed_ip.0.ip_address}"
     mac_address = "${openstack_networking_port_v2.vrrp_port_2.mac_address}"
+  }
+}
+`
+
+const testAccNetworkingV2Port_multipleFixedIPs = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.23"
+  }
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.20"
+  }
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.40"
   }
 }
 `


### PR DESCRIPTION
This commit changes the openstack_networking_port_v2 fixed_ip
parameter from a List to a Set. This is because OpenStack does not
preserve the original ordering of the fixed IPs.

Fixes #12110