### PR TITLE
provider/aws: Document usage for aws_vpn_gateway data resource

### DIFF
--- a/website/source/docs/providers/aws/d/vpn_gateway.html.markdown
+++ b/website/source/docs/providers/aws/d/vpn_gateway.html.markdown
@@ -14,7 +14,16 @@ a specific VPN gateway.
 ## Example Usage
 
 ```
+data "aws_vpn_gateway" "selected" {
+  filter {
+    name = "tag:Name"
+    values = ["vpn-gw"]
+  }
+}
 
+output "vpn_gateway_id" {
+  value = "${data.aws_vpn_gateway.selected.id}"
+}
 ```
 
 ## Argument Reference


### PR DESCRIPTION
There were no documented examples for this data resource.