### PR TITLE
provider/aws: Add support for IPv6 in aws_route

### DIFF
--- a/website/source/docs/providers/aws/r/route.html.markdown
+++ b/website/source/docs/providers/aws/r/route.html.markdown
@@ -27,19 +27,40 @@ resource "aws_route" "r" {
 }
 ```
 
+##Example IPv6 Usage:
+
+```
+resource "aws_vpc" "vpc" {
+  cidr_block = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_egress_only_internet_gateway" "egress" {
+  vpc_id = "${aws_vpc.vpc.id}"
+}
+
+resource "aws_route" "r" {
+  route_table_id               = "rtb-4fbb3ac4"
+  destination_ipv6_cidr_block  = "::/0"
+  egress_only_gateway_id = "${aws_egress_only_internet_gateway.egress.id}"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
 * `route_table_id` - (Required) The ID of the routing table.
-* `destination_cidr_block` - (Required) The destination CIDR block.
+* `destination_cidr_block` - (Optional) The destination CIDR block.
+* `destination_ipv6_cidr_block` - (Optional) The destination IPv6 CIDR block.
 * `vpc_peering_connection_id` - (Optional) An ID of a VPC peering connection.
+* `egress_only_gateway_id` - (Optional) An ID of a VPC Egress Only Internet Gateway.
 * `gateway_id` - (Optional) An ID of a VPC internet gateway or a virtual private gateway.
 * `nat_gateway_id` - (Optional) An ID of a VPC NAT gateway.
 * `instance_id` - (Optional) An ID of an EC2 instance.
 * `network_interface_id` - (Optional) An ID of a network interface.
 
-Each route must contain either a `gateway_id`, a `nat_gateway_id`, an
+Each route must contain either a `gateway_id`, `egress_only_gateway_id` a `nat_gateway_id`, an
 `instance_id` or a `vpc_peering_connection_id` or a `network_interface_id`.
 Note that the default route, mapping the VPC's CIDR block to "local", is
 created implicitly and cannot be specified.
@@ -53,7 +74,9 @@ will be exported as an attribute once the resource is created.
 
 * `route_table_id` - The ID of the routing table.
 * `destination_cidr_block` - The destination CIDR block.
+* `destination_ipv6_cidr_block` - The destination IPv6 CIDR block.
 * `vpc_peering_connection_id` - An ID of a VPC peering connection.
+* `egress_only_gateway_id` - An ID of a VPC Egress Only Internet Gateway.
 * `gateway_id` - An ID of a VPC internet gateway or a virtual private gateway.
 * `nat_gateway_id` - An ID of a VPC NAT gateway.
 * `instance_id` - An ID of a NAT instance.


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRoute_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/12 18:56:59 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRoute_ -timeout 120m
=== RUN   TestAccAWSRoute_basic
--- PASS: TestAccAWSRoute_basic (58.46s)
=== RUN   TestAccAWSRoute_ipv6Support
--- PASS: TestAccAWSRoute_ipv6Support (48.74s)
=== RUN   TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (90.23s)
=== RUN   TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (138.02s)
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (63.58s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	399.054s
```