### PR TITLE
Adding "since" info

### DIFF
--- a/website/source/docs/state/environments.html.md
+++ b/website/source/docs/state/environments.html.md
@@ -8,6 +8,8 @@ description: |-
 
 # State Environments
 
+*Since 0.9*
+
 An environment is a state namespace, allowing a single folder of Terraform
 configurations to manage multiple distinct infrastructure resources.
 


### PR DESCRIPTION
We need to start adding in the docs since what version of terraform a feature is supported. This will improve highly the usage of the docs