### PR TITLE
provider/aws: Specify that aws_network_acl_rule requires a cidr block

### DIFF
--- a/builtin/providers/aws/resource_aws_network_acl_rule.go
+++ b/builtin/providers/aws/resource_aws_network_acl_rule.go
@@ -109,12 +109,19 @@ func resourceAwsNetworkAclRuleCreate(d *schema.ResourceData, meta interface{}) e
 		},
 	}
 
-	if v, ok := d.GetOk("cidr_block"); ok {
-		params.CidrBlock = aws.String(v.(string))
+	cidr, hasCidr := d.GetOk("cidr_block")
+	ipv6Cidr, hasIpv6Cidr := d.GetOk("ipv6_cidr_block")
+
+	if hasCidr == false && hasIpv6Cidr == false {
+		return fmt.Errorf("Either `cidr_block` or `ipv6_cidr_block` must be defined")
 	}
 
-	if v, ok := d.GetOk("ipv6_cidr_block"); ok {
-		params.Ipv6CidrBlock = aws.String(v.(string))
+	if hasCidr {
+		params.CidrBlock = aws.String(cidr.(string))
+	}
+
+	if hasIpv6Cidr {
+		params.Ipv6CidrBlock = aws.String(ipv6Cidr.(string))
 	}
 
 	// Specify additional required fields for ICMP. For the list

--- a/website/source/docs/providers/aws/r/network_acl_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/network_acl_rule.html.markdown
@@ -29,6 +29,8 @@ resource "aws_network_acl_rule" "bar" {
 }
 ```
 
+~> **Note:** One of either `cidr_block` or `ipv6_cidr_block` is required.
+
 ## Argument Reference
 
 The following arguments are supported:


### PR DESCRIPTION
Fixes: #13011

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSNetworkAclRule_'           2 ↵ ✚
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/23 17:45:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSNetworkAclRule_ -timeout 120m
=== RUN   TestAccAWSNetworkAclRule_basic
--- PASS: TestAccAWSNetworkAclRule_basic (41.10s)
=== RUN   TestAccAWSNetworkAclRule_missingParam
--- PASS: TestAccAWSNetworkAclRule_missingParam (21.21s)
=== RUN   TestAccAWSNetworkAclRule_ipv6
--- PASS: TestAccAWSNetworkAclRule_ipv6 (53.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	115.333s
```