### PR TITLE
provider/openstack: Add fixed_ips computed attribute to port resource

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -98,6 +98,11 @@ func resourceNetworkingPortV2() *schema.Resource {
 					},
 				},
 			},
+			"fixed_ips": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 			"allowed_address_pairs": &schema.Schema{
 				Type:     schema.TypeSet,
 				Optional: true,
@@ -198,14 +203,21 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	d.Set("device_id", p.DeviceID)
 
 	// Convert FixedIPs to list of map
+	// ips2 is used for the `fixed_ips` exported attribute.
 	var ips []map[string]interface{}
+	var ips2 []string
 	for _, ipObject := range p.FixedIPs {
 		ip := make(map[string]interface{})
 		ip["subnet_id"] = ipObject.SubnetID
 		ip["ip_address"] = ipObject.IPAddress
 		ips = append(ips, ip)
+		ips2 = append(ips2, ipObject.IPAddress)
 	}
 	d.Set("fixed_ip", ips)
+
+	// The order of ips2 will be the order returned by the API.
+	// This is usually alphabetical/numerical order.
+	d.Set("fixed_ips", ips2)
 
 	// Convert AllowedAddressPairs to list of map
 	var pairs []map[string]interface{}

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
@@ -102,6 +102,32 @@ func TestAccNetworkingV2Port_multipleFixedIPs(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Port_fixedIPs(t *testing.T) {
+	var network networks.Network
+	var port ports.Port
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Port_fixedIPs,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_port_v2.port_1", "fixed_ips.0", "192.168.199.23"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_port_v2.port_1", "fixed_ips.1", "192.168.199.24"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2PortDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -301,6 +327,36 @@ resource "openstack_networking_port_v2" "port_1" {
   fixed_ip {
     subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
     ip_address = "192.168.199.40"
+  }
+}
+`
+
+const testAccNetworkingV2Port_fixedIPs = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.24"
+  }
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.23"
   }
 }
 `

--- a/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
@@ -95,7 +95,9 @@ The following attributes are exported:
 * `device_owner` - See Argument Reference above.
 * `security_group_ids` - See Argument Reference above.
 * `device_id` - See Argument Reference above.
-* `fixed_ip/ip_address` - See Argument Reference above.
+* `fixed_ip` - See Argument Reference above.
+* `fixed_ips` - The collection of Fixed IP addresses on the port in the order
+  returned by the Network v2 API.
 
 ## Import
 


### PR DESCRIPTION
This commit adds the `fixed_ips` attribute to the
openstack_networking_port_v2 resource. This contains all of the port's
Fixed IPs returned by the Networking v2 API.

/cc @sebastien-prudhomme