### PR TITLE
disallow env names that aren't url-safe

### DIFF
--- a/command/env_command.go
+++ b/command/env_command.go
@@ -1,6 +1,9 @@
 package command
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // EnvCommand is a Command Implementation that manipulates local state
 // environments.
@@ -37,6 +40,13 @@ Subcommands:
 
 func (c *EnvCommand) Synopsis() string {
 	return "Environment management"
+}
+
+// validEnvName returns true is this name is valid to use as an environment name.
+// Since most named states are accessed via a filesystem path or URL, check if
+// escaping the name would be required.
+func validEnvName(name string) bool {
+	return name == url.PathEscape(name)
 }
 
 const (
@@ -81,5 +91,10 @@ Environment %[1]q is your active environment!
 
 You cannot delete the currently active environment. Please switch
 to another environment and try again.
+`
+
+	envInvalidName = `
+The environment name %q is not allowed. The name must contain only URL safe
+characters, and no path separators.
 `
 )

--- a/command/env_delete.go
+++ b/command/env_delete.go
@@ -32,6 +32,11 @@ func (c *EnvDeleteCommand) Run(args []string) int {
 
 	delEnv := args[0]
 
+	if !validEnvName(delEnv) {
+		c.Ui.Error(fmt.Sprintf(envInvalidName, delEnv))
+		return 1
+	}
+
 	configPath, err := ModulePath(args[1:])
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/env_new.go
+++ b/command/env_new.go
@@ -35,6 +35,11 @@ func (c *EnvNewCommand) Run(args []string) int {
 
 	newEnv := args[0]
 
+	if !validEnvName(newEnv) {
+		c.Ui.Error(fmt.Sprintf(envInvalidName, newEnv))
+		return 1
+	}
+
 	configPath, err := ModulePath(args[1:])
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/env_select.go
+++ b/command/env_select.go
@@ -39,6 +39,10 @@ func (c *EnvSelectCommand) Run(args []string) int {
 	}
 
 	name := args[0]
+	if !validEnvName(name) {
+		c.Ui.Error(fmt.Sprintf(envInvalidName, name))
+		return 1
+	}
 
 	states, err := b.States()
 	if err != nil {


### PR DESCRIPTION
Environment names can be used in a number of contexts, and should be
properly escaped for safety. Since most state names are store in path
structures, and often in a URL, use `url.PathEscape` to check for
disallowed characters.