### PR TITLE
Fix govet error in consul provider

### DIFF
--- a/builtin/providers/consul/config.go
+++ b/builtin/providers/consul/config.go
@@ -52,7 +52,7 @@ func (c *Config) Client() (*consulapi.Client, error) {
 		} else {
 			username = c.HttpAuth
 		}
-		config.HttpAuth = &consulapi.HttpBasicAuth{username, password}
+		config.HttpAuth = &consulapi.HttpBasicAuth{Username: username, Password: password}
 	}
 
 	if c.Token != "" {


### PR DESCRIPTION
```
go vet .
builtin/providers/consul/config.go:55: github.com/hashicorp/terraform/vendor/github.com/hashicorp/consul/api.HttpBasicAuth composite literal uses unkeyed fields
exit status 1

Vet found suspicious constructs. Please check the reported constructs
and fix them if necessary before submitting the code for review.
make: *** [vet] Error 1
```