### PR TITLE
add Rehash to terraform.BackendState

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -406,6 +406,64 @@ func TestInit_copyBackendDst(t *testing.T) {
 	}
 }
 
+func TestInit_backendReinitWithExtra(t *testing.T) {
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("init-backend-empty"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	m := testMetaBackend(t, nil)
+	opts := &BackendOpts{
+		ConfigExtra: map[string]interface{}{"path": "hello"},
+		Init:        true,
+	}
+
+	b, err := m.backendConfig(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ui := new(cli.MockUi)
+	c := &InitCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{"-backend-config", "path=hello"}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	// Read our saved backend config and verify we have our settings
+	state := testStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
+	if v := state.Backend.Config["path"]; v != "hello" {
+		t.Fatalf("bad: %#v", v)
+	}
+
+	if state.Backend.Hash != b.Hash {
+		t.Fatal("mismatched state and config backend hashes")
+	}
+
+	if state.Backend.Rehash() != b.Rehash() {
+		t.Fatal("mismatched state and config re-hashes")
+	}
+
+	// init again and make sure nothing changes
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+	state = testStateRead(t, filepath.Join(DefaultDataDir, DefaultStateFilename))
+	if v := state.Backend.Config["path"]; v != "hello" {
+		t.Fatalf("bad: %#v", v)
+	}
+
+	if state.Backend.Hash != b.Hash {
+		t.Fatal("mismatched state and config backend hashes")
+	}
+}
+
 /*
 func TestInit_remoteState(t *testing.T) {
 	tmp, cwd := testCwd(t)

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1158,6 +1158,16 @@ func (m *Meta) backend_C_r_S_unchanged(
 	c *config.Backend, sMgr state.State) (backend.Backend, error) {
 	s := sMgr.State()
 
+	// it's possible for a backend to be unchanged, and the config itself to
+	// have changed by moving a paramter from the config to `-backend-config`
+	// In this case we only need to update the Hash.
+	if c != nil && s.Backend.Hash != c.Hash {
+		s.Backend.Hash = c.Hash
+		if err := sMgr.WriteState(s); err != nil {
+			return nil, fmt.Errorf(errBackendWriteSaved, err)
+		}
+	}
+
 	// Create the config. We do this from the backend state since this
 	// has the complete configuration data whereas the config itself
 	// may require input.

--- a/command/meta_backend_test.go
+++ b/command/meta_backend_test.go
@@ -3217,6 +3217,110 @@ func TestMetaBackend_planLegacy(t *testing.T) {
 	}
 }
 
+// init a backend using -backend-config options multiple times
+func TestMetaBackend_configureWithExtra(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("init-backend-empty"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	extras := map[string]interface{}{"path": "hello"}
+	m := testMetaBackend(t, nil)
+	opts := &BackendOpts{
+		ConfigExtra: extras,
+		Init:        true,
+	}
+
+	backendCfg, err := m.backendConfig(opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// init the backend
+	_, err = m.Backend(&BackendOpts{
+		ConfigExtra: extras,
+		Init:        true,
+	})
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	// Check the state
+	s := testStateRead(t, filepath.Join(DefaultDataDir, backendlocal.DefaultStateFilename))
+	if s.Backend.Hash != backendCfg.Hash {
+		t.Fatal("mismatched state and config backend hashes")
+	}
+	if s.Backend.Rehash() == s.Backend.Hash {
+		t.Fatal("saved hash should not match actual hash")
+	}
+	if s.Backend.Rehash() != backendCfg.Rehash() {
+		t.Fatal("mismatched state and config re-hashes")
+	}
+
+	// init the backend again with the same options
+	m = testMetaBackend(t, nil)
+	_, err = m.Backend(&BackendOpts{
+		ConfigExtra: extras,
+		Init:        true,
+	})
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	// Check the state
+	s = testStateRead(t, filepath.Join(DefaultDataDir, backendlocal.DefaultStateFilename))
+	if s.Backend.Hash != backendCfg.Hash {
+		t.Fatal("mismatched state and config backend hashes")
+	}
+}
+
+// move options from config to -backend-config
+func TestMetaBackend_configToExtra(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("init-backend"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// init the backend
+	m := testMetaBackend(t, nil)
+	_, err := m.Backend(&BackendOpts{
+		Init: true,
+	})
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	// Check the state
+	s := testStateRead(t, filepath.Join(DefaultDataDir, backendlocal.DefaultStateFilename))
+	backendHash := s.Backend.Hash
+
+	// init again but remove the path option from the config
+	cfg := "terraform {\n  backend \"local\" {}\n}\n"
+	if err := ioutil.WriteFile("main.tf", []byte(cfg), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// init the backend again with the  options
+	extras := map[string]interface{}{"path": "hello"}
+	m = testMetaBackend(t, nil)
+	m.forceInitCopy = true
+	_, err = m.Backend(&BackendOpts{
+		ConfigExtra: extras,
+		Init:        true,
+	})
+	if err != nil {
+		t.Fatalf("bad: %s", err)
+	}
+
+	s = testStateRead(t, filepath.Join(DefaultDataDir, backendlocal.DefaultStateFilename))
+
+	if s.Backend.Hash == backendHash {
+		t.Fatal("state.Backend.Hash was not updated")
+	}
+}
+
 func testMetaBackend(t *testing.T, args []string) *Meta {
 	var m Meta
 	m.Ui = new(cli.MockUi)

--- a/command/test-fixtures/init-backend-empty/main.tf
+++ b/command/test-fixtures/init-backend-empty/main.tf
@@ -1,0 +1,4 @@
+terraform {
+    backend "local" {
+    }
+}

--- a/config/config_terraform.go
+++ b/config/config_terraform.go
@@ -72,7 +72,7 @@ type Backend struct {
 	Hash uint64
 }
 
-// Hash returns a unique content hash for this backend's configuration
+// Rehash returns a unique content hash for this backend's configuration
 // as a uint64 value.
 func (b *Backend) Rehash() uint64 {
 	// If we have no backend, the value is zero

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -20,7 +20,6 @@ import (
 	"github.com/hashicorp/go-version"
 	"github.com/hashicorp/terraform/config"
 	"github.com/mitchellh/copystructure"
-	"github.com/mitchellh/hashstructure"
 	"github.com/satori/go.uuid"
 )
 
@@ -813,19 +812,14 @@ func (s *BackendState) Rehash() uint64 {
 		return 0
 	}
 
-	// Use hashstructure to hash only our type with the config.
-	code, err := hashstructure.Hash(map[string]interface{}{
-		"type":   s.Type,
-		"config": s.Config,
-	}, nil)
-
-	// This should never happen since we have just some basic primitives
-	// so panic if there is an error.
-	if err != nil {
-		panic(err)
+	cfg := config.Backend{
+		Type: s.Type,
+		RawConfig: &config.RawConfig{
+			Raw: s.Config,
+		},
 	}
 
-	return code
+	return cfg.Rehash()
 }
 
 // RemoteState is used to track the information about a remote


### PR DESCRIPTION
This method mirrors that of config.Backend, so we can compare the
configuration of a backend read from a config vs that of a backend read
from a state. This will prevent init from reinitializing when using
`-backend-config` options that match the existing state.

After determining that there is no drift in the config, check that the stored state has the correct hash for the configuration. If an option was removed from the config but supplied via the CLI, the effective hash is correct, but the stored backend state needs to be updated and no migration needs to be done. 

fixes #13149
fixes #13107