### PR TITLE
Rancher: error when no api_url is provided

### DIFF
--- a/builtin/providers/rancher/provider.go
+++ b/builtin/providers/rancher/provider.go
@@ -2,6 +2,7 @@ package rancher
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/url"
 	"os"
@@ -87,7 +88,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 			return config, err
 		}
 
-		if apiURL == "" {
+		if apiURL == "" && config.URL != "" {
 			u, err := url.Parse(config.URL)
 			if err != nil {
 				return config, err
@@ -102,6 +103,10 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		if secretKey == "" {
 			secretKey = config.SecretKey
 		}
+	}
+
+	if apiURL == "" {
+		return &Config{}, fmt.Errorf("No api_url provided")
 	}
 
 	config := &Config{


### PR DESCRIPTION
Since `api_url` is optional (which is required to get `config` to work), it is possible to end up with a provider that has no API URL provided, which should error.