### PR TITLE
Documentation Update: Fix a code sample that uses incorrect syntax.

### DIFF
--- a/website/source/docs/state/environments.html.md
+++ b/website/source/docs/state/environments.html.md
@@ -34,7 +34,7 @@ to switch environments you can use `terraform env select`, etc.
 For example, creating an environment:
 
 ```
-$ terraform env create bar
+$ terraform env new bar
 Created and switched to environment "bar"!
 
 You're now on a new, empty environment. Environments isolate their state,


### PR DESCRIPTION
## Reasoning for docs update

`terraform env create` is not the correct syntax and its usage results in an error.

## Relevant Terraform version

I found this error when using the released`0.9.0`, and it appears in the `master` branch.