### PR TITLE
Added data source aws_iam_role

### DIFF
--- a/builtin/providers/aws/data_source_aws_iam_role.go
+++ b/builtin/providers/aws/data_source_aws_iam_role.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsIAMRole() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsIAMRoleRead,
+
+		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"assume_role_policy_document": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"role_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsIAMRoleRead(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	roleName := d.Get("role_name").(string)
+
+	req := &iam.GetRoleInput{
+		RoleName: aws.String(roleName),
+	}
+
+	resp, err := iamconn.GetRole(req)
+	if err != nil {
+		return errwrap.Wrapf("Error getting roles: {{err}}", err)
+	}
+	if resp == nil {
+		return fmt.Errorf("no IAM role found")
+	}
+
+	role := resp.Role
+
+	d.SetId(*role.RoleId)
+	d.Set("arn", role.Arn)
+	d.Set("assume_role_policy_document", role.AssumeRolePolicyDocument)
+	d.Set("path", role.Path)
+	d.Set("role_id", role.RoleId)
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_iam_role_test.go
+++ b/builtin/providers/aws/data_source_aws_iam_role_test.go
@@ -1,0 +1,59 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSDataSourceIAMRole_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsIAMRoleConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.aws_iam_role.test", "role_id"),
+					resource.TestCheckResourceAttr("data.aws_iam_role.test", "assume_role_policy_document", "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Sid%22%3A%22%22%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D"),
+					resource.TestCheckResourceAttr("data.aws_iam_role.test", "path", "/testpath/"),
+					resource.TestCheckResourceAttr("data.aws_iam_role.test", "role_name", "TestRole"),
+					resource.TestMatchResourceAttr("data.aws_iam_role.test", "arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/testpath/TestRole$")),
+				),
+			},
+		},
+	})
+}
+
+const testAccAwsIAMRoleConfig = `
+provider "aws" {
+	region = "us-east-1"
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "TestRole"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+
+  path = "/testpath/"
+}
+
+data "aws_iam_role" "test" {
+	  role_name = "${aws_iam_role.test_role.name}"
+}
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -174,6 +174,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_elb_service_account":      dataSourceAwsElbServiceAccount(),
 			"aws_iam_account_alias":        dataSourceAwsIamAccountAlias(),
 			"aws_iam_policy_document":      dataSourceAwsIamPolicyDocument(),
+			"aws_iam_role":                 dataSourceAwsIAMRole(),
 			"aws_iam_server_certificate":   dataSourceAwsIAMServerCertificate(),
 			"aws_instance":                 dataSourceAwsInstance(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),

--- a/website/source/docs/providers/aws/d/iam_role.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_role.html.markdown
@@ -1,0 +1,35 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_role
+sidebar_current: "docs-aws-datasource-iam-role"
+description: |-
+  Get information on a Amazon IAM role
+---
+
+# aws\_iam\_role
+
+This data source can be used to fetch information about a specific
+IAM role. By using this data source, you can reference IAM role
+properties without having to hard code ARNs as input.
+
+## Example Usage
+
+```
+data "aws_iam_role" "example" {
+  role_name = "an_example_role_name"
+}
+```
+
+## Argument Reference
+
+* `role_name` - (Required) The friendly IAM role name to match.
+
+## Attributes Reference
+
+* `arn` - The Amazon Resource Name (ARN) specifying the role.
+
+* `assume_role_policy_document` - The policy document associated with the role.
+
+* `path` - The path to the role.
+
+* `role_id` - The stable and unique string identifying the role.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -74,6 +74,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-iam-policy-document") %>>
                             <a href="/docs/providers/aws/d/iam_policy_document.html">aws_iam_policy_document</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-iam-role") %>>
+                            <a href="/docs/providers/aws/d/iam_role.html">aws_iam_role</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-iam-server-certificate") %>>
                           <a href="/docs/providers/aws/d/iam_server_certificate.html">aws_iam_server_certificate</a>
                         </li>


### PR DESCRIPTION
The IAM role data source provides details about a specific IAM role and its attributes.

Acceptance tests:
`
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDataSourceIAMRole_basic'
`

==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/30 11:11:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDataSourceIAMRole_basic -timeout 120m
=== RUN   TestAccAWSDataSourceIAMRole_basic
--- PASS: TestAccAWSDataSourceIAMRole_basic (0.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.965s