### PR TITLE
Revert "Have the consul provider use a local test server"

### DIFF
--- a/builtin/providers/consul/data_source_consul_agent_self_test.go
+++ b/builtin/providers/consul/data_source_consul_agent_self_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAccDataConsulAgentSelf_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
@@ -24,8 +25,7 @@ func TestAccDataConsulAgentSelf_basic(t *testing.T) {
 					testAccCheckDataSourceValue("data.consul_agent_self.read", "advertise_addr", "<any>"),
 					testAccCheckDataSourceValue("data.consul_agent_self.read", "bind_addr", "<any>"),
 					testAccCheckDataSourceValue("data.consul_agent_self.read", "bootstrap_expect", "<all>"),
-					// the local test server is bootstrapped
-					testAccCheckDataSourceValue("data.consul_agent_self.read", "bootstrap_mode", "true"),
+					testAccCheckDataSourceValue("data.consul_agent_self.read", "bootstrap_mode", "false"),
 					testAccCheckDataSourceValue("data.consul_agent_self.read", "client_addr", "<any>"),
 					testAccCheckDataSourceValue("data.consul_agent_self.read", "datacenter", "<any>"),
 					testAccCheckDataSourceValue("data.consul_agent_self.read", "dev_mode", "<any>"),

--- a/builtin/providers/consul/data_source_consul_catalog_nodes_test.go
+++ b/builtin/providers/consul/data_source_consul_catalog_nodes_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestAccDataConsulCatalogNodes_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/builtin/providers/consul/data_source_consul_catalog_service_test.go
+++ b/builtin/providers/consul/data_source_consul_catalog_service_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestAccDataConsulCatalogService_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/builtin/providers/consul/data_source_consul_catalog_services_test.go
+++ b/builtin/providers/consul/data_source_consul_catalog_services_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestAccDataConsulCatalogServices_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/builtin/providers/consul/data_source_consul_keys_test.go
+++ b/builtin/providers/consul/data_source_consul_keys_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestAccDataConsulKeys_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{

--- a/builtin/providers/consul/resource_consul_key_prefix_test.go
+++ b/builtin/providers/consul/resource_consul_key_prefix_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccConsulKeyPrefix_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		CheckDestroy: resource.ComposeTestCheckFunc(
 			testAccCheckConsulKeyPrefixKeyAbsent("species"),

--- a/builtin/providers/consul/resource_consul_keys_test.go
+++ b/builtin/providers/consul/resource_consul_keys_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccConsulKeys_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckConsulKeysDestroy,
 		Steps: []resource.TestStep{

--- a/builtin/providers/consul/resource_consul_prepared_query_test.go
+++ b/builtin/providers/consul/resource_consul_prepared_query_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestAccConsulPreparedQuery_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckConsulPreparedQueryDestroy,
 		Steps: []resource.TestStep{

--- a/builtin/providers/consul/resource_provider_test.go
+++ b/builtin/providers/consul/resource_provider_test.go
@@ -1,62 +1,22 @@
 package consul
 
 import (
-	"io/ioutil"
-	"log"
 	"os"
 	"testing"
 
-	"github.com/hashicorp/consul/testutil"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"github.com/mitchellh/mapstructure"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
-var testConsulHTTPAddr string
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
-	testAccProvider.ConfigureFunc = testProviderConfigure
-
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"consul": testAccProvider,
 	}
-}
-
-// we need to overrride the configured address for the tests
-func testProviderConfigure(d *schema.ResourceData) (interface{}, error) {
-	var config Config
-	configRaw := d.Get("").(map[string]interface{})
-	if err := mapstructure.Decode(configRaw, &config); err != nil {
-		return nil, err
-	}
-	config.Address = testConsulHTTPAddr
-
-	log.Printf("[INFO] Initializing Consul test client")
-	return config.Client()
-}
-
-func TestMain(m *testing.M) {
-	t := struct {
-		testutil.TestingT
-	}{}
-
-	// start and stop the test consul server once for all tests
-	srv := testutil.NewTestServerConfig(t, func(c *testutil.TestServerConfig) {
-		c.LogLevel = "warn"
-		c.Stdout = ioutil.Discard
-		c.Stderr = ioutil.Discard
-	})
-
-	testConsulHTTPAddr = srv.HTTPAddr
-
-	ret := m.Run()
-
-	srv.Stop()
-	os.Exit(ret)
 }
 
 func TestResourceProvider(t *testing.T) {
@@ -72,9 +32,8 @@ func TestResourceProvider_impl(t *testing.T) {
 func TestResourceProvider_Configure(t *testing.T) {
 	rp := Provider()
 
-	// these configuration tests don't require an running server
 	raw := map[string]interface{}{
-		"address":    "example.com:8500",
+		"address":    "demo.consul.io:80",
 		"datacenter": "nyc3",
 		"scheme":     "https",
 	}
@@ -94,7 +53,7 @@ func TestResourceProvider_ConfigureTLS(t *testing.T) {
 	rp := Provider()
 
 	raw := map[string]interface{}{
-		"address":    "example.com:8943",
+		"address":    "demo.consul.io:80",
 		"ca_file":    "test-fixtures/cacert.pem",
 		"cert_file":  "test-fixtures/usercert.pem",
 		"datacenter": "nyc3",
@@ -111,4 +70,14 @@ func TestResourceProvider_ConfigureTLS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("CONSUL_HTTP_ADDR"); v != "" {
+		return
+	}
+	if v := os.Getenv("CONSUL_ADDRESS"); v != "" {
+		return
+	}
+	t.Fatal("Either CONSUL_ADDRESS or CONSUL_HTTP_ADDR must be set for acceptance tests")
 }


### PR DESCRIPTION
This reverts commit 9529bd3bf040e5c7d62468aa560f98f145dabc45.

Pulling the consul `testutil.TestServer` out of the provider tests for now. The consul testutil package uses a `*testing.T` for errors and control flow, and returns a server that needs to be stopped. The provider however is sometimes configured multiple times per test, and there's often no good point to insert the testing instance or clean up the server. 

It's probably easier to provide another hook at some point in the consul testutil package rather than refactor all the tests here to fit.