### PR TITLE
provider/aws: Update IAM Group+User Policy Tests

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_group_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_group_policy_test.go
@@ -7,18 +7,20 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccIAMGroupPolicyConfig,
+			{
+				Config: testAccIAMGroupPolicyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicy(
 						"aws_iam_group.group",
@@ -26,8 +28,8 @@ func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
-				Config: testAccIAMGroupPolicyConfigUpdate,
+			{
+				Config: testAccIAMGroupPolicyConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicy(
 						"aws_iam_group.group",
@@ -40,14 +42,15 @@ func TestAccAWSIAMGroupPolicy_basic(t *testing.T) {
 }
 
 func TestAccAWSIAMGroupPolicy_namePrefix(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_iam_group_policy.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccIAMGroupPolicyConfig_namePrefix,
+			{
+				Config: testAccIAMGroupPolicyConfig_namePrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicy(
 						"aws_iam_group.test",
@@ -60,14 +63,15 @@ func TestAccAWSIAMGroupPolicy_namePrefix(t *testing.T) {
 }
 
 func TestAccAWSIAMGroupPolicy_generatedName(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_iam_group_policy.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMGroupPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccIAMGroupPolicyConfig_generatedName,
+			{
+				Config: testAccIAMGroupPolicyConfig_generatedName(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMGroupPolicy(
 						"aws_iam_group.test",
@@ -142,86 +146,90 @@ func testAccCheckIAMGroupPolicy(
 	}
 }
 
-const testAccIAMGroupPolicyConfig = `
-resource "aws_iam_group" "group" {
-	name = "test_group"
-	path = "/"
-}
+func testAccIAMGroupPolicyConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_group" "group" {
+		name = "test_group_%d"
+		path = "/"
+	}
 
-resource "aws_iam_group_policy" "foo" {
-	name = "foo_policy"
-	group = "${aws_iam_group.group.name}"
-	policy = <<EOF
+	resource "aws_iam_group_policy" "foo" {
+		name = "foo_policy_%d"
+		group = "${aws_iam_group.group.name}"
+		policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
+	"Version": "2012-10-17",
+	"Statement": {
+		"Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+	}
 }
 EOF
-}
-`
-
-const testAccIAMGroupPolicyConfig_namePrefix = `
-resource "aws_iam_group" "test" {
-	name = "test_group"
-	path = "/"
+	}`, rInt, rInt)
 }
 
-resource "aws_iam_group_policy" "test" {
-	name_prefix = "test-"
-	group = "${aws_iam_group.test.name}"
-	policy = <<EOF
+func testAccIAMGroupPolicyConfig_namePrefix(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_group" "test" {
+		name = "test_group_%d"
+		path = "/"
+	}
+
+	resource "aws_iam_group_policy" "test" {
+		name_prefix = "test-%d"
+		group = "${aws_iam_group.test.name}"
+		policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
+	"Version": "2012-10-17",
+	"Statement": {
+		"Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+	}
 }
 EOF
-}
-`
-
-const testAccIAMGroupPolicyConfig_generatedName = `
-resource "aws_iam_group" "test" {
-	name = "test_group"
-	path = "/"
+	}`, rInt, rInt)
 }
 
-resource "aws_iam_group_policy" "test" {
-	group = "${aws_iam_group.test.name}"
-	policy = <<EOF
+func testAccIAMGroupPolicyConfig_generatedName(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_group" "test" {
+		name = "test_group_%d"
+		path = "/"
+	}
+
+	resource "aws_iam_group_policy" "test" {
+		group = "${aws_iam_group.test.name}"
+		policy = <<EOF
 {
-  "Version": "2012-10-17",
-  "Statement": {
-    "Effect": "Allow",
-    "Action": "*",
-    "Resource": "*"
-  }
+	"Version": "2012-10-17",
+	"Statement": {
+		"Effect": "Allow",
+		"Action": "*",
+		"Resource": "*"
+	}
 }
 EOF
-}
-`
-
-const testAccIAMGroupPolicyConfigUpdate = `
-resource "aws_iam_group" "group" {
-	name = "test_group"
-	path = "/"
+	}`, rInt)
 }
 
-resource "aws_iam_group_policy" "foo" {
-	name = "foo_policy"
-	group = "${aws_iam_group.group.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
-}
+func testAccIAMGroupPolicyConfigUpdate(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_group" "group" {
+		name = "test_group_%d"
+		path = "/"
+	}
 
-resource "aws_iam_group_policy" "bar" {
-	name = "bar_policy"
-	group = "${aws_iam_group.group.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	resource "aws_iam_group_policy" "foo" {
+		name = "foo_policy_%d"
+		group = "${aws_iam_group.group.name}"
+		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	}
+
+	resource "aws_iam_group_policy" "bar" {
+		name = "bar_policy_%d"
+		group = "${aws_iam_group.group.name}"
+		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	}`, rInt, rInt, rInt)
 }
-`

--- a/builtin/providers/aws/resource_aws_iam_user_policy_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_policy_test.go
@@ -7,18 +7,21 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccIAMUserPolicyConfig,
+			{
+				Config: testAccIAMUserPolicyConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(
 						"aws_iam_user.user",
@@ -26,8 +29,8 @@ func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 					),
 				),
 			},
-			resource.TestStep{
-				Config: testAccIAMUserPolicyConfigUpdate,
+			{
+				Config: testAccIAMUserPolicyConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(
 						"aws_iam_user.user",
@@ -40,14 +43,16 @@ func TestAccAWSIAMUserPolicy_basic(t *testing.T) {
 }
 
 func TestAccAWSIAMUserPolicy_namePrefix(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_iam_user_policy.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccIAMUserPolicyConfig_namePrefix,
+			{
+				Config: testAccIAMUserPolicyConfig_namePrefix(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(
 						"aws_iam_user.test",
@@ -60,14 +65,16 @@ func TestAccAWSIAMUserPolicy_namePrefix(t *testing.T) {
 }
 
 func TestAccAWSIAMUserPolicy_generatedName(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_iam_user_policy.test",
 		Providers:     testAccProviders,
 		CheckDestroy:  testAccCheckIAMUserPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccIAMUserPolicyConfig_generatedName,
+			{
+				Config: testAccIAMUserPolicyConfig_generatedName(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckIAMUserPolicy(
 						"aws_iam_user.test",
@@ -145,59 +152,63 @@ func testAccCheckIAMUserPolicy(
 	}
 }
 
-const testAccIAMUserPolicyConfig = `
-resource "aws_iam_user" "user" {
-	name = "test_user"
-	path = "/"
+func testAccIAMUserPolicyConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_user" "user" {
+		name = "test_user_%d"
+		path = "/"
+	}
+
+	resource "aws_iam_user_policy" "foo" {
+		name = "foo_policy_%d"
+		user = "${aws_iam_user.user.name}"
+		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	}`, rInt, rInt)
 }
 
-resource "aws_iam_user_policy" "foo" {
-	name = "foo_policy"
-	user = "${aws_iam_user.user.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
-}
-`
+func testAccIAMUserPolicyConfig_namePrefix(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_user" "test" {
+		name = "test_user_%d"
+		path = "/"
+	}
 
-const testAccIAMUserPolicyConfig_namePrefix = `
-resource "aws_iam_user" "test" {
-	name = "test_user"
-	path = "/"
-}
-
-resource "aws_iam_user_policy" "test" {
-	name_prefix = "test-"
-	user = "${aws_iam_user.test.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
-}
-`
-
-const testAccIAMUserPolicyConfig_generatedName = `
-resource "aws_iam_user" "test" {
-	name = "test_user"
-	path = "/"
+	resource "aws_iam_user_policy" "test" {
+		name_prefix = "test-%d"
+		user = "${aws_iam_user.test.name}"
+		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	}`, rInt, rInt)
 }
 
-resource "aws_iam_user_policy" "test" {
-	user = "${aws_iam_user.test.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
-}
-`
+func testAccIAMUserPolicyConfig_generatedName(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_user" "test" {
+		name = "test_user_%d"
+		path = "/"
+	}
 
-const testAccIAMUserPolicyConfigUpdate = `
-resource "aws_iam_user" "user" {
-	name = "test_user"
-	path = "/"
-}
-
-resource "aws_iam_user_policy" "foo" {
-	name = "foo_policy"
-	user = "${aws_iam_user.user.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	resource "aws_iam_user_policy" "test" {
+		user = "${aws_iam_user.test.name}"
+		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	}`, rInt)
 }
 
-resource "aws_iam_user_policy" "bar" {
-	name = "bar_policy"
-	user = "${aws_iam_user.user.name}"
-	policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+func testAccIAMUserPolicyConfigUpdate(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_iam_user" "user" {
+		name = "test_user_%d"
+		path = "/"
+	}
+
+	resource "aws_iam_user_policy" "foo" {
+		name = "foo_policy_%d"
+		user = "${aws_iam_user.user.name}"
+		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	}
+
+	resource "aws_iam_user_policy" "bar" {
+		name = "bar_policy_%d"
+		user = "${aws_iam_user.user.name}"
+		policy = "{\"Version\":\"2012-10-17\",\"Statement\":{\"Effect\":\"Allow\",\"Action\":\"*\",\"Resource\":\"*\"}}"
+	}`, rInt, rInt, rInt)
 }
-`


### PR DESCRIPTION
Updates the IAM Group Policy and IAM User Policy acceptance tests with random integer seeds.
Currently acceptance tests for these two resources are failing from leaked resources, adding distint naming should allow tests to pass regardless of parallel tests being ran or any resource leaks.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSIAMUserPolicy'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/22 00:19:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSIAMUserPolicy -timeout 120m
=== RUN   TestAccAWSIAMUserPolicy_basic
--- PASS: TestAccAWSIAMUserPolicy_basic (22.54s)
=== RUN   TestAccAWSIAMUserPolicy_namePrefix
--- PASS: TestAccAWSIAMUserPolicy_namePrefix (12.49s)
=== RUN   TestAccAWSIAMUserPolicy_generatedName
--- PASS: TestAccAWSIAMUserPolicy_generatedName (13.13s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    48.191s
```

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSIAMGroupPolicy'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/22 00:24:08 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSIAMGroupPolicy -timeout 120m
=== RUN   TestAccAWSIAMGroupPolicy_basic
--- PASS: TestAccAWSIAMGroupPolicy_basic (23.89s)
=== RUN   TestAccAWSIAMGroupPolicy_namePrefix
--- PASS: TestAccAWSIAMGroupPolicy_namePrefix (12.07s)
=== RUN   TestAccAWSIAMGroupPolicy_generatedName
--- PASS: TestAccAWSIAMGroupPolicy_generatedName (13.15s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    49.140s
```