### PR TITLE
provider aws: add more details to s3 error message

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -319,7 +319,7 @@ func resourceAwsS3BucketObjectDelete(d *schema.ResourceData, meta interface{}) e
 		}
 		_, err := s3conn.DeleteObject(&input)
 		if err != nil {
-			return fmt.Errorf("Error deleting S3 bucket object: %s", err)
+			return fmt.Errorf("Error deleting S3 bucket object: %s  Bucket: %q Object: %q", err, bucket, key)
 		}
 	}
 


### PR DESCRIPTION
Add bucket and key details to error message when deleting s3 bucket. 