### PR TITLE
add `-force-copy` option to init command

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -21,11 +21,14 @@ type InitCommand struct {
 func (c *InitCommand) Run(args []string) int {
 	var flagBackend, flagGet bool
 	var flagConfigExtra map[string]interface{}
+
 	args = c.Meta.process(args, false)
 	cmdFlags := c.flagSet("init")
 	cmdFlags.BoolVar(&flagBackend, "backend", true, "")
 	cmdFlags.Var((*variables.FlagAny)(&flagConfigExtra), "backend-config", "")
 	cmdFlags.BoolVar(&flagGet, "get", true, "")
+	cmdFlags.BoolVar(&c.forceInitCopy, "force-copy", false, "suppress prompts about copying state data")
+
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
 		return 1
@@ -224,6 +227,10 @@ Options:
                        input was required.
 
   -no-color            If specified, output won't contain any color.
+
+  -force-copy          Suppress prompts about copying state data. This is
+                       equivalent to providing a "yes" to all confirmation
+                       prompts.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -270,9 +270,6 @@ func TestInit_backendUnset(t *testing.T) {
 			t.Fatalf("err: %s", err)
 		}
 
-		// Run it again
-		defer testInteractiveInput(t, []string{"yes", "yes"})()
-
 		ui := new(cli.MockUi)
 		c := &InitCommand{
 			Meta: Meta{
@@ -281,7 +278,7 @@ func TestInit_backendUnset(t *testing.T) {
 			},
 		}
 
-		args := []string{}
+		args := []string{"-force-copy"}
 		if code := c.Run(args); code != 0 {
 			t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 		}

--- a/command/meta.go
+++ b/command/meta.go
@@ -87,14 +87,18 @@ type Meta struct {
 	//
 	// provider is to specify specific resource providers
 	//
-	// lockState is set to false to disable state locking
-	statePath    string
-	stateOutPath string
-	backupPath   string
-	parallelism  int
-	shadow       bool
-	provider     string
-	stateLock    bool
+	// stateLock is set to false to disable state locking
+	//
+	// forceInitCopy suppresses confirmation for copying state data during
+	// init.
+	statePath     string
+	stateOutPath  string
+	backupPath    string
+	parallelism   int
+	shadow        bool
+	provider      string
+	stateLock     bool
+	forceInitCopy bool
 }
 
 // initStatePaths is used to initialize the default values for

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -684,16 +684,20 @@ func (m *Meta) backend_c_r_S(
 	// Get the backend type for output
 	backendType := s.Backend.Type
 
-	// Confirm with the user that the copy should occur
-	copy, err := m.confirm(&terraform.InputOpts{
-		Id:    "backend-migrate-to-local",
-		Query: fmt.Sprintf("Do you want to copy the state from %q?", s.Backend.Type),
-		Description: fmt.Sprintf(
-			strings.TrimSpace(inputBackendMigrateLocal), s.Backend.Type),
-	})
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error asking for state copy action: %s", err)
+	copy := m.forceInitCopy
+	if !copy {
+		var err error
+		// Confirm with the user that the copy should occur
+		copy, err = m.confirm(&terraform.InputOpts{
+			Id:    "backend-migrate-to-local",
+			Query: fmt.Sprintf("Do you want to copy the state from %q?", s.Backend.Type),
+			Description: fmt.Sprintf(
+				strings.TrimSpace(inputBackendMigrateLocal), s.Backend.Type),
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error asking for state copy action: %s", err)
+		}
 	}
 
 	// If we're copying, perform the migration
@@ -805,16 +809,19 @@ func (m *Meta) backend_c_R_S(
 	s := sMgr.State()
 
 	// Ask the user if they want to migrate their existing remote state
-	copy, err := m.confirm(&terraform.InputOpts{
-		Id: "backend-migrate-to-new",
-		Query: fmt.Sprintf(
-			"Do you want to copy the legacy remote state from %q?",
-			s.Remote.Type),
-		Description: strings.TrimSpace(inputBackendMigrateLegacyLocal),
-	})
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error asking for state copy action: %s", err)
+	copy := m.forceInitCopy
+	if !copy {
+		copy, err = m.confirm(&terraform.InputOpts{
+			Id: "backend-migrate-to-new",
+			Query: fmt.Sprintf(
+				"Do you want to copy the legacy remote state from %q?",
+				s.Remote.Type),
+			Description: strings.TrimSpace(inputBackendMigrateLegacyLocal),
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error asking for state copy action: %s", err)
+		}
 	}
 
 	// If the user wants a copy, copy!
@@ -898,16 +905,19 @@ func (m *Meta) backend_C_R_s(
 
 	// Finally, ask the user if they want to copy the state from
 	// their old remote state location.
-	copy, err := m.confirm(&terraform.InputOpts{
-		Id: "backend-migrate-to-new",
-		Query: fmt.Sprintf(
-			"Do you want to copy the legacy remote state from %q?",
-			s.Remote.Type),
-		Description: strings.TrimSpace(inputBackendMigrateLegacy),
-	})
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error asking for state copy action: %s", err)
+	copy := m.forceInitCopy
+	if !copy {
+		copy, err = m.confirm(&terraform.InputOpts{
+			Id: "backend-migrate-to-new",
+			Query: fmt.Sprintf(
+				"Do you want to copy the legacy remote state from %q?",
+				s.Remote.Type),
+			Description: strings.TrimSpace(inputBackendMigrateLegacy),
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error asking for state copy action: %s", err)
+		}
 	}
 
 	// If the user wants a copy, copy!
@@ -1055,14 +1065,17 @@ func (m *Meta) backend_C_r_S_changed(
 	}
 
 	// Check with the user if we want to migrate state
-	copy, err := m.confirm(&terraform.InputOpts{
-		Id:          "backend-migrate-to-new",
-		Query:       fmt.Sprintf("Do you want to copy the state from %q?", c.Type),
-		Description: strings.TrimSpace(fmt.Sprintf(inputBackendMigrateChange, c.Type, s.Backend.Type)),
-	})
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error asking for state copy action: %s", err)
+	copy := m.forceInitCopy
+	if !copy {
+		copy, err = m.confirm(&terraform.InputOpts{
+			Id:          "backend-migrate-to-new",
+			Query:       fmt.Sprintf("Do you want to copy the state from %q?", c.Type),
+			Description: strings.TrimSpace(fmt.Sprintf(inputBackendMigrateChange, c.Type, s.Backend.Type)),
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error asking for state copy action: %s", err)
+		}
 	}
 
 	// If we are, then we need to initialize the old backend and
@@ -1198,16 +1211,19 @@ func (m *Meta) backend_C_R_S_unchanged(
 	}
 
 	// Ask if the user wants to move their legacy remote state
-	copy, err := m.confirm(&terraform.InputOpts{
-		Id: "backend-migrate-to-new",
-		Query: fmt.Sprintf(
-			"Do you want to copy the legacy remote state from %q?",
-			s.Remote.Type),
-		Description: strings.TrimSpace(inputBackendMigrateLegacy),
-	})
-	if err != nil {
-		return nil, fmt.Errorf(
-			"Error asking for state copy action: %s", err)
+	copy := m.forceInitCopy
+	if !copy {
+		copy, err = m.confirm(&terraform.InputOpts{
+			Id: "backend-migrate-to-new",
+			Query: fmt.Sprintf(
+				"Do you want to copy the legacy remote state from %q?",
+				s.Remote.Type),
+			Description: strings.TrimSpace(inputBackendMigrateLegacy),
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"Error asking for state copy action: %s", err)
+		}
 	}
 
 	// If the user wants a copy, copy!

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -480,11 +480,10 @@ func TestMetaBackend_configureNewWithStateExisting(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	// Ask input
-	defer testInteractiveInput(t, []string{"yes"})()
-
 	// Setup the meta
 	m := testMetaBackend(t, nil)
+	// suppress input
+	m.forceInitCopy = true
 
 	// Get the backend
 	b, err := m.Backend(&BackendOpts{Init: true})
@@ -722,11 +721,11 @@ func TestMetaBackend_configureNewLegacyCopy(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	// Ask input
-	defer testInteractiveInput(t, []string{"yes", "yes"})()
-
 	// Setup the meta
 	m := testMetaBackend(t, nil)
+
+	// suppress input
+	m.forceInitCopy = true
 
 	// Get the backend
 	b, err := m.Backend(&BackendOpts{Init: true})
@@ -1593,11 +1592,9 @@ func TestMetaBackend_configuredUnchangedLegacyCopy(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	// Ask input
-	defer testInteractiveInput(t, []string{"yes", "yes"})()
-
 	// Setup the meta
 	m := testMetaBackend(t, nil)
+	m.forceInitCopy = true
 
 	// Get the backend
 	b, err := m.Backend(&BackendOpts{Init: true})


### PR DESCRIPTION
The `-force-copy` option will suppress confirmation for copying state
data.

Modify some tests to use the option, making sure to leave coverage of
the Input code path.

fixes #12921 