### PR TITLE
provider/azurerm: Removing Deprecated Location Fields

### DIFF
--- a/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_backend_address_pool.html.markdown
@@ -51,7 +51,6 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the Backend Address Pool.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `location` - (Required) Specifies the supported Azure location where the resource exists.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the Backend Address Pool.
 
 ## Attributes Reference

--- a/website/source/docs/providers/azurerm/r/loadbalancer_nat_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer_nat_rule.html.markdown
@@ -39,7 +39,6 @@ resource "azurerm_lb" "test" {
 }
 
 resource "azurerm_lb_nat_rule" "test" {
-  location                       = "West US"
   resource_group_name            = "${azurerm_resource_group.test.name}"
   loadbalancer_id                = "${azurerm_lb.test.id}"
   name                           = "RDP Access"
@@ -56,7 +55,6 @@ The following arguments are supported:
 
 * `name` - (Required) Specifies the name of the NAT Rule.
 * `resource_group_name` - (Required) The name of the resource group in which to create the resource.
-* `location` - (Required) Specifies the supported Azure location where the resource exists.
 * `loadbalancer_id` - (Required) The ID of the LoadBalancer in which to create the NAT Rule.
 * `frontend_ip_configuration_name` - (Required) The name of the frontend IP configuration exposing this rule.
 * `protocol` - (Required) The transport protocol for the external endpoint. Possible values are `Udp` or `Tcp`.


### PR DESCRIPTION
Whilst reviewing #13118 I noticed there's a few extra `location` fields which are deprecated and should be removed from the Docs