### PR TITLE
provider/aws: Allow aws_alb subnets to change

### DIFF
--- a/builtin/providers/aws/resource_aws_alb.go
+++ b/builtin/providers/aws/resource_aws_alb.go
@@ -69,7 +69,6 @@ func resourceAwsAlb() *schema.Resource {
 			"subnets": {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				ForceNew: true,
 				Required: true,
 				Set:      schema.HashString,
 			},
@@ -310,6 +309,20 @@ func resourceAwsAlbUpdate(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Failure Setting ALB Security Groups: %s", err)
 		}
 
+	}
+
+	if d.HasChange("subnets") {
+		subnets := expandStringList(d.Get("subnets").(*schema.Set).List())
+
+		params := &elbv2.SetSubnetsInput{
+			LoadBalancerArn: aws.String(d.Id()),
+			Subnets:         subnets,
+		}
+
+		_, err := elbconn.SetSubnets(params)
+		if err != nil {
+			return fmt.Errorf("Failure Setting ALB Subnets: %s", err)
+		}
 	}
 
 	return resourceAwsAlbRead(d, meta)

--- a/builtin/providers/aws/resource_aws_alb_test.go
+++ b/builtin/providers/aws/resource_aws_alb_test.go
@@ -179,6 +179,35 @@ func TestAccAWSALB_updatedSecurityGroups(t *testing.T) {
 	})
 }
 
+func TestAccAWSALB_updatedSubnets(t *testing.T) {
+	var pre, post elbv2.LoadBalancer
+	albName := fmt.Sprintf("testaccawsalb-basic-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb.alb_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBConfig_basic(albName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBExists("aws_alb.alb_test", &pre),
+					resource.TestCheckResourceAttr("aws_alb.alb_test", "subnets.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSALBConfig_updateSubnets(albName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBExists("aws_alb.alb_test", &post),
+					resource.TestCheckResourceAttr("aws_alb.alb_test", "subnets.#", "3"),
+					testAccCheckAWSAlbARNs(&pre, &post),
+				),
+			},
+		},
+	})
+}
+
 // TestAccAWSALB_noSecurityGroup regression tests the issue in #8264,
 // where if an ALB is created without a security group, a default one
 // is assigned.
@@ -391,6 +420,73 @@ resource "aws_vpc" "alb_test" {
 
 resource "aws_subnet" "alb_test" {
   count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}`, albName)
+}
+
+func testAccAWSALBConfig_updateSubnets(albName string) string {
+	return fmt.Sprintf(`resource "aws_alb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24", "10.0.3.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 3
   vpc_id                  = "${aws_vpc.alb_test.id}"
   cidr_block              = "${element(var.subnets, count.index)}"
   map_public_ip_on_launch = true


### PR DESCRIPTION
Fixes: #12764

AWS ALB Allows the Subnets to be changed using the SetSubnets func -
previously we set ForceNew: true on this change

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSALB_'                                                                  ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/18 16:55:52 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSALB_ -timeout 120m
=== RUN   TestAccAWSALB_basic
--- PASS: TestAccAWSALB_basic (342.95s)
=== RUN   TestAccAWSALB_generatedName
--- PASS: TestAccAWSALB_generatedName (362.05s)
=== RUN   TestAccAWSALB_namePrefix
--- PASS: TestAccAWSALB_namePrefix (311.21s)
=== RUN   TestAccAWSALB_tags
--- PASS: TestAccAWSALB_tags (344.05s)
=== RUN   TestAccAWSALB_updatedSecurityGroups
--- PASS: TestAccAWSALB_updatedSecurityGroups (515.61s)
=== RUN   TestAccAWSALB_updatedSubnets
--- PASS: TestAccAWSALB_updatedSubnets (313.94s)
=== RUN   TestAccAWSALB_noSecurityGroup
--- PASS: TestAccAWSALB_noSecurityGroup (293.54s)
=== RUN   TestAccAWSALB_accesslogs
--- PASS: TestAccAWSALB_accesslogs (492.01s)
PASS
ok	github.com/hashicorp/terraform/builtin/providers/aws	2975.402s
```