### PR TITLE
test changes to travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ plugin-dev: generate
 test: fmtcheck errcheck generate
 	go test -i $(TEST) || exit 1
 	echo $(TEST) | \
-		xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+		xargs -t -n4 go test $(TESTARGS) -timeout=60s -parallel=4
 
 # testacc runs acceptance tests
 testacc: fmtcheck generate


### PR DESCRIPTION
Now that we've found the test busy-loops, travis should be able to run
them again in a single batch.

Increase timeout to 60s. The consul backend tests come too close to that
and timout every time they stall a little.