### PR TITLE
provider/google: drop the account file.

### DIFF
--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -15,13 +15,6 @@ import (
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		Schema: map[string]*schema.Schema{
-			"account_file": &schema.Schema{
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("GOOGLE_ACCOUNT_FILE", nil),
-				Removed:     "Use the credentials field instead",
-			},
-
 			"credentials": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,


### PR DESCRIPTION
This was already marked as removed, but the way the provider handled it,
people were still being prompted for input anyways. This removes it from
the provider entirely, so people won't be prompted for input.