### PR TITLE
helper/acctest: Add RandIntRange helper function

### DIFF
--- a/helper/acctest/random.go
+++ b/helper/acctest/random.go
@@ -24,6 +24,14 @@ func RandInt() int {
 	return rand.New(rand.NewSource(time.Now().UnixNano())).Int()
 }
 
+func RandIntRange(min int, max int) int {
+	reseed()
+	source := rand.New(rand.NewSource(time.Now().UnixNano()))
+	rangeMax := max - min
+
+	return int(source.Int31n(int32(rangeMax)))
+}
+
 // RandString generates a random alphanumeric string of the length specified
 func RandString(strlen int) string {
 	return RandStringFromCharSet(strlen, CharSetAlphaNum)


### PR DESCRIPTION
This commit adds a new RandIntRange function to the helper/acctest package for generating random integers in a given range. This is useful when randomizing test spaces with a constrained range (e.g. 0-4095).