### PR TITLE
Google Container Cluster: support tags and metadata

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -231,6 +231,19 @@ func resourceContainerCluster() *schema.Resource {
 							},
 						},
 
+						"metadata": &schema.Schema{
+							Type:     schema.TypeMap,
+							Optional: true,
+							Elem:     schema.TypeString,
+						},
+
+						"tags": &schema.Schema{
+							Type:     schema.TypeList,
+							Optional: true,
+							ForceNew: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+
 						"oauth_scopes": &schema.Schema{
 							Type:     schema.TypeList,
 							Optional: true,
@@ -367,6 +380,26 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 		if v, ok = nodeConfig["disk_size_gb"]; ok {
 			cluster.NodeConfig.DiskSizeGb = int64(v.(int))
+		}
+
+		if v, ok := nodeConfig["metadata"]; ok {
+			metadataMap := v.(map[string]interface{})
+			metadata := map[string]string{}
+			for k, v := range metadataMap {
+				metadata[k] = v.(string)
+			}
+
+			cluster.NodeConfig.Metadata = metadata
+		}
+
+		if v, ok := nodeConfig["tags"]; ok {
+			tagsList := v.([]interface{})
+			tags := []string{}
+			for _, v := range tagsList {
+				tags = append(tags, v.(string))
+			}
+
+			cluster.NodeConfig.Tags = tags
 		}
 
 		if v, ok := nodeConfig["oauth_scopes"]; ok {
@@ -561,6 +594,8 @@ func flattenClusterNodeConfig(c *container.NodeConfig) []map[string]interface{} 
 		map[string]interface{}{
 			"machine_type": c.MachineType,
 			"disk_size_gb": c.DiskSizeGb,
+			"metadata": c.Metadata,
+			"tags": c.Tags,
 		},
 	}
 

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -234,6 +234,7 @@ func resourceContainerCluster() *schema.Resource {
 						"metadata": &schema.Schema{
 							Type:     schema.TypeMap,
 							Optional: true,
+							ForceNew: true,
 							Elem:     schema.TypeString,
 						},
 
@@ -594,8 +595,8 @@ func flattenClusterNodeConfig(c *container.NodeConfig) []map[string]interface{} 
 		map[string]interface{}{
 			"machine_type": c.MachineType,
 			"disk_size_gb": c.DiskSizeGb,
-			"metadata": c.Metadata,
-			"tags": c.Tags,
+			"metadata":     c.Metadata,
+			"tags":         c.Tags,
 		},
 	}
 

--- a/vendor/google.golang.org/api/container/v1/container-api.json
+++ b/vendor/google.golang.org/api/container/v1/container-api.json
@@ -1,11 +1,11 @@
 {
  "kind": "discovery#restDescription",
- "etag": "\"jQLIOHBVnDZie4rQHGH1WJF-INE/cpP4K9eaLrLwMGtsdl5oXjxb8rw\"",
+ "etag": "\"tbys6C40o18GZwyMen5GMkdK-3s/aTs6tIgXySgjqhtr4EU6PD-kvdQ\"",
  "discoveryVersion": "v1",
  "id": "container:v1",
  "name": "container",
  "version": "v1",
- "revision": "20160421",
+ "revision": "20161024",
  "title": "Google Container Engine API",
  "description": "Builds and manages clusters that run container-based applications, powered by open source Kubernetes technology.",
  "ownerDomain": "google.com",
@@ -183,7 +183,7 @@
     },
     "nodePools": {
      "type": "array",
-     "description": "The node pools associated with this cluster. When creating a new cluster, only a single node pool should be specified. This field should not be set if \"node_config\" or \"initial_node_count\" are specified.",
+     "description": "The node pools associated with this cluster. This field should not be set if \"node_config\" or \"initial_node_count\" are specified.",
      "items": {
       "$ref": "NodePool"
      }
@@ -194,6 +194,10 @@
      "items": {
       "type": "string"
      }
+    },
+    "enableKubernetesAlpha": {
+     "type": "boolean",
+     "description": "Kubernetes alpha features are enabled on this cluster. This includes alpha API groups (e.g. v1alpha1) and features that may not be production ready in the kubernetes version of the master and nodes. The cluster has no SLA for uptime and master/node upgrades are disabled. Alpha enabled clusters are automatically deleted thirty days after creation."
     },
     "selfLink": {
      "type": "string",
@@ -259,6 +263,10 @@
      "type": "integer",
      "description": "[Output only] The number of nodes currently in the cluster.",
      "format": "int32"
+    },
+    "expireTime": {
+     "type": "string",
+     "description": "[Output only] The time the cluster will be automatically deleted in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format."
     }
    }
   },
@@ -283,12 +291,43 @@
       "type": "string"
      }
     },
+    "serviceAccount": {
+     "type": "string",
+     "description": "The Google Cloud Platform Service Account to be used by the node VMs. If no Service Account is specified, the \"default\" service account is used."
+    },
     "metadata": {
      "type": "object",
      "description": "The metadata key/value pairs assigned to instances in the cluster. Keys must conform to the regexp [a-zA-Z0-9-_]+ and be less than 128 bytes in length. These are reflected as part of a URL in the metadata server. Additionally, to avoid ambiguity, keys must not conflict with any other metadata keys for the project or be one of the four reserved keys: \"instance-template\", \"kube-env\", \"startup-script\", and \"user-data\" Values are free-form strings, and only have meaning as interpreted by the image running in the instance. The only restriction placed on them is that each value's size must be less than or equal to 32 KB. The total size of all keys and values must be less than 512 KB.",
      "additionalProperties": {
       "type": "string"
      }
+    },
+    "imageType": {
+     "type": "string",
+     "description": "The image type to use for this node. Note that for a given image type, the latest version of it will be used."
+    },
+    "labels": {
+     "type": "object",
+     "description": "The map of Kubernetes labels (key/value pairs) to be applied to each node. These will added in addition to any default label(s) that Kubernetes may apply to the node. In case of conflict in label keys, the applied set may differ depending on the Kubernetes version -- it's best to assume the behavior is undefined and conflicts should be avoided. For more information, including usage and the valid values, see: http://kubernetes.io/v1.1/docs/user-guide/labels.html",
+     "additionalProperties": {
+      "type": "string"
+     }
+    },
+    "localSsdCount": {
+     "type": "integer",
+     "description": "The number of local SSD disks to be attached to the node. The limit for this value is dependant upon the maximum number of disks available on a machine per zone. See: https://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_limits for more information.",
+     "format": "int32"
+    },
+    "tags": {
+     "type": "array",
+     "description": "The list of instance tags applied to all nodes. Tags are used to identify valid sources or targets for network firewalls and are specified by the client during cluster or node pool creation. Each tag within the list must comply with RFC1035.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "preemptible": {
+     "type": "boolean",
+     "description": "Whether the nodes are created as preemptible VM instances. See: https://cloud.google.com/compute/docs/instances/preemptible for more inforamtion about preemptible VM instances."
     }
    }
   },
@@ -376,11 +415,11 @@
     },
     "selfLink": {
      "type": "string",
-     "description": "Server-defined URL for the resource."
+     "description": "[Output only] Server-defined URL for the resource."
     },
     "version": {
      "type": "string",
-     "description": "The version of the Kubernetes of this node."
+     "description": "[Output only] The version of the Kubernetes of this node."
     },
     "instanceGroupUrls": {
      "type": "array",
@@ -391,7 +430,7 @@
     },
     "status": {
      "type": "string",
-     "description": "The status of the nodes in this pool instance.",
+     "description": "[Output only] The status of the nodes in this pool instance.",
      "enum": [
       "STATUS_UNSPECIFIED",
       "PROVISIONING",
@@ -405,6 +444,65 @@
     "statusMessage": {
      "type": "string",
      "description": "[Output only] Additional information about the current status of this node pool instance, if available."
+    },
+    "autoscaling": {
+     "$ref": "NodePoolAutoscaling",
+     "description": "Autoscaler configuration for this NodePool. Autoscaler is enabled only if a valid configuration is present."
+    },
+    "management": {
+     "$ref": "NodeManagement",
+     "description": "NodeManagement configuration for this NodePool."
+    }
+   }
+  },
+  "NodePoolAutoscaling": {
+   "id": "NodePoolAutoscaling",
+   "type": "object",
+   "description": "NodePoolAutoscaling contains information required by cluster autoscaler to adjust the size of the node pool to the current cluster usage.",
+   "properties": {
+    "enabled": {
+     "type": "boolean",
+     "description": "Is autoscaling enabled for this node pool."
+    },
+    "minNodeCount": {
+     "type": "integer",
+     "description": "Minimum number of nodes in the NodePool. Must be \u003e= 1 and \u003c= max_node_count.",
+     "format": "int32"
+    },
+    "maxNodeCount": {
+     "type": "integer",
+     "description": "Maximum number of nodes in the NodePool. Must be \u003e= min_node_count. There has to enough quota to scale up the cluster.",
+     "format": "int32"
+    }
+   }
+  },
+  "NodeManagement": {
+   "id": "NodeManagement",
+   "type": "object",
+   "description": "NodeManagement defines the set of node management services turned on for the node pool.",
+   "properties": {
+    "autoUpgrade": {
+     "type": "boolean",
+     "description": "Whether the nodes will be automatically upgraded."
+    },
+    "upgradeOptions": {
+     "$ref": "AutoUpgradeOptions",
+     "description": "Specifies the Auto Upgrade knobs for the node pool."
+    }
+   }
+  },
+  "AutoUpgradeOptions": {
+   "id": "AutoUpgradeOptions",
+   "type": "object",
+   "description": "AutoUpgradeOptions defines the set of options for the user to control how the Auto Upgrades will proceed.",
+   "properties": {
+    "autoUpgradeStartTime": {
+     "type": "string",
+     "description": "[Output only] This field is set when upgrades are about to commence with the approximate start time for the upgrades, in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text format."
+    },
+    "description": {
+     "type": "string",
+     "description": "[Output only] This field is set when upgrades are about to commence with the description of the upgrade."
     }
    }
   },
@@ -444,7 +542,8 @@
       "REPAIR_CLUSTER",
       "UPDATE_CLUSTER",
       "CREATE_NODE_POOL",
-      "DELETE_NODE_POOL"
+      "DELETE_NODE_POOL",
+      "SET_NODE_POOL_MANAGEMENT"
      ]
     },
     "status": {
@@ -454,7 +553,8 @@
       "STATUS_UNSPECIFIED",
       "PENDING",
       "RUNNING",
-      "DONE"
+      "DONE",
+      "ABORTING"
      ]
     },
     "detail": {
@@ -505,7 +605,22 @@
     },
     "desiredNodePoolId": {
      "type": "string",
-     "description": "The node pool to be upgraded. This field is mandatory if the \"desired_node_version\" or \"desired_image_family\" is specified and there is more than one node pool on the cluster."
+     "description": "The node pool to be upgraded. This field is mandatory if \"desired_node_version\", \"desired_image_family\" or \"desired_node_pool_autoscaling\" is specified and there is more than one node pool on the cluster."
+    },
+    "desiredImageType": {
+     "type": "string",
+     "description": "The desired image type for the node pool. NOTE: Set the \"desired_node_pool\" field as well."
+    },
+    "desiredNodePoolAutoscaling": {
+     "$ref": "NodePoolAutoscaling",
+     "description": "Autoscaler configuration for the node pool specified in desired_node_pool_id. If there is only one pool in the cluster and desired_node_pool_id is not provided then the change applies to that single node pool."
+    },
+    "desiredLocations": {
+     "type": "array",
+     "description": "The desired list of Google Compute Engine [locations](/compute/docs/zones#available) in which the cluster's nodes should be located. Changing the locations a cluster is in will result in nodes being either created or removed from the cluster, depending on whether locations are being added or removed. This list must always include the cluster's primary zone.",
+     "items": {
+      "type": "string"
+     }
     },
     "desiredMasterVersion": {
      "type": "string",
@@ -534,6 +649,16 @@
     }
    }
   },
+  "CancelOperationRequest": {
+   "id": "CancelOperationRequest",
+   "type": "object",
+   "description": "CancelOperationRequest cancels a single operation."
+  },
+  "Empty": {
+   "id": "Empty",
+   "type": "object",
+   "description": "A generic empty message that you can re-use to avoid defining duplicated empty messages in your APIs. A typical example is to use it as the request or the response type of an API method. For instance: service Foo { rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty); } The JSON representation for `Empty` is empty JSON object `{}`."
+  },
   "ServerConfig": {
    "id": "ServerConfig",
    "type": "object",
@@ -550,13 +675,20 @@
       "type": "string"
      }
     },
-    "defaultImageFamily": {
+    "defaultImageType": {
      "type": "string",
-     "description": "Default image family."
+     "description": "Default image type."
     },
-    "validImageFamilies": {
+    "validImageTypes": {
      "type": "array",
-     "description": "List of valid image families.",
+     "description": "List of valid image types.",
+     "items": {
+      "type": "string"
+     }
+    },
+    "validMasterVersions": {
+     "type": "array",
+     "description": "List of valid master versions.",
      "items": {
       "type": "string"
      }
@@ -585,6 +717,22 @@
     "nodePool": {
      "$ref": "NodePool",
      "description": "The node pool to create."
+    }
+   }
+  },
+  "RollbackNodePoolUpgradeRequest": {
+   "id": "RollbackNodePoolUpgradeRequest",
+   "type": "object",
+   "description": "RollbackNodePoolUpgradeRequest rollbacks the previously Aborted or Failed NodePool upgrade. This will be an no-op if the last upgrade successfully completed."
+  },
+  "SetNodePoolManagementRequest": {
+   "id": "SetNodePoolManagementRequest",
+   "type": "object",
+   "description": "SetNodePoolManagementRequest sets the node management properties of a node pool.",
+   "properties": {
+    "management": {
+     "$ref": "NodeManagement",
+     "description": "NodeManagement configuration for the node pool."
     }
    }
   }
@@ -973,6 +1121,100 @@
            "scopes": [
             "https://www.googleapis.com/auth/cloud-platform"
            ]
+          },
+          "rollback": {
+           "id": "container.projects.zones.clusters.nodePools.rollback",
+           "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}:rollback",
+           "httpMethod": "POST",
+           "description": "Roll back the previously Aborted or Failed NodePool upgrade. This will be an no-op if the last upgrade successfully completed.",
+           "parameters": {
+            "projectId": {
+             "type": "string",
+             "description": "The Google Developers Console [project ID or project number](https://support.google.com/cloud/answer/6158840).",
+             "required": true,
+             "location": "path"
+            },
+            "zone": {
+             "type": "string",
+             "description": "The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster resides.",
+             "required": true,
+             "location": "path"
+            },
+            "clusterId": {
+             "type": "string",
+             "description": "The name of the cluster to rollback.",
+             "required": true,
+             "location": "path"
+            },
+            "nodePoolId": {
+             "type": "string",
+             "description": "The name of the node pool to rollback.",
+             "required": true,
+             "location": "path"
+            }
+           },
+           "parameterOrder": [
+            "projectId",
+            "zone",
+            "clusterId",
+            "nodePoolId"
+           ],
+           "request": {
+            "$ref": "RollbackNodePoolUpgradeRequest"
+           },
+           "response": {
+            "$ref": "Operation"
+           },
+           "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+           ]
+          },
+          "setManagement": {
+           "id": "container.projects.zones.clusters.nodePools.setManagement",
+           "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setManagement",
+           "httpMethod": "POST",
+           "description": "Sets the NodeManagement options for a node pool.",
+           "parameters": {
+            "projectId": {
+             "type": "string",
+             "description": "The Google Developers Console [project ID or project number](https://support.google.com/cloud/answer/6158840).",
+             "required": true,
+             "location": "path"
+            },
+            "zone": {
+             "type": "string",
+             "description": "The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster resides.",
+             "required": true,
+             "location": "path"
+            },
+            "clusterId": {
+             "type": "string",
+             "description": "The name of the cluster to update.",
+             "required": true,
+             "location": "path"
+            },
+            "nodePoolId": {
+             "type": "string",
+             "description": "The name of the node pool to update.",
+             "required": true,
+             "location": "path"
+            }
+           },
+           "parameterOrder": [
+            "projectId",
+            "zone",
+            "clusterId",
+            "nodePoolId"
+           ],
+           "request": {
+            "$ref": "SetNodePoolManagementRequest"
+           },
+           "response": {
+            "$ref": "Operation"
+           },
+           "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform"
+           ]
           }
          }
         }
@@ -1042,6 +1284,46 @@
          ],
          "response": {
           "$ref": "Operation"
+         },
+         "scopes": [
+          "https://www.googleapis.com/auth/cloud-platform"
+         ]
+        },
+        "cancel": {
+         "id": "container.projects.zones.operations.cancel",
+         "path": "v1/projects/{projectId}/zones/{zone}/operations/{operationId}:cancel",
+         "httpMethod": "POST",
+         "description": "Cancels the specified operation.",
+         "parameters": {
+          "projectId": {
+           "type": "string",
+           "description": "The Google Developers Console [project ID or project number](https://support.google.com/cloud/answer/6158840).",
+           "required": true,
+           "location": "path"
+          },
+          "zone": {
+           "type": "string",
+           "description": "The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the operation resides.",
+           "required": true,
+           "location": "path"
+          },
+          "operationId": {
+           "type": "string",
+           "description": "The server-assigned `name` of the operation.",
+           "required": true,
+           "location": "path"
+          }
+         },
+         "parameterOrder": [
+          "projectId",
+          "zone",
+          "operationId"
+         ],
+         "request": {
+          "$ref": "CancelOperationRequest"
+         },
+         "response": {
+          "$ref": "Empty"
          },
          "scopes": [
           "https://www.googleapis.com/auth/cloud-platform"

--- a/vendor/google.golang.org/api/container/v1/container-gen.go
+++ b/vendor/google.golang.org/api/container/v1/container-gen.go
@@ -61,9 +61,10 @@ func New(client *http.Client) (*Service, error) {
 }
 
 type Service struct {
-	client    *http.Client
-	BasePath  string // API endpoint base URL
-	UserAgent string // optional additional User-Agent fragment
+	client                    *http.Client
+	BasePath                  string // API endpoint base URL
+	UserAgent                 string // optional additional User-Agent fragment
+	GoogleClientHeaderElement string // client header fragment, for Google use only
 
 	Projects *ProjectsService
 }
@@ -73,6 +74,10 @@ func (s *Service) userAgent() string {
 		return googleapi.UserAgent
 	}
 	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func (s *Service) clientHeader() string {
+	return gensupport.GoogleClientHeader("20170210", s.GoogleClientHeaderElement)
 }
 
 func NewProjectsService(s *Service) *ProjectsService {
@@ -171,6 +176,49 @@ func (s *AddonsConfig) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// AutoUpgradeOptions: AutoUpgradeOptions defines the set of options for
+// the user to control how the Auto Upgrades will proceed.
+type AutoUpgradeOptions struct {
+	// AutoUpgradeStartTime: [Output only] This field is set when upgrades
+	// are about to commence with the approximate start time for the
+	// upgrades, in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text
+	// format.
+	AutoUpgradeStartTime string `json:"autoUpgradeStartTime,omitempty"`
+
+	// Description: [Output only] This field is set when upgrades are about
+	// to commence with the description of the upgrade.
+	Description string `json:"description,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "AutoUpgradeStartTime") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AutoUpgradeStartTime") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AutoUpgradeOptions) MarshalJSON() ([]byte, error) {
+	type noMethod AutoUpgradeOptions
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CancelOperationRequest: CancelOperationRequest cancels a single
+// operation.
+type CancelOperationRequest struct {
+}
+
 // Cluster: A Google Container Engine cluster.
 type Cluster struct {
 	// AddonsConfig: Configurations for the various addons available to run
@@ -205,11 +253,24 @@ type Cluster struct {
 	// Description: An optional description of this cluster.
 	Description string `json:"description,omitempty"`
 
+	// EnableKubernetesAlpha: Kubernetes alpha features are enabled on this
+	// cluster. This includes alpha API groups (e.g. v1alpha1) and features
+	// that may not be production ready in the kubernetes version of the
+	// master and nodes. The cluster has no SLA for uptime and master/node
+	// upgrades are disabled. Alpha enabled clusters are automatically
+	// deleted thirty days after creation.
+	EnableKubernetesAlpha bool `json:"enableKubernetesAlpha,omitempty"`
+
 	// Endpoint: [Output only] The IP address of this cluster's master
 	// endpoint. The endpoint can be accessed from the internet at
 	// `https://username:password@endpoint/`. See the `masterAuth` property
 	// of this resource for username and password information.
 	Endpoint string `json:"endpoint,omitempty"`
+
+	// ExpireTime: [Output only] The time the cluster will be automatically
+	// deleted in [RFC3339](https://www.ietf.org/rfc/rfc3339.txt) text
+	// format.
+	ExpireTime string `json:"expireTime,omitempty"`
 
 	// InitialClusterVersion: [Output only] The software version of the
 	// master endpoint and kubelets used in the cluster when it was first
@@ -280,9 +341,8 @@ type Cluster struct {
 	// `container_ipv4_cidr` range.
 	NodeIpv4CidrSize int64 `json:"nodeIpv4CidrSize,omitempty"`
 
-	// NodePools: The node pools associated with this cluster. When creating
-	// a new cluster, only a single node pool should be specified. This
-	// field should not be set if "node_config" or "initial_node_count" are
+	// NodePools: The node pools associated with this cluster. This field
+	// should not be set if "node_config" or "initial_node_count" are
 	// specified.
 	NodePools []*NodePool `json:"nodePools,omitempty"`
 
@@ -355,6 +415,18 @@ type ClusterUpdate struct {
 	// to run in the cluster.
 	DesiredAddonsConfig *AddonsConfig `json:"desiredAddonsConfig,omitempty"`
 
+	// DesiredImageType: The desired image type for the node pool. NOTE: Set
+	// the "desired_node_pool" field as well.
+	DesiredImageType string `json:"desiredImageType,omitempty"`
+
+	// DesiredLocations: The desired list of Google Compute Engine
+	// [locations](/compute/docs/zones#available) in which the cluster's
+	// nodes should be located. Changing the locations a cluster is in will
+	// result in nodes being either created or removed from the cluster,
+	// depending on whether locations are being added or removed. This list
+	// must always include the cluster's primary zone.
+	DesiredLocations []string `json:"desiredLocations,omitempty"`
+
 	// DesiredMasterVersion: The Kubernetes version to change the master to.
 	// The only valid value is the latest supported version. Use "-" to have
 	// the server automatically select the latest version.
@@ -366,9 +438,16 @@ type ClusterUpdate struct {
 	// "none" - no metrics will be exported from the cluster
 	DesiredMonitoringService string `json:"desiredMonitoringService,omitempty"`
 
+	// DesiredNodePoolAutoscaling: Autoscaler configuration for the node
+	// pool specified in desired_node_pool_id. If there is only one pool in
+	// the cluster and desired_node_pool_id is not provided then the change
+	// applies to that single node pool.
+	DesiredNodePoolAutoscaling *NodePoolAutoscaling `json:"desiredNodePoolAutoscaling,omitempty"`
+
 	// DesiredNodePoolId: The node pool to be upgraded. This field is
-	// mandatory if the "desired_node_version" or "desired_image_family" is
-	// specified and there is more than one node pool on the cluster.
+	// mandatory if "desired_node_version", "desired_image_family" or
+	// "desired_node_pool_autoscaling" is specified and there is more than
+	// one node pool on the cluster.
 	DesiredNodePoolId string `json:"desiredNodePoolId,omitempty"`
 
 	// DesiredNodeVersion: The Kubernetes version to change the nodes to
@@ -456,6 +535,18 @@ func (s *CreateNodePoolRequest) MarshalJSON() ([]byte, error) {
 	type noMethod CreateNodePoolRequest
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Empty: A generic empty message that you can re-use to avoid defining
+// duplicated empty messages in your APIs. A typical example is to use
+// it as the request or the response type of an API method. For
+// instance: service Foo { rpc Bar(google.protobuf.Empty) returns
+// (google.protobuf.Empty); } The JSON representation for `Empty` is
+// empty JSON object `{}`.
+type Empty struct {
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
 }
 
 // HorizontalPodAutoscaling: Configuration options for the horizontal
@@ -689,6 +780,26 @@ type NodeConfig struct {
 	// disk size is 100GB.
 	DiskSizeGb int64 `json:"diskSizeGb,omitempty"`
 
+	// ImageType: The image type to use for this node. Note that for a given
+	// image type, the latest version of it will be used.
+	ImageType string `json:"imageType,omitempty"`
+
+	// Labels: The map of Kubernetes labels (key/value pairs) to be applied
+	// to each node. These will added in addition to any default label(s)
+	// that Kubernetes may apply to the node. In case of conflict in label
+	// keys, the applied set may differ depending on the Kubernetes version
+	// -- it's best to assume the behavior is undefined and conflicts should
+	// be avoided. For more information, including usage and the valid
+	// values, see: http://kubernetes.io/v1.1/docs/user-guide/labels.html
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// LocalSsdCount: The number of local SSD disks to be attached to the
+	// node. The limit for this value is dependant upon the maximum number
+	// of disks available on a machine per zone. See:
+	// https://cloud.google.com/compute/docs/disks/local-ssd#local_ssd_limits for more
+	// information.
+	LocalSsdCount int64 `json:"localSsdCount,omitempty"`
+
 	// MachineType: The name of a Google Compute Engine [machine
 	// type](/compute/docs/machine-types) (e.g. `n1-standard-1`). If
 	// unspecified, the default machine type is `n1-standard-1`.
@@ -719,6 +830,23 @@ type NodeConfig struct {
 	// case their required scopes will be added.
 	OauthScopes []string `json:"oauthScopes,omitempty"`
 
+	// Preemptible: Whether the nodes are created as preemptible VM
+	// instances. See:
+	// https://cloud.google.com/compute/docs/instances/preemptible for more
+	// inforamtion about preemptible VM instances.
+	Preemptible bool `json:"preemptible,omitempty"`
+
+	// ServiceAccount: The Google Cloud Platform Service Account to be used
+	// by the node VMs. If no Service Account is specified, the "default"
+	// service account is used.
+	ServiceAccount string `json:"serviceAccount,omitempty"`
+
+	// Tags: The list of instance tags applied to all nodes. Tags are used
+	// to identify valid sources or targets for network firewalls and are
+	// specified by the client during cluster or node pool creation. Each
+	// tag within the list must comply with RFC1035.
+	Tags []string `json:"tags,omitempty"`
+
 	// ForceSendFields is a list of field names (e.g. "DiskSizeGb") to
 	// unconditionally include in API requests. By default, fields with
 	// empty values are omitted from API requests. However, any non-pointer,
@@ -742,6 +870,38 @@ func (s *NodeConfig) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// NodeManagement: NodeManagement defines the set of node management
+// services turned on for the node pool.
+type NodeManagement struct {
+	// AutoUpgrade: Whether the nodes will be automatically upgraded.
+	AutoUpgrade bool `json:"autoUpgrade,omitempty"`
+
+	// UpgradeOptions: Specifies the Auto Upgrade knobs for the node pool.
+	UpgradeOptions *AutoUpgradeOptions `json:"upgradeOptions,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "AutoUpgrade") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AutoUpgrade") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *NodeManagement) MarshalJSON() ([]byte, error) {
+	type noMethod NodeManagement
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
 // NodePool: NodePool contains the name and configuration for a
 // cluster's node pool. Node pools are a set of nodes (i.e. VM's), with
 // a common configuration and specification, under the control of the
@@ -749,6 +909,10 @@ func (s *NodeConfig) MarshalJSON() ([]byte, error) {
 // them, which may be used to reference them during pod scheduling. They
 // may also be resized up or down, to accommodate the workload.
 type NodePool struct {
+	// Autoscaling: Autoscaler configuration for this NodePool. Autoscaler
+	// is enabled only if a valid configuration is present.
+	Autoscaling *NodePoolAutoscaling `json:"autoscaling,omitempty"`
+
 	// Config: The node configuration of the pool.
 	Config *NodeConfig `json:"config,omitempty"`
 
@@ -763,13 +927,16 @@ type NodePool struct {
 	// pool.
 	InstanceGroupUrls []string `json:"instanceGroupUrls,omitempty"`
 
+	// Management: NodeManagement configuration for this NodePool.
+	Management *NodeManagement `json:"management,omitempty"`
+
 	// Name: The name of the node pool.
 	Name string `json:"name,omitempty"`
 
-	// SelfLink: Server-defined URL for the resource.
+	// SelfLink: [Output only] Server-defined URL for the resource.
 	SelfLink string `json:"selfLink,omitempty"`
 
-	// Status: The status of the nodes in this pool instance.
+	// Status: [Output only] The status of the nodes in this pool instance.
 	//
 	// Possible values:
 	//   "STATUS_UNSPECIFIED"
@@ -785,14 +952,14 @@ type NodePool struct {
 	// status of this node pool instance, if available.
 	StatusMessage string `json:"statusMessage,omitempty"`
 
-	// Version: The version of the Kubernetes of this node.
+	// Version: [Output only] The version of the Kubernetes of this node.
 	Version string `json:"version,omitempty"`
 
 	// ServerResponse contains the HTTP response code and headers from the
 	// server.
 	googleapi.ServerResponse `json:"-"`
 
-	// ForceSendFields is a list of field names (e.g. "Config") to
+	// ForceSendFields is a list of field names (e.g. "Autoscaling") to
 	// unconditionally include in API requests. By default, fields with
 	// empty values are omitted from API requests. However, any non-pointer,
 	// non-interface field appearing in ForceSendFields will be sent to the
@@ -800,10 +967,10 @@ type NodePool struct {
 	// used to include empty fields in Patch requests.
 	ForceSendFields []string `json:"-"`
 
-	// NullFields is a list of field names (e.g. "Config") to include in API
-	// requests with the JSON null value. By default, fields with empty
-	// values are omitted from API requests. However, any field with an
-	// empty value appearing in NullFields will be sent to the server as
+	// NullFields is a list of field names (e.g. "Autoscaling") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
 	// null. It is an error if a field in this list has a non-empty value.
 	// This may be used to include null fields in Patch requests.
 	NullFields []string `json:"-"`
@@ -811,6 +978,44 @@ type NodePool struct {
 
 func (s *NodePool) MarshalJSON() ([]byte, error) {
 	type noMethod NodePool
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// NodePoolAutoscaling: NodePoolAutoscaling contains information
+// required by cluster autoscaler to adjust the size of the node pool to
+// the current cluster usage.
+type NodePoolAutoscaling struct {
+	// Enabled: Is autoscaling enabled for this node pool.
+	Enabled bool `json:"enabled,omitempty"`
+
+	// MaxNodeCount: Maximum number of nodes in the NodePool. Must be >=
+	// min_node_count. There has to enough quota to scale up the cluster.
+	MaxNodeCount int64 `json:"maxNodeCount,omitempty"`
+
+	// MinNodeCount: Minimum number of nodes in the NodePool. Must be >= 1
+	// and <= max_node_count.
+	MinNodeCount int64 `json:"minNodeCount,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Enabled") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Enabled") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *NodePoolAutoscaling) MarshalJSON() ([]byte, error) {
+	type noMethod NodePoolAutoscaling
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
@@ -837,6 +1042,7 @@ type Operation struct {
 	//   "UPDATE_CLUSTER"
 	//   "CREATE_NODE_POOL"
 	//   "DELETE_NODE_POOL"
+	//   "SET_NODE_POOL_MANAGEMENT"
 	OperationType string `json:"operationType,omitempty"`
 
 	// SelfLink: Server-defined URL for the resource.
@@ -849,6 +1055,7 @@ type Operation struct {
 	//   "PENDING"
 	//   "RUNNING"
 	//   "DONE"
+	//   "ABORTING"
 	Status string `json:"status,omitempty"`
 
 	// StatusMessage: If an error has occurred, a textual description of the
@@ -890,17 +1097,26 @@ func (s *Operation) MarshalJSON() ([]byte, error) {
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
 
+// RollbackNodePoolUpgradeRequest: RollbackNodePoolUpgradeRequest
+// rollbacks the previously Aborted or Failed NodePool upgrade. This
+// will be an no-op if the last upgrade successfully completed.
+type RollbackNodePoolUpgradeRequest struct {
+}
+
 // ServerConfig: Container Engine service configuration.
 type ServerConfig struct {
 	// DefaultClusterVersion: Version of Kubernetes the service deploys by
 	// default.
 	DefaultClusterVersion string `json:"defaultClusterVersion,omitempty"`
 
-	// DefaultImageFamily: Default image family.
-	DefaultImageFamily string `json:"defaultImageFamily,omitempty"`
+	// DefaultImageType: Default image type.
+	DefaultImageType string `json:"defaultImageType,omitempty"`
 
-	// ValidImageFamilies: List of valid image families.
-	ValidImageFamilies []string `json:"validImageFamilies,omitempty"`
+	// ValidImageTypes: List of valid image types.
+	ValidImageTypes []string `json:"validImageTypes,omitempty"`
+
+	// ValidMasterVersions: List of valid master versions.
+	ValidMasterVersions []string `json:"validMasterVersions,omitempty"`
 
 	// ValidNodeVersions: List of valid node upgrade target versions.
 	ValidNodeVersions []string `json:"validNodeVersions,omitempty"`
@@ -930,6 +1146,35 @@ type ServerConfig struct {
 
 func (s *ServerConfig) MarshalJSON() ([]byte, error) {
 	type noMethod ServerConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SetNodePoolManagementRequest: SetNodePoolManagementRequest sets the
+// node management properties of a node pool.
+type SetNodePoolManagementRequest struct {
+	// Management: NodeManagement configuration for the node pool.
+	Management *NodeManagement `json:"management,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Management") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Management") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SetNodePoolManagementRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SetNodePoolManagementRequest
 	raw := noMethod(*s)
 	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
 }
@@ -1025,6 +1270,7 @@ func (c *ProjectsZonesGetServerconfigCall) doRequest(alt string) (*http.Response
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	if c.ifNoneMatch_ != "" {
 		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
 	}
@@ -1171,6 +1417,7 @@ func (c *ProjectsZonesClustersCreateCall) doRequest(alt string) (*http.Response,
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	var body io.Reader = nil
 	body, err := googleapi.WithoutDataWrapper.JSONReader(c.createclusterrequest)
 	if err != nil {
@@ -1319,6 +1566,7 @@ func (c *ProjectsZonesClustersDeleteCall) doRequest(alt string) (*http.Response,
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	var body io.Reader = nil
 	c.urlParams_.Set("alt", alt)
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}")
@@ -1473,6 +1721,7 @@ func (c *ProjectsZonesClustersGetCall) doRequest(alt string) (*http.Response, er
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	if c.ifNoneMatch_ != "" {
 		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
 	}
@@ -1629,6 +1878,7 @@ func (c *ProjectsZonesClustersListCall) doRequest(alt string) (*http.Response, e
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	if c.ifNoneMatch_ != "" {
 		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
 	}
@@ -1769,6 +2019,7 @@ func (c *ProjectsZonesClustersUpdateCall) doRequest(alt string) (*http.Response,
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	var body io.Reader = nil
 	body, err := googleapi.WithoutDataWrapper.JSONReader(c.updateclusterrequest)
 	if err != nil {
@@ -1922,6 +2173,7 @@ func (c *ProjectsZonesClustersNodePoolsCreateCall) doRequest(alt string) (*http.
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	var body io.Reader = nil
 	body, err := googleapi.WithoutDataWrapper.JSONReader(c.createnodepoolrequest)
 	if err != nil {
@@ -2075,6 +2327,7 @@ func (c *ProjectsZonesClustersNodePoolsDeleteCall) doRequest(alt string) (*http.
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	var body io.Reader = nil
 	c.urlParams_.Set("alt", alt)
 	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}")
@@ -2239,6 +2492,7 @@ func (c *ProjectsZonesClustersNodePoolsGetCall) doRequest(alt string) (*http.Res
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	if c.ifNoneMatch_ != "" {
 		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
 	}
@@ -2404,6 +2658,7 @@ func (c *ProjectsZonesClustersNodePoolsListCall) doRequest(alt string) (*http.Re
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	if c.ifNoneMatch_ != "" {
 		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
 	}
@@ -2498,6 +2753,490 @@ func (c *ProjectsZonesClustersNodePoolsListCall) Do(opts ...googleapi.CallOption
 
 }
 
+// method id "container.projects.zones.clusters.nodePools.rollback":
+
+type ProjectsZonesClustersNodePoolsRollbackCall struct {
+	s                              *Service
+	projectId                      string
+	zone                           string
+	clusterId                      string
+	nodePoolId                     string
+	rollbacknodepoolupgraderequest *RollbackNodePoolUpgradeRequest
+	urlParams_                     gensupport.URLParams
+	ctx_                           context.Context
+	header_                        http.Header
+}
+
+// Rollback: Roll back the previously Aborted or Failed NodePool
+// upgrade. This will be an no-op if the last upgrade successfully
+// completed.
+func (r *ProjectsZonesClustersNodePoolsService) Rollback(projectId string, zone string, clusterId string, nodePoolId string, rollbacknodepoolupgraderequest *RollbackNodePoolUpgradeRequest) *ProjectsZonesClustersNodePoolsRollbackCall {
+	c := &ProjectsZonesClustersNodePoolsRollbackCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.zone = zone
+	c.clusterId = clusterId
+	c.nodePoolId = nodePoolId
+	c.rollbacknodepoolupgraderequest = rollbacknodepoolupgraderequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsZonesClustersNodePoolsRollbackCall) Fields(s ...googleapi.Field) *ProjectsZonesClustersNodePoolsRollbackCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsZonesClustersNodePoolsRollbackCall) Context(ctx context.Context) *ProjectsZonesClustersNodePoolsRollbackCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsZonesClustersNodePoolsRollbackCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsZonesClustersNodePoolsRollbackCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.rollbacknodepoolupgraderequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}:rollback")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId":  c.projectId,
+		"zone":       c.zone,
+		"clusterId":  c.clusterId,
+		"nodePoolId": c.nodePoolId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "container.projects.zones.clusters.nodePools.rollback" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ProjectsZonesClustersNodePoolsRollbackCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Roll back the previously Aborted or Failed NodePool upgrade. This will be an no-op if the last upgrade successfully completed.",
+	//   "httpMethod": "POST",
+	//   "id": "container.projects.zones.clusters.nodePools.rollback",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "zone",
+	//     "clusterId",
+	//     "nodePoolId"
+	//   ],
+	//   "parameters": {
+	//     "clusterId": {
+	//       "description": "The name of the cluster to rollback.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "nodePoolId": {
+	//       "description": "The name of the node pool to rollback.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The Google Developers Console [project ID or project number](https://support.google.com/cloud/answer/6158840).",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "zone": {
+	//       "description": "The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster resides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}:rollback",
+	//   "request": {
+	//     "$ref": "RollbackNodePoolUpgradeRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "container.projects.zones.clusters.nodePools.setManagement":
+
+type ProjectsZonesClustersNodePoolsSetManagementCall struct {
+	s                            *Service
+	projectId                    string
+	zone                         string
+	clusterId                    string
+	nodePoolId                   string
+	setnodepoolmanagementrequest *SetNodePoolManagementRequest
+	urlParams_                   gensupport.URLParams
+	ctx_                         context.Context
+	header_                      http.Header
+}
+
+// SetManagement: Sets the NodeManagement options for a node pool.
+func (r *ProjectsZonesClustersNodePoolsService) SetManagement(projectId string, zone string, clusterId string, nodePoolId string, setnodepoolmanagementrequest *SetNodePoolManagementRequest) *ProjectsZonesClustersNodePoolsSetManagementCall {
+	c := &ProjectsZonesClustersNodePoolsSetManagementCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.zone = zone
+	c.clusterId = clusterId
+	c.nodePoolId = nodePoolId
+	c.setnodepoolmanagementrequest = setnodepoolmanagementrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsZonesClustersNodePoolsSetManagementCall) Fields(s ...googleapi.Field) *ProjectsZonesClustersNodePoolsSetManagementCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsZonesClustersNodePoolsSetManagementCall) Context(ctx context.Context) *ProjectsZonesClustersNodePoolsSetManagementCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsZonesClustersNodePoolsSetManagementCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsZonesClustersNodePoolsSetManagementCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.setnodepoolmanagementrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setManagement")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId":  c.projectId,
+		"zone":       c.zone,
+		"clusterId":  c.clusterId,
+		"nodePoolId": c.nodePoolId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "container.projects.zones.clusters.nodePools.setManagement" call.
+// Exactly one of *Operation or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *Operation.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ProjectsZonesClustersNodePoolsSetManagementCall) Do(opts ...googleapi.CallOption) (*Operation, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Operation{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Sets the NodeManagement options for a node pool.",
+	//   "httpMethod": "POST",
+	//   "id": "container.projects.zones.clusters.nodePools.setManagement",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "zone",
+	//     "clusterId",
+	//     "nodePoolId"
+	//   ],
+	//   "parameters": {
+	//     "clusterId": {
+	//       "description": "The name of the cluster to update.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "nodePoolId": {
+	//       "description": "The name of the node pool to update.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The Google Developers Console [project ID or project number](https://support.google.com/cloud/answer/6158840).",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "zone": {
+	//       "description": "The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the cluster resides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}/zones/{zone}/clusters/{clusterId}/nodePools/{nodePoolId}/setManagement",
+	//   "request": {
+	//     "$ref": "SetNodePoolManagementRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Operation"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
+// method id "container.projects.zones.operations.cancel":
+
+type ProjectsZonesOperationsCancelCall struct {
+	s                      *Service
+	projectId              string
+	zone                   string
+	operationId            string
+	canceloperationrequest *CancelOperationRequest
+	urlParams_             gensupport.URLParams
+	ctx_                   context.Context
+	header_                http.Header
+}
+
+// Cancel: Cancels the specified operation.
+func (r *ProjectsZonesOperationsService) Cancel(projectId string, zone string, operationId string, canceloperationrequest *CancelOperationRequest) *ProjectsZonesOperationsCancelCall {
+	c := &ProjectsZonesOperationsCancelCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.zone = zone
+	c.operationId = operationId
+	c.canceloperationrequest = canceloperationrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsZonesOperationsCancelCall) Fields(s ...googleapi.Field) *ProjectsZonesOperationsCancelCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsZonesOperationsCancelCall) Context(ctx context.Context) *ProjectsZonesOperationsCancelCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsZonesOperationsCancelCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsZonesOperationsCancelCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.canceloperationrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1/projects/{projectId}/zones/{zone}/operations/{operationId}:cancel")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId":   c.projectId,
+		"zone":        c.zone,
+		"operationId": c.operationId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "container.projects.zones.operations.cancel" call.
+// Exactly one of *Empty or error will be non-nil. Any non-2xx status
+// code is an error. Response headers are in either
+// *Empty.ServerResponse.Header or (if a response was returned at all)
+// in error.(*googleapi.Error).Header. Use googleapi.IsNotModified to
+// check whether the returned error was because http.StatusNotModified
+// was returned.
+func (c *ProjectsZonesOperationsCancelCall) Do(opts ...googleapi.CallOption) (*Empty, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Empty{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Cancels the specified operation.",
+	//   "httpMethod": "POST",
+	//   "id": "container.projects.zones.operations.cancel",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "zone",
+	//     "operationId"
+	//   ],
+	//   "parameters": {
+	//     "operationId": {
+	//       "description": "The server-assigned `name` of the operation.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The Google Developers Console [project ID or project number](https://support.google.com/cloud/answer/6158840).",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "zone": {
+	//       "description": "The name of the Google Compute Engine [zone](/compute/docs/zones#available) in which the operation resides.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1/projects/{projectId}/zones/{zone}/operations/{operationId}:cancel",
+	//   "request": {
+	//     "$ref": "CancelOperationRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Empty"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform"
+	//   ]
+	// }
+
+}
+
 // method id "container.projects.zones.operations.get":
 
 type ProjectsZonesOperationsGetCall struct {
@@ -2561,6 +3300,7 @@ func (c *ProjectsZonesOperationsGetCall) doRequest(alt string) (*http.Response, 
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	if c.ifNoneMatch_ != "" {
 		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
 	}
@@ -2717,6 +3457,7 @@ func (c *ProjectsZonesOperationsListCall) doRequest(alt string) (*http.Response,
 		reqHeaders[k] = v
 	}
 	reqHeaders.Set("User-Agent", c.s.userAgent())
+	reqHeaders.Set("x-goog-api-client", c.s.clientHeader())
 	if c.ifNoneMatch_ != "" {
 		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
 	}

--- a/vendor/google.golang.org/api/gensupport/header.go
+++ b/vendor/google.golang.org/api/gensupport/header.go
@@ -1,0 +1,22 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gensupport
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// GoogleClientHeader returns the value to use for the x-goog-api-client
+// header, which is used internally by Google.
+func GoogleClientHeader(generatorVersion, clientElement string) string {
+	elts := []string{"gl-go/" + strings.Replace(runtime.Version(), " ", "_", -1)}
+	if clientElement != "" {
+		elts = append(elts, clientElement)
+	}
+	elts = append(elts, fmt.Sprintf("gdcl/%s", generatorVersion))
+	return strings.Join(elts, " ")
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3111,10 +3111,10 @@
 			"revisionTime": "2017-01-13T00:03:17Z"
 		},
 		{
-			"checksumSHA1": "qt8Mg1hYm0ApdGODreQxBh30FDU=",
+			"checksumSHA1": "lAMqZyc46cU5WaRuw4mVHFXpvps=",
 			"path": "google.golang.org/api/container/v1",
-			"revision": "3cc2e591b550923a2c5f0ab5a803feda924d5823",
-			"revisionTime": "2016-11-27T23:54:21Z"
+			"revision": "1202890e803f07684581b575fda809bf335a533f",
+			"revisionTime": "2017-03-10T20:16:04Z"
 		},
 		{
 			"checksumSHA1": "JYl35km48fLrIx7YUtzcgd4J7Rk=",
@@ -3123,10 +3123,10 @@
 			"revisionTime": "2016-11-27T23:54:21Z"
 		},
 		{
-			"checksumSHA1": "a1NkriuA/uk+Wv6yCFzxz4LIaDg=",
+			"checksumSHA1": "C7k1pbU/WU4CBoBwA4EBUnV/iek=",
 			"path": "google.golang.org/api/gensupport",
-			"revision": "8840436417f044055c16fc7e4018f08484f52839",
-			"revisionTime": "2017-01-13T00:03:17Z"
+			"revision": "1202890e803f07684581b575fda809bf335a533f",
+			"revisionTime": "2017-03-10T20:16:04Z"
 		},
 		{
 			"checksumSHA1": "yQREK/OWrz9PLljbr127+xFk6J0=",

--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -109,6 +109,10 @@ which the cluster's instances are launched
 * `disk_size_gb` - (Optional) Size of the disk attached to each node, specified
     in GB. The smallest allowed disk size is 10GB. Defaults to 100GB.
 
+* `metadata` - (Optional) Metadata to be set on each cluster node.
+
+* `tags` - (Optional) Tags to be set on each cluster node.
+
 * `oauth_scopes` - (Optional) The set of Google API scopes to be made available
     on all of the node VMs under the "default" service account. These can be
     either FQDNs, or scope aliases. The following scopes are necessary to ensure


### PR DESCRIPTION
We implemented support for tagging and adding metadata to kubernetes cluster nodes in google container engine. Tested and docs included.