### PR TITLE
Fix crash in import azurerm_local_network_gateway

### DIFF
--- a/builtin/providers/azurerm/resource_arm_local_network_gateway.go
+++ b/builtin/providers/azurerm/resource_arm_local_network_gateway.go
@@ -101,6 +101,9 @@ func resourceArmLocalNetworkGatewayRead(d *schema.ResourceData, meta interface{}
 		return err
 	}
 	name := id.Path["localNetworkGateways"]
+	if name == "" {
+		return fmt.Errorf("Cannot find parameter 'localNetworkGateways' from '%s'", id.Path)
+	}
 	resGroup := id.ResourceGroup
 
 	resp, err := lnetClient.Get(resGroup, name)

--- a/website/source/docs/providers/azurerm/r/local_network_gateway.html.markdown
+++ b/website/source/docs/providers/azurerm/r/local_network_gateway.html.markdown
@@ -52,5 +52,5 @@ The following attributes are exported:
 Local Network Gateways can be imported using the `resource id`, e.g.
 
 ```
-terraform import azurerm_local_network_gateway.lng1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/microsoft.network/localnetworkgateways/lng1
+terraform import azurerm_local_network_gateway.lng1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/localNetworkGateways/lng1
 ```


### PR DESCRIPTION
The plug-in crashes if "localNetworkGateways" is not found in the id parameter. The fix is to verify the parameter before proceeding.

Also the "import" example in the documentation is wrong, "localNetworkGateways" should be case sensitive. The current example actually causes the plugin to crash due to the bug.