### PR TITLE
provider/aws: Refresh aws_alb_target_group stickiness on manual updates

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group.go
@@ -258,11 +258,19 @@ func resourceAwsAlbTargetGroupRead(d *schema.ResourceData, meta interface{}) err
 	for _, attr := range attrResp.Attributes {
 		switch *attr.Key {
 		case "stickiness.enabled":
-			stickinessMap["enabled"] = *attr.Value
+			enabled, err := strconv.ParseBool(*attr.Value)
+			if err != nil {
+				return fmt.Errorf("Error converting stickiness.enabled to bool: %s", *attr.Value)
+			}
+			stickinessMap["enabled"] = enabled
 		case "stickiness.type":
 			stickinessMap["type"] = *attr.Value
 		case "stickiness.lb_cookie.duration_seconds":
-			stickinessMap["cookie_duration"] = *attr.Value
+			duration, err := strconv.Atoi(*attr.Value)
+			if err != nil {
+				return fmt.Errorf("Error converting stickiness.lb_cookie.duration_seconds to int: %s", *attr.Value)
+			}
+			stickinessMap["cookie_duration"] = duration
 		case "deregistration_delay.timeout_seconds":
 			timeout, err := strconv.Atoi(*attr.Value)
 			if err != nil {
@@ -271,7 +279,10 @@ func resourceAwsAlbTargetGroupRead(d *schema.ResourceData, meta interface{}) err
 			d.Set("deregistration_delay", timeout)
 		}
 	}
-	d.Set("stickiness", []interface{}{stickinessMap})
+
+	if err := d.Set("stickiness", []interface{}{stickinessMap}); err != nil {
+		return err
+	}
 
 	return nil
 }


### PR DESCRIPTION
Fixes: #13167

When changes to the target group were made via CLI or AWS Console, they
were not being picked up by terraform. This is because we were not
catching an error setting the `stickiness` parameters:

```
Error refreshing state: 1 error(s) occurred:

* aws_alb_target_group.test: aws_alb_target_group.test: stickiness.0.enabled: '' expected type 'bool', got unconvertible type 'string'
```

This meant that changes were not picked up in the following plan. The changes mean the following now:

```
~ aws_alb_target_group.test
    stickiness.0.cookie_duration: "10440" => "10000"
    stickiness.0.enabled:         "false" => "true"

Plan: 0 to add, 1 to change, 0 to destroy.
```