### PR TITLE
provider/aws: Add address, port, hosted_zone_id and endpoint for aws_db_instance datasource

### DIFF
--- a/builtin/providers/aws/data_source_aws_db_instance.go
+++ b/builtin/providers/aws/data_source_aws_db_instance.go
@@ -20,6 +20,11 @@ func dataSourceAwsDbInstance() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"allocated_storage": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -82,12 +87,22 @@ func dataSourceAwsDbInstance() *schema.Resource {
 				Computed: true,
 			},
 
+			"endpoint": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"engine": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
 			"engine_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"hosted_zone_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -131,6 +146,11 @@ func dataSourceAwsDbInstance() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+
+			"port": {
+				Type:     schema.TypeInt,
+				Computed: true,
 			},
 
 			"preferred_backup_window": {
@@ -232,6 +252,10 @@ func dataSourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("master_username", dbInstance.MasterUsername)
 	d.Set("monitoring_interval", dbInstance.MonitoringInterval)
 	d.Set("monitoring_role_arn", dbInstance.MonitoringRoleArn)
+	d.Set("address", dbInstance.Endpoint.Address)
+	d.Set("port", dbInstance.Endpoint.Port)
+	d.Set("hosted_zone_id", dbInstance.Endpoint.HostedZoneId)
+	d.Set("endpoint", fmt.Sprintf("%s:%d", *dbInstance.Endpoint.Address, *dbInstance.Endpoint.Port))
 
 	var optionGroups []string
 	for _, v := range dbInstance.OptionGroupMemberships {

--- a/builtin/providers/aws/data_source_aws_db_instance_test.go
+++ b/builtin/providers/aws/data_source_aws_db_instance_test.go
@@ -28,6 +28,25 @@ func TestAccAWSDataDbInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDataDbInstance_endpoint(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfigWithDataSource(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "address"),
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "port"),
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "hosted_zone_id"),
+					resource.TestCheckResourceAttrSet("data.aws_db_instance.bar", "endpoint"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSDBInstanceConfigWithDataSource(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_db_instance" "bar" {

--- a/website/source/docs/providers/aws/d/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/d/db_instance.html.markdown
@@ -28,6 +28,7 @@ The following arguments are supported:
 
 The following attributes are exported:
 
+* `address` - The address of the RDS instance.
 * `allocated_storage` - Specifies the allocated storage size specified in gigabytes.
 * `auto_minor_version_upgrade` - Indicates that minor version patches are applied automatically.
 * `availability_zone` - Specifies the name of the Availability Zone the DB instance is located in.
@@ -40,8 +41,10 @@ The following attributes are exported:
 * `db_security_groups` - Provides List of DB security groups associated to this DB instance.
 * `db_subnet_group` - Specifies the name of the subnet group associated with the DB instance.
 * `db_instance_port` - Specifies the port that the DB instance listens on.
+* `endpoint` - The connection endpoint.
 * `engine` - Provides the name of the database engine to be used for this DB instance.
 * `engine_version` - Indicates the database engine version.
+* `hosted_zone_id` - The canonical hosted zone ID of the DB instance (to be used in a Route 53 Alias record).
 * `iops` - Specifies the Provisioned IOPS (I/O operations per second) value.
 * `kms_key_id` - If StorageEncrypted is true, the KMS key identifier for the encrypted DB instance.
 * `license_model` - License model information for this DB instance.
@@ -50,6 +53,7 @@ The following attributes are exported:
 * `monitoring_role_arn` - The ARN for the IAM role that permits RDS to send Enhanced Monitoring metrics to CloudWatch Logs.
 * `multi_az` - Specifies if the DB instance is a Multi-AZ deployment.
 * `option_group_memberships` - Provides the list of option group memberships for this DB instance.
+* `port` - The database port.
 * `preferred_backup_window` - Specifies the daily time range during which automated backups are created.
 * `preferred_maintenance_window` -  Specifies the weekly time range during which system maintenance can occur in UTC.
 * `publicly_accessible` - Specifies the accessibility options for the DB instance.


### PR DESCRIPTION
- The `address` and `hosted_zone_id` can be used in a `route53_record`
- The `port` and the `endpoint` can be used to provide information when bootstrapping apps.

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSDataDbInstance_endpoint'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/12 19:04:37 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSDataDbInstance_endpoint -timeout 120m
=== RUN   TestAccAWSDataDbInstance_endpoint
--- PASS: TestAccAWSDataDbInstance_endpoint (579.47s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	579.491s
```