### PR TITLE
Fix ECS field inconsistency

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -356,8 +356,17 @@ func flattenPlacementStrategy(pss []*ecs.PlacementStrategy) []map[string]interfa
 	results := make([]map[string]interface{}, 0)
 	for _, ps := range pss {
 		c := make(map[string]interface{})
-		c["type"] = *ps.Type
-		c["field"] = strings.ToLower(*ps.Field)
+
+		specialCases := map[string]string{"CPU": "cpu", "MEMORY": "memory"}
+		apiFieldValue := *ps.Field
+		mappedValue, ok := specialCases[apiFieldValue]
+
+		if ok {
+			c["field"] = mappedValue
+		} else {
+			c["field"] = apiFieldValue
+		}
+
 		results = append(results, c)
 	}
 	return results


### PR DESCRIPTION
ECS has some inconsistency in the way it sends down
field names and the way it expects them in the api.

`MEMORY` and `CPU` are expected capitalized and `instanceId` should be sent as
is.

The previous fixed lowercased everything, meaning `instanceId` is being
saved as `instanceid` and causing a change in the resource.

PRs and issues

* https://github.com/hashicorp/terraform/pull/12199
* https://github.com/hashicorp/terraform/issues/11644
* https://github.com/hashicorp/terraform/issues/11844