### PR TITLE
vSphere disks: read disk capacity instead of file size

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_disk_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_disk_test.go
@@ -27,6 +27,8 @@ func TestAccVSphereVirtualDisk_basic(t *testing.T) {
 	}
 	if v := os.Getenv("VSPHERE_INIT_TYPE"); v != "" {
 		initTypeOpt += fmt.Sprintf("    type = \"%s\"\n", v)
+	} else {
+		initTypeOpt += fmt.Sprintf("    type = \"%s\"\n", "thin")
 	}
 	if v := os.Getenv("VSPHERE_ADAPTER_TYPE"); v != "" {
 		adapterTypeOpt += fmt.Sprintf("    adapter_type = \"%s\"\n", v)


### PR DESCRIPTION
Disks are created by setting `CapacityKb`, but are read using the file size. Although this is equivalent for eager provisioned thick volumes, this is not the case for thin volumes.

This PR modifies reading the disks to read back `CapacityKb`.

This also changes the default type in the tests to thin.

Closes #11722 