### PR TITLE
fix another hot lop in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 - 1.8
 
 env:
-  - CONSUL_VERSION=0.7.5 TF_CONSUL_TEST=1
+  - CONSUL_VERSION=0.7.5 TF_CONSUL_TEST=1 GOMAXPROCS=4
 
 # Fetch consul for the backend and provider tests
 before_install:

--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -1740,6 +1740,7 @@ func TestContext2Apply_cancel(t *testing.T) {
 				if ctx.sh.Stopped() {
 					break
 				}
+				time.Sleep(10 * time.Millisecond)
 			}
 		}
 


### PR DESCRIPTION
Found another test spinlock.
Slow it down to prevent it from blocking the runtime scheduler.