### PR TITLE
Update the S3 named state handling to match consul

### DIFF
--- a/backend/remote-state/s3/backend_old_state.go
+++ b/backend/remote-state/s3/backend_old_state.go
@@ -1,0 +1,227 @@
+package s3
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	multierror "github.com/hashicorp/go-multierror"
+	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/state"
+	"github.com/hashicorp/terraform/state/remote"
+)
+
+/*
+DEPRECATED FILE
+TODO: remove after 0.10
+these methods are only used to update the env format in S3
+*/
+
+const (
+	oldEnvPrefix = "env:"
+)
+
+func (b *Backend) oldStates() ([]string, error) {
+	params := &s3.ListObjectsInput{
+		Bucket: &b.bucketName,
+		Prefix: aws.String(oldEnvPrefix + "/"),
+	}
+
+	resp, err := b.s3Client.ListObjects(params)
+	if err != nil {
+		return nil, err
+	}
+
+	var envs []string
+	for _, obj := range resp.Contents {
+		env := oldKeyEnv(*obj.Key)
+		if env != "" {
+			envs = append(envs, env)
+		}
+	}
+
+	// don't add "default" here
+	sort.Strings(envs)
+	return envs, nil
+}
+
+// extract the env name from the S3 key
+func oldKeyEnv(key string) string {
+	parts := strings.Split(key, "/")
+	if len(parts) < 3 {
+		// no env here
+		return ""
+	}
+
+	if parts[0] != oldEnvPrefix {
+		// not our key, so ignore
+		return ""
+	}
+
+	return parts[1]
+}
+
+func (b *Backend) oldDeleteState(name string) error {
+	if name == backend.DefaultStateName || name == "" {
+		return fmt.Errorf("can't delete default state")
+	}
+
+	params := &s3.DeleteObjectInput{
+		Bucket: &b.bucketName,
+		Key:    aws.String(b.oldPath(name)),
+	}
+
+	_, err := b.s3Client.DeleteObject(params)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (b *Backend) oldState(name string) (state.State, error) {
+	client := &envUpgrader{
+		RemoteClient: &RemoteClient{
+			s3Client:             b.s3Client,
+			dynClient:            b.dynClient,
+			bucketName:           b.bucketName,
+			path:                 b.oldPath(name),
+			serverSideEncryption: b.serverSideEncryption,
+			acl:                  b.acl,
+			kmsKeyID:             b.kmsKeyID,
+			lockTable:            b.lockTable,
+		},
+		backend:      b,
+		name:         name,
+		needsUpgrade: true,
+	}
+
+	// No need for the initialization code, since we know this must already exist.
+	return &remote.State{Client: client}, nil
+}
+
+func (b *Backend) oldPath(name string) string {
+	if name == backend.DefaultStateName {
+		return b.keyName
+	}
+	return strings.Join([]string{oldEnvPrefix, name, b.keyName}, "/")
+}
+
+// envUpgrader wraps the Backend and RemoteClient to update a named state's
+// location when there's a write.
+type envUpgrader struct {
+	*RemoteClient
+	// we need the backend to help with the upgrade
+	backend *Backend
+
+	// only run upgrade onnce
+	needsUpgrade bool
+
+	// the name of this state
+	name string
+
+	// store the original lockInfo and original lock ID to translate the lock
+	// to the new path.
+	oldLockID string
+	lockInfo  *state.LockInfo
+}
+
+// we upgrade on write, so that we know the user is expected to have write
+// permissions, and we have a lock
+func (c *envUpgrader) Put(data []byte) error {
+	if c.needsUpgrade {
+		if err := c.putUpgrade(data); err != nil {
+			return err
+		}
+		c.needsUpgrade = false
+		return nil
+	}
+
+	return c.RemoteClient.Put(data)
+}
+
+// move the state to the new location, put the datam and remove the old state
+func (c *envUpgrader) putUpgrade(data []byte) error {
+	// make a copy of the client with the new path
+	newClient := new(RemoteClient)
+	*newClient = *c.RemoteClient
+	newClient.path = c.backend.path(c.name)
+
+	// we lock the new state if we have a lock on the old
+	if c.lockInfo != nil {
+		// If we are using locks, we already have one since this happens in WriteState/Put
+		lockInfo := state.NewLockInfo()
+		lockInfo.Operation = c.lockInfo.Operation
+		lockInfo.Info = "env path update"
+		// we don't need the lock id, bc we store the LockInfo, and know our
+		// impl uses that ID
+		_, err := newClient.Lock(lockInfo)
+		if err != nil {
+			return fmt.Errorf("failed to lock s3 state: %s", err)
+		}
+
+		// replace the lock info for the next Unlock call
+		c.lockInfo = lockInfo
+	}
+
+	// write the state to the new location
+	if err := newClient.Put(data); err != nil {
+		return err
+	}
+
+	// we've moved the state, now we can delete the old one
+	err := c.backend.oldDeleteState(c.name)
+
+	// if we're locking, make sure to remove the old lock
+	if c.lockInfo != nil {
+		if unlockErr := c.RemoteClient.Unlock(c.oldLockID); unlockErr != nil {
+			err = multierror.Append(err, unlockErr)
+			return fmt.Errorf("error removing old state during env upgrade: %s", err)
+		}
+	}
+
+	// replace the client with the new path
+	c.RemoteClient = newClient
+
+	return err
+}
+
+func (c *envUpgrader) Lock(info *state.LockInfo) (string, error) {
+	id, err := c.RemoteClient.Lock(info)
+	if c.needsUpgrade {
+		// store the lock ID for when the path gets updated
+		c.oldLockID = id
+		c.lockInfo = info
+	}
+	return id, err
+}
+
+func (c *envUpgrader) Unlock(id string) error {
+	// If terraform had a lock during the upgrade, we need to translate the old
+	// lock id to the new lock.
+	if c.lockInfo != nil {
+		if id != c.oldLockID {
+			// The lock id doesn't match, so something went wrong.
+			// Don't show the id to the user, since that id doesn't really
+			// exist any longer, and the user may need the new LockInfo to
+			// recover.
+			return &state.LockError{
+				Err:  errors.New("incorrect lock id"),
+				Info: c.lockInfo,
+			}
+		}
+
+		if err := c.RemoteClient.Unlock(c.lockInfo.ID); err != nil {
+			return err
+		}
+
+		c.oldLockID = ""
+		c.lockInfo = nil
+		return nil
+	}
+
+	return c.RemoteClient.Unlock(id)
+}

--- a/backend/remote-state/s3/backend_old_state.go
+++ b/backend/remote-state/s3/backend_old_state.go
@@ -146,9 +146,16 @@ func (c *envUpgrader) Put(data []byte) error {
 // move the state to the new location, put the datam and remove the old state
 func (c *envUpgrader) putUpgrade(data []byte) error {
 	// make a copy of the client with the new path
-	newClient := new(RemoteClient)
-	*newClient = *c.RemoteClient
-	newClient.path = c.backend.path(c.name)
+	newClient := &RemoteClient{
+		s3Client:             c.RemoteClient.s3Client,
+		dynClient:            c.RemoteClient.dynClient,
+		bucketName:           c.RemoteClient.bucketName,
+		path:                 c.backend.path(c.name),
+		serverSideEncryption: c.RemoteClient.serverSideEncryption,
+		acl:                  c.RemoteClient.acl,
+		kmsKeyID:             c.RemoteClient.kmsKeyID,
+		lockTable:            c.RemoteClient.lockTable,
+	}
 
 	// we lock the new state if we have a lock on the old
 	if c.lockInfo != nil {

--- a/backend/remote-state/s3/backend_old_state_test.go
+++ b/backend/remote-state/s3/backend_old_state_test.go
@@ -1,0 +1,325 @@
+package s3
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/state"
+	"github.com/hashicorp/terraform/state/remote"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// run through a multi-step upgrade in a single long script
+func TestOldEnvUpgrade(t *testing.T) {
+	testACC(t)
+	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
+	keyName := "testState"
+
+	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
+		"bucket":     bucketName,
+		"key":        keyName,
+		"encrypt":    true,
+		"lock_table": bucketName,
+	}).(*Backend)
+
+	createS3Bucket(t, b.s3Client, bucketName)
+	defer deleteS3Bucket(t, b.s3Client, bucketName)
+	createDynamoDBTable(t, b.dynClient, bucketName)
+	defer deleteDynamoDBTable(t, b.dynClient, bucketName)
+
+	// put multiple states in old env paths.
+	s1 := terraform.NewState()
+	s1.Modules[0] = &terraform.ModuleState{
+		Path: []string{"root"},
+		Resources: map[string]*terraform.ResourceState{
+			"aws_instance.a": &terraform.ResourceState{
+				Type: "aws_instance",
+				Primary: &terraform.InstanceState{
+					ID: "bar",
+				},
+			},
+		},
+	}
+
+	s2 := terraform.NewState()
+	s2.Modules[0] = &terraform.ModuleState{
+		Path: []string{"root"},
+		Resources: map[string]*terraform.ResourceState{
+			"aws_instance.b": &terraform.ResourceState{
+				Type: "aws_instance",
+				Primary: &terraform.InstanceState{
+					ID: "baz",
+				},
+			},
+		},
+	}
+
+	// RemoteClient to Put things in the old paths
+	client := &RemoteClient{
+		s3Client:             b.s3Client,
+		dynClient:            b.dynClient,
+		bucketName:           b.bucketName,
+		path:                 b.oldPath("s1"),
+		serverSideEncryption: b.serverSideEncryption,
+		acl:                  b.acl,
+		kmsKeyID:             b.kmsKeyID,
+		lockTable:            b.lockTable,
+	}
+
+	stateMgr := &remote.State{Client: client}
+	stateMgr.WriteState(s1)
+	if err := stateMgr.PersistState(); err != nil {
+		t.Fatal(err)
+	}
+
+	client.path = b.oldPath("s2")
+	stateMgr.WriteState(s2)
+	if err := stateMgr.PersistState(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := checkStateList(b, []string{"default", "s1", "s2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// add a new state
+	s3Mgr, err := b.State("s3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// make sure we didn't get an upgrader
+	_, ok := s3Mgr.(*remote.State).Client.(*envUpgrader)
+	if ok {
+		t.Fatal("s3 should not be upgraded")
+	}
+	if err := checkStateList(b, []string{"default", "s1", "s2", "s3"}); err != nil {
+		t.Fatal(err)
+	}
+
+	testUpgradeAndCompare(t, "s1", b, s1)
+	if err := checkStateList(b, []string{"default", "s1", "s2", "s3"}); err != nil {
+		t.Fatal(err)
+	}
+
+	testUpgradeAndCompare(t, "s2", b, s2)
+	if err := checkStateList(b, []string{"default", "s1", "s2", "s3"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the old state paths don't exist.
+	// Refreshing swallows the error if the key doesn't exist, so just check
+	// for empty state.
+	client.path = b.oldPath("s1")
+	stateMgr = &remote.State{Client: client}
+	if err := stateMgr.RefreshState(); err != nil {
+		t.Fatal("error refreshing old s1 state path:", err)
+	}
+	if stateMgr.State() != nil {
+		t.Fatal("expected empty state at old s1 path, got", stateMgr.State())
+	}
+
+	client.path = b.oldPath("s2")
+	stateMgr = &remote.State{Client: client}
+	if err := stateMgr.RefreshState(); err != nil {
+		t.Fatal("error refreshing old s2 state path:", err)
+	}
+	if stateMgr.State() != nil {
+		t.Fatal("expected empty state at old s2 path, got", stateMgr.State())
+	}
+}
+
+// Pre-load an old named state and test that it can be correctly locked and
+// unlocked around the upgrade.
+func TestOldEnvUpgradeLocked(t *testing.T) {
+	testACC(t)
+	bucketName := fmt.Sprintf("terraform-remote-s3-test-%x", time.Now().Unix())
+	keyName := "testState"
+
+	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+		"bucket":     bucketName,
+		"key":        keyName,
+		"encrypt":    true,
+		"lock_table": bucketName,
+	}).(*Backend)
+
+	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
+		"bucket":     bucketName,
+		"key":        keyName,
+		"encrypt":    true,
+		"lock_table": bucketName,
+	}).(*Backend)
+
+	createS3Bucket(t, b1.s3Client, bucketName)
+	defer deleteS3Bucket(t, b1.s3Client, bucketName)
+	createDynamoDBTable(t, b1.dynClient, bucketName)
+	defer deleteDynamoDBTable(t, b1.dynClient, bucketName)
+
+	// create a legacy named state
+	s1 := terraform.NewState()
+
+	// RemoteClient to Put things in the old paths
+	client := &RemoteClient{
+		s3Client:             b1.s3Client,
+		dynClient:            b1.dynClient,
+		bucketName:           b1.bucketName,
+		path:                 b1.oldPath("s1"),
+		serverSideEncryption: b1.serverSideEncryption,
+		acl:                  b1.acl,
+		kmsKeyID:             b1.kmsKeyID,
+		lockTable:            b1.lockTable,
+	}
+
+	stateMgr := &remote.State{Client: client}
+	stateMgr.WriteState(s1)
+	if err := stateMgr.PersistState(); err != nil {
+		t.Fatal(err)
+	}
+
+	s1Mgr, err := b1.State("s1")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s1LockInfo := state.NewLockInfo()
+	s1LockInfo.Operation = "test"
+	s1LockInfo.Who = "s1"
+	s1LockID, err := s1Mgr.Lock(s1LockInfo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if s1LockID == "" {
+		t.Fatal("s1 not locked")
+	}
+
+	{
+		// check that we can't get a lock on s1 from b2
+		s1Mgr, err := b2.State("s1")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s1LockInfo := state.NewLockInfo()
+		s1LockInfo.Operation = "test-fail"
+		s1LockInfo.Who = "b2"
+		_, err = s1Mgr.Lock(s1LockInfo)
+		if err == nil {
+			t.Fatal("expected error getting second lock on s1")
+		}
+	}
+
+	// upgrade the state on write
+	s1.Serial++
+	s1Mgr.WriteState(s1)
+	if err := s1Mgr.PersistState(); err != nil {
+		t.Fatal("error persisting s1", err)
+	}
+
+	// check that we have a different lockInfo now stored from the upgrade
+	newLockInfo := s1Mgr.(*remote.State).Client.(*envUpgrader).lockInfo
+	if newLockInfo.ID == s1LockID {
+		t.Fatal("upgraded state should have a new lock ID")
+	}
+
+	// make sure we still can't get a second lock
+	{
+		// this time it will fail when trying fetch the new state because we
+		// may need to create one
+		_, err = b2.State("s1")
+		if err == nil {
+			t.Fatal("expected lock failure fetching s1")
+		}
+	}
+
+	if err := s1Mgr.Unlock(newLockInfo.ID); err == nil {
+		t.Fatal("unlocking with the new lock should have failed")
+	}
+
+	if err := s1Mgr.Unlock(s1LockID); err != nil {
+		t.Fatal("unlock failed:", err)
+	}
+
+	// now we should be able to get a second lock
+	{
+		s1Mgr, err := b2.State("s1")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s1LockInfo := state.NewLockInfo()
+		s1LockInfo.Operation = "test-fail"
+		s1LockInfo.Who = "b2"
+		id, err := s1Mgr.Lock(s1LockInfo)
+		if err != nil {
+			t.Fatal("expected error getting second lock on s1")
+		}
+		defer func() {
+			if err := s1Mgr.Unlock(id); err != nil {
+				t.Fatal(err)
+			}
+		}()
+	}
+}
+
+func checkStateList(b backend.Backend, expected []string) error {
+	states, err := b.States()
+	if err != nil {
+		return err
+	}
+
+	if !reflect.DeepEqual(states, expected) {
+		return fmt.Errorf("incorrect states listed: %q", states)
+	}
+	return nil
+}
+
+func testUpgradeAndCompare(t *testing.T, name string, b backend.Backend, s *terraform.State) {
+	sMgr, err := b.State(name)
+	if err != nil {
+		t.Fatal("error fetching", name, err)
+	}
+
+	// make sure we got our envUpgrader
+	upgrader, ok := sMgr.(*remote.State).Client.(*envUpgrader)
+	if !ok {
+		t.Fatalf("expected envUpgrader for %q, got %T", name, sMgr.(*remote.State).Client)
+	}
+
+	if err := sMgr.RefreshState(); err != nil {
+		t.Fatal(err)
+	}
+
+	// upgrade the state on write
+	s.Serial++
+	sMgr.WriteState(s)
+	if err := sMgr.PersistState(); err != nil {
+		t.Fatal("error persisting", name, err)
+	}
+
+	// the upgrader should be done
+	if upgrader.needsUpgrade {
+		t.Fatalf("%q not marked as upgraded", name)
+	}
+
+	if upgrader.RemoteClient.path != b.(*Backend).path(name) {
+		t.Fatalf("incorrect path for %q: %s", name, upgrader.RemoteClient.path)
+	}
+
+	// fetch the state again, and compare
+	sMgr, err = b.State(name)
+	if err != nil {
+		t.Fatal("error fetching", name, err)
+	}
+
+	if err := sMgr.RefreshState(); err != nil {
+		t.Fatal("error refreshing", name, err)
+	}
+
+	upgraded := sMgr.State()
+	if !(upgraded.Equal(s) && upgraded.Lineage == s.Lineage) {
+		t.Fatalf("incorrectly upgraded %q: got: %s\nexpected: %s", name, upgraded, s)
+	}
+}

--- a/backend/remote-state/s3/client.go
+++ b/backend/remote-state/s3/client.go
@@ -26,6 +26,9 @@ type RemoteClient struct {
 	acl                  string
 	kmsKeyID             string
 	lockTable            string
+
+	// TODO: remove with env upgrade after 0.10
+	updatePath string
 }
 
 func (c *RemoteClient) Get() (*remote.Payload, error) {


### PR DESCRIPTION
The S3 remote-state backend was using an env directory, which allowed
configurations with different state keys to list the same environments.
This turns out to have limited utility, and it's better to have matching
behavior between backends, so this changes the implementation to mirror
that of the consul backend.