### PR TITLE
provider/aws: Add support for IPv6 to aws_network_acl

### DIFF
--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -20,34 +20,34 @@ func TestAccAWSNetworkAcl_EgressAndIngressRules(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclEgressNIngressConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.109047673.protocol", "6"),
+						"aws_network_acl.bar", "ingress.1871939009.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.109047673.rule_no", "1"),
+						"aws_network_acl.bar", "ingress.1871939009.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.109047673.from_port", "80"),
+						"aws_network_acl.bar", "ingress.1871939009.from_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.109047673.to_port", "80"),
+						"aws_network_acl.bar", "ingress.1871939009.to_port", "80"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.109047673.action", "allow"),
+						"aws_network_acl.bar", "ingress.1871939009.action", "allow"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "ingress.109047673.cidr_block", "10.3.0.0/18"),
+						"aws_network_acl.bar", "ingress.1871939009.cidr_block", "10.3.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.868403673.protocol", "6"),
+						"aws_network_acl.bar", "egress.3111164687.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.868403673.rule_no", "2"),
+						"aws_network_acl.bar", "egress.3111164687.rule_no", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.868403673.from_port", "443"),
+						"aws_network_acl.bar", "egress.3111164687.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.868403673.to_port", "443"),
+						"aws_network_acl.bar", "egress.3111164687.to_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.868403673.cidr_block", "10.3.0.0/18"),
+						"aws_network_acl.bar", "egress.3111164687.cidr_block", "10.3.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.bar", "egress.868403673.action", "allow"),
+						"aws_network_acl.bar", "egress.3111164687.action", "allow"),
 				),
 			},
 		},
@@ -63,23 +63,22 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclIngressConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
-					// testAccCheckSubnetAssociation("aws_network_acl.foos", "aws_subnet.blob"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.protocol", "6"),
+						"aws_network_acl.foos", "ingress.4245812720.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.rule_no", "2"),
+						"aws_network_acl.foos", "ingress.4245812720.rule_no", "2"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.from_port", "443"),
+						"aws_network_acl.foos", "ingress.4245812720.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.to_port", "443"),
+						"aws_network_acl.foos", "ingress.4245812720.to_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.action", "deny"),
+						"aws_network_acl.foos", "ingress.4245812720.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.cidr_block", "10.2.0.0/18"),
+						"aws_network_acl.foos", "ingress.4245812720.cidr_block", "10.2.0.0/18"),
 				),
 			},
 		},
@@ -95,46 +94,46 @@ func TestAccAWSNetworkAcl_OnlyIngressRules_update(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclIngressConfig,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					testIngressRuleLength(&networkAcl, 2),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.protocol", "6"),
+						"aws_network_acl.foos", "ingress.401088754.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.rule_no", "1"),
+						"aws_network_acl.foos", "ingress.401088754.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.from_port", "0"),
+						"aws_network_acl.foos", "ingress.401088754.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.to_port", "22"),
+						"aws_network_acl.foos", "ingress.401088754.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.action", "deny"),
+						"aws_network_acl.foos", "ingress.401088754.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.cidr_block", "10.2.0.0/18"),
+						"aws_network_acl.foos", "ingress.4245812720.cidr_block", "10.2.0.0/18"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.from_port", "443"),
+						"aws_network_acl.foos", "ingress.4245812720.from_port", "443"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.1451312565.rule_no", "2"),
+						"aws_network_acl.foos", "ingress.4245812720.rule_no", "2"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclIngressConfigChange,
-				Check: resource.ComposeTestCheckFunc(
+				Check: resource.ComposeAggregateTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
 					testIngressRuleLength(&networkAcl, 1),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.protocol", "6"),
+						"aws_network_acl.foos", "ingress.401088754.protocol", "6"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.rule_no", "1"),
+						"aws_network_acl.foos", "ingress.401088754.rule_no", "1"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.from_port", "0"),
+						"aws_network_acl.foos", "ingress.401088754.from_port", "0"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.to_port", "22"),
+						"aws_network_acl.foos", "ingress.401088754.to_port", "22"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.action", "deny"),
+						"aws_network_acl.foos", "ingress.401088754.action", "deny"),
 					resource.TestCheckResourceAttr(
-						"aws_network_acl.foos", "ingress.2048097841.cidr_block", "10.2.0.0/18"),
+						"aws_network_acl.foos", "ingress.401088754.cidr_block", "10.2.0.0/18"),
 				),
 			},
 		},
@@ -150,7 +149,7 @@ func TestAccAWSNetworkAcl_OnlyEgressRules(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclEgressConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.bond", &networkAcl),
@@ -169,13 +168,13 @@ func TestAccAWSNetworkAcl_SubnetChange(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclSubnetConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.old"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclSubnetConfigChange,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSubnetIsNotAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.old"),
@@ -206,7 +205,7 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIds,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
@@ -216,7 +215,7 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclSubnet_SubnetIdsUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.bar", &networkAcl),
@@ -224,6 +223,37 @@ func TestAccAWSNetworkAcl_Subnets(t *testing.T) {
 					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.three"),
 					testAccCheckSubnetIsAssociatedWithAcl("aws_network_acl.bar", "aws_subnet.four"),
 					checkACLSubnets(&networkAcl, 3),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNetworkAcl_ipv6Rules(t *testing.T) {
+	var networkAcl ec2.NetworkAcl
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_network_acl.foos",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNetworkAclIpv6Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclExists("aws_network_acl.foos", &networkAcl),
+					resource.TestCheckResourceAttr(
+						"aws_network_acl.foos", "ingress.1976110835.protocol", "6"),
+					resource.TestCheckResourceAttr(
+						"aws_network_acl.foos", "ingress.1976110835.rule_no", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_network_acl.foos", "ingress.1976110835.from_port", "0"),
+					resource.TestCheckResourceAttr(
+						"aws_network_acl.foos", "ingress.1976110835.to_port", "22"),
+					resource.TestCheckResourceAttr(
+						"aws_network_acl.foos", "ingress.1976110835.action", "allow"),
+					resource.TestCheckResourceAttr(
+						"aws_network_acl.foos", "ingress.1976110835.ipv6_cidr_block", "::/0"),
 				),
 			},
 		},
@@ -239,7 +269,7 @@ func TestAccAWSNetworkAcl_espProtocol(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckAWSNetworkAclDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclEsp,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclExists("aws_network_acl.testesp", &networkAcl),
@@ -336,7 +366,7 @@ func testAccCheckSubnetIsAssociatedWithAcl(acl string, sub string) resource.Test
 		resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
 			NetworkAclIds: []*string{aws.String(networkAcl.Primary.ID)},
 			Filters: []*ec2.Filter{
-				&ec2.Filter{
+				{
 					Name:   aws.String("association.subnet-id"),
 					Values: []*string{aws.String(subnet.Primary.ID)},
 				},
@@ -362,7 +392,7 @@ func testAccCheckSubnetIsNotAssociatedWithAcl(acl string, subnet string) resourc
 		resp, err := conn.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
 			NetworkAclIds: []*string{aws.String(networkAcl.Primary.ID)},
 			Filters: []*ec2.Filter{
-				&ec2.Filter{
+				{
 					Name:   aws.String("association.subnet-id"),
 					Values: []*string{aws.String(subnet.Primary.ID)},
 				},
@@ -378,6 +408,33 @@ func testAccCheckSubnetIsNotAssociatedWithAcl(acl string, subnet string) resourc
 		return nil
 	}
 }
+
+const testAccAWSNetworkAclIpv6Config = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+	tags {
+		Name = "TestAccAWSNetworkAcl_ipv6Rules"
+	}
+}
+resource "aws_subnet" "blob" {
+	cidr_block = "10.1.1.0/24"
+	vpc_id = "${aws_vpc.foo.id}"
+	map_public_ip_on_launch = true
+}
+resource "aws_network_acl" "foos" {
+	vpc_id = "${aws_vpc.foo.id}"
+	ingress = {
+		protocol = "tcp"
+		rule_no = 1
+		action = "allow"
+		ipv6_cidr_block =  "::/0"
+		from_port = 0
+		to_port = 22
+	}
+
+	subnet_ids = ["${aws_subnet.blob.id}"]
+}
+`
 
 const testAccAWSNetworkAclIngressConfig = `
 resource "aws_vpc" "foo" {

--- a/website/source/docs/providers/aws/r/network_acl.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl.html.markdown
@@ -63,6 +63,7 @@ Both `egress` and `ingress` support the following keys:
 protocol, you must specify a from and to port of 0.
 * `cidr_block` - (Optional) The CIDR block to match. This must be a
 valid network mask.
+* `ipv6_cidr_block` - (Optional) The IPv6 CIDR block.
 * `icmp_type` - (Optional) The ICMP type to be used. Default 0.
 * `icmp_code` - (Optional) The ICMP type code to be used. Default 0.
 


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSNetworkAcl_'              2 ↵ ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/13 14:04:41 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSNetworkAcl_ -timeout 120m
=== RUN   TestAccAWSNetworkAcl_importBasic
--- PASS: TestAccAWSNetworkAcl_importBasic (55.44s)
=== RUN   TestAccAWSNetworkAcl_EgressAndIngressRules
--- PASS: TestAccAWSNetworkAcl_EgressAndIngressRules (48.19s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_basic
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_basic (65.29s)
=== RUN   TestAccAWSNetworkAcl_OnlyIngressRules_update
--- PASS: TestAccAWSNetworkAcl_OnlyIngressRules_update (103.19s)
=== RUN   TestAccAWSNetworkAcl_OnlyEgressRules
--- PASS: TestAccAWSNetworkAcl_OnlyEgressRules (59.65s)
=== RUN   TestAccAWSNetworkAcl_SubnetChange
--- PASS: TestAccAWSNetworkAcl_SubnetChange (93.90s)
=== RUN   TestAccAWSNetworkAcl_Subnets
--- PASS: TestAccAWSNetworkAcl_Subnets (103.51s)
=== RUN   TestAccAWSNetworkAcl_ipv6Rules
--- PASS: TestAccAWSNetworkAcl_ipv6Rules (56.67s)
=== RUN   TestAccAWSNetworkAcl_espProtocol
--- PASS: TestAccAWSNetworkAcl_espProtocol (51.40s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	637.283s
```