### PR TITLE
provider/aws: Update data_source_route53_zone acctest

### DIFF
--- a/builtin/providers/aws/data_source_aws_route53_zone_test.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone_test.go
@@ -4,69 +4,52 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
+	rInt := acctest.RandInt()
+	publicResourceName := "aws_route53_zon.test"
+	publicDomain := fmt.Sprintf("terraformtestacchz-%d.com.", rInt)
+	privateResourceName := "aws_route53_zone.test_private"
+	privateDomain := fmt.Sprintf("test.acc-%d.", rInt)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccDataSourceAwsRoute53ZoneConfig,
+			{
+				Config: testAccDataSourceAwsRoute53ZoneConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsRoute53ZoneCheck("data.aws_route53_zone.by_zone_id"),
-					testAccDataSourceAwsRoute53ZoneCheck("data.aws_route53_zone.by_name"),
-					testAccDataSourceAwsRoute53ZoneCheckPrivate("data.aws_route53_zone.by_vpc"),
-					testAccDataSourceAwsRoute53ZoneCheckPrivate("data.aws_route53_zone.by_tag"),
+					testAccDataSourceAwsRoute53ZoneCheck(
+						publicResourceName, "data.aws_route53_zone.by_zone_id", publicDomain),
+					testAccDataSourceAwsRoute53ZoneCheck(
+						publicResourceName, "data.aws_route53_zone.by_name", publicDomain),
+					testAccDataSourceAwsRoute53ZoneCheck(
+						privateResourceName, "data.aws_route53_zone.by_vpc", privateDomain),
+					testAccDataSourceAwsRoute53ZoneCheck(
+						privateResourceName, "data.aws_route53_zone.by_tag", privateDomain),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsRoute53ZoneCheck(name string) resource.TestCheckFunc {
+// rsName for the name of the created resource
+// dsName for the name of the created data source
+// zName for the name of the domain
+func testAccDataSourceAwsRoute53ZoneCheck(rsName, dsName, zName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
+		rs, ok := s.RootModule().Resources[rsName]
 		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
+			return fmt.Errorf("root module has no resource called %s", rsName)
 		}
 
-		hostedZone, ok := s.RootModule().Resources["aws_route53_zone.test"]
+		hostedZone, ok := s.RootModule().Resources[dsName]
 		if !ok {
-			return fmt.Errorf("can't find aws_hosted_zone.test in state")
-		}
-		attr := rs.Primary.Attributes
-		if attr["id"] != hostedZone.Primary.Attributes["id"] {
-			return fmt.Errorf(
-				"id is %s; want %s",
-				attr["id"],
-				hostedZone.Primary.Attributes["id"],
-			)
-		}
-
-		if attr["name"] != "terraformtestacchz.com." {
-			return fmt.Errorf(
-				"Route53 Zone name is %s; want terraformtestacchz.com.",
-				attr["name"],
-			)
-		}
-
-		return nil
-	}
-}
-
-func testAccDataSourceAwsRoute53ZoneCheckPrivate(name string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("root module has no resource called %s", name)
-		}
-
-		hostedZone, ok := s.RootModule().Resources["aws_route53_zone.test_private"]
-		if !ok {
-			return fmt.Errorf("can't find aws_hosted_zone.test in state")
+			return fmt.Errorf("can't find zone %q in state", dsName)
 		}
 
 		attr := rs.Primary.Attributes
@@ -78,56 +61,54 @@ func testAccDataSourceAwsRoute53ZoneCheckPrivate(name string) resource.TestCheck
 			)
 		}
 
-		if attr["name"] != "test.acc." {
-			return fmt.Errorf(
-				"Route53 Zone name is %s; want test.acc.",
-				attr["name"],
-			)
+		if attr["name"] != zName {
+			return fmt.Errorf("Route53 Zone name is %q; want %q", attr["name"], zName)
 		}
 
 		return nil
 	}
 }
 
-const testAccDataSourceAwsRoute53ZoneConfig = `
+func testAccDataSourceAwsRoute53ZoneConfig(rInt int) string {
+	return fmt.Sprintf(`
+	provider "aws" {
+		region = "us-east-2"
+	}
 
-provider "aws" {
-  region = "us-east-2"
-}
+	resource "aws_vpc" "test" {
+		cidr_block = "172.16.0.0/16"
+	}
 
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-}
+	resource "aws_route53_zone" "test_private" {
+		name = "test.acc-%d."
+		vpc_id = "${aws_vpc.test.id}"
+		tags {
+			Environment = "dev-%d"
+		}
+	}
 
-resource "aws_route53_zone" "test_private" {
-  name = "test.acc."
-  vpc_id = "${aws_vpc.test.id}"
-  tags {
-    Environment = "dev"
-  }
-}
-data "aws_route53_zone" "by_vpc" {
- name = "${aws_route53_zone.test_private.name}"
- vpc_id = "${aws_vpc.test.id}"
-}
+	data "aws_route53_zone" "by_vpc" {
+	 name = "${aws_route53_zone.test_private.name}"
+	 vpc_id = "${aws_vpc.test.id}"
+	}
 
-data "aws_route53_zone" "by_tag" {
- name = "${aws_route53_zone.test_private.name}"
- private_zone = true
- tags {
- 	Environment = "dev"
- }
-}
+	data "aws_route53_zone" "by_tag" {
+	 name = "${aws_route53_zone.test_private.name}"
+	 private_zone = true
+	 tags {
+		 Environment = "dev-%d"
+	 }
+	}
 
-resource "aws_route53_zone" "test" {
-  name = "terraformtestacchz.com."
-}
-data "aws_route53_zone" "by_zone_id" {
-  zone_id = "${aws_route53_zone.test.zone_id}"
-}
+	resource "aws_route53_zone" "test" {
+		name = "terraformtestacchz-%d.com."
+	}
 
-data "aws_route53_zone" "by_name" {
-  name = "${data.aws_route53_zone.by_zone_id.name}"
-}
+	data "aws_route53_zone" "by_zone_id" {
+		zone_id = "${aws_route53_zone.test.zone_id}"
+	}
 
-`
+	data "aws_route53_zone" "by_name" {
+		name = "${data.aws_route53_zone.by_zone_id.name}"
+	}`, rInt, rInt, rInt, rInt)
+}


### PR DESCRIPTION
Updates the `data_source_route53_zone` acceptance test to better handle parallel runs. Also better handles tests that potentially leak resources by adding a random integer suffix to domain names.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRolePolicyAttachment_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/22 20:18:05 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRolePolicyAttachment_basic -timeout 120m
=== RUN   TestAccAWSRolePolicyAttachment_basic
--- PASS: TestAccAWSRolePolicyAttachment_basic (31.94s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    31.949s
```