### PR TITLE
Spotlight-like search facility in the Terraform documentation

### DIFF
--- a/website/source/assets/javascripts/app/_Init.js
+++ b/website/source/assets/javascripts/app/_Init.js
@@ -23,10 +23,16 @@ var Init = {
 		}
 		//always init sidebar
 		Init.initializeSidebar();
+		Init.initializeSpotlight();
 	},
 
 	initializeSidebar: function(){
 		new Sidebar();
+	},
+
+	initializeSpotlight: function() {
+		if (window.spotlight) return;
+		window.spotlight = new Spotlight();
 	},
 
 	generateAnimatedLogo: function(){

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -1,4 +1,4 @@
-(function($) {
+function Spotlight() {
     "use strict";
 
     var pages = {};
@@ -221,4 +221,4 @@
         }
     }
 
-})(jQuery);
+};

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -49,7 +49,7 @@ function Spotlight() {
 
         $(document).keydown(function(e) {
             if (e.altKey || e.metaKey || e.shiftKey) return;
-            if (e.key.toLowerCase() == 'p' && e.ctrlKey) {
+            if (e.keyCode == 80 && e.ctrlKey) {
                 handleShowRequest(e);
             }
         });
@@ -139,7 +139,7 @@ function Spotlight() {
         visible = true;
         $('body').prepend(
             '<div id="spotlight"><div id="spotlight-contents">' +
-            '<input type="text" placeholder="Quick search" />' +
+            '<input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" placeholder="Quick search" />' +
             '<div id="spotlight-results">' +
             '</div></div></div>');
         $('#spotlight input').focus();

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -122,6 +122,7 @@
 
     function handleSelectionChanged(e, delta) {
         var index = (selected + delta) % choices.length;
+        while (index < 0) index += choices.length;
         selectChoice(index);
         e.preventDefault();
     }
@@ -204,7 +205,19 @@
         }
         selected = index;
         if (selected >= 0 && selected < choices.length) {
-            choices[selected].addClass('selected');
+            var el = choices[selected];
+            var parent = el.parent();
+            el.addClass('selected');
+            var scrollTop = parent.scrollTop();
+            var top = el.position().top;
+            var maxTop = parent.height() - el.height()
+                - parseInt(el.css('padding-top')) - parseInt(el.css('padding-bottom'));
+
+            // Scroll into view if we've gone off the top.
+            if (top < 0) parent.scrollTop(scrollTop + top);
+            if (top > maxTop) {
+                parent.scrollTop(scrollTop + top - maxTop);
+            }
         }
     }
 

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -1,0 +1,172 @@
+(function($) {
+    "use strict";
+
+    var pages = {};
+    var visible = false;
+    var lastText = null;
+
+    $.ajax({
+        url: '/sitemap.xml',
+        dataType: 'xml'
+    }).done(function(data) {
+        pages = loadSitemap(data);
+        $(function() {
+            initSpotlight();
+        });
+    });
+
+    function loadSitemap(data) {
+        var nsSitemaps = "http://www.sitemaps.org/schemas/sitemap/0.9";
+        var nsDcTerms = "http://purl.org/dc/terms/"
+
+        var nodes = data.documentElement.getElementsByTagNameNS(nsSitemaps, 'url');
+        nodes = Array.prototype.map.call(nodes, function(node) {
+            var title = node.getElementsByTagNameNS(nsDcTerms, 'title')[0];
+            if (!title) return null;
+            return {
+                title: title.textContent,
+                url: node.getElementsByTagNameNS(nsSitemaps, 'loc')[0].textContent
+            };
+        });
+        var result = nodes.filter(function(x) { return !!x; });
+        result.sort(function(a, b) {
+            a = a.title.toLowerCase();
+            b = b.title.toLowerCase();
+            return a < b ? -1 : a > b ? 1 : 0;
+        });
+        return result;
+    }
+
+
+    function initSpotlight() {
+
+        // Ctrl-P brings up the spotlight
+
+        $(document).keyup(function(e) {
+            if (e.altKey || e.metaKey || e.shiftKey) return;
+            if (e.key.toLowerCase() == 'p' && e.ctrlKey) {
+                handleShowRequest(e);
+            }
+        });
+
+        // Esc dismisses it
+
+        $(document).on('keyup', '#spotlight', function(e) {
+            if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) return;
+            switch (e.keyCode) {
+                case 27: // esc
+                    handleEsc(e);
+            }
+        });
+
+        // So too does losing focus
+
+        $(document).on('focusout', '#spotlight', function(e) {
+            handleFocusOut(this);
+        });
+
+        // A key press in the input box refreshes the results
+
+        $(document).on('keyup', '#spotlight input', function(e) {
+            handleKeyInInputBox();
+        });
+    }
+
+
+    function handleShowRequest(e) {
+        showSpotlight();
+        updateSpotlight();
+        e.preventDefault();
+    }
+
+    function handleEsc(e) {
+        if (hideSpotlight()) {
+            e.preventDefault();
+        }
+    }
+
+    function handleFocusOut(spotlightElement) {
+        // Wait till focus has finished moving before testing whether
+        // or not to dismiss the spotlight.
+        window.setTimeout(function() {
+            if (!$.contains(spotlightElement, document.activeElement)) {
+                hideSpotlight();
+            }
+        }, 1);
+    }
+
+    function handleKeyInInputBox() {
+        var text = $("#spotlight input").val();
+        if (text === lastText) return;
+        lastText = text;
+        updateSpotlight(text);
+    }
+
+    function showSpotlight() {
+        if (visible) return;
+        visible = true;
+        $('body').prepend(
+            '<div id="spotlight"><div id="spotlight-contents">' +
+            '<input type="text" placeholder="Quick search" />' +
+            '<div id="spotlight-results">' +
+            '</div></div></div>');
+        $('#spotlight input').focus().keyup(updateSpotlight);
+        $('#spotlight-contents').focusout(function() {
+            var contents = this;
+        });
+    }
+
+    function hideSpotlight() {
+        if (!visible) return false;
+        visible = false;
+        lastText = null;
+        $("#spotlight").hide(0, function() {
+            $('#spotlight').remove();
+        });
+        return true;
+    }
+
+    function updateSpotlight(text) {
+        var matches = getMatches(text);
+        $('#spotlight-results a').remove();
+        if(matches.length) {
+            $('#spotlight-results').append(matches).show(0);
+        }
+        else {
+            $('#spotlight-results').hide(0);
+        }
+    }
+
+    function getMatches(text) {
+        if (text.length < 2) return [];
+        var links = [];
+        for (var i = 0; i < pages.length; i++) {
+            var p = pages[i];
+            var ix = p.title.toLowerCase().indexOf(text.toLowerCase());
+            if (ix >= 0) {
+                var $element = $('<a>');
+                $element.append(p.title.substr(0, ix));
+                var $selection = $('<strong>');
+                $selection.append(p.title.substr(ix, text.length));
+                $element.append($selection);
+                $element.append(p.title.substr(ix + text.length));
+
+                var url = p.url.replace(/^http.*:\/\/.*?\//, '/');
+                var isDataSource = /\/d\//.test(url);
+                var isResource = /\/r\//.test(url);
+                if (isDataSource) {
+                    $element.append($('<em>(Data Source)</em>'));
+                }
+                if (isResource) {
+                    $element.append($('<em>(Resource)</em>'));
+                }
+
+                $element.attr('href', url);
+                links.push($element);
+            }
+        }
+
+        return links;
+    }
+
+})(jQuery);

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -4,6 +4,8 @@
     var pages = {};
     var visible = false;
     var lastText = null;
+    var selected = NaN;
+    var choices = [];
 
     $.ajax({
         url: '/sitemap.xml',
@@ -45,7 +47,7 @@
 
         // Ctrl-P brings up the spotlight
 
-        $(document).keyup(function(e) {
+        $(document).keydown(function(e) {
             if (e.altKey || e.metaKey || e.shiftKey) return;
             if (e.key.toLowerCase() == 'p' && e.ctrlKey) {
                 handleShowRequest(e);
@@ -54,11 +56,24 @@
 
         // Esc dismisses it
 
-        $(document).on('keyup', '#spotlight', function(e) {
+        $(document).on('keydown', '#spotlight', function(e) {
             if (e.altKey || e.ctrlKey || e.shiftKey || e.metaKey) return;
             switch (e.keyCode) {
                 case 27: // esc
                     handleEsc(e);
+                    break;
+                case 38: // up arrow
+                    handleSelectionChanged(e, -1);
+                    break;
+                case 40: // down arrow
+                    handleSelectionChanged(e, 1);
+                    break;
+                case 13: // enter
+                    handleEnter(e);
+                    break;
+                default:
+                    console.log(e);
+                    break;
             }
         });
 
@@ -105,6 +120,19 @@
         updateSpotlight(text);
     }
 
+    function handleSelectionChanged(e, delta) {
+        var index = (selected + delta) % choices.length;
+        selectChoice(index);
+        e.preventDefault();
+    }
+
+    function handleEnter(e) {
+        if (selected >= 0 && selected < choices.length) {
+            window.location.href = choices[selected].attr('href');
+        }
+        e.preventDefault();
+    }
+
     function showSpotlight() {
         if (visible) return;
         visible = true;
@@ -127,17 +155,18 @@
     }
 
     function updateSpotlight(text) {
-        var matches = getMatches(text);
+        choices = getChoices(text);
+        selectChoice(0);
         $('#spotlight-results a').remove();
-        if(matches.length) {
-            $('#spotlight-results').append(matches).show(0);
+        if(choices.length) {
+            $('#spotlight-results').append(choices).show(0);
         }
         else {
             $('#spotlight-results').hide(0);
         }
     }
 
-    function getMatches(text) {
+    function getChoices(text) {
         if (text.length < 2) return [];
         var links = [];
         for (var i = 0; i < pages.length; i++) {
@@ -167,6 +196,16 @@
         }
 
         return links;
+    }
+
+    function selectChoice(index) {
+        if (selected >= 0 && selected < choices.length) {
+            choices[selected].removeClass('selected');
+        }
+        selected = index;
+        if (selected >= 0 && selected < choices.length) {
+            choices[selected].addClass('selected');
+        }
     }
 
 })(jQuery);

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -71,9 +71,6 @@ function Spotlight() {
                 case 13: // enter
                     handleEnter(e);
                     break;
-                default:
-                    console.log(e);
-                    break;
             }
         });
 

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -78,7 +78,7 @@
 
     function handleShowRequest(e) {
         showSpotlight();
-        updateSpotlight();
+        updateSpotlight($('#spotlight input').val());
         e.preventDefault();
     }
 
@@ -113,10 +113,7 @@
             '<input type="text" placeholder="Quick search" />' +
             '<div id="spotlight-results">' +
             '</div></div></div>');
-        $('#spotlight input').focus().keyup(updateSpotlight);
-        $('#spotlight-contents').focusout(function() {
-            var contents = this;
-        });
+        $('#spotlight input').focus();
     }
 
     function hideSpotlight() {

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -45,11 +45,10 @@ function Spotlight() {
 
     function initSpotlight() {
 
-        // Ctrl-P brings up the spotlight
+        // Ctrl-/ or Cmd-/ brings up the spotlight
 
         $(document).keydown(function(e) {
-            if (e.altKey || e.metaKey || e.shiftKey) return;
-            if (e.keyCode == 80 && e.ctrlKey) {
+            if (e.keyCode == 191 && (e.ctrlKey || e.metaKey)) {
                 handleShowRequest(e);
             }
         });

--- a/website/source/assets/javascripts/app/_Spotlight.js
+++ b/website/source/assets/javascripts/app/_Spotlight.js
@@ -23,9 +23,12 @@
         nodes = Array.prototype.map.call(nodes, function(node) {
             var title = node.getElementsByTagNameNS(nsDcTerms, 'title')[0];
             if (!title) return null;
+            var url = node.getElementsByTagNameNS(nsSitemaps, 'loc')[0].textContent;
+            url = url.replace(/^http.*:\/\/.*?\//, '/');
+
             return {
                 title: title.textContent,
-                url: node.getElementsByTagNameNS(nsSitemaps, 'loc')[0].textContent
+                url: url
             };
         });
         var result = nodes.filter(function(x) { return !!x; });
@@ -151,7 +154,7 @@
                 $element.append($selection);
                 $element.append(p.title.substr(ix + text.length));
 
-                var url = p.url.replace(/^http.*:\/\/.*?\//, '/');
+                var url = p.url;
                 var isDataSource = /\/d\//.test(url);
                 var isResource = /\/r\//.test(url);
                 if (isDataSource) {

--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require app/_Engine.Shape.Puller
 //= require app/_Engine.Typewriter
 //= require app/_Sidebar
+//= require app/_Spotlight
 //= require app/_Init
 
 // assets/javascripts/application.js

--- a/website/source/assets/stylesheets/_spotlight.scss
+++ b/website/source/assets/stylesheets/_spotlight.scss
@@ -1,0 +1,72 @@
+#spotlight {
+    position: fixed;
+    left: 0px;
+    top: 0px;
+    right: 0px;
+    bottom: 0px;
+    background-color: rgba(0,0,0,0.5);
+    z-index: 99999;
+
+    #spotlight-contents {
+        position: absolute;
+        left: 25%;
+        right: 25%;
+        top: 10%;
+        background-color: $gray-darker;
+        border: 1px solid $gray-secondary;
+        box-shadow: 0px 0px 10px 5px rgba(0,0,0,1);
+        color: $white;
+        padding: 0px;
+
+        input {
+            display: block;
+            width: 100%;
+            background-color: $gray-secondary;
+            color: $white;
+            border: 1px solid $black;
+            padding: 2px;
+        }
+
+        #spotlight-results {
+            overflow-y: scroll;
+            overflow-x: clip;
+            max-height: 450px;
+            display: none;
+
+            a {
+                display: block;
+                width: 100%;
+                padding: 2px;
+                background-color: $gray-darker;
+                color: $white;
+
+                strong {
+                    background-color: $gray-secondary;
+                }
+
+                em {
+                    float: right;
+                    font-size: 80%;
+                }
+            }
+
+            a:hover {
+                background-color: $gray;
+                color: $black;
+
+                strong {
+                    background-color: $gray;
+                }
+            }
+
+            a:focus {
+                background-color: $white;
+                color: $black;
+
+                strong {
+                    background-color: $white;
+                }
+            }
+        }
+    }
+}

--- a/website/source/assets/stylesheets/_spotlight.scss
+++ b/website/source/assets/stylesheets/_spotlight.scss
@@ -32,6 +32,8 @@
             overflow-x: clip;
             max-height: 450px;
             display: none;
+            position: relative;
+            box-sizing: border-box;
 
             a {
                 display: block;
@@ -41,6 +43,7 @@
                 color: $white;
                 white-space: nowrap;
                 position: relative;
+                box-sizing: border-box;
 
                 strong {
                     background-color: $gray-secondary;

--- a/website/source/assets/stylesheets/_spotlight.scss
+++ b/website/source/assets/stylesheets/_spotlight.scss
@@ -39,24 +39,23 @@
                 padding: 2px;
                 background-color: $gray-darker;
                 color: $white;
+                white-space: nowrap;
+                position: relative;
 
                 strong {
                     background-color: $gray-secondary;
                 }
 
                 em {
-                    float: right;
+                    position: absolute;
+                    right: 3pt;
+                    bottom: 3pt;
                     font-size: 80%;
                 }
             }
 
             a:hover {
-                background-color: $gray;
-                color: $black;
-
-                strong {
-                    background-color: $gray;
-                }
+                background-color: $black;
             }
 
             a.selected {

--- a/website/source/assets/stylesheets/_spotlight.scss
+++ b/website/source/assets/stylesheets/_spotlight.scss
@@ -59,7 +59,7 @@
                 }
             }
 
-            a:focus {
+            a.selected {
                 background-color: $white;
                 color: $black;
 

--- a/website/source/assets/stylesheets/application.scss
+++ b/website/source/assets/stylesheets/application.scss
@@ -33,3 +33,4 @@
 @import '_community';
 @import '_docs';
 @import '_downloads';
+@import '_spotlight';

--- a/website/source/docs/index.html.markdown
+++ b/website/source/docs/index.html.markdown
@@ -13,6 +13,6 @@ guide for all available features and options of Terraform. If you're just gettin
 started with Terraform, please start with the
 [introduction and getting started guide](/intro/index.html) instead.
 
-If you know the page in the documentation that you wish to go to, pressing Ctrl-P
-will open up a quick search window, to let you quickly navigate to the page you
-want by typing part of its title.
+If you know the page in the documentation that you wish to go to, pressing Ctrl-/
+or Cmd-/ will open up a quick search window, to let you quickly navigate to the
+page you want by typing part of its title.

--- a/website/source/docs/index.html.markdown
+++ b/website/source/docs/index.html.markdown
@@ -12,3 +12,7 @@ Welcome to the Terraform documentation! This documentation is more of a referenc
 guide for all available features and options of Terraform. If you're just getting
 started with Terraform, please start with the
 [introduction and getting started guide](/intro/index.html) instead.
+
+If you know the page in the documentation that you wish to go to, pressing Ctrl-P
+will open up a quick search window, to let you quickly navigate to the page you
+want by typing part of its title.

--- a/website/source/sitemap.xml.builder
+++ b/website/source/sitemap.xml.builder
@@ -3,7 +3,7 @@ layout: false
 ---
 
 xml.instruct!
-xml.urlset 'xmlns' => "http://www.sitemaps.org/schemas/sitemap/0.9" do
+xml.urlset 'xmlns' => "http://www.sitemaps.org/schemas/sitemap/0.9", 'xmlns:tf' => "http://www.terraform.io/ns/sitemap" do
   sitemap
     .resources
     .select { |page| page.path =~ /\.html/ }
@@ -14,6 +14,9 @@ xml.urlset 'xmlns' => "http://www.sitemaps.org/schemas/sitemap/0.9" do
         xml.lastmod Date.today.to_time.iso8601
         xml.changefreq page.data.changefreq || "monthly"
         xml.priority page.data.priority || "0.5"
+        if page.data.page_title
+          xml.tag! 'tf:title', page.data.page_title
+        end
       end
   end
 end

--- a/website/source/sitemap.xml.builder
+++ b/website/source/sitemap.xml.builder
@@ -3,7 +3,7 @@ layout: false
 ---
 
 xml.instruct!
-xml.urlset 'xmlns' => "http://www.sitemaps.org/schemas/sitemap/0.9", 'xmlns:tf' => "http://www.terraform.io/ns/sitemap" do
+xml.urlset 'xmlns' => "http://www.sitemaps.org/schemas/sitemap/0.9", 'xmlns:dc' => "http://purl.org/dc/terms/" do
   sitemap
     .resources
     .select { |page| page.path =~ /\.html/ }
@@ -15,7 +15,7 @@ xml.urlset 'xmlns' => "http://www.sitemaps.org/schemas/sitemap/0.9", 'xmlns:tf' 
         xml.changefreq page.data.changefreq || "monthly"
         xml.priority page.data.priority || "0.5"
         if page.data.page_title
-          xml.tag! 'tf:title', page.data.page_title
+          xml.tag! 'dc:title', page.data.page_title
         end
       end
   end


### PR DESCRIPTION
This is a quick lookup feature that I proposed as a possible solution for #9589. It will allow users to navigate quickly and easily to other pages on the site. This is especially important for very large providers such as AWS that have a large number of data sources and resources and that are difficult to navigate.

When the user presses the appropriate keystroke (Ctrl-/ or Cmd-/ on the Mac), it will bring up a Spotlight-style search box, similar to the Ctrl-P functionality in text editors such as Sublime Text, Visual Studio Code, and Vim's CtrlP extension. The user can then type in a part of the title and will be shown a list of pages that changes as they type.

Once they've got a list of candidates, they can then either click on one of them directly, or else use the Tab key to navigate to the one they wish to choose.

Tested on IE10, IE11, Edge, Firefox 52, Chrome 56, Safari 10.

# A couple of questions here for feedback:

1. Is the styling OK? Any particular changes necessary?
2. Is Ctrl-/ or Cmd-/ the best key combination to invoke the search box? Would a different combination be better? I originally went for Ctrl-P but changed this to avoid conflicting with browsers' print dialogs.
3. Do you want a visible clickable link for this or will the key combination suffice?

# Technical notes:

I'm keeping some fairly comprehensive lab notes on this pull request as I'm working on it; these explain my thinking behind the design in greater detail. You can find these at https://github.com/jammycakes/terraform/wiki/issue_9589.