### PR TITLE
honor `input=false` in state migration

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -508,6 +508,32 @@ func TestInit_backendReinitConfigToExtra(t *testing.T) {
 	}
 }
 
+// make sure inputFalse stops execution on migrate
+func TestInit_inputFalse(t *testing.T) {
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("init-backend"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	c := &InitCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{"-input=false", "-backend-config=path=foo"}
+	if code := c.Run([]string{"-input=false"}); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter)
+	}
+
+	args = []string{"-input=false", "-backend-config=path=bar"}
+	if code := c.Run(args); code == 0 {
+		t.Fatal("init should have failed", ui.OutputWriter)
+	}
+}
+
 /*
 func TestInit_remoteState(t *testing.T) {
 	tmp, cwd := testCwd(t)

--- a/command/meta.go
+++ b/command/meta.go
@@ -3,6 +3,7 @@ package command
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -341,6 +342,9 @@ func (m *Meta) uiHook() *UiHook {
 
 // confirm asks a yes/no confirmation.
 func (m *Meta) confirm(opts *terraform.InputOpts) (bool, error) {
+	if !m.input {
+		return false, errors.New("input disabled")
+	}
 	for {
 		v, err := m.UIInput().Input(opts)
 		if err != nil {


### PR DESCRIPTION
return an error when confirming a copy if -input=false

Fixes #13054