### PR TITLE
provider/aws: Randomize acc tests for Inspector Assesment Tpl

### DIFF
--- a/builtin/providers/aws/resource_aws_inspector_assessment_template_test.go
+++ b/builtin/providers/aws/resource_aws_inspector_assessment_template_test.go
@@ -7,24 +7,27 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/inspector"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSInspectorTemplate_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSInspectorTemplateDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSInspectorTemplateAssessment,
+				Config: testAccAWSInspectorTemplateAssessment(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSInspectorTemplateExists("aws_inspector_assessment_template.foo"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckAWSInspectorTemplatetModified,
+				Config: testAccCheckAWSInspectorTemplatetModified(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSInspectorTargetExists("aws_inspector_assessment_template.foo"),
 				),
@@ -74,20 +77,21 @@ func testAccCheckAWSInspectorTemplateExists(name string) resource.TestCheckFunc 
 	}
 }
 
-var testAccAWSInspectorTemplateAssessment = `
+func testAccAWSInspectorTemplateAssessment(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_inspector_resource_group" "foo" {
 	tags {
-	  Name  = "bar"
+	  Name  = "tf-acc-test-%d"
   }
 }
 
 resource "aws_inspector_assessment_target" "foo" {
-	name = "foo"
+	name = "tf-acc-test-basic-%d"
 	resource_group_arn =  "${aws_inspector_resource_group.foo.arn}"
 }
 
 resource "aws_inspector_assessment_template" "foo" {
-  name = "foo template"
+  name = "tf-acc-test-basic-tpl-%d"
   target_arn    = "${aws_inspector_assessment_target.foo.arn}"
   duration      = 3600
 
@@ -97,22 +101,24 @@ resource "aws_inspector_assessment_template" "foo" {
 	  "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ",
 	  "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-vg5GGHSD",
   ]
-}`
+}`, rInt, rInt, rInt)
+}
 
-var testAccCheckAWSInspectorTemplatetModified = `
+func testAccCheckAWSInspectorTemplatetModified(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_inspector_resource_group" "foo" {
 	tags {
-	  Name  = "bar"
+	  Name  = "tf-acc-test-%d"
   }
 }
 
 resource "aws_inspector_assessment_target" "foo" {
-	name = "foo"
+	name = "tf-acc-test-basic-%d"
 	resource_group_arn =  "${aws_inspector_resource_group.foo.arn}"
 }
 
 resource "aws_inspector_assessment_template" "foo" {
-  name = "bar template"
+  name = "tf-acc-test-basic-tpl-%d"
   target_arn    = "${aws_inspector_assessment_target.foo.arn}"
   duration      = 3600
 
@@ -122,4 +128,5 @@ resource "aws_inspector_assessment_template" "foo" {
 	  "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-JJOtZiqQ",
 	  "arn:aws:inspector:us-west-2:758058086616:rulespackage/0-vg5GGHSD",
   ]
-}`
+}`, rInt, rInt, rInt)
+}


### PR DESCRIPTION
This is to get rid of the following test failure which occurred in our nightly run:

```
=== RUN   TestAccAWSInspectorTemplate_basic
--- FAIL: TestAccAWSInspectorTemplate_basic (2.92s)
    testing.go:268: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_inspector_assessment_target.foo: 1 error(s) occurred:
        
        * aws_inspector_assessment_target.foo: InvalidInputException: Create assessmentTarget - Name already exists; Name: foo ParentOwner: *******
            status code: 400, request id: 94059064-0ec8-11e7-977f-19982edd9556
FAIL
```

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSInspectorTemplate_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/22 22:03:07 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInspectorTemplate_ -timeout 120m
=== RUN   TestAccAWSInspectorTemplate_basic
--- PASS: TestAccAWSInspectorTemplate_basic (273.50s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	273.544s
```