### PR TITLE
provider/aws: Preserve default retain_on_delete in cloudfront import

### DIFF
--- a/builtin/providers/aws/import_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/import_aws_cloudfront_distribution.go
@@ -7,6 +7,10 @@ import (
 )
 
 func resourceAwsCloudFrontDistributionImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	// This is a non API attribute
+	// We are merely setting this to the same value as the Default setting in the schema
+	d.Set("retain_on_delete", false)
+
 	conn := meta.(*AWSClient).cloudfrontconn
 	id := d.Id()
 	resp, err := conn.GetDistributionConfig(&cloudfront.GetDistributionConfigInput{

--- a/builtin/providers/aws/import_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/import_aws_cloudfront_distribution_test.go
@@ -19,16 +19,13 @@ func TestAccAWSCloudFrontDistribution_importBasic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testConfig,
 			},
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				// Ignore retain_on_delete since it doesn't come from the AWS
-				// API.
-				ImportStateVerifyIgnore: []string{"retain_on_delete"},
 			},
 		},
 	})


### PR DESCRIPTION
Fixes: #10969

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudFrontDistribution_importBasic'                                   ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/30 17:52:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudFrontDistribution_importBasic -timeout 120m
=== RUN   TestAccAWSCloudFrontDistribution_importBasic
--- PASS: TestAccAWSCloudFrontDistribution_importBasic (1431.77s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1431.800s
```