### PR TITLE
provider/aws: Update calling_identity

### DIFF
--- a/builtin/providers/aws/data_source_aws_caller_identity.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity.go
@@ -50,8 +50,8 @@ func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	log.Printf("[DEBUG] Setting AWS Account ID to %s.", *res.Account)
-	d.Set("account_id", *res.Account)
-	d.Set("arn", *res.Arn)
-	d.Set("user_id", *res.UserId)
+	d.Set("account_id", res.Account)
+	d.Set("arn", res.Arn)
+	d.Set("user_id", res.UserId)
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_caller_identity.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"time"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -17,24 +18,40 @@ func dataSourceAwsCallerIdentity() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"user_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
 
 func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*AWSClient)
+	client := meta.(*AWSClient).stsconn
+
+	res, err := client.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		return fmt.Errorf("Error getting Caller Identity: %v", err)
+	}
 
 	log.Printf("[DEBUG] Reading Caller Identity.")
 	d.SetId(time.Now().UTC().String())
 
-	if client.accountid == "" {
+	if *res.Account == "" {
 		log.Println("[DEBUG] No Account ID available, failing")
 		return fmt.Errorf("No AWS Account ID is available to the provider. Please ensure that\n" +
 			"skip_requesting_account_id is not set on the AWS provider.")
 	}
 
-	log.Printf("[DEBUG] Setting AWS Account ID to %s.", client.accountid)
-	d.Set("account_id", meta.(*AWSClient).accountid)
-
+	log.Printf("[DEBUG] Setting AWS Account ID to %s.", *res.Account)
+	d.Set("account_id", *res.Account)
+	d.Set("arn", *res.Arn)
+	d.Set("user_id", *res.UserId)
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_caller_identity_test.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity_test.go
@@ -39,6 +39,14 @@ func testAccCheckAwsCallerIdentityAccountId(n string) resource.TestCheckFunc {
 			return fmt.Errorf("Incorrect Account ID: expected %q, got %q", expected, rs.Primary.Attributes["account_id"])
 		}
 
+		if rs.Primary.Attributes["user_id"] == "" {
+			return fmt.Errorf("UserID expected to not be nil")
+		}
+
+		if rs.Primary.Attributes["arn"] == "" {
+			return fmt.Errorf("ARN expected to not be nil")
+		}
+
 		return nil
 	}
 }

--- a/website/source/docs/providers/aws/d/caller_identity.html.markdown
+++ b/website/source/docs/providers/aws/d/caller_identity.html.markdown
@@ -40,6 +40,6 @@ There are no arguments available for this data source.
 
 ## Attributes Reference
 
-`account_id` - The AWS Account ID number of the account that owns or contains the calling entity.
-`arn` - The AWS ARN associated with the calling entity.
-`user_id` - The unique identifier of the calling entity.
+* `account_id` - The AWS Account ID number of the account that owns or contains the calling entity.
+* `arn` - The AWS ARN associated with the calling entity.
+* `user_id` - The unique identifier of the calling entity.

--- a/website/source/docs/providers/aws/d/caller_identity.html.markdown
+++ b/website/source/docs/providers/aws/d/caller_identity.html.markdown
@@ -9,8 +9,8 @@ description: |-
 
 # aws\_caller\_identity
 
-Use this data source to get the access to the effective Account ID in
-which Terraform is working.
+Use this data source to get the access to the effective Account ID, User ID, and ARN in
+which Terraform is authorized.
 
 ~> **NOTE on `aws_caller_identity`:** - an Account ID is only available
 if `skip_requesting_account_id` is not set on the AWS provider. In such
@@ -24,6 +24,14 @@ data "aws_caller_identity" "current" {}
 output "account_id" {
   value = "${data.aws_caller_identity.current.account_id}"
 }
+
+output "caller_arn" {
+  value = "${data.aws_caller_identity.current.arn}"
+}
+
+output "caller_user" {
+  value = "${data.aws_caller_identity.current.user_id}"
+}
 ```
 
 ## Argument Reference
@@ -32,4 +40,6 @@ There are no arguments available for this data source.
 
 ## Attributes Reference
 
-`account_id` is set to the ID of the AWS account.
+`account_id` - The AWS Account ID number of the account that owns or contains the calling entity.
+`arn` - The AWS ARN associated with the calling entity.
+`user_id` - The unique identifier of the calling entity.


### PR DESCRIPTION
Updates `aws_caller_identity` data source to actually include the correct attributes from the `GetCallerIdentity` API function.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCallerIdentity_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/27 09:26:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCallerIdentity_basic -timeout 120m
=== RUN   TestAccAWSCallerIdentity_basic
--- PASS: TestAccAWSCallerIdentity_basic (12.74s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    12.767s
```

Fixes: #13084 