### PR TITLE
provider/aws: Add support for Lightsail Static IP Attachment

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -338,6 +338,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_lightsail_instance":                       resourceAwsLightsailInstance(),
 			"aws_lightsail_key_pair":                       resourceAwsLightsailKeyPair(),
 			"aws_lightsail_static_ip":                      resourceAwsLightsailStaticIp(),
+			"aws_lightsail_static_ip_attachment":           resourceAwsLightsailStaticIpAttachment(),
 			"aws_lb_cookie_stickiness_policy":              resourceAwsLBCookieStickinessPolicy(),
 			"aws_load_balancer_policy":                     resourceAwsLoadBalancerPolicy(),
 			"aws_load_balancer_backend_server_policy":      resourceAwsLoadBalancerBackendServerPolicies(),

--- a/builtin/providers/aws/resource_aws_lightsail_static_ip_attachment.go
+++ b/builtin/providers/aws/resource_aws_lightsail_static_ip_attachment.go
@@ -1,0 +1,96 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsLightsailStaticIpAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsLightsailStaticIpAttachmentCreate,
+		Read:   resourceAwsLightsailStaticIpAttachmentRead,
+		Delete: resourceAwsLightsailStaticIpAttachmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"static_ip_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsLightsailStaticIpAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	staticIpName := d.Get("static_ip_name").(string)
+	log.Printf("[INFO] Attaching Lightsail Static IP: %q", staticIpName)
+	out, err := conn.AttachStaticIp(&lightsail.AttachStaticIpInput{
+		StaticIpName: aws.String(staticIpName),
+		InstanceName: aws.String(d.Get("instance_name").(string)),
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Lightsail Static IP attached: %s", *out)
+
+	d.SetId(staticIpName)
+
+	return resourceAwsLightsailStaticIpAttachmentRead(d, meta)
+}
+
+func resourceAwsLightsailStaticIpAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	staticIpName := d.Get("static_ip_name").(string)
+	log.Printf("[INFO] Reading Lightsail Static IP: %q", staticIpName)
+	out, err := conn.GetStaticIp(&lightsail.GetStaticIpInput{
+		StaticIpName: aws.String(staticIpName),
+	})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				log.Printf("[WARN] Lightsail Static IP (%s) not found, removing from state", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
+		return err
+	}
+	if !*out.StaticIp.IsAttached {
+		log.Printf("[WARN] Lightsail Static IP (%s) is not attached, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	log.Printf("[INFO] Received Lightsail Static IP: %s", *out)
+
+	d.Set("instance_name", out.StaticIp.AttachedTo)
+
+	return nil
+}
+
+func resourceAwsLightsailStaticIpAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).lightsailconn
+
+	name := d.Get("static_ip_name").(string)
+	log.Printf("[INFO] Detaching Lightsail Static IP: %q", name)
+	out, err := conn.DetachStaticIp(&lightsail.DetachStaticIpInput{
+		StaticIpName: aws.String(name),
+	})
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Detached Lightsail Static IP: %s", *out)
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_lightsail_static_ip_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_lightsail_static_ip_attachment_test.go
@@ -1,0 +1,163 @@
+package aws
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSLightsailStaticIpAttachment_basic(t *testing.T) {
+	var staticIp lightsail.StaticIp
+	staticIpName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+	instanceName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+	keypairName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailStaticIpAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailStaticIpAttachmentConfig_basic(staticIpName, instanceName, keypairName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailStaticIpAttachmentExists("aws_lightsail_static_ip_attachment.test", &staticIp),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLightsailStaticIpAttachment_disappears(t *testing.T) {
+	var staticIp lightsail.StaticIp
+	staticIpName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+	instanceName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+	keypairName := fmt.Sprintf("tf-test-lightsail-%s", acctest.RandString(5))
+
+	staticIpDestroy := func(*terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+		_, err := conn.DetachStaticIp(&lightsail.DetachStaticIpInput{
+			StaticIpName: aws.String(staticIpName),
+		})
+
+		if err != nil {
+			return fmt.Errorf("Error deleting Lightsail Static IP in disappear test")
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLightsailStaticIpAttachmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailStaticIpAttachmentConfig_basic(staticIpName, instanceName, keypairName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailStaticIpAttachmentExists("aws_lightsail_static_ip_attachment.test", &staticIp),
+					staticIpDestroy,
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSLightsailStaticIpAttachmentExists(n string, staticIp *lightsail.StaticIp) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return errors.New("No Lightsail Static IP Attachment ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetStaticIp(&lightsail.GetStaticIpInput{
+			StaticIpName: aws.String(rs.Primary.ID),
+		})
+		if err != nil {
+			return err
+		}
+
+		if resp == nil || resp.StaticIp == nil {
+			return fmt.Errorf("Static IP (%s) not found", rs.Primary.ID)
+		}
+
+		if !*resp.StaticIp.IsAttached {
+			return fmt.Errorf("Static IP (%s) not attached", rs.Primary.ID)
+		}
+
+		*staticIp = *resp.StaticIp
+		return nil
+	}
+}
+
+func testAccCheckAWSLightsailStaticIpAttachmentDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_lightsail_static_ip_attachment" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).lightsailconn
+
+		resp, err := conn.GetStaticIp(&lightsail.GetStaticIpInput{
+			StaticIpName: aws.String(rs.Primary.ID),
+		})
+
+		if err == nil {
+			if *resp.StaticIp.IsAttached {
+				return fmt.Errorf("Lightsail Static IP %q is still attached (to %q)", rs.Primary.ID, *resp.StaticIp.AttachedTo)
+			}
+		}
+
+		// Verify the error
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				return nil
+			}
+		}
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSLightsailStaticIpAttachmentConfig_basic(staticIpName, instanceName, keypairName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_lightsail_static_ip_attachment" "test" {
+  static_ip_name = "${aws_lightsail_static_ip.test.name}"
+  instance_name = "${aws_lightsail_instance.test.name}"
+}
+
+resource "aws_lightsail_static_ip" "test" {
+  name = "%s"
+}
+
+resource "aws_lightsail_instance" "test" {
+  name              = "%s"
+  availability_zone = "us-east-1b"
+  blueprint_id      = "wordpress_4_6_1"
+  bundle_id         = "micro_1_0"
+  key_pair_name     = "${aws_lightsail_key_pair.test.name}"
+}
+
+resource "aws_lightsail_key_pair" "test" {
+  name = "%s"
+}
+`, staticIpName, instanceName, keypairName)
+}

--- a/website/source/docs/providers/aws/r/lightsail_static_ip_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/lightsail_static_ip_attachment.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "aws"
+page_title: "AWS: aws_lightsail_static_ip_attachment"
+sidebar_current: "docs-aws-resource-lightsail-static-ip-attachment"
+description: |-
+  Provides an Lightsail Static IP Attachment
+---
+
+# aws\_lightsail\_static\_ip\_attachment
+
+Provides a static IP address attachment - relationship between a Lightsail static IP & Lightsail instance.
+
+~> **Note:** Lightsail is currently only supported in `us-east-1` region.
+
+## Example Usage
+
+```
+resource "aws_lightsail_static_ip_attachment" "test" {
+  static_ip_name = "${aws_lightsail_static_ip.test.name}"
+  instance_name = "${aws_lightsail_instance.test.name}"
+}
+
+resource "aws_lightsail_static_ip" "test" {
+  name = "example"
+}
+
+resource "aws_lightsail_instance" "test" {
+  name              = "example"
+  availability_zone = "us-east-1b"
+  blueprint_id      = "string"
+  bundle_id         = "string"
+  key_pair_name     = "some_key_name"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `static_ip_name` - (Required) The name of the allocated static IP
+* `instance_name` - (Required) The name of the Lightsail instance to attach the IP to
+
+## Attributes Reference
+
+The following attributes are exported in addition to the arguments listed above:
+
+* `arn` - The ARN of the Lightsail static IP
+* `ip_address` - The allocated static IP address
+* `support_code` - The support code.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -885,6 +885,10 @@
                             <a href="/docs/providers/aws/r/lightsail_static_ip.html">aws_lightsail_static_ip</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-lightsail-static-ip-attachment") %>>
+                            <a href="/docs/providers/aws/r/lightsail_static_ip_attachment.html">aws_lightsail_static_ip_attachment</a>
+                        </li>
+
                     </ul>
                 </li>
 


### PR DESCRIPTION
### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLightsailStaticIpAttachment'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/30 15:04:32 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLightsailStaticIpAttachment -timeout 120m
=== RUN   TestAccAWSLightsailStaticIpAttachment_basic
--- PASS: TestAccAWSLightsailStaticIpAttachment_basic (84.95s)
=== RUN   TestAccAWSLightsailStaticIpAttachment_disappears
--- PASS: TestAccAWSLightsailStaticIpAttachment_disappears (62.38s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	147.366s
```