### PR TITLE
schema: Allow *Resource as Elem of TypeMap in validation

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1357,6 +1357,13 @@ func getValueType(k string, schema *Schema) (ValueType, error) {
 			return vt, nil
 		}
 	}
+
+	if _, ok := schema.Elem.(*Resource); ok {
+		// TODO: We don't actually support this (yet)
+		// but silently pass the validation, until we decide
+		// how to handle nested structures in maps
+		return TypeString, nil
+	}
 	return 0, fmt.Errorf("%s: unexpected map value type: %#v", k, schema.Elem)
 }
 


### PR DESCRIPTION
This is a follow up to https://github.com/hashicorp/terraform/pull/12638

I'm not overly happy about this PR as there's very likely a handful of resources _actually_ genuinely broken due to the chosen schema, but as @jbardin mentioned we need to decide how are we going to handle nested structures and these resources will remain broken until then (unless someone fixes them by changing the schema & CRUD).

### Depends on

https://github.com/hashicorp/terraform/pull/12720
https://github.com/hashicorp/terraform/pull/12721

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSSSMDocument'
```
```
make testacc TEST=./builtin/providers/consul TESTARGS='-run=TestAccDataConsul'
```
```
make testacc TEST=./builtin/providers/datadog TESTARGS='-run=TestAccDatadogMonitor'
```
```
make testacc TEST=./builtin/providers/ns1 TESTARGS='-run=TestAccUser'
```