### PR TITLE
Joyent cloud uses user-data for some of their smart datacenter config…

### DIFF
--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -25,6 +25,7 @@ var (
 		"user_script":          "user-script",
 		"user_data":            "user-data",
 		"administrator_pw":     "administrator-pw",
+		"cloud_config":         "cloud-init:user-data",
 	}
 )
 
@@ -185,6 +186,12 @@ func resourceMachine() *schema.Resource {
 			},
 			"user_script": {
 				Description: "user script to run on boot (every boot on SmartMachines)",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
+			"cloud_config": {
+				Description: "copied to machine on boot",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,

--- a/website/source/docs/providers/triton/r/triton_machine.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_machine.html.markdown
@@ -62,6 +62,9 @@ The following arguments are supported:
 * `administrator_pw` - (string)
     The initial password for the Administrator user. Only used for Windows virtual machines.
 
+* `cloud_config` - (string)
+    Populate the cloud-init:user-data field. Cloud config data to pass to the instance. Traditionally user-data is used, however joyent uses that key for their own purposes. At least on ubuntu cloud-init, it expects the cloud_config to be in cloud-init:user-data instead of just user-data.
+
 ## Attribute Reference
 
 The following attributes are exported:

--- a/website/source/docs/providers/triton/r/triton_machine.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_machine.html.markdown
@@ -3,7 +3,7 @@ layout: "triton"
 page_title: "Triton: triton_machine"
 sidebar_current: "docs-triton-firewall"
 description: |-
-    The `triton_machine` resource represents a virtual machine or infrastructure container running in Triton. 
+    The `triton_machine` resource represents a virtual machine or infrastructure container running in Triton.
 ---
 
 # triton\_machine
@@ -17,15 +17,14 @@ Run a SmartOS base-64 machine.
 
 ```
 resource "triton_machine" "test" {
-    name = "example-machine"
-    package = "g3-standard-0.25-smartos"
-    image = "842e6fa6-6e9b-11e5-8402-1b490459e334"
+  name    = "example-machine"
+  package = "g3-standard-0.25-smartos"
+  image   = "842e6fa6-6e9b-11e5-8402-1b490459e334"
 
-    tags = {
-        hello = "world"
-    }
+  tags = {
+    hello = "world"
+  }
 }
-                
 ```
 
 ## Argument Reference
@@ -44,8 +43,8 @@ The following arguments are supported:
 * `image` - (string, Required)
     The UUID of the image to provision.
 
-* `networks` - (list of string)
-    A list of the IDs of the desired networks for the machine.
+* `nic` - (list of NIC blocks, Optional)
+    NICs associated with the machine. The fields allowed in a `NIC` block are defined below.
 
 * `firewall_enabled` - (boolean)  Default: `false`
     Whether the cloud firewall should be enabled for this machine.
@@ -65,17 +64,21 @@ The following arguments are supported:
 * `cloud_config` - (string)
     Populate the cloud-init:user-data field. Cloud config data to pass to the instance. Traditionally user-data is used, however joyent uses that key for their own purposes. At least on ubuntu cloud-init, it expects the cloud_config to be in cloud-init:user-data instead of just user-data.
 
+The nested `nic` block supports the following:
+* `network` - (string, Optional)
+    The network id to attach to the network interface. It will be hex, in the format: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.
+
 ## Attribute Reference
 
 The following attributes are exported:
 
-* `id` - (string) - The identifier representing the firewall rule in Triton. 
-* `type` - (string) - The type of the machine (`smartmachine` or `virtualmachine`). 
-* `state` - (string) - The current state of the machine. 
-* `dataset` - (string) - The dataset URN with which the machine was provisioned. 
-* `memory` - (int) - The amount of memory the machine has (in Mb). 
-* `disk` - (int) - The amount of disk the machine has (in Gb). 
-* `ips` - (list of strings) - IP addresses of the machine. 
-* `primaryip` - (string) - The primary (public) IP address for the machine. 
-* `created` - (string) - The time at which the machine was created. 
-* `updated` - (string) - The time at which the machine was last updated. 
+* `id` - (string) - The identifier representing the firewall rule in Triton.
+* `type` - (string) - The type of the machine (`smartmachine` or `virtualmachine`).
+* `state` - (string) - The current state of the machine.
+* `dataset` - (string) - The dataset URN with which the machine was provisioned.
+* `memory` - (int) - The amount of memory the machine has (in Mb).
+* `disk` - (int) - The amount of disk the machine has (in Gb).
+* `ips` - (list of strings) - IP addresses of the machine.
+* `primaryip` - (string) - The primary (public) IP address for the machine.
+* `created` - (string) - The time at which the machine was created.
+* `updated` - (string) - The time at which the machine was last updated.


### PR DESCRIPTION
In Joyent's images, at least for ubuntu, user-data is used for joyent infrastructure and cloud-init needs to be uploaded to cloud-init:user-data instead of just user-data.

See notes in: https://docs.joyent.com/public-cloud/instances/virtual-machines/images/linux/ubuntu-certified#cloud-init-examples

`Cloud-init data is provided as metadata with the cloud-init:user-data key. Joyent boot-time data is supplied as metadata with the user-data and user-script keys.`

I've built and tested this in my own infrastructure in joyent, with v0.9.0. This successfully placed the key onto the machine, and a basic cloud-config template was applied.

```  cloud_config = <<EOF
#cloud-config
write_files:
-   content: test123
    owner: root:root
    path: /tmp/testfile123
    permissions: '0644'
EOF
```

```
ubuntu@dev-infra-01:~$ cat /tmp/testfile123 
test123ubuntu@dev-infra-01:~$
```
