### PR TITLE
remind users if there is a missing snapshot

### DIFF
--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -171,6 +171,19 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if v, ok := d.GetOk("snapshot"); ok {
+		snapshotName := v.(string)
+		log.Printf("[DEBUG] Loading snapshot: %s", snapshotName)
+		_, err := config.clientCompute.Snapshots.Get(
+			project, snapshotName).Do()
+
+		if err != nil {
+			return fmt.Errorf(
+				"Error loading snapshot '%s': %s",
+				snapshotName, err)
+		}
+	}
+
 	disk, err := config.clientCompute.Disks.Get(
 		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {


### PR DESCRIPTION
Fixes #12900 
&
Related to #12859

```
google_compute_disk.blog: Refreshing state... (ID: blog)
Error refreshing state: 1 error(s) occurred:

* google_compute_disk.blog: google_compute_disk.blog: Error loading snapshot 'snapshot-1': googleapi: Error 404: The resource 'projects/sign-in-test-1025/global/snapshots/snapshot-1' was not found, notFound
```