### PR TITLE
provider/dnsimple: Don't prompt the user for email address

### DIFF
--- a/builtin/providers/dnsimple/provider.go
+++ b/builtin/providers/dnsimple/provider.go
@@ -14,7 +14,7 @@ func Provider() terraform.ResourceProvider {
 			"email": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("DNSIMPLE_EMAIL", nil),
+				DefaultFunc: schema.EnvDefaultFunc("DNSIMPLE_EMAIL", ""),
 				Description: "The DNSimple account email address.",
 			},
 


### PR DESCRIPTION
As part of the new changes to the DNSimple provider, we changed to use
the new API version. This requires a token and *not* email address

In order for backwards compatibility - we kept the email address in the
schema but we had the default as nil, meaning that Terraform was
prompting the user for it, they would enter it, then Terraform would
error out due to using a combination of token and email address

This commit makes the default email address an empty String. This means
we don't prompt the user