### PR TITLE
provider/aws: Add IPv6 Support to aws_route_table

### DIFF
--- a/builtin/providers/aws/data_source_aws_route_table.go
+++ b/builtin/providers/aws/data_source_aws_route_table.go
@@ -41,6 +41,16 @@ func dataSourceAwsRouteTable() *schema.Resource {
 							Computed: true,
 						},
 
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
+						"egress_only_gateway_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+
 						"gateway_id": {
 							Type:     schema.TypeString,
 							Computed: true,
@@ -176,6 +186,12 @@ func dataSourceRoutesRead(ec2Routes []*ec2.Route) []map[string]interface{} {
 
 		if r.DestinationCidrBlock != nil {
 			m["cidr_block"] = *r.DestinationCidrBlock
+		}
+		if r.DestinationIpv6CidrBlock != nil {
+			m["ipv6_cidr_block"] = *r.DestinationIpv6CidrBlock
+		}
+		if r.EgressOnlyInternetGatewayId != nil {
+			m["egress_only_gateway_id"] = *r.EgressOnlyInternetGatewayId
 		}
 		if r.GatewayId != nil {
 			m["gateway_id"] = *r.GatewayId

--- a/builtin/providers/aws/data_source_aws_route_table_test.go
+++ b/builtin/providers/aws/data_source_aws_route_table_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceAwsRouteTable_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsRouteTableGroupConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRouteTableCheck("data.aws_route_table.by_tag"),
@@ -33,7 +33,7 @@ func TestAccDataSourceAwsRouteTable_main(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsRouteTableMainRoute,
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsRouteTableCheckMain("data.aws_route_table.by_filter"),

--- a/builtin/providers/aws/import_aws_route_table.go
+++ b/builtin/providers/aws/import_aws_route_table.go
@@ -51,6 +51,7 @@ func resourceAwsRouteTableImportState(
 			d.SetType("aws_route")
 			d.Set("route_table_id", id)
 			d.Set("destination_cidr_block", route.DestinationCidrBlock)
+			d.Set("destination_ipv6_cidr_block", route.DestinationIpv6CidrBlock)
 			d.SetId(routeIDHash(d, route))
 			results = append(results, d)
 		}

--- a/builtin/providers/aws/import_aws_route_table_test.go
+++ b/builtin/providers/aws/import_aws_route_table_test.go
@@ -23,11 +23,11 @@ func TestAccAWSRouteTable_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfig,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:     "aws_route_table.foo",
 				ImportState:      true,
 				ImportStateCheck: checkFn,
@@ -51,11 +51,11 @@ func TestAccAWSRouteTable_complex(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfig_complexImport,
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:     "aws_route_table.mod",
 				ImportState:      true,
 				ImportStateCheck: checkFn,

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -63,7 +63,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -72,7 +72,7 @@ func TestAccAWSRouteTable_basic(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigChange,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -113,11 +113,40 @@ func TestAccAWSRouteTable_instance(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigInstance,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
 						"aws_route_table.foo", &v),
+					testCheck,
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRouteTable_ipv6(t *testing.T) {
+	var v ec2.RouteTable
+
+	testCheck := func(*terraform.State) error {
+		// Expect 3: 2 IPv6 (local + all outbound) + 1 IPv4
+		if len(v.Routes) != 3 {
+			return fmt.Errorf("bad routes: %#v", v.Routes)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_route_table.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRouteTableConfigIpv6,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRouteTableExists("aws_route_table.foo", &v),
 					testCheck,
 				),
 			},
@@ -134,7 +163,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigTags,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
@@ -142,7 +171,7 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccRouteTableConfigTagsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists("aws_route_table.foo", &route_table),
@@ -244,7 +273,7 @@ func TestAccAWSRouteTable_vpcPeering(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableVpcPeeringConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -285,7 +314,7 @@ func TestAccAWSRouteTable_vgwRoutePropagation(t *testing.T) {
 			testAccCheckRouteTableDestroy,
 		),
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccRouteTableVgwRoutePropagationConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -338,6 +367,26 @@ resource "aws_route_table" "foo" {
 	route {
 		cidr_block = "10.4.0.0/16"
 		gateway_id = "${aws_internet_gateway.foo.id}"
+	}
+}
+`
+
+const testAccRouteTableConfigIpv6 = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+}
+
+resource "aws_egress_only_internet_gateway" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	route {
+		ipv6_cidr_block = "::/0"
+		egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
 	}
 }
 `

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -71,6 +71,8 @@ the selected Route Table.
 Each route supports the following:
 
 * `cidr_block` - The CIDR block of the route.
+* `ipv6_cidr_block` - The IPv6 CIDR block of the route.
+* `egress_only_gateway_id` - The ID of the Egress Only Internet Gateway.
 * `gateway_id` - The Internet Gateway ID.
 * `nat_gateway_id` - The NAT Gateway ID.
 * `instance_id` - The EC2 instance ID.

--- a/website/source/docs/providers/aws/r/route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/route_table.html.markdown
@@ -27,6 +27,11 @@ resource "aws_route_table" "r" {
     gateway_id = "${aws_internet_gateway.main.id}"
   }
 
+  route {
+    ipv6_cidr_block = "::/0"
+    egress_only_gateway_id = "${aws_egress_only_internet_gateway.foo.id}"
+  }
+
   tags {
     Name = "main"
   }
@@ -44,7 +49,9 @@ The following arguments are supported:
 
 Each route supports the following:
 
-* `cidr_block` - (Required) The CIDR block of the route.
+* `cidr_block` - (Optional) The CIDR block of the route.
+* `ipv6_cidr_block` - Optional) The Ipv6 CIDR block of the route
+* `egress_only_gateway_id` - (Optional) The Egress Only Internet Gateway ID.
 * `gateway_id` - (Optional) The Internet Gateway ID.
 * `nat_gateway_id` - (Optional) The NAT Gateway ID.
 * `instance_id` - (Optional) The EC2 instance ID.


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRouteTable_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/13 10:11:09 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRouteTable_ -timeout 120m
=== RUN   TestAccAWSRouteTable_importBasic
--- PASS: TestAccAWSRouteTable_importBasic (63.14s)
=== RUN   TestAccAWSRouteTable_complex
--- PASS: TestAccAWSRouteTable_complex (241.57s)
=== RUN   TestAccAWSRouteTable_basic
--- PASS: TestAccAWSRouteTable_basic (91.26s)
=== RUN   TestAccAWSRouteTable_instance
--- PASS: TestAccAWSRouteTable_instance (158.18s)
=== RUN   TestAccAWSRouteTable_ipv6
--- PASS: TestAccAWSRouteTable_ipv6 (48.99s)
=== RUN   TestAccAWSRouteTable_tags
--- PASS: TestAccAWSRouteTable_tags (71.68s)
=== RUN   TestAccAWSRouteTable_vpcPeering
--- PASS: TestAccAWSRouteTable_vpcPeering (58.33s)
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
--- PASS: TestAccAWSRouteTable_vgwRoutePropagation (59.64s)
PASS
ok	github.com/hashicorp/terraform/builtin/providers/aws	780.400s
```