### PR TITLE
provider/google: turn compute_instance_group.instances into a set

### DIFF
--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -242,8 +242,8 @@ func resourceComputeInstanceGroupUpdate(d *schema.ResourceData, meta interface{}
 		// to-do check for no instances
 		from_, to_ := d.GetChange("instances")
 
-		from := convertStringArr(from_.([]interface{}))
-		to := convertStringArr(to_.([]interface{}))
+		from := convertStringArr(from_.(*schema.Set).List())
+		to := convertStringArr(to_.(*schema.Set).List())
 
 		if !validInstanceURLs(from) {
 			return fmt.Errorf("Error invalid instance URLs: %v", from)

--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -18,6 +18,8 @@ func resourceComputeInstanceGroup() *schema.Resource {
 		Update: resourceComputeInstanceGroupUpdate,
 		Delete: resourceComputeInstanceGroupDelete,
 
+		SchemaVersion: 1,
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -38,9 +38,10 @@ func resourceComputeInstanceGroup() *schema.Resource {
 			},
 
 			"instances": &schema.Schema{
-				Type:     schema.TypeList,
+				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
 			},
 
 			"named_port": &schema.Schema{
@@ -142,7 +143,7 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 	}
 
 	if v, ok := d.GetOk("instances"); ok {
-		instanceUrls := convertStringArr(v.([]interface{}))
+		instanceUrls := convertStringArr(v.(*schema.Set).List())
 		if !validInstanceURLs(instanceUrls) {
 			return fmt.Errorf("Error invalid instance URLs: %v", instanceUrls)
 		}

--- a/builtin/providers/google/resource_compute_instance_group_migrate.go
+++ b/builtin/providers/google/resource_compute_instance_group_migrate.go
@@ -1,0 +1,74 @@
+package google
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceComputeInstanceGroupMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Compute Instance Group State v0; migrating to v1")
+		is, err := migrateInstanceGroupStateV0toV1(is)
+		if err != nil {
+			return is, err
+		}
+		return is, nil
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateInstanceGroupStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	newInstances := []string{}
+
+	for k, v := range is.Attributes {
+		if !strings.HasPrefix(k, "instances.") {
+			continue
+		}
+
+		if k == "instances.#" {
+			continue
+		}
+
+		// Key is now of the form instances.%d
+		kParts := strings.Split(k, ".")
+
+		// Sanity check: two parts should be there and <N> should be a number
+		badFormat := false
+		if len(kParts) != 2 {
+			badFormat = true
+		} else if _, err := strconv.Atoi(kParts[1]); err != nil {
+			badFormat = true
+		}
+
+		if badFormat {
+			return is, fmt.Errorf("migration error: found instances key in unexpected format: %s", k)
+		}
+
+		newInstances = append(newInstances, v)
+		delete(is.Attributes, k)
+	}
+
+	for _, v := range newInstances {
+		hash := schema.HashString(v)
+		newKey := fmt.Sprintf("instances.%d", hash)
+		is.Attributes[newKey] = v
+	}
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/google/resource_compute_instance_group_migrate_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_migrate_test.go
@@ -1,0 +1,75 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestComputeInstanceGroupMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"change instances from list to set": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"instances.#": "1",
+				"instances.0": "https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instancegroup-test-1",
+				"instances.1": "https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instancegroup-test-0",
+			},
+			Expected: map[string]string{
+				"instances.#":          "1",
+				"instances.764135222":  "https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instancegroup-test-1",
+				"instances.1519187872": "https://www.googleapis.com/compute/v1/projects/project_name/zones/zone_name/instances/instancegroup-test-0",
+			},
+			Meta: &Config{},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "i-abc123",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceComputeInstanceGroupMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}
+
+func TestComputeInstanceGroupMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta *Config
+
+	// should handle nil
+	is, err := resourceComputeInstanceGroupMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceComputeInstanceGroupMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}


### PR DESCRIPTION
Fixes #12213. The issue is that the ListInstances call returns the instances in lexicographical order, so passing them in out of order will lead to a perpetual diff.

Test without change:
```
--- FAIL: TestAccComputeInstanceGroup_outOfOrderInstances (104.68s)
	testing.go:268: Step 0 error: After applying this step, the plan was not empty:

		DIFF:

		UPDATE: google_compute_instance_group.group
		  instances.0: "https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-1" => "https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-2"
		  instances.1: "https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-2" => "https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-1"

		STATE:

		google_compute_instance.ig_instance:
		  ID = instancegroup-test-3a61mts0wh-1
		  can_ip_forward = false
		  create_timeout = 4
		  disk.# = 1
		  disk.0.auto_delete = true
		  disk.0.device_name =
		  disk.0.disk =
		  disk.0.disk_encryption_key_raw =
		  disk.0.disk_encryption_key_sha256 =
		  disk.0.image = debian-8-jessie-v20160803
		  disk.0.scratch = false
		  disk.0.size = 0
		  disk.0.type =
		  machine_type = n1-standard-1
		  metadata.% = 0
		  metadata_fingerprint = Sw05i8BgITo=
		  name = instancegroup-test-3a61mts0wh-1
		  network.# = 0
		  network_interface.# = 1
		  network_interface.0.access_config.# = 0
		  network_interface.0.address = 10.128.0.6
		  network_interface.0.name = nic0
		  network_interface.0.network = default
		  network_interface.0.subnetwork =
		  network_interface.0.subnetwork_project =
		  self_link = https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-1
		  service_account.# = 0
		  tags_fingerprint = 42WmSpB8rSM=
		  zone = us-central1-c
		google_compute_instance.ig_instance_2:
		  ID = instancegroup-test-3a61mts0wh-2
		  can_ip_forward = false
		  create_timeout = 4
		  disk.# = 1
		  disk.0.auto_delete = true
		  disk.0.device_name =
		  disk.0.disk =
		  disk.0.disk_encryption_key_raw =
		  disk.0.disk_encryption_key_sha256 =
		  disk.0.image = debian-8-jessie-v20160803
		  disk.0.scratch = false
		  disk.0.size = 0
		  disk.0.type =
		  machine_type = n1-standard-1
		  metadata.% = 0
		  metadata_fingerprint = Sw05i8BgITo=
		  name = instancegroup-test-3a61mts0wh-2
		  network.# = 0
		  network_interface.# = 1
		  network_interface.0.access_config.# = 0
		  network_interface.0.address = 10.128.0.7
		  network_interface.0.name = nic0
		  network_interface.0.network = default
		  network_interface.0.subnetwork =
		  network_interface.0.subnetwork_project =
		  self_link = https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-2
		  service_account.# = 0
		  tags_fingerprint = 42WmSpB8rSM=
		  zone = us-central1-c
		google_compute_instance_group.group:
		  ID = instancegroup-test-3a61mts0wh
		  description = Terraform test instance group
		  instances.# = 2
		  instances.0 = https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-1
		  instances.1 = https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instances/instancegroup-test-3a61mts0wh-2
		  name = instancegroup-test-3a61mts0wh
		  named_port.# = 2
		  named_port.0.name = http
		  named_port.0.port = 8080
		  named_port.1.name = https
		  named_port.1.port = 8443
		  network = https://www.googleapis.com/compute/v1/projects/danahoffman-145601/global/networks/default
		  self_link = https://www.googleapis.com/compute/v1/projects/danahoffman-145601/zones/us-central1-c/instanceGroups/instancegroup-test-3a61mts0wh
		  size = 2
		  zone = us-central1-c

		  Dependencies:
		    google_compute_instance.ig_instance
		    google_compute_instance.ig_instance_2
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/google	104.805s
```

With change:
```
--- PASS: TestAccComputeInstanceGroup_outOfOrderInstances (96.98s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	97.099s
```