### PR TITLE
provider/aws: Add support for IPv6 to aws_network_acl_rule

### DIFF
--- a/builtin/providers/aws/resource_aws_network_acl_rule.go
+++ b/builtin/providers/aws/resource_aws_network_acl_rule.go
@@ -21,54 +21,59 @@ func resourceAwsNetworkAclRule() *schema.Resource {
 		Delete: resourceAwsNetworkAclRuleDelete,
 
 		Schema: map[string]*schema.Schema{
-			"network_acl_id": &schema.Schema{
+			"network_acl_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"rule_number": &schema.Schema{
+			"rule_number": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
-			"egress": &schema.Schema{
+			"egress": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				ForceNew: true,
 				Default:  false,
 			},
-			"protocol": &schema.Schema{
+			"protocol": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"rule_action": &schema.Schema{
+			"rule_action": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"cidr_block": &schema.Schema{
+			"cidr_block": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 			},
-			"from_port": &schema.Schema{
+			"ipv6_cidr_block": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"from_port": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 			},
-			"to_port": &schema.Schema{
+			"to_port": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				ForceNew: true,
 			},
-			"icmp_type": &schema.Schema{
+			"icmp_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateICMPArgumentValue,
 			},
-			"icmp_code": &schema.Schema{
+			"icmp_code": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
@@ -97,12 +102,19 @@ func resourceAwsNetworkAclRuleCreate(d *schema.ResourceData, meta interface{}) e
 		Egress:       aws.Bool(d.Get("egress").(bool)),
 		RuleNumber:   aws.Int64(int64(d.Get("rule_number").(int))),
 		Protocol:     aws.String(strconv.Itoa(p)),
-		CidrBlock:    aws.String(d.Get("cidr_block").(string)),
 		RuleAction:   aws.String(d.Get("rule_action").(string)),
 		PortRange: &ec2.PortRange{
 			From: aws.Int64(int64(d.Get("from_port").(int))),
 			To:   aws.Int64(int64(d.Get("to_port").(int))),
 		},
+	}
+
+	if v, ok := d.GetOk("cidr_block"); ok {
+		params.CidrBlock = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("ipv6_cidr_block"); ok {
+		params.Ipv6CidrBlock = aws.String(v.(string))
 	}
 
 	// Specify additional required fields for ICMP. For the list
@@ -160,6 +172,7 @@ func resourceAwsNetworkAclRuleRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("rule_number", resp.RuleNumber)
 	d.Set("cidr_block", resp.CidrBlock)
+	d.Set("ipv6_cidr_block", resp.Ipv6CidrBlock)
 	d.Set("egress", resp.Egress)
 	if resp.IcmpTypeCode != nil {
 		d.Set("icmp_code", resp.IcmpTypeCode.Code)

--- a/builtin/providers/aws/resource_aws_network_acl_rule_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_rule_test.go
@@ -20,12 +20,30 @@ func TestAccAWSNetworkAclRule_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSNetworkAclRuleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSNetworkAclRuleBasicConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
 					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.qux", &networkAcl),
 					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.wibble", &networkAcl),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSNetworkAclRule_ipv6(t *testing.T) {
+	var networkAcl ec2.NetworkAcl
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSNetworkAclRuleIpv6Config,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSNetworkAclRuleExists("aws_network_acl_rule.baz", &networkAcl),
 				),
 			},
 		},
@@ -194,4 +212,24 @@ resource "aws_network_acl_rule" "wibble" {
 	icmp_type = -1
 	icmp_code = -1
 }
+`
+
+const testAccAWSNetworkAclRuleIpv6Config = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.3.0.0/16"
+}
+resource "aws_network_acl" "bar" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+resource "aws_network_acl_rule" "baz" {
+	network_acl_id = "${aws_network_acl.bar.id}"
+	rule_number = 150
+	egress = false
+	protocol = "tcp"
+	rule_action = "allow"
+	ipv6_cidr_block = "::/0"
+	from_port = 22
+	to_port = 22
+}
+
 `

--- a/website/source/docs/providers/aws/r/network_acl_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl_rule.html.markdown
@@ -38,7 +38,8 @@ The following arguments are supported:
 * `egress` - (Optional, bool) Indicates whether this is an egress rule (rule is applied to traffic leaving the subnet). Default `false`.
 * `protocol` - (Required) The protocol. A value of -1 means all protocols.
 * `rule_action` - (Required) Indicates whether to allow or deny the traffic that matches the rule. Accepted values: `allow` | `deny`
-* `cidr_block` - (Required) The network range to allow or deny, in CIDR notation (for example 172.16.0.0/24 ).
+* `cidr_block` - (Optional) The network range to allow or deny, in CIDR notation (for example 172.16.0.0/24 ).
+* `ipv6_cidr_block` - (Optional) The IPv6 CIDR block to allow or deny.
 * `from_port` - (Optional) The from port to match.
 * `to_port` - (Optional) The to port to match.
 * `icmp_type` - (Optional) ICMP protocol: The ICMP type. Required if specifying ICMP for the protocol. e.g. -1


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSNetworkAclRule_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/13 14:39:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSNetworkAclRule_ -timeout 120m
=== RUN   TestAccAWSNetworkAclRule_basic
--- PASS: TestAccAWSNetworkAclRule_basic (70.58s)
=== RUN   TestAccAWSNetworkAclRule_ipv6
--- PASS: TestAccAWSNetworkAclRule_ipv6 (81.93s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	152.535s
```