### PR TITLE
Correct handling of network ACL default IPv6 ingress/egress rules

### DIFF
--- a/builtin/providers/aws/resource_aws_default_network_acl.go
+++ b/builtin/providers/aws/resource_aws_default_network_acl.go
@@ -9,11 +9,14 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-// ACL Network ACLs all contain an explicit deny-all rule that cannot be
-// destroyed or changed by users. This rule is numbered very high to be a
+// ACL Network ACLs all contain explicit deny-all rules that cannot be
+// destroyed or changed by users. This rules are numbered very high to be a
 // catch-all.
 // See http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html#default-network-acl
-const awsDefaultAclRuleNumber = 32767
+const (
+	awsDefaultAclRuleNumberIpv4 = 32767
+	awsDefaultAclRuleNumberIpv6 = 32768
+)
 
 func resourceAwsDefaultNetworkAcl() *schema.Resource {
 	return &schema.Resource{
@@ -258,7 +261,8 @@ func revokeAllNetworkACLEntries(netaclId string, meta interface{}) error {
 	for _, e := range networkAcl.Entries {
 		// Skip the default rules added by AWS. They can be neither
 		// configured or deleted by users. See http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_ACLs.html#default-network-acl
-		if *e.RuleNumber == awsDefaultAclRuleNumber {
+		if *e.RuleNumber == awsDefaultAclRuleNumberIpv4 ||
+			*e.RuleNumber == awsDefaultAclRuleNumberIpv6 {
 			continue
 		}
 

--- a/builtin/providers/aws/resource_aws_network_acl.go
+++ b/builtin/providers/aws/resource_aws_network_acl.go
@@ -201,7 +201,8 @@ func resourceAwsNetworkAclRead(d *schema.ResourceData, meta interface{}) error {
 	for _, e := range networkAcl.Entries {
 		// Skip the default rules added by AWS. They can be neither
 		// configured or deleted by users.
-		if *e.RuleNumber == awsDefaultAclRuleNumber {
+		if *e.RuleNumber == awsDefaultAclRuleNumberIpv4 ||
+			*e.RuleNumber == awsDefaultAclRuleNumberIpv6 {
 			continue
 		}
 
@@ -358,7 +359,8 @@ func updateNetworkAclEntries(d *schema.ResourceData, entryType string, conn *ec2
 			// neither modified nor destroyed. They have a custom rule
 			// number that is out of bounds for any other rule. If we
 			// encounter it, just continue. There's no work to be done.
-			if *remove.RuleNumber == awsDefaultAclRuleNumber {
+			if *remove.RuleNumber == awsDefaultAclRuleNumberIpv4 ||
+				*remove.RuleNumber == awsDefaultAclRuleNumberIpv6 {
 				continue
 			}
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/12831.

* Handle IPv6 default rules the same as IPv4 default rules
* A NACL only has IPv6 default rules if the associated VPC has an IPv6 CIDR block, so in the `aws_default_network_acl` resource acceptance tests make the number of hidden rules a variable

Acceptance tests:
```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSDefaultNetworkAcl_basicIpv6Vpc'
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSNetworkAcl_ipv6VpcRules'
```