### PR TITLE
reify the list values before validation

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1219,6 +1219,13 @@ func (m schemaMap) validateList(
 	for i, raw := range raws {
 		key := fmt.Sprintf("%s.%d", k, i)
 
+		// Reify the key value from the ResourceConfig.
+		// If the list was computed we have all raw values, but some of these
+		// may be known in the config, and aren't individually marked as Computed.
+		if r, ok := c.Get(key); ok {
+			raw = r
+		}
+
 		var ws2 []string
 		var es2 []error
 		switch t := schema.Elem.(type) {


### PR DESCRIPTION
If the list was marked as computed, all values will be raw config
values. Fetch the individual keys from the config to get any known
values before validating.

#12892