### PR TITLE
docs/google: Fix sidebar highlighting for service account

### DIFF
--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -22,7 +22,7 @@
 		</ul>
 		</li>
 
-		<li<%= sidebar_current(/^docs-google-project/) %>>
+		<li<%= sidebar_current(/^docs-google-(project|service)/) %>>
 		<a href="#">Google Cloud Platform Resources</a>
 		<ul class="nav nav-visible">
 			<li<%= sidebar_current("docs-google-project") %>>


### PR DESCRIPTION
Before:
![screen shot 2017-03-28 at 11 31 41](https://cloud.githubusercontent.com/assets/287584/24400916/2acbfcfc-13aa-11e7-9217-9fb4b7001bc8.png)

After:
![screen shot 2017-03-28 at 11 31 20](https://cloud.githubusercontent.com/assets/287584/24400924/32cf02be-13aa-11e7-8b91-8c426880e613.png)
