### PR TITLE
merge config.Terraform fields in config.Append

### DIFF
--- a/config/append.go
+++ b/config/append.go
@@ -35,8 +35,13 @@ func Append(c1, c2 *Config) (*Config, error) {
 		c.Atlas = c2.Atlas
 	}
 
-	c.Terraform = c1.Terraform
-	if c2.Terraform != nil {
+	// merge Terraform blocks
+	if c1.Terraform != nil {
+		c.Terraform = c1.Terraform
+		if c2.Terraform != nil {
+			c.Terraform.Merge(c2.Terraform)
+		}
+	} else {
 		c.Terraform = c2.Terraform
 	}
 

--- a/config/append_test.go
+++ b/config/append_test.go
@@ -119,6 +119,7 @@ func TestAppend(t *testing.T) {
 			false,
 		},
 
+		// appending configs merges terraform blocks
 		{
 			&Config{
 				Terraform: &Terraform{

--- a/config/append_test.go
+++ b/config/append_test.go
@@ -118,6 +118,30 @@ func TestAppend(t *testing.T) {
 			},
 			false,
 		},
+
+		{
+			&Config{
+				Terraform: &Terraform{
+					RequiredVersion: "A",
+				},
+			},
+			&Config{
+				Terraform: &Terraform{
+					Backend: &Backend{
+						Type: "test",
+					},
+				},
+			},
+			&Config{
+				Terraform: &Terraform{
+					RequiredVersion: "A",
+					Backend: &Backend{
+						Type: "test",
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {

--- a/config/config_terraform.go
+++ b/config/config_terraform.go
@@ -47,6 +47,18 @@ func (t *Terraform) Validate() []error {
 	return errs
 }
 
+// Merge t with t2.
+// Any conflicting fields are overwritten by t2.
+func (t *Terraform) Merge(t2 *Terraform) {
+	if t2.RequiredVersion != "" {
+		t.RequiredVersion = t2.RequiredVersion
+	}
+
+	if t2.Backend != nil {
+		t.Backend = t2.Backend
+	}
+}
+
 // Backend is the configuration for the "backend" to use with Terraform.
 // A backend is responsible for all major behavior of Terraform's core.
 // The abstraction layer above the core (the "backend") allows for behavior

--- a/config/merge.go
+++ b/config/merge.go
@@ -32,9 +32,13 @@ func Merge(c1, c2 *Config) (*Config, error) {
 		c.Atlas = c2.Atlas
 	}
 
-	// Merge the Terraform configuration, which is a complete overwrite.
-	c.Terraform = c1.Terraform
-	if c2.Terraform != nil {
+	// Merge the Terraform configuration
+	if c1.Terraform != nil {
+		c.Terraform = c1.Terraform
+		if c2.Terraform != nil {
+			c.Terraform.Merge(c2.Terraform)
+		}
+	} else {
 		c.Terraform = c2.Terraform
 	}
 

--- a/config/merge_test.go
+++ b/config/merge_test.go
@@ -434,6 +434,31 @@ func TestMerge(t *testing.T) {
 			},
 			false,
 		},
+
+		// terraform blocks are merged, not overwritten
+		{
+			&Config{
+				Terraform: &Terraform{
+					RequiredVersion: "A",
+				},
+			},
+			&Config{
+				Terraform: &Terraform{
+					Backend: &Backend{
+						Type: "test",
+					},
+				},
+			},
+			&Config{
+				Terraform: &Terraform{
+					RequiredVersion: "A",
+					Backend: &Backend{
+						Type: "test",
+					},
+				},
+			},
+			false,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
Ensure that fields set in an earlier Terraform config block aren't
removed by Append when encountering another Terraform block. When
multiple blocks contain the same field, the later one still wins.

Fixes #12905 