### PR TITLE
ns1: Fix incorrect schema for 'ns1_user.notify'

### DIFF
--- a/builtin/providers/ns1/resource_user.go
+++ b/builtin/providers/ns1/resource_user.go
@@ -28,14 +28,7 @@ func userResource() *schema.Resource {
 		"notify": &schema.Schema{
 			Type:     schema.TypeMap,
 			Optional: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"billing": &schema.Schema{
-						Type:     schema.TypeBool,
-						Required: true,
-					},
-				},
-			},
+			Elem:     schema.TypeBool,
 		},
 		"teams": &schema.Schema{
 			Type:     schema.TypeList,

--- a/builtin/providers/ns1/resource_user_test.go
+++ b/builtin/providers/ns1/resource_user_test.go
@@ -1,0 +1,102 @@
+package ns1
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
+	"gopkg.in/ns1/ns1-go.v2/rest/model/account"
+)
+
+func TestAccUser_basic(t *testing.T) {
+	var user account.User
+	rString := acctest.RandStringFromCharSet(15, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("terraform acc test user %s", rString)
+	username := fmt.Sprintf("tf_acc_test_user_%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckUserDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccUserBasic(rString),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckUserExists("ns1_user.u", &user),
+					resource.TestCheckResourceAttr("ns1_user.u", "email", "tf_acc_test_ns1@hashicorp.com"),
+					resource.TestCheckResourceAttr("ns1_user.u", "name", name),
+					resource.TestCheckResourceAttr("ns1_user.u", "teams.#", "1"),
+					resource.TestCheckResourceAttr("ns1_user.u", "notify.%", "1"),
+					resource.TestCheckResourceAttr("ns1_user.u", "notify.billing", "true"),
+					resource.TestCheckResourceAttr("ns1_user.u", "username", username),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckUserDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*ns1.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "ns1_user" {
+			continue
+		}
+
+		user, _, err := client.Users.Get(rs.Primary.Attributes["id"])
+		if err == nil {
+			return fmt.Errorf("User still exists: %#v: %#v", err, user.Name)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckUserExists(n string, user *account.User) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		client := testAccProvider.Meta().(*ns1.Client)
+
+		foundUser, _, err := client.Users.Get(rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundUser.Username != rs.Primary.ID {
+			return fmt.Errorf("User not found (%#v != %s)", foundUser, rs.Primary.ID)
+		}
+
+		*user = *foundUser
+
+		return nil
+	}
+}
+
+func testAccUserBasic(rString string) string {
+	return fmt.Sprintf(`resource "ns1_team" "t" {
+  name = "terraform acc test team %s"
+}
+
+resource "ns1_user" "u" {
+  name = "terraform acc test user %s"
+  username = "tf_acc_test_user_%s"
+  email = "tf_acc_test_ns1@hashicorp.com"
+  teams = ["${ns1_team.t.id}"]
+  notify {
+  	billing = true
+  }
+}
+`, rString, rString, rString)
+}


### PR DESCRIPTION
This was uncovered as part of tightening validation in #12638

Prior to this patch user could run into a crash just by specifying `notify`:

```hcl
resource "ns1_team" "t" {
  name = "any test team"
}

resource "ns1_user" "u" {
  name = "terraform acc test user"
  username = "test_user_any"
  email = "any_test_ns1@hashicorp.com"
  teams = ["${ns1_team.t.id}"]
  notify {
  	billing = true
  }
}
```

```
panic: interface conversion: interface {} is string, not bool

goroutine 132 [running]:
github.com/hashicorp/terraform/builtin/providers/ns1.resourceDataToUser(0xc4203c2460, 0xc4200543f0, 0xc420020600, 0xc4203db490)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/builtin/providers/ns1/resource_user.go:83 +0x448
github.com/hashicorp/terraform/builtin/providers/ns1.UserCreate(0xc4200543f0, 0x1588de0, 0xc4203c2000, 0x0, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/builtin/providers/ns1/resource_user.go:93 +0xbf
github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc42001db00, 0xc4204a4c30, 0xc4204902c0, 0x1588de0, 0xc4203c2000, 0xc420400901, 0x2a, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/resource.go:186 +0x48d
github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc420180e00, 0xc4204a4460, 0xc4204a4c30, 0xc4204902c0, 0x1, 0xd05b3877, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/helper/schema/provider.go:242 +0x9b
github.com/hashicorp/terraform/terraform.(*EvalApply).Eval(0xc420348800, 0x18b5a00, 0xc4200a4c40, 0x2, 0x2, 0x1616cdf, 0x4)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval_apply.go:57 +0x232
github.com/hashicorp/terraform/terraform.EvalRaw(0x18aa740, 0xc420348800, 0x18b5a00, 0xc4200a4c40, 0x0, 0x0, 0x0, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval.go:53 +0x175
github.com/hashicorp/terraform/terraform.(*EvalSequence).Eval(0xc4204a3c20, 0x18b5a00, 0xc4200a4c40, 0x2, 0x2, 0x1616cdf, 0x4)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval_sequence.go:14 +0xc1
github.com/hashicorp/terraform/terraform.EvalRaw(0x18ab080, 0xc4204a3c20, 0x18b5a00, 0xc4200a4c40, 0x1567500, 0xc4204a1b4a, 0x154fac0, 0xc4204a1bf0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval.go:53 +0x175
github.com/hashicorp/terraform/terraform.Eval(0x18ab080, 0xc4204a3c20, 0x18b5a00, 0xc4200a4c40, 0xc4204a3c20, 0x18ab080, 0xc4204a3c20, 0xc420035be0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/eval.go:34 +0x4d
github.com/hashicorp/terraform/terraform.(*Graph).walk.func1(0x15f5920, 0xc42000fca8, 0x0, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/terraform/graph.go:126 +0xd4d
github.com/hashicorp/terraform/dag.(*Walker).walkVertex(0xc420379880, 0x15f5920, 0xc42000fca8, 0xc420399380)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/dag/walk.go:387 +0x392
created by github.com/hashicorp/terraform/dag.(*Walker).Update
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/dag/walk.go:310 +0x9ca
```

The crash is just hidden behind an error due to the mentioned tight validation.

### Test plan

```
make testacc TEST=./builtin/providers/ns1 TESTARGS='-run=TestAccUser'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/15 13:42:15 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/ns1 -v -run=TestAccUser -timeout 120m
=== RUN   TestAccUser_basic
--- PASS: TestAccUser_basic (14.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/ns1	14.025s
```