### PR TITLE
Allow dnsimple_record.priority attribute to be set

### DIFF
--- a/builtin/providers/dnsimple/resource_dnsimple_record.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record.go
@@ -58,6 +58,7 @@ func resourceDNSimpleRecord() *schema.Resource {
 			"priority": {
 				Type:     schema.TypeString,
 				Computed: true,
+				Optional: true,
 			},
 		},
 	}
@@ -74,6 +75,10 @@ func resourceDNSimpleRecordCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 	if attr, ok := d.GetOk("ttl"); ok {
 		newRecord.TTL, _ = strconv.Atoi(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("priority"); ok {
+		newRecord.Priority, _ = strconv.Atoi(attr.(string))
 	}
 
 	log.Printf("[DEBUG] DNSimple Record create configuration: %#v", newRecord)
@@ -140,6 +145,10 @@ func resourceDNSimpleRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 	}
 	if attr, ok := d.GetOk("ttl"); ok {
 		updateRecord.TTL, _ = strconv.Atoi(attr.(string))
+	}
+
+	if attr, ok := d.GetOk("priority"); ok {
+		updateRecord.Priority, _ = strconv.Atoi(attr.(string))
 	}
 
 	log.Printf("[DEBUG] DNSimple Record update configuration: %#v", updateRecord)

--- a/builtin/providers/dnsimple/resource_dnsimple_record_test.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record_test.go
@@ -37,6 +37,33 @@ func TestAccDNSimpleRecord_Basic(t *testing.T) {
 	})
 }
 
+func TestAccDNSimpleRecord_CreateMxWithPriority(t *testing.T) {
+	var record dnsimple.ZoneRecord
+	domain := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_mx, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "name", ""),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "domain", domain),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "value", "mx.example.com"),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "priority", "5"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDNSimpleRecord_Updated(t *testing.T) {
 	var record dnsimple.ZoneRecord
 	domain := os.Getenv("DNSIMPLE_DOMAIN")
@@ -70,6 +97,47 @@ func TestAccDNSimpleRecord_Updated(t *testing.T) {
 						"dnsimple_record.foobar", "domain", domain),
 					resource.TestCheckResourceAttr(
 						"dnsimple_record.foobar", "value", "192.168.0.11"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDNSimpleRecord_UpdatedMx(t *testing.T) {
+	var record dnsimple.ZoneRecord
+	domain := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_mx, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "name", ""),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "domain", domain),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "value", "mx.example.com"),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "priority", "5"),
+				),
+			},
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_mx_new_value, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "name", ""),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "domain", domain),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "value", "mx2.example.com"),
+					resource.TestCheckResourceAttr(
+						"dnsimple_record.foobar", "priority", "10"),
 				),
 			},
 		},
@@ -165,4 +233,26 @@ resource "dnsimple_record" "foobar" {
 	value = "192.168.0.11"
 	type = "A"
 	ttl = 3600
+}`
+
+const testAccCheckDNSimpleRecordConfig_mx = `
+resource "dnsimple_record" "foobar" {
+	domain = "%s"
+
+	name = ""
+	value = "mx.example.com"
+	type = "MX"
+	ttl = 3600
+	priority = 5
+}`
+
+const testAccCheckDNSimpleRecordConfig_mx_new_value = `
+resource "dnsimple_record" "foobar" {
+	domain = "%s"
+
+	name = ""
+	value = "mx2.example.com"
+	type = "MX"
+	ttl = 3600
+	priority = 10
 }`

--- a/website/source/docs/providers/dnsimple/r/record.html.markdown
+++ b/website/source/docs/providers/dnsimple/r/record.html.markdown
@@ -43,6 +43,7 @@ The following arguments are supported:
 * `value` - (Required) The value of the record
 * `type` - (Required) The type of the record
 * `ttl` - (Optional) The TTL of the record
+* `priority` - (Optional) The priority of the record - only useful for some record types
 
 
 ## Attributes Reference


### PR DESCRIPTION
This is an updated version of PR #9128. Unlike the original PR, this one isn't blocked by an upstream change (thanks to #10760) and is hopefully ready for review.

Some DNS record types (like MX) allow a priority to specified, and the ability to do so is important in many environments.

This diff makes `dnsimple_record.priority` optional, allowing it to be used in terraform configs like so:

```
    resource "dnsimple_record" "mx1" {
        domain = "example.com"
        name = ""
        value = "mx1.example.com"
        type = "MX"
        priority = "1"
    }

    resource "dnsimple_record" "mx2" {
        domain = "example.com"
        name = ""
        value = "mx2.example.com"
        type = "MX"
        priority = "2"
    }
```

An earlier issue (https://github.com/hashicorp/terraform/issues/1058) proposed this feature , but was eventually closed due to inactivity.
