### PR TITLE
provider/aws: Add 'aws_network_acl' data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_network_acl.go
+++ b/builtin/providers/aws/data_source_aws_network_acl.go
@@ -1,0 +1,198 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsNetworkAcl() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsNetworkAclRead,
+
+		Schema: map[string]*schema.Schema{
+			"network_acl_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"vpc_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"subnet_ids": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"filter": ec2CustomFiltersSchema(),
+			"tags":   tagsSchemaComputed(),
+			"ingress": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"from_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"to_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"rule_no": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"cidr_block": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"icmp_type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"icmp_code": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+			"egress": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"from_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"to_port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"rule_no": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"action": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"protocol": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"cidr_block": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"ipv6_cidr_block": {
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"icmp_type": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+						"icmp_code": {
+							Type:     schema.TypeInt,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+
+	req := &ec2.DescribeNetworkAclsInput{}
+
+	if naclId, ok := d.GetOk("network_acl_id"); ok {
+		req.NetworkAclIds = aws.StringSlice([]string{naclId.(string)})
+	}
+
+	isDefaultStr := ""
+	if d.Get("default").(bool) {
+		isDefaultStr = "true"
+	}
+	req.Filters = buildEC2AttributeFilterList(
+		map[string]string{
+			"default": isDefaultStr,
+			"vpc-id":  d.Get("vpc_id").(string),
+		},
+	)
+	if v, ok := d.GetOk("subnet_ids"); ok {
+		var subnetIds []string
+		ids := v.(*schema.Set).List()
+		for _, id := range ids {
+			subnetIds = append(subnetIds, id.(string))
+		}
+
+		req.Filters = append(req.Filters, &ec2.Filter{
+			Name:   aws.String("association.subnet-id"),
+			Values: aws.StringSlice(subnetIds),
+		})
+	}
+	req.Filters = append(req.Filters, buildEC2TagFilterList(
+		tagsFromMap(d.Get("tags").(map[string]interface{})),
+	)...)
+	req.Filters = append(req.Filters, buildEC2CustomFilterList(
+		d.Get("filter").(*schema.Set),
+	)...)
+	if len(req.Filters) == 0 {
+		// Don't send an empty filters list; the EC2 API won't accept it.
+		req.Filters = nil
+	}
+
+	log.Printf("[DEBUG] Describe network ACLs %v\n", req)
+
+	resp, err := conn.DescribeNetworkAcls(req)
+	if err != nil {
+		return err
+	}
+	if resp == nil || len(resp.NetworkAcls) == 0 {
+		return fmt.Errorf("no matching network ACL found")
+	}
+	if len(resp.NetworkAcls) > 1 {
+		return fmt.Errorf("multiple network ACLs matched; use additional constraints to reduce matches to a single network ACL")
+	}
+
+	networkAcl := resp.NetworkAcls[0]
+	d.SetId(aws.StringValue(networkAcl.NetworkAclId))
+	if err := awsNetworkAclAttributes(d, networkAcl); err != nil {
+		return err
+	}
+
+	d.Set("network_acl_id", networkAcl.NetworkAclId)
+	d.Set("default", networkAcl.IsDefault)
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_network_acl_test.go
+++ b/builtin/providers/aws/data_source_aws_network_acl_test.go
@@ -1,0 +1,230 @@
+// make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccDataSourceAwsNetworkAcl_'
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataSourceAwsNetworkAcl_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsNetworkAclBasicConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.aws_network_acl.test_by_network_acl_id", "id",
+						"aws_network_acl.bar", "id"),
+					resource.TestCheckResourceAttrPair(
+						"data.aws_network_acl.test_by_network_acl_id", "vpc_id",
+						"aws_vpc.foo", "id"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "tags.%", "1"),
+					resource.TestCheckNoResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "subnet_ids"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "egress.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "egress.0.rule_no", "2"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "egress.0.cidr_block", "10.3.0.0/18"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "egress.0.ipv6_cidr_block", ""),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "ingress.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "ingress.0.protocol", "6"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "ingress.0.from_port", "80"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_network_acl_id", "ingress.0.to_port", "81"),
+					resource.TestCheckResourceAttrPair(
+						"data.aws_network_acl.test_by_name_tag", "network_acl_id",
+						"aws_network_acl.bar", "id"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_by_name_tag", "default", "false"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsNetworkAcl_default(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsNetworkAclDefaultConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.aws_network_acl.test_default", "id",
+						"aws_vpc.foo", "default_network_acl_id"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_default", "default", "true"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsNetworkAcl_subnets(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsNetworkAclSubnetsConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(
+						"data.aws_network_acl.test_one_subnet", "id",
+						"aws_network_acl.bar", "id"),
+					resource.TestCheckNoResourceAttr(
+						"data.aws_network_acl.test_one_subnet", "ingress"),
+					resource.TestCheckResourceAttr(
+						"data.aws_network_acl.test_one_subnet", "subnet_ids.#", "2"),
+					resource.TestCheckResourceAttrPair(
+						"data.aws_network_acl.test_two_subnets", "network_acl_id",
+						"aws_network_acl.bar", "id"),
+					resource.TestCheckNoResourceAttr(
+						"data.aws_network_acl.test_two_subnets", "egress"),
+				),
+			},
+		},
+	})
+}
+
+const testAccDataSourceAwsNetworkAclBasicConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-nacl-data-source-foo"
+  }
+}
+
+resource "aws_network_acl" "bar" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+	egress {
+			protocol = "tcp"
+			rule_no = 2
+			action = "allow"
+			cidr_block =  "10.3.0.0/18"
+			from_port = 443
+			to_port = 443
+	}
+
+	ingress {
+			protocol = "tcp"
+			rule_no = 1
+			action = "allow"
+			cidr_block =  "10.3.0.0/18"
+			from_port = 80
+			to_port = 81
+	}
+
+	tags {
+			Name = "terraform-testacc-nacl-data-source-bar"
+	}
+}
+
+data "aws_network_acl" "test_by_network_acl_id" {
+	network_acl_id = "${aws_network_acl.bar.id}"
+}
+
+data "aws_network_acl" "test_by_name_tag" {
+	vpc_id = "${aws_network_acl.bar.vpc_id}"
+
+	tags {
+			Name = "terraform-testacc-nacl-data-source-bar"
+	}
+}
+`
+
+const testAccDataSourceAwsNetworkAclDefaultConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-nacl-data-source-foo"
+  }
+}
+
+data "aws_network_acl" "test_default" {
+	vpc_id  = "${aws_vpc.foo.id}"
+	default = true
+}
+`
+
+const testAccDataSourceAwsNetworkAclSubnetsConfig = `
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "foo" {
+	cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "terraform-testacc-nacl-data-source-foo"
+  }
+}
+
+resource "aws_subnet" "baz" {
+	cidr_block = "10.1.1.0/24"
+	vpc_id = "${aws_vpc.foo.id}"
+
+  tags {
+    Name = "terraform-testacc-nacl-data-source-baz"
+  }
+}
+
+resource "aws_subnet" "quux" {
+	cidr_block = "10.1.111.0/24"
+	vpc_id = "${aws_vpc.foo.id}"
+
+  tags {
+    Name = "terraform-testacc-nacl-data-source-quux"
+  }
+}
+
+resource "aws_network_acl" "bar" {
+	vpc_id = "${aws_vpc.foo.id}"
+	subnet_ids = [
+		"${aws_subnet.baz.id}",
+		"${aws_subnet.quux.id}",
+	]
+
+	tags {
+			Name = "terraform-testacc-nacl-data-source-bar"
+	}
+}
+
+data "aws_network_acl" "test_one_subnet" {
+	vpc_id = "${aws_network_acl.bar.vpc_id}"
+
+	subnet_ids = [
+		"${aws_subnet.baz.id}",
+	]
+}
+
+data "aws_network_acl" "test_two_subnets" {
+	vpc_id = "${aws_network_acl.bar.vpc_id}"
+
+	subnet_ids = [
+		"${aws_subnet.baz.id}",
+		"${aws_subnet.quux.id}",
+	]
+}
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -178,6 +178,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_instance":                 dataSourceAwsInstance(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
 			"aws_kms_secret":               dataSourceAwsKmsSecret(),
+			"aws_network_acl":              dataSourceAwsNetworkAcl(),
 			"aws_partition":                dataSourceAwsPartition(),
 			"aws_prefix_list":              dataSourceAwsPrefixList(),
 			"aws_redshift_service_account": dataSourceAwsRedshiftServiceAccount(),

--- a/builtin/providers/aws/resource_aws_default_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_default_network_acl_test.go
@@ -1,3 +1,4 @@
+// make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSDefaultNetworkAcl_'
 package aws
 
 import (

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -193,7 +193,10 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	networkAcl := resp.NetworkAcls[0]
+	return awsNetworkAclAttributes(d, resp.NetworkAcls[0])
+}
+
+func awsNetworkAclAttributes(d *schema.ResourceData, networkAcl *ec2.NetworkAcl) error {
 	var ingressEntries []*ec2.NetworkAclEntry
 	var egressEntries []*ec2.NetworkAclEntry
 

--- a/builtin/providers/aws/resource_aws_network_acl_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_test.go
@@ -1,3 +1,4 @@
+// make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSNetworkAcl_'
 package aws
 
 import (

--- a/website/source/docs/providers/aws/d/network_acl.html.markdown
+++ b/website/source/docs/providers/aws/d/network_acl.html.markdown
@@ -1,0 +1,76 @@
+---
+layout: "aws"
+page_title: "AWS: aws_network_acl"
+sidebar_current: "docs-aws-datasource-network-acl"
+description: |-
+    Provides details about a specific network ACL.
+---
+
+# aws\network\_acl
+
+The Network ACL data source provides details about
+a specific network ACL.
+
+## Example Usage
+
+This example shows how you might select a network ACL by name
+and add a rule to it.
+
+```
+data "aws_network_acl" "foo" {
+  tags {
+    Name = "Foo NACL"
+  }
+}
+
+resource "aws_network_acl_rule" "bar" {
+  network_acl_id = "${data.aws_network_acl.foo.id}"
+
+  rule_number = 200
+  egress      = false
+  protocol    = "tcp"
+  rule_action = "allow"
+  cidr_block  = "0.0.0.0/0"
+  from_port   = 22
+  to_port     = 22"
+}
+```
+
+## Argument Reference
+
+The arguments of this data source act as filters for querying the available network ACLs in the current region.
+The given filters must match exactly one network ACL whose data will be exported as attributes.
+
+
+* `network_acl_id` - (Optional) The ID of the desired network ACL.
+* `vpc_id` - (Optional) The ID of the VPC that the desired network ACL belongs to.
+* `default` - (Optional) Boolean constraint on whether the desired network ACL is
+  the default network ACL for the VPC.
+* `subnet_ids` - (Optional)  A list of Subnet IDs which are associated with the desired network ACL
+* `filter` - (Optional) Custom filter block as described below.
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired network ACL.
+
+More complex filters can be expressed using one or more `filter` sub-blocks,
+which take the following arguments:
+
+* `name` - (Required) The name of the field to filter by, as defined by
+  [the underlying AWS API](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkAcls.html).
+* `values` - (Required) Set of values that are accepted for the given field.
+  A network ACL will be selected if any one of the given values matches.
+
+## Attributes Reference
+
+All of the argument attributes except `filter` are also exported as result attributes.
+
+`ingress` and `egress` rules are also exported with the following attributes:
+
+* `from_port` - The from port of the rule.
+* `to_port` - The to port of the rule.
+* `rule_no` - The rule number.
+* `action` - The rule's action.
+* `protocol` - The rule's protocol.
+* `cidr_block` - The CIDR block of the rule.
+* `ipv6_cidr_block` - The IPv6 CIDR block of the rule.
+* `icmp_type` - The rule's ICMP type.
+* `icmp_code` - The rule's ICMP type code.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -86,6 +86,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-kms-secret") %>>
                             <a href="/docs/providers/aws/d/kms_secret.html">aws_kms_secret</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-network-acl") %>>
+                          <a href="/docs/providers/aws/d/network_acl.html">aws_network_acl</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-partition") %>>
                             <a href="/docs/providers/aws/d/partition.html">aws_partition</a>
                         </li>


### PR DESCRIPTION
The network ACL data source provides details about a specific network ACL.
Acceptance tests:
```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccDataSourceAwsNetworkAcl_'
```

Refactored `awsNetworkAclAttributes` from `resourceAwsNetworkAclRead` so that we can share common attribute setting code between the resource and corresponding data source.
