### PR TITLE
core: Add ImportStateIdPrefix field for testing

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -174,6 +174,13 @@ type TestStep struct {
 	// determined by inspecting the state for ResourceName's ID.
 	ImportStateId string
 
+	// ImportStateIdPrefix is the prefix added in front of ImportStateId.
+	// This can be useful in complex import cases, where more than one
+	// attribute needs to be passed on as the Import ID. Mainly in cases
+	// where the ID is not known, and a known prefix needs to be added to
+	// the unset ImportStateId field.
+	ImportStateIdPrefix string
+
 	// ImportStateCheck checks the results of ImportState. It should be
 	// used to verify that the resulting value of ImportState has the
 	// proper resources, IDs, and attributes.

--- a/helper/resource/testing_import_state.go
+++ b/helper/resource/testing_import_state.go
@@ -25,6 +25,10 @@ func testStepImportState(
 
 		importId = resource.Primary.ID
 	}
+	importPrefix := step.ImportStateIdPrefix
+	if importPrefix != "" {
+		importId = fmt.Sprintf("%s%s", importPrefix, importId)
+	}
 
 	// Setup the context. We initialize with an empty state. We use the
 	// full config for provider configurations.

--- a/helper/resource/testing_import_state_test.go
+++ b/helper/resource/testing_import_state_test.go
@@ -178,6 +178,80 @@ func TestTest_importStateDetectId(t *testing.T) {
 	}
 }
 
+func TestTest_importStateIdPrefix(t *testing.T) {
+	mp := testProvider()
+	mp.DiffReturn = nil
+	mp.ApplyFn = func(
+		info *terraform.InstanceInfo,
+		state *terraform.InstanceState,
+		diff *terraform.InstanceDiff) (*terraform.InstanceState, error) {
+		if !diff.Destroy {
+			return &terraform.InstanceState{
+				ID: "foo",
+			}, nil
+		}
+
+		return nil, nil
+	}
+
+	mp.RefreshFn = func(
+		i *terraform.InstanceInfo,
+		s *terraform.InstanceState) (*terraform.InstanceState, error) {
+		return s, nil
+	}
+
+	mp.ImportStateFn = func(
+		info *terraform.InstanceInfo, id string) ([]*terraform.InstanceState, error) {
+		if id != "bazfoo" {
+			return nil, fmt.Errorf("bad import ID: %s", id)
+		}
+
+		return []*terraform.InstanceState{
+			{
+				ID:        "bar",
+				Ephemeral: terraform.EphemeralState{Type: "test_instance"},
+			},
+		}, nil
+	}
+
+	checked := false
+	checkFn := func(s []*terraform.InstanceState) error {
+		checked = true
+
+		if s[0].ID != "bar" {
+			return fmt.Errorf("bad: %#v", s)
+		}
+
+		return nil
+	}
+
+	mt := new(mockT)
+	Test(mt, TestCase{
+		Providers: map[string]terraform.ResourceProvider{
+			"test": mp,
+		},
+
+		Steps: []TestStep{
+			{
+				Config: testConfigStr,
+			},
+			{
+				ResourceName:        "test_instance.foo",
+				ImportState:         true,
+				ImportStateCheck:    checkFn,
+				ImportStateIdPrefix: "baz",
+			},
+		},
+	})
+
+	if mt.failed() {
+		t.Fatalf("test failed: %s", mt.failMessage())
+	}
+	if !checked {
+		t.Fatal("didn't call check")
+	}
+}
+
 func TestTest_importStateVerify(t *testing.T) {
 	mp := testProvider()
 	mp.DiffReturn = nil


### PR DESCRIPTION
Adds the `ImportStateIdPrefix` field for import acceptance tests. There are (albeit fairly rare) import cases where a resource needs to be imported with a combination of the resource's ID and a known string prefix. This allows the developer to specify the known prefix, and omit the `ImportStateId` field.

```
$ make test TEST=./helper/resource TESTARGS="-run=TestTest_importStateIdPrefix"
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/30 18:08:36 Generated command/internal_plugin_list.go
go test -i ./helper/resource || exit 1
echo ./helper/resource | \
                xargs -t -n4 go test -run=TestTest_importStateIdPrefix -timeout=60s -parallel=4
go test -run=TestTest_importStateIdPrefix -timeout=60s -parallel=4 ./helper/resource
ok      github.com/hashicorp/terraform/helper/resource  0.025s
```