### PR TITLE
provider/aws: Wait for aws_opsworks_instance to be running when it's specified

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_instance.go
+++ b/builtin/providers/aws/resource_aws_opsworks_instance.go
@@ -781,7 +781,7 @@ func resourceAwsOpsworksInstanceCreate(d *schema.ResourceData, meta interface{})
 	d.Set("id", instanceId)
 
 	if v, ok := d.GetOk("state"); ok && v.(string) == "running" {
-		err := startOpsworksInstance(d, meta, false)
+		err := startOpsworksInstance(d, meta, true)
 		if err != nil {
 			return err
 		}
@@ -860,7 +860,7 @@ func resourceAwsOpsworksInstanceUpdate(d *schema.ResourceData, meta interface{})
 			}
 		} else {
 			if status != "stopped" && status != "stopping" && status != "shutting_down" {
-				err := stopOpsworksInstance(d, meta, false)
+				err := stopOpsworksInstance(d, meta, true)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Fixes: #9959

When we specify that we want an opsworks_instance state of running, we
should wait for that the be the case. This will then allow us to use the
Computed values (e.g. private_ip) etc and allow us to use provisioners
as part of the terraform config

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksInstance'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/30 20:55:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksInstance -timeout 120m
=== RUN   TestAccAWSOpsworksInstance_importBasic
--- PASS: TestAccAWSOpsworksInstance_importBasic (72.28s)
=== RUN   TestAccAWSOpsworksInstance
--- PASS: TestAccAWSOpsworksInstance (110.17s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	182.479s
```