### PR TITLE
ignore_changes causes keys in other flatmapped objects to be lost from diff

### DIFF
--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -3095,3 +3095,53 @@ func TestContext2Plan_listOrder(t *testing.T) {
 		t.Fatal("aws_instance.a and aws_instance.b diffs should match:\n", plan)
 	}
 }
+
+// Make sure ignore-changes doesn't interfere with set/list/map diffs.
+// If a resource was being replaced by a RequiresNew attribute that gets
+// ignores, we need to filter out the diff properly.
+func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
+	m := testModule(t, "plan-ignore-changes-with-flatmaps")
+	p := testProvider("aws")
+	p.DiffFn = testDiffFn
+	s := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.foo": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"user_data":   "x",
+								"require_new": "",
+								"set.#":       "1",
+								"set.0.a":     "1",
+								"lst.#":       "1",
+								"lst.0":       "j",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	ctx := testContext2(t, &ContextOpts{
+		Module: m,
+		Providers: map[string]ResourceProviderFactory{
+			"aws": testProviderFuncFixed(p),
+		},
+		State: s,
+	})
+
+	plan, err := ctx.Plan()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	actual := strings.TrimSpace(plan.Diff.String())
+	expected := strings.TrimSpace(testTFPlanDiffIgnoreChangesWithFlatmaps)
+	if actual != expected {
+		t.Fatalf("bad:\n%s\n\nexpected\n\n%s", actual, expected)
+	}
+}

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -3098,7 +3098,8 @@ func TestContext2Plan_listOrder(t *testing.T) {
 
 // Make sure ignore-changes doesn't interfere with set/list/map diffs.
 // If a resource was being replaced by a RequiresNew attribute that gets
-// ignores, we need to filter out the diff properly.
+// ignored, we need to filter the diff properly to properly update rather than
+// replace.
 func TestContext2Plan_ignoreChangesWithFlatmaps(t *testing.T) {
 	m := testModule(t, "plan-ignore-changes-with-flatmaps")
 	p := testProvider("aws")

--- a/terraform/context_test.go
+++ b/terraform/context_test.go
@@ -262,6 +262,11 @@ func testDiffFn(
 			if _, ok := c.Raw["__"+k+"_requires_new"]; ok {
 				attrDiff.RequiresNew = true
 			}
+
+			if attr, ok := s.Attributes[k]; ok {
+				attrDiff.Old = attr
+			}
+
 			diff.Attributes[k] = attrDiff
 		}
 	}

--- a/terraform/diff.go
+++ b/terraform/diff.go
@@ -25,6 +25,9 @@ const (
 	DiffDestroyCreate
 )
 
+// multiVal matches the index key to a flatmapped set, list or map
+var multiVal = regexp.MustCompile(`\.(#|%)$`)
+
 // Diff trackes the changes that are necessary to apply a configuration
 // to an existing infrastructure.
 type Diff struct {
@@ -808,7 +811,6 @@ func (d *InstanceDiff) Same(d2 *InstanceDiff) (bool, string) {
 		}
 
 		// search for the suffix of the base of a [computed] map, list or set.
-		multiVal := regexp.MustCompile(`\.(#|~#|%)$`)
 		match := multiVal.FindStringSubmatch(k)
 
 		if diffOld.NewComputed && len(match) == 2 {

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1570,6 +1570,17 @@ aws_instance.foo:
   ami = ami-abcd1234
 `
 
+const testTFPlanDiffIgnoreChangesWithFlatmaps = `
+UPDATE: aws_instance.foo
+  lst.#:   "1" => "2"
+  lst.0:   "j" => "j"
+  lst.1:   "" => "k"
+  set.#:   "1" => "1"
+  set.0.a: "1" => "1"
+  set.0.b: "" => "2"
+  type:    "" => "aws_instance"
+`
+
 const testTerraformPlanIgnoreChangesWildcardStr = `
 DIFF:
 

--- a/terraform/terraform_test.go
+++ b/terraform/terraform_test.go
@@ -1500,7 +1500,7 @@ DIFF:
 
 DESTROY/CREATE: aws_instance.foo
   type: "" => "aws_instance"
-  vars: "" => "foo"
+  vars: "foo" => "foo"
 
 STATE:
 

--- a/terraform/test-fixtures/plan-ignore-changes-with-flatmaps/main.tf
+++ b/terraform/test-fixtures/plan-ignore-changes-with-flatmaps/main.tf
@@ -1,0 +1,16 @@
+resource "aws_instance" "foo" {
+  id = "bar"
+  user_data = "x"
+  require_new = "yes"
+
+  set = {
+	  a = "1"
+	  b = "2"
+  }
+
+  lst = ["j", "k"]
+
+  lifecycle {
+    ignore_changes = ["require_new"]
+  }
+}


### PR DESCRIPTION
When transforming a diff from DestroyCreate to a simple update cause be
ignore_changes, we need to filter each flatmapped container as a whole
to ensure that unchanged keys aren't lost in the update.

Previously, unchanged fields in a list, set or map were being filtered out of the diff because they looked like empty, but because they are updated as a whole these fields would then be removed from the instance. 

Fixes #9043