### PR TITLE
index(list, var.element) throws error when element not found

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -594,7 +594,7 @@ func interpolationFuncIndex() ast.Function {
 					return index, nil
 				}
 			}
-			return nil, fmt.Errorf("Could not find '%s' in '%s'", needle, haystack)
+			return -1, nil
 		},
 	}
 }


### PR DESCRIPTION
Fixes #12066 