### PR TITLE
config/module: don't panic when referencing undefined module

### DIFF
--- a/config/module/test-fixtures/validate-module-unknown/main.tf
+++ b/config/module/test-fixtures/validate-module-unknown/main.tf
@@ -1,0 +1,3 @@
+resource "null_resource" "var" {
+    key = "${module.unknown.value}"
+}

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -354,8 +354,10 @@ func (t *Tree) Validate() error {
 
 			tree, ok := children[mv.Name]
 			if !ok {
-				// This should never happen because Load watches us
-				panic("module not found in children: " + mv.Name)
+				newErr.Add(fmt.Errorf(
+					"%s: undefined module referenced %s",
+					source, mv.Name))
+				continue
 			}
 
 			found := false

--- a/config/module/tree_test.go
+++ b/config/module/tree_test.go
@@ -424,6 +424,18 @@ func TestTreeValidate_requiredChildVar(t *testing.T) {
 	}
 }
 
+func TestTreeValidate_unknownModule(t *testing.T) {
+	tree := NewTree("", testConfig(t, "validate-module-unknown"))
+
+	if err := tree.Load(testStorage(t), GetModeNone); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if err := tree.Validate(); err == nil {
+		t.Fatal("should error")
+	}
+}
+
 const treeLoadStr = `
 root
   foo (path: foo)


### PR DESCRIPTION
Fixes #12788

We would panic when referencing an output from an undefined module. The
panic above this is correct but in this case Load will not catch
interpolated variables that _reference_ an unloaded/undefined module.
Test included.