### PR TITLE
Remove alb_listener ssl_policy restriction

### DIFF
--- a/website/source/docs/providers/aws/r/alb_listener.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_listener.html.markdown
@@ -43,7 +43,7 @@ The following arguments are supported:
 * `load_balancer_arn` - (Required, Forces New Resource) The ARN of the load balancer.
 * `port` - (Required) The port on which the load balancer is listening.
 * `protocol` - (Optional) The protocol for connections from clients to the load balancer. Valid values are `HTTP` and `HTTPS`. Defaults to `HTTP`.
-* `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`. The only valid value is currently `ELBSecurityPolicy-2015-05`.
+* `ssl_policy` - (Optional) The name of the SSL Policy for the listener. Required if `protocol` is `HTTPS`.
 * `certificate_arn` - (Optional) The ARN of the SSL server certificate. Exactly one certificate is required if the protocol is HTTPS.
 * `default_action` - (Required) An Action block. Action blocks are documented below.
 


### PR DESCRIPTION
## Reasoning for docs update

Currently [aws_alb_listener resource document](https://www.terraform.io/docs/providers/aws/r/alb_listener.html) says that `ssl_policy` must be `ELBSecurityPolicy-2015-05`. However, [ALB official document](http://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html) says that there are other security policies, e.g. `ELBSecurityPolicy-2016-08`.

I confirmed that `ELBSecurityPolicy-2016-08` was accepted with Terraform v0.8.7.

The document should be updated not to restrict the value to `ELBSecurityPolicy-2015-05`.

## Relevant Terraform version

All versions which support `aws_alb_listener` resource.