### PR TITLE
provider/kubernetes: Use PATCH to update namespace

### DIFF
--- a/builtin/providers/kubernetes/resource_kubernetes_namespace.go
+++ b/builtin/providers/kubernetes/resource_kubernetes_namespace.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	pkgApi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/errors"
 	api "k8s.io/kubernetes/pkg/api/v1"
 	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
@@ -69,15 +70,14 @@ func resourceKubernetesNamespaceRead(d *schema.ResourceData, meta interface{}) e
 func resourceKubernetesNamespaceUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*kubernetes.Clientset)
 
-	metadata := expandMetadata(d.Get("metadata").([]interface{}))
-	// This is necessary in case the name is generated
-	metadata.Name = d.Id()
-
-	namespace := api.Namespace{
-		ObjectMeta: metadata,
+	ops := patchMetadata("metadata.0.", "/metadata/", d)
+	data, err := ops.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("Failed to marshal update operations: %s", err)
 	}
-	log.Printf("[INFO] Updating namespace: %#v", namespace)
-	out, err := conn.CoreV1().Namespaces().Update(&namespace)
+
+	log.Printf("[INFO] Updating namespace: %s", ops)
+	out, err := conn.CoreV1().Namespaces().Patch(d.Id(), pkgApi.JSONPatchType, data)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Reasons are explained in https://github.com/hashicorp/terraform/pull/12945

### Test plan

```
make testacc TEST=./builtin/providers/kubernetes TESTARGS='-run=TestAccKubernetesNamespace_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/28 07:09:39 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/kubernetes -v -run=TestAccKubernetesNamespace_ -timeout 120m
=== RUN   TestAccKubernetesNamespace_basic
--- PASS: TestAccKubernetesNamespace_basic (17.25s)
=== RUN   TestAccKubernetesNamespace_importBasic
--- PASS: TestAccKubernetesNamespace_importBasic (6.19s)
=== RUN   TestAccKubernetesNamespace_generatedName
--- PASS: TestAccKubernetesNamespace_generatedName (5.87s)
=== RUN   TestAccKubernetesNamespace_importGeneratedName
--- PASS: TestAccKubernetesNamespace_importGeneratedName (6.75s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/kubernetes	36.132s
```