### PR TITLE
Fixes TestAccAWSOpsworksInstance

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_instance.go
+++ b/builtin/providers/aws/resource_aws_opsworks_instance.go
@@ -565,6 +565,10 @@ func resourceAwsOpsworksInstanceRead(d *schema.ResourceData, meta interface{}) e
 	for _, v := range instance.LayerIds {
 		layerIds = append(layerIds, *v)
 	}
+	layerIds, err = sortListBasedonTFFile(layerIds, d, "layer_ids")
+	if err != nil {
+		return fmt.Errorf("[DEBUG] Error sorting layer_ids attribute: %#v", err)
+	}
 	if err := d.Set("layer_ids", layerIds); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting layer_ids attribute: %#v, error: %#v", layerIds, err)
 	}
@@ -820,7 +824,6 @@ func resourceAwsOpsworksInstanceUpdate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("layer_ids"); ok {
 		req.LayerIds = expandStringList(v.([]interface{}))
-
 	}
 
 	if v, ok := d.GetOk("os"); ok {

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1490,6 +1490,22 @@ func sortInterfaceSlice(in []interface{}) []interface{} {
 	return b
 }
 
+// This function sorts List A to look like a list found in the tf file.
+func sortListBasedonTFFile(in []string, d *schema.ResourceData, listName string) ([]string, error) {
+	if attributeCount, ok := d.Get(listName + ".#").(int); ok {
+		for i := 0; i < attributeCount; i++ {
+			currAttributeId := d.Get(listName + "." + strconv.Itoa(i))
+			for j := 0; j < len(in); j++ {
+				if currAttributeId == in[j] {
+					in[i], in[j] = in[j], in[i]
+				}
+			}
+		}
+		return in, nil
+	}
+	return in, fmt.Errorf("Could not find list: %s", listName)
+}
+
 func flattenApiGatewayThrottleSettings(settings *apigateway.ThrottleSettings) []map[string]interface{} {
 	result := make([]map[string]interface{}, 0, 1)
 


### PR DESCRIPTION
This tests fixes TestAccAWSOpsworksInstance

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksInstance'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/27 09:37:15 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksInstance -timeout 120m
=== RUN   TestAccAWSOpsworksInstance_importBasic
--- PASS: TestAccAWSOpsworksInstance_importBasic (38.07s)
=== RUN   TestAccAWSOpsworksInstance
--- PASS: TestAccAWSOpsworksInstance (55.05s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	93.162s
```