### PR TITLE
Fix go vet error

### DIFF
--- a/builtin/providers/aws/resource_aws_kms_key.go
+++ b/builtin/providers/aws/resource_aws_kms_key.go
@@ -178,7 +178,7 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 		KeyId: metadata.KeyId,
 	})
 	if err != nil {
-		return fmt.Errorf("Failed to get KMS key tags (key: %s): %s", metadata.KeyId, err)
+		return fmt.Errorf("Failed to get KMS key tags (key: %s): %s", d.Get("key_id").(string), err)
 	}
 	d.Set("tags", tagsToMapKMS(tagList.Tags))
 


### PR DESCRIPTION
```
go vet .
builtin/providers/aws/resource_aws_kms_key.go:181: arg metadata.KeyId for printf verb %s of wrong type: *string
exit status 1
```

Fix vet error introduced in #12243