### PR TITLE
Doc: google_compute_health_check resource has no type attribute

### DIFF
--- a/website/source/docs/providers/google/r/compute_region_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_region_backend_service.html.markdown
@@ -56,7 +56,6 @@ resource "google_compute_health_check" "default" {
   name               = "test"
   check_interval_sec = 1
   timeout_sec        = 1
-  type               = "TCP"
 
   tcp_health_check {
     port = "80"


### PR DESCRIPTION
The `google_compute_health_check` resource has no `type` attribute.

cf. https://www.terraform.io/docs/providers/google/r/compute_health_check.html