### PR TITLE
Enforce LF line-ending for .sh files.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+*.go  eol=lf
+*.sh  eol=lf


### PR DESCRIPTION
I'm editing files in Windows and running the shell scripts in a Linux Docker container with volumes mounted into the Windows filesystem. I was getting CRLF line-endings on .sh files in Windows. This broke the execution of the .sh scripts on Linux.

This will ensure the .sh files always have a LF line-ending.