### PR TITLE
command/push: properly test for local state 

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -138,6 +138,20 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, error) {
 	return local, nil
 }
 
+// IsLocalBackend returns true if the backend is a local backend. We use this
+// for some checks that require a remote backend.
+func (m *Meta) IsLocalBackend(b backend.Backend) bool {
+	// Is it a local backend?
+	bLocal, ok := b.(*backendlocal.Local)
+
+	// If it is, does it not have an alternate state backend?
+	if ok {
+		ok = bLocal.Backend == nil
+	}
+
+	return ok
+}
+
 // Operation initializes a new backend.Operation struct.
 //
 // This prepares the operation. After calling this, the caller is expected

--- a/command/push.go
+++ b/command/push.go
@@ -71,24 +71,6 @@ func (c *PushCommand) Run(args []string) int {
 		return 1
 	}
 
-	/*
-		// Verify the state is remote, we can't push without a remote state
-		s, err := c.State()
-		if err != nil {
-			c.Ui.Error(fmt.Sprintf("Failed to read state: %s", err))
-			return 1
-		}
-		if !s.State().IsRemote() {
-			c.Ui.Error(
-				"Remote state is not enabled. For Atlas to run Terraform\n" +
-					"for you, remote state must be used and configured. Remote\n" +
-					"state via any backend is accepted, not just Atlas. To\n" +
-					"configure remote state, use the `terraform remote config`\n" +
-					"command.")
-			return 1
-		}
-	*/
-
 	// Check if the path is a plan
 	plan, err := c.Plan(configPath)
 	if err != nil {
@@ -122,6 +104,17 @@ func (c *PushCommand) Run(args []string) int {
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+		return 1
+	}
+
+	// We require a non-local backend
+	if c.IsLocalBackend(b) {
+		c.Ui.Error(
+			"Remote state is not enabled. For Atlas to run Terraform\n" +
+				"for you, remote state must be used and configured. Remote\n" +
+				"state via any backend is accepted, not just Atlas. To\n" +
+				"configure remote state, use the `terraform remote config`\n" +
+				"command.")
 		return 1
 	}
 

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -75,6 +75,70 @@ func TestPush_good(t *testing.T) {
 	}
 }
 
+func TestPush_goodBackendInit(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("push-backend-new"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// init backend
+	ui := new(cli.MockUi)
+	ci := &InitCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+	if code := ci.Run(nil); code != 0 {
+		t.Fatalf("bad: %d\n%s", code, ui.ErrorWriter)
+	}
+
+	// Path where the archive will be "uploaded" to
+	archivePath := testTempFile(t)
+	defer os.Remove(archivePath)
+
+	client := &mockPushClient{File: archivePath}
+	ui = new(cli.MockUi)
+	c := &PushCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+
+		client: client,
+	}
+
+	args := []string{
+		"-vcs=false",
+		td,
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	actual := testArchiveStr(t, archivePath)
+	expected := []string{
+		// Expected weird behavior, doesn't affect unpackaging
+		".terraform/",
+		".terraform/",
+		".terraform/terraform.tfstate",
+		".terraform/terraform.tfstate",
+		"main.tf",
+	}
+	if !reflect.DeepEqual(actual, expected) {
+		t.Fatalf("bad: %#v", actual)
+	}
+
+	variables := make(map[string]interface{})
+	if !reflect.DeepEqual(client.UpsertOptions.Variables, variables) {
+		t.Fatalf("bad: %#v", client.UpsertOptions)
+	}
+
+	if client.UpsertOptions.Name != "hello" {
+		t.Fatalf("bad: %#v", client.UpsertOptions)
+	}
+}
+
 func TestPush_noUploadModules(t *testing.T) {
 	// Path where the archive will be "uploaded" to
 	archivePath := testTempFile(t)

--- a/command/test-fixtures/push-backend-new/main.tf
+++ b/command/test-fixtures/push-backend-new/main.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "inmem" {}
+}
+
+atlas { name = "hello" }

--- a/command/test-fixtures/push-no-remote/main.tf
+++ b/command/test-fixtures/push-no-remote/main.tf
@@ -1,0 +1,5 @@
+resource "aws_instance" "foo" {}
+
+atlas {
+    name = "foo"
+}


### PR DESCRIPTION
This fixes the remote state check. This didn't result in any terribly bad behavior: if you ran `init`, push worked fine. If you didn't, then you could get a misleading error message. 