### PR TITLE
provider/aws: Increase timeout for AMI registration

### DIFF
--- a/builtin/providers/aws/resource_aws_ami.go
+++ b/builtin/providers/aws/resource_aws_ami.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	AWSAMIRetryTimeout       = 10 * time.Minute
+	AWSAMIRetryTimeout       = 20 * time.Minute
 	AWSAMIDeleteRetryTimeout = 20 * time.Minute
 	AWSAMIRetryDelay         = 5 * time.Second
 	AWSAMIRetryMinTimeout    = 3 * time.Second


### PR DESCRIPTION
This is to make the following flaky test pass:

```
=== RUN   TestAccAWSAMILaunchPermission_Basic
--- FAIL: TestAccAWSAMILaunchPermission_Basic (645.62s)
    testing.go:273: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_ami_copy.test: 1 error(s) occurred:
        
        * aws_ami_copy.test: Error waiting for AMI (ami-13ce5a73) to be ready: timeout while waiting for state to become 'available' (last state: 'pending', timeout: 10m0s)
FAIL
```

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAMILaunchPermission_Basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/29 16:50:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAMILaunchPermission_Basic -timeout 120m
=== RUN   TestAccAWSAMILaunchPermission_Basic
--- PASS: TestAccAWSAMILaunchPermission_Basic (380.01s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	380.046s
```