### PR TITLE
provider/kubernetes: ConfigMap metadata name did not comply to the regex rules

### DIFF
--- a/website/source/docs/providers/kubernetes/r/config_map.html.markdown
+++ b/website/source/docs/providers/kubernetes/r/config_map.html.markdown
@@ -16,7 +16,7 @@ Config Map can be used to store fine-grained information like individual propert
 ```
 resource "kubernetes_config_map" "example" {
   metadata {
-  	name = "my_config"
+  	name = "my-config"
   }
   data {
   	api_host = "myhost:443"
@@ -56,5 +56,5 @@ The following arguments are supported:
 Config Map can be imported using its name, e.g.
 
 ```
-$ terraform import kubernetes_config_map.example my_config
+$ terraform import kubernetes_config_map.example my-config
 ```


### PR DESCRIPTION
According to the [Kubernetes documentation](https://kubernetes.io/docs/user-guide/identifiers/#names) the name cannot contain an underscore. I've updated the ConfigMap documentation to comply to the naming regex.