### PR TITLE
provider/azurerm: Network Security Group - ignoring protocol casing at Import time

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_security_group.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group.go
@@ -66,6 +66,7 @@ func resourceArmNetworkSecurityGroup() *schema.Resource {
 							Type:         schema.TypeString,
 							Required:     true,
 							ValidateFunc: validateNetworkSecurityRuleProtocol,
+							StateFunc:    ignoreCaseStateFunc,
 						},
 
 						"source_port_range": {

--- a/builtin/providers/azurerm/resource_arm_network_security_group_test.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_group_test.go
@@ -204,7 +204,7 @@ resource "azurerm_network_security_group" "test" {
     	priority = 100
     	direction = "Inbound"
     	access = "Allow"
-    	protocol = "Tcp"
+    	protocol = "TCP"
     	source_port_range = "*"
     	destination_port_range = "*"
     	source_address_prefix = "*"


### PR DESCRIPTION
Fixes #13085 - when importing a Network Security Group, the Protocol this PR ignores the casing on the Protocol field

Tests pass:
```
 $ envchain azurerm make testacc TEST=./builtin/providers/azurerm/ TESTARGS='-run=TestAccAzureRMNetworkSecurityGroup'
TF_ACC=1 go test ./builtin/providers/azurerm/ -v -run=TestAccAzureRMNetworkSecurityGroup -timeout 120m
=== RUN   TestAccAzureRMNetworkSecurityGroup_importBasic
--- PASS: TestAccAzureRMNetworkSecurityGroup_importBasic (113.06s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_basic
--- PASS: TestAccAzureRMNetworkSecurityGroup_basic (109.59s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_disappears
--- PASS: TestAccAzureRMNetworkSecurityGroup_disappears (107.92s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_withTags
--- PASS: TestAccAzureRMNetworkSecurityGroup_withTags (136.80s)
=== RUN   TestAccAzureRMNetworkSecurityGroup_addingExtraRules
--- PASS: TestAccAzureRMNetworkSecurityGroup_addingExtraRules (144.80s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	612.193s
```