### PR TITLE
Allow `name_prefix` to be used with various IAM resources

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_policy_test.go
@@ -39,6 +39,46 @@ func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMGroupPolicy_namePrefix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_iam_group_policy.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMGroupPolicyConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMGroupPolicy(
+						"aws_iam_group.test",
+						"aws_iam_group_policy.test",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIAMGroupPolicy_generatedName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_iam_group_policy.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMGroupPolicyConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMGroupPolicy(
+						"aws_iam_group.test",
+						"aws_iam_group_policy.test",
+					),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIAMGroupPolicyDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*AWSClient).iamconn
 
@@ -111,6 +151,49 @@ resource "aws_iam_group" "group" {
 resource "aws_iam_group_policy" "foo" {
 	name = "foo_policy"
 	group = "${aws_iam_group.group.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+`
+
+const testAccIAMGroupPolicyConfig_namePrefix = `
+resource "aws_iam_group" "test" {
+	name = "test_group"
+	path = "/"
+}
+
+resource "aws_iam_group_policy" "test" {
+	name_prefix = "test-"
+	group = "${aws_iam_group.test.name}"
+	policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": {
+    "Effect": "Allow",
+    "Action": "*",
+    "Resource": "*"
+  }
+}
+EOF
+}
+`
+
+const testAccIAMGroupPolicyConfig_generatedName = `
+resource "aws_iam_group" "test" {
+	name = "test_group"
+	path = "/"
+}
+
+resource "aws_iam_group_policy" "test" {
+	group = "${aws_iam_group.test.name}"
 	policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/builtin/providers/aws/resource_aws_iam_user_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_policy_test.go
@@ -39,6 +39,46 @@ func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSIAMUserPolicy_namePrefix(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_iam_user_policy.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMUserPolicyConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMUserPolicy(
+						"aws_iam_user.test",
+						"aws_iam_user_policy.test",
+					),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIAMUserPolicy_generatedName(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_iam_user_policy.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMUserPolicyConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMUserPolicy(
+						"aws_iam_user.test",
+						"aws_iam_user_policy.test",
+					),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckIAMUserPolicyDestroy(s *terraform.State) error {
 	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
 
@@ -114,6 +154,31 @@ resource "aws_iam_user" "user" {
 resource "aws_iam_user_policy" "foo" {
 	name = "foo_policy"
 	user = "${aws_iam_user.user.name}"
+	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+}
+`
+
+const testAccIAMUserPolicyConfig_namePrefix = `
+resource "aws_iam_user" "test" {
+	name = "test_user"
+	path = "/"
+}
+
+resource "aws_iam_user_policy" "test" {
+	name_prefix = "test-"
+	user = "${aws_iam_user.test.name}"
+	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+}
+`
+
+const testAccIAMUserPolicyConfig_generatedName = `
+resource "aws_iam_user" "test" {
+	name = "test_user"
+	path = "/"
+}
+
+resource "aws_iam_user_policy" "test" {
+	user = "${aws_iam_user.test.name}"
 	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
 }
 `

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -949,3 +949,28 @@ func validateAccountAlias(v interface{}, k string) (ws []string, es []error) {
 
 	return
 }
+
+func validateIamRolePolicyName(v interface{}, k string) (ws []string, errors []error) {
+	// https://github.com/boto/botocore/blob/2485f5c/botocore/data/iam/2010-05-08/service-2.json#L8291-L8296
+	value := v.(string)
+	if len(value) > 128 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 128 characters", k))
+	}
+	if !regexp.MustCompile("^[\\w+=,.@-]+$").MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q must match [\\w+=,.@-]", k))
+	}
+	return
+}
+
+func validateIamRolePolicyNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if len(value) > 100 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 100 characters", k))
+	}
+	if !regexp.MustCompile("^[\\w+=,.@-]+$").MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q must match [\\w+=,.@-]", k))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1579,3 +1579,53 @@ func TestValidateAccountAlias(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateIamRoleProfileName(t *testing.T) {
+	validNames := []string{
+		"tf-test-role-profile-1",
+	}
+
+	for _, s := range validNames {
+		_, errors := validateIamRolePolicyName(s, "name")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid IAM role policy name: %v", s, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"invalid#name",
+		"this-is-a-very-long-role-policy-name-this-is-a-very-long-role-policy-name-this-is-a-very-long-role-policy-name-this-is-a-very-long",
+	}
+
+	for _, s := range invalidNames {
+		_, errors := validateIamRolePolicyName(s, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid IAM role policy name: %v", s, errors)
+		}
+	}
+}
+
+func TestValidateIamRoleProfileNamePrefix(t *testing.T) {
+	validNamePrefixes := []string{
+		"tf-test-role-profile-",
+	}
+
+	for _, s := range validNamePrefixes {
+		_, errors := validateIamRolePolicyNamePrefix(s, "name_prefix")
+		if len(errors) > 0 {
+			t.Fatalf("%q should be a valid IAM role policy name prefix: %v", s, errors)
+		}
+	}
+
+	invalidNamePrefixes := []string{
+		"invalid#name_prefix",
+		"this-is-a-very-long-role-policy-name-prefix-this-is-a-very-long-role-policy-name-prefix-this-is-a-very-",
+	}
+
+	for _, s := range invalidNamePrefixes {
+		_, errors := validateIamRolePolicyNamePrefix(s, "name_prefix")
+		if len(errors) == 0 {
+			t.Fatalf("%q should not be a valid IAM role policy name prefix: %v", s, errors)
+		}
+	}
+}

--- a/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_group_policy.html.markdown
@@ -45,7 +45,10 @@ The following arguments are supported:
 
 * `policy` - (Required) The policy document. This is a JSON formatted string.
   The heredoc syntax or `file` function is helpful here.
-* `name` - (Required) Name of the policy.
+* `name` - (Optional) The name of the policy. If omitted, Terraform will
+assign a random, unique name.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
 * `group` - (Required) The IAM group to attach to the policy.
 
 ## Attributes Reference

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -44,7 +44,7 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Optional, Forces new resource) The profile's name.
+* `name` - (Optional, Forces new resource) The profile's name. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the profile.
 * `roles` - (Required) A list of role names to include in the profile.  The current default is 1.  If you see an error message similar to `Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1`, then you must contact AWS support and ask for a limit increase.

--- a/website/source/docs/providers/aws/r/iam_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy.html.markdown
@@ -38,7 +38,7 @@ EOF
 The following arguments are supported:
 
 * `description` - (Optional) Description of the IAM policy.
-* `name` - (Optional, Forces new resource) The name of the policy.
+* `name` - (Optional, Forces new resource) The name of the policy. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the policy.
   See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.

--- a/website/source/docs/providers/aws/r/iam_role.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_role.html.markdown
@@ -38,7 +38,7 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Optional, Forces new resource) The name of the role.
+* `name` - (Optional, Forces new resource) The name of the role. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `assume_role_policy` - (Required) The policy that grants an entity permission to assume the role.
 

--- a/website/source/docs/providers/aws/r/iam_role_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_role_policy.html.markdown
@@ -58,7 +58,10 @@ EOF
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the role policy.
+* `name` - (Optional) The name of the role policy. If omitted, Terraform will
+assign a random, unique name.
+* `name_prefix` - (Optional) Creates a unique name beginning with the specified
+  prefix. Conflicts with `name`.
 * `policy` - (Required) The policy document. This is a JSON formatted string.
   The heredoc syntax or `file` function is helpful here.
 * `role` - (Required) The IAM role to attach to the policy.

--- a/website/source/docs/providers/aws/r/iam_user_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_user_policy.html.markdown
@@ -49,7 +49,8 @@ The following arguments are supported:
 
 * `policy` - (Required) The policy document. This is a JSON formatted string.
 	The heredoc syntax or `file` function is helpful here.
-* `name` - (Required) Name of the policy.
+* `name` - (Optional) The name of the policy. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `user` - (Required) IAM user to which to attach this policy.
 
 ## Attributes Reference


### PR DESCRIPTION
Adds the `name_prefix` to `aws_iam_group_policy`, `aws_iam_role_policy` and `aws_iam_user_policy`.