### PR TITLE
provider/aws: Only call replace Iam Instance Profile on existing machines

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -611,7 +611,7 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 		d.SetPartial("tags")
 	}
 
-	if d.HasChange("iam_instance_profile") {
+	if d.HasChange("iam_instance_profile") && !d.IsNewResource() {
 		request := &ec2.DescribeIamInstanceProfileAssociationsInput{
 			Filters: []*ec2.Filter{
 				&ec2.Filter{

--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -656,7 +656,38 @@ func TestAccAWSInstance_instanceProfileChange(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccInstanceConfigAttachInstanceProfile(rName),
+				Config: testAccInstanceConfigWithInstanceProfile(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckInstanceExists("aws_instance.foo", &v),
+					testCheckInstanceProfile(),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSInstance_withIamInstanceProfile(t *testing.T) {
+	var v ec2.Instance
+	rName := acctest.RandString(5)
+
+	testCheckInstanceProfile := func() resource.TestCheckFunc {
+		return func(*terraform.State) error {
+			if v.IamInstanceProfile == nil {
+				return fmt.Errorf("Instance Profile is nil - we expected an InstanceProfile associated with the Instance")
+			}
+
+			return nil
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_instance.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceConfigWithInstanceProfile(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
 					testCheckInstanceProfile(),
@@ -1281,7 +1312,7 @@ resource "aws_instance" "foo" {
 }`, rName, rName)
 }
 
-func testAccInstanceConfigAttachInstanceProfile(rName string) string {
+func testAccInstanceConfigWithInstanceProfile(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
 	name = "test-%s"


### PR DESCRIPTION
Fixes: #12898
Fixes: #12927

The way aws_instance works is that we call the Create func then the
Update func then the Read func. The way the work to implement the change
to iam_instance_profile was added meant that when a machine was created
with an iam_instance_profile, it would then try and update that
iam_instance_profile because the state hadn't been updated at that point

We have changed the Update func to only check for the change to
iam_instance_profile when it *is an existing machine* - this will solve
the problem of those bringing up new machines and getting hit with the
permissions error