### PR TITLE
provider/azurerm: Remove location argument from azurerm_lb_nat_pool

### DIFF
--- a/website/source/docs/providers/azurerm/r/loadbalancer_nat_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_nat_pool.html.markdown
@@ -39,7 +39,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_nat_pool" "test" {
-  location                       = "West US"
   resource_group_name            = "${azurerm_resource_group.test.name}"
   loadbalancer_id                = "${azurerm_lb.test.id}"
   name                           = "SampleApplication Pool"
@@ -57,7 +56,6 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the NAT pool.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `location` - (Required) Specifies the supported Azure location where the resource exists.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT pool.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration exposing this rule.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp` or `Tcp`.


### PR DESCRIPTION
According to documentation, `location` is a required argument for
`azurerm_lb_nat_pool`. However, configuring an `azurerm_lb_nat_pool`
with a `location` argument leads to the following warning:

```
There are warnings and/or errors related to your configuration. Please
fix these before continuing.

Warnings:

  * azurerm_lb_nat_pool.test: "location": [DEPRECATED] location is no longer used

No errors found. Continuing with 1 warning(s).
```

Disclaimer: Terraform v0.8.8, haven't moved to 0.9.x yet :/