### PR TITLE
NS1: Fix zone value in example

### DIFF
--- a/website/source/docs/providers/ns1/r/record.html.markdown
+++ b/website/source/docs/providers/ns1/r/record.html.markdown
@@ -18,7 +18,7 @@ resource "ns1_zone" "tld" {
 }
 
 resource "ns1_record" "www" {
-  zone   = "${ns1_zone.tld.id}"
+  zone   = "${ns1_zone.tld.zone}"
   domain = "www.${ns1_zone.tld.zone}"
   type   = "CNAME"
   ttl    = 60


### PR DESCRIPTION
As experienced during testing, the value of the zone needs to be the zone name, and not the NS1 internal ID.

@pashap 