### PR TITLE
provider/aws: Don't set DBName on `aws_db_instance` from snapshot

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -407,7 +407,14 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 		}
 
 		if attr, ok := d.GetOk("name"); ok {
-			opts.DBName = aws.String(attr.(string))
+			// "Note: This parameter [DBName] doesn't apply to the MySQL, PostgreSQL, or MariaDB engines."
+			// https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_RestoreDBInstanceFromDBSnapshot.html
+			switch strings.ToLower(d.Get("engine").(string)) {
+			case "mysql", "postgres", "mariadb":
+				// skip
+			default:
+				opts.DBName = aws.String(attr.(string))
+			}
 		}
 
 		if attr, ok := d.GetOk("availability_zone"); ok {


### PR DESCRIPTION
It turns out if you're trying to write a config to conditionally restore
an instance from a snapshot, you end up painted into a corner with the
combination of `snapshot_identifier` and `name`.

You need `name` to be specified for DBs you're creating, but when
`snapshot_identifier` is populated you need it to be blank or else the
AWS API throws an error.

The logical next step is to drop a ternary in:

```tf
resource "aws_db_instance" "foo" {
 # ...
 snapshot_identifier = "${var.snap}"
 name = "${var.snap != "" ? "" : var.dbname}"
}
```

**BUT** the above config will _replace_ the DB on subsequent runs as the
config basically has `name = ""` which will trigger a ForceNew diff once
the `name` is populated from the snapshot restore.

**SO** we can get a workable solution by actively avoiding populating
DBName when we're using one of the engines the docs explicitly mention.

It does not look like there are any tests covering `snapshot_identifer`,
so I'll subject this to some manual tests and follow up with some
results.