### PR TITLE
Remove .gitattributes, treating all files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-# Set the default behavior, in case people don't have core.autocrlf set.
-* text=auto
-
-*.go  eol=lf


### PR DESCRIPTION
This was added earlier in an attempt to tolerate CRLF and convert CRLF line endings on Windows, but it causes issues where vendored files (which could be using either LF or CRLF depending on the original author's preference) get permanent diffs when inconsistent with the platform's preference.

The goal of this change, therefore, is to treat all of the files as binary, with the standard that all of Terraform's own files will use Unix-style LF endings (enforced by our gofmt check) and the vendor stuff will just be verbatim, byte-for-byte copies of what's upstream.

This will apparently cause some difficulty for people hacking on Terraform on Windows machines, because gofmt on Windows reportedly wants to convert all files to CRLF endings. Unfortunately we're forced to compromise here and treat development on Windows as an edge case in order to avoid the weirdness with inconsistent endings in the vendor tree.