### PR TITLE
provider/dnsimple: Handle 404 on DNSimple records

### DIFF
--- a/builtin/providers/dnsimple/resource_dnsimple_record.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"strconv"
+	"strings"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -104,6 +105,11 @@ func resourceDNSimpleRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 	resp, err := provider.client.Zones.GetRecord(provider.config.Account, d.Get("domain").(string), recordID)
 	if err != nil {
+		if err != nil && strings.Contains(err.Error(), "404") {
+			log.Printf("DNSimple Record Not Found - Refreshing from State")
+			d.SetId("")
+			return nil
+		}
 		return fmt.Errorf("Couldn't find DNSimple Record: %s", err)
 	}
 

--- a/builtin/providers/dnsimple/resource_dnsimple_record_test.go
+++ b/builtin/providers/dnsimple/resource_dnsimple_record_test.go
@@ -20,7 +20,7 @@ func TestAccDNSimpleRecord_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_basic, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
@@ -46,7 +46,7 @@ func TestAccDNSimpleRecord_CreateMxWithPriority(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_mx, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
@@ -73,7 +73,7 @@ func TestAccDNSimpleRecord_Updated(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_basic, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
@@ -86,7 +86,7 @@ func TestAccDNSimpleRecord_Updated(t *testing.T) {
 						"dnsimple_record.foobar", "value", "192.168.0.10"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_new_value, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
@@ -103,6 +103,27 @@ func TestAccDNSimpleRecord_Updated(t *testing.T) {
 	})
 }
 
+func TestAccDNSimpleRecord_disappears(t *testing.T) {
+	var record dnsimple.ZoneRecord
+	domain := os.Getenv("DNSIMPLE_DOMAIN")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_basic, domain),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
+					testAccCheckDNSimpleRecordDisappears(&record, domain),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
 func TestAccDNSimpleRecord_UpdatedMx(t *testing.T) {
 	var record dnsimple.ZoneRecord
 	domain := os.Getenv("DNSIMPLE_DOMAIN")
@@ -112,7 +133,7 @@ func TestAccDNSimpleRecord_UpdatedMx(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckDNSimpleRecordDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_mx, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
@@ -126,7 +147,7 @@ func TestAccDNSimpleRecord_UpdatedMx(t *testing.T) {
 						"dnsimple_record.foobar", "priority", "5"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: fmt.Sprintf(testAccCheckDNSimpleRecordConfig_mx_new_value, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDNSimpleRecordExists("dnsimple_record.foobar", &record),
@@ -142,6 +163,21 @@ func TestAccDNSimpleRecord_UpdatedMx(t *testing.T) {
 			},
 		},
 	})
+}
+
+func testAccCheckDNSimpleRecordDisappears(record *dnsimple.ZoneRecord, domain string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		provider := testAccProvider.Meta().(*Client)
+
+		_, err := provider.client.Zones.DeleteRecord(provider.config.Account, domain, record.ID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
 }
 
 func testAccCheckDNSimpleRecordDestroy(s *terraform.State) error {


### PR DESCRIPTION
When a record was manually deleted from the console, we got an error
saying 404 Record Not Found

//cc @weppos

This PR now handles the usecase:

```
% make testacc TEST=./builtin/providers/dnsimple
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/28 21:48:19 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/dnsimple -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccDNSimpleRecord_Basic
--- PASS: TestAccDNSimpleRecord_Basic (1.81s)
=== RUN   TestAccDNSimpleRecord_CreateMxWithPriority
--- PASS: TestAccDNSimpleRecord_CreateMxWithPriority (1.32s)
=== RUN   TestAccDNSimpleRecord_Updated
--- PASS: TestAccDNSimpleRecord_Updated (4.46s)
=== RUN   TestAccDNSimpleRecord_disappears
--- PASS: TestAccDNSimpleRecord_disappears (1.20s)
=== RUN   TestAccDNSimpleRecord_UpdatedMx
--- PASS: TestAccDNSimpleRecord_UpdatedMx (2.91s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/dnsimple	11.723s
```