### PR TITLE
docs/providers/random: Fix typo in `random_pet` documentation

### DIFF
--- a/website/source/docs/providers/random/r/pet.html.md
+++ b/website/source/docs/providers/random/r/pet.html.md
@@ -53,7 +53,7 @@ The following arguments are supported:
   trigger a new id to be generated. See
   [the main provider documentation](../index.html) for more information.
 
-* `length` - (Optional) The lenth (in words) of the pet name.
+* `length` - (Optional) The length (in words) of the pet name.
 
 * `prefix` - (Optional) A string to prefix the name with.
 


### PR DESCRIPTION
s/lenth/length/