### PR TITLE
provider/aws: Only allow 1 value in alb_listener_rule condition

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_listener_rule.go
+++ b/builtin/providers/aws/resource_aws_alb_listener_rule.go
@@ -66,6 +66,7 @@ func resourceAwsAlbListenerRule() *schema.Resource {
 						},
 						"values": {
 							Type:     schema.TypeList,
+							MaxItems: 1,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Optional: true,
 						},

--- a/builtin/providers/aws/resource_aws_alb_listener_rule_test.go
+++ b/builtin/providers/aws/resource_aws_alb_listener_rule_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -38,6 +39,23 @@ func TestAccAWSALBListenerRule_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb_listener_rule.static", "condition.0.values.#", "1"),
 					resource.TestCheckResourceAttrSet("aws_alb_listener_rule.static", "condition.0.values.0"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBListenerRule_multipleConditionThrowsError(t *testing.T) {
+	albName := fmt.Sprintf("testrule-basic-%s", acctest.RandStringFromCharSet(13, acctest.CharSetAlphaNum))
+	targetGroupName := fmt.Sprintf("testtargetgroup-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSALBListenerRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAWSALBListenerRuleConfig_multipleConditions(albName, targetGroupName),
+				ExpectError: regexp.MustCompile(`attribute supports 1 item maximum`),
 			},
 		},
 	})
@@ -102,6 +120,117 @@ func testAccCheckAWSALBListenerRuleDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSALBListenerRuleConfig_multipleConditions(albName, targetGroupName string) string {
+	return fmt.Sprintf(`resource "aws_alb_listener_rule" "static" {
+  listener_arn = "${aws_alb_listener.front_end.arn}"
+  priority = 100
+
+  action {
+    type = "forward"
+    target_group_arn = "${aws_alb_target_group.test.arn}"
+  }
+
+  condition {
+    field = "path-pattern"
+    values = ["/static/*", "static"]
+  }
+}
+
+resource "aws_alb_listener" "front_end" {
+   load_balancer_arn = "${aws_alb.alb_test.id}"
+   protocol = "HTTP"
+   port = "80"
+
+   default_action {
+     target_group_arn = "${aws_alb_target_group.test.id}"
+     type = "forward"
+   }
+}
+
+resource "aws_alb" "alb_test" {
+  name            = "%s"
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 8080
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}`, albName, targetGroupName)
 }
 
 func testAccAWSALBListenerRuleConfig_basic(albName, targetGroupName string) string {

--- a/website/source/docs/providers/aws/r/alb_listener_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_listener_rule.html.markdown
@@ -55,7 +55,7 @@ Action Blocks (for `default_action`) support the following:
 Condition Blocks (for `default_condition`) support the following:
 
 * `field` - (Required) The name of the field. The only valid value is `path-pattern`.
-* `values` - (Required) The path patterns to match.
+* `values` - (Required) The path patterns to match. A maximum of 1 can be defined.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #12983

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSALBListenerRule_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/24 19:31:26 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSALBListenerRule_ -timeout 120m
=== RUN   TestAccAWSALBListenerRule_basic
--- PASS: TestAccAWSALBListenerRule_basic (247.76s)
=== RUN   TestAccAWSALBListenerRule_multipleConditionThrowsError
--- PASS: TestAccAWSALBListenerRule_multipleConditionThrowsError (0.02s)
PASS
ok	github.com/hashicorp/terraform/builtin/providers/aws	247.815s
```