### PR TITLE
aws: Fix opsworks app acc test w/ missing value

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_application_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application_test.go
@@ -8,25 +8,30 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/opsworks"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSOpsworksApplication(t *testing.T) {
 	var opsapp opsworks.App
+
+	rInt := acctest.RandInt()
+	name := fmt.Sprintf("tf-ops-acc-application-%d", rInt)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksApplicationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAwsOpsworksApplicationCreate,
+				Config: testAccAwsOpsworksApplicationCreate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksApplicationExists(
 						"aws_opsworks_application.tf-acc-app", &opsapp),
 					testAccCheckAWSOpsworksCreateAppAttributes(&opsapp),
 					resource.TestCheckResourceAttr(
-						"aws_opsworks_application.tf-acc-app", "name", "tf-ops-acc-application",
+						"aws_opsworks_application.tf-acc-app", "name", name,
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "type", "other",
@@ -58,13 +63,13 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccAwsOpsworksApplicationUpdate,
+				Config: testAccAwsOpsworksApplicationUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksApplicationExists(
 						"aws_opsworks_application.tf-acc-app", &opsapp),
 					testAccCheckAWSOpsworksUpdateAppAttributes(&opsapp),
 					resource.TestCheckResourceAttr(
-						"aws_opsworks_application.tf-acc-app", "name", "tf-ops-acc-application",
+						"aws_opsworks_application.tf-acc-app", "name", name,
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "type", "rails",
@@ -308,10 +313,12 @@ func testAccCheckAwsOpsworksApplicationDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAwsOpsworksApplicationCreate = testAccAwsOpsworksStackConfigVpcCreate("tf-ops-acc-application") + `
+func testAccAwsOpsworksApplicationCreate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		fmt.Sprintf(`
 resource "aws_opsworks_application" "tf-acc-app" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
-  name = "tf-ops-acc-application"
+  name = "%s"
   type = "other"
   enable_ssl = false
   app_source ={
@@ -320,12 +327,15 @@ resource "aws_opsworks_application" "tf-acc-app" {
 	environment = { key = "key1" value = "value1" secure = false}
 	document_root = "foo"
 }
-`
+`, name)
+}
 
-var testAccAwsOpsworksApplicationUpdate = testAccAwsOpsworksStackConfigVpcCreate("tf-ops-acc-application") + `
+func testAccAwsOpsworksApplicationUpdate(name string) string {
+	return testAccAwsOpsworksStackConfigVpcCreate(name) +
+		fmt.Sprintf(`
 resource "aws_opsworks_application" "tf-acc-app" {
   stack_id = "${aws_opsworks_stack.tf-acc.id}"
-  name = "tf-ops-acc-application"
+  name = "%s"
   type = "rails"
   domains = ["example.com", "sub.example.com"]
   enable_ssl = true
@@ -372,4 +382,5 @@ EOS
   auto_bundle_on_deploy = "true"
   rails_env = "staging"
 }
-`
+`, name)
+}

--- a/builtin/providers/aws/resource_aws_opsworks_application_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application_test.go
@@ -34,14 +34,14 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "enable_ssl", "false",
 					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_application.tf-acc-app", "ssl_configuration", "",
+					resource.TestCheckNoResourceAttr(
+						"aws_opsworks_application.tf-acc-app", "ssl_configuration",
 					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_application.tf-acc-app", "domains", "",
+					resource.TestCheckNoResourceAttr(
+						"aws_opsworks_application.tf-acc-app", "domains",
 					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_application.tf-acc-app", "app_source", "",
+					resource.TestCheckNoResourceAttr(
+						"aws_opsworks_application.tf-acc-app", "app_source",
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "environment.3077298702.key", "key1",
@@ -49,8 +49,8 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "environment.3077298702.value", "value1",
 					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_application.tf-acc-app", "environment.3077298702.secret", "",
+					resource.TestCheckNoResourceAttr(
+						"aws_opsworks_application.tf-acc-app", "environment.3077298702.secret",
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "document_root", "foo",
@@ -117,8 +117,8 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "environment.3077298702.value", "value1",
 					),
-					resource.TestCheckResourceAttr(
-						"aws_opsworks_application.tf-acc-app", "environment.3077298702.secret", "",
+					resource.TestCheckNoResourceAttr(
+						"aws_opsworks_application.tf-acc-app", "environment.3077298702.secret",
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_application.tf-acc-app", "document_root", "root",


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksApplication'
```
```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/13 08:06:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksApplication -timeout 120m
=== RUN   TestAccAWSOpsworksApplication
--- PASS: TestAccAWSOpsworksApplication (76.40s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	76.431s
```

Related to #11218