### PR TITLE
[docs] fix cloudstack_disk documentation

### DIFF
--- a/website/source/docs/providers/cloudstack/r/disk.html.markdown
+++ b/website/source/docs/providers/cloudstack/r/disk.html.markdown
@@ -15,12 +15,12 @@ a virtual machine if the optional parameters are configured.
 
 ```
 resource "cloudstack_disk" "default" {
-  name            = "test-disk"
-  attach          = "true"
-  disk_offering   = "custom"
-  size            = 50
-  virtual_machine = "server-1"
-  zone            = "zone-1"
+  name               = "test-disk"
+  attach             = "true"
+  disk_offering      = "custom"
+  size               = 50
+  virtual_machine_id = "server-1"
+  zone               = "zone-1"
 }
 ```
 


### PR DESCRIPTION
Example usage part gives the following info : 
`  virtual_machine = "server-1"` whereas the correct parameter is ` virtual_machine_id`