### PR TITLE
provider/openstack: Deprecating Instance Volume attribute

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -243,8 +243,9 @@ func resourceComputeInstanceV2() *schema.Resource {
 				},
 			},
 			"volume": &schema.Schema{
-				Type:     schema.TypeSet,
-				Optional: true,
+				Type:       schema.TypeSet,
+				Optional:   true,
+				Deprecated: "Use block_device or openstack_compute_volume_attach_v2 instead",
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": &schema.Schema{

--- a/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_instance_v2.html.markdown
@@ -35,13 +35,13 @@ resource "openstack_compute_instance_v2" "basic" {
 ### Instance With Attached Volume
 
 ```
-resource "openstack_blockstorage_volume_v1" "myvol" {
+resource "openstack_blockstorage_volume_v2" "myvol" {
   name = "myvol"
   size = 1
 }
 
-resource "openstack_compute_instance_v2" "volume-attached" {
-  name            = "volume-attached"
+resource "openstack_compute_instance_v2" "myinstance" {
+  name            = "myinstance"
   image_id        = "ad091b52-742f-469e-8f3c-fd81cadf0743"
   flavor_id       = "3"
   key_pair        = "my_key_pair_name"
@@ -50,10 +50,11 @@ resource "openstack_compute_instance_v2" "volume-attached" {
   network {
     name = "my_network"
   }
+}
 
-  volume {
-    volume_id = "${openstack_blockstorage_volume_v1.myvol.id}"
-  }
+resource "openstack_compute_volume_attach_v2" "attached" {
+  compute_id = "${openstack_compute_instance_v2.myinstance.id}"
+  volume_id = "${openstack_blockstorage_volume_v2.myvol.id}"
 }
 ```
 
@@ -320,7 +321,7 @@ The following arguments are supported:
     following [reference](http://docs.openstack.org/developer/nova/block_device_mapping.html)
     for more information.
 
-* `volume` - (Optional) Attach an existing volume to the instance. The volume
+* `volume` - (Deprecated) Attach an existing volume to the instance. The volume
     structure is described below. *Note*: This is no longer the recommended
     method of attaching a volume to an instance. Please see `block_device`
     (above) or the `openstack_compute_volume_attach_v2` and


### PR DESCRIPTION
This commit deprecates the volume attribute in the
openstack_compute_instance_v2 resource. It's recommended to either
use the block_device attribute or the openstack_compute_volume_attach_v2
resource.

I've been planning to do this for quite a while now. There are a few good reasons for doing this:

1. The `volume` attribute requires a BlockStorage client to be mixed in with the Compute resource. Right now it's hard-coded for the v1 API.
2. `block_device` provides a wealth of volume attachment capabilities and strictly uses the Compute API.
3. The `openstack_compute_volume_attach_v2` resource has been around for a while now and has been reported to work as it should. It provides the flexibility and decoupled design that `volume` is missing.