### PR TITLE
Add named state support to the s3 backend

### DIFF
--- a/backend/remote-state/consul/backend_state.go
+++ b/backend/remote-state/consul/backend_state.go
@@ -56,7 +56,7 @@ func (b *Backend) States() ([]string, error) {
 }
 
 func (b *Backend) DeleteState(name string) error {
-	if name == backend.DefaultStateName {
+	if name == backend.DefaultStateName || name == "" {
 		return fmt.Errorf("can't delete default state")
 	}
 

--- a/backend/remote-state/s3/backend_state.go
+++ b/backend/remote-state/s3/backend_state.go
@@ -1,13 +1,18 @@
 package s3
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/state"
 	"github.com/hashicorp/terraform/state/remote"
 )
 
 const (
-	keyEnvPrefix = "-env:"
+	// This will be used a directory name, the odd looking colon is to reduce
+	// the chance of name conflicts with existing deployments.
+	keyEnvPrefix = "env:"
 )
 
 func (b *Backend) States() ([]string, error) {
@@ -16,6 +21,20 @@ func (b *Backend) States() ([]string, error) {
 
 func (b *Backend) DeleteState(name string) error {
 	return backend.ErrNamedStatesNotSupported
+	if name == backend.DefaultStateName || name == "" {
+		return fmt.Errorf("can't delete default state")
+	}
+
+	//params := &s3.ListObjectsInput{
+	//    Bucket:       &b.client.bucketName,
+	//    Delimiter:    aws.String("Delimiter"),
+	//    EncodingType: aws.String("EncodingType"),
+	//    Marker:       aws.String("Marker"),
+	//    MaxKeys:      aws.Int64(1),
+	//    Prefix:       aws.String("env"),
+	//    RequestPayer: aws.String("RequestPayer"),
+	//}
+	return nil
 }
 
 func (b *Backend) State(name string) (state.State, error) {
@@ -23,5 +42,30 @@ func (b *Backend) State(name string) (state.State, error) {
 		return nil, backend.ErrNamedStatesNotSupported
 	}
 
-	return &remote.State{Client: b.client}, nil
+	client := &RemoteClient{
+		s3Client:             b.s3Client,
+		dynClient:            b.dynClient,
+		bucketName:           b.bucketName,
+		path:                 b.path(name),
+		serverSideEncryption: b.serverSideEncryption,
+		acl:                  b.acl,
+		kmsKeyID:             b.kmsKeyID,
+		lockTable:            b.lockTable,
+	}
+
+	// TODO: create new state if it doesn't exist
+
+	return &remote.State{Client: client}, nil
+}
+
+func (b *Backend) client() *RemoteClient {
+	return &RemoteClient{}
+}
+
+func (b *Backend) path(name string) string {
+	if name == backend.DefaultStateName {
+		return b.keyName
+	}
+
+	return strings.Join([]string{keyEnvPrefix, name, b.keyName}, "/")
 }

--- a/backend/remote-state/s3/client_test.go
+++ b/backend/remote-state/s3/client_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestRemoteClient_impl(t *testing.T) {
-	var _ remote.Client = new(S3Client)
-	var _ remote.ClientLocker = new(S3Client)
+	var _ remote.Client = new(RemoteClient)
+	var _ remote.ClientLocker = new(RemoteClient)
 }
 
 func TestRemoteClient(t *testing.T) {
@@ -31,8 +31,8 @@ func TestRemoteClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	createS3Bucket(t, b.client, bucketName)
-	defer deleteS3Bucket(t, b.client, bucketName)
+	createS3Bucket(t, b.s3Client, bucketName)
+	defer deleteS3Bucket(t, b.s3Client, bucketName)
 
 	remote.TestClient(t, state.(*remote.State).Client)
 }
@@ -67,10 +67,10 @@ func TestRemoteClientLocks(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	createS3Bucket(t, b1.client, bucketName)
-	defer deleteS3Bucket(t, b1.client, bucketName)
-	createDynamoDBTable(t, b1.client, bucketName)
-	defer deleteDynamoDBTable(t, b1.client, bucketName)
+	createS3Bucket(t, b1.s3Client, bucketName)
+	defer deleteS3Bucket(t, b1.s3Client, bucketName)
+	createDynamoDBTable(t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t, b1.dynClient, bucketName)
 
 	remote.TestRemoteLocks(t, s1.(*remote.State).Client, s2.(*remote.State).Client)
 }


### PR DESCRIPTION
This adds named state (environment) support to the S3 backend.

A state NAME will prepend the configured s3 key with `env:/NAME/`.
The default state will remain rooted in the bucket for backwards
compatibility.

Locks in DynamoDB use the S3 key as the as the primary key value, so
locking will work as expected for multiple states.

Fixes #12768 