### PR TITLE
provider/aws: Mark password fields as sensitive

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_domain_name.go
@@ -48,6 +48,7 @@ func resourceAwsApiGatewayDomainName() *schema.Resource {
 				Type:          schema.TypeString,
 				ForceNew:      true,
 				Optional:      true,
+				Sensitive:     true,
 				ConflictsWith: []string{"certificate_arn"},
 			},
 

--- a/builtin/providers/aws/resource_aws_directory_service_directory.go
+++ b/builtin/providers/aws/resource_aws_directory_service_directory.go
@@ -33,9 +33,10 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 				ForceNew: true,
 			},
 			"password": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:      schema.TypeString,
+				Required:  true,
+				ForceNew:  true,
+				Sensitive: true,
 			},
 			"size": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream.go
@@ -150,8 +150,9 @@ func resourceAwsKinesisFirehoseDeliveryStream() *schema.Resource {
 						},
 
 						"password": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
 						},
 
 						"role_arn": {

--- a/builtin/providers/aws/resource_aws_opsworks_application.go
+++ b/builtin/providers/aws/resource_aws_opsworks_application.go
@@ -102,8 +102,9 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 						},
 
 						"password": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
 						},
 
 						"revision": {
@@ -187,8 +188,9 @@ func resourceAwsOpsworksApplication() *schema.Resource {
 							},
 						},
 						"private_key": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:      schema.TypeString,
+							Required:  true,
+							Sensitive: true,
 							StateFunc: func(v interface{}) string {
 								switch v.(type) {
 								case string:

--- a/builtin/providers/aws/resource_aws_opsworks_stack.go
+++ b/builtin/providers/aws/resource_aws_opsworks_stack.go
@@ -111,8 +111,9 @@ func resourceAwsOpsworksStack() *schema.Resource {
 						},
 
 						"password": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
 						},
 
 						"revision": {


### PR DESCRIPTION
Related to https://github.com/hashicorp/terraform/pull/13132 and https://github.com/hashicorp/terraform/pull/13145

These came up when I `grep`ped through aws provider for `password"` and `key"`.
