### PR TITLE
Add log message about if changes are being applied now or later

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -840,7 +840,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	d.SetPartial("apply_immediately")
 
 	if !d.Get("apply_immediately").(bool) {
-		log.Println("[INFO] Only settings updating, instances changes will be applied in next maintenance window")
+		log.Println("[INFO] Only settings updating, instance changes will be applied in next maintenance window")
 	}
 
 	requestUpdate := false

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -840,7 +840,7 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	d.SetPartial("apply_immediately")
 
 	if !d.Get("apply_immediately").(bool) {
-		log.Println("[INFO] Only settings updating, instances changes applied in next maintenance window")
+		log.Println("[INFO] Only settings updating, instances changes will be applied in next maintenance window")
 	}
 
 	requestUpdate := false

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -839,6 +839,10 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 	d.SetPartial("apply_immediately")
 
+	if !d.Get("apply_immediately").(bool) {
+		log.Println("[INFO] Only settings updating, instances changes applied in next maintenance window")
+	}
+
 	requestUpdate := false
 	if d.HasChange("allocated_storage") || d.HasChange("iops") {
 		d.SetPartial("allocated_storage")


### PR DESCRIPTION
The behavior of `apply_immediately` is spelled out clearly in the docs, but it's easy for users (such as myself) to misunderstand, forget, or not read in the first place. A simple log message informing them that the only thing being applied at this time is the settings helps users avoid confusion.