### PR TITLE
testing: Add option to run only a plan on a TestStep configuration

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -151,6 +151,11 @@ type TestStep struct {
 	// test to pass.
 	ExpectError *regexp.Regexp
 
+	// PlanOnly can be set to only run `plan` with this configuration, and not
+	// actually apply it. This is useful for ensuring config changes result in
+	// no-op plans
+	PlanOnly bool
+
 	// PreventPostDestroyRefresh can be set to true for cases where data sources
 	// are tested alongside real resources
 	PreventPostDestroyRefresh bool


### PR DESCRIPTION
Allow option to only run `plan` on a `TestStep` configuration 