### PR TITLE
provider/arukas: Increase timeout to 15mins & use standard helper

### DIFF
--- a/builtin/providers/arukas/provider.go
+++ b/builtin/providers/arukas/provider.go
@@ -35,7 +35,7 @@ func Provider() terraform.ResourceProvider {
 			"timeout": &schema.Schema{
 				Type:        schema.TypeInt,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc(JSONTimeoutParamName, "600"),
+				DefaultFunc: schema.EnvDefaultFunc(JSONTimeoutParamName, "900"),
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{


### PR DESCRIPTION
A few Arukas tests keep failing, specifically with this output:

```
=== RUN   TestAccArukasContainer_Import
--- FAIL: TestAccArukasContainer_Import (627.64s)
    testing.go:268: Step 0 error: Error applying: 1 error(s) occurred:
        
        * arukas_container.foobar: 1 error(s) occurred:
        
        * arukas_container.foobar: Timeout: sleepUntilUp
FAIL
```

Therefore I decided to increase the default timeout from 10 to 15 minutes and also replace the custom waiter logic with standard helper which should also provide us more details when/if this times out again.

### Test plan
```
make testacc TEST=./builtin/providers/arukas TESTARGS='-run=TestAccArukas'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/18 14:59:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/arukas -v -run=TestAccArukas -timeout 120m
=== RUN   TestAccArukasContainer_Basic
--- PASS: TestAccArukasContainer_Basic (84.99s)
=== RUN   TestAccArukasContainer_Update
--- PASS: TestAccArukasContainer_Update (165.89s)
=== RUN   TestAccArukasContainer_Minimum
--- PASS: TestAccArukasContainer_Minimum (85.09s)
=== RUN   TestAccArukasContainer_Import
--- PASS: TestAccArukasContainer_Import (93.70s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/arukas	429.688s
```