### PR TITLE
Closes #12376 - implements aws_instances data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_instance.go
+++ b/builtin/providers/aws/data_source_aws_instance.go
@@ -6,196 +6,189 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func dataSourceAwsInstance() *schema.Resource {
-	return &schema.Resource{
-		Read: dataSourceAwsInstanceRead,
+func awsInstanceSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"ami": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"instance_type": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"instance_state": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"availability_zone": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"tenancy": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"key_name": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"public_dns": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"public_ip": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"private_dns": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"private_ip": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"iam_instance_profile": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"subnet_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"network_interface_id": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"associate_public_ip_address": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"ebs_optimized": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"source_dest_check": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"monitoring": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"user_data": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"security_groups": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"vpc_security_group_ids": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"ephemeral_block_device": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"device_name": {
+						Type:     schema.TypeString,
+						Required: true,
+					},
 
-		Schema: map[string]*schema.Schema{
-			"filter":        dataSourceFiltersSchema(),
-			"tags":          dataSourceTagsSchema(),
-			"instance_tags": tagsSchemaComputed(),
-			"instance_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-			"ami": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"instance_type": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"instance_state": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"availability_zone": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"tenancy": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"key_name": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"public_dns": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"public_ip": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"private_dns": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"private_ip": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"iam_instance_profile": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"subnet_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"network_interface_id": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"associate_public_ip_address": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"ebs_optimized": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"source_dest_check": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"monitoring": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"user_data": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
-			"security_groups": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"vpc_security_group_ids": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
-			},
-			"ephemeral_block_device": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"device_name": {
-							Type:     schema.TypeString,
-							Required: true,
-						},
+					"virtual_name": {
+						Type:     schema.TypeString,
+						Optional: true,
+					},
 
-						"virtual_name": {
-							Type:     schema.TypeString,
-							Optional: true,
-						},
-
-						"no_device": {
-							Type:     schema.TypeBool,
-							Optional: true,
-						},
+					"no_device": {
+						Type:     schema.TypeBool,
+						Optional: true,
 					},
 				},
 			},
-			"ebs_block_device": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"delete_on_termination": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
+		},
+		"ebs_block_device": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"delete_on_termination": {
+						Type:     schema.TypeBool,
+						Computed: true,
+					},
 
-						"device_name": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					"device_name": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
 
-						"encrypted": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
+					"encrypted": {
+						Type:     schema.TypeBool,
+						Computed: true,
+					},
 
-						"iops": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
+					"iops": {
+						Type:     schema.TypeInt,
+						Computed: true,
+					},
 
-						"snapshot_id": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					"snapshot_id": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
 
-						"volume_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
+					"volume_size": {
+						Type:     schema.TypeInt,
+						Computed: true,
+					},
 
-						"volume_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					"volume_type": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},
-			"root_block_device": {
-				Type:     schema.TypeSet,
-				Computed: true,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"delete_on_termination": {
-							Type:     schema.TypeBool,
-							Computed: true,
-						},
+		},
+		"root_block_device": {
+			Type:     schema.TypeSet,
+			Computed: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"delete_on_termination": {
+						Type:     schema.TypeBool,
+						Computed: true,
+					},
 
-						"iops": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
+					"iops": {
+						Type:     schema.TypeInt,
+						Computed: true,
+					},
 
-						"volume_size": {
-							Type:     schema.TypeInt,
-							Computed: true,
-						},
+					"volume_size": {
+						Type:     schema.TypeInt,
+						Computed: true,
+					},
 
-						"volume_type": {
-							Type:     schema.TypeString,
-							Computed: true,
-						},
+					"volume_type": {
+						Type:     schema.TypeString,
+						Computed: true,
 					},
 				},
 			},
@@ -203,14 +196,63 @@ func dataSourceAwsInstance() *schema.Resource {
 	}
 }
 
-// dataSourceAwsInstanceRead performs the instanceID lookup
-func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
+func dataSourceAwsInstance() *schema.Resource {
+	s := map[string]*schema.Schema{
+		"filter":        dataSourceFiltersSchema(),
+		"tags":          dataSourceTagsSchema(),
+		"instance_tags": tagsSchemaComputed(),
+		"instance_id": {
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
+	}
+	for k, v := range awsInstanceSchema() {
+		s[k] = v
+	}
+	return &schema.Resource{
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			return dataSourceAwsInstanceRead(d, meta, false)
+		},
+		Schema: s,
+	}
+}
+
+func dataSourceAwsInstances() *schema.Resource {
+	return &schema.Resource{
+		Read: func(d *schema.ResourceData, meta interface{}) error {
+			return dataSourceAwsInstanceRead(d, meta, true)
+		},
+		Schema: map[string]*schema.Schema{
+			"filter":        dataSourceFiltersSchema(),
+			"tags":          dataSourceTagsSchema(),
+			"instance_tags": tagsSchemaComputed(),
+			"instance_ids": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"instances": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Resource{Schema: awsInstanceSchema()},
+			},
+		},
+	}
+}
+
+func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}, multi bool) error {
 	conn := meta.(*AWSClient).ec2conn
 
 	filters, filtersOk := d.GetOk("filter")
 	instanceID, instanceIDOk := d.GetOk("instance_id")
+	if multi {
+		instanceID, instanceIDOk = d.GetOk("instance_ids")
+	}
 	tags, tagsOk := d.GetOk("instance_tags")
 
+	// Exit if none of the optional query parameters were provided
 	if filtersOk == false && instanceIDOk == false && tagsOk == false {
 		return fmt.Errorf("One of filters, instance_tags, or instance_id must be assigned")
 	}
@@ -220,7 +262,11 @@ func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	if filtersOk {
 		params.Filters = buildAwsDataSourceFilters(filters.(*schema.Set))
 	}
-	if instanceIDOk {
+	if instanceIDOk && multi {
+		for _, id := range instanceID.([]interface{}) {
+			params.InstanceIds = append(params.InstanceIds, aws.String(id.(string)))
+		}
+	} else if instanceIDOk {
 		params.InstanceIds = []*string{aws.String(instanceID.(string))}
 	}
 	if tagsOk {
@@ -235,14 +281,8 @@ func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	// If no instances were returned, return
-	if len(resp.Reservations) == 0 {
-		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
-	}
-
+	// Loop through reservations, and remove terminated instances, populate instance slice
 	var filteredInstances []*ec2.Instance
-
-	// loop through reservations, and remove terminated instances, populate instance slice
 	for _, res := range resp.Reservations {
 		for _, instance := range res.Instances {
 			if instance.State != nil && *instance.State.Name != "terminated" {
@@ -251,35 +291,60 @@ func dataSourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	var instance *ec2.Instance
-	if len(filteredInstances) < 1 {
-		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	// Handle case for aws_instance data source
+	if !multi {
+		if len(filteredInstances) < 1 {
+			return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+		}
+		if len(filteredInstances) > 1 {
+			return fmt.Errorf("Your query returned more than one result. Please try a more specific search criteria.")
+		}
+		log.Printf("[DEBUG] aws_instance - Single Instance ID found: %s", *filteredInstances[0].InstanceId)
+		if _, err := instanceDescriptionAttributes(d, filteredInstances[0], conn); err != nil {
+			return err
+		}
+		return nil
 	}
 
-	// (TODO: Support a list of instances to be returned)
-	// Possibly with a different data source that returns a list of individual instance data sources
-	if len(filteredInstances) > 1 {
-		return fmt.Errorf("Your query returned more than one result. Please try a more " +
-			"specific search criteria.")
-	} else {
-		instance = filteredInstances[0]
+	// Handle case for aws_instances data source
+	instances := make([]map[string]interface{}, 0, len(filteredInstances))
+	instanceIds := make([]string, 0, len(filteredInstances))
+	instanceResource := &schema.Resource{Schema: awsInstanceSchema()}
+	instanceData := instanceResource.Data(nil)
+	for _, i := range filteredInstances {
+		// Use ResourceData, so we can reuse single instance attributes code
+		if instanceData, err = instanceDescriptionAttributes(instanceData, i, conn); err != nil {
+			return err
+		}
+
+		// Rebuild map from ResourceData, so it can be a part of aws_instances
+		mapping := make(map[string]interface{})
+		for k, _ := range instanceResource.Schema {
+			if v, ok := instanceData.GetOk(k); ok {
+				mapping[k] = v
+			}
+		}
+		log.Printf("[DEBUG] aws_instances - Instance ID found: %s", mapping["id"])
+		instances = append(instances, mapping)
+		instanceIds = append(instanceIds, mapping["id"].(string))
 	}
 
-	log.Printf("[DEBUG] aws_instance - Single Instance ID found: %s", *instance.InstanceId)
-	return instanceDescriptionAttributes(d, instance, conn)
+	log.Printf("[DEBUG] - ids: %s", instanceIds)
+	log.Printf("[DEBUG] - instances: %s", instances)
+	if err = d.Set("instances", instances); err != nil {
+		return err
+	}
+	d.SetId(hashcode.Strings(instanceIds))
+	return nil
 }
 
 // Populate instance attribute fields with the returned instance
-func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.EC2) error {
+func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instance, conn *ec2.EC2) (*schema.ResourceData, error) {
 	d.SetId(*instance.InstanceId)
+
 	// Set the easy attributes
 	d.Set("instance_state", instance.State.Name)
-	if instance.Placement != nil {
-		d.Set("availability_zone", instance.Placement.AvailabilityZone)
-	}
-	if instance.Placement.Tenancy != nil {
-		d.Set("tenancy", instance.Placement.Tenancy)
-	}
+	d.Set("id", instance.InstanceId)
 	d.Set("ami", instance.ImageId)
 	d.Set("instance_type", instance.InstanceType)
 	d.Set("key_name", instance.KeyName)
@@ -288,8 +353,14 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 	d.Set("private_dns", instance.PrivateDnsName)
 	d.Set("private_ip", instance.PrivateIpAddress)
 	d.Set("iam_instance_profile", iamInstanceProfileArnToName(instance.IamInstanceProfile))
+	if instance.Placement != nil {
+		d.Set("availability_zone", instance.Placement.AvailabilityZone)
+	}
+	if instance.Placement.Tenancy != nil {
+		d.Set("tenancy", instance.Placement.Tenancy)
+	}
 
-	// iterate through network interfaces, and set subnet, network_interface, public_addr
+	// Iterate through network interfaces, and set subnet, network_interface, public_addr
 	if len(instance.NetworkInterfaces) > 0 {
 		for _, ni := range instance.NetworkInterfaces {
 			if *ni.Attachment.DeviceIndex == 0 {
@@ -317,25 +388,25 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 
 	// Security Groups
 	if err := readSecurityGroups(d, instance); err != nil {
-		return err
+		return nil, err
 	}
 
 	// Block devices
 	if err := readBlockDevices(d, instance, conn); err != nil {
-		return err
+		return nil, err
 	}
 	if _, ok := d.GetOk("ephemeral_block_device"); !ok {
 		d.Set("ephemeral_block_device", []interface{}{})
 	}
 
-	// Lookup and Set Instance Attributes
+	// Look up and Set Instance Attributes
 	{
 		attr, err := conn.DescribeInstanceAttribute(&ec2.DescribeInstanceAttributeInput{
 			Attribute:  aws.String("disableApiTermination"),
 			InstanceId: aws.String(d.Id()),
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 		d.Set("disable_api_termination", attr.DisableApiTermination.Value)
 	}
@@ -345,12 +416,12 @@ func instanceDescriptionAttributes(d *schema.ResourceData, instance *ec2.Instanc
 			InstanceId: aws.String(d.Id()),
 		})
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if attr.UserData.Value != nil {
 			d.Set("user_data", userDataHashSum(*attr.UserData.Value))
 		}
 	}
 
-	return nil
+	return d, nil
 }

--- a/builtin/providers/aws/data_source_aws_instance_test.go
+++ b/builtin/providers/aws/data_source_aws_instance_test.go
@@ -29,6 +29,28 @@ func TestAccAWSInstanceDataSource_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSInstancesDataSource_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstancesDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"data.aws_instances.web-group.instances.0", "ami", "ami-4fccb37f"),
+					resource.TestCheckResourceAttr(
+						"data.aws_instances.web-group.instances.0", "instance_type", "m1.small"),
+					resource.TestCheckResourceAttr(
+						"data.aws_instances.web-group.instances.1", "tags.#", "1"),
+					resource.TestCheckResourceAttr(
+						"data.aws_instances.web-group.instances.1", "instance_type", "m1.large"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSInstanceDataSource_tags(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
@@ -269,7 +291,7 @@ func TestAccAWSInstanceDataSource_VPCSecurityGroups(t *testing.T) {
 // Lookup based on InstanceID
 const testAccInstanceDataSourceConfig = `
 resource "aws_instance" "web" {
-	# us-west-2
+  # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
   tags {
@@ -285,11 +307,36 @@ data "aws_instance" "web-instance" {
 }
 `
 
+// Lookup based on InstanceID
+const testAccInstancesDataSourceConfig = `
+resource "aws_instance" "web1" {
+  # us-west-2
+  ami = "ami-4fccb37f"
+  instance_type = "m1.small"
+  tags {
+    Name = "HelloWorld1"
+  }
+}
+
+resource "aws_instance" "web2" {
+  # us-west-2
+  ami = "ami-4fccb37f"
+  instance_type = "m1.large"
+  tags {
+    Name = "HelloWorld2"
+  }
+}
+
+data "aws_instances" "web-group" {
+  instance_ids = ["${aws_instance.web1.id}", "${aws_instance.web2.id}"]
+}
+`
+
 // Use the tags attribute to filter
 func testAccInstanceDataSourceConfig_Tags(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_instance" "web" {
-	# us-west-2
+  # us-west-2
   ami = "ami-4fccb37f"
   instance_type = "m1.small"
   tags {

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -176,6 +176,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_policy_document":      dataSourceAwsIamPolicyDocument(),
 			"aws_iam_server_certificate":   dataSourceAwsIAMServerCertificate(),
 			"aws_instance":                 dataSourceAwsInstance(),
+			"aws_instances":                dataSourceAwsInstances(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
 			"aws_kms_secret":               dataSourceAwsKmsSecret(),
 			"aws_partition":                dataSourceAwsPartition(),

--- a/helper/hashcode/hashcode.go
+++ b/helper/hashcode/hashcode.go
@@ -1,6 +1,8 @@
 package hashcode
 
 import (
+	"bytes"
+	"fmt"
 	"hash/crc32"
 )
 
@@ -19,4 +21,15 @@ func String(s string) int {
 	}
 	// v == MinInt
 	return 0
+}
+
+// Strings hashes a list of strings to a unique hashcode.
+func Strings(strings []string) string {
+	var buf bytes.Buffer
+
+	for _, s := range strings {
+		buf.WriteString(fmt.Sprintf("%s-", s))
+	}
+
+	return fmt.Sprintf("%d", String(buf.String()))
 }

--- a/website/source/docs/providers/aws/d/instance.html.markdown
+++ b/website/source/docs/providers/aws/d/instance.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # aws\_instance
 
-Use this data source to get the ID of an Amazon EC2 Instance for use in other
+Use this data source to get the attributes of an Amazon EC2 Instance for use in other
 resources.
 
 ## Example Usage

--- a/website/source/docs/providers/aws/d/instances.html.markdown
+++ b/website/source/docs/providers/aws/d/instances.html.markdown
@@ -1,0 +1,61 @@
+---
+layout: "aws"
+page_title: "AWS: aws_instances"
+sidebar_current: "docs-aws-datasource-instances"
+description: |-
+  Get information on multiple Amazon EC2 Instances.
+---
+
+# aws\_instances
+
+Use this data source to get the attributes of multiple Amazon EC2 Instances for use in other
+resources.
+
+## Example Usage
+
+```
+data "aws_instances" "foo" {
+  instance_ids = ["i-instanceid1"]
+
+  filter {
+    name   = "image-id"
+    values = ["ami-xxxxxxxx"]
+  }
+
+  filter {
+    name   = "tag:Name"
+    values = ["instance-name-tag"]
+  }
+}
+```
+
+## Argument Reference
+
+* `instance_ids` - (Optional) Specify list of Instance IDs with which to populate the data source.
+
+* `instance_tags` - (Optional) A mapping of tags, each pair of which must
+exactly match a pair on the desired Instances.
+
+* `filter` - (Optional) One or more name/value pairs to use as filters. There are
+several valid keys, for a full reference, check out
+[describe-instances in the AWS CLI reference][1].
+
+~> **NOTE:** At least one of `filter`, `instance_tags`, or `instance_ids` must be specified.
+
+~> **NOTE:** Unlike the `aws_instance` data source, the search arguments used with `aws_instances`
+may match 0 or more instances.
+
+## Attributes Reference
+
+All of the argument attributes are also exported as result attributes. This data source will
+complete the data by populating any fields that are not included in the configuration with
+the data for the selected AWS Instances.
+
+~> **NOTE:** Some values are not always set and may not be available for
+interpolation.
+
+* `instances` - The attributes of all the AWS Instances matched by the provided search arguments.
+Refer to documenation for [aws_instance](/docs/providers/aws/d/instance.html) to view attributes
+that should be available on each instance.
+
+[1]: http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html


### PR DESCRIPTION
I wanted to work through the code once more to make sure I did it correctly. Once my tests pass, I'll close my other PR for #12376 in favor of this one. It implements an `aws_instances` resource with an attribute `instances` which is essentially a list of [`aws_instance`](https://www.terraform.io/docs/providers/aws/d/instance.html) data sources minus the search arguments, since they're located at the root of the `aws_instances` data source.

As far as I know, this code works and shouldn't introduce any bugs. Any feedback is appreciated.

EDIT:
> The changes made to builtin/providers/postgresql/resource_postgresql_database.go are a result of running `make fmt` on the repo. I can revert it back if it's an unwanted change.

Actually, the `make fmt` caused the tests to fail... unsure why