### PR TITLE
provider/aws: Add support for aws_lightsail_static_ip

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -337,6 +337,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lightsail_domain":                         resourceAwsLightsailDomain(),
 			"aws_lightsail_instance":                       resourceAwsLightsailInstance(),
 			"aws_lightsail_key_pair":                       resourceAwsLightsailKeyPair(),
+			"aws_lightsail_static_ip":                      resourceAwsLightsailStaticIp(),
 			"aws_lb_cookie_stickiness_policy":              resourceAwsLBCookieStickinessPolicy(),
 			"aws_load_balancer_policy":                     resourceAwsLoadBalancerPolicy(),
 			"aws_load_balancer_backend_server_policy":      resourceAwsLoadBalancerBackendServerPolicies(),

--- a/builtin/providers/aws/resource_aws_lightsail_static_ip.go
+++ b/builtin/providers/aws/resource_aws_lightsail_static_ip.go
@@ -1,0 +1,98 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLightsailStaticIp() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLightsailStaticIpCreate,
+		Read:   resourceAwsLightsailStaticIpRead,
+		Delete: resourceAwsLightsailStaticIpDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"ip_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"support_code": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceAwsLightsailStaticIpCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Allocating Lightsail Static IP: %q", name)
+	out, err := conn.AllocateStaticIp(&lightsail.AllocateStaticIpInput{
+		StaticIpName: aws.String(name),
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Lightsail Static IP allocated: %s", *out)
+
+	d.SetId(name)
+
+	return resourceAwsLightsailStaticIpRead(d, meta)
+}
+
+func resourceAwsLightsailStaticIpRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Reading Lightsail Static IP: %q", name)
+	out, err := conn.GetStaticIp(&lightsail.GetStaticIpInput{
+		StaticIpName: aws.String(name),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				log.Printf("[WARN] Lightsail Static IP (%s) not found, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+	log.Printf("[INFO] Received Lightsail Static IP: %s", *out)
+
+	d.Set("arn", out.StaticIp.Arn)
+	d.Set("ip_address", out.StaticIp.IpAddress)
+	d.Set("support_code", out.StaticIp.SupportCode)
+
+	return nil
+}
+
+func resourceAwsLightsailStaticIpDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Deleting Lightsail Static IP: %q", name)
+	out, err := conn.ReleaseStaticIp(&lightsail.ReleaseStaticIpInput{
+		StaticIpName: aws.String(name),
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Deleted Lightsail Static IP: %s", *out)
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_lightsail_static_ip_test.go
+++ b/builtin/providers/aws/resource_aws_lightsail_static_ip_test.go
@@ -1,0 +1,138 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSLightsailStaticIp_basic(t *testing.T) {
+	var staticIp lightsail.StaticIp
+	staticIpName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailStaticIpDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailStaticIpConfig_basic(staticIpName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailStaticIpExists("aws_lightsail_static_ip.test", &staticIp),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLightsailStaticIp_disappears(t *testing.T) {
+	var staticIp lightsail.StaticIp
+	staticIpName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+
+	staticIpDestroy := func(*terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+		_, err := conn.ReleaseStaticIp(&lightsail.ReleaseStaticIpInput{
+			StaticIpName: aws.String(staticIpName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting Lightsail Static IP in disapear test")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailStaticIpDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailStaticIpConfig_basic(staticIpName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailStaticIpExists("aws_lightsail_static_ip.test", &staticIp),
+					staticIpDestroy,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSLightsailStaticIpExists(n string, staticIp *lightsail.StaticIp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Lightsail Static IP ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetStaticIp(&lightsail.GetStaticIpInput{
+			StaticIpName: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.StaticIp == nil {
+			return fmt.Errorf("Static IP (%s) not found", rs.Primary.ID)
+		}
+		*staticIp = *resp.StaticIp
+		return nil
+	}
+}
+
+func testAccCheckAWSLightsailStaticIpDestroy(s *terraform.State) error {
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_static_ip" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetStaticIp(&lightsail.GetStaticIpInput{
+			StaticIpName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if resp.StaticIp != nil {
+				return fmt.Errorf("Lightsail Static IP %q still exists", rs.Primary.ID)
+			}
+		}
+
+		// Verify the error
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				return nil
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSLightsailStaticIpConfig_basic(staticIpName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+resource "aws_lightsail_static_ip" "test" {
+  name = "%s"
+}
+`, staticIpName)
+}

--- a/website/source/docs/providers/aws/r/lightsail_static_ip.html.markdown
+++ b/website/source/docs/providers/aws/r/lightsail_static_ip.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lightsail_static_ip"
+sidebar_current: "docs-aws-resource-lightsail-static-ip"
+description: |-
+  Provides an Lightsail Static IP
+---
+
+# aws\_lightsail\_static\_ip
+
+Allocates a static IP address.
+
+~> **Note:** Lightsail is currently only supported in `us-east-1` region.
+
+## Example Usage
+
+```
+resource "aws_lightsail_static_ip" "test" {
+  name = "example"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name for the allocated static IP
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `arn` - The ARN of the Lightsail static IP
+* `ip_address` - The allocated static IP address
+* `support_code` - The support code.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -881,6 +881,10 @@
                             <a href="/docs/providers/aws/r/lightsail_key_pair.html">aws_lightsail_key_pair</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-lightsail-static-ip") %>>
+                            <a href="/docs/providers/aws/r/lightsail_static_ip.html">aws_lightsail_static_ip</a>
+                        </li>
+
                     </ul>
                 </li>
 


### PR DESCRIPTION
Related: https://github.com/hashicorp/terraform/issues/10447

I'll submit `aws_lightsail_static_ip_attachment` too and that should hopefully allow us to close the mentioned issue and satisfy Lightsail users for a while.

There's a potential for a few more resources based on the current API, but I'd close that issue anyway, otherwise it will have no end. People can always submit PRs for those if they wish.

 - `aws_lightsail_domain_entry`
 - `aws_lightsail_public_port`

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=AWSLightsailStaticIp'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/29 21:23:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=AWSLightsailStaticIp -timeout 120m
=== RUN   TestAccAWSLightsailStaticIp_basic
--- PASS: TestAccAWSLightsailStaticIp_basic (19.12s)
=== RUN   TestAccAWSLightsailStaticIp_disappears
--- PASS: TestAccAWSLightsailStaticIp_disappears (13.50s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	32.662s
```