### PR TITLE
Add puppetdb provider

### DIFF
--- a/builtin/bins/provider-puppetdb/main.go
+++ b/builtin/bins/provider-puppetdb/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/puppetdb"
+	"github.com/hashicorp/terraform/plugin"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: func() terraform.ResourceProvider {
+			return puppetdb.Provider()
+		},
+	})
+}

--- a/builtin/providers/puppetdb/client.go
+++ b/builtin/providers/puppetdb/client.go
@@ -1,0 +1,67 @@
+package puppetdb
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+type PuppetDBClient struct {
+	URL string
+}
+
+type PuppetDBResp struct {
+	Error                        error  `json:"error"`
+	Certname                     string `json:"certname"`
+	Deactivated                  string `json:"deactivated"`
+	Expired                      string `json:"expired"`
+	CachedCatalogStatus          string `json:"cached_catalog_status"`
+	CatalogEnvironment           string `json:"catalog_environment"`
+	FactsEnvironment             string `json:"facts_environment"`
+	ReportEnvironment            string `json:"report_environment"`
+	CatalogTimestamp             string `json:"catalog_timestamp"`
+	FactsTimestamp               string `json:"facts_timestamp"`
+	ReportTimestamp              string `json:"report_timestamp"`
+	LatestReportCorrectiveChange string `json:"latest_report_corrective_change"`
+	LatestReportHash             string `json:"latest_report_hash"`
+	LatestReportNoop             bool   `json:"latest_report_noop"`
+	LatestReportNoopPending      bool   `json:"latest_report_noop_pending"`
+	LatestReportStatus           string `json:"latest_report_status"`
+}
+
+type commandsPayload struct {
+	Command string            `json:"command"`
+	Version int               `json:"version"`
+	Payload map[string]string `json:"payload"`
+}
+
+func (p *PuppetDBClient) Query(query string, verb string, payload string) (pdbResp PuppetDBResp, err error) {
+	url := p.URL + "/pdb/" + query
+	form := strings.NewReader(payload)
+	req, err := http.NewRequest(verb, url, form)
+	if err != nil {
+		return
+	}
+	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Accept", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	json.Unmarshal(body, &pdbResp)
+
+	if err = pdbResp.Error; err != nil {
+		return
+	}
+
+	return pdbResp, nil
+}

--- a/builtin/providers/puppetdb/client.go
+++ b/builtin/providers/puppetdb/client.go
@@ -3,8 +3,8 @@ package puppetdb
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"encoding/json"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"strings"
 )
@@ -16,7 +16,7 @@ type PuppetDBClient struct {
 	CA   string
 }
 
-type PuppetDBResp struct {
+type PuppetDBNodeResp struct {
 	Error                        error  `json:"error"`
 	Certname                     string `json:"certname"`
 	Deactivated                  string `json:"deactivated"`
@@ -41,8 +41,9 @@ type commandsPayload struct {
 	Payload map[string]string `json:"payload"`
 }
 
-func (p *PuppetDBClient) Query(query string, verb string, payload string) (pdbResp PuppetDBResp, err error) {
+func (p *PuppetDBClient) Query(query string, verb string, payload string) (body []byte, err error) {
 	url := p.URL + "/pdb/" + query
+	log.Printf("[RANCHER] url=%s\n", url)
 	form := strings.NewReader(payload)
 	req, err := http.NewRequest(verb, url, form)
 	if err != nil {
@@ -56,13 +57,13 @@ func (p *PuppetDBClient) Query(query string, verb string, payload string) (pdbRe
 		// Load cert pair
 		cert, err := tls.LoadX509KeyPair(p.Cert, p.Key)
 		if err != nil {
-			return pdbResp, err
+			return body, err
 		}
 
 		// Load CA cert
 		caCert, err := ioutil.ReadFile(p.CA)
 		if err != nil {
-			return pdbResp, err
+			return body, err
 		}
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(caCert)
@@ -84,16 +85,12 @@ func (p *PuppetDBClient) Query(query string, verb string, payload string) (pdbRe
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err = ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return
 	}
 
-	json.Unmarshal(body, &pdbResp)
+	log.Printf("[RANCHER] body=%v\n", string(body))
 
-	if err = pdbResp.Error; err != nil {
-		return
-	}
-
-	return pdbResp, nil
+	return body, nil
 }

--- a/builtin/providers/puppetdb/config.go
+++ b/builtin/providers/puppetdb/config.go
@@ -2,5 +2,8 @@ package puppetdb
 
 // Config is the configuration parameters for a PuppetDB
 type Config struct {
-	URL string
+	URL  string
+	Cert string
+	Key  string
+	CA   string
 }

--- a/builtin/providers/puppetdb/config.go
+++ b/builtin/providers/puppetdb/config.go
@@ -1,0 +1,6 @@
+package puppetdb
+
+// Config is the configuration parameters for a PuppetDB
+type Config struct {
+	URL string
+}

--- a/builtin/providers/puppetdb/data_source_pql.go
+++ b/builtin/providers/puppetdb/data_source_pql.go
@@ -1,0 +1,82 @@
+package puppetdb
+
+import (
+	"crypto/md5"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+var PQLCertnames []string
+
+func dataSourcePQL() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourcePQLRead,
+
+		Schema: map[string]*schema.Schema{
+			"query": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"data_json": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"data": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeMap},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourcePQLRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Refreshing PuppetDB Node: %s", d.Id())
+
+	query := d.Get("query").(string)
+	client := meta.(*PuppetDBClient)
+
+	queryMap := map[string]string{
+		"query": query,
+	}
+	queryStr, err := json.Marshal(&queryMap)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Query("query/v4", "POST", string(queryStr))
+	if err != nil {
+		return err
+	}
+
+	md5sum := fmt.Sprintf("%x", md5.Sum(queryStr))
+	d.SetId(md5sum)
+
+	d.Set("data_json", string(resp))
+
+	var respPdb []map[string]interface{}
+	err = json.Unmarshal(resp, &respPdb)
+	if err != nil {
+		log.Printf("[RANCHER] unmarshaling failed: %v\n", err)
+		d.Set("data", string(resp))
+	} else {
+		dataList := flattenMapList(respPdb)
+		d.Set("data", dataList)
+	}
+	return nil
+}
+
+func flattenMapList(list []map[string]interface{}) []interface{} {
+	vs := make([]interface{}, 0, len(list))
+	for _, v := range list {
+		// Cast everything as strings: UGLY!!
+		m := make(map[string]string)
+		for k, v := range v {
+			m[k] = fmt.Sprintf("%v", v)
+		}
+		vs = append(vs, m)
+	}
+	return vs
+}

--- a/builtin/providers/puppetdb/provider.go
+++ b/builtin/providers/puppetdb/provider.go
@@ -15,6 +15,24 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("PUPPETDB_URL", "http://localhost:8080"),
 				Description: descriptions["url"],
 			},
+			"cert": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("PUPPETDB_CERT", ""),
+				Description: descriptions["cert"],
+			},
+			"key": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("PUPPETDB_KEY", ""),
+				Description: descriptions["key"],
+			},
+			"ca": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("PUPPETDB_CA", ""),
+				Description: descriptions["ca"],
+			},
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -29,15 +47,24 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"url": "The URL to the PuppetDB",
+		"url":  "The URL to the PuppetDB",
+		"cert": "The SSL certificate to connect to the PuppetDB",
+		"key":  "The SSL private key to connect to the PuppetDB",
+		"ca":   "The SSL CA certificate to connect to the PuppetDB",
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	url := d.Get("url").(string)
+	cert := d.Get("cert").(string)
+	key := d.Get("key").(string)
+	ca := d.Get("ca").(string)
 
 	client := PuppetDBClient{
-		URL: url,
+		URL:  url,
+		Cert: cert,
+		Key:  key,
+		CA:   ca,
 	}
 	return &client, nil
 }

--- a/builtin/providers/puppetdb/provider.go
+++ b/builtin/providers/puppetdb/provider.go
@@ -39,6 +39,10 @@ func Provider() terraform.ResourceProvider {
 			"puppetdb_node": resourcePuppetDBNode(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"puppetdb_pql": dataSourcePQL(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/builtin/providers/puppetdb/provider.go
+++ b/builtin/providers/puppetdb/provider.go
@@ -1,0 +1,43 @@
+package puppetdb
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Provider returns a terraform.ResourceProvider.
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"url": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("PUPPETDB_URL", "http://localhost:8080"),
+				Description: descriptions["url"],
+			},
+		},
+
+		ResourcesMap: map[string]*schema.Resource{
+			"puppetdb_node": resourcePuppetDBNode(),
+		},
+
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+var descriptions map[string]string
+
+func init() {
+	descriptions = map[string]string{
+		"url": "The URL to the PuppetDB",
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	url := d.Get("url").(string)
+
+	client := PuppetDBClient{
+		URL: url,
+	}
+	return &client, nil
+}

--- a/builtin/providers/puppetdb/provider_test.go
+++ b/builtin/providers/puppetdb/provider_test.go
@@ -1,0 +1,28 @@
+package puppetdb
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"puppetdb": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}

--- a/builtin/providers/puppetdb/resource_puppetdb_node.go
+++ b/builtin/providers/puppetdb/resource_puppetdb_node.go
@@ -103,7 +103,13 @@ func resourcePuppetDBNodeRead(d *schema.ResourceData, meta interface{}) error {
 
 	certname := d.Get("certname").(string)
 	client := meta.(*PuppetDBClient)
-	pdbResp, err := client.Query("query/v4/nodes/"+certname, "GET", "")
+	resp, err := client.Query("query/v4/nodes/"+certname, "GET", "")
+	if err != nil {
+		return err
+	}
+
+	var pdbResp PuppetDBNodeResp
+	err = json.Unmarshal(resp, &pdbResp)
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/puppetdb/resource_puppetdb_node.go
+++ b/builtin/providers/puppetdb/resource_puppetdb_node.go
@@ -1,0 +1,152 @@
+package puppetdb
+
+import (
+	"encoding/json"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourcePuppetDBNode() *schema.Resource {
+	return &schema.Resource{
+		Create: resourcePuppetDBNodeCreate,
+		Read:   resourcePuppetDBNodeRead,
+		Delete: resourcePuppetDBNodeDelete,
+
+		Schema: map[string]*schema.Schema{
+			"id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"certname": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"deactivated": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expired": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"cached_catalog_status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"catalog_environment": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"facts_environment": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"report_environment": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"catalog_timestamp": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"facts_timestamp": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"report_timestamp": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_report_corrective_change": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_report_hash": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_report_noop": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_report_noop_pending": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"latest_report_status": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourcePuppetDBNodeCreate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Creating PuppetDB node: %s", d.Id())
+
+	certname := d.Get("certname").(string)
+
+	client := meta.(*PuppetDBClient)
+	_, err := client.Query("query/v4/nodes/"+certname, "GET", "")
+	if err != nil {
+		return err
+	}
+
+	d.SetId(certname)
+	return resourcePuppetDBNodeRead(d, meta)
+}
+
+func resourcePuppetDBNodeRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Refreshing PuppetDB Node: %s", d.Id())
+
+	certname := d.Get("certname").(string)
+	client := meta.(*PuppetDBClient)
+	pdbResp, err := client.Query("query/v4/nodes/"+certname, "GET", "")
+	if err != nil {
+		return err
+	}
+
+	d.Set("deactivated", pdbResp.Deactivated)
+	d.Set("expired", pdbResp.Expired)
+	d.Set("cached_catalog_status", pdbResp.CachedCatalogStatus)
+	d.Set("catalog_environment", pdbResp.CatalogEnvironment)
+	d.Set("facts_environment", pdbResp.FactsEnvironment)
+	d.Set("report_environment", pdbResp.ReportEnvironment)
+	d.Set("catalog_timestamp", pdbResp.CatalogTimestamp)
+	d.Set("facts_timestamp", pdbResp.FactsTimestamp)
+	d.Set("report_timestamp", pdbResp.ReportTimestamp)
+	d.Set("latest_report_corrective_change", pdbResp.LatestReportCorrectiveChange)
+	d.Set("latest_report_hash", pdbResp.LatestReportHash)
+	d.Set("latest_report_noop", pdbResp.LatestReportNoop)
+	d.Set("latest_report_noop_pending", pdbResp.LatestReportNoopPending)
+	d.Set("latest_report_status", pdbResp.LatestReportStatus)
+
+	return nil
+}
+
+func resourcePuppetDBNodeDelete(d *schema.ResourceData, meta interface{}) (err error) {
+	log.Printf("[INFO] Deactivating PuppetDB Node: %s", d.Id())
+
+	certname := d.Get("certname").(string)
+	client := meta.(*PuppetDBClient)
+
+	payload := commandsPayload{
+		Command: "deactivate node",
+		Version: 3,
+		Payload: map[string]string{"certname": certname},
+	}
+
+	stringPayload, err := json.Marshal(&payload)
+	if err != nil {
+		return
+	}
+	_, err = client.Query("cmd/v1", "POST", string(stringPayload))
+	if err != nil {
+		return
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -53,6 +53,7 @@ import (
 	postgresqlprovider "github.com/hashicorp/terraform/builtin/providers/postgresql"
 	powerdnsprovider "github.com/hashicorp/terraform/builtin/providers/powerdns"
 	profitbricksprovider "github.com/hashicorp/terraform/builtin/providers/profitbricks"
+	puppetdbprovider "github.com/hashicorp/terraform/builtin/providers/puppetdb"
 	rabbitmqprovider "github.com/hashicorp/terraform/builtin/providers/rabbitmq"
 	rancherprovider "github.com/hashicorp/terraform/builtin/providers/rancher"
 	randomprovider "github.com/hashicorp/terraform/builtin/providers/random"
@@ -129,6 +130,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"postgresql":   postgresqlprovider.Provider,
 	"powerdns":     powerdnsprovider.Provider,
 	"profitbricks": profitbricksprovider.Provider,
+	"puppetdb":     puppetdbprovider.Provider,
 	"rabbitmq":     rabbitmqprovider.Provider,
 	"rancher":      rancherprovider.Provider,
 	"random":       randomprovider.Provider,

--- a/website/source/docs/providers/puppetdb/index.html.markdown
+++ b/website/source/docs/providers/puppetdb/index.html.markdown
@@ -1,0 +1,34 @@
+---
+layout: "puppetdb"
+page_title: "Provider: PuppetDB"
+sidebar_current: "docs-puppetdb-index"
+description: |-
+  The PuppetDB provider is used to interact with the PuppetDB.
+---
+
+# PuppetDB Provider
+
+The PuppetDB provider is used to interact with the
+resources supported by PuppetDB. The provider needs to be configured
+with the URL of the PuppetDB server at minimum and SSL keys if using HTTPS.
+
+## Example Usage
+
+```hcl
+# Configure the PuppetDB provider
+provider "puppetdb" {
+  url        = "https://puppetdb.my-domain.com:8081"
+  key        = "certs/my.key"
+  cert       = "certs/my.crt"
+  ca         = "certs/ca.crt"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `url` - (Required) PuppetDB url. It must be provided, but it can also be sourced from the `PUPPETDB_URL` environment variable.
+* `key` - (Optional) SSL key used for authentication. It can also be sourced from the `PUPPETDB_KEY` environment variable.
+* `cert` - (Optional) SSL certificate used for authentication. It can also be sourced from the `PUPPETDB_CERT` environment variable.
+* `ca` - (Optional) SSL CA certificate used for authentication. It can also be sourced from the `PUPPETDB_CA` environment variable.

--- a/website/source/docs/providers/puppetdb/r/node.html.markdown
+++ b/website/source/docs/providers/puppetdb/r/node.html.markdown
@@ -1,0 +1,46 @@
+---
+layout: "puppetdb"
+page_title: "PuppetDB: puppetdb_node"
+sidebar_current: "docs-puppetdb-resource-node"
+description: |-
+  Provides a PuppetDB Node resource. This can be used to manage and delete nodes on PuppetDB.
+---
+
+# puppetdb\_node
+
+Provides a PuppetDB Node resource. This can be used to manage and delete nodes on PuppetDB.
+
+## Example usage
+
+```hcl
+# Manage an existing PuppetDB node
+resource puppetdb_node "foo" {
+  certname       = "foo.example.com"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `certname` - (Required) The certificate name of the node.
+
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `deactivated` - The deactivation date of the node.
+* `expired` - The expiration date of the node.
+* `cached_catalog_status` - Cached catalog status of the last puppet run for the node.
+* `catalog_environment` - The environment for the last received catalog.
+* `facts_environment` - The environment for the last received fact set.
+* `report_environment` - The environment for the last received report.
+* `catalog_timestamp` - The last time a catalog was received. Timestamps are always ISO-8601 compatible date/time strings.
+* `facts_timestamp` - The last time a fact set was received. Timestamps are always ISO-8601 compatible date/time strings.
+* `report_timestamp` - The last time a report run was complete. Timestamps are always ISO-8601 compatible date/time strings.
+* `latest_report_corrective_change` - Whether the latest report for the node included events that remediated configuration drift. This field is only populated in PE.
+* `latest_report_hash` - A hash of the latest report for the node.
+* `latest_report_noop` - Whether the most recent report for the node was a noop run.
+* `latest_report_noop_pending` - Whether the most recent report for the node contained noop events.
+* `latest_report_status` - The status of the latest report.

--- a/website/source/layouts/puppetdb.erb
+++ b/website/source/layouts/puppetdb.erb
@@ -1,0 +1,26 @@
+<% wrap_layout :inner do %>
+	<% content_for :sidebar do %>
+		<div class="docs-sidebar hidden-print affix-top" role="complementary">
+			<ul class="nav docs-sidenav">
+				<li<%= sidebar_current("docs-home") %>>
+					<a href="/docs/providers/index.html">&laquo; Documentation Home</a>
+				</li>
+
+				<li<%= sidebar_current("docs-puppetdb-index") %>>
+					<a href="/docs/providers/puppetdb/index.html">PuppetDB Provider</a>
+				</li>
+
+				<li<%= sidebar_current(/^docs-puppetdb-resource/) %>>
+					<a href="#">Resources</a>
+					<ul class="nav nav-visible">
+						<li<%= sidebar_current("docs-puppetdb-resource-certificate") %>>
+							<a href="/docs/providers/puppetdb/r/node.html">puppetdb node</a>
+						</li>
+					</ul>
+				</li>
+			</ul>
+		</div>
+	<% end %>
+
+	<%= yield %>
+<% end %>


### PR DESCRIPTION
This adds a PuppetDB provider with a `puppetdb_node` type. Used as:

```hcl
provider puppetdb {
  url        = "https://puppetdb:8081"
  key        = "certs/my.key"
  cert       = "certs/my.crt"
  ca         = "certs/ca.crt"
}

resource puppetdb_node "foo" {
  certname = "foo.example.com"
}
```

This type will detect if the node is present in the PuppetDB. It exposes various attributes (read-only):

```
id                              = foo.example.com
cached_catalog_status           = 
catalog_environment             = 
catalog_timestamp               = 
certname                        = foo.example.com
deactivated                     = 
expired                         = 
facts_environment               = production
facts_timestamp                 = 2017-03-15T06:10:08.957Z
latest_report_corrective_change = 
latest_report_hash              = c6509b124d494060f667153673eeaddef6abf159
latest_report_status            = failed
report_environment              = production
report_timestamp                = 2017-03-15T06:09:55.894Z
```

and deactivates the node in the PuppetDB when the resource is destroyed.
