### PR TITLE
[docs][tfstate]Align document to the general recommendation

### DIFF
--- a/website/source/docs/state/environments.html.md
+++ b/website/source/docs/state/environments.html.md
@@ -114,7 +114,7 @@ aren't any more complex than that. Terraform wraps this simple notion with
 a set of protections and support for remote state.
 
 For local state, Terraform stores the state environments in a folder
-`terraform.state.d`. This folder should be committed to version control
+`terraform.state.d`. This folder should not be committed to version control
 (just like local-only `terraform.tfstate`).
 
 For [remote state](/docs/state/remote.html), the environments are stored

--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -179,7 +179,7 @@ Terraform also puts some state into the `terraform.tfstate` file
 by default. This state file is extremely important; it maps various
 resource metadata to actual resource IDs so that Terraform knows
 what it is managing. This file must be saved and distributed
-to anyone who might run Terraform. It is generally recommended to 
+to anyone who might run Terraform. It is generally recommended to
 [setup remote state](https://www.terraform.io/docs/state/remote.html)
 when working with Terraform. This will mean that any potential secrets
 stored in the state file, will not be checked into version control


### PR DESCRIPTION
Terraform also puts some state into the `terraform.tfstate` file
by default. This state file is extremely important...
This will mean that any potential secrets
stored in the state file, will not be checked into version control

Related issue #516