### PR TITLE
provider/ns1: Ensure provider checks for credentials

### DIFF
--- a/builtin/providers/ns1/config.go
+++ b/builtin/providers/ns1/config.go
@@ -1,0 +1,46 @@
+package ns1
+
+import (
+	"crypto/tls"
+	"errors"
+	"log"
+	"net/http"
+
+	ns1 "gopkg.in/ns1/ns1-go.v2/rest"
+)
+
+type Config struct {
+	Key       string
+	Endpoint  string
+	IgnoreSSL bool
+}
+
+// Client() returns a new NS1 client.
+func (c *Config) Client() (*ns1.Client, error) {
+	httpClient := &http.Client{}
+	decos := []func(*ns1.Client){}
+
+	if c.Key == "" {
+		return nil, errors.New(`No valid credential sources found for NS1 Provider.
+  Please see https://terraform.io/docs/providers/ns1/index.html for more information on
+  providing credentials for the NS1 Provider`)
+	}
+
+	decos = append(decos, ns1.SetAPIKey(c.Key))
+	if c.Endpoint != "" {
+		decos = append(decos, ns1.SetEndpoint(c.Endpoint))
+	}
+	if c.IgnoreSSL {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		httpClient.Transport = tr
+	}
+
+	client := ns1.NewClient(httpClient, decos...)
+	client.RateLimitStrategySleep()
+
+	log.Printf("[INFO] NS1 Client configured for Endpoint: %s", client.Endpoint.String())
+
+	return client, nil
+}

--- a/builtin/providers/ns1/provider.go
+++ b/builtin/providers/ns1/provider.go
@@ -18,13 +18,13 @@ func Provider() terraform.ResourceProvider {
 			"endpoint": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NS1_ENDPOINT", "https://api.nsone.net/v1/"),
+				DefaultFunc: schema.EnvDefaultFunc("NS1_ENDPOINT", nil),
 				Description: descriptions["endpoint"],
 			},
 			"ignore_ssl": &schema.Schema{
 				Type:        schema.TypeBool,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("NS1_IGNORE_SSL", false),
+				DefaultFunc: schema.EnvDefaultFunc("NS1_IGNORE_SSL", nil),
 				Description: descriptions["ignore_ssl"],
 			},
 		},
@@ -45,9 +45,14 @@ func Provider() terraform.ResourceProvider {
 
 func ns1Configure(d *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		Key:       d.Get("apikey").(string),
-		Endpoint:  d.Get("endpoint").(string),
-		IgnoreSSL: d.Get("ignore_ssl").(bool),
+		Key: d.Get("apikey").(string),
+	}
+
+	if v, ok := d.GetOk("endpoint"); ok {
+		config.Endpoint = v.(string)
+	}
+	if v, ok := d.GetOk("ignore_ssl"); ok {
+		config.IgnoreSSL = v.(bool)
 	}
 
 	return config.Client()

--- a/builtin/providers/ns1/resource_record_test.go
+++ b/builtin/providers/ns1/resource_record_test.go
@@ -120,9 +120,9 @@ func testAccCheckRecordDestroy(s *terraform.State) error {
 		}
 	}
 
-	foundRecord, _, err := client.Records.Get(recordDomain, recordZone, recordType)
-	if err != nil {
-		return fmt.Errorf("Record still exists: %#v", foundRecord)
+	foundRecord, _, err := client.Records.Get(recordZone, recordDomain, recordType)
+	if err != ns1.ErrRecordMissing {
+		return fmt.Errorf("Record still exists: %#v %#v", foundRecord, err)
 	}
 
 	return nil

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_apikey.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_apikey.go
@@ -49,9 +49,9 @@ func (s *APIKeysService) Get(keyID string) (*account.APIKey, *http.Response, err
 			if err.(*Error).Message == "unknown api key" {
 				return nil, resp, ErrKeyMissing
 			}
-		default:
-			return nil, resp, err
+
 		}
+		return nil, resp, err
 	}
 
 	return &a, resp, nil
@@ -74,9 +74,8 @@ func (s *APIKeysService) Create(a *account.APIKey) (*http.Response, error) {
 			if err.(*Error).Message == fmt.Sprintf("api key with name \"%s\" exists", a.Name) {
 				return resp, ErrKeyExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -101,9 +100,8 @@ func (s *APIKeysService) Update(a *account.APIKey) (*http.Response, error) {
 			if err.(*Error).Message == "unknown api key" {
 				return resp, ErrKeyMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -127,9 +125,8 @@ func (s *APIKeysService) Delete(keyID string) (*http.Response, error) {
 			if err.(*Error).Message == "unknown api key" {
 				return resp, ErrKeyMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_team.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_team.go
@@ -48,9 +48,8 @@ func (s *TeamsService) Get(id string) (*account.Team, *http.Response, error) {
 			if err.(*Error).Message == "Unknown team id" {
 				return nil, resp, ErrTeamMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &t, resp, nil
@@ -73,9 +72,8 @@ func (s *TeamsService) Create(t *account.Team) (*http.Response, error) {
 			if err.(*Error).Message == fmt.Sprintf("team with name \"%s\" exists", t.Name) {
 				return resp, ErrTeamExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -100,9 +98,8 @@ func (s *TeamsService) Update(t *account.Team) (*http.Response, error) {
 			if err.(*Error).Message == "unknown team id" {
 				return resp, ErrTeamMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -126,9 +123,8 @@ func (s *TeamsService) Delete(id string) (*http.Response, error) {
 			if err.(*Error).Message == "unknown team id" {
 				return resp, ErrTeamMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_user.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/account_user.go
@@ -48,9 +48,8 @@ func (s *UsersService) Get(username string) (*account.User, *http.Response, erro
 			if err.(*Error).Message == "Unknown user" {
 				return nil, resp, ErrUserMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &u, resp, nil
@@ -73,9 +72,8 @@ func (s *UsersService) Create(u *account.User) (*http.Response, error) {
 			if err.(*Error).Message == "request failed:Login Name is already in use." {
 				return resp, ErrUserExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -100,9 +98,8 @@ func (s *UsersService) Update(u *account.User) (*http.Response, error) {
 			if err.(*Error).Message == "Unknown user" {
 				return resp, ErrUserMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -126,9 +123,8 @@ func (s *UsersService) Delete(username string) (*http.Response, error) {
 			if err.(*Error).Message == "Unknown user" {
 				return resp, ErrUserMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/monitor_notify.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/monitor_notify.go
@@ -48,9 +48,8 @@ func (s *NotificationsService) Get(listID string) (*monitor.NotifyList, *http.Re
 			if err.(*Error).Message == "unknown notification list" {
 				return nil, resp, ErrListMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &nl, resp, nil
@@ -73,9 +72,8 @@ func (s *NotificationsService) Create(nl *monitor.NotifyList) (*http.Response, e
 			if err.(*Error).Message == fmt.Sprintf("notification list with name \"%s\" exists", nl.Name) {
 				return resp, ErrListExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/record.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/record.go
@@ -30,9 +30,8 @@ func (s *RecordsService) Get(zone, domain, t string) (*dns.Record, *http.Respons
 			if err.(*Error).Message == "record not found" {
 				return nil, resp, ErrRecordMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &r, resp, nil
@@ -61,9 +60,8 @@ func (s *RecordsService) Create(r *dns.Record) (*http.Response, error) {
 			case "record already exists":
 				return resp, ErrRecordExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -92,9 +90,8 @@ func (s *RecordsService) Update(r *dns.Record) (*http.Response, error) {
 			case "record already exists":
 				return resp, ErrRecordExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -118,9 +115,8 @@ func (s *RecordsService) Delete(zone string, domain string, t string) (*http.Res
 			if err.(*Error).Message == "record not found" {
 				return resp, ErrRecordMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/vendor/gopkg.in/ns1/ns1-go.v2/rest/zone.go
+++ b/vendor/gopkg.in/ns1/ns1-go.v2/rest/zone.go
@@ -48,9 +48,8 @@ func (s *ZonesService) Get(zone string) (*dns.Zone, *http.Response, error) {
 			if err.(*Error).Message == "zone not found" {
 				return nil, resp, ErrZoneMissing
 			}
-		default:
-			return nil, resp, err
 		}
+		return nil, resp, err
 	}
 
 	return &z, resp, nil
@@ -75,9 +74,8 @@ func (s *ZonesService) Create(z *dns.Zone) (*http.Response, error) {
 			if err.(*Error).Message == "zone already exists" {
 				return resp, ErrZoneExists
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -102,9 +100,8 @@ func (s *ZonesService) Update(z *dns.Zone) (*http.Response, error) {
 			if err.(*Error).Message == "zone not found" {
 				return resp, ErrZoneMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil
@@ -128,9 +125,8 @@ func (s *ZonesService) Delete(zone string) (*http.Response, error) {
 			if err.(*Error).Message == "zone not found" {
 				return resp, ErrZoneMissing
 			}
-		default:
-			return resp, err
 		}
+		return resp, err
 	}
 
 	return resp, nil

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3424,50 +3424,50 @@
 		{
 			"checksumSHA1": "IOhjrvLMN5Mw8PeiRF/xAfSxvew=",
 			"path": "gopkg.in/ns1/ns1-go.v2",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
-			"checksumSHA1": "t20/HSVruhTb/TVwgc9mpw/oMTA=",
+			"checksumSHA1": "e7eKqt/2RnmGPYJtcJd4IY2M/DU=",
 			"path": "gopkg.in/ns1/ns1-go.v2/rest",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
 			"checksumSHA1": "euh1cYwe0t2erigdvOMueyniPH0=",
 			"path": "gopkg.in/ns1/ns1-go.v2/rest/model",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
 			"checksumSHA1": "tdMxXKsUHn3yZpur14ZNLMVyQJM=",
 			"path": "gopkg.in/ns1/ns1-go.v2/rest/model/account",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
 			"checksumSHA1": "gBVND8veklEQV0gxF3lERV6mSZk=",
 			"path": "gopkg.in/ns1/ns1-go.v2/rest/model/data",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
 			"checksumSHA1": "GbL7ThrBZfKs1lhzguxzscIynac=",
 			"path": "gopkg.in/ns1/ns1-go.v2/rest/model/dns",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
 			"checksumSHA1": "CuurmNep8iMdYFodxRxAeewowsQ=",
 			"path": "gopkg.in/ns1/ns1-go.v2/rest/model/filter",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
 			"checksumSHA1": "B0C8F5th11AHl1fo8k0I8+DvrjE=",
 			"path": "gopkg.in/ns1/ns1-go.v2/rest/model/monitor",
-			"revision": "49e3a8a0b594e847e01cdac77810ba49f9564ccf",
-			"revisionTime": "2017-03-02T13:56:36Z"
+			"revision": "5bff869d22e76e3699281eaa61d9d285216f321a",
+			"revisionTime": "2017-03-21T12:56:04Z"
 		},
 		{
 			"checksumSHA1": "mkLQOQwQwoUc9Kr9+PaVGrKUzI4=",


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/terraform/issues/12833

I somehow never added a check for the ns1 api key, this PR mimics other providers `Config` structures. Also, this PR ensures defaults for the ns1 api endpoint and whether to ignore ssl in the client(use terraform often for local development).