### PR TITLE
Add basic auth to consul provider

### DIFF
--- a/builtin/providers/consul/config.go
+++ b/builtin/providers/consul/config.go
@@ -3,6 +3,7 @@ package consul
 import (
 	"log"
 	"net/http"
+	"strings"
 
 	consulapi "github.com/hashicorp/consul/api"
 )
@@ -11,6 +12,7 @@ type Config struct {
 	Datacenter string `mapstructure:"datacenter"`
 	Address    string `mapstructure:"address"`
 	Scheme     string `mapstructure:"scheme"`
+	HttpAuth   string `mapstructure:"http_auth"`
 	Token      string `mapstructure:"token"`
 	CAFile     string `mapstructure:"ca_file"`
 	CertFile   string `mapstructure:"cert_file"`
@@ -40,6 +42,18 @@ func (c *Config) Client() (*consulapi.Client, error) {
 		return nil, err
 	}
 	config.HttpClient.Transport.(*http.Transport).TLSClientConfig = cc
+
+	if c.HttpAuth != "" {
+		var username, password string
+		if strings.Contains(c.HttpAuth, ":") {
+			split := strings.SplitN(c.HttpAuth, ":", 2)
+			username = split[0]
+			password = split[1]
+		} else {
+			username = c.HttpAuth
+		}
+		config.HttpAuth = &consulapi.HttpBasicAuth{username, password}
+	}
 
 	if c.Token != "" {
 		config.Token = c.Token

--- a/builtin/providers/consul/resource_provider.go
+++ b/builtin/providers/consul/resource_provider.go
@@ -35,6 +35,12 @@ func Provider() terraform.ResourceProvider {
 				}, "http"),
 			},
 
+			"http_auth": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CONSUL_HTTP_AUTH", ""),
+			},
+
 			"ca_file": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,

--- a/website/source/docs/providers/consul/index.html.markdown
+++ b/website/source/docs/providers/consul/index.html.markdown
@@ -45,6 +45,7 @@ The following arguments are supported:
 
 * `address` - (Optional) The HTTP(S) API address of the agent to use. Defaults to "127.0.0.1:8500".
 * `scheme` - (Optional) The URL scheme of the agent to use ("http" or "https"). Defaults to "http".
+* `http_auth` - (Optional) HTTP Basic Authentication credentials to be used when communicating with Consul, in the format of either `user` or `user:pass`. This may also be specified using the `CONSUL_HTTP_AUTH` environment variable.
 * `datacenter` - (Optional) The datacenter to use. Defaults to that of the agent.
 * `token` - (Optional) The ACL token to use by default when making requests to the agent.
 * `ca_file` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.


### PR DESCRIPTION
This PR adds a basic auth option to the consul provider.

Most of the code is copied from this https://github.com/hashicorp/terraform/pull/4166