### PR TITLE
provider/google: remove deprecated account_file field.

### DIFF
--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -21,7 +21,7 @@ func Provider() terraform.ResourceProvider {
 				Optional:     true,
 				DefaultFunc:  schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
 				ValidateFunc: validateAccountFile,
-				Deprecated:   "Use the credentials field instead",
+				Removed:      "Use the credentials field instead",
 			},
 
 			"credentials": &schema.Schema{
@@ -115,9 +115,6 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	credentials := d.Get("credentials").(string)
-	if credentials == "" {
-		credentials = d.Get("account_file").(string)
-	}
 	config := Config{
 		Credentials: credentials,
 		Project:     d.Get("project").(string),
@@ -147,9 +144,7 @@ func validateAccountFile(v interface{}, k string) (warnings []string, errors []e
 		errors = append(errors, fmt.Errorf("Error loading Account File: %s", err))
 	}
 	if wasPath {
-		warnings = append(warnings, `account_file was provided as a path instead of
-as file contents. This support will be removed in the future. Please update
-your configuration to use ${file("filename.json")} instead.`)
+		errors = append(errors, fmt.Errorf(`Error loading credentials; they were provided as a path instead of file contents. Please use ${file("%s")} instead.`, value))
 	}
 
 	var account accountFile

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/hashicorp/terraform/helper/pathorcontents"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -17,11 +16,10 @@ func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
 			"account_file": &schema.Schema{
-				Type:         schema.TypeString,
-				Optional:     true,
-				DefaultFunc:  schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
-				ValidateFunc: validateAccountFile,
-				Removed:      "Use the credentials field instead",
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
+				Removed:     "Use the credentials field instead",
 			},
 
 			"credentials": &schema.Schema{
@@ -126,34 +124,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	}
 
 	return &config, nil
-}
-
-func validateAccountFile(v interface{}, k string) (warnings []string, errors []error) {
-	if v == nil {
-		return
-	}
-
-	value := v.(string)
-
-	if value == "" {
-		return
-	}
-
-	contents, wasPath, err := pathorcontents.Read(value)
-	if err != nil {
-		errors = append(errors, fmt.Errorf("Error loading Account File: %s", err))
-	}
-	if wasPath {
-		errors = append(errors, fmt.Errorf(`Error loading credentials; they were provided as a path instead of file contents. Please use ${file("%s")} instead.`, value))
-	}
-
-	var account accountFile
-	if err := json.Unmarshal([]byte(contents), &account); err != nil {
-		errors = append(errors,
-			fmt.Errorf("account_file not valid JSON '%s': %s", contents, err))
-	}
-
-	return
 }
 
 func validateCredentials(v interface{}, k string) (warnings []string, errors []error) {

--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -62,19 +62,6 @@ The following keys can be used to configure the provider.
     * `GCLOUD_REGION`
     * `CLOUDSDK_COMPUTE_REGION`
 
-The following keys are supported for backwards compatibility, and may be
-removed in a future version:
-
-* `account_file` - __Deprecated: please use `credentials` instead.__
-  Path to or contents of the JSON file used to describe your
-  account credentials, downloaded from Google Cloud Console. More details on
-  retrieving this file are below. The `account file` can be "" if you are running
-  terraform from a GCE instance with a properly-configured [Compute Engine
-  Service Account](https://cloud.google.com/compute/docs/authentication). This
-  can also be specified with the `GOOGLE_ACCOUNT_FILE` shell environment
-  variable.
-
-
 ## Authentication JSON File
 
 Authenticating with Google Cloud services requires a JSON


### PR DESCRIPTION
Remove the shims for the long-deprecated account_file field in the
Google provider.