### PR TITLE
P aws randomize test names

### DIFF
--- a/builtin/providers/aws/import_aws_customer_gateway_test.go
+++ b/builtin/providers/aws/import_aws_customer_gateway_test.go
@@ -3,19 +3,20 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSCustomerGateway_importBasic(t *testing.T) {
 	resourceName := "aws_customer_gateway.foo"
-
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCustomerGatewayConfig,
+				Config: testAccCustomerGatewayConfig(randInt),
 			},
 
 			resource.TestStep{

--- a/builtin/providers/aws/import_aws_efs_file_system_test.go
+++ b/builtin/providers/aws/import_aws_efs_file_system_test.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSEFSFileSystem_importBasic(t *testing.T) {
 	resourceName := "aws_efs_file_system.foo-with-tags"
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +17,7 @@ func TestAccAWSEFSFileSystem_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckEfsFileSystemDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSEFSFileSystemConfigWithTags,
+				Config: testAccAWSEFSFileSystemConfigWithTags(rInt),
 			},
 
 			resource.TestStep{

--- a/builtin/providers/aws/resource_aws_customer_gateway_test.go
+++ b/builtin/providers/aws/resource_aws_customer_gateway_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSCustomerGateway_basic(t *testing.T) {
 	var gateway ec2.CustomerGateway
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_customer_gateway.foo",
@@ -23,19 +25,19 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig,
+				Config: testAccCustomerGatewayConfig(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 				),
 			},
 			{
-				Config: testAccCustomerGatewayConfigUpdateTags,
+				Config: testAccCustomerGatewayConfigUpdateTags(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 				),
 			},
 			{
-				Config: testAccCustomerGatewayConfigForceReplace,
+				Config: testAccCustomerGatewayConfigForceReplace(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 				),
@@ -46,6 +48,7 @@ func TestAccAWSCustomerGateway_basic(t *testing.T) {
 
 func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 	var gateway ec2.CustomerGateway
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_customer_gateway.foo",
@@ -53,13 +56,13 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 		CheckDestroy:  testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig,
+				Config: testAccCustomerGatewayConfig(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 				),
 			},
 			{
-				Config:      testAccCustomerGatewayConfigIdentical,
+				Config:      testAccCustomerGatewayConfigIdentical(randInt),
 				ExpectError: regexp.MustCompile("An existing customer gateway"),
 			},
 		},
@@ -68,13 +71,14 @@ func TestAccAWSCustomerGateway_similarAlreadyExists(t *testing.T) {
 
 func TestAccAWSCustomerGateway_disappears(t *testing.T) {
 	var gateway ec2.CustomerGateway
+	randInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCustomerGatewayDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCustomerGatewayConfig,
+				Config: testAccCustomerGatewayConfig(randInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCustomerGateway("aws_customer_gateway.foo", &gateway),
 					testAccAWSCustomerGatewayDisappears(&gateway),
@@ -190,59 +194,67 @@ func testAccCheckCustomerGateway(gatewayResource string, cgw *ec2.CustomerGatewa
 	}
 }
 
-const testAccCustomerGatewayConfig = `
-resource "aws_customer_gateway" "foo" {
-	bgp_asn = 65000
-	ip_address = "172.0.0.1"
-	type = "ipsec.1"
-	tags {
-		Name = "foo-gateway"
+func testAccCustomerGatewayConfig(randInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_customer_gateway" "foo" {
+		bgp_asn = 65000
+		ip_address = "172.0.0.1"
+		type = "ipsec.1"
+		tags {
+			Name = "foo-gateway-%d"
+		}
 	}
-}
-`
-
-const testAccCustomerGatewayConfigIdentical = `
-resource "aws_customer_gateway" "foo" {
-	bgp_asn = 65000
-	ip_address = "172.0.0.1"
-	type = "ipsec.1"
-	tags {
-		Name = "foo-gateway"
-	}
+	`, randInt)
 }
 
-resource "aws_customer_gateway" "identical" {
-	bgp_asn = 65000
-	ip_address = "172.0.0.1"
-	type = "ipsec.1"
-	tags {
-		Name = "foo-gateway-identical"
-	}
+func testAccCustomerGatewayConfigIdentical(randInt int) string {
+	return fmt.Sprintf(`
+		resource "aws_customer_gateway" "foo" {
+			bgp_asn = 65000
+			ip_address = "172.0.0.1"
+			type = "ipsec.1"
+			tags {
+				Name = "foo-gateway-%d"
+			}
+		}
+
+		resource "aws_customer_gateway" "identical" {
+			bgp_asn = 65000
+			ip_address = "172.0.0.1"
+			type = "ipsec.1"
+			tags {
+				Name = "foo-gateway-identical-%d"
+			}
+		}
+		`, randInt, randInt)
 }
-`
 
 // Add the Another: "tag" tag.
-const testAccCustomerGatewayConfigUpdateTags = `
-resource "aws_customer_gateway" "foo" {
-	bgp_asn = 65000
-	ip_address = "172.0.0.1"
-	type = "ipsec.1"
-	tags {
-		Name = "foo-gateway"
-		Another = "tag"
-	}
+func testAccCustomerGatewayConfigUpdateTags(randInt int) string {
+	return fmt.Sprintf(`
+		resource "aws_customer_gateway" "foo" {
+			bgp_asn = 65000
+			ip_address = "172.0.0.1"
+			type = "ipsec.1"
+			tags {
+				Name = "foo-gateway-%d"
+				Another = "tag-%d"
+			}
+		}
+		`, randInt, randInt)
 }
-`
 
 // Change the ip_address.
-const testAccCustomerGatewayConfigForceReplace = `
-resource "aws_customer_gateway" "foo" {
-	bgp_asn = 65000
-	ip_address = "172.10.10.1"
-	type = "ipsec.1"
-	tags {
-		Name = "foo-gateway"
-		Another = "tag"
+func testAccCustomerGatewayConfigForceReplace(randInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_customer_gateway" "foo" {
+		bgp_asn = 65000
+		ip_address = "172.10.10.1"
+		type = "ipsec.1"
+		tags {
+			Name = "foo-gateway-%d"
+			Another = "tag-%d"
+		}
 	}
+	`, randInt, randInt)
 }
-`

--- a/builtin/providers/aws/resource_aws_dms_replication_instance_test.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_instance_test.go
@@ -169,7 +169,7 @@ resource "aws_dms_replication_instance" "dms_replication_instance" {
 func dmsReplicationInstanceConfigUpdate(randId string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "dms_iam_role" {
-  name = "dms-vpc-role"
+  name = "dms-vpc-role-%[1]s"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"dms.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
 }
 

--- a/builtin/providers/aws/resource_aws_dms_replication_subnet_group_test.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_subnet_group_test.go
@@ -102,7 +102,7 @@ func dmsReplicationSubnetGroupDestroy(s *terraform.State) error {
 func dmsReplicationSubnetGroupConfig(randId string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "dms_iam_role" {
-  name = "dms-vpc-role"
+  name = "dms-vpc-role-%[1]s"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"dms.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
 }
 

--- a/builtin/providers/aws/resource_aws_dms_replication_task_test.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_task_test.go
@@ -102,7 +102,7 @@ func dmsReplicationTaskDestroy(s *terraform.State) error {
 func dmsReplicationTaskConfig(randId string) string {
 	return fmt.Sprintf(`
 resource "aws_iam_role" "dms_iam_role" {
-  name = "dms-vpc-role"
+  name = "dms-vpc-role-%[1]s"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"dms.amazonaws.com\"},\"Action\":\"sts:AssumeRole\"}]}"
 }
 

--- a/builtin/providers/aws/resource_aws_efs_file_system_test.go
+++ b/builtin/providers/aws/resource_aws_efs_file_system_test.go
@@ -82,6 +82,7 @@ func TestResourceAWSEFSFileSystem_hasEmptyFileSystems(t *testing.T) {
 }
 
 func TestAccAWSEFSFileSystem_basic(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -104,7 +105,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSEFSFileSystemConfigWithTags,
+				Config: testAccAWSEFSFileSystemConfigWithTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckEfsFileSystem(
 						"aws_efs_file_system.foo-with-tags",
@@ -116,7 +117,7 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 					testAccCheckEfsFileSystemTags(
 						"aws_efs_file_system.foo-with-tags",
 						map[string]string{
-							"Name":    "foo-efs",
+							"Name":    fmt.Sprintf("foo-efs-%d", rInt),
 							"Another": "tag",
 						},
 					),
@@ -143,13 +144,14 @@ func TestAccAWSEFSFileSystem_basic(t *testing.T) {
 }
 
 func TestAccAWSEFSFileSystem_pagedTags(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckEfsFileSystemDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSEFSFileSystemConfigPagedTags,
+				Config: testAccAWSEFSFileSystemConfigPagedTags(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"aws_efs_file_system.foo",
@@ -312,34 +314,38 @@ resource "aws_efs_file_system" "foo" {
 }
 `
 
-const testAccAWSEFSFileSystemConfigPagedTags = `
-resource "aws_efs_file_system" "foo" {
-	creation_token = "radeksimko"
-	tags {
-		Name = "foo-efs"
-		Another = "tag"
-		Test = "yes"
-		User = "root"
-		Page = "1"
-		Environment = "prod"
-		CostCenter = "terraform"
-		AcceptanceTest = "PagedTags"
-		CreationToken = "radek"
-		PerfMode = "max"
-		Region = "us-west-2"
+func testAccAWSEFSFileSystemConfigPagedTags(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_efs_file_system" "foo" {
+		creation_token = "radeksimko"
+		tags {
+			Name = "foo-efs-%d"
+			Another = "tag"
+			Test = "yes"
+			User = "root"
+			Page = "1"
+			Environment = "prod"
+			CostCenter = "terraform"
+			AcceptanceTest = "PagedTags"
+			CreationToken = "radek"
+			PerfMode = "max"
+			Region = "us-west-2"
+		}
 	}
+	`, rInt)
 }
-`
 
-const testAccAWSEFSFileSystemConfigWithTags = `
-resource "aws_efs_file_system" "foo-with-tags" {
-	creation_token = "yada_yada"
-	tags {
-		Name = "foo-efs"
-		Another = "tag"
+func testAccAWSEFSFileSystemConfigWithTags(rInt int) string {
+	return fmt.Sprintf(`
+	resource "aws_efs_file_system" "foo-with-tags" {
+		creation_token = "yada_yada"
+		tags {
+			Name = "foo-efs-%d"
+			Another = "tag"
+		}
 	}
+	`, rInt)
 }
-`
 
 const testAccAWSEFSFileSystemConfigWithPerformanceMode = `
 resource "aws_efs_file_system" "foo-with-performance-mode" {

--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -661,7 +661,7 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 func testAccBeanstalkWorkerEnvConfig(rInt int) string {
 	return fmt.Sprintf(`
  resource "aws_iam_instance_profile" "tftest" {
-	 name = "tftest_profile"
+	 name = "tftest_profile-%d"
 	 roles = ["${aws_iam_role.tftest.name}"]
  }
 
@@ -693,7 +693,7 @@ func testAccBeanstalkWorkerEnvConfig(rInt int) string {
 		 name      = "IamInstanceProfile"
 		 value     = "${aws_iam_instance_profile.tftest.name}"
 	 }
- }`, rInt, rInt)
+ }`, rInt, rInt, rInt)
 }
 
 func testAccBeanstalkEnvCnamePrefixConfig(randString string, rInt int) string {
@@ -937,24 +937,24 @@ resource "aws_s3_bucket_object" "default" {
 }
 
 resource "aws_elastic_beanstalk_application" "default" {
-  name = "tf-test-name"
+  name = "tf-test-name-%d"
   description = "tf-test-desc"
 }
 
 resource "aws_elastic_beanstalk_application_version" "default" {
-  application = "tf-test-name"
+  application = "tf-test-name-%d"
   name = "tf-test-version-label"
   bucket = "${aws_s3_bucket.default.id}"
   key = "${aws_s3_bucket_object.default.id}"
 }
 
 resource "aws_elastic_beanstalk_environment" "default" {
-  name = "tf-test-name"
+  name = "tf-test-name-%d"
   application = "${aws_elastic_beanstalk_application.default.name}"
   version_label = "${aws_elastic_beanstalk_application_version.default.name}"
   solution_stack_name = "64bit Amazon Linux running Python"
 }
-`, randInt)
+`, randInt, randInt, randInt, randInt)
 }
 
 func testAccBeanstalkEnvApplicationVersionConfigUpdate(randInt int) string {
@@ -970,22 +970,22 @@ resource "aws_s3_bucket_object" "default" {
 }
 
 resource "aws_elastic_beanstalk_application" "default" {
-  name = "tf-test-name"
+  name = "tf-test-name-%d"
   description = "tf-test-desc"
 }
 
 resource "aws_elastic_beanstalk_application_version" "default" {
-  application = "tf-test-name"
+  application = "tf-test-name-%d"
   name = "tf-test-version-label-v2"
   bucket = "${aws_s3_bucket.default.id}"
   key = "${aws_s3_bucket_object.default.id}"
 }
 
 resource "aws_elastic_beanstalk_environment" "default" {
-  name = "tf-test-name"
+  name = "tf-test-name-%d"
   application = "${aws_elastic_beanstalk_application.default.name}"
   version_label = "${aws_elastic_beanstalk_application_version.default.name}"
   solution_stack_name = "64bit Amazon Linux running Python"
 }
-`, randInt)
+`, randInt, randInt, randInt, randInt)
 }

--- a/builtin/providers/aws/resource_aws_ses_configuration_set_test.go
+++ b/builtin/providers/aws/resource_aws_ses_configuration_set_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -42,7 +43,7 @@ func testAccCheckSESConfigurationSetDestroy(s *terraform.State) error {
 
 		found := false
 		for _, element := range response.ConfigurationSets {
-			if *element.Name == "some-configuration-set" {
+			if *element.Name == fmt.Sprintf("some-configuration-set-%d", escRandomInteger) {
 				found = true
 			}
 		}
@@ -77,7 +78,7 @@ func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
 
 		found := false
 		for _, element := range response.ConfigurationSets {
-			if *element.Name == "some-configuration-set" {
+			if *element.Name == fmt.Sprintf("some-configuration-set-%d", escRandomInteger) {
 				found = true
 			}
 		}
@@ -90,8 +91,9 @@ func testAccCheckAwsSESConfigurationSetExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccAWSSESConfigurationSetConfig = `
+var escRandomInteger = acctest.RandInt()
+var testAccAWSSESConfigurationSetConfig = fmt.Sprintf(`
 resource "aws_ses_configuration_set" "test" {
-    name = "some-configuration-set"
+    name = "some-configuration-set-%d"
 }
-`
+`, escRandomInteger)

--- a/builtin/providers/aws/resource_aws_ses_event_destination_test.go
+++ b/builtin/providers/aws/resource_aws_ses_event_destination_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -46,7 +47,7 @@ func testAccCheckSESEventDestinationDestroy(s *terraform.State) error {
 
 		found := false
 		for _, element := range response.ConfigurationSets {
-			if *element.Name == "some-configuration-set" {
+			if *element.Name == fmt.Sprintf("some-configuration-set-%d", edRandomInteger) {
 				found = true
 			}
 		}
@@ -81,7 +82,7 @@ func testAccCheckAwsSESEventDestinationExists(n string) resource.TestCheckFunc {
 
 		found := false
 		for _, element := range response.ConfigurationSets {
-			if *element.Name == "some-configuration-set" {
+			if *element.Name == fmt.Sprintf("some-configuration-set-%d", edRandomInteger) {
 				found = true
 			}
 		}
@@ -94,7 +95,8 @@ func testAccCheckAwsSESEventDestinationExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccAWSSESEventDestinationConfig = `
+var edRandomInteger = acctest.RandInt()
+var testAccAWSSESEventDestinationConfig = fmt.Sprintf(`
 resource "aws_s3_bucket" "bucket" {
   bucket = "tf-test-bucket-format"
   acl = "private"
@@ -155,7 +157,7 @@ data "aws_iam_policy_document" "fh_felivery_document" {
 }
 
 resource "aws_ses_configuration_set" "test" {
-    name = "some-configuration-set"
+    name = "some-configuration-set-%d"
 }
 
 resource "aws_ses_event_destination" "kinesis" {
@@ -182,4 +184,4 @@ resource "aws_ses_event_destination" "cloudwatch" {
 	value_source = "emailHeader"
   }
 }
-`
+`, edRandomInteger)

--- a/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
+++ b/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
@@ -186,8 +186,8 @@ func testAccCheckAwsSESReceiptRuleActions(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).sesConn
 
 		params := &ses.DescribeReceiptRuleInput{
-			RuleName:    aws.String("actions"),
-			RuleSetName: aws.String(fmt.Sprintf("test-me")),
+			RuleName:    aws.String("actions4"),
+			RuleSetName: aws.String(fmt.Sprintf("test-me-%d", srrsRandomInt)),
 		}
 
 		response, err := conn.DescribeReceiptRule(params)
@@ -267,28 +267,28 @@ resource "aws_s3_bucket" "emails" {
 }
 
 resource "aws_ses_receipt_rule_set" "test" {
-    rule_set_name = "test-me"
+    rule_set_name = "test-me-%d"
 }
 
 resource "aws_ses_receipt_rule" "actions" {
-    name = "actions"
+    name = "actions4"
     rule_set_name = "${aws_ses_receipt_rule_set.test.rule_set_name}"
 
     add_header_action {
-	header_name = "Added-By"
-	header_value = "Terraform"
-	position = 1
+			header_name = "Added-By"
+			header_value = "Terraform"
+			position = 1
     }
 
     add_header_action {
-	header_name = "Another-Header"
-	header_value = "First"
-	position = 0
+			header_name = "Another-Header"
+			header_value = "First"
+			position = 0
     }
 
     stop_action {
-	scope = "RuleSet"
-	position = 2
+			scope = "RuleSet"
+			position = 2
     }
 }
-`)
+`, srrsRandomInt)

--- a/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
+++ b/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ses"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -111,7 +112,7 @@ func testAccCheckAwsSESReceiptRuleExists(n string) resource.TestCheckFunc {
 
 		params := &ses.DescribeReceiptRuleInput{
 			RuleName:    aws.String("basic"),
-			RuleSetName: aws.String("test-me"),
+			RuleSetName: aws.String(fmt.Sprintf("test-me-%d", srrsRandomInt)),
 		}
 
 		response, err := conn.DescribeReceiptRule(params)
@@ -153,7 +154,7 @@ func testAccCheckAwsSESReceiptRuleOrder(n string) resource.TestCheckFunc {
 		conn := testAccProvider.Meta().(*AWSClient).sesConn
 
 		params := &ses.DescribeReceiptRuleSetInput{
-			RuleSetName: aws.String("test-me"),
+			RuleSetName: aws.String(fmt.Sprintf("test-me-%d", srrsRandomInt)),
 		}
 
 		response, err := conn.DescribeReceiptRuleSet(params)
@@ -186,7 +187,7 @@ func testAccCheckAwsSESReceiptRuleActions(n string) resource.TestCheckFunc {
 
 		params := &ses.DescribeReceiptRuleInput{
 			RuleName:    aws.String("actions"),
-			RuleSetName: aws.String("test-me"),
+			RuleSetName: aws.String(fmt.Sprintf("test-me")),
 		}
 
 		response, err := conn.DescribeReceiptRule(params)
@@ -227,9 +228,10 @@ func testAccCheckAwsSESReceiptRuleActions(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccAWSSESReceiptRuleBasicConfig = `
+var srrsRandomInt = acctest.RandInt()
+var testAccAWSSESReceiptRuleBasicConfig = fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
-    rule_set_name = "test-me"
+    rule_set_name = "test-me-%d"
 }
 
 resource "aws_ses_receipt_rule" "basic" {
@@ -240,11 +242,11 @@ resource "aws_ses_receipt_rule" "basic" {
     scan_enabled = true
     tls_policy = "Require"
 }
-`
+`, srrsRandomInt)
 
-const testAccAWSSESReceiptRuleOrderConfig = `
+var testAccAWSSESReceiptRuleOrderConfig = fmt.Sprintf(`
 resource "aws_ses_receipt_rule_set" "test" {
-    rule_set_name = "test-me"
+    rule_set_name = "test-me-%d"
 }
 
 resource "aws_ses_receipt_rule" "second" {
@@ -257,9 +259,9 @@ resource "aws_ses_receipt_rule" "first" {
     name = "first"
     rule_set_name = "${aws_ses_receipt_rule_set.test.rule_set_name}"
 }
-`
+`, srrsRandomInt)
 
-const testAccAWSSESReceiptRuleActionsConfig = `
+var testAccAWSSESReceiptRuleActionsConfig = fmt.Sprintf(`
 resource "aws_s3_bucket" "emails" {
     bucket = "ses-terraform-emails"
 }
@@ -289,4 +291,4 @@ resource "aws_ses_receipt_rule" "actions" {
 	position = 2
     }
 }
-`
+`)


### PR DESCRIPTION
These changes should fix the failing tests from ses, ses receipt, dms replication, elastic beanstalk environment, gateway, and efs tests. Some tests are still broken in this block but this fixes the duplicate name issues. 

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSESReceiptRule'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/27 16:25:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSESReceiptRule -timeout 120m
=== RUN   TestAccAWSSESReceiptRuleSet_importBasic
--- PASS: TestAccAWSSESReceiptRuleSet_importBasic (16.88s)
=== RUN   TestAccAWSSESReceiptRuleSet_basic
--- PASS: TestAccAWSSESReceiptRuleSet_basic (16.29s)
=== RUN   TestAccAWSSESReceiptRule_basic
--- PASS: TestAccAWSSESReceiptRule_basic (14.85s)
=== RUN   TestAccAWSSESReceiptRule_order
--- PASS: TestAccAWSSESReceiptRule_order (17.14s)
=== RUN   TestAccAWSSESReceiptRule_actions
--- PASS: TestAccAWSSESReceiptRule_actions (31.43s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	96.622s
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAwsDmsReplicationTaskBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/27 16:42:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAwsDmsReplicationTaskBasic -timeout 120m
=== RUN   TestAccAwsDmsReplicationTaskBasic
--- PASS: TestAccAwsDmsReplicationTaskBasic (2811.05s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	2811.079s
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSBeanstalkEnv'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/28 10:07:47 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSBeanstalkEnv -timeout 120m
=== RUN   TestAccAWSBeanstalkEnv_basic
--- PASS: TestAccAWSBeanstalkEnv_basic (374.34s)
=== RUN   TestAccAWSBeanstalkEnv_tier
--- PASS: TestAccAWSBeanstalkEnv_tier (605.13s
)=== RUN   TestAccAWSBeanstalkEnv_outputs
--- PASS: TestAccAWSBeanstalkEnv_outputs (426.65s)
=== RUN   TestAccAWSBeanstalkEnv_cname_prefix
--- PASS: TestAccAWSBeanstalkEnv_cname_prefix (427.25s)
=== RUN   TestAccAWSBeanstalkEnv_config
--- PASS: TestAccAWSBeanstalkEnv_config (540.49s)
=== RUN   TestAccAWSBeanstalkEnv_resource
--- PASS: TestAccAWSBeanstalkEnv_resource (483.87s)
=== RUN   TestAccAWSBeanstalkEnv_vpc
--- PASS: TestAccAWSBeanstalkEnv_vpc (594.11s)
=== RUN   TestAccAWSBeanstalkEnv_template_change
--- PASS: TestAccAWSBeanstalkEnv_template_change (595.64s)
=== RUN   TestAccAWSBeanstalkEnv_basic_settings_update
--- PASS: TestAccAWSBeanstalkEnv_basic_settings_update (706.97s)
=== RUN   TestAccAWSBeanstalkEnv_version_label
--- PASS: TestAccAWSBeanstalkEnv_version_label (824.64s)
PASS
ok	github.com/hashicorp/terraform/builtin/providers/aws	4986.215s
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCustomerGateway'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/28 12:33:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCustomerGateway -timeout 120m
=== RUN   TestAccAWSCustomerGateway_importBasic
--- PASS: TestAccAWSCustomerGateway_importBasic (26.98s)
=== RUN   TestAccAWSCustomerGateway_basic
--- PASS: TestAccAWSCustomerGateway_basic (66.57s)
=== RUN   TestAccAWSCustomerGateway_similarAlreadyExists
--- PASS: TestAccAWSCustomerGateway_similarAlreadyExists (36.25s)
=== RUN   TestAccAWSCustomerGateway_disappears
--- PASS: TestAccAWSCustomerGateway_disappears (23.61s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	153.450s
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEFSFileSystem'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/28 14:50:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEFSFileSystem -timeout 120m
=== RUN   TestAccAWSEFSFileSystem_importBasic
--- PASS: TestAccAWSEFSFileSystem_importBasic (44.33s)
=== RUN   TestAccAWSEFSFileSystem_basic
--- PASS: TestAccAWSEFSFileSystem_basic (99.59s)
=== RUN   TestAccAWSEFSFileSystem_pagedTags
--- PASS: TestAccAWSEFSFileSystem_pagedTags (26.26s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	170.221s
```