### PR TITLE
Fix invalid yaml syntax

### DIFF
--- a/website/source/docs/providers/aws/d/sns_topic.html.markdown
+++ b/website/source/docs/providers/aws/d/sns_topic.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_sns_topic
+page_title: "AWS: aws_sns_topic"
 sidebar_current: "docs-aws-datasource-sns-topic"
 description: |-
   Get information on a Amazon Simple Notification Service (SNS) Topic


### PR DESCRIPTION
This page's meta data has invalid syntax and cause error when building web site.

My PR will fix the problem.