### PR TITLE
provider/openstack: Adding all_metadata attribute

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -335,6 +335,10 @@ func resourceComputeInstanceV2() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"all_metadata": &schema.Schema{
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -554,7 +558,7 @@ func resourceComputeInstanceV2Read(d *schema.ResourceData, meta interface{}) err
 		})
 	}
 
-	d.Set("metadata", server.Metadata)
+	d.Set("all_metadata", server.Metadata)
 
 	secGrpNames := []string{}
 	for _, sg := range server.SecurityGroups {

--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2_test.go
@@ -30,6 +30,8 @@ func TestAccComputeV2Instance_basic(t *testing.T) {
 					testAccCheckComputeV2InstanceExists("openstack_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
 					resource.TestCheckResourceAttr(
+						"openstack_compute_instance_v2.instance_1", "all_metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(
 						"openstack_compute_instance_v2.instance_1", "availability_zone", "nova"),
 				),
 			},
@@ -607,6 +609,10 @@ func TestAccComputeV2Instance_metadataRemove(t *testing.T) {
 					testAccCheckComputeV2InstanceExists("openstack_compute_instance_v2.instance_1", &instance),
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeV2InstanceMetadata(&instance, "abc", "def"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_instance_v2.instance_1", "all_metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_instance_v2.instance_1", "all_metadata.abc", "def"),
 				),
 			},
 			resource.TestStep{
@@ -616,6 +622,10 @@ func TestAccComputeV2Instance_metadataRemove(t *testing.T) {
 					testAccCheckComputeV2InstanceMetadata(&instance, "foo", "bar"),
 					testAccCheckComputeV2InstanceMetadata(&instance, "ghi", "jkl"),
 					testAccCheckComputeV2InstanceNoMetadataKey(&instance, "abc"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_instance_v2.instance_1", "all_metadata.foo", "bar"),
+					resource.TestCheckResourceAttr(
+						"openstack_compute_instance_v2.instance_1", "all_metadata.ghi", "jkl"),
 				),
 			},
 		},

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -446,6 +446,8 @@ The following attributes are exported:
 * `network/floating_ip` - The Floating IP address of the Instance on that
     network.
 * `network/mac` - The MAC address of the NIC on that network.
+* `all_metadata` - Contains all instance metadata, even metadata not set
+    by Terraform.
 
 ## Notes
 


### PR DESCRIPTION
This commit adds the all_metadata attribute which contains all
instance metadata returned from the OpenStack Compute API. This
is useful for gaining access to metadata which was applied
out of band of Terraform.

This commit also stops setting the original metadata attribute,
effectively making metadata an input and all_metadata the output
to reference all data from.