### PR TITLE
provider/aws: Make alb_target_group_attachment port optional

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_attachment_test.go
@@ -3,14 +3,15 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
-	"strconv"
-	"testing"
 )
 
 func TestAccAWSALBTargetGroupAttachment_basic(t *testing.T) {
@@ -32,6 +33,25 @@ func TestAccAWSALBTargetGroupAttachment_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSALBTargetGroupAttachment_withoutPort(t *testing.T) {
+	targetGroupName := fmt.Sprintf("test-target-group-%s", acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupAttachmentConfigWithoutPort(targetGroupName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBTargetGroupAttachmentExists("aws_alb_target_group_attachment.test"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSALBTargetGroupAttachmentExists(n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -45,15 +65,20 @@ func testAccCheckAWSALBTargetGroupAttachmentExists(n string) resource.TestCheckF
 
 		conn := testAccProvider.Meta().(*AWSClient).elbv2conn
 
-		port, _ := strconv.Atoi(rs.Primary.Attributes["port"])
+		_, hasPort := rs.Primary.Attributes["port"]
+		targetGroupArn, _ := rs.Primary.Attributes["target_group_arn"]
+
+		target := &elbv2.TargetDescription{
+			Id: aws.String(rs.Primary.Attributes["target_id"]),
+		}
+		if hasPort == true {
+			port, _ := strconv.Atoi(rs.Primary.Attributes["port"])
+			target.Port = aws.Int64(int64(port))
+		}
+
 		describe, err := conn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
-			TargetGroupArn: aws.String(rs.Primary.Attributes["target_group_arn"]),
-			Targets: []*elbv2.TargetDescription{
-				{
-					Id:   aws.String(rs.Primary.Attributes["target_id"]),
-					Port: aws.Int64(int64(port)),
-				},
-			},
+			TargetGroupArn: aws.String(targetGroupArn),
+			Targets:        []*elbv2.TargetDescription{target},
 		})
 
 		if err != nil {
@@ -76,15 +101,20 @@ func testAccCheckAWSALBTargetGroupAttachmentDestroy(s *terraform.State) error {
 			continue
 		}
 
-		port, _ := strconv.Atoi(rs.Primary.Attributes["port"])
+		_, hasPort := rs.Primary.Attributes["port"]
+		targetGroupArn, _ := rs.Primary.Attributes["target_group_arn"]
+
+		target := &elbv2.TargetDescription{
+			Id: aws.String(rs.Primary.Attributes["target_id"]),
+		}
+		if hasPort == true {
+			port, _ := strconv.Atoi(rs.Primary.Attributes["port"])
+			target.Port = aws.Int64(int64(port))
+		}
+
 		describe, err := conn.DescribeTargetHealth(&elbv2.DescribeTargetHealthInput{
-			TargetGroupArn: aws.String(rs.Primary.Attributes["target_group_arn"]),
-			Targets: []*elbv2.TargetDescription{
-				{
-					Id:   aws.String(rs.Primary.Attributes["target_id"]),
-					Port: aws.Int64(int64(port)),
-				},
-			},
+			TargetGroupArn: aws.String(targetGroupArn),
+			Targets:        []*elbv2.TargetDescription{target},
 		})
 		if err == nil {
 			if len(describe.TargetHealthDescriptions) != 0 {
@@ -101,6 +131,55 @@ func testAccCheckAWSALBTargetGroupAttachmentDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSALBTargetGroupAttachmentConfigWithoutPort(targetGroupName string) string {
+	return fmt.Sprintf(`
+resource "aws_alb_target_group_attachment" "test" {
+  target_group_arn = "${aws_alb_target_group.test.arn}"
+  target_id = "${aws_instance.test.id}"
+}
+
+resource "aws_instance" "test" {
+  ami = "ami-f701cb97"
+  instance_type = "t2.micro"
+  subnet_id = "${aws_subnet.subnet.id}"
+}
+
+resource "aws_alb_target_group" "test" {
+  name = "%s"
+  port = 443
+  protocol = "HTTPS"
+  vpc_id = "${aws_vpc.test.id}"
+
+  deregistration_delay = 200
+
+  stickiness {
+    type = "lb_cookie"
+    cookie_duration = 10000
+  }
+
+  health_check {
+    path = "/health"
+    interval = 60
+    port = 8081
+    protocol = "HTTP"
+    timeout = 3
+    healthy_threshold = 3
+    unhealthy_threshold = 3
+    matcher = "200-299"
+  }
+}
+
+resource "aws_subnet" "subnet" {
+  cidr_block = "10.0.1.0/24"
+  vpc_id = "${aws_vpc.test.id}"
+
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}`, targetGroupName)
 }
 
 func testAccAWSALBTargetGroupAttachmentConfig_basic(targetGroupName string) string {

--- a/website/source/docs/providers/aws/r/alb_target_group_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_target_group_attachment.html.markdown
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `target_group_arn` - (Required) The ARN of the target group with which to register targets
 * `target_id` (Required) The ID of the target. This is the Instance ID for an instance, or the container ID for an ECS container.
-* `port` - (Required) The port on which targets receive traffic.
+* `port` - (Optional) The port on which targets receive traffic.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #9460

```
% TF_LOG=1 make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSALBTargetGroupAttachment_' 2>~/tf.log
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSALBTargetGroupAttachment_ -timeout 120m
=== RUN   TestAccAWSALBTargetGroupAttachment_basic
--- PASS: TestAccAWSALBTargetGroupAttachment_basic (267.66s)
=== RUN   TestAccAWSALBTargetGroupAttachment_withoutPort
--- PASS: TestAccAWSALBTargetGroupAttachment_withoutPort (147.89s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	415.589s
```