### PR TITLE
provider/aws: Refresh aws_alb_target_group tags

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group.go
@@ -273,6 +273,20 @@ func resourceAwsAlbTargetGroupRead(d *schema.ResourceData, meta interface{}) err
 	}
 	d.Set("stickiness", []interface{}{stickinessMap})
 
+	tagsResp, err := elbconn.DescribeTags(&elbv2.DescribeTagsInput{
+		ResourceArns: []*string{aws.String(d.Id())},
+	})
+	if err != nil {
+		return errwrap.Wrapf("Error retrieving Target Group Tags: {{err}}", err)
+	}
+	for _, t := range tagsResp.TagDescriptions {
+		if *t.ResourceArn == d.Id() {
+			if err := d.Set("tags", tagsToMapELBv2(t.Tags)); err != nil {
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/builtin/providers/aws/resource_aws_alb_target_group_test.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_test.go
@@ -77,6 +77,8 @@ func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.healthy_threshold", "3"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.unhealthy_threshold", "3"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200-299"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "1"),
+					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.TestName", "TestAccAWSALBTargetGroup_basic"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes: #8847

We actually didn't get the list of tags from the API, therefore, any
manual changes were not actually showing up in subsequent plans

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSALBTargetGroup_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/30 15:45:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSALBTargetGroup_basic -timeout 120m
=== RUN   TestAccAWSALBTargetGroup_basic
--- PASS: TestAccAWSALBTargetGroup_basic (62.76s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	62.787s
```