### PR TITLE
provider/aws: Added conflictsWith for API GW Domain Name certificate_arn

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -25,26 +25,30 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 			//to ApiGateway DomainNames. When this happens, we will be deprecating all certificate methods
 			//except certificate_arn. We are not quite sure when this will happen.
 			"certificate_body": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"certificate_arn"},
 			},
 
 			"certificate_chain": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"certificate_arn"},
 			},
 
 			"certificate_name": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"certificate_arn"},
 			},
 
 			"certificate_private_key": {
-				Type:     schema.TypeString,
-				ForceNew: true,
-				Optional: true,
+				Type:          schema.TypeString,
+				ForceNew:      true,
+				Optional:      true,
+				ConflictsWith: []string{"certificate_arn"},
 			},
 
 			"domain_name": {
@@ -54,8 +58,9 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 			},
 
 			"certificate_arn": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				ConflictsWith: []string{"certificate_body", "certificate_chain", "certificate_name", "certificate_private_key"},
 			},
 
 			"cloudfront_domain_name": {

--- a/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_domain_name.html.markdown
@@ -56,15 +56,15 @@ The following arguments are supported:
 
 * `domain_name` - (Required) The fully-qualified domain name to register
 * `certificate_name` - (Optional) The unique name to use when registering this
-  cert as an IAM server certificate
+  cert as an IAM server certificate. Conflicts with `certificate_arn`.
 * `certificate_body` - (Optional) The certificate issued for the domain name
-  being registered, in PEM format
+  being registered, in PEM format. Conflicts with `certificate_arn`.
 * `certificate_chain` - (Optional) The certificate for the CA that issued the
   certificate, along with any intermediate CA certificates required to
-  create an unbroken chain to a certificate trusted by the intended API clients.
+  create an unbroken chain to a certificate trusted by the intended API clients. Conflicts with `certificate_arn`.
 * `certificate_private_key` - (Optional) The private key associated with the
-  domain certificate given in `certificate_body`.
-* `certificate_arn` - (Optional) The ARN for an AWS-managed certificate.
+  domain certificate given in `certificate_body`. Conflicts with `certificate_arn`.
+* `certificate_arn` - (Optional) The ARN for an AWS-managed certificate. Conflicts with `certificate_name`, `certificate_body`, `certificate_chain` and `certificate_private_key`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
## Description
This follows https://github.com/hashicorp/terraform/pull/12592#issuecomment-286074544 to add the `ConflictsWith` attribute, since you can only choose to have your certificate or an ACM one.

## Tests
```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayDomainName_' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/13 15:59:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAPIGatewayDomainName_ -timeout 120m
=== RUN   TestAccAWSAPIGatewayDomainName_basic
--- PASS: TestAccAWSAPIGatewayDomainName_basic (62.44s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	62.544s
```