### PR TITLE
provider/aws: Lower metadata log msg from WARN to INFO

### DIFF
--- a/builtin/providers/aws/auth_helpers.go
+++ b/builtin/providers/aws/auth_helpers.go
@@ -134,7 +134,7 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 			if usedEndpoint == "" {
 				usedEndpoint = "default location"
 			}
-			log.Printf("[WARN] Ignoring AWS metadata API endpoint at %s "+
+			log.Printf("[INFO] Ignoring AWS metadata API endpoint at %s "+
 				"as it doesn't return any instance-id", usedEndpoint)
 		}
 	}


### PR DESCRIPTION
No need to worry about such cases as it just means metadata service is not available at all or doesn't look like metadata service - i.e. no need to keep this at WARN level.