### PR TITLE
provider/google: fix single port diff cycle

### DIFF
--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -76,6 +76,12 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == new+"-"+new {
+						return true
+					}
+					return false
+				},
 			},
 
 			"ports": &schema.Schema{

--- a/builtin/providers/google/resource_compute_forwarding_rule_test.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule_test.go
@@ -29,6 +29,26 @@ func TestAccComputeForwardingRule_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeForwardingRule_singlePort(t *testing.T) {
+	poolName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+	ruleName := fmt.Sprintf("tf-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeForwardingRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeForwardingRule_singlePort(poolName, ruleName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeForwardingRuleExists(
+						"google_compute_forwarding_rule.foobar"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeForwardingRule_ip(t *testing.T) {
 	addrName := fmt.Sprintf("tf-%s", acctest.RandString(10))
 	poolName := fmt.Sprintf("tf-%s", acctest.RandString(10))
@@ -128,6 +148,23 @@ resource "google_compute_forwarding_rule" "foobar" {
   ip_protocol = "UDP"
   name        = "%s"
   port_range  = "80-81"
+  target      = "${google_compute_target_pool.foobar-tp.self_link}"
+}
+`, poolName, ruleName)
+}
+
+func testAccComputeForwardingRule_singlePort(poolName, ruleName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_target_pool" "foobar-tp" {
+  description = "Resource created for Terraform acceptance testing"
+  instances   = ["us-central1-a/foo", "us-central1-b/bar"]
+  name        = "%s"
+}
+resource "google_compute_forwarding_rule" "foobar" {
+  description = "Resource created for Terraform acceptance testing"
+  ip_protocol = "UDP"
+  name        = "%s"
+  port_range  = "80"
   target      = "${google_compute_target_pool.foobar-tp.self_link}"
 }
 `, poolName, ruleName)


### PR DESCRIPTION
When specifying a single port in port_range, the API would accept it as
input, but would return it as {PORT}-{PORT}. Terraform would then see
this as different, even though (semantically) it's the same.

This commit adds a test that exposes the diff cycle created by this, and
an inline DiffSuppressFunc to resolve it.

Fixes #9051.

Failure of new unit test before fix applied:

```
=== RUN   TestAccComputeForwardingRule_singlePort
--- FAIL: TestAccComputeForwardingRule_singlePort (44.72s)
        testing.go:265: Step 0 error: After applying this step, the plan was not empty:

                DIFF:

                DESTROY/CREATE: google_compute_forwarding_rule.foobar
                  description:           "Resource created for Terraform acceptance testing" => "Resource created for Terraform acceptance testing"
                  ip_address:            "35.184.15.161" => "<computed>"
                  ip_protocol:           "UDP" => "UDP"
                  load_balancing_scheme: "EXTERNAL" => "EXTERNAL"
                  name:                  "tf-uxitnvxk70" => "tf-uxitnvxk70"
                  network:               "" => "<computed>"
                  port_range:            "80-80" => "80" (forces new resource)
                  project:               "hc-terraform-testing" => "<computed>"
                  region:                "us-central1" => "<computed>"
                  self_link:             "https://www.googleapis.com/compute/v1/projects/hc-terraform-testing/regions/us-central1/forwardingRules/tf-uxitnvxk70" => "<computed>"
                  subnetwork:            "" => "<computed>"
                  target:                "https://www.googleapis.com/compute/v1/projects/hc-terraform-testing/regions/us-central1/targetPools/tf-6zzlxj9y2p" => "https://www.googleapis.com/compute/v1/projects/hc-terraform-testing/regions/us-central1/targetPools/tf-6zzlxj9y2p"

                STATE:

                google_compute_forwarding_rule.foobar:
                  ID = tf-uxitnvxk70
                  backend_service =
                  description = Resource created for Terraform acceptance testing
                  ip_address = 35.184.15.161
                  ip_protocol = UDP
                  load_balancing_scheme = EXTERNAL
                  name = tf-uxitnvxk70
                  network =
                  port_range = 80-80
                  ports.# = 0
                  project = hc-terraform-testing
                  region = us-central1
                  self_link = https://www.googleapis.com/compute/v1/projects/hc-terraform-testing/regions/us-central1/forwardingRules/tf-uxitnvxk70
                  subnetwork =
                  target = https://www.googleapis.com/compute/v1/projects/hc-terraform-testing/regions/us-central1/targetPools/tf-6zzlxj9y2p

                  Dependencies:
                    google_compute_target_pool.foobar-tp
                google_compute_target_pool.foobar-tp:
                  ID = tf-6zzlxj9y2p
                  backup_pool =
                  description = Resource created for Terraform acceptance testing
                  failover_ratio = 0
                  health_checks.# = 0
                  instances.# = 2
                  instances.0 = us-central1-a/foo
                  instances.1 = us-central1-b/bar
                  name = tf-6zzlxj9y2p
                  project = hc-terraform-testing
                  region = us-central1
                  self_link = https://www.googleapis.com/compute/v1/projects/hc-terraform-testing/regions/us-central1/targetPools/tf-6zzlxj9y2p
                  session_affinity =
FAIL
```

Unit test after fix applied:

```
=== RUN   TestAccComputeForwardingRule_singlePort
--- PASS: TestAccComputeForwardingRule_singlePort (45.11s)
PASS
```