### PR TITLE
[docs] Fix wrong attributes in lambda_permission doc

### DIFF
--- a/website/source/docs/providers/aws/r/lambda_permission.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_permission.html.markdown
@@ -27,7 +27,7 @@ resource "aws_lambda_permission" "allow_cloudwatch" {
 resource "aws_lambda_alias" "test_alias" {
   name             = "testalias"
   description      = "a sample description"
-  function_name    = "${aws_lambda_function.test_lambda.arn}"
+  function_name    = "${aws_lambda_function.test_lambda.function_name}"
   function_version = "$LATEST"
 }
 
@@ -65,7 +65,7 @@ EOF
 resource "aws_lambda_permission" "with_sns" {
   statement_id  = "AllowExecutionFromSNS"
   action        = "lambda:InvokeFunction"
-  function_name = "${aws_lambda_function.my-func.arn}"
+  function_name = "${aws_lambda_function.my-func.function_name}"
   principal     = "sns.amazonaws.com"
   source_arn    = "${aws_sns_topic.default.arn}"
 }

--- a/website/source/docs/providers/aws/r/lambda_permission.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_permission.html.markdown
@@ -36,6 +36,7 @@ resource "aws_lambda_function" "test_lambda" {
   function_name = "lambda_function_name"
   role          = "${aws_iam_role.iam_for_lambda.arn}"
   handler       = "exports.handler"
+  runtime       = "nodejs6.10"
 }
 
 resource "aws_iam_role" "iam_for_lambda" {
@@ -85,6 +86,7 @@ resource "aws_lambda_function" "func" {
   function_name = "lambda_called_from_sns"
   role          = "${aws_iam_role.default.arn}"
   handler       = "exports.handler"
+  runtime       = "python2.7"
 }
 
 resource "aws_iam_role" "default" {


### PR DESCRIPTION
## Reasoning for docs update
Examples in the doc uses wrong attributes:

- `${aws_lambda_function.test_lambda.arn}` as lambda's function name
- `${aws_iam_role.default.arn}` as IAM role name

The doc should be use `${aws_lambda_function.test_lambda.function_name}` as lambda's function name and  `"${aws_iam_role.default.name}` as IAM role name.

## Relevant Terraform version
All versions which support `aws_lambda_permission` resource.
