### PR TITLE
Add DigitalOcean snapshot Data Source.

### DIFF
--- a/builtin/providers/digitalocean/data_source_digitalocean_snapshot.go
+++ b/builtin/providers/digitalocean/data_source_digitalocean_snapshot.go
@@ -1,0 +1,218 @@
+package digitalocean
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"time"
+
+	"github.com/digitalocean/godo"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDigitalOceanSnapshot() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDoSnapshotRead,
+
+		Schema: map[string]*schema.Schema{
+			"name_regex": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateNameRegex,
+			},
+			"most_recent": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"region_filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"resource_type": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateResourceType,
+			},
+			// Computed values.
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"min_disk_size": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"regions": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"size_gigabytes": {
+				Type:     schema.TypeFloat,
+				Computed: true,
+			},
+		},
+	}
+}
+
+// dataSourceDoSnapshotRead performs the Snapshot lookup.
+func dataSourceDoSnapshotRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*godo.Client)
+
+	resourceType := d.Get("resource_type")
+	nameRegex, nameRegexOk := d.GetOk("name_regex")
+	regionFilter, regionFilterOk := d.GetOk("region_filter")
+
+	pageOpt := &godo.ListOptions{
+		Page:    1,
+		PerPage: 200,
+	}
+
+	var snapshotList []godo.Snapshot
+	for {
+		var snapshots []godo.Snapshot
+		var resp *godo.Response
+		var err error
+
+		switch resourceType {
+		case "droplet":
+			snapshots, resp, err = client.Snapshots.ListDroplet(pageOpt)
+		case "volume":
+			snapshots, resp, err = client.Snapshots.ListVolume(pageOpt)
+		}
+
+		for _, s := range snapshots {
+			snapshotList = append(snapshotList, s)
+		}
+
+		if resp.Links == nil || resp.Links.IsLastPage() {
+			break
+		}
+
+		page, err := resp.Links.CurrentPage()
+		if err != nil {
+			return err
+		}
+
+		pageOpt.Page = page + 1
+	}
+
+	var snapshotsFilteredByName []godo.Snapshot
+	if nameRegexOk {
+		r := regexp.MustCompile(nameRegex.(string))
+		for _, snapshot := range snapshotList {
+			if r.MatchString(snapshot.Name) {
+				snapshotsFilteredByName = append(snapshotsFilteredByName, snapshot)
+			}
+		}
+	} else {
+		snapshotsFilteredByName = snapshotList[:]
+	}
+
+	var snapshotsFilteredByRegion []godo.Snapshot
+	if regionFilterOk {
+		for _, snapshot := range snapshotsFilteredByName {
+			for _, region := range snapshot.Regions {
+				if region == regionFilter {
+					snapshotsFilteredByRegion = append(snapshotsFilteredByRegion, snapshot)
+				}
+			}
+		}
+	} else {
+		snapshotsFilteredByRegion = snapshotsFilteredByName[:]
+	}
+
+	var snapshot godo.Snapshot
+	if len(snapshotsFilteredByRegion) < 1 {
+		return fmt.Errorf("Your query returned no results. Please change your search criteria and try again.")
+	}
+
+	if len(snapshotsFilteredByRegion) > 1 {
+		recent := d.Get("most_recent").(bool)
+		log.Printf("[DEBUG] do_snapshot - multiple results found and `most_recent` is set to: %t", recent)
+		if recent {
+			snapshot = mostRecentSnapshot(snapshotsFilteredByRegion)
+		} else {
+			return fmt.Errorf("Your query returned more than one result. Please try a more " +
+				"specific search criteria, or set `most_recent` attribute to true.")
+		}
+	} else {
+		// Query returned single result.
+		snapshot = snapshotsFilteredByRegion[0]
+	}
+
+	log.Printf("[DEBUG] do_snapshot - Single Snapshot found: %s", snapshot.ID)
+	return snapshotDescriptionAttributes(d, snapshot)
+}
+
+type snapshotSort []godo.Snapshot
+
+func (a snapshotSort) Len() int      { return len(a) }
+func (a snapshotSort) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
+func (a snapshotSort) Less(i, j int) bool {
+	itime, _ := time.Parse(time.RFC3339, a[i].Created)
+	jtime, _ := time.Parse(time.RFC3339, a[j].Created)
+	return itime.Unix() < jtime.Unix()
+}
+
+// Returns the most recent Snapshot out of a slice of Snapshots.
+func mostRecentSnapshot(snapshots []godo.Snapshot) godo.Snapshot {
+	sortedSnapshots := snapshots
+	sort.Sort(snapshotSort(sortedSnapshots))
+	return sortedSnapshots[len(sortedSnapshots)-1]
+}
+
+// populate the numerous fields that the Snapshot description returns.
+func snapshotDescriptionAttributes(d *schema.ResourceData, snapshot godo.Snapshot) error {
+	d.SetId(snapshot.ID)
+	d.Set("created_at", snapshot.Created)
+	d.Set("min_disk_size", snapshot.MinDiskSize)
+	d.Set("name", snapshot.Name)
+	d.Set("regions", snapshot.Regions)
+	d.Set("resource_id", snapshot.ResourceID)
+	d.Set("size_gigabytes", snapshot.SizeGigaBytes)
+
+	return nil
+}
+
+func validateNameRegex(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if _, err := regexp.Compile(value); err != nil {
+		errors = append(errors, fmt.Errorf(
+			"%q contains an invalid regular expression: %s",
+			k, err))
+	}
+	return
+}
+
+func validateResourceType(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	switch value {
+	case
+		"droplet",
+		"volume":
+		return
+	}
+
+	errors = append(errors, fmt.Errorf(
+		"Invalid %q specified: %s",
+		k, value))
+
+	return
+}

--- a/builtin/providers/digitalocean/data_source_digitalocean_snapshot_test.go
+++ b/builtin/providers/digitalocean/data_source_digitalocean_snapshot_test.go
@@ -1,0 +1,136 @@
+package digitalocean
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDigitalOceanSnapshotDataSource_droplet(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanDropletSnapshotDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanSnapshotDataSourceID("data.digitalocean_snapshot.droplet_snapshot"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_snapshot", "name", "web-01"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_snapshot", "created_at", "2017-03-01T04:04:58Z"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_snapshot", "min_disk_size", "30"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_snapshot", "size_gigabytes", "2.69"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_snapshot", "resource_id", "35539772"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.droplet_snapshot", "regions.0", "nyc3"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDigitalOceanSnapshotDataSource_volume(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanVolumeSnapshotDataSourceConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanSnapshotDataSourceID("data.digitalocean_snapshot.volume_snapshot"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_snapshot", "name", "volume-01"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_snapshot", "created_at", "2017-03-02T04:04:58Z"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_snapshot", "min_disk_size", "100"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_snapshot", "size_gigabytes", "1"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_snapshot", "resource_id", "a3feba45-914f-11e6-bd40-000f53315820"),
+					resource.TestCheckResourceAttr("data.digitalocean_snapshot.volume_snapshot", "regions.0", "nyc3"),
+				),
+			},
+		},
+	})
+}
+
+func TestResourceValidateNameRegex(t *testing.T) {
+	type testCases struct {
+		Value    string
+		ErrCount int
+	}
+
+	invalidCases := []testCases{
+		{
+			Value:    `\`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `**`,
+			ErrCount: 1,
+		},
+		{
+			Value:    `(.+`,
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range invalidCases {
+		_, errors := validateNameRegex(tc.Value, "name_regex")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
+		}
+	}
+
+	validCases := []testCases{
+		{
+			Value:    `\/`,
+			ErrCount: 0,
+		},
+		{
+			Value:    `.*`,
+			ErrCount: 0,
+		},
+		{
+			Value:    `\b(?:\d{1,3}\.){3}\d{1,3}\b`,
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range validCases {
+		_, errors := validateNameRegex(tc.Value, "name_regex")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
+		}
+	}
+}
+
+func testAccCheckDigitalOceanSnapshotDataSourceDestroy(s *terraform.State) error {
+	return nil
+}
+
+func testAccCheckDigitalOceanSnapshotDataSourceID(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Can't find Snapshot data source: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("Snapshot data source ID not set")
+		}
+		return nil
+	}
+}
+
+const testAccCheckDigitalOceanDropletSnapshotDataSourceConfig = `
+data "digitalocean_snapshot" "droplet_snapshot" {
+    most_recent = true
+    resource_type = "droplet"
+    name_regex = "^web"
+}
+`
+
+const testAccCheckDigitalOceanVolumeSnapshotDataSourceConfig = `
+data "digitalocean_snapshot" "volume_snapshot" {
+    most_recent = true
+    resource_type = "volume"
+    name_regex = "^volume"
+}
+`

--- a/builtin/providers/digitalocean/provider.go
+++ b/builtin/providers/digitalocean/provider.go
@@ -16,6 +16,9 @@ func Provider() terraform.ResourceProvider {
 				Description: "The token key for API operations.",
 			},
 		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"digitalocean_snapshot": dataSourceDigitalOceanSnapshot(),
+		},
 
 		ResourcesMap: map[string]*schema.Resource{
 			"digitalocean_domain":       resourceDigitalOceanDomain(),

--- a/website/source/docs/providers/do/d/snapshot.html.mdown
+++ b/website/source/docs/providers/do/d/snapshot.html.mdown
@@ -1,0 +1,49 @@
+---
+layout: "digitalocean"
+page_title: "DigitalOcean: digitalocean_snapshot"
+sidebar_current: "docs-do-datasource-snapshot"
+description: |-
+  Get information on a DigitalOcean snapshot.
+---
+
+# digitalocean\_snapshot
+
+Use this data source to get the ID of a DigitalOcean snapshot for use in other
+resources.
+
+## Example Usage
+
+```
+data "digitalocean_snapshot" "snapshot" {
+  most_recent = true
+  name_regex  = "^web"
+  region_filter = "nyc2"
+  resource_type = "droplet"
+}
+```
+
+## Argument Reference
+
+* `resource_type` - (Required) The type of DigitalOcean resource from which the snapshot originated. This currently must be either `droplet` or `volume`.
+
+* `most_recent` - (Optional) If more than one result is returned, use the most
+recent snapshot.
+
+* `name_regex` - (Optional) A regex string to apply to the snapshot list returned by DigitalOcean. This allows more advanced filtering not supported from the DigitalOcean API. This filtering is done locally on what DigitalOcean returns.
+
+* `region_filter` - (Optional) A "slug" representing a DigitalOcean region (e.g. `nyc1`). If set, only snapshots available in the region will be returned.
+
+~> **NOTE:** If more or less than a single match is returned by the search,
+Terraform will fail. Ensure that your search is specific enough to return
+a single snapshot ID only, or use `most_recent` to choose the most recent one.
+
+## Attributes Reference
+
+`id` is set to the ID of the found snapshot. In addition, the following attributes are exported:
+
+* `created_at` - The date and time the image was created.
+* `min_disk_size` - The minimum size in gigabytes required for a volume or Droplet to be created based on this snapshot.
+* `name` - The name of the snapshot.
+* `regions` - A list of DigitalOcean region "slugs" indicating where the snapshot is available.
+* `resource_id` - The ID of the resource from which the snapshot originated.
+* `size_gigabytes` - The billable size of the snapshot in gigabytes.

--- a/website/source/layouts/digitalocean.erb
+++ b/website/source/layouts/digitalocean.erb
@@ -10,6 +10,15 @@
 				<a href="/docs/providers/do/index.html">DigitalOcean Provider</a>
                 </li>
 
+                <li<%= sidebar_current(/^docs-do-datasource/) %>>
+                <a href="#">Data Sources</a>
+                <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-do-datasource-snapshot") %>>
+                    <a href="/docs/providers/do/d/snapshot.html">digitalocean_snapshot</a>
+                    </li>
+                </ul>
+                </li>
+
 				<li<%= sidebar_current(/^docs-do-resource/) %>>
 				<a href="#">Resources</a>
                 <ul class="nav nav-visible">


### PR DESCRIPTION
This PR adds a data source for DigitalOcean snapshots similar to the aws_ami data source. This allows for referencing user created snapshots when creating a new Droplet or volume.