### PR TITLE
Add navigation for aws_instance documentation

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -77,6 +77,9 @@
                         <li<%= sidebar_current("docs-aws-iam-server-certificate") %>>
                           <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-instance") %>>
+                          <a href="/docs/providers/aws/d/instance.html">aws_instance</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-ip_ranges") %>>
                             <a href="/docs/providers/aws/d/ip_ranges.html">aws_ip_ranges</a>
                         </li>


### PR DESCRIPTION
aws_instance documentation is currently available on the site; however, a link is not provided via the navigation under the data sources section.  This adds that link.