### PR TITLE
Added "$" back into aws_iam_policy_attachment example.

### DIFF
--- a/website/source/docs/providers/aws/r/iam_policy_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_policy_attachment.html.markdown
@@ -33,9 +33,9 @@ resource "aws_iam_policy" "policy" {
 
 resource "aws_iam_policy_attachment" "test-attach" {
   name       = "test-attachment"
-  users      = ["{aws_iam_user.user.name}"]
-  roles      = ["{aws_iam_role.role.name}"]
-  groups     = ["{aws_iam_group.group.name}"]
+  users      = ["${aws_iam_user.user.name}"]
+  roles      = ["${aws_iam_role.role.name}"]
+  groups     = ["${aws_iam_group.group.name}"]
   policy_arn = "${aws_iam_policy.policy.arn}"
 }
 ```


### PR DESCRIPTION
The aws_iam_policy_attachment example is missing the "$" from roles, groups, users properties, so I simply added it back in.

