### PR TITLE
provider/aws: Add support for ENI as Instance Primary Network Interface

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -129,8 +129,11 @@ func resourceAwsInstance() *schema.Resource {
 			},
 
 			"network_interface_id": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"vpc_security_group_ids", "subnet_id", "associate_public_ip_address"},
 			},
 
 			"public_ip": {
@@ -1260,7 +1263,13 @@ func buildAwsInstanceOpts(
 		}
 	}
 
-	if hasSubnet && associatePublicIPAddress {
+	if v, ok := d.GetOk("network_interface_id"); ok {
+		ni := &ec2.InstanceNetworkInterfaceSpecification{
+			DeviceIndex:        aws.Int64(int64(0)),
+			NetworkInterfaceId: aws.String(v.(string)),
+		}
+		opts.NetworkInterfaces = []*ec2.InstanceNetworkInterfaceSpecification{ni}
+	} else if hasSubnet && associatePublicIPAddress {
 		// If we have a non-default VPC / Subnet specified, we can flag
 		// AssociatePublicIpAddress to get a Public IP assigned. By default these are not provided.
 		// You cannot specify both SubnetId and the NetworkInterface.0.* parameters though, otherwise

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -981,7 +981,7 @@ func driftTags(instance *ec2.Instance) resource.TestCheckFunc {
 	}
 }
 
-func TestAccAWSInstanceWithNetworkInterface(t *testing.T) {
+func TestAccAWSInstance_withNetworkInterface(t *testing.T) {
 	var before ec2.Instance
 	var after ec2.Instance
 

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -1011,23 +1011,11 @@ func TestAccAWSInstance_withNetworkInterface(t *testing.T) {
 				Config: testAccInstanceConfigWithNetworkInterface("test2"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &after),
-					testAccCheckInstanceRecreated(
-						t, &before, &after),
 					testCheckPrivateIP("10.1.1.12", &after),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckInstanceRecreated(t *testing.T,
-	before, after *ec2.Instance) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *before.InstanceId == *after.InstanceId {
-			t.Fatalf("AWS Instance IDs have not changed. Before %s. After %s", *before.InstanceId, *after.InstanceId)
-		}
-		return nil
-	}
 }
 
 const testAccInstanceConfig_pre = `

--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -69,6 +69,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
    If you are creating Instances in a VPC, use `vpc_security_group_ids` instead.
 * `vpc_security_group_ids` - (Optional) A list of security group IDs to associate with.
 * `subnet_id` - (Optional) The VPC Subnet ID to launch in.
+* `network_interface_id` - (Optional) The network interface ID to attach to the instance.
 * `associate_public_ip_address` - (Optional) Associate a public ip address with an instance in a VPC.  Boolean value.
 * `private_ip` - (Optional) Private IP address to associate with the
      instance in a VPC.


### PR DESCRIPTION
This PR is an implementation of issue [2998](https://github.com/hashicorp/terraform/issues/2998).

I am aware to two other open PRs that attempt to address this issue, [10516](https://github.com/hashicorp/terraform/pull/10516) and [10244](https://github.com/hashicorp/terraform/pull/10244).

The PR changes the network_interface_id parameter of an aws_instance resource to be an optional parameter that conflicts with the following parameters: vpc_security_group_ids, subnet_id and associate_public_ip_address. This follows the same patterns as the two PR mentioned above.

Additionally, the network_interface_id parameter is configured with “ForceNew=true” as the primary network interface of an AWS instance can’t be changed without recreating the instance.

A new acceptance test case (TestAccAWSInstance_withNetworkInterface) is also included in the PR. It checks that specified network interface is attached to created instance and the network interface is changed (by recreating the instance) should the network_interface_id parameter be changed.

I run the acceptance tests for AWSInstance as follows:

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSInstance_withNetworkInterface’
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 08:45:24 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_with -timeout 120m
=== RUN   TestAccAWSInstance_withNetworkInterface
--- PASS: TestAccAWSInstance_withNetworkInterface (309.01s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	309.033s
```
```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSInstance_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 09:11:35 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_ -timeout 120m
=== RUN   TestAccAWSInstance_importBasic
--- PASS: TestAccAWSInstance_importBasic (179.53s)
=== RUN   TestAccAWSInstance_basic
--- PASS: TestAccAWSInstance_basic (240.96s)
=== RUN   TestAccAWSInstance_GP2IopsDevice
--- PASS: TestAccAWSInstance_GP2IopsDevice (112.66s)
=== RUN   TestAccAWSInstance_blockDevices
--- PASS: TestAccAWSInstance_blockDevices (119.65s)
=== RUN   TestAccAWSInstance_rootInstanceStore
--- PASS: TestAccAWSInstance_rootInstanceStore (119.37s)
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (328.66s)
=== RUN   TestAccAWSInstance_disableApiTermination
--- PASS: TestAccAWSInstance_disableApiTermination (279.02s)
=== RUN   TestAccAWSInstance_vpc
--- PASS: TestAccAWSInstance_vpc (181.95s)
=== RUN   TestAccAWSInstance_ipv6_supportAddressCount
--- PASS: TestAccAWSInstance_ipv6_supportAddressCount (185.19s)
=== RUN   TestAccAWSInstance_multipleRegions
--- FAIL: TestAccAWSInstance_multipleRegions (121.37s)
	testing.go:268: Step 0 error: Error applying: 1 error(s) occurred:

		* aws_instance.foo: 1 error(s) occurred:

		* aws_instance.foo: Error launching source instance: InvalidAMIID.NotFound: The image id '[ami-4fccb37f]' does not exist
			status code: 400, request id: 41674ce3-0e12-4a98-af4c-9f2778c67fae
=== RUN   TestAccAWSInstance_NetworkInstanceSecurityGroups
--- PASS: TestAccAWSInstance_NetworkInstanceSecurityGroups (206.71s)
=== RUN   TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs
--- PASS: TestAccAWSInstance_NetworkInstanceVPCSecurityGroupIDs (206.80s)
=== RUN   TestAccAWSInstance_tags
--- PASS: TestAccAWSInstance_tags (189.57s)
=== RUN   TestAccAWSInstance_instanceProfileChange
--- PASS: TestAccAWSInstance_instanceProfileChange (197.11s)
=== RUN   TestAccAWSInstance_privateIP
--- PASS: TestAccAWSInstance_privateIP (190.93s)
=== RUN   TestAccAWSInstance_associatePublicIPAndPrivateIP
--- PASS: TestAccAWSInstance_associatePublicIPAndPrivateIP (185.40s)
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (104.64s)
=== RUN   TestAccAWSInstance_rootBlockDeviceMismatch
--- PASS: TestAccAWSInstance_rootBlockDeviceMismatch (195.65s)
=== RUN   TestAccAWSInstance_forceNewAndTagsDrift
--- PASS: TestAccAWSInstance_forceNewAndTagsDrift (300.71s)
=== RUN   TestAccAWSInstance_changeInstanceType
--- PASS: TestAccAWSInstance_changeInstanceType (205.14s)
=== RUN   TestAccAWSInstance_withNetworkInterface
--- PASS: TestAccAWSInstance_withNetworkInterface (331.57s)
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/aws	4182.595s
make: *** [testacc] Error 1
```

Please note that the TestAccAWSInstance_multipleRegions test fails. This failure occurs without the PR being applied to the master branch.

From my analysis the commit that introduced this regression is 1eb9a2d083eb070a2b49b4ca7261a23e452b8bb9.

Thank you for considering this PR.
