### PR TITLE
provider/kubernetes: Allow defining custom config context

### DIFF
--- a/builtin/providers/kubernetes/provider.go
+++ b/builtin/providers/kubernetes/provider.go
@@ -66,6 +66,11 @@ func Provider() terraform.ResourceProvider {
 				DefaultFunc: schema.EnvDefaultFunc("KUBE_CONFIG", "~/.kube/config"),
 				Description: "Path to the kube config file, defaults to ~/.kube/config",
 			},
+			"config_context": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KUBE_CTX", ""),
+			},
 			"config_context_auth_info": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -140,22 +145,32 @@ func tryLoadingConfigFile(d *schema.ResourceData) (*restclient.Config, error) {
 	loader := &clientcmd.ClientConfigLoadingRules{
 		ExplicitPath: path,
 	}
+
 	overrides := &clientcmd.ConfigOverrides{}
-	ctxSuffix := "; no context"
+	ctxSuffix := "; default context"
+
+	ctx, ctxOk := d.GetOk("config_context")
 	authInfo, authInfoOk := d.GetOk("config_context_auth_info")
 	cluster, clusterOk := d.GetOk("config_context_cluster")
-	if authInfoOk || clusterOk {
+	if ctxOk || authInfoOk || clusterOk {
+		ctxSuffix = "; overriden context"
+		if ctxOk {
+			overrides.CurrentContext = ctx.(string)
+			ctxSuffix += fmt.Sprintf("; config ctx: %s", overrides.CurrentContext)
+			log.Printf("[DEBUG] Using custom current context: %q", overrides.CurrentContext)
+		}
+
 		overrides.Context = clientcmdapi.Context{}
 		if authInfoOk {
 			overrides.Context.AuthInfo = authInfo.(string)
+			ctxSuffix += fmt.Sprintf("; auth_info: %s", overrides.Context.AuthInfo)
 		}
 		if clusterOk {
 			overrides.Context.Cluster = cluster.(string)
+			ctxSuffix += fmt.Sprintf("; cluster: %s", overrides.Context.Cluster)
 		}
-		ctxSuffix = fmt.Sprintf("; auth_info: %s, cluster: %s",
-			overrides.Context.AuthInfo, overrides.Context.Cluster)
+		log.Printf("[DEBUG] Using overidden context: %#v", overrides.Context)
 	}
-	log.Printf("[DEBUG] Using override context: %#v", *overrides)
 
 	cc := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loader, overrides)
 	cfg, err := cc.ClientConfig()

--- a/website/source/docs/providers/kubernetes/index.html.markdown
+++ b/website/source/docs/providers/kubernetes/index.html.markdown
@@ -33,8 +33,28 @@ resource "kubernetes_namespace" "example" {
 
 There are generally two ways to configure the Kubernetes provider.
 
+### File config
+
 The provider always first tries to load **a config file** from a given
-(or default) location - this requires valid `config_context_auth_info` & `config_context_cluster`.
+(or default) location. Depending on whether you have current context set
+this _may_ require `config_context_auth_info` and/or `config_context_cluster`
+and/or `config_context`.
+
+#### Setting default config context
+
+Here's an example for how to set default context and avoid all provider configuration:
+
+```
+kubectl config set-context default-system \
+  --cluster=chosen-cluster \
+  --user=chosen-user
+
+kubectl config use-context default-system
+```
+
+Read [more about `kubectl` in the official docs](https://kubernetes.io/docs/user-guide/kubectl-overview/).
+
+### Statically defined credentials
 
 The other way is **statically** define all the credentials:
 
@@ -64,5 +84,6 @@ The following arguments are supported:
 * `client_key` - (Optional) PEM-encoded client certificate key for TLS authentication. Can be sourced from `KUBE_CLIENT_KEY_DATA`.
 * `cluster_ca_certificate` - (Optional) PEM-encoded root certificates bundle for TLS authentication. Can be sourced from `KUBE_CLUSTER_CA_CERT_DATA`.
 * `config_path` - (Optional) Path to the kube config file. Can be sourced from `KUBE_CONFIG`. Defaults to `~/.kube/config`.
+* `config_context` - (Optional) Context to choose from the config file. Can be sourced from `KUBE_CTX`.
 * `config_context_auth_info` - (Optional) Authentication info context of the kube config (name of the kubeconfig user, `--user` flag in `kubectl`). Can be sourced from `KUBE_CTX_AUTH_INFO`.
 * `config_context_cluster` - (Optional) Cluster context of the kube config (name of the kubeconfig cluster, `--cluster` flag in `kubectl`). Can be sourced from `KUBE_CTX_CLUSTER`.


### PR DESCRIPTION
It wasn't entirely clear to me when I was implementing this initially whether one can load a config file without specifying auth_info and/or cluster context, but I figured it's possible, so I'm documenting this appropriately.

This also allows the user to specify/override the high-level config context and avoid provider configuration in Terraform completely.

I'm removing a DEBUG log which could contain some sensitive data, so this should reduce the risk of exposing such data.