### PR TITLE
provider/scaleway: work around API concurrency issue

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_ip.go
+++ b/builtin/providers/scaleway/resource_scaleway_ip.go
@@ -2,6 +2,7 @@ package scaleway
 
 import (
 	"log"
+	"sync"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/scaleway/scaleway-cli/pkg/api"
@@ -30,8 +31,12 @@ func resourceScalewayIP() *schema.Resource {
 	}
 }
 
+var mu = sync.Mutex{}
+
 func resourceScalewayIPCreate(d *schema.ResourceData, m interface{}) error {
 	scaleway := m.(*Client).scaleway
+	mu.Lock()
+	defer mu.Unlock()
 	resp, err := scaleway.NewIP()
 	if err != nil {
 		return err

--- a/builtin/providers/scaleway/resource_scaleway_ip_test.go
+++ b/builtin/providers/scaleway/resource_scaleway_ip_test.go
@@ -8,6 +8,23 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestAccScalewayIP_Count(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScalewayIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckScalewayIPConfig_Count,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScalewayIPExists("scaleway_ip.base.0"),
+					testAccCheckScalewayIPExists("scaleway_ip.base.1"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccScalewayIP_Basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -126,6 +143,12 @@ func testAccCheckScalewayIPAttachment(n string, check func(string) bool, msg str
 
 var testAccCheckScalewayIPConfig = `
 resource "scaleway_ip" "base" {
+}
+`
+
+var testAccCheckScalewayIPConfig_Count = `
+resource "scaleway_ip" "base" {
+  count = 2
 }
 `
 


### PR DESCRIPTION
when creating IPs concurrently the Scaleway API starts to return 500 internal
server errors.

since the error goes away when limiting concurrent requests, as well as the fact that the golang net/http client is safe for concurrent use,
I'm assuming this is an API error on Scaleways side.

this CS introduces a workaround so terraform does not crash.
the work around needs to be removed once Scaleway fixes their API

I've added a test case which reproduces the error mentioned in #12608:

```
make testacc TEST=./builtin/providers/scaleway TESTARGS='-run=TestAccScalewayIP_Count'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 22:24:15 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScalewayIP_Count -timeout 120m
=== RUN   TestAccScalewayIP_Count
--- FAIL: TestAccScalewayIP_Count (2.73s)
    testing.go:268: Step 0 error: Error applying: 1 error(s) occurred:

        * scaleway_ip.base[1]: 1 error(s) occurred:

        * scaleway_ip.base.1: {"message": "Internal error", "type": "server_error"}
FAIL
exit status 1
FAIL    github.com/hashicorp/terraform/builtin/providers/scaleway    2.742s
```

and the mutex fixes this:

```
make testacc TEST=./builtin/providers/scaleway TESTARGS='-run=TestAccScalewayIP_Count'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/14 22:34:56 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/scaleway -v -run=TestAccScalewayIP_Count -timeout 120m
=== RUN   TestAccScalewayIP_Count
--- PASS: TestAccScalewayIP_Count (5.17s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/scaleway    5.182s
```