### PR TITLE
nil checks when assigning to param map in resourceAwsSsmDocumentRead

### DIFF
--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -169,8 +169,6 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		return errwrap.Wrapf("[ERROR] Error describing SSM document: {{err}}", err)
 	}
 
-	fmt.Println(*resp.Document)
-
 	doc := resp.Document
 	d.Set("created_date", doc.CreatedDate)
 	d.Set("default_version", doc.DefaultVersion)

--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -169,6 +169,8 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		return errwrap.Wrapf("[ERROR] Error describing SSM document: {{err}}", err)
 	}
 
+	fmt.Println(*resp.Document)
+
 	doc := resp.Document
 	d.Set("created_date", doc.CreatedDate)
 	d.Set("default_version", doc.DefaultVersion)
@@ -205,9 +207,15 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 		if dp.DefaultValue != nil {
 			param["default_value"] = *dp.DefaultValue
 		}
-		param["description"] = *dp.Description
-		param["name"] = *dp.Name
-		param["type"] = *dp.Type
+		if dp.Description != nil {
+			param["description"] = *dp.Description
+		}
+		if dp.Name != nil {
+			param["name"] = *dp.Name
+		}
+		if dp.Type != nil {
+			param["type"] = *dp.Type
+		}
 		params = append(params, param)
 	}
 


### PR DESCRIPTION
Fields in the Parameters struct were being set as nil. Those fields were marked as optional in AWS anyway. To prevent a panic when the nil pointer is dereferenced I wrapped the assignments with a nil check. 