### PR TITLE
provider/azurerm: Setting an optional field on Service Bus Topic

### DIFF
--- a/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_namespace.go
@@ -132,7 +132,7 @@ func resourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}
 
 	resp, err := namespaceClient.Get(resGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure ServiceBus Namespace %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure ServiceBus Namespace %s: %+v", name, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
@@ -147,7 +147,7 @@ func resourceArmServiceBusNamespaceRead(d *schema.ResourceData, meta interface{}
 
 	keys, err := namespaceClient.ListKeys(resGroup, name, serviceBusNamespaceDefaultAuthorizationRule)
 	if err != nil {
-		log.Printf("[ERROR] Unable to List default keys for Namespace %s: %s", name, err)
+		log.Printf("[ERROR] Unable to List default keys for Namespace %s: %+v", name, err)
 	} else {
 		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
 		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
@@ -173,7 +173,7 @@ func resourceArmServiceBusNamespaceDelete(d *schema.ResourceData, meta interface
 	resp, err := namespaceClient.Delete(resGroup, name, make(chan struct{}))
 
 	if resp.StatusCode != http.StatusNotFound {
-		return fmt.Errorf("Error issuing Azure ARM delete request of ServiceBus Namespace'%s': %s", name, err)
+		return fmt.Errorf("Error issuing Azure ARM delete request of ServiceBus Namespace'%s': %+v", name, err)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_servicebus_namespace_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_namespace_test.go
@@ -140,7 +140,7 @@ func testCheckAzureRMServiceBusNamespaceDestroy(s *terraform.State) error {
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("ServiceBus Namespace still exists:\n%#v", resp.NamespaceProperties)
+			return fmt.Errorf("ServiceBus Namespace still exists:\n%+v", resp)
 		}
 	}
 
@@ -165,7 +165,7 @@ func testCheckAzureRMServiceBusNamespaceExists(name string) resource.TestCheckFu
 
 		resp, err := conn.Get(resourceGroup, namespaceName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on serviceBusNamespacesClient: %s", err)
+			return fmt.Errorf("Bad: Get on serviceBusNamespacesClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {

--- a/builtin/providers/azurerm/resource_arm_servicebus_subscription.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_subscription.go
@@ -163,7 +163,7 @@ func resourceArmServiceBusSubscriptionRead(d *schema.ResourceData, meta interfac
 
 	resp, err := client.Get(resGroup, namespaceName, topicName, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure ServiceBus Subscription %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure ServiceBus Subscription %s: %+v", name, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")

--- a/builtin/providers/azurerm/resource_arm_servicebus_subscription_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_subscription_test.go
@@ -105,7 +105,7 @@ func testCheckAzureRMServiceBusSubscriptionDestroy(s *terraform.State) error {
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("ServiceBus Subscription still exists:\n%#v", resp.SubscriptionProperties)
+			return fmt.Errorf("ServiceBus Subscription still exists:\n%+v", resp.SubscriptionProperties)
 		}
 	}
 
@@ -132,7 +132,7 @@ func testCheckAzureRMServiceBusSubscriptionExists(name string) resource.TestChec
 
 		resp, err := client.Get(resourceGroup, namespaceName, topicName, subscriptionName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on serviceBusSubscriptionsClient: %s", err)
+			return fmt.Errorf("Bad: Get on serviceBusSubscriptionsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic.go
@@ -173,7 +173,7 @@ func resourceArmServiceBusTopicRead(d *schema.ResourceData, meta interface{}) er
 
 	resp, err := client.Get(resGroup, namespaceName, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure ServiceBus Topic %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure ServiceBus Topic %s: %+v", name, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic.go
@@ -55,6 +55,7 @@ func resourceArmServiceBusTopic() *schema.Resource {
 			"duplicate_detection_history_time_window": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"enable_batched_operations": {

--- a/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
+++ b/builtin/providers/azurerm/resource_arm_servicebus_topic_test.go
@@ -165,7 +165,7 @@ func testCheckAzureRMServiceBusTopicDestroy(s *terraform.State) error {
 		}
 
 		if resp.StatusCode != http.StatusNotFound {
-			return fmt.Errorf("ServiceBus Topic still exists:\n%#v", resp.TopicProperties)
+			return fmt.Errorf("ServiceBus Topic still exists:\n%+v", resp.TopicProperties)
 		}
 	}
 
@@ -191,7 +191,7 @@ func testCheckAzureRMServiceBusTopicExists(name string) resource.TestCheckFunc {
 
 		resp, err := client.Get(resourceGroup, namespaceName, topicName)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on serviceBusTopicsClient: %s", err)
+			return fmt.Errorf("Bad: Get on serviceBusTopicsClient: %+v", err)
 		}
 
 		if resp.StatusCode == http.StatusNotFound {

--- a/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
+++ b/website/source/docs/providers/azurerm/r/servicebus_topic.html.markdown
@@ -67,7 +67,7 @@ The following arguments are supported:
     format.
 
 * `duplicate_detection_history_time_window` - (Optional) The duration during which
-    duplicates can be detected. Provided in the [TimeSpan](#timespan-format) format.
+    duplicates can be detected. Provided in the [TimeSpan](#timespan-format) format. Defaults to 10 minutes (`00:10:00`)
 
 * `enable_batched_operations` - (Optional) Boolean flag which controls if server-side
     batched operations are enabled. Defaults to false.


### PR DESCRIPTION
The field `duplicate_detection_history_time_window` is defaulted at the API to `00:10:00`

Due a bug in the current version of the Azure SDK, this value wasn't being surfaced correctly, however we're going to need to make this optional by default

(also fixing the logging to output the error's)
