### PR TITLE
provider/openstack: Add network_id to Network data source

### DIFF
--- a/builtin/providers/openstack/data_source_openstack_networking_network_v2.go
+++ b/builtin/providers/openstack/data_source_openstack_networking_network_v2.go
@@ -17,6 +17,10 @@ func dataSourceNetworkingNetworkV2() *schema.Resource {
 		Read: dataSourceNetworkingNetworkV2Read,
 
 		Schema: map[string]*schema.Schema{
+			"network_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -56,6 +60,7 @@ func dataSourceNetworkingNetworkV2Read(d *schema.ResourceData, meta interface{})
 	networkingClient, err := config.networkingV2Client(GetRegion(d))
 
 	listOpts := networks.ListOpts{
+		ID:       d.Get("network_id").(string),
 		Name:     d.Get("name").(string),
 		TenantID: d.Get("tenant_id").(string),
 		Status:   "ACTIVE",

--- a/builtin/providers/openstack/data_source_openstack_networking_network_v2_test.go
+++ b/builtin/providers/openstack/data_source_openstack_networking_network_v2_test.go
@@ -52,6 +52,28 @@ func TestAccOpenStackNetworkingNetworkV2DataSource_subnet(t *testing.T) {
 	})
 }
 
+func TestAccOpenStackNetworkingNetworkV2DataSource_networkID(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_network,
+			},
+			resource.TestStep{
+				Config: testAccOpenStackNetworkingNetworkV2DataSource_networkID,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingNetworkV2DataSourceID("data.openstack_networking_network_v2.net"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "name", "tf_test_network"),
+					resource.TestCheckResourceAttr(
+						"data.openstack_networking_network_v2.net", "admin_state_up", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingNetworkV2DataSourceID(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -94,5 +116,13 @@ var testAccOpenStackNetworkingNetworkV2DataSource_subnet = fmt.Sprintf(`
 
 data "openstack_networking_network_v2" "net" {
 	matching_subnet_cidr = "${openstack_networking_subnet_v2.subnet.cidr}"
+}
+`, testAccOpenStackNetworkingNetworkV2DataSource_network)
+
+var testAccOpenStackNetworkingNetworkV2DataSource_networkID = fmt.Sprintf(`
+%s
+
+data "openstack_networking_network_v2" "net" {
+	network_id = "${openstack_networking_network_v2.net.id}"
 }
 `, testAccOpenStackNetworkingNetworkV2DataSource_network)

--- a/website/source/docs/providers/openstack/d/networking_network_v2.html.markdown
+++ b/website/source/docs/providers/openstack/d/networking_network_v2.html.markdown
@@ -24,6 +24,8 @@ data "openstack_networking_network_v2" "network" {
   A Neutron client is needed to retrieve networks ids. If omitted, the
   `OS_REGION_NAME` environment variable is used.
 
+* `network_id` - (Optional) The ID of the network.
+
 * `name` - (Optional) The name of the network.
 
 * `matching_subnet_cidr` - (Optional) The CIDR of a subnet within the network.


### PR DESCRIPTION
This commit adds the ability to search for a network by its ID. This
is useful for doing ID-to-name translations.

For #9952