### PR TITLE
terraform: unknown value for variables not set

### DIFF
--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -60,6 +60,32 @@ func TestContext2Refresh(t *testing.T) {
 	}
 }
 
+func TestContext2Refresh_dataComputedModuleVar(t *testing.T) {
+	p := testProvider("aws")
+	m := testModule(t, "refresh-data-module-var")
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+	})
+
+	p.RefreshFn = nil
+	p.RefreshReturn = &InstanceState{
+		ID: "foo",
+	}
+
+	s, err := ctx.Refresh()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	checkStateString(t, s, `
+<no state>
+module.child:
+  <no state>`)
+}
+
 func TestContext2Refresh_targeted(t *testing.T) {
 	p := testProvider("aws")
 	m := testModule(t, "refresh-targeted")

--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -262,7 +262,7 @@ func (i *Interpolater) valueResourceVar(
 		// If it truly is missing, we'll catch it on a later walk.
 		// This applies only to graph nodes that interpolate during the
 		// config walk, e.g. providers.
-		if i.Operation == walkInput {
+		if i.Operation == walkInput || i.Operation == walkRefresh {
 			result[n] = unknownVariable()
 			return nil
 		}

--- a/terraform/test-fixtures/refresh-data-module-var/child/main.tf
+++ b/terraform/test-fixtures/refresh-data-module-var/child/main.tf
@@ -1,0 +1,6 @@
+variable "key" {}
+
+data "aws_data_source" "foo" {
+  id = "${var.key}"
+}
+

--- a/terraform/test-fixtures/refresh-data-module-var/main.tf
+++ b/terraform/test-fixtures/refresh-data-module-var/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "A" {
+    foo = "bar"
+}
+
+module "child" {
+    source = "child"
+    key    = "${aws_instance.A.id}"
+}


### PR DESCRIPTION
Fixes #12836

Realistically, these should be caught during validation anyways. In this
case, this was causing 12386 because refresh with a data source will
attempt to use module variables. I don't see any clear logic to prune
those module variables or not add them so its easier to return unknown
to cause the data to be computed and not run.