### PR TITLE
provider/aws: Deprecate the usage of Api Gateway Key Stages in favor of Usage Plans

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_api_key.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_api_key.go
@@ -42,8 +42,9 @@ func resourceAwsApiGatewayApiKey() *schema.Resource {
 			},
 
 			"stage_key": {
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Deprecated: "Since the API Gateway usage plans feature was launched on August 11, 2016, usage plans are now required to associate an API key with an API stage",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"rest_api_id": {

--- a/website/source/docs/providers/aws/r/api_gateway_api_key.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_api_key.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an API Gateway API Key.
 
+~> **Warning:** Since the API Gateway usage plans feature was launched on August 11, 2016, usage plans are now **required** to associate an API key with an API stage.
+
 ## Example Usage
 
 ```


### PR DESCRIPTION
## Description
Due to a change in the APIGateway API itself, API keys needs to be associated to a usage plan rather than setting `stage_keys` on the API Key itself.

This adds a warning in the documentation, plus a deprecation on the api key resource at the `stage_key`-level.

Related Documentation: http://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-api-keys.html

## Related issues
N/A