### PR TITLE
Fix some backend locking issues

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -237,7 +237,6 @@ Options:
   -force-copy          Suppress prompts about copying state data. This is
                        equivalent to providing a "yes" to all confirmation
                        prompts.
-
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -264,6 +264,10 @@ func (m *Meta) flagSet(n string) *flag.FlagSet {
 	// Set the default Usage to empty
 	f.Usage = func() {}
 
+	// command that bypass locking will supply their own flag on this var, but
+	// set the initial meta value to true as a failsafe.
+	m.stateLock = true
+
 	return f
 }
 


### PR DESCRIPTION
Skip copying of states during migration if they are the same state. This
can happen when trying to reconfigure a backend's options, or if the
state was manually transferred. This can fail unexpectedly with locking
enabled.

Honor the `-input` flag for all confirmations (the new test hit some
more). Also unify where we reference the Meta.forceInitCopy and transfer
the value to the existing backendMigrateOpts.force field.

fixes #13215