### PR TITLE
provider/docker: Removing the note on docker provider about Terraform 0.4

### DIFF
--- a/website/source/docs/providers/docker/index.html.markdown
+++ b/website/source/docs/providers/docker/index.html.markdown
@@ -16,12 +16,6 @@ API hosts.
 
 Use the navigation to the left to read about the available resources.
 
-<div class="alert alert-block alert-info">
-<strong>Note:</strong> The Docker provider is new as of Terraform 0.4.
-It is ready to be used but many features are still being added. If there
-is a Docker feature missing, please report it in the GitHub repo.
-</div>
-
 ## Example Usage
 
 ```


### PR DESCRIPTION
Fixes: #12670