### PR TITLE
Change example value to lower case in ECS service

### DIFF
--- a/website/source/docs/providers/aws/r/ecs_service.html.markdown
+++ b/website/source/docs/providers/aws/r/ecs_service.html.markdown
@@ -27,7 +27,7 @@ resource "aws_ecs_service" "mongo" {
 
   placement_strategy {
     type  = "binpack"
-    field = "CPU"
+    field = "cpu"
   }
 
   load_balancer {


### PR DESCRIPTION
According to the validator, the only acceptable values are 'cpu' and 'memory' (both lower case).
https://github.com/hashicorp/terraform/blob/73f4acf0415925399c521982e2d48225ab611a52/builtin/providers/aws/validators.go#L722:L725
Updating the docs so that this example works out of the box.