### PR TITLE
docs: update Cloudflare casing

### DIFF
--- a/website/source/docs/providers/cloudflare/index.html.markdown
+++ b/website/source/docs/providers/cloudflare/index.html.markdown
@@ -3,13 +3,13 @@ layout: "cloudflare"
 page_title: "Provider: Cloudflare"
 sidebar_current: "docs-cloudflare-index"
 description: |-
-  The CloudFlare provider is used to interact with the DNS resources supported by CloudFlare. The provider needs to be configured with the proper credentials before it can be used.
+  The Cloudflare provider is used to interact with the DNS resources supported by Cloudflare. The provider needs to be configured with the proper credentials before it can be used.
 ---
 
-# CloudFlare Provider
+# Cloudflare Provider
 
-The CloudFlare provider is used to interact with the
-DNS resources supported by CloudFlare. The provider needs to be configured
+The Cloudflare provider is used to interact with the
+DNS resources supported by Cloudflare. The provider needs to be configured
 with the proper credentials before it can be used.
 
 Use the navigation to the left to read about the available resources.
@@ -17,7 +17,7 @@ Use the navigation to the left to read about the available resources.
 ## Example Usage
 
 ```
-# Configure the CloudFlare provider
+# Configure the Cloudflare provider
 provider "cloudflare" {
   email = "${var.cloudflare_email}"
   token = "${var.cloudflare_token}"

--- a/website/source/docs/providers/cloudflare/r/record.html.markdown
+++ b/website/source/docs/providers/cloudflare/r/record.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "cloudflare"
-page_title: "CloudFlare: cloudflare_record"
+page_title: "Cloudflare: cloudflare_record"
 sidebar_current: "docs-cloudflare-resource-record"
 description: |-
   Provides a Cloudflare record resource.
@@ -33,7 +33,7 @@ The following arguments are supported:
 * `type` - (Required) The type of the record
 * `ttl` - (Optional) The TTL of the record
 * `priority` - (Optional) The priority of the record
-* `proxied` - (Optional) Whether the record gets CloudFlares origin protection.
+* `proxied` - (Optional) Whether the record gets Cloudflare's origin protection.
 
 ## Attributes Reference
 
@@ -46,5 +46,5 @@ The following attributes are exported:
 * `ttl` - The TTL of the record
 * `priority` - The priority of the record
 * `hostname` - The FQDN of the record
-* `proxied` - (Optional) Whether the record gets CloudFlares origin protection.
+* `proxied` - (Optional) Whether the record gets Cloudflare's origin protection.
 

--- a/website/source/docs/providers/index.html.markdown
+++ b/website/source/docs/providers/index.html.markdown
@@ -16,6 +16,6 @@ Terraform is agnostic to the underlying platforms by supporting providers. A
 provider is responsible for understanding API interactions and exposing
 resources. Providers generally are an IaaS (e.g. AWS, GCP, Microsoft Azure,
 OpenStack), PaaS (e.g. Heroku), or SaaS services (e.g. Atlas, DNSimple,
-CloudFlare).
+Cloudflare).
 
 Use the navigation to the left to read about the available providers.

--- a/website/source/intro/use-cases.html.markdown
+++ b/website/source/intro/use-cases.html.markdown
@@ -22,7 +22,7 @@ non-trivial applications quickly need many add-ons and external services.
 
 Terraform can be used to codify the setup required for a Heroku application, ensuring
 that all the required add-ons are available, but it can go even further: configuring
-DNSimple to set a CNAME, or setting up CloudFlare as a CDN for the
+DNSimple to set a CNAME, or setting up Cloudflare as a CDN for the
 app. Best of all, Terraform can do all of this in under 30 seconds without
 using a web interface.
 

--- a/website/source/intro/vs/cloudformation.html.markdown
+++ b/website/source/intro/vs/cloudformation.html.markdown
@@ -17,7 +17,7 @@ Terraform similarly uses configuration files to detail the infrastructure
 setup, but it goes further by being both cloud-agnostic and enabling
 multiple providers and services to be combined and composed. For example,
 Terraform can be used to orchestrate an AWS and OpenStack cluster simultaneously,
-while enabling 3rd-party providers like CloudFlare and DNSimple to be integrated
+while enabling 3rd-party providers like Cloudflare and DNSimple to be integrated
 to provide CDN and DNS services. This enables Terraform to represent and
 manage the entire infrastructure with its supporting services, instead of
 only the subset that exists within a single provider. It provides a single

--- a/website/source/layouts/cloudflare.erb
+++ b/website/source/layouts/cloudflare.erb
@@ -7,7 +7,7 @@
                 </li>
 
 				<li<%= sidebar_current("docs-cloudflare-index") %>>
-				<a href="/docs/providers/cloudflare/index.html">CloudFlare Provider</a>
+				<a href="/docs/providers/cloudflare/index.html">Cloudflare Provider</a>
                 </li>
 
 				<li<%= sidebar_current(/^docs-cloudflare-resource/) %>>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -223,7 +223,7 @@
 					        </li>
 
 						<li<%= sidebar_current("docs-providers-cloudflare") %>>
-							<a href="/docs/providers/cloudflare/index.html">CloudFlare</a>
+							<a href="/docs/providers/cloudflare/index.html">Cloudflare</a>
 						</li>
 
 						<li<%= sidebar_current("docs-providers-cloudstack") %>>


### PR DESCRIPTION
It changed with the logo, for brand reasons.

https://www.cloudflare.com/trademark/