### PR TITLE
provider/packet: Update ssh-key resource test to run in parallel better

### DIFF
--- a/builtin/providers/packet/resource_packet_ssh_key_test.go
+++ b/builtin/providers/packet/resource_packet_ssh_key_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/packethost/packngo"
@@ -12,19 +13,19 @@ import (
 
 func TestAccPacketSSHKey_Basic(t *testing.T) {
 	var key packngo.SSHKey
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPacketSSHKeyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccCheckPacketSSHKeyConfig_basic,
+			{
+				Config: testAccCheckPacketSSHKeyConfig_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPacketSSHKeyExists("packet_ssh_key.foobar", &key),
-					testAccCheckPacketSSHKeyAttributes(&key),
 					resource.TestCheckResourceAttr(
-						"packet_ssh_key.foobar", "name", "foobar"),
+						"packet_ssh_key.foobar", "name", fmt.Sprintf("foobar-%d", rInt)),
 					resource.TestCheckResourceAttr(
 						"packet_ssh_key.foobar", "public_key", testAccValidPublicKey),
 				),
@@ -46,15 +47,6 @@ func testAccCheckPacketSSHKeyDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckPacketSSHKeyAttributes(key *packngo.SSHKey) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if key.Label != "foobar" {
-			return fmt.Errorf("Bad name: %s", key.Label)
-		}
-		return nil
-	}
 }
 
 func testAccCheckPacketSSHKeyExists(n string, key *packngo.SSHKey) resource.TestCheckFunc {
@@ -84,11 +76,13 @@ func testAccCheckPacketSSHKeyExists(n string, key *packngo.SSHKey) resource.Test
 	}
 }
 
-var testAccCheckPacketSSHKeyConfig_basic = fmt.Sprintf(`
+func testAccCheckPacketSSHKeyConfig_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "packet_ssh_key" "foobar" {
-    name = "foobar"
+    name = "foobar-%d"
     public_key = "%s"
-}`, testAccValidPublicKey)
+}`, rInt, testAccValidPublicKey)
+}
 
 var testAccValidPublicKey = strings.TrimSpace(`
 ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKVmnMOlHKcZK8tpt3MP1lqOLAcqcJzhsvJcjscgVERRN7/9484SOBJ3HSKxxNG5JN8owAjy5f9yYwcUg+JaUVuytn5Pv3aeYROHGGg+5G346xaq3DAwX6Y5ykr2fvjObgncQBnuU5KHWCECO/4h8uWuwh/kfniXPVjFToc+gnkqA+3RKpAecZhFXwfalQ9mMuYGFxn+fwn8cYEApsJbsEmb0iJwPiZ5hjFC8wREuiTlhPHDgkBLOiycd20op2nXzDbHfCHInquEe/gYxEitALONxm0swBOwJZwlTDOB7C6y2dzlrtxr1L59m7pCkWI4EtTRLvleehBoj3u7jB4usR


### PR DESCRIPTION
Allows the ssh-key test to pass when ran in parallel with different branches.

```
$ make testacc TEST=./builtin/providers/packet TESTARGS='-run=TestAccPacketSSHKey_Basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 11:10:28 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/packet -v -run=TestAccPacketSSHKey_Basic -timeout 120m
=== RUN   TestAccPacketSSHKey_Basic
PASS
ok      github.com/hashicorp/terraform/builtin/providers/packet 3.503s
```