### PR TITLE
kubernetes: Ignore internal K8S annotations in config_map + use PATCH

### DIFF
--- a/builtin/providers/kubernetes/patch_operations.go
+++ b/builtin/providers/kubernetes/patch_operations.go
@@ -1,0 +1,135 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+func diffStringMap(pathPrefix string, oldV, newV map[string]interface{}) PatchOperations {
+	ops := make([]PatchOperation, 0, 0)
+
+	pathPrefix = strings.TrimRight(pathPrefix, "/")
+
+	// This is suboptimal for adding whole new map from scratch
+	// or deleting the whole map, but it's actually intention.
+	// There may be some other map items managed outside of TF
+	// and we don't want to touch these.
+
+	for k, _ := range oldV {
+		if _, ok := newV[k]; ok {
+			continue
+		}
+		ops = append(ops, &RemoveOperation{Path: pathPrefix + "/" + k})
+	}
+
+	for k, v := range newV {
+		newValue := v.(string)
+
+		if oldValue, ok := oldV[k].(string); ok {
+			if oldValue == newValue {
+				continue
+			}
+
+			ops = append(ops, &ReplaceOperation{
+				Path:  pathPrefix + "/" + k,
+				Value: newValue,
+			})
+			continue
+		}
+
+		ops = append(ops, &AddOperation{
+			Path:  pathPrefix + "/" + k,
+			Value: newValue,
+		})
+	}
+
+	return ops
+}
+
+type PatchOperations []PatchOperation
+
+func (po PatchOperations) MarshalJSON() ([]byte, error) {
+	var v []PatchOperation = po
+	return json.Marshal(v)
+}
+
+func (po PatchOperations) Equal(ops []PatchOperation) bool {
+	var v []PatchOperation = po
+
+	sort.Slice(v, sortByPathAsc(ops))
+	sort.Slice(ops, sortByPathAsc(ops))
+
+	return reflect.DeepEqual(v, ops)
+}
+
+func sortByPathAsc(ops []PatchOperation) func(i, j int) bool {
+	return func(i, j int) bool {
+		return ops[i].GetPath() < ops[j].GetPath()
+	}
+}
+
+type PatchOperation interface {
+	MarshalJSON() ([]byte, error)
+	GetPath() string
+}
+
+type ReplaceOperation struct {
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+	Op    string      `json:"op"`
+}
+
+func (o *ReplaceOperation) GetPath() string {
+	return o.Path
+}
+
+func (o *ReplaceOperation) MarshalJSON() ([]byte, error) {
+	o.Op = "replace"
+	return json.Marshal(*o)
+}
+
+func (o *ReplaceOperation) String() string {
+	b, _ := o.MarshalJSON()
+	return string(b)
+}
+
+type AddOperation struct {
+	Path  string      `json:"path"`
+	Value interface{} `json:"value"`
+	Op    string      `json:"op"`
+}
+
+func (o *AddOperation) GetPath() string {
+	return o.Path
+}
+
+func (o *AddOperation) MarshalJSON() ([]byte, error) {
+	o.Op = "add"
+	return json.Marshal(*o)
+}
+
+func (o *AddOperation) String() string {
+	b, _ := o.MarshalJSON()
+	return string(b)
+}
+
+type RemoveOperation struct {
+	Path string `json:"path"`
+	Op   string `json:"op"`
+}
+
+func (o *RemoveOperation) GetPath() string {
+	return o.Path
+}
+
+func (o *RemoveOperation) MarshalJSON() ([]byte, error) {
+	o.Op = "remove"
+	return json.Marshal(*o)
+}
+
+func (o *RemoveOperation) String() string {
+	b, _ := o.MarshalJSON()
+	return string(b)
+}

--- a/builtin/providers/kubernetes/patch_operations_test.go
+++ b/builtin/providers/kubernetes/patch_operations_test.go
@@ -1,0 +1,126 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestDiffStringMap(t *testing.T) {
+	testCases := []struct {
+		Path        string
+		Old         map[string]interface{}
+		New         map[string]interface{}
+		ExpectedOps PatchOperations
+	}{
+		{
+			Path: "/parent/",
+			Old: map[string]interface{}{
+				"one": "111",
+				"two": "222",
+			},
+			New: map[string]interface{}{
+				"one":   "111",
+				"two":   "222",
+				"three": "333",
+			},
+			ExpectedOps: []PatchOperation{
+				&AddOperation{
+					Path:  "/parent/three",
+					Value: "333",
+				},
+			},
+		},
+		{
+			Path: "/parent/",
+			Old: map[string]interface{}{
+				"one": "111",
+				"two": "222",
+			},
+			New: map[string]interface{}{
+				"one": "111",
+				"two": "abcd",
+			},
+			ExpectedOps: []PatchOperation{
+				&ReplaceOperation{
+					Path:  "/parent/two",
+					Value: "abcd",
+				},
+			},
+		},
+		{
+			Path: "/parent/",
+			Old: map[string]interface{}{
+				"one": "111",
+				"two": "222",
+			},
+			New: map[string]interface{}{
+				"two":   "abcd",
+				"three": "333",
+			},
+			ExpectedOps: []PatchOperation{
+				&RemoveOperation{Path: "/parent/one"},
+				&ReplaceOperation{
+					Path:  "/parent/two",
+					Value: "abcd",
+				},
+				&AddOperation{
+					Path:  "/parent/three",
+					Value: "333",
+				},
+			},
+		},
+		{
+			Path: "/parent/",
+			Old: map[string]interface{}{
+				"one": "111",
+				"two": "222",
+			},
+			New: map[string]interface{}{
+				"two": "222",
+			},
+			ExpectedOps: []PatchOperation{
+				&RemoveOperation{Path: "/parent/one"},
+			},
+		},
+		{
+			Path: "/parent/",
+			Old: map[string]interface{}{
+				"one": "111",
+				"two": "222",
+			},
+			New: map[string]interface{}{},
+			ExpectedOps: []PatchOperation{
+				&RemoveOperation{Path: "/parent/one"},
+				&RemoveOperation{Path: "/parent/two"},
+			},
+		},
+		{
+			Path: "/parent/",
+			Old:  map[string]interface{}{},
+			New: map[string]interface{}{
+				"one": "111",
+				"two": "222",
+			},
+			ExpectedOps: []PatchOperation{
+				&AddOperation{
+					Path:  "/parent/one",
+					Value: "111",
+				},
+				&AddOperation{
+					Path:  "/parent/two",
+					Value: "222",
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			ops := diffStringMap(tc.Path, tc.Old, tc.New)
+			if !tc.ExpectedOps.Equal(ops) {
+				t.Fatalf("Operations don't match.\nExpected: %v\nGiven:    %v\n", tc.ExpectedOps, ops)
+			}
+		})
+	}
+
+}

--- a/builtin/providers/kubernetes/structures.go
+++ b/builtin/providers/kubernetes/structures.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/hashicorp/terraform/helper/schema"
 	api "k8s.io/kubernetes/pkg/api/v1"
 )
 
@@ -37,6 +38,21 @@ func expandMetadata(in []interface{}) api.ObjectMeta {
 	}
 
 	return meta
+}
+
+func patchMetadata(keyPrefix, pathPrefix string, d *schema.ResourceData) PatchOperations {
+	ops := make([]PatchOperation, 0, 0)
+	if d.HasChange(keyPrefix + "annotations") {
+		oldV, newV := d.GetChange(keyPrefix + "annotations")
+		diffOps := diffStringMap(pathPrefix+"annotations", oldV.(map[string]interface{}), newV.(map[string]interface{}))
+		ops = append(ops, diffOps...)
+	}
+	if d.HasChange(keyPrefix + "labels") {
+		oldV, newV := d.GetChange(keyPrefix + "labels")
+		diffOps := diffStringMap(pathPrefix+"labels", oldV.(map[string]interface{}), newV.(map[string]interface{}))
+		ops = append(ops, diffOps...)
+	}
+	return ops
 }
 
 func expandStringMap(m map[string]interface{}) map[string]string {

--- a/builtin/providers/kubernetes/structures_test.go
+++ b/builtin/providers/kubernetes/structures_test.go
@@ -1,0 +1,32 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestIsInternalAnnotationKey(t *testing.T) {
+	testCases := []struct {
+		Key      string
+		Expected bool
+	}{
+		{"", false},
+		{"anyKey", false},
+		{"any.hostname.io", false},
+		{"any.hostname.com/with/path", false},
+		{"any.kubernetes.io", true},
+		{"kubernetes.io", true},
+		{"pv.kubernetes.io/any/path", true},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			isInternal := isInternalAnnotationKey(tc.Key)
+			if tc.Expected && isInternal != tc.Expected {
+				t.Fatalf("Expected %q to be internal", tc.Key)
+			}
+			if !tc.Expected && isInternal != tc.Expected {
+				t.Fatalf("Expected %q not to be internal", tc.Key)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is something you'd unlikely noticed in the context of config map since config maps aren't annotated internally by default, but some other resources which I'm going to PR very soon are and I'd like to have the code in place and reviewed in isolation before adding more LOC.

### Why ignoring internal annotations

Each K8S object can have annotations which can be defined by the user, but more often are used by tools that interact w/ the K8S API - also by kubelet internally. Kubelet is maintaining annotations like these:

 - `pv.kubernetes.io/bound-by-controller = yes`
 - `pv.kubernetes.io/bind-completed = yes`

[et cetera](https://kubernetes.io/docs/api-reference/labels-annotations-taints/). [The convention and expectation](https://github.com/kubernetes/kubernetes/blob/v1.5.3/pkg/api/v1/types.go#L186-L191) from a K8S API consumer is to preserve any existing ones that it doesn't manage - therefore Terraform should not be deleting any existing annotations (which is what it does now).

#### Should Terraform have dedicated annotations prefix, e.g. `terraform.io/`?

I don't know, maybe? I'm not sure where is the right balance between allowing people to do anything, exclusively w/ Terraform VS allowing them to use Terraform alongside other tools with may be annotating resources too.

Looking at some other tools the approach really differs:

 - https://fabric8.io/guide/annotations.html (strictly separated)
 - https://www.projectcalico.org/calico-network-policy-comes-to-kubernetes/ (generic, i.e. `policy`)

Feedback welcomed. If we decide to have our own namespace, it would mean BC, but it's early enough in the life of the K8S provider, so should be pretty painless for most users.

### Why `PATCH`

While `Update()`s seem to be working fine, it's merely because kubelet is watching for any changes in the cluster and re-associates any annotations as necessary (you're able to watch how this happens in a matter of seconds via `kubectl get -w`). We do not want Terraform to stamp over other APIs or Kubelet annotations in any way.
