### PR TITLE
provider/aws: Add Cognito Identity Pool Roles Attachment

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -261,6 +261,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_config_configuration_recorder_status":     resourceAwsConfigConfigurationRecorderStatus(),
 			"aws_config_delivery_channel":                  resourceAwsConfigDeliveryChannel(),
 			"aws_cognito_identity_pool":                    resourceAwsCognitoIdentityPool(),
+			"aws_cognito_identity_pool_roles_attachment":   resourceAwsCognitoIdentityPoolRolesAttachment(),
 			"aws_autoscaling_lifecycle_hook":               resourceAwsAutoscalingLifecycleHook(),
 			"aws_cloudwatch_metric_alarm":                  resourceAwsCloudWatchMetricAlarm(),
 			"aws_codedeploy_app":                           resourceAwsCodeDeployApp(),

--- a/builtin/providers/aws/resource_aws_cognito_identity_pool_roles_attachment.go
+++ b/builtin/providers/aws/resource_aws_cognito_identity_pool_roles_attachment.go
@@ -1,0 +1,315 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"bytes"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsCognitoIdentityPoolRolesAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsCognitoIdentityPoolRolesAttachmentCreate,
+		Read:   resourceAwsCognitoIdentityPoolRolesAttachmentRead,
+		Update: resourceAwsCognitoIdentityPoolRolesAttachmentUpdate,
+		Delete: resourceAwsCognitoIdentityPoolRolesAttachmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"identity_pool_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"role_mappings": {
+				Type:     schema.TypeList,
+				Optional: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"role_mapping": {
+							Type:     schema.TypeSet,
+							Required: true,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"key": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+									"value": {
+										Type:     schema.TypeSet,
+										MaxItems: 1,
+										Required: true,
+										Elem: &schema.Resource{
+											Schema: map[string]*schema.Schema{
+												"ambiguous_role_resolution": {
+													Type:         schema.TypeString,
+													ValidateFunc: validateCognitoRoleMappingsAmbiguousRoleResolution,
+													Optional:     true, // Required if Type equals Token or Rules.
+												},
+												"rules_configuration": {
+													Type:     schema.TypeSet,
+													MaxItems: 1,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"rules": {
+																Type:     schema.TypeList,
+																Required: true,
+																MaxItems: 25,
+																Elem: &schema.Resource{
+																	Schema: map[string]*schema.Schema{
+																		"claim": {
+																			Type:         schema.TypeString,
+																			Required:     true,
+																			ValidateFunc: validateCognitoRoleMappingsRulesClaim,
+																		},
+																		"match_type": {
+																			Type:         schema.TypeString,
+																			Required:     true,
+																			ValidateFunc: validateCognitoRoleMappingsRulesMatchType,
+																		},
+																		"role_arn": {
+																			Type:         schema.TypeString,
+																			Required:     true,
+																			ValidateFunc: validateArn,
+																		},
+																		"value": {
+																			Type:         schema.TypeString,
+																			Required:     true,
+																			ValidateFunc: validateCognitoRoleMappingsRulesValue,
+																		},
+																	},
+																},
+															},
+														},
+													},
+												},
+												"type": {
+													Type:         schema.TypeString,
+													Required:     true,
+													ValidateFunc: validateCognitoRoleMappingsType,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+
+			"roles": {
+				Type:     schema.TypeMap,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"authenticated": {
+							Type:         schema.TypeString,
+							ValidateFunc: validateArn,
+							Optional:     true, // Required if unauthenticated isn't defined.
+						},
+						"unauthenticated": {
+							Type:         schema.TypeString,
+							ValidateFunc: validateArn,
+							Optional:     true, // Required if authenticated isn't defined.
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsCognitoIdentityPoolRolesAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoconn
+	log.Print("[DEBUG] Creating Cognito Identity Pool Roles Association")
+
+	// Validates role keys to be either authenticated or unauthenticated,
+	// since ValidateFunc validates only the value not the key.
+	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles"); len(errors) > 0 {
+		return fmt.Errorf("Error validating Roles: %v", errors)
+	}
+
+	params := &cognitoidentity.SetIdentityPoolRolesInput{
+		IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
+		Roles:          expandCognitoIdentityPoolRoles(d.Get("roles").(map[string]interface{})),
+	}
+
+	if v, ok := d.GetOk("role_mappings"); ok {
+		rms := v.([]interface{})[0].(map[string]interface{})
+		errors := validateRoleMappings(rms["role_mapping"].(*schema.Set).List())
+
+		if len(errors) > 0 {
+			return fmt.Errorf("Error validating ambiguous role resolution: %v", errors)
+		}
+
+		params.RoleMappings = expandCognitoIdentityPoolRoleMappingsAttachment(v.([]interface{}))
+	}
+
+	_, err := conn.SetIdentityPoolRoles(params)
+	if err != nil {
+		return fmt.Errorf("Error creating Cognito Identity Pool Roles Association: %s", err)
+	}
+
+	d.SetId(d.Get("identity_pool_id").(string))
+
+	return resourceAwsCognitoIdentityPoolRolesAttachmentRead(d, meta)
+}
+
+func resourceAwsCognitoIdentityPoolRolesAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoconn
+	log.Printf("[DEBUG] Reading Cognito Identity Pool Roles Association: %s", d.Id())
+
+	ip, err := conn.GetIdentityPoolRoles(&cognitoidentity.GetIdentityPoolRolesInput{
+		IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceNotFoundException" {
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	if err := d.Set("roles", flattenCognitoIdentityPoolRoles(ip.Roles)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting roles error: %#v", err)
+	}
+
+	if err := d.Set("role_mappings", flattenCognitoIdentityPoolRoleMappingsAttachment(ip.RoleMappings)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting role mappings error: %#v", err)
+	}
+
+	return nil
+}
+
+func resourceAwsCognitoIdentityPoolRolesAttachmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoconn
+	log.Printf("[DEBUG] Updating Cognito Identity Pool Roles Association: %s", d.Id())
+
+	// Validates role keys to be either authenticated or unauthenticated,
+	// since ValidateFunc validates only the value not the key.
+	if errors := validateCognitoRoles(d.Get("roles").(map[string]interface{}), "roles"); len(errors) > 0 {
+		return fmt.Errorf("Error validating Roles: %v", errors)
+	}
+
+	params := &cognitoidentity.SetIdentityPoolRolesInput{
+		IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
+		Roles:          expandCognitoIdentityPoolRoles(d.Get("roles").(map[string]interface{})),
+	}
+
+	if d.HasChange("role_mappings") {
+		v, ok := d.GetOk("role_mappings")
+		var mappings []interface{}
+
+		if ok {
+			rms := v.([]interface{})[0].(map[string]interface{})
+			errors := validateRoleMappings(rms["role_mapping"].(*schema.Set).List())
+
+			if len(errors) > 0 {
+				return fmt.Errorf("Error validating ambiguous role resolution: %v", errors)
+			}
+			mappings = v.([]interface{})
+		} else {
+			mappings = []interface{}{}
+		}
+
+		params.RoleMappings = expandCognitoIdentityPoolRoleMappingsAttachment(mappings)
+	}
+
+	_, err := conn.SetIdentityPoolRoles(params)
+	if err != nil {
+		return fmt.Errorf("Error updating Cognito Identity Pool Roles Association: %s", err)
+	}
+
+	d.SetId(d.Get("identity_pool_id").(string))
+
+	return resourceAwsCognitoIdentityPoolRolesAttachmentRead(d, meta)
+}
+
+func resourceAwsCognitoIdentityPoolRolesAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cognitoconn
+	log.Printf("[DEBUG] Deleting Cognito Identity Pool Roles Association: %s", d.Id())
+
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := conn.SetIdentityPoolRoles(&cognitoidentity.SetIdentityPoolRolesInput{
+			IdentityPoolId: aws.String(d.Get("identity_pool_id").(string)),
+			Roles:          expandCognitoIdentityPoolRoles(make(map[string]interface{})),
+			RoleMappings:   expandCognitoIdentityPoolRoleMappingsAttachment([]interface{}{}),
+		})
+
+		if err == nil {
+			return nil
+		}
+
+		return resource.NonRetryableError(err)
+	})
+}
+
+// Validating that each role_mapping ambiguous_role_resolution
+// is defined when "type" equals Token or Rules.
+func validateRoleMappings(roleMappings []interface{}) []error {
+	errors := make([]error, 0)
+
+	for _, r := range roleMappings {
+		rm := r.(map[string]interface{})
+		roleMapping := rm["value"].(*schema.Set).List()
+
+		// If Type equals "Token" or "Rules", ambiguous_role_resolution must be defined.
+		// This should be removed as soon as we can have a ValidateFuncAgainst callable on the schema.
+		if err := validateCognitoRoleMappingsAmbiguousRoleResolutionAgainstType(roleMapping[0].(map[string]interface{})); len(err) > 0 {
+			errors = append(errors, fmt.Errorf("Role Mapping %q: %v", rm["key"].(string), err))
+		}
+
+		// Validating that Rules Configuration is defined when Type equals Rules
+		// but not defined when Type equals Token.
+		if err := validateCognitoRoleMappingsRulesConfiguration(roleMapping[0].(map[string]interface{})); len(err) > 0 {
+			errors = append(errors, fmt.Errorf("Role Mapping %q: %v", rm["key"].(string), err))
+		}
+	}
+
+	return errors
+}
+
+func cognitoRoleMappingHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["key"].(string)))
+
+	return hashcode.String(buf.String())
+}
+
+func cognitoRoleMappingValueHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", m["type"].(string)))
+	if d, ok := m["ambiguous_role_resolution"]; ok {
+		buf.WriteString(fmt.Sprintf("%s-", d.(string)))
+	}
+
+	return hashcode.String(buf.String())
+}
+
+func cognitoRoleMappingRulesConfigurationHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	for _, rule := range m["rules"].([]interface{}) {
+		r := rule.(map[string]interface{})
+		buf.WriteString(fmt.Sprintf("%s-", r["claim"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", r["match_type"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", r["role_arn"].(string)))
+		buf.WriteString(fmt.Sprintf("%s-", r["value"].(string)))
+	}
+
+	return hashcode.String(buf.String())
+}

--- a/builtin/providers/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_cognito_identity_pool_roles_attachment_test.go
@@ -1,0 +1,458 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/cognitoidentity"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSCognitoIdentityPoolRolesAttachment_basic(t *testing.T) {
+	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+	updatedName := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(updatedName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings(t *testing.T) {
+	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mappings.#", "0"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappings(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mappings.#", "1"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsUpdated(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mappings.#", "1"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+				),
+			},
+			{
+				Config: testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists("aws_cognito_identity_pool_roles_attachment.main"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "identity_pool_id"),
+					resource.TestCheckResourceAttr("aws_cognito_identity_pool_roles_attachment.main", "role_mappings.#", "0"),
+					resource.TestCheckResourceAttrSet("aws_cognito_identity_pool_roles_attachment.main", "roles.authenticated"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithAmbiguousRoleResolutionError(t *testing.T) {
+	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithAmbiguousRoleResolutionError(name),
+				ExpectError: regexp.MustCompile(`Error validating ambiguous role resolution`),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithRulesTypeError(t *testing.T) {
+	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithRulesTypeError(name),
+				ExpectError: regexp.MustCompile(`rules_configuration is required for Rules`),
+			},
+		},
+	})
+}
+
+func TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithTokenTypeError(t *testing.T) {
+	name := fmt.Sprintf("%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithTokenTypeError(name),
+				ExpectError: regexp.MustCompile(`rules_configuration must not be set for Token based role mapping`),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSCognitoIdentityPoolRolesAttachmentExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Cognito Identity Pool Roles Attachment ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).cognitoconn
+
+		_, err := conn.GetIdentityPoolRoles(&cognitoidentity.GetIdentityPoolRolesInput{
+			IdentityPoolId: aws.String(rs.Primary.Attributes["identity_pool_id"]),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSCognitoIdentityPoolRolesAttachmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*AWSClient).cognitoconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_cognito_identity_pool_roles_attachment" {
+			continue
+		}
+
+		_, err := conn.GetIdentityPoolRoles(&cognitoidentity.GetIdentityPoolRolesInput{
+			IdentityPoolId: aws.String(rs.Primary.Attributes["identity_pool_id"]),
+		})
+
+		if err != nil {
+			if wserr, ok := err.(awserr.Error); ok && wserr.Code() == "ResourceNotFoundException" {
+				return nil
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+const baseAWSCognitoIdentityPoolRolesAttachmentConfig = `
+resource "aws_cognito_identity_pool" "main" {
+  identity_pool_name               = "identity pool %s"
+  allow_unauthenticated_identities = false
+
+  supported_login_providers {
+    "graph.facebook.com" = "7346241598935555"
+  }
+}
+
+# Unauthenticated Role
+resource "aws_iam_role" "unauthenticated" {
+  name = "cognito_unauthenticated_%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "cognito-identity.amazonaws.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "cognito-identity.amazonaws.com:aud": "${aws_cognito_identity_pool.main.id}"
+        },
+        "ForAnyValue:StringLike": {
+          "cognito-identity.amazonaws.com:amr": "unauthenticated"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "unauthenticated" {
+  name = "unauthenticated_policy_%s"
+  role = "${aws_iam_role.unauthenticated.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "mobileanalytics:PutEvents",
+        "cognito-sync:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+# Authenticated Role
+resource "aws_iam_role" "authenticated" {
+  name = "cognito_authenticated_%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "cognito-identity.amazonaws.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "cognito-identity.amazonaws.com:aud": "${aws_cognito_identity_pool.main.id}"
+        },
+        "ForAnyValue:StringLike": {
+          "cognito-identity.amazonaws.com:amr": "authenticated"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "authenticated" {
+  name = "authenticated_policy_%s"
+  role = "${aws_iam_role.authenticated.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "mobileanalytics:PutEvents",
+        "cognito-sync:*",
+        "cognito-identity:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+`
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_basic(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig+`
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`, name, name, name, name, name)
+}
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappings(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig+`
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  role_mappings {
+    role_mapping {
+      key   = "graph.facebook.com"
+      value = {
+        ambiguous_role_resolution = "AuthenticatedRole"
+        type                      = "Rules"
+
+        rules_configuration {
+          rules {
+            claim      = "isAdmin"
+            match_type = "Equals"
+            role_arn   = "${aws_iam_role.authenticated.arn}"
+            value      = "paid"
+          }
+        }
+      }
+    }
+  }
+
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`, name, name, name, name, name)
+}
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsUpdated(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig+`
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  role_mappings {
+    role_mapping {
+      key   = "graph.facebook.com"
+      value = {
+        ambiguous_role_resolution = "AuthenticatedRole"
+        type                      = "Rules"
+
+        rules_configuration {
+          rules {
+            claim      = "isPaid"
+            match_type = "Equals"
+            role_arn   = "${aws_iam_role.authenticated.arn}"
+            value      = "unpaid"
+          }
+        }
+      }
+    }
+  }
+
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`, name, name, name, name, name)
+}
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithAmbiguousRoleResolutionError(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig+`
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  role_mappings {
+    role_mapping {
+      key   = "graph.facebook.com"
+      value = {
+        type = "Rules"
+
+        rules_configuration {
+          rules {
+            claim      = "isAdmin"
+            match_type = "Equals"
+            role_arn   = "${aws_iam_role.authenticated.arn}"
+            value      = "paid"
+          }
+        }
+      }
+    }
+  }
+
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`, name, name, name, name, name)
+}
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithRulesTypeError(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig+`
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  role_mappings {
+    role_mapping {
+      key   = "graph.facebook.com"
+      value = {
+        ambiguous_role_resolution = "AuthenticatedRole"
+        type = "Rules"
+      }
+    }
+  }
+
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`, name, name, name, name, name)
+}
+
+func testAccAWSCognitoIdentityPoolRolesAttachmentConfig_roleMappingsWithTokenTypeError(name string) string {
+	return fmt.Sprintf(baseAWSCognitoIdentityPoolRolesAttachmentConfig+`
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  role_mappings {
+    role_mapping {
+      key   = "graph.facebook.com"
+      value = {
+        ambiguous_role_resolution = "AuthenticatedRole"
+        type = "Token"
+
+        rules_configuration {
+          rules {
+            claim      = "isAdmin"
+            match_type = "Equals"
+            role_arn   = "${aws_iam_role.authenticated.arn}"
+            value      = "paid"
+          }
+        }
+      }
+    }
+  }
+
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+`, name, name, name, name, name)
+}

--- a/website/source/docs/providers/aws/r/cognito_identity_pool_roles_attachment.markdown
+++ b/website/source/docs/providers/aws/r/cognito_identity_pool_roles_attachment.markdown
@@ -1,0 +1,145 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cognito_identity_pool_roles_attachment"
+sidebar_current: "docs-aws-resource-cognito-identity-pool-roles-attachment"
+description: |-
+  Provides an AWS Cognito Identity Pool Roles Attachment.
+---
+
+# aws\_cognito\_identity\_pool\_roles\_attachment
+
+Provides an AWS Cognito Identity Pool Roles Attachment.
+
+## Example Usage
+
+```
+resource "aws_cognito_identity_pool" "main" {
+  identity_pool_name               = "identity pool"
+  allow_unauthenticated_identities = false
+
+  supported_login_providers {
+    "graph.facebook.com" = "7346241598935555"
+  }
+}
+
+resource "aws_iam_role" "authenticated" {
+  name = "cognito_authenticated"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "cognito-identity.amazonaws.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "cognito-identity.amazonaws.com:aud": "${aws_cognito_identity_pool.main.id}"
+        },
+        "ForAnyValue:StringLike": {
+          "cognito-identity.amazonaws.com:amr": "authenticated"
+        }
+      }
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "authenticated" {
+  name = "authenticated_policy"
+  role = "${aws_iam_role.authenticated.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "mobileanalytics:PutEvents",
+        "cognito-sync:*",
+        "cognito-identity:*"
+      ],
+      "Resource": [
+        "*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_cognito_identity_pool_roles_attachment" "main" {
+  identity_pool_id = "${aws_cognito_identity_pool.main.id}"
+
+  role_mappings {
+    role_mapping {
+      key   = "graph.facebook.com"
+      value = {
+        ambiguous_role_resolution = "AuthenticatedRole"
+        type                      = "Rules"
+
+        rules_configuration {
+          rules {
+            claim      = "isAdmin"
+            match_type = "Equals"
+            role_arn   = "${aws_iam_role.authenticated.arn}"
+            value      = "paid"
+          }
+        }
+      }
+    }
+  }
+
+  roles {
+    "authenticated" = "${aws_iam_role.authenticated.arn}"
+  }
+}
+```
+
+## Argument Reference
+
+The Cognito Identity Pool Roles Attachment argument layout is a structure composed of several sub-resources - these resources are laid out below.
+
+* `identity_pool_id` (Required) - An identity pool ID in the format REGION:GUID.
+* `role_mappings` (Optional) - A List of [Role Mapping](#role-mappings).
+* `roles` (Required) - The map of roles associated with this pool. For a given role, the key will be either "authenticated" or "unauthenticated" and the value will be the Role ARN.
+
+#### Role Mappings
+
+* `role_mapping` (Optional) - A set of [Role Mapping entries](#role-mapping-entries).
+
+#### Role Mapping Entries
+
+* `key` (Required) - A string identifying the identity provider, for example, "graph.facebook.com" or "cognito-idp-east-1.amazonaws.com/us-east-1_abcdefghi:app_client_id".
+* `value` (Required) - A [Role Mapping](#role-mapping) structure.
+
+#### Role Mapping
+
+* `ambiguous_role_resolution` (Optional) - Specifies the action to be taken if either no rules match the claim value for the Rules type, or there is no cognito:preferred_role claim and there are multiple cognito:roles matches for the Token type. `Required` if you specify Token or Rules as the Type.
+* `rules_configuration` (Optional) - The [Rules Configuration](#rules-configuration) to be used for mapping users to roles.
+* `type` (Required) - The role mapping type.
+
+#### Rules Configuration
+
+* `rules` (Required) - An array of [rules](#rules). You can specify up to 25 rules per identity provider. Rules are evaluated in order. The first one to match specifies the role.
+
+#### Rules
+
+* `claim` (Required) - The claim name that must be present in the token, for example, "isAdmin" or "paid".
+* `match_type` (Required) - The match condition that specifies how closely the claim value in the IdP token must match Value.
+* `role_arn` (Required) - The role ARN.
+* `value` (Required) - A brief string that the claim must match, for example, "paid" or "yes".
+
+## Attributes Reference
+
+In addition to the arguments, which are exported, the following attributes are exported:
+
+* `id` - The identity pool ID.
+* `identity_pool_id` (Required) - An identity pool ID in the format REGION:GUID.
+* `role_mappings` (Optional) - The List of [Role Mapping](#role-mappings).
+* `roles` (Required) - The map of roles associated with this pool. For a given role, the key will be either "authenticated" or "unauthenticated" and the value will be the Role ARN.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -351,6 +351,10 @@
                         <li<%= sidebar_current("docs-aws-resource-cognito-identity-pool") %>>
                             <a href="/docs/providers/aws/r/cognito_identity_pool.html">aws_cognito_identity_pool</a>
                         </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-cognito-identity-pool-roles-attachment") %>>
+                            <a href="/docs/providers/aws/r/cognito_identity_pool_roles_attachment.html">aws_cognito_identity_pool_roles_attachment</a>
+                        </li>
                     </ul>
                 </li>
 


### PR DESCRIPTION
## Description
This adds the AWS Cognito Identity Roles association resource, based on the following API: http://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_SetIdentityPoolRoles.html

## Related issues
* https://github.com/hashicorp/terraform/issues/8309

## Tests
```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCognitoIdentityPoolRolesAttachment_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/21 20:27:48 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCognitoIdentityPoolRolesAttachment_ -timeout 120m
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_basic
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_basic (59.64s)
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappings (103.70s)
=== RUN   TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithError
--- PASS: TestAccAWSCognitoIdentityPoolRolesAttachment_roleMappingsWithError (17.80s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    181.171s
```

## TODOs
- [x] Add the Cognito Identity Roles Resource
- [x] Add Cognito Identity Roles Resource validation
- [x] Add the Cognito Identity Roles Resource documentation
- [x] Add Cognito Identity Roles Resource test cases