### PR TITLE
aws: Refactor API mock helpers

### DIFF
--- a/builtin/providers/aws/config_test.go
+++ b/builtin/providers/aws/config_test.go
@@ -1,0 +1,73 @@
+package aws
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	awsCredentials "github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+)
+
+// getMockedAwsApiSession establishes a httptest server to simulate behaviour
+// of a real AWS API server
+func getMockedAwsApiSession(svcName string, endpoints []*awsMockEndpoint) (func(), *session.Session, error) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		buf := new(bytes.Buffer)
+		buf.ReadFrom(r.Body)
+		requestBody := buf.String()
+
+		log.Printf("[DEBUG] Received %s API %q request to %q: %s",
+			svcName, r.Method, r.RequestURI, requestBody)
+
+		for _, e := range endpoints {
+			if r.Method == e.Request.Method && r.RequestURI == e.Request.Uri && requestBody == e.Request.Body {
+				log.Printf("[DEBUG] Mocked %s API responding with %d: %s",
+					svcName, e.Response.StatusCode, e.Response.Body)
+
+				w.WriteHeader(e.Response.StatusCode)
+				w.Header().Set("Content-Type", e.Response.ContentType)
+				w.Header().Set("X-Amzn-Requestid", "1b206dd1-f9a8-11e5-becf-051c60f11c4a")
+				w.Header().Set("Date", time.Now().Format(time.RFC1123))
+
+				fmt.Fprintln(w, e.Response.Body)
+				return
+			}
+		}
+
+		w.WriteHeader(400)
+		return
+	}))
+
+	sc := awsCredentials.NewStaticCredentials("accessKey", "secretKey", "")
+
+	sess, err := session.NewSession(&aws.Config{
+		Credentials:                   sc,
+		Region:                        aws.String("us-east-1"),
+		Endpoint:                      aws.String(ts.URL),
+		CredentialsChainVerboseErrors: aws.Bool(true),
+	})
+
+	return ts.Close, sess, err
+}
+
+type awsMockEndpoint struct {
+	Request  *awsMockRequest
+	Response *awsMockResponse
+}
+
+type awsMockRequest struct {
+	Method string
+	Uri    string
+	Body   string
+}
+
+type awsMockResponse struct {
+	StatusCode  int
+	Body        string
+	ContentType string
+}


### PR DESCRIPTION
This makes helpers generic enough to be useful for any AWS service.

It's cleaner approach and I'd like to use it also in https://github.com/hashicorp/terraform/pull/7568 for mocking EC2 API.

```
make test TEST=./builtin/providers/aws TESTARGS='-run=TestAWSGetAccountInfo -v' 2
>/dev/null
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
go test -i ./builtin/providers/aws || exit 1
echo ./builtin/providers/aws | \
		xargs -t -n4 go test -run=TestAWSGetAccountInfo -v -timeout=30s -parallel=4
=== RUN   TestAWSGetAccountInfo_shouldBeValid_fromEC2Role
--- PASS: TestAWSGetAccountInfo_shouldBeValid_fromEC2Role (0.00s)
=== RUN   TestAWSGetAccountInfo_shouldBeValid_EC2RoleHasPriority
--- PASS: TestAWSGetAccountInfo_shouldBeValid_EC2RoleHasPriority (0.00s)
=== RUN   TestAWSGetAccountInfo_shouldBeValid_fromIamUser
--- PASS: TestAWSGetAccountInfo_shouldBeValid_fromIamUser (0.00s)
=== RUN   TestAWSGetAccountInfo_shouldBeValid_fromGetCallerIdentity
--- PASS: TestAWSGetAccountInfo_shouldBeValid_fromGetCallerIdentity (0.00s)
=== RUN   TestAWSGetAccountInfo_shouldBeValid_fromIamListRoles
--- PASS: TestAWSGetAccountInfo_shouldBeValid_fromIamListRoles (0.00s)
=== RUN   TestAWSGetAccountInfo_shouldBeValid_federatedRole
--- PASS: TestAWSGetAccountInfo_shouldBeValid_federatedRole (0.00s)
=== RUN   TestAWSGetAccountInfo_shouldError_unauthorizedFromIam
--- PASS: TestAWSGetAccountInfo_shouldError_unauthorizedFromIam (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.047s
```