### PR TITLE
Don't Validate if we have an execution plan

### DIFF
--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -802,6 +802,39 @@ func TestApply_planVars(t *testing.T) {
 	}
 }
 
+// we should be able to apply a plan file with no other file dependencies
+func TestApply_planNoModuleFiles(t *testing.T) {
+	// temprary data directory which we can remove between commands
+	td, err := ioutil.TempDir("", "tf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(td)
+
+	defer testChdir(t, td)()
+
+	p := testProvider()
+	planFile := testPlanFile(t, &terraform.Plan{
+		Module: testModule(t, "apply-plan-no-module"),
+	})
+
+	contextOpts := testCtxConfig(p)
+
+	apply := &ApplyCommand{
+		Meta: Meta{
+			ContextOpts: contextOpts,
+			Ui:          new(cli.MockUi),
+		},
+	}
+	args := []string{
+		planFile,
+	}
+	apply.Run(args)
+	if p.ValidateCalled {
+		t.Fatal("Validate should not be called with a plan")
+	}
+}
+
 func TestApply_refresh(t *testing.T) {
 	originalState := &terraform.State{
 		Modules: []*terraform.ModuleState{

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -104,8 +104,12 @@ func (m *Meta) Backend(opts *BackendOpts) (backend.Enhanced, error) {
 		StateBackupPath: m.backupPath,
 		ContextOpts:     m.contextOpts(),
 		Input:           m.Input(),
-		Validation:      true,
 	}
+
+	// Don't validate if we have a plan.  Validation is normally harmless here,
+	// but validation requires interpolation, and `file()` function calls may
+	// not have the original files in the current execution context.
+	cliOpts.Validation = opts.Plan == nil
 
 	// If the backend supports CLI initialization, do it.
 	if cli, ok := b.(backend.CLI); ok {

--- a/command/test-fixtures/apply-plan-no-module/main.tf
+++ b/command/test-fixtures/apply-plan-no-module/main.tf
@@ -1,0 +1,7 @@
+resource "test_instance" "tmpl" {
+  foo = "${file("${path.module}/template.txt")}"
+}
+
+output "template" {
+	value = "${test_instance.tmpl.foo}"
+}


### PR DESCRIPTION
The plan file should contain all data required to execute the apply
operation. Validation requires interpolation, and the `file()`
interpolation function may fail if the module files are not present.
This is the case currently with how TFE executes plans.