### PR TITLE
provider/openstack: Resolve issues with Port Fixed IPs

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -85,10 +85,9 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Computed: true,
 			},
 			"fixed_ip": &schema.Schema{
-				Type:     schema.TypeSet,
+				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: false,
-				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"subnet_id": &schema.Schema{
@@ -98,7 +97,6 @@ func resourceNetworkingPortV2() *schema.Resource {
 						"ip_address": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							Computed: true,
 						},
 					},
 				},
@@ -207,22 +205,14 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	d.Set("security_group_ids", p.SecurityGroups)
 	d.Set("device_id", p.DeviceID)
 
-	// Convert FixedIPs to list of map
-	// ips2 is used for the `all_fixed_ips` exported attribute.
-	var ips []map[string]interface{}
-	var ips2 []string
+	// Create a slice of all returned Fixed IPs.
+	// This will be in the order returned by the API,
+	// which is usually alpha-numeric.
+	var ips []string
 	for _, ipObject := range p.FixedIPs {
-		ip := make(map[string]interface{})
-		ip["subnet_id"] = ipObject.SubnetID
-		ip["ip_address"] = ipObject.IPAddress
-		ips = append(ips, ip)
-		ips2 = append(ips2, ipObject.IPAddress)
+		ips = append(ips, ipObject.IPAddress)
 	}
-	d.Set("fixed_ip", ips)
-
-	// The order of ips2 will be the order returned by the API.
-	// This is usually alphabetical/numerical order.
-	d.Set("all_fixed_ips", ips2)
+	d.Set("all_fixed_ips", ips)
 
 	// Convert AllowedAddressPairs to list of map
 	var pairs []map[string]interface{}
@@ -321,7 +311,7 @@ func resourcePortSecurityGroupsV2(d *schema.ResourceData) []string {
 }
 
 func resourcePortFixedIpsV2(d *schema.ResourceData) interface{} {
-	rawIP := d.Get("fixed_ip").(*schema.Set).List()
+	rawIP := d.Get("fixed_ip").([]interface{})
 
 	if len(rawIP) == 0 {
 		return nil

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2.go
@@ -128,6 +128,11 @@ func resourceNetworkingPortV2() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 			},
+			"all_fixed_ips": &schema.Schema{
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -203,14 +208,21 @@ func resourceNetworkingPortV2Read(d *schema.ResourceData, meta interface{}) erro
 	d.Set("device_id", p.DeviceID)
 
 	// Convert FixedIPs to list of map
+	// ips2 is used for the `all_fixed_ips` exported attribute.
 	var ips []map[string]interface{}
+	var ips2 []string
 	for _, ipObject := range p.FixedIPs {
 		ip := make(map[string]interface{})
 		ip["subnet_id"] = ipObject.SubnetID
 		ip["ip_address"] = ipObject.IPAddress
 		ips = append(ips, ip)
+		ips2 = append(ips2, ipObject.IPAddress)
 	}
 	d.Set("fixed_ip", ips)
+
+	// The order of ips2 will be the order returned by the API.
+	// This is usually alphabetical/numerical order.
+	d.Set("all_fixed_ips", ips2)
 
 	// Convert AllowedAddressPairs to list of map
 	var pairs []map[string]interface{}

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
@@ -50,6 +50,30 @@ func TestAccNetworkingV2Port_noip(t *testing.T) {
 					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
 					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
 					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
+					testAccCheckNetworkingV2PortCountFixedIPs(&port, 1),
+				),
+			},
+		},
+	})
+}
+
+func TestAccNetworkingV2Port_multipleNoIP(t *testing.T) {
+	var network networks.Network
+	var port ports.Port
+	var subnet subnets.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Port_multipleNoIP,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
+					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
+					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
+					testAccCheckNetworkingV2PortCountFixedIPs(&port, 3),
 				),
 			},
 		},
@@ -96,6 +120,7 @@ func TestAccNetworkingV2Port_multipleFixedIPs(t *testing.T) {
 					testAccCheckNetworkingV2SubnetExists("openstack_networking_subnet_v2.subnet_1", &subnet),
 					testAccCheckNetworkingV2NetworkExists("openstack_networking_network_v2.network_1", &network),
 					testAccCheckNetworkingV2PortExists("openstack_networking_port_v2.port_1", &port),
+					testAccCheckNetworkingV2PortCountFixedIPs(&port, 3),
 				),
 			},
 		},
@@ -196,6 +221,16 @@ func testAccCheckNetworkingV2PortExists(n string, port *ports.Port) resource.Tes
 	}
 }
 
+func testAccCheckNetworkingV2PortCountFixedIPs(port *ports.Port, expected int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if len(port.FixedIPs) != expected {
+			return fmt.Errorf("Expected %d Fixed IPs, got %d", expected, len(port.FixedIPs))
+		}
+
+		return nil
+	}
+}
+
 const testAccNetworkingV2Port_basic = `
 resource "openstack_networking_network_v2" "network_1" {
   name = "network_1"
@@ -238,6 +273,38 @@ resource "openstack_networking_port_v2" "port_1" {
   name = "port_1"
   admin_state_up = "true"
   network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+  }
+}
+`
+
+const testAccNetworkingV2Port_multipleNoIP = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+  }
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+  }
 
   fixed_ip {
     subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"

--- a/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_port_v2_test.go
@@ -124,6 +124,25 @@ func TestAccNetworkingV2Port_timeout(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2Port_fixedIPs(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2PortDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2Port_fixedIPs,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"openstack_networking_port_v2.port_1", "all_fixed_ips.0", "192.168.199.23"),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_port_v2.port_1", "all_fixed_ips.1", "192.168.199.24"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2PortDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -353,6 +372,36 @@ resource "openstack_networking_port_v2" "port_1" {
   timeouts {
     create = "5m"
     delete = "5m"
+  }
+}
+`
+
+const testAccNetworkingV2Port_fixedIPs = `
+resource "openstack_networking_network_v2" "network_1" {
+  name = "network_1"
+  admin_state_up = "true"
+}
+
+resource "openstack_networking_subnet_v2" "subnet_1" {
+  name = "subnet_1"
+  cidr = "192.168.199.0/24"
+  ip_version = 4
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+}
+
+resource "openstack_networking_port_v2" "port_1" {
+  name = "port_1"
+  admin_state_up = "true"
+  network_id = "${openstack_networking_network_v2.network_1.id}"
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.24"
+  }
+
+  fixed_ip {
+    subnet_id =  "${openstack_networking_subnet_v2.subnet_1.id}"
+    ip_address = "192.168.199.23"
   }
 }
 `

--- a/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/networking_port_v2.html.markdown
@@ -95,7 +95,9 @@ The following attributes are exported:
 * `device_owner` - See Argument Reference above.
 * `security_group_ids` - See Argument Reference above.
 * `device_id` - See Argument Reference above.
-* `fixed_ip/ip_address` - See Argument Reference above.
+* `fixed_ip` - See Argument Reference above.
+* `all fixed_ips` - The collection of Fixed IP addresses on the port in the
+  order returned by the Network v2 API.
 
 ## Import
 


### PR DESCRIPTION
This commit has two parts:

1. It adds a new computed-only attribute called `all_fixed_ips` which contain all of the fixed IPs returned by the OpenStack Networking API in the order the API sent them.

2. It changes the `fixed_ip` attribute back to a TypeList, reverting the change made in #12613. The change made in #12613 resolved the reported issue, but created other state issues in different use-cases. 

Fixes #13052
Supersedes #12807

@stack72 Let me know if you would like to discuss this one in more detail. 

I'm pretty sure moving from `TypeSet` to `TypeList` is safe to do, but maybe I am wrong about that. 

The main change being made (making `fixed_ip` non-compute) will affect users who were relying on referencing a DHCP-allocated IP by `openstack_networking_port_v2.foo.fixed_ip.0.ip_address`. They will now need to use `openstack_networking_port_v2.foo.all_fixed_ips.0`. This should probably be noted in the CHANGELOG.

Users who specified a static IP can return to referencing `openstack_networking_port_v2.foo.fixed_ip.0.ip_address` as they did before, since it's not relying on a returned API value. The most notable reason for doing this is to make implicit ordering between resources.

Users who reported issues with `fixed_ip` being re-ordered upon a `refresh` are still in the clear since `fixed_ip` is no longer being set by Terraform.

Unless I'm mistaken, with the list of scenarios in #13052, there are just too many varied cases that can be cleanly applied in `fixed_ip` alone. Notably, creating a unique hash with `TypeSet` is not possible when a user wants multiple DHCP-based Fixed IPs since the only required piece of data is a `subnet_id`, and if there are multiple entries with the same `subnet_id`, Terraform will hash them all the same and aggregate them into 1 requested IP. _Further_, if `ip_address` is also used in the hash, then DHCP IPs will have a new generated hash after `apply` finishes. Therefore, something like `all_fixed_ips` is needed.

Perhaps a better long-term design is to create a dedicated `openstack_networking_port_fixedip_v2` resource and deprecate the use of `fixed_ip` and `all_fixed_ips`, but, again, the multiple-DHCP use-case is probably going to make that difficult.

/cc @sebastien-prudhomme