### PR TITLE
provider/aws: Improve error when failing to get S3 tags

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -275,7 +275,7 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 			Key:    aws.String(key),
 		})
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to get object tags (bucket: %s, key: %s): %s", bucket, key, err)
 	}
 	d.Set("tags", tagsToMapS3(tagResp.TagSet))
 


### PR DESCRIPTION
As mentioned in https://github.com/hashicorp/terraform/issues/12137

Tiny improvement, but it can make some folks happier when debugging permission issues.

### Example

```
aws_s3_bucket_object.object: Refreshing state... (ID: new_object_key)
Error refreshing state: 1 error(s) occurred:

* aws_s3_bucket_object.object: aws_s3_bucket_object.object: Failed to get tags (bucket: my-special-bucket, key: new_object_key): AccessDenied: Access Denied
	status code: 403, request id: 4BF1BD088F914F31
```