### PR TITLE
provider/aws: OpsWorks updates

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -71,7 +71,7 @@ func resourceAwsOpsworksStack() *schema.Resource {
 			"configuration_manager_version": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "11.4",
+				Default:  "11.10",
 			},
 
 			"manage_berkshelf": {
@@ -156,6 +156,7 @@ func resourceAwsOpsworksStack() *schema.Resource {
 			"default_subnet_id": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"hostname_theme": {
@@ -179,6 +180,7 @@ func resourceAwsOpsworksStack() *schema.Resource {
 			"vpc_id": {
 				Type:     schema.TypeString,
 				ForceNew: true,
+				Computed: true,
 				Optional: true,
 			},
 		},
@@ -431,10 +433,17 @@ func resourceAwsOpsworksStackUpdate(d *schema.ResourceData, meta interface{}) er
 	if v, ok := d.GetOk("color"); ok {
 		req.Attributes["Color"] = aws.String(v.(string))
 	}
+
 	req.ChefConfiguration = &opsworks.ChefConfiguration{
-		BerkshelfVersion: aws.String(d.Get("berkshelf_version").(string)),
-		ManageBerkshelf:  aws.Bool(d.Get("manage_berkshelf").(bool)),
+		ManageBerkshelf: aws.Bool(d.Get("manage_berkshelf").(bool)),
 	}
+
+	if v := d.Get("manage_berkshelf").(bool); v {
+		req.ChefConfiguration = &opsworks.ChefConfiguration{
+			BerkshelfVersion: aws.String(d.Get("berkshelf_version").(string)),
+		}
+	}
+
 	req.ConfigurationManager = &opsworks.StackConfigurationManager{
 		Name:    aws.String(d.Get("configuration_manager_name").(string)),
 		Version: aws.String(d.Get("configuration_manager_version").(string)),

--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -435,13 +435,8 @@ func resourceAwsOpsworksStackUpdate(d *schema.ResourceData, meta interface{}) er
 	}
 
 	req.ChefConfiguration = &opsworks.ChefConfiguration{
-		ManageBerkshelf: aws.Bool(d.Get("manage_berkshelf").(bool)),
-	}
-
-	if v := d.Get("manage_berkshelf").(bool); v {
-		req.ChefConfiguration = &opsworks.ChefConfiguration{
-			BerkshelfVersion: aws.String(d.Get("berkshelf_version").(string)),
-		}
+		BerkshelfVersion: aws.String(d.Get("berkshelf_version").(string)),
+		ManageBerkshelf:  aws.Bool(d.Get("manage_berkshelf").(bool)),
 	}
 
 	req.ConfigurationManager = &opsworks.StackConfigurationManager{


### PR DESCRIPTION
Minor OpsWorks updates to allow minimal configuration

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworks -timeout 120m
=== RUN   TestAccAWSOpsworksCustomLayerImportBasic
--- PASS: TestAccAWSOpsworksCustomLayerImportBasic (30.96s)
=== RUN   TestAccAWSOpsworksStackImportBasic
--- PASS: TestAccAWSOpsworksStackImportBasic (29.90s)
=== RUN   TestAccAWSOpsworksApplication
--- PASS: TestAccAWSOpsworksApplication (43.34s)
=== RUN   TestAccAWSOpsworksCustomLayer
--- PASS: TestAccAWSOpsworksCustomLayer (36.21s)
=== RUN   TestAccAWSOpsworksInstance_importBasic
--- PASS: TestAccAWSOpsworksInstance_importBasic (33.57s)
=== RUN   TestAccAWSOpsworksInstance
--- PASS: TestAccAWSOpsworksInstance (54.05s)
=== RUN   TestAccAWSOpsworksPermission
--- PASS: TestAccAWSOpsworksPermission (79.53s)
=== RUN   TestAccAWSOpsworksRailsAppLayer
--- PASS: TestAccAWSOpsworksRailsAppLayer (47.21s)
=== RUN   TestAccAWSOpsworksRdsDbInstance
--- PASS: TestAccAWSOpsworksRdsDbInstance (862.82s)
=== RUN   TestAccAWSOpsworksStackNoVpc
--- PASS: TestAccAWSOpsworksStackNoVpc (20.33s)
=== RUN   TestAccAWSOpsworksStackVpc
--- PASS: TestAccAWSOpsworksStackVpc (44.31s)
=== RUN   TestAccAWSOpsworksUserProfile
--- PASS: TestAccAWSOpsworksUserProfile (25.28s)
```