### PR TITLE
provider/aws: Add network_interface to aws_instance

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -86,6 +86,7 @@ instances. See [Shutdown Behavior](https://docs.aws.amazon.com/AWSEC2/latest/Use
   instance.  See [Block Devices](#block-devices) below for details.
 * `ephemeral_block_device` - (Optional) Customize Ephemeral (also known as
   "Instance Store") volumes on the instance. See [Block Devices](#block-devices) below for details.
+* `network_interface` - (Optional) Customize network interfaces to be attached at instance boot time. See [Network Interfaces](#network-interfaces) below for more details.
 
 
 ## Block devices
@@ -149,6 +150,59 @@ resources cannot be automatically detected by Terraform. After making updates
 to block device configuration, resource recreation can be manually triggered by
 using the [`taint` command](/docs/commands/taint.html).
 
+## Network Interfaces
+
+Each of the `network_interface` blocks attach a network interface to an EC2 Instance during boot time. However, because
+the network interface is attached at boot-time, replacing/modifying the network interface **WILL** trigger a recreation
+of the EC2 Instance. If you should need at any point to detach/modify/re-attach a network interface to the instance, use
+the `aws_network_interface` or `aws_network_interface_attachment` resources instead.
+
+The `network_interface` configuration block _does_, however, allow users to supply their own network interface to be used
+as the default network interface on an EC2 Instance, attached at `eth0`.
+
+Each `network_interface` block supports the following:
+
+* `device_index` - (Required) The integer index of the network interface attachment. Limited by instance type.
+* `network_interface_id` - (Required) The ID of the network interface to attach.
+* `delete_on_termination` - (Optional) Whether or not to delete the network interface on instance termination. Defaults to `false`.
+
+### Example
+
+```hcl
+resource "aws_vpc" "my_vpc" {
+  cidr_block = "172.16.0.0/16"
+  tags {
+    Name = "tf-example"
+  }
+}
+
+resource "aws_subnet" "my_subnet" {
+  vpc_id = "${aws_vpc.my_vpc.id}"
+  cidr_block = "172.16.10.0/24"
+  availability_zone = "us-west-2a"
+  tags {
+    Name = "tf-example"
+  }
+}
+
+resource "aws_network_interface" "foo" {
+  subnet_id = "${aws_subnet.my_subnet.id}"
+  private_ips = ["172.16.10.100"]
+  tags {
+    Name = "primary_network_interface"
+  }
+}
+
+resource "aws_instance" "foo" {
+	ami = "ami-22b9a343" // us-west-2
+	instance_type = "t2.micro"
+	network_interface {
+	 network_interface_id = "${aws_network_interface.foo.id}"
+	 device_index = 0
+  }
+}
+```
+
 ## Attributes Reference
 
 The following attributes are exported:
@@ -161,6 +215,7 @@ The following attributes are exported:
   is only available if you've enabled DNS hostnames for your VPC
 * `public_ip` - The public IP address assigned to the instance, if applicable. **NOTE**: If you are using an [`aws_eip`](/docs/providers/aws/r/eip.html) with your instance, you should refer to the EIP's address directly and not use `public_ip`, as this field will change after the EIP is attached.
 * `network_interface_id` - The ID of the network interface that was created with the instance.
+* `primary_network_interface_id` - The ID of the instance's primary network interface.
 * `private_dns` - The private DNS name assigned to the instance. Can only be
   used inside the Amazon EC2, and only available if you've enabled DNS hostnames
   for your VPC


### PR DESCRIPTION
Adds the `network_interface` schema object to `aws_instance` resources. 

Would preferably want to remove the custom `Set` function, but without the hash on `device_index`, we incur state diffs on every apply. 

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSInstance_NetworkInterface'   
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/21 13:08:33 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_NetworkInterface -timeout 120m
=== RUN   TestAccAWSInstance_NetworkInterfacePrimary
--- PASS: TestAccAWSInstance_NetworkInterfacePrimary (121.01s)
=== RUN   TestAccAWSInstance_NetworkInterfaceExisting
--- PASS: TestAccAWSInstance_NetworkInterfaceExisting (164.98s)
=== RUN   TestAccAWSInstance_NetworkInterfaceMultiple
--- PASS: TestAccAWSInstance_NetworkInterfaceMultiple (144.31s)
=== RUN   TestAccAWSInstance_NetworkInterfaceSG
--- PASS: TestAccAWSInstance_NetworkInterfaceSG (116.07s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    546.383s
```

Fixes: #2989, #2998, #3105, #1557, #5765
Closes: #12694, #10244, #7096, #10516
Related to: #4231, #1149, #10593, #3205