### PR TITLE
command: use backendinit instead of initializing legacy directly

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1394,7 +1394,7 @@ The error(s) configuring the legacy remote state:
 const errBackendLegacyUnknown = `
 The legacy remote state type %q could not be found.
 
-Terraform 0.9.0 shipped with backwards compatible for all built-in
+Terraform 0.9.0 shipped with backwards compatibility for all built-in
 legacy remote state types. This error may mean that you were using a
 custom Terraform build that perhaps supported a different type of
 remote state.

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -23,7 +23,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/mapstructure"
 
-	backendlegacy "github.com/hashicorp/terraform/backend/legacy"
 	backendlocal "github.com/hashicorp/terraform/backend/local"
 )
 
@@ -1325,8 +1324,12 @@ func (m *Meta) backendInitFromLegacy(s *terraform.RemoteState) (backend.Backend,
 	}
 	config := terraform.NewResourceConfig(rawC)
 
-	// Initialize the legacy remote backend
-	b := &backendlegacy.Backend{Type: s.Type}
+	// Get the backend
+	f := backendinit.Backend(s.Type)
+	if f == nil {
+		return nil, fmt.Errorf(strings.TrimSpace(errBackendLegacyUnknown), s.Type)
+	}
+	b := f()
 
 	// Configure
 	if err := b.Configure(config); err != nil {
@@ -1381,7 +1384,7 @@ If fixing these errors requires changing your remote state configuration,
 you must switch your configuration to the new remote backend configuration.
 You can learn more about remote backends at the URL below:
 
-TODO: URL
+https://www.terraform.io/docs/backends/index.html
 
 The error(s) configuring the legacy remote state:
 


### PR DESCRIPTION
Fixes #12806

This should've been part of https://github.com/hashicorp/terraform/commit/2c19aa69d9f4d4da43b1cedd17c5484c121fcc18

This is the same issue, just missed a spot. Tests are hard to cover for
this since we're removing the legacy backends one by one, eventually
it'll be gone. A good sign is that we don't import backendlegacy at all
anymore in command/