### PR TITLE
provider/aws: Add DiffSuppression to aws_ecs_service placement_strategies

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -118,6 +118,12 @@ func resourceAwsEcsService() *schema.Resource {
 							Type:     schema.TypeString,
 							ForceNew: true,
 							Optional: true,
+							DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+								if strings.ToLower(old) == strings.ToLower(new) {
+									return true
+								}
+								return false
+							},
 						},
 					},
 				},


### PR DESCRIPTION
Fixes: #13216

Prior to Terraform 0.9.2, we always set placement_strategies to
lowercase. Therefore, people using it in Terraform 0.9.2 are getting
continual diffs:

```
-/+ aws_ecs_service.mongo
    cluster:                             "arn:aws:ecs:us-west-2:187416307283:cluster/terraformecstest1" => "arn:aws:ecs:us-west-2:187416307283:cluster/terraformecstest1"
    deployment_maximum_percent:          "200" => "200"
    deployment_minimum_healthy_percent:  "100" => "100"
    desired_count:                       "1" => "1"
    name:                                "mongodb" => "mongodb"
    placement_strategy.#:                "1" => "1"
    placement_strategy.1676812570.field: "instanceid" => "" (forces new resource)
    placement_strategy.1676812570.type:  "spread" => "" (forces new resource)
    placement_strategy.3946258308.field: "" => "instanceId" (forces new resource)
    placement_strategy.3946258308.type:  "" => "spread" (forces new resource)
    task_definition:                     "arn:aws:ecs:us-west-2:187416307283:task-definition/mongodb:1991" => "arn:aws:ecs:us-west-2:187416307283:task-definition/mongodb:1991"

Plan: 1 to add, 0 to change, 1 to destroy.
```

This adds a DiffSuppression func to make sure this doesn't trigger a
ForceNew resource:

```
% terraform plan                                                                                                                           ✹ ✭
[WARN] /Users/stacko/Code/go/bin/terraform-provider-aws overrides an internal plugin for aws-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_ecs_cluster.default: Refreshing state... (ID: arn:aws:e...ecstest1)
aws_ecs_task_definition.mongo: Refreshing state... (ID: mongodb)
aws_ecs_service.mongo: Refreshing state... (ID: arn:aws:e.../mongodb)
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```

```

```