### PR TITLE
provider/aws: Set aws_vpn_connection to recreate when in deleted state

### DIFF
--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -294,6 +294,11 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	vpnConnection := resp.VpnConnections[0]
+	if vpnConnection == nil || *vpnConnection.State == "deleted" {
+		// Seems we have lost our VPN Connection
+		d.SetId("")
+		return nil
+	}
 
 	// Set attributes under the user's control.
 	d.Set("vpn_gateway_id", vpnConnection.VpnGatewayId)

--- a/builtin/providers/aws/resource_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestAccAWSVpnConnection_basic(t *testing.T) {
+	var vpn ec2.VpnConnection
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_vpn_connection.foo",
@@ -27,6 +30,7 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 						"aws_vpn_gateway.vpn_gateway",
 						"aws_customer_gateway.customer_gateway",
 						"aws_vpn_connection.foo",
+						&vpn,
 					),
 				),
 			},
@@ -38,6 +42,7 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 						"aws_vpn_gateway.vpn_gateway",
 						"aws_customer_gateway.customer_gateway",
 						"aws_vpn_connection.foo",
+						&vpn,
 					),
 				),
 			},
@@ -46,6 +51,7 @@ func TestAccAWSVpnConnection_basic(t *testing.T) {
 }
 
 func TestAccAWSVpnConnection_withoutStaticRoutes(t *testing.T) {
+	var vpn ec2.VpnConnection
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_vpn_connection.foo",
@@ -60,12 +66,81 @@ func TestAccAWSVpnConnection_withoutStaticRoutes(t *testing.T) {
 						"aws_vpn_gateway.vpn_gateway",
 						"aws_customer_gateway.customer_gateway",
 						"aws_vpn_connection.foo",
+						&vpn,
 					),
 					resource.TestCheckResourceAttr("aws_vpn_connection.foo", "static_routes_only", "false"),
 				),
 			},
 		},
 	})
+}
+
+func TestAccAWSVpnConnection_disappears(t *testing.T) {
+	var vpn ec2.VpnConnection
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccAwsVpnConnectionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsVpnConnectionConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccAwsVpnConnection(
+						"aws_vpc.vpc",
+						"aws_vpn_gateway.vpn_gateway",
+						"aws_customer_gateway.customer_gateway",
+						"aws_vpn_connection.foo",
+						&vpn,
+					),
+					testAccAWSVpnConnectionDisappears(&vpn),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccAWSVpnConnectionDisappears(connection *ec2.VpnConnection) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		_, err := conn.DeleteVpnConnection(&ec2.DeleteVpnConnectionInput{
+			VpnConnectionId: connection.VpnConnectionId,
+		})
+		if err != nil {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidVpnConnectionID.NotFound" {
+				return nil
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		return resource.Retry(40*time.Minute, func() *resource.RetryError {
+			opts := &ec2.DescribeVpnConnectionsInput{
+				VpnConnectionIds: []*string{connection.VpnConnectionId},
+			}
+			resp, err := conn.DescribeVpnConnections(opts)
+			if err != nil {
+				cgw, ok := err.(awserr.Error)
+				if ok && cgw.Code() == "InvalidVpnConnectionID.NotFound" {
+					return nil
+				}
+				if ok && cgw.Code() == "IncorrectState" {
+					return resource.RetryableError(fmt.Errorf(
+						"Waiting for VPN Connection to be in the correct state: %v", connection.VpnConnectionId))
+				}
+				return resource.NonRetryableError(
+					fmt.Errorf("Error retrieving VPN Connection: %s", err))
+			}
+			if *resp.VpnConnections[0].State == "deleted" {
+				return nil
+			}
+			return resource.RetryableError(fmt.Errorf(
+				"Waiting for VPN Connection: %v", connection.VpnConnectionId))
+		})
+	}
 }
 
 func testAccAwsVpnConnectionDestroy(s *terraform.State) error {
@@ -112,7 +187,8 @@ func testAccAwsVpnConnection(
 	vpcResource string,
 	vpnGatewayResource string,
 	customerGatewayResource string,
-	vpnConnectionResource string) resource.TestCheckFunc {
+	vpnConnectionResource string,
+	vpnConnection *ec2.VpnConnection) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[vpnConnectionResource]
 		if !ok {
@@ -129,13 +205,15 @@ func testAccAwsVpnConnection(
 
 		ec2conn := testAccProvider.Meta().(*AWSClient).ec2conn
 
-		_, err := ec2conn.DescribeVpnConnections(&ec2.DescribeVpnConnectionsInput{
+		resp, err := ec2conn.DescribeVpnConnections(&ec2.DescribeVpnConnectionsInput{
 			VpnConnectionIds: []*string{aws.String(connection.Primary.ID)},
 		})
 
 		if err != nil {
 			return err
 		}
+
+		*vpnConnection = *resp.VpnConnections[0]
 
 		return nil
 	}


### PR DESCRIPTION
Fixes: #12440

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSVpnConnection_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/30 16:16:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSVpnConnection_ -timeout 120m
=== RUN   TestAccAWSVpnConnection_importBasic
--- PASS: TestAccAWSVpnConnection_importBasic (208.68s)
=== RUN   TestAccAWSVpnConnection_basic
--- PASS: TestAccAWSVpnConnection_basic (391.02s)
=== RUN   TestAccAWSVpnConnection_withoutStaticRoutes
--- PASS: TestAccAWSVpnConnection_withoutStaticRoutes (316.99s)
=== RUN   TestAccAWSVpnConnection_disappears
--- PASS: TestAccAWSVpnConnection_disappears (202.84s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1119.563s
```