### PR TITLE
[WIP] provider/aws: Expanding AWS ec2 IPv6 Support

### DIFF
--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -41,6 +41,16 @@ func dataSourceAwsRouteTable() *schema.Resource {
 							Computed: true,
 						},
 
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"egress_only_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"gateway_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -176,6 +186,12 @@ func dataSourceRoutesRead(ec2Routes []*ec2.Route) []map[string]interface{} {
 
 		if r.DestinationCidrBlock != nil {
 			m["cidr_block"] = *r.DestinationCidrBlock
+		}
+		if r.DestinationIpv6CidrBlock != nil {
+			m["ipv6_cidr_block"] = *r.DestinationIpv6CidrBlock
+		}
+		if r.EgressOnlyInternetGatewayId != nil {
+			m["egress_only_gateway_id"] = *r.EgressOnlyInternetGatewayId
 		}
 		if r.GatewayId != nil {
 			m["gateway_id"] = *r.GatewayId

--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsRouteTableGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_tag"),
@@ -33,7 +33,7 @@ func TestAccDataSourceAwsRouteTable_main(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsRouteTableMainRoute,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRouteTableCheckMain("data.aws_route_table.by_filter"),

--- a/builtin/providers/aws/import_aws_route_table.go
+++ b/builtin/providers/aws/import_aws_route_table.go
@@ -51,6 +51,7 @@ func resourceAwsRouteTableImportState(
 			d.SetType("aws_route")
 			d.Set("route_table_id", id)
 			d.Set("destination_cidr_block", route.DestinationCidrBlock)
+			d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
 			d.SetId(routeIDHash(d, route))
 			results = append(results, d)
 		}

--- a/builtin/providers/aws/import_aws_route_table_test.go
+++ b/builtin/providers/aws/import_aws_route_table_test.go
@@ -23,11 +23,11 @@ func TestAccAWSRouteTable_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfig,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:     "aws_route_table.foo",
 				ImportState:      true,
 				ImportStateCheck: checkFn,
@@ -51,11 +51,11 @@ func TestAccAWSRouteTable_complex(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfig_complexImport,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:     "aws_route_table.mod",
 				ImportState:      true,
 				ImportStateCheck: checkFn,

--- a/builtin/providers/aws/resource_aws_default_route_table.go
+++ b/builtin/providers/aws/resource_aws_default_route_table.go
@@ -17,56 +17,66 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 		Delete: resourceAwsDefaultRouteTableDelete,
 
 		Schema: map[string]*schema.Schema{
-			"default_route_table_id": &schema.Schema{
+			"default_route_table_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"vpc_id": &schema.Schema{
+			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"propagating_vgws": &schema.Schema{
+			"propagating_vgws": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
 
-			"route": &schema.Schema{
+			"route": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"cidr_block": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
-						"gateway_id": &schema.Schema{
+						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"instance_id": &schema.Schema{
+						"ipv6_cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"nat_gateway_id": &schema.Schema{
+						"egress_only_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"vpc_peering_connection_id": &schema.Schema{
+						"gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"network_interface_id": &schema.Schema{
+						"instance_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"nat_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"vpc_peering_connection_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"network_interface_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -193,16 +203,33 @@ func revokeAllRouteTableRules(defaultRouteTableId string, meta interface{}) erro
 			// See aws_vpc_endpoint
 			continue
 		}
-		log.Printf(
-			"[INFO] Deleting route from %s: %s",
-			defaultRouteTableId, *r.DestinationCidrBlock)
-		_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
-			RouteTableId:         aws.String(defaultRouteTableId),
-			DestinationCidrBlock: r.DestinationCidrBlock,
-		})
-		if err != nil {
-			return err
+
+		if r.DestinationCidrBlock != nil {
+			log.Printf(
+				"[INFO] Deleting route from %s: %s",
+				defaultRouteTableId, *r.DestinationCidrBlock)
+			_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
+				RouteTableId:         aws.String(defaultRouteTableId),
+				DestinationCidrBlock: r.DestinationCidrBlock,
+			})
+			if err != nil {
+				return err
+			}
 		}
+
+		if r.DestinationIpv6CidrBlock != nil {
+			log.Printf(
+				"[INFO] Deleting route from %s: %s",
+				defaultRouteTableId, *r.DestinationIpv6CidrBlock)
+			_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
+				RouteTableId:             aws.String(defaultRouteTableId),
+				DestinationIpv6CidrBlock: r.DestinationIpv6CidrBlock,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_default_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_default_route_table_test.go
@@ -20,7 +20,7 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTableConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -40,7 +40,7 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTable_change,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -53,7 +53,7 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 			// behavior that may happen, in which case a follow up plan will show (in
 			// this case) a diff as the table now needs to be updated to match the
 			// config
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTable_change_mod,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -74,7 +74,7 @@ func TestAccAWSDefaultRouteTable_vpc_endpoint(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTable_vpc_endpoint,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -63,7 +63,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -72,7 +72,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigChange,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -113,11 +113,40 @@ func TestAccAWSRouteTable_instance(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigInstance,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
 						"aws_route_table.foo", &v),
+					testCheck,
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRouteTable_ipv6(t *testing.T) {
+	var v ec2.RouteTable
+
+	testCheck := func(*terraform.State) error {
+		// Expect 3: 2 IPv6 (local + all outbound) + 1 IPv4
+		if len(v.Routes) != 3 {
+			return fmt.Errorf("bad routes: %#v", v.Routes)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_route_table.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTableConfigIpv6,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists("aws_route_table.foo", &v),
 					testCheck,
 				),
 			},
@@ -134,7 +163,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
@@ -142,7 +171,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
@@ -244,7 +273,7 @@ func TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableVpcPeeringConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -285,7 +314,7 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 			testAccCheckRouteTableDestroy,
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableVgwRoutePropagationConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -338,6 +367,26 @@ resource "aws_route_table" "foo" {
 	route {
 		cidr_block = "10.4.0.0/16"
 		gateway_id = "${aws_internet_gateway.foo.id}"
+	}
+}
+`
+
+const testAccRouteTableConfigIpv6 = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_egress_only_internet_gateway" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	route {
+		ipv6_cidr_block = "::/0"
+		egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
 	}
 }
 `

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -71,6 +71,8 @@ the selected Route Table.
 Each route supports the following:
 
 * `cidr_block` - The CIDR block of the route.
+* `ipv6_cidr_block` - The IPv6 CIDR block of the route.
+* `egress_only_gateway_id` - The ID of the Egress Only Internet Gateway.
 * `gateway_id` - The Internet Gateway ID.
 * `nat_gateway_id` - The NAT Gateway ID.
 * `instance_id` - The EC2 instance ID.

--- a/website/source/docs/providers/aws/r/default_route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/default_route_table.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 Each route supports the following:
 
 * `cidr_block` - (Required) The CIDR block of the route.
+* `ipv6_cidr_block` - Optional) The Ipv6 CIDR block of the route
+* `egress_only_gateway_id` - (Optional) The Egress Only Internet Gateway ID.
 * `gateway_id` - (Optional) The Internet Gateway ID.
 * `nat_gateway_id` - (Optional) The NAT Gateway ID.
 * `instance_id` - (Optional) The EC2 instance ID.

--- a/website/source/docs/providers/aws/r/route.html.markdown
+++ b/website/source/docs/providers/aws/r/route.html.markdown
@@ -27,19 +27,40 @@ resource "aws_route" "r" {
 }
 ```
 
+##Example IPv6 Usage:
+
+```
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_egress_only_internet_gateway" "egress" {
+  vpc_id = "${aws_vpc.vpc.id}"
+}
+
+resource "aws_route" "r" {
+  route_table_id               = "rtb-4fbb3ac4"
+  destination_ipv6_cidr_block  = "::/0"
+  egress_only_gateway_id = "${aws_egress_only_internet_gateway.egress.id}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `route_table_id` - (Required) The ID of the routing table.
-* `destination_cidr_block` - (Required) The destination CIDR block.
+* `destination_cidr_block` - (Optional) The destination CIDR block.
+* `destination_ipv6_cidr_block` - (Optional) The destination IPv6 CIDR block.
 * `vpc_peering_connection_id` - (Optional) An ID of a VPC peering connection.
+* `egress_only_gateway_id` - (Optional) An ID of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) An ID of a VPC internet gateway or a virtual private gateway.
 * `nat_gateway_id` - (Optional) An ID of a VPC NAT gateway.
 * `instance_id` - (Optional) An ID of an EC2 instance.
 * `network_interface_id` - (Optional) An ID of a network interface.
 
-Each route must contain either a `gateway_id`, a `nat_gateway_id`, an
+Each route must contain either a `gateway_id`, `egress_only_gateway_id` a `nat_gateway_id`, an
 `instance_id` or a `vpc_peering_connection_id` or a `network_interface_id`.
 Note that the default route, mapping the VPC's CIDR block to "local", is
 created implicitly and cannot be specified.
@@ -53,7 +74,9 @@ will be exported as an attribute once the resource is created.
 
 * `route_table_id` - The ID of the routing table.
 * `destination_cidr_block` - The destination CIDR block.
+* `destination_ipv6_cidr_block` - The destination IPv6 CIDR block.
 * `vpc_peering_connection_id` - An ID of a VPC peering connection.
+* `egress_only_gateway_id` - An ID of a VPC Egress Only Internet Gateway.
 * `gateway_id` - An ID of a VPC internet gateway or a virtual private gateway.
 * `nat_gateway_id` - An ID of a VPC NAT gateway.
 * `instance_id` - An ID of a NAT instance.

--- a/website/source/docs/providers/aws/r/route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/route_table.html.markdown
@@ -27,6 +27,11 @@ resource "aws_route_table" "r" {
     gateway_id = "${aws_internet_gateway.main.id}"
   }
 
+  route {
+    ipv6_cidr_block = "::/0"
+    egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
+  }
+
   tags {
     Name = "main"
   }
@@ -44,7 +49,9 @@ The following arguments are supported:
 
 Each route supports the following:
 
-* `cidr_block` - (Required) The CIDR block of the route.
+* `cidr_block` - (Optional) The CIDR block of the route.
+* `ipv6_cidr_block` - Optional) The Ipv6 CIDR block of the route
+* `egress_only_gateway_id` - (Optional) The Egress Only Internet Gateway ID.
 * `gateway_id` - (Optional) The Internet Gateway ID.
 * `nat_gateway_id` - (Optional) The NAT Gateway ID.
 * `instance_id` - (Optional) The EC2 instance ID.


### PR DESCRIPTION
Fixes: #12515

- [x] aws_route
- [x] aws_route_table
- [x] aws_default_route_table
- [ ] aws_network_acl
- [ ] aws_network_acl_rule
- [ ] aws_security_group
- [ ] aws_security_group_rule

We need all resources and data sources to support the IPv6