### PR TITLE
terraform: V1 to V2 upgrade should treat nil path as root path

### DIFF
--- a/terraform/state_upgrade_v1_to_v2.go
+++ b/terraform/state_upgrade_v1_to_v2.go
@@ -68,6 +68,11 @@ func (old *moduleStateV1) upgradeToV2() (*ModuleState, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error upgrading ModuleState V1: %v", err)
 	}
+	if path == nil {
+		// We found some V1 states with a nil path. Assume root and catch
+		// duplicate path errors later (as part of Validate).
+		path = rootModulePath
+	}
 
 	// Outputs needs upgrading to use the new structure
 	outputs := make(map[string]*OutputState)

--- a/terraform/state_upgrade_v2_to_v3.go
+++ b/terraform/state_upgrade_v2_to_v3.go
@@ -18,7 +18,7 @@ func upgradeStateV2ToV3(old *State) (*State, error) {
 
 	// Ensure the copied version is v2 before attempting to upgrade
 	if new.Version != 2 {
-		return nil, fmt.Errorf("Cannot appply v2->v3 state upgrade to " +
+		return nil, fmt.Errorf("Cannot apply v2->v3 state upgrade to " +
 			"a state which is not version 2.")
 	}
 


### PR DESCRIPTION
It appears there are no tests for this as far as I can find.

We change V1 states (very old) to assume a nil path is a root path.
Staet.Validate() later will catch any duplicate paths.