### PR TITLE
docs: fix some broken links related to remote state

### DIFF
--- a/website/source/docs/commands/apply.html.markdown
+++ b/website/source/docs/commands/apply.html.markdown
@@ -43,11 +43,11 @@ The command-line flags are all optional. The list of available flags are:
   apply.
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when
-  [remote state](/docs/state/remote/index.html) is used.
+  [remote state](/docs/state/remote.html) is used.
 
 * `-target=resource` - A [Resource
   Address](/docs/internals/resource-addressing.html) to target. Operation will

--- a/website/source/docs/commands/console.html.markdown
+++ b/website/source/docs/commands/console.html.markdown
@@ -53,7 +53,7 @@ $ echo "1 + 5" | terraform console
 ## Remote State
 
 The `terraform console `command will read configured state even if it
-is [remote](/docs/state/remote/index.html). This is great for scripting
+is [remote](/docs/state/remote.html). This is great for scripting
 state reading in CI environments or other remote scenarios.
 
 After configuring remote state, run a `terraform remote pull` command

--- a/website/source/docs/commands/import.html.md
+++ b/website/source/docs/commands/import.html.md
@@ -43,10 +43,10 @@ The command-line flags are all optional. The list of available flags are:
 * `-input=true` - Whether to ask for input for provider configuration.
 
 * `-state=path` - The path to read and save state files (unless state-out is
-  specified). Ignored when [remote state](/docs/state/remote/index.html) is used.
+  specified). Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-state-out=path` - Path to write the final state file. By default, this is
-  the state path. Ignored when [remote state](/docs/state/remote/index.html) is
+  the state path. Ignored when [remote state](/docs/state/remote.html) is
   used.
 
 * `-provider=provider` - Specified provider to use for import. This is used for

--- a/website/source/docs/commands/output.html.markdown
+++ b/website/source/docs/commands/output.html.markdown
@@ -25,7 +25,7 @@ The command-line flags are all optional. The list of available flags are:
     a key per output. If `NAME` is specified, only the output specified will be
     returned. This can be piped into tools such as `jq` for further processing.
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-    Ignored when [remote state](/docs/state/remote/index.html) is used.
+    Ignored when [remote state](/docs/state/remote.html) is used.
 * `-module=module_name` - The module path which has needed output.
     By default this is the root path. Other modules can be specified by
     a period-separated list. Example: "foo" would reference the module

--- a/website/source/docs/commands/plan.html.markdown
+++ b/website/source/docs/commands/plan.html.markdown
@@ -56,7 +56,7 @@ The command-line flags are all optional. The list of available flags are:
 * `-refresh=true` - Update the state prior to checking for differences.
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-target=resource` - A [Resource
   Address](/docs/internals/resource-addressing.html) to target. Operation will

--- a/website/source/docs/commands/push.html.markdown
+++ b/website/source/docs/commands/push.html.markdown
@@ -117,7 +117,7 @@ or plan), and the `-overwrite` flag tells the push command to update Atlas.
 ## Remote State Requirement
 
 `terraform push` requires that
-[remote state](/docs/commands/remote-config.html)
+[remote state](/docs/state/remote.html)
 is enabled. The reasoning for this is simple: `terraform push` sends your
 configuration to be managed remotely. For it to keep the state in sync
 and for you to be able to easily access that state, remote state must

--- a/website/source/docs/commands/refresh.html.markdown
+++ b/website/source/docs/commands/refresh.html.markdown
@@ -32,11 +32,11 @@ The command-line flags are all optional. The list of available flags are:
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when
-  [remote state](/docs/state/remote/index.html) is used.
+  [remote state](/docs/state/remote.html) is used.
 
 * `-target=resource` - A [Resource
   Address](/docs/internals/resource-addressing.html) to target. Operation will

--- a/website/source/docs/commands/state/list.html.md
+++ b/website/source/docs/commands/state/list.html.md
@@ -30,7 +30,7 @@ in [resource addressing format](/docs/commands/state/addressing.html).
 The command-line flags are all optional. The list of available flags are:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 ## Example: All Resources
 

--- a/website/source/docs/commands/state/mv.html.md
+++ b/website/source/docs/commands/state/mv.html.md
@@ -47,12 +47,12 @@ The command-line flags are all optional. The list of available flags are:
                        This is only necessary if `-state-out` is specified.
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-state-out=path` - Path to the state file to write to. If this isn't specified
                       the state specified by `-state` will be used. This can be
                       a new or existing path. Ignored when
-                      [remote state](/docs/state/remote/index.html) is used.
+                      [remote state](/docs/state/remote.html) is used.
 
 ## Example: Rename a Resource
 

--- a/website/source/docs/commands/state/show.html.md
+++ b/website/source/docs/commands/state/show.html.md
@@ -30,7 +30,7 @@ in [resource addressing format](/docs/commands/state/addressing.html).
 The command-line flags are all optional. The list of available flags are:
 
 * `-state=path` - Path to the state file. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 ## Example: Show a Resource
 

--- a/website/source/docs/commands/taint.html.markdown
+++ b/website/source/docs/commands/taint.html.markdown
@@ -56,8 +56,8 @@ The command-line flags are all optional. The list of available flags are:
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when
-  [remote state](/docs/state/remote/index.html) is used.
+  [remote state](/docs/state/remote.html) is used.

--- a/website/source/docs/commands/untaint.html.markdown
+++ b/website/source/docs/commands/untaint.html.markdown
@@ -56,8 +56,8 @@ certain cases, see above note). The list of available flags are:
 * `-no-color` - Disables output with coloring
 
 * `-state=path` - Path to read and write the state file to. Defaults to "terraform.tfstate".
-  Ignored when [remote state](/docs/state/remote/index.html) is used.
+  Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-state-out=path` - Path to write updated state file. By default, the
   `-state` path will be used. Ignored when
-  [remote state](/docs/state/remote/index.html) is used.
+  [remote state](/docs/state/remote.html) is used.

--- a/website/source/docs/providers/terraform/d/remote_state.html.md
+++ b/website/source/docs/providers/terraform/d/remote_state.html.md
@@ -32,7 +32,7 @@ The following arguments are supported:
 
 * `backend` - (Required) The remote backend to use.
 * `config` - (Optional) The configuration of the remote backend.
- * Remote state config docs can be found [here](https://www.terraform.io/docs/state/remote/atlas.html)
+ * Remote state config docs can be found [here](/docs/backends/types/atlas.html)
 
 ## Attributes Reference
 

--- a/website/source/docs/state/purpose.html.md
+++ b/website/source/docs/state/purpose.html.md
@@ -92,7 +92,7 @@ The primary motivation people have to remove state files is in an attempt
 to improve using Terraform with teams. State files can easily result in
 conflicts when two people modify infrastructure at the same time.
 
-[Remote state](/docs/state/remote/index.html) is the recommended solution
+[Remote state](/docs/state/remote.html) is the recommended solution
 to this problem. At the time of writing, remote state works well but there
 are still scenarios that can result in state conflicts. A priority for future
 versions of Terraform is to improve this.

--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -180,7 +180,7 @@ by default. This state file is extremely important; it maps various
 resource metadata to actual resource IDs so that Terraform knows
 what it is managing. This file must be saved and distributed
 to anyone who might run Terraform. It is generally recommended to 
-[setup remote state](https://www.terraform.io/docs/state/remote/index.html)
+[setup remote state](https://www.terraform.io/docs/state/remote.html)
 when working with Terraform. This will mean that any potential secrets
 stored in the state file, will not be checked into version control
 

--- a/website/source/layouts/remotestate.erb
+++ b/website/source/layouts/remotestate.erb
@@ -7,7 +7,7 @@
             </li>
 
             <li<%= sidebar_current("docs-state-remote_index") %>>
-              <a href="/docs/state/remote/index.html">Remote State</a>
+              <a href="/docs/state/remote.html">Remote State</a>
             </li>
 
             <li<%= sidebar_current(/^docs-state-remote-/) %>>


### PR DESCRIPTION
Remote state got some changes to do with the addition of backends, and the docs got some links broken. 