### PR TITLE
docs bug syntax change

### DIFF
--- a/website/source/docs/modules/sources.html.markdown
+++ b/website/source/docs/modules/sources.html.markdown
@@ -157,7 +157,7 @@ URLs for Mercurial repositories support the following query parameters:
 
 ```
 module "consul" {
-  source = "hg::http://hashicorp.com/consul.hg?ref=master"
+  source = "hg::http://hashicorp.com/consul.hg?rev=default"
 }
 ```
 


### PR DESCRIPTION
Simple docs update.

HG uses 'rev' for commits, not 'ref'. The default branch on hg is default, not master.

Took me a while to figure out why it was not working due to this.
