### PR TITLE
fix race in hook ui PreApply test

### DIFF
--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -39,6 +39,8 @@ type uiResourceState struct {
 	Start      time.Time
 
 	DoneCh chan struct{} // To be used for cancellation
+
+	done chan struct{} // used to coordinate tests
 }
 
 // uiResourceOp is an enum for operations on a resource
@@ -146,6 +148,7 @@ func (h *UiHook) PreApply(
 		Op:         op,
 		Start:      time.Now().Round(time.Second),
 		DoneCh:     make(chan struct{}),
+		done:       make(chan struct{}),
 	}
 
 	h.l.Lock()
@@ -159,6 +162,7 @@ func (h *UiHook) PreApply(
 }
 
 func (h *UiHook) stillApplying(state uiResourceState) {
+	defer close(state.done)
 	for {
 		select {
 		case <-state.DoneCh:

--- a/command/hook_ui_test.go
+++ b/command/hook_ui_test.go
@@ -65,6 +65,11 @@ func TestUiHookPreApply_periodicTimer(t *testing.T) {
 
 	time.Sleep(3100 * time.Millisecond)
 
+	// stop the background writer
+	uiState := h.resources[n.HumanId()]
+	close(uiState.DoneCh)
+	<-uiState.done
+
 	expectedOutput := `data.aws_availability_zones.available: Destroying... (ID: 2017-03-0...0000 UTC)
 data.aws_availability_zones.available: Still destroying... (ID: 2017-03-0...0000 UTC, 1s elapsed)
 data.aws_availability_zones.available: Still destroying... (ID: 2017-03-0...0000 UTC, 2s elapsed)


### PR DESCRIPTION
Fix a race in the PreApply test, and make the PreApply background task
actually concealable.