### PR TITLE
Fixed failing tests when ~/.aws/credentials file is present

### DIFF
--- a/builtin/providers/aws/auth_helpers.go
+++ b/builtin/providers/aws/auth_helpers.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/go-cleanhttp"
 )
 
+// GetAccountInfo returns AWS account info from the given IAM role.
 func GetAccountInfo(iamconn *iam.IAM, stsconn *sts.STS, authProviderName string) (string, string, error) {
 	// If we have creds from instance profile, we can use metadata API
 	if authProviderName == ec2rolecreds.ProviderName {
@@ -91,7 +92,7 @@ func parseAccountInfoFromArn(arn string) (string, string, error) {
 	return parts[1], parts[4], nil
 }
 
-// This function is responsible for reading credentials from the
+// GetCredentials is responsible for reading credentials from the
 // environment in the case that they're not explicitly specified
 // in the Terraform configuration.
 func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {


### PR DESCRIPTION
When the file ~/.aws/credentials is present the tests will fail when the AWS SDK is resolving a provider as the SharedProvider will be evaluated as true.

This is because the SDK will first look at the AWS_SHARED_CREDENTIALS_FILE env var and if this is not set will fall back to ~/.aws/credentials.  The fix makes sure that AWS_SHARED_CREDENTIALS is set to a fake value to stop the provider being resolved when it shouldn't.

Failing test example:
```
  github.com/hashicorp/terraform/builtin/providers/aws
auth_helpers_test.go:565  
2017/03/30 12:22:00 [INFO] Setting custom metadata endpoint: "http://127.0.0.1:57822/latest"
2017/03/30 12:22:00 [DEBUG] Mocker server received request to "/latest/meta-data/instance-id"
2017/03/30 12:22:00 http: multiple response.WriteHeader calls
2017/03/30 12:22:00 [INFO] AWS EC2 instance detected via default metadata API endpoint, EC2RoleProvider added to the auth chain
auth_helpers_test.go:565: Expected provider name to be "EC2RoleProvider", "SharedCredentialsProvider" given
  github.com/hashicorp/terraform/builtin/providers/aws
auth_helpers_test.go:345  
2017/03/30 12:21:59 [INFO] Setting custom metadata endpoint: "http://127.0.0.1:57778/latest"
2017/03/30 12:21:59 [INFO] Ignoring AWS metadata API endpoint at http://127.0.0.1:57778/latest as it doesn't return any instance-id
auth_helpers_test.go:345: Expected an error with empty env, keys, and IAM in AWS Config
  github.com/hashicorp/terraform/builtin/providers/aws
auth_helpers_test.go:503  
2017/03/30 12:22:00 [INFO] Setting custom metadata endpoint: "http://127.0.0.1:57818/latest"
2017/03/30 12:22:00 [INFO] Ignoring AWS metadata API endpoint at http://127.0.0.1:57818/latest as it doesn't return any instance-id
auth_helpers_test.go:503: Expected error returned when getting creds w/ invalid EC2 endpoint
  github.com/hashicorp/terraform/builtin/providers/aws
2017/03/30 12:22  
2017/03/30 12:22:00 [INFO] Setting custom metadata endpoint: "http://127.0.0.1:57813/latest"
2017/03/30 12:22:00 [DEBUG] Mocker server received request to "/latest/meta-data/instance-id"
2017/03/30 12:22:00 http: multiple response.WriteHeader calls
2017/03/30 12:22:00 [INFO] AWS EC2 instance detected via default metadata API endpoint, EC2RoleProvider added to the auth chain
auth_helpers_test.go:423: AccessKeyID mismatch, expected: (somekey), got (AKIAIPGFHXN4CRC7A4NQ)
```