### PR TITLE
helper/resource: Allow unknown "pending" states

### DIFF
--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -141,7 +141,7 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 					}
 				}
 
-				if !found {
+				if !found && len(conf.Pending) > 0 {
 					result.Error = &UnexpectedStateError{
 						LastError:     err,
 						State:         result.State,


### PR DESCRIPTION
Sometimes when waiting on a target state, the set of valid states through which a value will transition is unknown. This commit adds support for an empty Pending slice and will treat any states that are not the target as valid provided the timeouts are not exceeded.