### PR TITLE
provider/github: Randomize repo and team names in acc tests

### DIFF
--- a/builtin/providers/github/resource_github_issue_label.go
+++ b/builtin/providers/github/resource_github_issue_label.go
@@ -2,6 +2,7 @@ package github
 
 import (
 	"context"
+	"log"
 
 	"github.com/google/go-github/github"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -44,11 +45,14 @@ func resourceGithubIssueLabelCreate(d *schema.ResourceData, meta interface{}) er
 	r := d.Get("repository").(string)
 	n := d.Get("name").(string)
 	c := d.Get("color").(string)
-
-	_, _, err := client.Issues.CreateLabel(context.TODO(), meta.(*Organization).name, r, &github.Label{
+	label := github.Label{
 		Name:  &n,
 		Color: &c,
-	})
+	}
+
+	log.Printf("[DEBUG] Creating label: %#v", label)
+	_, resp, err := client.Issues.CreateLabel(context.TODO(), meta.(*Organization).name, r, &label)
+	log.Printf("[DEBUG] Response from creating label: %s", *resp)
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/github/resource_github_team_repository_test.go
+++ b/builtin/providers/github/resource_github_team_repository_test.go
@@ -6,12 +6,14 @@ import (
 	"testing"
 
 	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccGithubTeamRepository_basic(t *testing.T) {
 	var repository github.Repository
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,14 +21,14 @@ func TestAccGithubTeamRepository_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamRepositoryConfig,
+				Config: testAccGithubTeamRepositoryConfig(randString, testRepo),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamRepositoryExists("github_team_repository.test_team_test_repo", &repository),
 					testAccCheckGithubTeamRepositoryRoleState("pull", &repository),
 				),
 			},
 			{
-				Config: testAccGithubTeamRepositoryUpdateConfig,
+				Config: testAccGithubTeamRepositoryUpdateConfig(randString, testRepo),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamRepositoryExists("github_team_repository.test_team_test_repo", &repository),
 					testAccCheckGithubTeamRepositoryRoleState("push", &repository),
@@ -37,13 +39,15 @@ func TestAccGithubTeamRepository_basic(t *testing.T) {
 }
 
 func TestAccGithubTeamRepository_importBasic(t *testing.T) {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamRepositoryConfig,
+				Config: testAccGithubTeamRepositoryConfig(randString, testRepo),
 			},
 			{
 				ResourceName:      "github_team_repository.test_team_test_repo",
@@ -148,9 +152,10 @@ func testAccCheckGithubTeamRepositoryDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccGithubTeamRepositoryConfig string = fmt.Sprintf(`
+func testAccGithubTeamRepositoryConfig(randString, repoName string) string {
+	return fmt.Sprintf(`
 resource "github_team" "test_team" {
-	name = "foo"
+	name = "tf-acc-test-team-repo-%s"
 	description = "Terraform acc test group"
 }
 
@@ -159,11 +164,13 @@ resource "github_team_repository" "test_team_test_repo" {
 	repository = "%s"
 	permission = "pull"
 }
-`, testRepo)
+`, randString, repoName)
+}
 
-var testAccGithubTeamRepositoryUpdateConfig string = fmt.Sprintf(`
+func testAccGithubTeamRepositoryUpdateConfig(randString, repoName string) string {
+	return fmt.Sprintf(`
 resource "github_team" "test_team" {
-	name = "foo"
+	name = "tf-acc-test-team-repo-%s"
 	description = "Terraform acc test group"
 }
 
@@ -172,4 +179,5 @@ resource "github_team_repository" "test_team_test_repo" {
 	repository = "%s"
 	permission = "push"
 }
-`, testRepo)
+`, randString, repoName)
+}

--- a/builtin/providers/github/resource_github_team_test.go
+++ b/builtin/providers/github/resource_github_team_test.go
@@ -6,12 +6,16 @@ import (
 	"testing"
 
 	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccGithubTeam_basic(t *testing.T) {
 	var team github.Team
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	name := fmt.Sprintf("tf-acc-test-%s", randString)
+	updatedName := fmt.Sprintf("tf-acc-test-updated-%s", randString)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,17 +23,17 @@ func TestAccGithubTeam_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGithubTeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamConfig,
+				Config: testAccGithubTeamConfig(randString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamExists("github_team.foo", &team),
-					testAccCheckGithubTeamAttributes(&team, "foo", "Terraform acc test group"),
+					testAccCheckGithubTeamAttributes(&team, name, "Terraform acc test group"),
 				),
 			},
 			{
-				Config: testAccGithubTeamUpdateConfig,
+				Config: testAccGithubTeamUpdateConfig(randString),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamExists("github_team.foo", &team),
-					testAccCheckGithubTeamAttributes(&team, "foo2", "Terraform acc test group - updated"),
+					testAccCheckGithubTeamAttributes(&team, updatedName, "Terraform acc test group - updated"),
 				),
 			},
 		},
@@ -37,13 +41,15 @@ func TestAccGithubTeam_basic(t *testing.T) {
 }
 
 func TestAccGithubTeam_importBasic(t *testing.T) {
+	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubTeamDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamConfig,
+				Config: testAccGithubTeamConfig(randString),
 			},
 			{
 				ResourceName:      "github_team.foo",
@@ -112,18 +118,22 @@ func testAccCheckGithubTeamDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccGithubTeamConfig = `
+func testAccGithubTeamConfig(randString string) string {
+	return fmt.Sprintf(`
 resource "github_team" "foo" {
-	name = "foo"
+	name = "tf-acc-test-%s"
 	description = "Terraform acc test group"
 	privacy = "secret"
 }
-`
+`, randString)
+}
 
-const testAccGithubTeamUpdateConfig = `
+func testAccGithubTeamUpdateConfig(randString string) string {
+	return fmt.Sprintf(`
 resource "github_team" "foo" {
-	name = "foo2"
+	name = "tf-acc-test-updated-%s"
 	description = "Terraform acc test group - updated"
 	privacy = "closed"
 }
-`
+`, randString)
+}


### PR DESCRIPTION
This will help us to get rid of the following failure in acceptance tests:

```
* github_team.test_team: POST https://api.github.com/orgs/terraformtesting/teams: 422 Validation Failed [{Resource:Team Field:name Code:already_exists Message:}]
```

### Test plan

```
make testacc TEST=./builtin/providers/github TESTARGS='-run=TestAccGithub'
```
```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/17 10:33:32 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/github -v -run=TestAccGithub -timeout 120m
=== RUN   TestAccGithubIssueLabel_basic
--- PASS: TestAccGithubIssueLabel_basic (1.90s)
=== RUN   TestAccGithubIssueLabel_importBasic
--- PASS: TestAccGithubIssueLabel_importBasic (0.97s)
=== RUN   TestAccGithubMembership_basic
--- PASS: TestAccGithubMembership_basic (1.30s)
=== RUN   TestAccGithubMembership_importBasic
--- PASS: TestAccGithubMembership_importBasic (1.22s)
=== RUN   TestAccGithubRepositoryCollaborator_basic
--- PASS: TestAccGithubRepositoryCollaborator_basic (1.72s)
=== RUN   TestAccGithubRepositoryCollaborator_importBasic
--- PASS: TestAccGithubRepositoryCollaborator_importBasic (1.71s)
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (2.37s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (1.59s)
=== RUN   TestAccGithubTeamMembership_basic
--- PASS: TestAccGithubTeamMembership_basic (3.53s)
=== RUN   TestAccGithubTeamMembership_importBasic
--- PASS: TestAccGithubTeamMembership_importBasic (1.80s)
=== RUN   TestAccGithubTeamRepository_basic
--- PASS: TestAccGithubTeamRepository_basic (2.61s)
=== RUN   TestAccGithubTeamRepository_importBasic
--- PASS: TestAccGithubTeamRepository_importBasic (1.85s)
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (2.42s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (1.04s)
=== RUN   TestAccGithubUtilRole_validation
--- PASS: TestAccGithubUtilRole_validation (0.00s)
=== RUN   TestAccGithubUtilTwoPartID
--- PASS: TestAccGithubUtilTwoPartID (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/github	26.068s
```