### PR TITLE
provider/aws: aws_network_acl_rule treat all and -1 for protocol the same

### DIFF
--- a/builtin/providers/aws/resource_aws_network_acl_rule.go
+++ b/builtin/providers/aws/resource_aws_network_acl_rule.go
@@ -41,6 +41,12 @@ func resourceAwsNetworkAclRule() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					if old == "all" && new == "-1" || old == "-1" && new == "all" {
+						return true
+					}
+					return false
+				},
 			},
 			"rule_action": {
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_network_acl_rule_test.go
+++ b/builtin/providers/aws/resource_aws_network_acl_rule_test.go
@@ -66,6 +66,25 @@ func TestAccAWSNetworkAclRule_ipv6(t *testing.T) {
 	})
 }
 
+func TestAccAWSNetworkAclRule_allProtocol(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSNetworkAclRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:             testAccAWSNetworkAclRuleAllProtocolConfig,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				Config:             testAccAWSNetworkAclRuleAllProtocolConfigNoRealUpdate,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+	})
+}
+
 func TestResourceAWSNetworkAclRule_validateICMPArgumentValue(t *testing.T) {
 	type testCases struct {
 		Value    string
@@ -246,6 +265,44 @@ resource "aws_network_acl_rule" "baz" {
 	egress = false
 	protocol = "tcp"
 	rule_action = "allow"
+	from_port = 22
+	to_port = 22
+}
+`
+
+const testAccAWSNetworkAclRuleAllProtocolConfigNoRealUpdate = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.3.0.0/16"
+}
+resource "aws_network_acl" "bar" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+resource "aws_network_acl_rule" "baz" {
+	network_acl_id = "${aws_network_acl.bar.id}"
+	rule_number = 150
+	egress = false
+	protocol = "all"
+	rule_action = "allow"
+	cidr_block = "0.0.0.0/0"
+	from_port = 22
+	to_port = 22
+}
+`
+
+const testAccAWSNetworkAclRuleAllProtocolConfig = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.3.0.0/16"
+}
+resource "aws_network_acl" "bar" {
+	vpc_id = "${aws_vpc.foo.id}"
+}
+resource "aws_network_acl_rule" "baz" {
+	network_acl_id = "${aws_network_acl.bar.id}"
+	rule_number = 150
+	egress = false
+	protocol = "-1"
+	rule_action = "allow"
+	cidr_block = "0.0.0.0/0"
 	from_port = 22
 	to_port = 22
 }


### PR DESCRIPTION
Fixes: #13012

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSNetworkAclRule_allProtocol'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/24 18:42:05 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSNetworkAclRule_allProtocol -timeout 120m
=== RUN   TestAccAWSNetworkAclRule_allProtocol
--- PASS: TestAccAWSNetworkAclRule_allProtocol (53.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	53.974s
```