### PR TITLE
provider/aws: Add support for IPv6 to aws_default_route_table

### DIFF
--- a/builtin/providers/aws/resource_aws_default_route_table.go
+++ b/builtin/providers/aws/resource_aws_default_route_table.go
@@ -17,56 +17,66 @@ func resourceAwsDefaultRouteTable() *schema.Resource {
 		Delete: resourceAwsDefaultRouteTableDelete,
 
 		Schema: map[string]*schema.Schema{
-			"default_route_table_id": &schema.Schema{
+			"default_route_table_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"vpc_id": &schema.Schema{
+			"vpc_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"propagating_vgws": &schema.Schema{
+			"propagating_vgws": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
 
-			"route": &schema.Schema{
+			"route": {
 				Type:     schema.TypeSet,
 				Computed: true,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"cidr_block": &schema.Schema{
-							Type:     schema.TypeString,
-							Required: true,
-						},
-
-						"gateway_id": &schema.Schema{
+						"cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"instance_id": &schema.Schema{
+						"ipv6_cidr_block": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"nat_gateway_id": &schema.Schema{
+						"egress_only_gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"vpc_peering_connection_id": &schema.Schema{
+						"gateway_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"network_interface_id": &schema.Schema{
+						"instance_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"nat_gateway_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"vpc_peering_connection_id": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+
+						"network_interface_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -193,16 +203,33 @@ func revokeAllRouteTableRules(defaultRouteTableId string, meta interface{}) erro
 			// See aws_vpc_endpoint
 			continue
 		}
-		log.Printf(
-			"[INFO] Deleting route from %s: %s",
-			defaultRouteTableId, *r.DestinationCidrBlock)
-		_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
-			RouteTableId:         aws.String(defaultRouteTableId),
-			DestinationCidrBlock: r.DestinationCidrBlock,
-		})
-		if err != nil {
-			return err
+
+		if r.DestinationCidrBlock != nil {
+			log.Printf(
+				"[INFO] Deleting route from %s: %s",
+				defaultRouteTableId, *r.DestinationCidrBlock)
+			_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
+				RouteTableId:         aws.String(defaultRouteTableId),
+				DestinationCidrBlock: r.DestinationCidrBlock,
+			})
+			if err != nil {
+				return err
+			}
 		}
+
+		if r.DestinationIpv6CidrBlock != nil {
+			log.Printf(
+				"[INFO] Deleting route from %s: %s",
+				defaultRouteTableId, *r.DestinationIpv6CidrBlock)
+			_, err := conn.DeleteRoute(&ec2.DeleteRouteInput{
+				RouteTableId:             aws.String(defaultRouteTableId),
+				DestinationIpv6CidrBlock: r.DestinationIpv6CidrBlock,
+			})
+			if err != nil {
+				return err
+			}
+		}
+
 	}
 
 	return nil

--- a/builtin/providers/aws/resource_aws_default_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_default_route_table_test.go
@@ -20,7 +20,7 @@ func TestAccAWSDefaultRouteTable_basic(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTableConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -40,7 +40,7 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTable_change,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -53,7 +53,7 @@ func TestAccAWSDefaultRouteTable_swap(t *testing.T) {
 			// behavior that may happen, in which case a follow up plan will show (in
 			// this case) a diff as the table now needs to be updated to match the
 			// config
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTable_change_mod,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(
@@ -74,7 +74,7 @@ func TestAccAWSDefaultRouteTable_vpc_endpoint(t *testing.T) {
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckDefaultRouteTableDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDefaultRouteTable_vpc_endpoint,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckRouteTableExists(

--- a/website/source/docs/providers/aws/r/default_route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/default_route_table.html.markdown
@@ -68,6 +68,8 @@ The following arguments are supported:
 Each route supports the following:
 
 * `cidr_block` - (Required) The CIDR block of the route.
+* `ipv6_cidr_block` - Optional) The Ipv6 CIDR block of the route
+* `egress_only_gateway_id` - (Optional) The Egress Only Internet Gateway ID.
 * `gateway_id` - (Optional) The Internet Gateway ID.
 * `nat_gateway_id` - (Optional) The NAT Gateway ID.
 * `instance_id` - (Optional) The EC2 instance ID.


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDefaultRouteTable_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/13 10:57:45 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDefaultRouteTable_ -timeout 120m
=== RUN   TestAccAWSDefaultRouteTable_basic
--- PASS: TestAccAWSDefaultRouteTable_basic (88.23s)
=== RUN   TestAccAWSDefaultRouteTable_swap
--- PASS: TestAccAWSDefaultRouteTable_swap (136.60s)
=== RUN   TestAccAWSDefaultRouteTable_vpc_endpoint
--- PASS: TestAccAWSDefaultRouteTable_vpc_endpoint (84.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	309.723s
```