### PR TITLE
Expanded Joyent Triton documentation

### DIFF
--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -177,7 +177,8 @@ To make a resource importable, please see the
 
 ### Triton
 
-* triton_firewall_rule
 * triton_key
-* triton_machine
+* triton_firewall_rule
 * triton_vlan
+* triton_fabric
+* triton_machine

--- a/website/source/docs/providers/triton/index.html.markdown
+++ b/website/source/docs/providers/triton/index.html.markdown
@@ -20,7 +20,7 @@ provider "triton" {
   key_material = "${file("~/.ssh/id_rsa")}"
   key_id       = "25:d4:a9:fe:ef:e6:c0:bf:b4:4b:4b:d4:a8:8f:01:0f"
 
-  # If using a private installation of Triton, specify the URL
+  # Set the URL to specify the specific Triton Data Center:
   url = "https://us-west-1.api.joyentcloud.com"
 }
 ```
@@ -32,4 +32,4 @@ The following arguments are supported in the `provider` block:
 * `account` - (Required) This is the name of the Triton account. It can also be provided via the `SDC_ACCOUNT` environment variable.
 * `key_material` - (Required) This is the private key of an SSH key associated with the Triton account to be used.
 * `key_id` - (Required) This is the fingerprint of the public key matching the key specified in `key_path`. It can be obtained via the command `ssh-keygen -l -E md5 -f /path/to/key`
-* `url` - (Optional) This is the URL to the Triton API endpoint. It is required if using a private installation of Triton. The default is to use the Joyent public cloud.
+* `url` - (Optional) This is the URL to the Triton API endpoint. It is required if using a private installation of Triton. The default is to use the Joyent public cloud us-west-1 endpoint. Valid public cloud endpoints include: `us-east-1`, `us-east-2`, `us-east-3`, `us-sw-1`, `us-west-1`, `eu-ams-1`

--- a/website/source/docs/providers/triton/r/triton_fabric.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_fabric.html.markdown
@@ -1,0 +1,88 @@
+---
+layout: "triton"
+page_title: "Triton: triton_fabric"
+sidebar_current: "docs-triton-fabric"
+description: |-
+    The `triton_fabric` resource represents an SSH fabric for a Triton account.
+---
+
+# triton\_fabric
+
+The `triton_fabric` resource represents an fabric for a Triton account. The fabric is a logical set of interconnected switches.
+
+## Example Usages
+
+### Create a fabric
+
+
+```
+resource "triton_fabric" "dmz" {
+  vlan_id            = 100
+  name               = "dmz"
+  description        = "DMZ Network"
+  subnet             = "10.60.1.0/24"
+  provision_start_ip = "10.60.1.10"
+  provision_end_ip   = "10.60.1.240"
+  gateway            = "10.60.1.1"
+  resolvers          = ["8.8.8.8", "8.8.4.4"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+
+* `name` - (String, Required, Change forces new resource)
+    Network name.
+
+* `description` - (String, Optional, Change forces new resource)
+    Optional description of network.
+
+* `subnet` - (String, Required, Change forces new resource)
+    CIDR formatted string describing network.
+
+* `provision_start_ip` - (String, Required, Change forces new resource)
+    First IP on the network that can be assigned.
+
+* `provision_end_ip` - (String, Required, Change forces new resource)
+    Last assignable IP on the network.
+
+* `gateway` - (String, Optional, Change forces new resource)
+    Optional gateway IP.
+
+* `resolvers` - (List, Optional)
+    Array of IP addresses for resolvers.
+
+* `routes` - (Map, Optional, Change forces new resource)
+    Map of CIDR block to Gateway IP address.
+
+* `internet_nat` - (Bool, Optional, Change forces new resource)
+    If a NAT zone is provisioned at Gateway IP address.
+
+* `vlan_id` - (Int, Required, Change forces new resource)
+    VLAN id the network is on. Number between 0-4095 indicating VLAN ID.
+
+
+
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `name` - (String) - Network name.
+* `public` - (Bool) - Whether or not this is an RFC1918 network.
+* `fabric` - (Bool) - Whether or not this network is on a fabric.
+* `description` - (String) - Optional description of network.
+* `subnet` - (String) - CIDR formatted string describing network.
+* `provision_start_ip` - (String) - First IP on the network that can be assigned.
+* `provision_end_ip` - (String) - Last assignable IP on the network.
+* `gateway` - (String) - Optional gateway IP.
+* `resolvers` - (List) - Array of IP addresses for resolvers.
+* `routes` - (Map) - Map of CIDR block to Gateway IP address.
+* `internet_nat` - (Bool) - If a NAT zone is provisioned at Gateway IP address.
+* `vlan_id` - (Int) - VLAN id the network is on. Number between 0-4095 indicating VLAN ID.
+
+
+
+

--- a/website/source/docs/providers/triton/r/triton_fabric.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_fabric.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "triton"
 page_title: "Triton: triton_fabric"
-sidebar_current: "docs-triton-fabric"
+sidebar_current: "docs-triton-resource-fabric"
 description: |-
     The `triton_fabric` resource represents an SSH fabric for a Triton account.
 ---

--- a/website/source/docs/providers/triton/r/triton_firewall_rule.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_firewall_rule.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "triton"
 page_title: "Triton: triton_firewall_rule"
-sidebar_current: "docs-triton-firewall"
+sidebar_current: "docs-triton-resource-firewall-rule"
 description: |-
     The `triton_firewall_rule` resource represents a rule for the Triton cloud firewall.
 ---

--- a/website/source/docs/providers/triton/r/triton_firewall_rule.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_firewall_rule.html.markdown
@@ -12,7 +12,7 @@ The `triton_firewall_rule` resource represents a rule for the Triton cloud firew
 
 ## Example Usages
 
-Allow traffic on ports tcp/80 and tcp/443 to machines with the 'www' tag from any source
+### Allow traffic on ports tcp/80 and tcp/443 to machines with the 'www' tag from any source
 
 
 ```
@@ -21,8 +21,21 @@ resource "triton_firewall_rule" "www" {
   enabled = true
 }
 ```
-Block traffic on port tcp/143 to all machines
 
+
+### Allow ssh traffic to all machines from known remote IPs
+
+
+```
+resource "triton_firewall_rule" "22" {
+  rule    = "FROM IP w.x.y.z TO all vms ALLOW tcp port 22"
+  enabled = true
+}
+```
+
+
+
+### Block traffic on port tcp/143 to all machines
 
 ```
 resource "triton_firewall_rule" "imap" {
@@ -30,6 +43,8 @@ resource "triton_firewall_rule" "imap" {
   enabled = true
 }
 ```
+
+
 
 ## Argument Reference
 

--- a/website/source/docs/providers/triton/r/triton_firewall_rule.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_firewall_rule.html.markdown
@@ -12,7 +12,7 @@ The `triton_firewall_rule` resource represents a rule for the Triton cloud firew
 
 ## Example Usages
 
-### Allow traffic on ports tcp/80 and tcp/443 to machines with the 'www' tag from any source
+### Allow web traffic on ports tcp/80 and tcp/443 to machines with the 'www' tag from any source
 
 
 ```
@@ -23,19 +23,19 @@ resource "triton_firewall_rule" "www" {
 ```
 
 
-### Allow ssh traffic to all machines from known remote IPs
+### Allow ssh traffic on port tcp/22 to all machines from known remote IPs
 
 
 ```
 resource "triton_firewall_rule" "22" {
-  rule    = "FROM IP w.x.y.z TO all vms ALLOW tcp port 22"
+  rule    = "FROM IP (IP w.x.y.z OR IP w.x.y.z) TO all vms ALLOW tcp port 22"
   enabled = true
 }
 ```
 
 
 
-### Block traffic on port tcp/143 to all machines
+### Block IMAP traffic on port tcp/143 to all machines
 
 ```
 resource "triton_firewall_rule" "imap" {

--- a/website/source/docs/providers/triton/r/triton_key.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_key.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "triton"
 page_title: "Triton: triton_key"
-sidebar_current: "docs-triton-key"
+sidebar_current: "docs-triton-resource-key"
 description: |-
     The `triton_key` resource represents an SSH key for a Triton account.
 ---

--- a/website/source/docs/providers/triton/r/triton_key.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_key.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "triton"
 page_title: "Triton: triton_key"
-sidebar_current: "docs-triton-firewall"
+sidebar_current: "docs-triton-key"
 description: |-
     The `triton_key` resource represents an SSH key for a Triton account.
 ---

--- a/website/source/docs/providers/triton/r/triton_machine.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_machine.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "triton"
 page_title: "Triton: triton_machine"
-sidebar_current: "docs-triton-machine"
+sidebar_current: "docs-triton-resource-machine"
 description: |-
     The `triton_machine` resource represents a virtual machine or infrastructure container running in Triton.
 ---

--- a/website/source/docs/providers/triton/r/triton_machine.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_machine.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "triton"
 page_title: "Triton: triton_machine"
-sidebar_current: "docs-triton-firewall"
+sidebar_current: "docs-triton-machine"
 description: |-
     The `triton_machine` resource represents a virtual machine or infrastructure container running in Triton.
 ---
@@ -12,12 +12,12 @@ The `triton_machine` resource represents a virtual machine or infrastructure con
 
 ## Example Usages
 
-Run a SmartOS base-64 machine.
+### Run a SmartOS base-64 machine.
 
 
 ```
-resource "triton_machine" "test" {
-  name    = "example-machine"
+resource "triton_machine" "test-smartos" {
+  name    = "test-smartos"
   package = "g3-standard-0.25-smartos"
   image   = "842e6fa6-6e9b-11e5-8402-1b490459e334"
 
@@ -26,6 +26,25 @@ resource "triton_machine" "test" {
   }
 }
 ```
+
+### Run an Ubuntu 14.04 LTS machine.
+
+```
+resource "triton_machine" "test-ubuntu" {
+  name                 = "test-ubuntu"
+  package              = "g4-general-4G"
+  image                = "1996a1d6-c0d9-11e6-8b80-4772e39dc920"
+  firewall_enabled     = true
+  root_authorized_keys = "Example Key"
+  user_script          = "#!/bin/bash\necho 'testing user-script' >> /tmp/test.out\nhostname $IMAGENAME"
+
+  tags = {
+    purpose = "testing ubuntu"
+  } ## tags
+} ## resource
+```
+
+
 
 ## Argument Reference
 

--- a/website/source/docs/providers/triton/r/triton_vlan.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_vlan.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "triton"
+page_title: "Triton: triton_vlan"
+sidebar_current: "docs-triton-vlan"
+description: |-
+    The `triton_vlan` resource represents an VLAN for a Triton account.
+---
+
+# triton\_vlan
+
+The `triton_vlan` resource represents an Triton VLAN. A VLAN provides a low level way to segregate and subdivide the network. Traffic on one VLAN cannot, _on its own_, reach another VLAN.
+
+## Example Usages
+
+### Create a VLAN
+
+
+```
+resource "triton_vlan" "dmz" {
+  vlan_id     = 100
+  name        = "dmz"
+  description = "DMZ VLAN"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `vlan_id` - (int, Required, Change forces new resource)
+    Number between 0-4095 indicating VLAN ID
+
+* `name` - (string, Required)
+    Unique name to identify VLAN
+
+* `description` - (string, Optional)
+    Description of the VLAN

--- a/website/source/docs/providers/triton/r/triton_vlan.html.markdown
+++ b/website/source/docs/providers/triton/r/triton_vlan.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "triton"
 page_title: "Triton: triton_vlan"
-sidebar_current: "docs-triton-vlan"
+sidebar_current: "docs-triton-resource-vlan"
 description: |-
     The `triton_vlan` resource represents an VLAN for a Triton account.
 ---

--- a/website/source/layouts/triton.erb
+++ b/website/source/layouts/triton.erb
@@ -14,11 +14,17 @@
                     <a href="#">Resources</a>
 
                     <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-triton-resource-key") %>>
+                            <a href="/docs/providers/triton/r/triton_key.html">triton_key</a>
+                        </li>
                         <li<%= sidebar_current("docs-triton-resource-firewall-rule") %>>
                             <a href="/docs/providers/triton/r/triton_firewall_rule.html">triton_firewall_rule</a>
                         </li>
-                        <li<%= sidebar_current("docs-triton-resource-key") %>>
-                            <a href="/docs/providers/triton/r/triton_key.html">triton_key</a>
+                        <li<%= sidebar_current("docs-triton-resource-vlan") %>>
+                            <a href="/docs/providers/triton/r/triton_vlan.html">triton_vlan</a>
+                        </li>
+                        <li<%= sidebar_current("docs-triton-resource-fabric") %>>
+                            <a href="/docs/providers/triton/r/triton_fabric.html">triton_fabric</a>
                         </li>
                         <li<%= sidebar_current("docs-triton-resource-machine") %>>
                             <a href="/docs/providers/triton/r/triton_machine.html">triton_machine</a>


### PR DESCRIPTION
1. Added triton_vlan and triton_fabric documentation.
2. Added Data Center information to the Triton provider documentation.
3. Added an Ubuntu example to triton_machine. 
4. Cleaned up a copy-and-paste error in the sidebar_current of the Front Matter.