### PR TITLE
DigitalOcean infinite apply loop (forces new resource)

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -26,7 +26,6 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 			"image": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 
 			"name": {


### PR DESCRIPTION
Fixes #12255

```
ubuntu@ubuntu-xenial:~/go/src/github.com/hashicorp$ terraform/bin/terraform apply
digitalocean_droplet.stage_server: Creating...
  disk:                 "" => "<computed>"
  image:                "" => "ubuntu-14-04-x64"
  ipv4_address:         "" => "<computed>"
  ipv4_address_private: "" => "<computed>"
  ipv6_address:         "" => "<computed>"
  ipv6_address_private: "" => "<computed>"
  locked:               "" => "<computed>"
  name:                 "" => "test"
  region:               "" => "nyc1"
  resize_disk:          "" => "true"
  size:                 "" => "512mb"
  status:               "" => "<computed>"
  vcpus:                "" => "<computed>"
digitalocean_droplet.stage_server: Still creating... (10s elapsed)
digitalocean_droplet.stage_server: Still creating... (20s elapsed)
digitalocean_droplet.stage_server: Still creating... (30s elapsed)
digitalocean_droplet.stage_server: Creation complete (ID: 42472221)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

The state of your infrastructure has been saved to the path
below. This state is required to modify and destroy your
infrastructure, so keep it safe. To inspect the complete state
use the `terraform show` command.

State path:
```
There is no forced new resource any more:
```
ubuntu@ubuntu-xenial:~/go/src/github.com/hashicorp$ terraform/bin/terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

digitalocean_droplet.stage_server: Refreshing state... (ID: 42472221)
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```