### PR TITLE
provider/aws: Consider ACTIVE as pending state during ECS svc deletion

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -467,7 +467,7 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 
 	// Wait until it's deleted
 	wait := resource.StateChangeConf{
-		Pending:    []string{"DRAINING"},
+		Pending:    []string{"ACTIVE", "DRAINING"},
 		Target:     []string{"INACTIVE"},
 		Timeout:    10 * time.Minute,
 		MinTimeout: 1 * time.Second,


### PR DESCRIPTION
This is to avoid the following failure/error which occurred in our nightly acceptance tests:

```
=== RUN   TestAccAWSEcsServiceWithARN
--- FAIL: TestAccAWSEcsServiceWithARN (105.79s)
    testing.go:332: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_ecs_service.mongo (destroy): 1 error(s) occurred:
        
        * aws_ecs_service.mongo: unexpected state 'ACTIVE', wanted target 'INACTIVE'. last error: %!s(<nil>)
        
        State: aws_ecs_cluster.default:
          ID = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest1
          name = terraformecstest1
        aws_ecs_service.mongo:
          ID = arn:aws:ecs:us-west-2:*******:service/mongodb
          cluster = arn:aws:ecs:us-west-2:*******:cluster/terraformecstest1
          deployment_maximum_percent = 200
          deployment_minimum_healthy_percent = 100
          desired_count = 2
          name = mongodb
          placement_constraints.# = 0
          placement_strategy.# = 0
          task_definition = arn:aws:ecs:us-west-2:*******:task-definition/mongodb:1910
        
          Dependencies:
            aws_ecs_cluster.default
            aws_ecs_task_definition.mongo
        aws_ecs_task_definition.mongo:
          ID = mongodb
          arn = arn:aws:ecs:us-west-2:*******:task-definition/mongodb:1910
          container_definitions = bdae2e050cbcada848106f226d19af2b62c3433b
          family = mongodb
          network_mode = 
          placement_constraints.# = 0
          revision = 1910
          task_role_arn =
```