### PR TITLE
Add the `check_id` out parameter to `circonus_check`.

### DIFF
--- a/builtin/providers/circonus/resource_circonus_check.go
+++ b/builtin/providers/circonus/resource_circonus_check.go
@@ -61,12 +61,13 @@ const (
 
 	// Out parameters for circonus_check
 	checkOutByCollectorAttr        = "check_by_collector"
-	checkOutCheckUUIDsAttr         = "uuids"
+	checkOutIDAttr                 = "check_id"
 	checkOutChecksAttr             = "checks"
 	checkOutCreatedAttr            = "created"
 	checkOutLastModifiedAttr       = "last_modified"
 	checkOutLastModifiedByAttr     = "last_modified_by"
 	checkOutReverseConnectURLsAttr = "reverse_connect_urls"
+	checkOutCheckUUIDsAttr         = "uuids"
 )
 
 const (
@@ -104,10 +105,11 @@ var checkDescriptions = attrDescrs{
 	checkTimeoutAttr:     "The length of time in seconds (and fractions of a second) before the check will timeout if no response is returned to the collector",
 	checkTypeAttr:        "The check type",
 
-	checkOutChecksAttr:             "",
 	checkOutByCollectorAttr:        "",
 	checkOutCheckUUIDsAttr:         "",
+	checkOutChecksAttr:             "",
 	checkOutCreatedAttr:            "",
+	checkOutIDAttr:                 "",
 	checkOutLastModifiedAttr:       "",
 	checkOutLastModifiedByAttr:     "",
 	checkOutReverseConnectURLsAttr: "",
@@ -246,6 +248,10 @@ func resourceCheck() *schema.Resource {
 			},
 
 			// Out parameters
+			checkOutIDAttr: &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			checkOutByCollectorAttr: &schema.Schema{
 				Type:     schema.TypeMap,
 				Computed: true,
@@ -343,6 +349,11 @@ func checkRead(d *schema.ResourceData, meta interface{}) error {
 		checkIDsByCollector[b] = c.Checks[i]
 	}
 
+	var checkID string
+	if len(c.Checks) == 1 {
+		checkID = c.Checks[0]
+	}
+
 	metrics := schema.NewSet(checkMetricChecksum, nil)
 	for _, m := range c.Metrics {
 		metricAttrs := map[string]interface{}{
@@ -403,6 +414,10 @@ func checkRead(d *schema.ResourceData, meta interface{}) error {
 
 	if err := d.Set(checkOutChecksAttr, c.Checks); err != nil {
 		return errwrap.Wrapf(fmt.Sprintf("Unable to store check %q attribute: {{err}}", checkOutChecksAttr), err)
+	}
+
+	if checkID != "" {
+		d.Set(checkOutIDAttr, checkID)
 	}
 
 	d.Set(checkOutCreatedAttr, c.Created)

--- a/builtin/providers/circonus/resource_circonus_check_icmp_ping_test.go
+++ b/builtin/providers/circonus/resource_circonus_check_icmp_ping_test.go
@@ -2,8 +2,10 @@ package circonus
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
+	"github.com/circonus-labs/circonus-gometrics/api/config"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
@@ -20,7 +22,13 @@ func TestAccCirconusCheckICMPPing_basic(t *testing.T) {
 				Config: fmt.Sprintf(testAccCirconusCheckICMPPingConfigFmt, checkName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "active", "true"),
-					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.#", "1"),
+					resource.TestCheckNoResourceAttr("circonus_check.loopback_latency", "check_id"),
+					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "checks.#", "2"),
+					resource.TestMatchResourceAttr("circonus_check.loopback_latency", "checks.0", regexp.MustCompile(config.CheckCIDRegex)),
+					resource.TestMatchResourceAttr("circonus_check.loopback_latency", "checks.1", regexp.MustCompile(config.CheckCIDRegex)),
+					resource.TestCheckNoResourceAttr("circonus_check.loopback_latency", "check_id"),
+					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "check_by_collector.%", "2"),
+					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.#", "2"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "collector.2388330941.id", "/broker/1"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.loopback_latency", "icmp_ping.979664239.availability", "100"),
@@ -88,6 +96,10 @@ resource "circonus_check" "loopback_latency" {
 
   collector {
     id = "/broker/1"
+  }
+
+  collector {
+    id = "/broker/275"
   }
 
   icmp_ping {

--- a/builtin/providers/circonus/resource_circonus_check_json_test.go
+++ b/builtin/providers/circonus/resource_circonus_check_json_test.go
@@ -1,8 +1,10 @@
 package circonus
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/circonus-labs/circonus-gometrics/api/config"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
@@ -16,6 +18,7 @@ func TestAccCirconusCheckJSON_basic(t *testing.T) {
 				Config: testAccCirconusCheckJSONConfig1,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("circonus_check.usage", "active", "true"),
+					resource.TestMatchResourceAttr("circonus_check.usage", "check_id", regexp.MustCompile(config.CheckCIDRegex)),
 					resource.TestCheckResourceAttr("circonus_check.usage", "collector.#", "1"),
 					resource.TestCheckResourceAttr("circonus_check.usage", "collector.2388330941.id", "/broker/1"),
 					resource.TestCheckResourceAttr("circonus_check.usage", "json.#", "1"),

--- a/website/source/docs/providers/circonus/r/check.html.markdown
+++ b/website/source/docs/providers/circonus/r/check.html.markdown
@@ -468,8 +468,27 @@ resource "circonus_check" "tcp_check" {
 
 ## Out Parameters
 
-* `check_by_collector` - Map of each check (value) that was created for every
-  specified broker (key).
+* `check_by_collector` - Maps the ID of the collector (`collector_id`, the map
+  key) to the `check_id` (value) that is registered to a collector.
+
+* `check_id` - If there is only one `collector` specified for the check, this
+  value will be populated with the `check_id`.  If more than one `collector` is
+  specified in the check, then this value will be an empty string.
+  `check_by_collector` will always be populated.
+
+* `checks` - List of `check_id`s created by this `circonus_check`.  There is one
+  element in this list per collector specified in the check.
+
+* `created` - UNIX time at which this check was created.
+
+* `last_modified` - UNIX time at which this check was last modified.
+
+* `last_modified_by` - User ID in Circonus who modified this check last.
+
+* `reverse_connect_urls` - Only relevant to Circonus support.
+
+* `uuids` - List of Check `uuid`s created by this `circonus_check`.  There is
+  one element in this list per collector specified in the check.
 
 ## Import Example
 


### PR DESCRIPTION
This is an important optimization for dynamically created resources
via the `count` attribute.

I'm reasonably certain there will be a merge conflict with #12820 once #12820 is merged.  If/when that happens, I will update this PR with the resolution.