### PR TITLE
provider/aws: Migrate the state for AWS VPC after IPv6 changes

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc.go
+++ b/builtin/providers/aws/resource_aws_vpc.go
@@ -22,6 +22,9 @@ func resourceAwsVpc() *schema.Resource {
 			State: resourceAwsVpcInstanceImport,
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsVpcMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"cidr_block": {
 				Type:         schema.TypeString,

--- a/builtin/providers/aws/resource_aws_vpc_migrate.go
+++ b/builtin/providers/aws/resource_aws_vpc_migrate.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsVpcMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS VPC State v0; migrating to v1")
+		return migrateVpcStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateVpcStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty VPC State; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	is.Attributes["assign_generated_ipv6_cidr_block"] = "false"
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/aws/resource_aws_vpc_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_vpc_migrate_test.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSVpcMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1": {
+			StateVersion: 0,
+			ID:           "some_id",
+			Attributes: map[string]string{
+				"assign_generated_ipv6_cidr_block": "true",
+			},
+			Expected: "false",
+		},
+		"v0_1_without_value": {
+			StateVersion: 0,
+			ID:           "some_id",
+			Attributes:   map[string]string{},
+			Expected:     "false",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsVpcMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.Attributes["assign_generated_ipv6_cidr_block"] != tc.Expected {
+			t.Fatalf("bad VPC Migrate: %s\n\n expected: %s", is.Attributes["assign_generated_ipv6_cidr_block"], tc.Expected)
+		}
+	}
+}


### PR DESCRIPTION
Fixes: #13035

It was pointed out in the issue that the addition of a new parameter
with a default value AND a ForceNew: true is causing Terraform to try
and recreate the VPC

This PR migrates the state to add the default value of false for `assign_generated_ipv6_cidr_block`

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAWSVpcMigrateState'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/24 12:51:41 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAWSVpcMigrateState -timeout 120m
=== RUN   TestAWSVpcMigrateState
2017/03/24 12:52:26 [INFO] Found AWS VPC State v0; migrating to v1
2017/03/24 12:52:26 [DEBUG] Attributes before migration: map[string]string{"assign_generated_ipv6_cidr_block":"true"}
2017/03/24 12:52:26 [DEBUG] Attributes after migration: map[string]string{"assign_generated_ipv6_cidr_block":"false"}
2017/03/24 12:52:26 [INFO] Found AWS VPC State v0; migrating to v1
2017/03/24 12:52:26 [DEBUG] Attributes before migration: map[string]string{}
2017/03/24 12:52:26 [DEBUG] Attributes after migration: map[string]string{"assign_generated_ipv6_cidr_block":"false"}
--- PASS: TestAWSVpcMigrateState (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.024s
```