### PR TITLE
Fix `aws_cloudfront_distribution` resource schema

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -216,7 +216,7 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 								Schema: map[string]*schema.Schema{
 									"cookies": {
 										Type:     schema.TypeSet,
-										Optional: true,
+										Required: true,
 										Set:      cookiePreferenceHash,
 										MaxItems: 1,
 										Elem: &schema.Resource{


### PR DESCRIPTION
Ensure schemas for `default_cache_behavior` and `cache_behavior` are same except `path_pattern`
Originally from my comments to https://github.com/hashicorp/terraform/commit/8129c0589cc85879752173585ce3245ab26abe01