### PR TITLE
Fixes route53 test

### DIFF
--- a/builtin/providers/aws/data_source_aws_route53_zone_test.go
+++ b/builtin/providers/aws/data_source_aws_route53_zone_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAccDataSourceAwsRoute53Zone(t *testing.T) {
 	rInt := acctest.RandInt()
-	publicResourceName := "aws_route53_zon.test"
+	publicResourceName := "aws_route53_zone.test"
 	publicDomain := fmt.Sprintf("terraformtestacchz-%d.com.", rInt)
 	privateResourceName := "aws_route53_zone.test_private"
 	privateDomain := fmt.Sprintf("test.acc-%d.", rInt)


### PR DESCRIPTION
This fixes TestAccDataSourceAwsRoute53Zone

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccDataSourceAwsRoute53Zone'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/24 10:19:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccDataSourceAwsRoute53Zone -timeout 120m
=== RUN   TestAccDataSourceAwsRoute53Zone
--- PASS: TestAccDataSourceAwsRoute53Zone (81.83s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	81.872s
```