### PR TITLE
provider/aws: Remove restriction on running aws_opsworks_* on us-east-1

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -308,7 +308,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.kmsconn = kms.New(sess)
 	client.lambdaconn = lambda.New(sess)
 	client.lightsailconn = lightsail.New(usEast1Sess)
-	client.opsworksconn = opsworks.New(usEast1Sess)
+	client.opsworksconn = opsworks.New(sess)
 	client.r53conn = route53.New(usEast1Sess)
 	client.rdsconn = rds.New(sess)
 	client.redshiftconn = redshift.New(sess)

--- a/builtin/providers/aws/resource_aws_opsworks_application.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application.go
@@ -21,21 +21,21 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 		Update: resourceAwsOpsworksApplicationUpdate,
 		Delete: resourceAwsOpsworksApplicationDelete,
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"short_name": &schema.Schema{
+			"short_name": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
 			},
 			// aws-flow-ruby | java | rails | php | nodejs | static | other
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
@@ -56,62 +56,62 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 					return
 				},
 			},
-			"stack_id": &schema.Schema{
+			"stack_id": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 			// TODO: the following 4 vals are really part of the Attributes array. We should validate that only ones relevant to the chosen type are set, perhaps. (what is the default type? how do they map?)
-			"document_root": &schema.Schema{
+			"document_root": {
 				Type:     schema.TypeString,
 				Optional: true,
 				//Default:  "public",
 			},
-			"rails_env": &schema.Schema{
+			"rails_env": {
 				Type:     schema.TypeString,
 				Optional: true,
 				//Default:  "production",
 			},
-			"auto_bundle_on_deploy": &schema.Schema{
+			"auto_bundle_on_deploy": {
 				Type:     schema.TypeString,
 				Optional: true,
 				//Default:  true,
 			},
-			"aws_flow_ruby_settings": &schema.Schema{
+			"aws_flow_ruby_settings": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"app_source": &schema.Schema{
+			"app_source": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": &schema.Schema{
+						"type": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"url": &schema.Schema{
+						"url": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"username": &schema.Schema{
+						"username": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"password": &schema.Schema{
+						"password": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"revision": &schema.Schema{
+						"revision": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"ssh_key": &schema.Schema{
+						"ssh_key": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -121,41 +121,41 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 			// AutoSelectOpsworksMysqlInstance, OpsworksMysqlInstance, or RdsDbInstance.
 			// anything beside auto select will lead into failure in case the instance doesn't exist
 			// XXX: validation?
-			"data_source_type": &schema.Schema{
+			"data_source_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"data_source_database_name": &schema.Schema{
+			"data_source_database_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"data_source_arn": &schema.Schema{
+			"data_source_arn": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"domains": &schema.Schema{
+			"domains": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
-			"environment": &schema.Schema{
+			"environment": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"key": &schema.Schema{
+						"key": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"value": &schema.Schema{
+						"value": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"secure": &schema.Schema{
+						"secure": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  true,
@@ -163,18 +163,18 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 					},
 				},
 			},
-			"enable_ssl": &schema.Schema{
+			"enable_ssl": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
-			"ssl_configuration": &schema.Schema{
+			"ssl_configuration": {
 				Type:     schema.TypeList,
 				Optional: true,
 				//Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"certificate": &schema.Schema{
+						"certificate": {
 							Type:     schema.TypeString,
 							Required: true,
 							StateFunc: func(v interface{}) string {
@@ -186,7 +186,7 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 								}
 							},
 						},
-						"private_key": &schema.Schema{
+						"private_key": {
 							Type:     schema.TypeString,
 							Required: true,
 							StateFunc: func(v interface{}) string {
@@ -198,7 +198,7 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 								}
 							},
 						},
-						"chain": &schema.Schema{
+						"chain": {
 							Type:     schema.TypeString,
 							Optional: true,
 							StateFunc: func(v interface{}) string {

--- a/builtin/providers/aws/resource_aws_opsworks_application_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application_test.go
@@ -24,7 +24,7 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksApplicationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksApplicationCreate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksApplicationExists(
@@ -62,7 +62,7 @@ func TestAccAWSOpsworksApplication(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksApplicationUpdate(name),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksApplicationExists(
@@ -193,7 +193,7 @@ func testAccCheckAWSOpsworksCreateAppAttributes(
 		}
 
 		expectedEnv := []*opsworks.EnvironmentVariable{
-			&opsworks.EnvironmentVariable{
+			{
 				Key:    aws.String("key1"),
 				Value:  aws.String("value1"),
 				Secure: aws.Bool(false),
@@ -253,12 +253,12 @@ func testAccCheckAWSOpsworksUpdateAppAttributes(
 		}
 
 		expectedEnv := []*opsworks.EnvironmentVariable{
-			&opsworks.EnvironmentVariable{
+			{
 				Key:    aws.String("key2"),
 				Value:  aws.String("*****FILTERED*****"),
 				Secure: aws.Bool(true),
 			},
-			&opsworks.EnvironmentVariable{
+			{
 				Key:    aws.String("key1"),
 				Value:  aws.String("value1"),
 				Secure: aws.Bool(false),

--- a/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_custom_layer_test.go
@@ -24,7 +24,7 @@ func TestAccAWSOpsworksCustomLayer(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksCustomLayerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksCustomLayerConfigNoVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksCustomLayerExists(
@@ -74,7 +74,7 @@ func TestAccAWSOpsworksCustomLayer(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksCustomLayerConfigUpdate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -219,7 +219,7 @@ func testAccCheckAWSOpsworksCreateLayerAttributes(
 		}
 
 		expectedEbsVolumes := []*opsworks.VolumeConfiguration{
-			&opsworks.VolumeConfiguration{
+			{
 				VolumeType:    aws.String("gp2"),
 				NumberOfDisks: aws.Int64(2),
 				MountPoint:    aws.String("/home"),

--- a/builtin/providers/aws/resource_aws_opsworks_ganglia_layer.go
+++ b/builtin/providers/aws/resource_aws_opsworks_ganglia_layer.go
@@ -10,17 +10,17 @@ func resourceAwsOpsworksGangliaLayer() *schema.Resource {
 		DefaultLayerName: "Ganglia",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
-			"url": &opsworksLayerTypeAttribute{
+			"url": {
 				AttrName: "GangliaUrl",
 				Type:     schema.TypeString,
 				Default:  "/ganglia",
 			},
-			"username": &opsworksLayerTypeAttribute{
+			"username": {
 				AttrName: "GangliaUser",
 				Type:     schema.TypeString,
 				Default:  "opsworks",
 			},
-			"password": &opsworksLayerTypeAttribute{
+			"password": {
 				AttrName:  "GangliaPassword",
 				Type:      schema.TypeString,
 				Required:  true,

--- a/builtin/providers/aws/resource_aws_opsworks_haproxy_layer.go
+++ b/builtin/providers/aws/resource_aws_opsworks_haproxy_layer.go
@@ -10,33 +10,33 @@ func resourceAwsOpsworksHaproxyLayer() *schema.Resource {
 		DefaultLayerName: "HAProxy",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
-			"stats_enabled": &opsworksLayerTypeAttribute{
+			"stats_enabled": {
 				AttrName: "EnableHaproxyStats",
 				Type:     schema.TypeBool,
 				Default:  true,
 			},
-			"stats_url": &opsworksLayerTypeAttribute{
+			"stats_url": {
 				AttrName: "HaproxyStatsUrl",
 				Type:     schema.TypeString,
 				Default:  "/haproxy?stats",
 			},
-			"stats_user": &opsworksLayerTypeAttribute{
+			"stats_user": {
 				AttrName: "HaproxyStatsUser",
 				Type:     schema.TypeString,
 				Default:  "opsworks",
 			},
-			"stats_password": &opsworksLayerTypeAttribute{
+			"stats_password": {
 				AttrName:  "HaproxyStatsPassword",
 				Type:      schema.TypeString,
 				WriteOnly: true,
 				Required:  true,
 			},
-			"healthcheck_url": &opsworksLayerTypeAttribute{
+			"healthcheck_url": {
 				AttrName: "HaproxyHealthCheckUrl",
 				Type:     schema.TypeString,
 				Default:  "/",
 			},
-			"healthcheck_method": &opsworksLayerTypeAttribute{
+			"healthcheck_method": {
 				AttrName: "HaproxyHealthCheckMethod",
 				Type:     schema.TypeString,
 				Default:  "OPTIONS",

--- a/builtin/providers/aws/resource_aws_opsworks_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_instance_test.go
@@ -71,7 +71,7 @@ func TestAccAWSOpsworksInstance(t *testing.T) {
 						"aws_opsworks_instance.tf-acc", "tenancy", "default",
 					),
 					resource.TestCheckResourceAttr(
-						"aws_opsworks_instance.tf-acc", "os", "Amazon Linux 2014.09", // inherited from opsworks_stack_test
+						"aws_opsworks_instance.tf-acc", "os", "Amazon Linux 2016.09", // inherited from opsworks_stack_test
 					),
 					resource.TestCheckResourceAttr(
 						"aws_opsworks_instance.tf-acc", "root_device_type", "ebs", // inherited from opsworks_stack_test

--- a/builtin/providers/aws/resource_aws_opsworks_java_app_layer.go
+++ b/builtin/providers/aws/resource_aws_opsworks_java_app_layer.go
@@ -10,27 +10,27 @@ func resourceAwsOpsworksJavaAppLayer() *schema.Resource {
 		DefaultLayerName: "Java App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
-			"jvm_type": &opsworksLayerTypeAttribute{
+			"jvm_type": {
 				AttrName: "Jvm",
 				Type:     schema.TypeString,
 				Default:  "openjdk",
 			},
-			"jvm_version": &opsworksLayerTypeAttribute{
+			"jvm_version": {
 				AttrName: "JvmVersion",
 				Type:     schema.TypeString,
 				Default:  "7",
 			},
-			"jvm_options": &opsworksLayerTypeAttribute{
+			"jvm_options": {
 				AttrName: "JvmOptions",
 				Type:     schema.TypeString,
 				Default:  "",
 			},
-			"app_server": &opsworksLayerTypeAttribute{
+			"app_server": {
 				AttrName: "JavaAppServer",
 				Type:     schema.TypeString,
 				Default:  "tomcat",
 			},
-			"app_server_version": &opsworksLayerTypeAttribute{
+			"app_server_version": {
 				AttrName: "JavaAppServerVersion",
 				Type:     schema.TypeString,
 				Default:  "7",

--- a/builtin/providers/aws/resource_aws_opsworks_memcached_layer.go
+++ b/builtin/providers/aws/resource_aws_opsworks_memcached_layer.go
@@ -10,7 +10,7 @@ func resourceAwsOpsworksMemcachedLayer() *schema.Resource {
 		DefaultLayerName: "Memcached",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
-			"allocated_memory": &opsworksLayerTypeAttribute{
+			"allocated_memory": {
 				AttrName: "MemcachedMemory",
 				Type:     schema.TypeInt,
 				Default:  512,

--- a/builtin/providers/aws/resource_aws_opsworks_mysql_layer.go
+++ b/builtin/providers/aws/resource_aws_opsworks_mysql_layer.go
@@ -10,12 +10,12 @@ func resourceAwsOpsworksMysqlLayer() *schema.Resource {
 		DefaultLayerName: "MySQL",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
-			"root_password": &opsworksLayerTypeAttribute{
+			"root_password": {
 				AttrName:  "MysqlRootPassword",
 				Type:      schema.TypeString,
 				WriteOnly: true,
 			},
-			"root_password_on_all_instances": &opsworksLayerTypeAttribute{
+			"root_password_on_all_instances": {
 				AttrName: "MysqlRootPasswordUbiquitous",
 				Type:     schema.TypeBool,
 				Default:  true,

--- a/builtin/providers/aws/resource_aws_opsworks_nodejs_app_layer.go
+++ b/builtin/providers/aws/resource_aws_opsworks_nodejs_app_layer.go
@@ -10,7 +10,7 @@ func resourceAwsOpsworksNodejsAppLayer() *schema.Resource {
 		DefaultLayerName: "Node.js App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
-			"nodejs_version": &opsworksLayerTypeAttribute{
+			"nodejs_version": {
 				AttrName: "NodejsVersion",
 				Type:     schema.TypeString,
 				Default:  "0.10.38",

--- a/builtin/providers/aws/resource_aws_opsworks_permission.go
+++ b/builtin/providers/aws/resource_aws_opsworks_permission.go
@@ -20,26 +20,26 @@ func resourceAwsOpsworksPermission() *schema.Resource {
 		Read:   resourceAwsOpsworksPermissionRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"allow_ssh": &schema.Schema{
+			"allow_ssh": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Optional: true,
 			},
-			"allow_sudo": &schema.Schema{
+			"allow_sudo": {
 				Type:     schema.TypeBool,
 				Computed: true,
 				Optional: true,
 			},
-			"user_arn": &schema.Schema{
+			"user_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 			// one of deny, show, deploy, manage, iam_only
-			"level": &schema.Schema{
+			"level": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,
@@ -61,7 +61,7 @@ func resourceAwsOpsworksPermission() *schema.Resource {
 					return
 				},
 			},
-			"stack_id": &schema.Schema{
+			"stack_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 				Optional: true,

--- a/builtin/providers/aws/resource_aws_opsworks_permission_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_permission_test.go
@@ -20,7 +20,7 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksPermissionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "true", "true", "iam_only"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksPermissionExists(
@@ -37,7 +37,7 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "true", "false", "iam_only"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksPermissionExists(
@@ -54,7 +54,7 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "false", "false", "deny"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksPermissionExists(
@@ -71,7 +71,7 @@ func TestAccAWSOpsworksPermission(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksPermissionCreate(sName, "false", "false", "show"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksPermissionExists(

--- a/builtin/providers/aws/resource_aws_opsworks_rails_app_layer.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rails_app_layer.go
@@ -10,32 +10,32 @@ func resourceAwsOpsworksRailsAppLayer() *schema.Resource {
 		DefaultLayerName: "Rails App Server",
 
 		Attributes: map[string]*opsworksLayerTypeAttribute{
-			"ruby_version": &opsworksLayerTypeAttribute{
+			"ruby_version": {
 				AttrName: "RubyVersion",
 				Type:     schema.TypeString,
 				Default:  "2.0.0",
 			},
-			"app_server": &opsworksLayerTypeAttribute{
+			"app_server": {
 				AttrName: "RailsStack",
 				Type:     schema.TypeString,
 				Default:  "apache_passenger",
 			},
-			"passenger_version": &opsworksLayerTypeAttribute{
+			"passenger_version": {
 				AttrName: "PassengerVersion",
 				Type:     schema.TypeString,
 				Default:  "4.0.46",
 			},
-			"rubygems_version": &opsworksLayerTypeAttribute{
+			"rubygems_version": {
 				AttrName: "RubygemsVersion",
 				Type:     schema.TypeString,
 				Default:  "2.2.2",
 			},
-			"manage_bundler": &opsworksLayerTypeAttribute{
+			"manage_bundler": {
 				AttrName: "ManageBundler",
 				Type:     schema.TypeBool,
 				Default:  true,
 			},
-			"bundler_version": &opsworksLayerTypeAttribute{
+			"bundler_version": {
 				AttrName: "BundlerVersion",
 				Type:     schema.TypeString,
 				Default:  "1.5.3",

--- a/builtin/providers/aws/resource_aws_opsworks_rails_app_layer_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rails_app_layer_test.go
@@ -22,7 +22,7 @@ func TestAccAWSOpsworksRailsAppLayer(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksRailsAppLayerDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksRailsAppLayerConfigVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
@@ -33,7 +33,7 @@ func TestAccAWSOpsworksRailsAppLayer(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksRailsAppLayerNoManageBundlerConfigVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance.go
@@ -20,26 +20,26 @@ func resourceAwsOpsworksRdsDbInstance() *schema.Resource {
 		Read:   resourceAwsOpsworksRdsDbInstanceRead,
 
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"stack_id": &schema.Schema{
+			"stack_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"rds_db_instance_arn": &schema.Schema{
+			"rds_db_instance_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"db_password": &schema.Schema{
+			"db_password": {
 				Type:      schema.TypeString,
 				Required:  true,
 				Sensitive: true,
 			},
-			"db_user": &schema.Schema{
+			"db_user": {
 				Type:     schema.TypeString,
 				Required: true,
 			},

--- a/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_rds_db_instance_test.go
@@ -20,7 +20,7 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksRdsDbDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksRdsDbInstance(sName, "foo", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksRdsDbExists(
@@ -31,7 +31,7 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksRdsDbInstance(sName, "bar", "barbarbarbar"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksRdsDbExists(
@@ -42,7 +42,7 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksRdsDbInstance(sName, "bar", "foofoofoofoofoo"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksRdsDbExists(
@@ -53,7 +53,7 @@ func TestAccAWSOpsworksRdsDbInstance(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksRdsDbInstanceForceNew(sName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksRdsDbExists(

--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -25,99 +25,99 @@ func resourceAwsOpsworksStack() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"agent_version": &schema.Schema{
+			"agent_version": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"region": &schema.Schema{
+			"region": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Required: true,
 			},
 
-			"service_role_arn": &schema.Schema{
+			"service_role_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"default_instance_profile_arn": &schema.Schema{
+			"default_instance_profile_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"color": &schema.Schema{
+			"color": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"configuration_manager_name": &schema.Schema{
+			"configuration_manager_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "Chef",
 			},
 
-			"configuration_manager_version": &schema.Schema{
+			"configuration_manager_version": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "11.4",
 			},
 
-			"manage_berkshelf": &schema.Schema{
+			"manage_berkshelf": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
 
-			"berkshelf_version": &schema.Schema{
+			"berkshelf_version": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "3.2.0",
 			},
 
-			"custom_cookbooks_source": &schema.Schema{
+			"custom_cookbooks_source": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": &schema.Schema{
+						"type": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"url": &schema.Schema{
+						"url": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"username": &schema.Schema{
+						"username": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"password": &schema.Schema{
+						"password": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"revision": &schema.Schema{
+						"revision": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 
-						"ssh_key": &schema.Schema{
+						"ssh_key": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -125,58 +125,58 @@ func resourceAwsOpsworksStack() *schema.Resource {
 				},
 			},
 
-			"custom_json": &schema.Schema{
+			"custom_json": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"default_availability_zone": &schema.Schema{
+			"default_availability_zone": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 
-			"default_os": &schema.Schema{
+			"default_os": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "Ubuntu 12.04 LTS",
 			},
 
-			"default_root_device_type": &schema.Schema{
+			"default_root_device_type": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "instance-store",
 			},
 
-			"default_ssh_key_name": &schema.Schema{
+			"default_ssh_key_name": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"default_subnet_id": &schema.Schema{
+			"default_subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
 
-			"hostname_theme": &schema.Schema{
+			"hostname_theme": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "Layer_Dependent",
 			},
 
-			"use_custom_cookbooks": &schema.Schema{
+			"use_custom_cookbooks": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
 
-			"use_opsworks_security_groups": &schema.Schema{
+			"use_opsworks_security_groups": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
 
-			"vpc_id": &schema.Schema{
+			"vpc_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
 				Optional: true,

--- a/builtin/providers/aws/resource_aws_opsworks_stack_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack_test.go
@@ -25,7 +25,7 @@ func TestAccAWSOpsworksStackNoVpc(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksStackConfigNoVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksStackExists(
@@ -36,10 +36,6 @@ func TestAccAWSOpsworksStackNoVpc(t *testing.T) {
 						"us-east-1a", stackName),
 				),
 			},
-			// resource.TestStep{
-			// 	Config: testAccAWSOpsworksStackConfigNoVpcUpdate(stackName),
-			// 	Check:  testAccAwsOpsworksStackCheckResourceAttrsUpdate("us-east-1c", stackName),
-			// },
 		},
 	})
 }
@@ -52,7 +48,7 @@ func TestAccAWSOpsworksStackVpc(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksStackDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksStackConfigVpcCreate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksStackExists(
@@ -63,7 +59,7 @@ func TestAccAWSOpsworksStackVpc(t *testing.T) {
 						"us-west-2a", stackName),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSOpsworksStackConfigVpcUpdate(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksStackExists(
@@ -97,7 +93,7 @@ func testAccAwsOpsworksStackCheckResourceAttrsCreate(zone, stackName string) res
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
 			"default_os",
-			"Amazon Linux 2014.09",
+			"Amazon Linux 2016.09",
 		),
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
@@ -137,7 +133,7 @@ func testAccAwsOpsworksStackCheckResourceAttrsUpdate(zone, stackName string) res
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
 			"default_os",
-			"Amazon Linux 2014.09",
+			"Amazon Linux 2015.09",
 		),
 		resource.TestCheckResourceAttr(
 			"aws_opsworks_stack.tf-acc",
@@ -240,7 +236,7 @@ func testAccCheckAWSOpsworksCreateStackAttributes(
 			return fmt.Errorf("Unnexpected DefaultAvailabilityZone: %s", *opsstack.DefaultAvailabilityZone)
 		}
 
-		if *opsstack.DefaultOs != "Amazon Linux 2014.09" {
+		if *opsstack.DefaultOs != "Amazon Linux 2016.09" {
 			return fmt.Errorf("Unnexpected stackName: %s", *opsstack.DefaultOs)
 		}
 
@@ -275,7 +271,7 @@ func testAccCheckAWSOpsworksUpdateStackAttributes(
 			return fmt.Errorf("Unnexpected DefaultAvailabilityZone: %s", *opsstack.DefaultAvailabilityZone)
 		}
 
-		if *opsstack.DefaultOs != "Amazon Linux 2014.09" {
+		if *opsstack.DefaultOs != "Amazon Linux 2015.09" {
 			return fmt.Errorf("Unnexpected stackName: %s", *opsstack.DefaultOs)
 		}
 
@@ -348,13 +344,16 @@ func testAccCheckAwsOpsworksStackDestroy(s *terraform.State) error {
 
 func testAccAwsOpsworksStackConfigNoVpcCreate(name string) string {
 	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
 resource "aws_opsworks_stack" "tf-acc" {
   name = "%s"
   region = "us-east-1"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
   default_availability_zone = "us-east-1a"
-  default_os = "Amazon Linux 2014.09"
+  default_os = "Amazon Linux 2016.09"
   default_root_device_type = "ebs"
   custom_json = "{\"key\": \"value\"}"
   configuration_manager_version = "11.10"
@@ -427,95 +426,6 @@ resource "aws_iam_instance_profile" "opsworks_instance" {
 }`, name, name, name, name, name)
 }
 
-func testAccAWSOpsworksStackConfigNoVpcUpdate(name string) string {
-	return fmt.Sprintf(`
-resource "aws_opsworks_stack" "tf-acc" {
-  name = "%s"
-  region = "us-east-1"
-  service_role_arn = "${aws_iam_role.opsworks_service.arn}"
-  default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
-  default_availability_zone = "us-east-1a"
-  default_os = "Amazon Linux 2014.09"
-  default_root_device_type = "ebs"
-  custom_json = "{\"key\": \"value\"}"
-  configuration_manager_version = "11.10"
-  use_opsworks_security_groups = false
-  use_custom_cookbooks = true
-  manage_berkshelf = true
-  custom_cookbooks_source {
-    type = "git"
-    revision = "master"
-    url = "https://github.com/aws/opsworks-example-cookbooks.git"
-    username = "example"
-    password = "example"
-  }
-resource "aws_iam_role" "opsworks_service" {
-    name = "%s_opsworks_service"
-    assume_role_policy = <<EOT
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "opsworks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOT
-}
-
-resource "aws_iam_role_policy" "opsworks_service" {
-    name = "%s_opsworks_service"
-    role = "${aws_iam_role.opsworks_service.id}"
-    policy = <<EOT
-{
-  "Statement": [
-    {
-      "Action": [
-        "ec2:*",
-        "iam:PassRole",
-        "cloudwatch:GetMetricStatistics",
-        "elasticloadbalancing:*",
-        "rds:*"
-      ],
-      "Effect": "Allow",
-      "Resource": ["*"]
-    }
-  ]
-}
-EOT
-}
-
-resource "aws_iam_role" "opsworks_instance" {
-    name = "%s_opsworks_instance"
-    assume_role_policy = <<EOT
-{
-  "Version": "2008-10-17",
-  "Statement": [
-    {
-      "Sid": "",
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "ec2.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-EOT
-}
-
-resource "aws_iam_instance_profile" "opsworks_instance" {
-    name = "%s_opsworks_instance"
-    roles = ["${aws_iam_role.opsworks_instance.name}"]
-}
-`, name, name, name, name, name)
-}
-
 ////////////////////////////
 //// Tests for the VPC case
 ////////////////////////////
@@ -537,7 +447,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   default_subnet_id = "${aws_subnet.tf-acc.id}"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
-  default_os = "Amazon Linux 2014.09"
+  default_os = "Amazon Linux 2016.09"
   default_root_device_type = "ebs"
   custom_json = "{\"key\": \"value\"}"
   configuration_manager_version = "11.10"
@@ -628,7 +538,7 @@ resource "aws_opsworks_stack" "tf-acc" {
   default_subnet_id = "${aws_subnet.tf-acc.id}"
   service_role_arn = "${aws_iam_role.opsworks_service.arn}"
   default_instance_profile_arn = "${aws_iam_instance_profile.opsworks_instance.arn}"
-  default_os = "Amazon Linux 2014.09"
+  default_os = "Amazon Linux 2015.09"
   default_root_device_type = "ebs"
   custom_json = "{\"key\": \"value\"}"
   configuration_manager_version = "11.10"

--- a/builtin/providers/aws/resource_aws_opsworks_user_profile.go
+++ b/builtin/providers/aws/resource_aws_opsworks_user_profile.go
@@ -18,29 +18,29 @@ func resourceAwsOpsworksUserProfile() *schema.Resource {
 		Delete: resourceAwsOpsworksUserProfileDelete,
 
 		Schema: map[string]*schema.Schema{
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"user_arn": &schema.Schema{
+			"user_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"allow_self_management": &schema.Schema{
+			"allow_self_management": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
 			},
 
-			"ssh_username": &schema.Schema{
+			"ssh_username": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
 
-			"ssh_public_key": &schema.Schema{
+			"ssh_public_key": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},

--- a/builtin/providers/aws/resource_aws_opsworks_user_profile_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_user_profile_test.go
@@ -20,7 +20,7 @@ func TestAccAWSOpsworksUserProfile(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAwsOpsworksUserProfileDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksUserProfileCreate(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksUserProfileExists(
@@ -36,7 +36,7 @@ func TestAccAWSOpsworksUserProfile(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAwsOpsworksUserProfileUpdate(rName, updateRName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSOpsworksUserProfileExists(


### PR DESCRIPTION
Fixes: #11824
Fixes: #9826

A full set of acceptance tests for *all* OpsWorks tests are below. There is a single issue, opsworks_instance isn't ordering the layer_ids so it's non-deterministic which can come back. This introduces a false positive.

The opsworks tests are running both against us-east-1 for some and us-west-2 for others. This must be marked as a backwards incompatibility in 0.9 just incase people are using the opsworks region parameter to try and override the provider region

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksApplication'                                                              2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 17:11:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksApplication -timeout 120m
=== RUN   TestAccAWSOpsworksApplication
--- PASS: TestAccAWSOpsworksApplication (164.29s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	164.319s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksCustomLayer'                                                                  ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 17:16:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksCustomLayer -timeout 120m
=== RUN   TestAccAWSOpsworksCustomLayerImportBasic
--- PASS: TestAccAWSOpsworksCustomLayerImportBasic (105.98s)
=== RUN   TestAccAWSOpsworksCustomLayer
--- PASS: TestAccAWSOpsworksCustomLayer (92.68s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	198.684s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksPermission'                                                                   ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 17:23:28 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksPermission -timeout 120m
=== RUN   TestAccAWSOpsworksPermission
--- PASS: TestAccAWSOpsworksPermission (226.36s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	226.386s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksRailsAppLayer'                          ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 17:28:01 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksRailsAppLayer -timeout 120m
=== RUN   TestAccAWSOpsworksRailsAppLayer
--- PASS: TestAccAWSOpsworksRailsAppLayer (129.39s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	129.426s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksUserProfile'                            ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 17:37:46 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksUserProfile -timeout 120m
=== RUN   TestAccAWSOpsworksUserProfile
--- PASS: TestAccAWSOpsworksUserProfile (42.60s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	42.624s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksStack'                                                                     2 ↵ ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 18:00:50 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksStack -timeout 120m
=== RUN   TestAccAWSOpsworksStackImportBasic
--- PASS: TestAccAWSOpsworksStackImportBasic (50.28s)
=== RUN   TestAccAWSOpsworksStackNoVpc
--- PASS: TestAccAWSOpsworksStackNoVpc (25.92s)
=== RUN   TestAccAWSOpsworksStackVpc
--- PASS: TestAccAWSOpsworksStackVpc (76.80s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	153.025s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksRdsDbInstance'                                                                                                               ✹
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 17:38:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksRdsDbInstance -timeout 120m
=== RUN   TestAccAWSOpsworksRdsDbInstance
--- PASS: TestAccAWSOpsworksRdsDbInstance (916.15s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	916.177s
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksInstance'           2 ↵
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 17:26:45 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksInstance -timeout 120m
=== RUN   TestAccAWSOpsworksInstance_importBasic
--- PASS: TestAccAWSOpsworksInstance_importBasic (85.52s)
=== RUN   TestAccAWSOpsworksInstance
--- FAIL: TestAccAWSOpsworksInstance (114.09s)
	testing.go:268: Step 1 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: aws_opsworks_instance.tf-acc
		  layer_ids.0: "4c29b76f-df72-409e-a5c4-9459b7d9b4a4" => "a4a859cf-2a07-447e-a151-a97a6d827db7"
		  layer_ids.1: "a4a859cf-2a07-447e-a151-a97a6d827db7" => "4c29b76f-df72-409e-a5c4-9459b7d9b4a4"

      FAIL
      exit status 1
      FAIL	github.com/hashicorp/terraform/builtin/providers/aws	199.643s
      make: *** [testacc] Error 1
```