### PR TITLE
provider/vsphere Change default adapter_type to lsiLogic

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_disk.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_disk.go
@@ -61,7 +61,7 @@ func resourceVSphereVirtualDisk() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  "ide",
+				Default:  "lsiLogic",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
 					if value != "ide" && value != "busLogic" && value != "lsiLogic" {


### PR DESCRIPTION
It's a very small, but very important change in my opinion.

There is no logical reason for setting up "ide" as the default adapter_type. This controller type is useless in the VMware world - disk cannot be resized, has less performance etc. Most of the OSes have drivers for vSCSI controllers and VMware recommends to convert every IDE disk to SCSI. Only for old Operating Systems (like virtualized Windows XP) there is a sense in using IDE. Of course after converting P2V, VM has IDE controller, but VMware recommends to convert IDE to SCSI too.

I have changed default adapter_type in the resource_vsphere_virtual_disk.go to "lsiLogic". Most of the operating systems have LSI Logic SCSI drivers. LSI Logic Parallel and LSI Logic SAS are being the most frequently used controllers now. Sometimes one can see BusLogic, but it's not as popular as LSI Logic SCSI. So, I think it's a very useful change - now there is a necessity of manual changing adapter_type in every infrastructure configuration. With 'lsiLogic' by the default, life would be simpler. :smiley: 