### PR TITLE
Adding ability to send cloud-init user-data to triton machines

### DIFF
--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -25,6 +25,7 @@ var (
 		"user_script":          "user-script",
 		"user_data":            "user-data",
 		"administrator_pw":     "administrator-pw",
+		"cloud_config":         "cloud-init:user-data",
 	}
 )
 
@@ -185,6 +186,12 @@ func resourceMachine() *schema.Resource {
 			},
 			"user_script": {
 				Description: "user script to run on boot (every boot on SmartMachines)",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+			},
+			"cloud_config": {
+				Description: "copied to machine on boot",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,

--- a/website/source/docs/providers/triton/r/triton_machine.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_machine.html.markdown
@@ -61,6 +61,9 @@ The following arguments are supported:
 * `administrator_pw` - (string)
     The initial password for the Administrator user. Only used for Windows virtual machines.
 
+* `cloud_config` - (string)
+    Populate the cloud-init:user-data field. Cloud config data to pass to the instance. Traditionally user-data is used, however joyent uses that key for their own purposes. At least on ubuntu cloud-init, it expects the cloud_config to be in cloud-init:user-data instead of just user-data.
+
 The nested `nic` block supports the following:
 * `network` - (string, Optional)
     The network id to attach to the network interface. It will be hex, in the format: `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`.


### PR DESCRIPTION
In Joyent's images, at least for ubuntu, user-data is used for joyent infrastructure and cloud-init needs to be uploaded to cloud-init:user-data instead of just user-data.

See notes in: https://docs.joyent.com/public-cloud/instances/virtual-machines/images/linux/ubuntu-certified#cloud-init-examples

`Cloud-init data is provided as metadata with the cloud-init:user-data key. Joyent boot-time data is supplied as metadata with the user-data and user-script keys.`

I've built and tested this in my own infrastructure in joyent, with v0.9.0. This successfully placed the key onto the machine, and a basic cloud-config template was applied.

```
#cloud-config
write_files:
-   content: test123
    owner: root:root
    path: /tmp/testfile123
    permissions: '0644'
EOF
```
```
ubuntu@dev-infra-01:~$ cat /tmp/testfile123 
test123ubuntu@dev-infra-01:~$
```