### PR TITLE
backend/atlas: accept ATLAS_ADDRESS env var for address

### DIFF
--- a/backend/atlas/backend.go
+++ b/backend/atlas/backend.go
@@ -110,8 +110,8 @@ func (b *Backend) init() {
 			"address": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				Default:     defaultAtlasServer,
 				Description: schemaDescriptions["address"],
+				DefaultFunc: schema.EnvDefaultFunc("ATLAS_ADDRESS", defaultAtlasServer),
 			},
 		},
 

--- a/backend/atlas/backend_test.go
+++ b/backend/atlas/backend_test.go
@@ -1,12 +1,49 @@
 package atlas
 
 import (
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestImpl(t *testing.T) {
 	var _ backend.Backend = new(Backend)
 	var _ backend.CLI = new(Backend)
+}
+
+func TestConfigure_envAddr(t *testing.T) {
+	defer os.Setenv("ATLAS_ADDRESS", os.Getenv("ATLAS_ADDRESS"))
+	os.Setenv("ATLAS_ADDRESS", "http://foo.com")
+
+	b := &Backend{}
+	err := b.Configure(terraform.NewResourceConfig(config.TestRawConfig(t, map[string]interface{}{
+		"name": "foo/bar",
+	})))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if b.stateClient.Server != "http://foo.com" {
+		t.Fatalf("bad: %#v", b.stateClient)
+	}
+}
+
+func TestConfigure_envToken(t *testing.T) {
+	defer os.Setenv("ATLAS_TOKEN", os.Getenv("ATLAS_TOKEN"))
+	os.Setenv("ATLAS_TOKEN", "foo")
+
+	b := &Backend{}
+	err := b.Configure(terraform.NewResourceConfig(config.TestRawConfig(t, map[string]interface{}{
+		"name": "foo/bar",
+	})))
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if b.stateClient.AccessToken != "foo" {
+		t.Fatalf("bad: %#v", b.stateClient)
+	}
 }


### PR DESCRIPTION
This is required for on-premise TFE.