### PR TITLE
provider/kubernetes: Fix sorting of the PatchOperations

### DIFF
--- a/builtin/providers/kubernetes/patch_operations.go
+++ b/builtin/providers/kubernetes/patch_operations.go
@@ -58,7 +58,7 @@ func (po PatchOperations) MarshalJSON() ([]byte, error) {
 func (po PatchOperations) Equal(ops []PatchOperation) bool {
 	var v []PatchOperation = po
 
-	sort.Slice(v, sortByPathAsc(ops))
+	sort.Slice(v, sortByPathAsc(v))
 	sort.Slice(ops, sortByPathAsc(ops))
 
 	return reflect.DeepEqual(v, ops)


### PR DESCRIPTION
Sorry for the typo (caused purely by copy-pastah laziness 🙈 ). This has no effect on the user since that equality function is not used anywhere except in test. That test is just flaky now.

Test plan - Travis should suffice. The goal was to eliminate the following failures:

```
--- FAIL: TestDiffStringMap (0.00s)
    --- FAIL: TestDiffStringMap/4 (0.00s)
    	patch_operations_test.go:121: Operations don't match.
    		Expected: [{"path":"/parent/two","op":"remove"} {"path":"/parent/one","op":"remove"}]
    		Given:    [{"path":"/parent/one","op":"remove"} {"path":"/parent/two","op":"remove"}]
FAIL
```
which also appeared [in Travis yesterday](https://travis-ci.org/hashicorp/terraform/builds/215581575#L248), after merging https://github.com/hashicorp/terraform/pull/12945