### PR TITLE
provider/aws: Add plan-level validation for SG CIDR blocks

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -105,13 +105,19 @@ func resourceAwsSecurityGroup() *schema.Resource {
 						"cidr_blocks": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
 						},
 
 						"ipv6_cidr_blocks": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
 						},
 
 						"security_groups": {
@@ -156,13 +162,19 @@ func resourceAwsSecurityGroup() *schema.Resource {
 						"cidr_blocks": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
 						},
 
 						"ipv6_cidr_blocks": {
 							Type:     schema.TypeList,
 							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
+							Elem: &schema.Schema{
+								Type:         schema.TypeString,
+								ValidateFunc: validateCIDRNetworkAddress,
+							},
 						},
 
 						"prefix_list_ids": {

--- a/builtin/providers/aws/resource_aws_security_group_rule.go
+++ b/builtin/providers/aws/resource_aws_security_group_rule.go
@@ -58,14 +58,20 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateCIDRNetworkAddress,
+				},
 			},
 
 			"ipv6_cidr_blocks": {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateCIDRNetworkAddress,
+				},
 			},
 
 			"prefix_list_ids": {


### PR DESCRIPTION
Adds plan-level validation for both IPv4 and IPv6 CIDR Blocks in an AWS SecurityGroup resource, as well as the AWS Security Group Rule resource.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSecurityGroup_invalidCIDRBlock'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/16 11:32:54 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSecurityGroup_invalidCIDRBlock -timeout 120m
=== RUN   TestAccAWSSecurityGroup_invalidCIDRBlock
--- PASS: TestAccAWSSecurityGroup_invalidCIDRBlock (0.01s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    0.017s
```

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSecurityGroupRule_ExpectInvalidCIDR'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/16 11:46:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSecurityGroupRule_ExpectInvalidCIDR -timeout 120m
=== RUN   TestAccAWSSecurityGroupRule_ExpectInvalidCIDR
--- PASS: TestAccAWSSecurityGroupRule_ExpectInvalidCIDR (0.01s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    0.016s
```
Fixes: #9481 