### PR TITLE
provider/google: remove the backend region field

### DIFF
--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -118,10 +118,10 @@ func resourceComputeBackendService() *schema.Resource {
 			},
 
 			"region": &schema.Schema{
-				Type:       schema.TypeString,
-				Optional:   true,
-				ForceNew:   true,
-				Deprecated: "This parameter has been removed as it was never used",
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Removed:  "region has been removed as it was never used",
 			},
 
 			"self_link": &schema.Schema{


### PR DESCRIPTION
Remove the field region on compute_backend_service as it has been
deprecated a while now and was never used to begin with.