### PR TITLE
docs: Update getting started docs to use a valid AMI in us-east-1, vpc

### DIFF
--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -59,7 +59,7 @@ provider "aws" {
 }
 
 resource "aws_instance" "example" {
-  ami           = "ami-0d729a60"
+  ami           = "ami-2757f631"
   instance_type = "t2.micro"
 }
 ```
@@ -125,7 +125,7 @@ $ terraform plan
 ...
 
 + aws_instance.example
-    ami:                      "ami-0d729a60"
+    ami:                      "ami-2757f631"
     availability_zone:        "<computed>"
     ebs_block_device.#:       "<computed>"
     ephemeral_block_device.#: "<computed>"
@@ -170,7 +170,7 @@ since Terraform waits for the EC2 instance to become available.
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:                      "" => "ami-0d729a60"
+  ami:                      "" => "ami-2757f631"
   instance_type:            "" => "t2.micro"
   [...]
 
@@ -201,7 +201,7 @@ You can inspect the state using `terraform show`:
 $ terraform show
 aws_instance.example:
   id = i-32cf65a8
-  ami = ami-0d729a60
+  ami = ami-2757f631
   availability_zone = us-east-1a
   instance_state = running
   instance_type = t2.micro

--- a/website/source/intro/getting-started/change.html.md
+++ b/website/source/intro/getting-started/change.html.md
@@ -23,20 +23,20 @@ can see how the infrastructure evolved over time.
 
 ## Configuration
 
-Let's modify the `ami` of our instance. Edit the "aws\_instance.example"
+Let's modify the `ami` of our instance. Edit the `aws_instance.example`
 resource in your configuration and change it to the following:
 
 ```
 resource "aws_instance" "example" {
-  ami           = "ami-13be557e"
+  ami           = "ami-b374d5a5"
   instance_type = "t2.micro"
 }
 ```
 
 ~> **Note:** EC2 Classic users please use AMI `ami-656be372` and type `t1.micro`
 
-We've changed the AMI from being an Ubuntu 14.04 LTS AMI to being
-an Ubuntu 16.04 LTS AMI. Terraform configurations are meant to be
+We've changed the AMI from being an Ubuntu 16.04 LTS AMI to being
+an Ubuntu 16.10 AMI. Terraform configurations are meant to be
 changed like this. You can also completely remove resources
 and Terraform will know to destroy the old one.
 
@@ -49,7 +49,7 @@ $ terraform plan
 ...
 
 -/+ aws_instance.example
-    ami:                      "ami-0d729a60" => "ami-13be557e" (forces new resource)
+    ami:                      "ami-2757f631" => "ami-b374d5a5" (forces new resource)
     availability_zone:        "us-east-1a" => "<computed>"
     ebs_block_device.#:       "0" => "<computed>"
     ephemeral_block_device.#: "0" => "<computed>"
@@ -86,7 +86,7 @@ aws_instance.example: Refreshing state... (ID: i-64c268fe)
 aws_instance.example: Destroying...
 aws_instance.example: Destruction complete
 aws_instance.example: Creating...
-  ami:                      "" => "ami-13be557e"
+  ami:                      "" => "ami-b374d5a5"
   availability_zone:        "" => "<computed>"
   ebs_block_device.#:       "" => "<computed>"
   ephemeral_block_device.#: "" => "<computed>"

--- a/website/source/intro/getting-started/dependencies.html.md
+++ b/website/source/intro/getting-started/dependencies.html.md
@@ -70,7 +70,7 @@ $ terraform plan
     public_ip:         "<computed>"
 
 + aws_instance.example
-    ami:                      "ami-13be557e"
+    ami:                      "ami-b374d5a5"
     availability_zone:        "<computed>"
     ebs_block_device.#:       "<computed>"
     ephemeral_block_device.#: "<computed>"
@@ -102,7 +102,7 @@ following:
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:                      "" => "ami-13be557e"
+  ami:                      "" => "ami-b374d5a5"
   instance_type:            "" => "t2.micro"
   [..]
 aws_instance.example: Still creating... (10s elapsed)
@@ -166,7 +166,7 @@ created in parallel to everything else.
 
 ```
 resource "aws_instance" "another" {
-  ami           = "ami-13be557e"
+  ami           = "ami-b374d5a5"
   instance_type = "t2.micro"
 }
 ```

--- a/website/source/intro/getting-started/provision.html.md
+++ b/website/source/intro/getting-started/provision.html.md
@@ -25,7 +25,7 @@ To define a provisioner, modify the resource block defining the
 
 ```
 resource "aws_instance" "example" {
-  ami           = "ami-13be557e"
+  ami           = "ami-b374d5a5"
   instance_type = "t2.micro"
 
   provisioner "local-exec" {
@@ -61,7 +61,7 @@ then run `apply`:
 ```
 $ terraform apply
 aws_instance.example: Creating...
-  ami:           "" => "ami-13be557e"
+  ami:           "" => "ami-b374d5a5"
   instance_type: "" => "t2.micro"
 aws_eip.ip: Creating...
   instance: "" => "i-213f350a"

--- a/website/source/intro/getting-started/variables.html.md
+++ b/website/source/intro/getting-started/variables.html.md
@@ -167,8 +167,8 @@ support for the `us-west-2` region as well:
 variable "amis" {
   type = "map"
   default = {
-    us-east-1 = "ami-13be557e"
-    us-west-2 = "ami-06b94666"
+    us-east-1 = "ami-b374d5a5"
+    us-west-2 = "ami-4b32be2b"
   }
 }
 ```


### PR DESCRIPTION
Supersedes #12932 , populating the entire guide with the correct AMI(s)