### PR TITLE
provider/pagerduty: Validate credentials

### DIFF
--- a/builtin/providers/pagerduty/config.go
+++ b/builtin/providers/pagerduty/config.go
@@ -37,7 +37,7 @@ func (c *Config) Client() (*pagerduty.Client, error) {
 		// if we get a 401 response back we return an error to the user
 		if _, err := client.ListAbilities(); err != nil {
 			if isUnauthorized(err) {
-				return nil, fmt.Errorf(invalidCreds)
+				return nil, fmt.Errorf(fmt.Sprintf("%s\n%s", err, invalidCreds))
 			}
 			return nil, err
 		}

--- a/builtin/providers/pagerduty/config.go
+++ b/builtin/providers/pagerduty/config.go
@@ -1,6 +1,7 @@
 package pagerduty
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/PagerDuty/go-pagerduty"
@@ -11,9 +12,30 @@ type Config struct {
 	Token string
 }
 
+const invalidCredentials = `
+
+No valid credentials found for PagerDuty provider.
+Please see https://www.terraform.io/docs/providers/pagerduty/index.html
+for more information on providing credentials for this provider.
+`
+
 // Client returns a new PagerDuty client
 func (c *Config) Client() (*pagerduty.Client, error) {
+	// Validate that the PagerDuty token is set
+	if c.Token == "" {
+		return nil, fmt.Errorf(invalidCredentials)
+	}
+
 	client := pagerduty.NewClient(c.Token)
+
+	// Validate the credentials by calling the abilities endpoint,
+	// if we get a 401 response back we return an error to the user
+	if _, err := client.ListAbilities(); err != nil {
+		if isUnauthorized(err) {
+			return nil, fmt.Errorf(invalidCredentials)
+		}
+		return nil, err
+	}
 
 	log.Printf("[INFO] PagerDuty client configured")
 

--- a/builtin/providers/pagerduty/config.go
+++ b/builtin/providers/pagerduty/config.go
@@ -16,7 +16,7 @@ type Config struct {
 	SkipCredsValidation bool
 }
 
-const invalidCredentials = `
+const invalidCreds = `
 
 No valid credentials found for PagerDuty provider.
 Please see https://www.terraform.io/docs/providers/pagerduty/index.html
@@ -27,7 +27,7 @@ for more information on providing credentials for this provider.
 func (c *Config) Client() (*pagerduty.Client, error) {
 	// Validate that the PagerDuty token is set
 	if c.Token == "" {
-		return nil, fmt.Errorf(invalidCredentials)
+		return nil, fmt.Errorf(invalidCreds)
 	}
 
 	client := pagerduty.NewClient(c.Token)
@@ -37,7 +37,7 @@ func (c *Config) Client() (*pagerduty.Client, error) {
 		// if we get a 401 response back we return an error to the user
 		if _, err := client.ListAbilities(); err != nil {
 			if isUnauthorized(err) {
-				return nil, fmt.Errorf(invalidCredentials)
+				return nil, fmt.Errorf(invalidCreds)
 			}
 			return nil, err
 		}

--- a/builtin/providers/pagerduty/config_test.go
+++ b/builtin/providers/pagerduty/config_test.go
@@ -1,0 +1,28 @@
+package pagerduty
+
+import (
+	"testing"
+)
+
+// Test config with an empty token
+func TestConfigEmptyToken(t *testing.T) {
+	config := Config{
+		Token: "",
+	}
+
+	if _, err := config.Client(); err == nil {
+		t.Fatalf("expected error, but got nil")
+	}
+}
+
+// Test config with invalid token but with SkipCredsValidation
+func TestConfigSkipCredsValidation(t *testing.T) {
+	config := Config{
+		Token:               "foo",
+		SkipCredsValidation: true,
+	}
+
+	if _, err := config.Client(); err != nil {
+		t.Fatalf("error: expected the client to not fail: %v", err)
+	}
+}

--- a/builtin/providers/pagerduty/errors.go
+++ b/builtin/providers/pagerduty/errors.go
@@ -9,3 +9,7 @@ func isNotFound(err error) bool {
 
 	return false
 }
+
+func isUnauthorized(err error) bool {
+	return strings.Contains(err.Error(), "HTTP response code: 401")
+}

--- a/builtin/providers/pagerduty/provider.go
+++ b/builtin/providers/pagerduty/provider.go
@@ -20,6 +20,7 @@ func Provider() terraform.ResourceProvider {
 			"skip_credentials_validation": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				Default:  false,
 			},
 		},
 

--- a/builtin/providers/pagerduty/provider.go
+++ b/builtin/providers/pagerduty/provider.go
@@ -16,6 +16,11 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("PAGERDUTY_TOKEN", nil),
 			},
+
+			"skip_credentials_validation": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -40,7 +45,11 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(data *schema.ResourceData) (interface{}, error) {
-	config := Config{Token: data.Get("token").(string)}
+	config := Config{
+		Token:               data.Get("token").(string),
+		SkipCredsValidation: data.Get("skip_credentials_validation").(bool),
+	}
+
 	log.Println("[INFO] Initializing PagerDuty client")
 	return config.Client()
 }

--- a/website/source/docs/providers/pagerduty/index.html.markdown
+++ b/website/source/docs/providers/pagerduty/index.html.markdown
@@ -39,4 +39,4 @@ resource "pagerduty_user" "earline" {
 The following arguments are supported:
 
 * `token` - (Required) The v2 authorization token. See [API Documentation](https://v2.developer.pagerduty.com/docs/authentication) for more information.
-* `skip_credentials_validation` - (Optional) Skip the credentials validation via the PagerDuty API.
+* `skip_credentials_validation` - (Optional) Skip validation of the token against the PagerDuty API.

--- a/website/source/docs/providers/pagerduty/index.html.markdown
+++ b/website/source/docs/providers/pagerduty/index.html.markdown
@@ -39,3 +39,4 @@ resource "pagerduty_user" "earline" {
 The following arguments are supported:
 
 * `token` - (Required) The v2 authorization token. See [API Documentation](https://v2.developer.pagerduty.com/docs/authentication) for more information.
+* `skip_credentials_validation` - (Optional) Skip the credentials validation via the PagerDuty API.


### PR DESCRIPTION
This PR adds token validation to the PagerDuty provider.

Previously if the token was missing (empty string) or invalid, 
an error message like this was displayed to the user:

```bash
* data.pagerduty_user.me: Response did not contain formatted error: Could not decode JSON response: EOF. HTTP response code: 401. Raw response: &{Status:401 Unauthorized StatusCode:401 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Connection:[keep-alive] X-Request-Id:[444f0bcbd1fc02a3ab93e8833c9e3c4c] Server:[nginx] Content-Type:[text/html; charset=utf-8] Status:[401 Unauthorized] X-Ua-Compatible:[IE=Edge,chrome=1] Cache-Control:[no-cache] Date:[Tue, 14 Mar 2017 22:01:56 GMT]] Body:0xc4201ce340 ContentLength:-1 TransferEncoding:[chunked] Close:false Uncompressed:false Trailer:map[] Request:0xc4200de300 TLS:0xc4200aa370}
```

To make the error a bit more user-friendly we instead display this error message if the token is missing or invalid:

No token
```bash
$ terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

Error refreshing state: 1 error(s) occurred:

* provider.pagerduty:

No valid credentials found for PagerDuty provider.
Please see https://www.terraform.io/docs/providers/pagerduty/index.html
for more information on providing credentials for this provider.
```

Invalid token
```bash
$ terraform plan                                                                                                                                                          Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

Error refreshing state: 1 error(s) occurred:

* provider.pagerduty: Response did not contain formatted error: Could not decode JSON response: EOF. HTTP response code: 401. Raw response: &{Status:401 Unauthorized StatusCode:401 Proto:HTTP/1.1 ProtoMajor:1 ProtoMinor:1 Header:map[Connection:[keep-alive] Status:[401 Unauthorized] X-Ua-Compatible:[IE=Edge,chrome=1] Server:[nginx] Date:[Sun, 19 Mar 2017 13:14:46 GMT] X-Request-Id:[b3342ecc6a5a067dd1c048b4e7f62728] Content-Type:[text/html; charset=utf-8] Cache-Control:[no-cache]] Body:0xc420406080 ContentLength:-1 TransferEncoding:[chunked] Close:false Uncompressed:false Trailer:map[] Request:0xc4201fa600 TLS:0xc4201e53f0}


No valid credentials found for PagerDuty provider.
Please see https://www.terraform.io/docs/providers/pagerduty/index.html
for more information on providing credentials for this provider.
 ```