### PR TITLE
provider/aws: Deprecate roles in favour of role in iam_instance_profile

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_instance_profile_test.go
+++ b/builtin/providers/aws/resource_aws_iam_instance_profile_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -37,6 +38,8 @@ func TestAccAWSIAMInstanceProfile_importBasic(t *testing.T) {
 }
 
 func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
+	var conf iam.GetInstanceProfileOutput
+
 	rName := acctest.RandString(5)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
@@ -44,6 +47,41 @@ func TestAccAWSIAMInstanceProfile_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: testAccAwsIamInstanceProfileConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInstanceProfileExists("aws_iam_instance_profile.test", &conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIAMInstanceProfile_withRoleNotRoles(t *testing.T) {
+	var conf iam.GetInstanceProfileOutput
+
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSInstanceProfileWithRoleSpecified(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSInstanceProfileExists("aws_iam_instance_profile.test", &conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSIAMInstanceProfile_missingRoleThrowsError(t *testing.T) {
+	rName := acctest.RandString(5)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccAwsIamInstanceProfileConfigMissingRole(rName),
+				ExpectError: regexp.MustCompile("Either `roles` or `role` must be specified when creating an IAM Instance Profile"),
 			},
 		},
 	})
@@ -157,6 +195,13 @@ resource "aws_iam_instance_profile" "test" {
 }`, rName)
 }
 
+func testAccAwsIamInstanceProfileConfigMissingRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_instance_profile" "test" {
+	name = "test-%s"
+}`, rName)
+}
+
 func testAccAWSInstanceProfilePrefixNameConfig(rName string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "test" {
@@ -167,5 +212,18 @@ resource "aws_iam_role" "test" {
 resource "aws_iam_instance_profile" "test" {
 	name_prefix = "test-"
 	roles = ["${aws_iam_role.test.name}"]
+}`, rName)
+}
+
+func testAccAWSInstanceProfileWithRoleSpecified(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "test" {
+	name = "test-%s"
+	assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+
+resource "aws_iam_instance_profile" "test" {
+	name_prefix = "test-"
+	role = "${aws_iam_role.test.name}"
 }`, rName)
 }

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -49,7 +49,7 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) The profile's name. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the profile.
-* `roles` - (Optional) A list of role names to include in the profile.  The current default is 1.  If you see an error message similar to `Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1`, then you must contact AWS support and ask for a limit increase.
+* `roles` - (Optional) A list of role names to include in the profile.  The current default is 1.  If you see an error message similar to `Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1`, then you must contact AWS support and ask for a limit increase. `WARNING: This will be deprecated in a future version of Terraform`.
 * `role` - (Optional) The role name to include in the profile. This.
 
 ## Attribute Reference

--- a/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_instance_profile.html.markdown
@@ -10,6 +10,8 @@ description: |-
 
 Provides an IAM instance profile.
 
+~> **NOTE:** Either `roles` or `role` must be specified in the IAM Instance Profile.
+
 ## Example Usage
 
 ```
@@ -47,7 +49,8 @@ The following arguments are supported:
 * `name` - (Optional, Forces new resource) The profile's name. If omitted, Terraform will assign a random, unique name.
 * `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `path` - (Optional, default "/") Path in which to create the profile.
-* `roles` - (Required) A list of role names to include in the profile.  The current default is 1.  If you see an error message similar to `Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1`, then you must contact AWS support and ask for a limit increase.
+* `roles` - (Optional) A list of role names to include in the profile.  The current default is 1.  If you see an error message similar to `Cannot exceed quota for InstanceSessionsPerInstanceProfile: 1`, then you must contact AWS support and ask for a limit increase.
+* `role` - (Optional) The role name to include in the profile. This.
 
 ## Attribute Reference
 
@@ -57,6 +60,7 @@ The following arguments are supported:
 * `name` - The instance profile's name.
 * `path` - The path of the instance profile in IAM.
 * `roles` - The list of roles assigned to the instance profile.
+* `role` - The role assigned to the instance profile
 * `unique_id` - The [unique ID][1] assigned by AWS.
 
   [1]: https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html#GUIDs


### PR DESCRIPTION
Fixes: #11575

You can only specify a single role to an IAM Instance Profile. So having
a slice of roles in the provider makes no sense. Therefore, we are going
to deprecate this infavour of `role`

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSIAMInstanceProfile_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/28 21:24:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSIAMInstanceProfile_ -timeout 120m
=== RUN   TestAccAWSIAMInstanceProfile_importBasic
--- PASS: TestAccAWSIAMInstanceProfile_importBasic (25.08s)
=== RUN   TestAccAWSIAMInstanceProfile_basic
--- PASS: TestAccAWSIAMInstanceProfile_basic (22.40s)
=== RUN   TestAccAWSIAMInstanceProfile_withRoleNotRoles
--- PASS: TestAccAWSIAMInstanceProfile_withRoleNotRoles (22.63s)
=== RUN   TestAccAWSIAMInstanceProfile_missingRoleThrowsError
--- PASS: TestAccAWSIAMInstanceProfile_missingRoleThrowsError (4.02s)
=== RUN   TestAccAWSIAMInstanceProfile_namePrefix
--- PASS: TestAccAWSIAMInstanceProfile_namePrefix (22.18s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	96.349s
```