### PR TITLE
Don't interpolate multivariables during walkInput

### DIFF
--- a/terraform/context_input_test.go
+++ b/terraform/context_input_test.go
@@ -658,3 +658,30 @@ func TestContext2Input_hcl(t *testing.T) {
 		t.Fatalf("bad: \n%s", actualStr)
 	}
 }
+
+// adding a list interpolation in fails to interpolate the count variable
+func TestContext2Input_submoduleTriggersInvalidCount(t *testing.T) {
+	input := new(MockUIInput)
+	m := testModule(t, "input-submodule-count")
+	p := testProvider("aws")
+	p.ApplyFn = testApplyFn
+	p.DiffFn = testDiffFn
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		UIInput: input,
+	})
+
+	p.InputFn = func(i UIInput, c *ResourceConfig) (*ResourceConfig, error) {
+		return c, nil
+	}
+	p.ConfigureFn = func(c *ResourceConfig) error {
+		return nil
+	}
+
+	if err := ctx.Input(InputModeStd); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -540,6 +540,13 @@ func (i *Interpolater) computeResourceMultiVariable(
 
 	unknownVariable := unknownVariable()
 
+	// If we're only looking for input, we don't need to expand a
+	// multi-variable. This prevents us from encountering things that should be
+	// known but aren't because the state has yet to be refreshed.
+	if i.Operation == walkInput {
+		return &unknownVariable, nil
+	}
+
 	// Get the information about this resource variable, and verify
 	// that it exists and such.
 	module, cr, err := i.resourceVariableInfo(scope, v)

--- a/terraform/test-fixtures/input-submodule-count/main.tf
+++ b/terraform/test-fixtures/input-submodule-count/main.tf
@@ -1,0 +1,4 @@
+module "mod" {
+  source = "./mod"
+  count = 2
+}

--- a/terraform/test-fixtures/input-submodule-count/mod/main.tf
+++ b/terraform/test-fixtures/input-submodule-count/mod/main.tf
@@ -1,0 +1,11 @@
+variable "count" {
+}
+
+resource "aws_instance" "foo" {
+  count = "${var.count}"
+}
+
+module "submod" {
+  source = "./submod"
+  list = ["${aws_instance.foo.*.id}"]
+}

--- a/terraform/test-fixtures/input-submodule-count/mod/submod/main.tf
+++ b/terraform/test-fixtures/input-submodule-count/mod/submod/main.tf
@@ -1,0 +1,7 @@
+variable "list" {
+  type = "list"
+}
+
+resource "aws_instance" "bar" {
+	count = "${var.list[0]}"
+}


### PR DESCRIPTION
Another unfortunate instance of an `i.Operation ==` check in the interpolator.

We don't need these expanded for input, and if the multivar's count is a
variable, it may be known but not available during the input walk.

Fixes #12742