### PR TITLE
provider/aws: Fix ES Domain acceptance tests

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -83,6 +83,7 @@ func resourceAwsElasticSearchDomain() *schema.Resource {
 						"volume_type": {
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 					},
 				},

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_policy_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_policy_test.go
@@ -85,6 +85,13 @@ func testAccESDomainPolicyConfig(randInt int, policy string) string {
 resource "aws_elasticsearch_domain" "example" {
     domain_name = "tf-test-%d"
     elasticsearch_version = "2.3"
+    cluster_config {
+        instance_type = "t2.micro.elasticsearch"
+    }
+    ebs_options {
+        ebs_enabled = true
+        volume_size = 10
+    }
 }
 
 resource "aws_elasticsearch_domain_policy" "main" {

--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -96,7 +96,7 @@ func TestAccAWSElasticSearchDomain_complex(t *testing.T) {
 	})
 }
 
-func TestAccAWSElasticSearch_tags(t *testing.T) {
+func TestAccAWSElasticSearchDomain_tags(t *testing.T) {
 	var domain elasticsearch.ElasticsearchDomainStatus
 	var td elasticsearch.ListTagsOutput
 	ri := acctest.RandInt()
@@ -198,6 +198,10 @@ func testAccESDomainConfig(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
 }
 `, randInt)
 }
@@ -206,6 +210,10 @@ func testAccESDomainConfig_TagUpdate(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
 
   tags {
     foo = "bar"
@@ -219,6 +227,10 @@ func testAccESDomainConfig_complex(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
+
+  cluster_config {
+    instance_type = "r3.large.elasticsearch"
+  }
 
   advanced_options {
     "indices.fielddata.cache.size" = 80
@@ -248,6 +260,10 @@ func testAccESDomainConfigV23(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
   elasticsearch_version = "2.3"
 }
 `, randInt)


### PR DESCRIPTION
### Why are tests failing?

See context in https://github.com/hashicorp/terraform/pull/13157#issue-217889509

Here is a snippet from a debug log **before 23rd March**:

```
---[ REQUEST POST-SIGN ]-----------------------------
POST /2015-01-01/es/domain HTTP/1.1
Host: es.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.7.9 (go1.8; linux; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.9.2-dev
Content-Length: 72
Authorization: *REDACTED*
X-Amz-Date: 20170322T061231Z
Accept-Encoding: gzip

{"DomainName":"tf-test-530907444151386247","ElasticsearchVersion":"2.3"}
--
2017/03/22 06:12:32 [DEBUG] [aws-sdk-go] DEBUG: Response es/CreateElasticsearchDomain Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Content-Length: 734
Content-Type: application/json
Date: Wed, 22 Mar 2017 06:12:32 GMT
X-Amzn-Requestid: *REDACTED*

{"DomainStatus":{"ARN":"arn:aws:es:us-west-2:*REDACTED*:domain/tf-test-530907444151386247","AccessPolicies":"","AdvancedOptions":{"rest.action.multi.allow_explicit_index":"true"},"Created":true,"Deleted":false,"DomainId":"*REDACTED*/tf-test-530907444151386247","DomainName":"tf-test-530907444151386247","EBSOptions":{"EBSEnabled":false,"EncryptionEnabled":null,"Iops":null,"VolumeSize":null,"VolumeType":null},"ElasticsearchClusterConfig":{"DedicatedMasterCount":null,"DedicatedMasterEnabled":false,"DedicatedMasterType":null,"InstanceCount":1,"InstanceType":"m3.medium.elasticsearch","ZoneAwarenessEnabled":false},"ElasticsearchVersion":"2.3","Endpoint":null,"Processing":true,"SnapshotOptions":{"AutomatedSnapshotStartHour":0}}}
-----------------------------------------------------
```

and snippet from **this morning**:
```
2017/03/29 06:14:14 [DEBUG] [aws-sdk-go] DEBUG: Request es/CreateElasticsearchDomain Details:
---[ REQUEST POST-SIGN ]-----------------------------
POST /2015-01-01/es/domain HTTP/1.1
Host: es.us-west-2.amazonaws.com
User-Agent: aws-sdk-go/1.7.9 (go1.8; linux; amd64) APN/1.0 HashiCorp/1.0 Terraform/0.9.3-dev
Content-Length: 73
Authorization: *REDACTED*
X-Amz-Date: 20170329T061414Z
Accept-Encoding: gzip

{"DomainName":"tf-test-4999745254680115254","ElasticsearchVersion":"2.3"}
-----------------------------------------------------
2017/03/29 06:14:15 [DEBUG] [aws-sdk-go] DEBUG: Response es/CreateElasticsearchDomain Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Content-Length: 69
Content-Type: application/json
Date: Wed, 29 Mar 2017 06:14:15 GMT
X-Amzn-Errortype: ValidationException
X-Amzn-Requestid: *REDACTED*

{"message":"EBS storage must be selected for m4.large.elasticsearch"}
-----------------------------------------------------
```

### Why make `volume_type` Computed?

Volume type seems to default to `gp2` (general purpose SSD) on the API side if not defined but I was unable to verify from available docs this is the case for all instance types and I wanted to avoid making it `Default` anyway because the `ebs_options` block may not be defined at all or `ebs_enabled` may be `false` in which case this should be empty.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSElasticSearchDomain'
```
```
=== RUN   TestAccAWSElasticSearchDomainPolicy_basic
--- PASS: TestAccAWSElasticSearchDomainPolicy_basic (3527.08s)
=== RUN   TestAccAWSElasticSearchDomain_basic
--- PASS: TestAccAWSElasticSearchDomain_basic (1384.46s)
=== RUN   TestAccAWSElasticSearchDomain_importBasic
--- PASS: TestAccAWSElasticSearchDomain_importBasic (1373.07s)
=== RUN   TestAccAWSElasticSearchDomain_v23
--- PASS: TestAccAWSElasticSearchDomain_v23 (1509.51s)
=== RUN   TestAccAWSElasticSearchDomain_tags
--- PASS: TestAccAWSElasticSearchDomain_tags (1408.22s)
```