### PR TITLE
Add `name_prefix` to RDS resources

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -53,6 +53,46 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSDBInstance_namePrefix(t *testing.T) {
+	var v rds.DBInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.test", &v),
+					testAccCheckAWSDBInstanceAttributes(&v),
+					resource.TestMatchResourceAttr(
+						"aws_db_instance.test", "identifier", regexp.MustCompile("^tf-test-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBInstance_generatedName(t *testing.T) {
+	var v rds.DBInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBInstanceConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBInstanceExists("aws_db_instance.test", &v),
+					testAccCheckAWSDBInstanceAttributes(&v),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSDBInstance_kmsKey(t *testing.T) {
 	var v rds.DBInstance
 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
@@ -613,8 +653,8 @@ resource "aws_db_instance" "bar" {
 	username = "foo"
 
 
-	# Maintenance Window is stored in lower case in the API, though not strictly 
-	# documented. Terraform will downcase this to match (as opposed to throw a 
+	# Maintenance Window is stored in lower case in the API, though not strictly
+	# documented. Terraform will downcase this to match (as opposed to throw a
 	# validation error).
 	maintenance_window = "Fri:09:00-Fri:09:30"
 	skip_final_snapshot = true
@@ -622,6 +662,39 @@ resource "aws_db_instance" "bar" {
 	backup_retention_period = 0
 
 	parameter_group_name = "default.mysql5.6"
+
+	timeouts {
+		create = "30m"
+	}
+}`
+
+const testAccAWSDBInstanceConfig_namePrefix = `
+resource "aws_db_instance" "test" {
+	allocated_storage = 10
+	engine = "MySQL"
+	identifier_prefix = "tf-test-"
+	instance_class = "db.t1.micro"
+	password = "password"
+	username = "root"
+	security_group_names = ["default"]
+	publicly_accessible = true
+	skip_final_snapshot = true
+
+	timeouts {
+		create = "30m"
+	}
+}`
+
+const testAccAWSDBInstanceConfig_generatedName = `
+resource "aws_db_instance" "test" {
+	allocated_storage = 10
+	engine = "MySQL"
+	instance_class = "db.t1.micro"
+	password = "password"
+	username = "root"
+	security_group_names = ["default"]
+	publicly_accessible = true
+	skip_final_snapshot = true
 
 	timeouts {
 		create = "30m"
@@ -720,7 +793,7 @@ func testAccReplicaInstanceConfig(val int) string {
 
 		parameter_group_name = "default.mysql5.6"
 	}
-	
+
 	resource "aws_db_instance" "replica" {
 		identifier = "tf-replica-db-%d"
 		backup_retention_period = 0

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -36,10 +36,19 @@ func resourceAwsRDSCluster() *schema.Resource {
 			},
 
 			"cluster_identifier": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"cluster_identifier_prefix"},
+				ValidateFunc:  validateRdsIdentifier,
+			},
+			"cluster_identifier_prefix": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
-				ValidateFunc: validateRdsId,
+				ValidateFunc: validateRdsIdentifierPrefix,
 			},
 
 			"cluster_members": {
@@ -224,6 +233,19 @@ func resourceAwsRdsClusterImport(
 func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).rdsconn
 	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
+
+	var identifier string
+	if v, ok := d.GetOk("cluster_identifier"); ok {
+		identifier = v.(string)
+	} else {
+		if v, ok := d.GetOk("cluster_identifier_prefix"); ok {
+			identifier = resource.PrefixedUniqueId(v.(string))
+		} else {
+			identifier = resource.PrefixedUniqueId("tf-")
+		}
+
+		d.Set("cluster_identifier", identifier)
+	}
 
 	if _, ok := d.GetOk("snapshot_identifier"); ok {
 		opts := rds.RestoreDBClusterFromSnapshotInput{

--- a/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_instance_test.go
@@ -46,6 +46,48 @@ func TestAccAWSRDSClusterInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSRDSClusterInstance_namePrefix(t *testing.T) {
+	var v rds.DBInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfig_namePrefix(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.test", &v),
+					testAccCheckAWSDBClusterInstanceAttributes(&v),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster_instance.test", "identifier", regexp.MustCompile("^tf-cluster-instance-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRDSClusterInstance_generatedName(t *testing.T) {
+	var v rds.DBInstance
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSClusterDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSClusterInstanceConfig_generatedName(acctest.RandInt()),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSClusterInstanceExists("aws_rds_cluster_instance.test", &v),
+					testAccCheckAWSDBClusterInstanceAttributes(&v),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster_instance.test", "identifier", regexp.MustCompile("^tf-")),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSRDSClusterInstance_kmsKey(t *testing.T) {
 	var v rds.DBInstance
 	keyRegex := regexp.MustCompile("^arn:aws:kms:")
@@ -254,6 +296,83 @@ resource "aws_db_parameter_group" "bar" {
   }
 }
 `, n, n, n)
+}
+
+func testAccAWSClusterInstanceConfig_namePrefix(n int) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster_instance" "test" {
+  identifier_prefix = "tf-cluster-instance-"
+  cluster_identifier = "${aws_rds_cluster.test.id}"
+  instance_class = "db.r3.large"
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  master_username = "root"
+  master_password = "password"
+  db_subnet_group_name = "${aws_db_subnet_group.test.name}"
+  skip_final_snapshot = true
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "a" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.0.0.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_subnet" "b" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.0.1.0/24"
+  availability_zone = "us-west-2b"
+}
+
+resource "aws_db_subnet_group" "test" {
+  name = "tf-test-%d"
+  subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
+}
+`, n, n)
+}
+
+func testAccAWSClusterInstanceConfig_generatedName(n int) string {
+	return fmt.Sprintf(`
+resource "aws_rds_cluster_instance" "test" {
+  cluster_identifier = "${aws_rds_cluster.test.id}"
+  instance_class = "db.r3.large"
+}
+
+resource "aws_rds_cluster" "test" {
+  cluster_identifier = "tf-aurora-cluster-%d"
+  master_username = "root"
+  master_password = "password"
+  db_subnet_group_name = "${aws_db_subnet_group.test.name}"
+  skip_final_snapshot = true
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_subnet" "a" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.0.0.0/24"
+  availability_zone = "us-west-2a"
+}
+
+resource "aws_subnet" "b" {
+  vpc_id = "${aws_vpc.test.id}"
+  cidr_block = "10.0.1.0/24"
+  availability_zone = "us-west-2b"
+}
+
+resource "aws_db_subnet_group" "test" {
+  name = "tf-test-%d"
+  subnet_ids = ["${aws_subnet.a.id}", "${aws_subnet.b.id}"]
+}
+`, n, n)
 }
 
 func testAccAWSClusterInstanceConfigKmsKey(n int) string {

--- a/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_parameter_group.go
@@ -29,10 +29,19 @@ func resourceAwsRDSClusterParameterGroup() *schema.Resource {
 				Computed: true,
 			},
 			"name": &schema.Schema{
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateDbParamGroupName,
+			},
+			"name_prefix": &schema.Schema{
 				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
 				ForceNew:     true,
-				Required:     true,
-				ValidateFunc: validateDbParamGroupName,
+				ValidateFunc: validateDbParamGroupNamePrefix,
 			},
 			"family": &schema.Schema{
 				Type:     schema.TypeString,
@@ -86,8 +95,17 @@ func resourceAwsRDSClusterParameterGroupCreate(d *schema.ResourceData, meta inte
 	rdsconn := meta.(*AWSClient).rdsconn
 	tags := tagsFromMapRDS(d.Get("tags").(map[string]interface{}))
 
+	var groupName string
+	if v, ok := d.GetOk("name"); ok {
+		groupName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		groupName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		groupName = resource.UniqueId()
+	}
+
 	createOpts := rds.CreateDBClusterParameterGroupInput{
-		DBClusterParameterGroupName: aws.String(d.Get("name").(string)),
+		DBClusterParameterGroupName: aws.String(groupName),
 		DBParameterGroupFamily:      aws.String(d.Get("family").(string)),
 		Description:                 aws.String(d.Get("description").(string)),
 		Tags:                        tags,

--- a/builtin/providers/aws/resource_aws_rds_cluster_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_parameter_group_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -84,6 +85,44 @@ func TestAccAWSDBClusterParameterGroup_basic(t *testing.T) {
 						"aws_rds_cluster_parameter_group.bar", "parameter.2478663599.value", "utf8"),
 					resource.TestCheckResourceAttr(
 						"aws_rds_cluster_parameter_group.bar", "tags.%", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBClusterParameterGroup_namePrefix(t *testing.T) {
+	var v rds.DBClusterParameterGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBClusterParameterGroupConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
+					resource.TestMatchResourceAttr(
+						"aws_rds_cluster_parameter_group.test", "name", regexp.MustCompile("^tf-test-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBClusterParameterGroup_generatedName(t *testing.T) {
+	var v rds.DBClusterParameterGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBClusterParameterGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBClusterParameterGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBClusterParameterGroupExists("aws_rds_cluster_parameter_group.test", &v),
 				),
 			},
 		},
@@ -365,3 +404,15 @@ func testAccAWSDBClusterParameterGroupOnlyConfig(name string) string {
   family      = "aurora5.6"
 }`, name)
 }
+
+const testAccAWSDBClusterParameterGroupConfig_namePrefix = `
+resource "aws_rds_cluster_parameter_group" "test" {
+  name_prefix = "tf-test-"
+  family = "aurora5.6"
+}
+`
+const testAccAWSDBClusterParameterGroupConfig_generatedName = `
+resource "aws_rds_cluster_parameter_group" "test" {
+  family = "aurora5.6"
+}
+`

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-func validateRdsId(v interface{}, k string) (ws []string, errors []error) {
+func validateRdsIdentifier(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -29,6 +29,23 @@ func validateRdsId(v interface{}, k string) (ws []string, errors []error) {
 	if regexp.MustCompile(`-$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot end with a hyphen", k))
+	}
+	return
+}
+
+func validateRdsIdentifierPrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
 	}
 	return
 }
@@ -103,7 +120,27 @@ func validateDbParamGroupName(v interface{}, k string) (ws []string, errors []er
 			"%q cannot be greater than 255 characters", k))
 	}
 	return
+}
 
+func validateDbParamGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 226 characters", k))
+	}
+	return
 }
 
 func validateStreamViewType(v interface{}, k string) (ws []string, errors []error) {
@@ -1039,5 +1076,81 @@ func validateApiGatewayUsagePlanQuotaSettings(v map[string]interface{}) (errors 
 		errors = append(errors, fmt.Errorf("Usage Plan quota offset must be between 0 and 27 inclusive in the MONTH period"))
 	}
 
+	return
+}
+
+func validateDbSubnetGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[ .0-9a-z-_]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 255 characters", k))
+	}
+	if regexp.MustCompile(`(?i)^default$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q is not allowed as %q", "Default", k))
+	}
+	return
+}
+
+func validateDbSubnetGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[ .0-9a-z-_]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only lowercase alphanumeric characters, hyphens, underscores, periods, and spaces allowed in %q", k))
+	}
+	if len(value) > 229 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be longer than 229 characters", k))
+	}
+	return
+}
+
+func validateDbOptionGroupName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if regexp.MustCompile(`-$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot end with a hyphen", k))
+	}
+	if len(value) > 255 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 255 characters", k))
+	}
+	return
+}
+
+func validateDbOptionGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-z]`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"first character of %q must be a letter", k))
+	}
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q", k))
+	}
+	if regexp.MustCompile(`--`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot contain two consecutive hyphens", k))
+	}
+	if len(value) > 229 {
+		errors = append(errors, fmt.Errorf(
+			"%q cannot be greater than 229 characters", k))
+	}
 	return
 }

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1785,3 +1785,131 @@ func TestValidateElbNamePrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateDbSubnetGroupName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing?",
+			ErrCount: 1,
+		},
+		{
+			Value:    "default",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(300),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDbSubnetGroupName(tc.Value, "aws_db_subnet_group")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the DB Subnet Group name to trigger a validation error")
+		}
+	}
+}
+
+func TestValidateDbSubnetGroupNamePrefix(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "tEsting",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing?",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(230),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDbSubnetGroupNamePrefix(tc.Value, "aws_db_subnet_group")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the DB Subnet Group name prefix to trigger a validation error")
+		}
+	}
+}
+
+func TestValidateDbOptionGroupName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1testing123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing--123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing123-",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(256),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDbOptionGroupName(tc.Value, "aws_db_option_group_name")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the DB Option Group Name to trigger a validation error")
+		}
+	}
+}
+
+func TestValidateDbOptionGroupNamePrefix(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "testing123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "1testing123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "testing--123",
+			ErrCount: 1,
+		},
+		{
+			Value:    randomString(230),
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDbOptionGroupNamePrefix(tc.Value, "aws_db_option_group_name")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the DB Option Group name prefix to trigger a validation error")
+		}
+	}
+}

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -55,7 +55,8 @@ The following arguments are supported:
 * `allocated_storage` - (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) The allocated storage in gigabytes.
 * `engine` - (Required unless a `snapshot_identifier` or `replicate_source_db` is provided) The database engine to use.
 * `engine_version` - (Optional) The engine version to use.
-* `identifier` - (Optional) The name of the RDS instance, if omitted, Terraform will assign a random, unique name
+* `identifier` - (Optional, Forces new resource) The name of the RDS instance, if omitted, Terraform will assign a random, unique identifier.
+* `identifier_prefix` - (Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifer`.
 * `instance_class` - (Required) The instance type of the RDS instance.
 * `storage_type` - (Optional) One of "standard" (magnetic), "gp2" (general
     purpose SSD), or "io1" (provisioned IOPS SSD). The default is "io1" if
@@ -156,7 +157,7 @@ On Oracle instances the following is exported additionally:
 
 - `create` - (Default `40 minutes`) Used for Creating Instances, Replicas, and
 restoring from Snapshots
-- `update` - (Default `80 minutes`) Used for Database modifications 
+- `update` - (Default `80 minutes`) Used for Database modifications
 - `delete` - (Default `40 minutes`) Used for destroying databases. This includes
 the time required to take snapshots
 

--- a/website/source/docs/providers/aws/r/db_option_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_option_group.html.markdown
@@ -38,8 +38,9 @@ resource "aws_db_option_group" "bar" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the Option group to be created.
-* `option_group_description` - (Required) The description of the option group.
+* `name` - (Optional, Forces new resource) The name of the option group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `option_group_description` - (Optional) The description of the option group. Defaults to "Managed by Terraform".
 * `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with..
 * `major_engine_version` - (Required) Specifies the major version of the engine that this option group should be associated with.
 * `option` - (Optional) A list of Options to apply.

--- a/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_parameter_group.html.markdown
@@ -31,7 +31,8 @@ resource "aws_db_parameter_group" "default" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DB parameter group.
+* `name` - (Optional, Forces new resource) The name of the DB parameter group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `family` - (Required) The family of the DB parameter group.
 * `description` - (Optional) The description of the DB parameter group. Defaults to "Managed by Terraform".
 * `parameter` - (Optional) A list of DB parameters to apply.

--- a/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_subnet_group.html.markdown
@@ -27,7 +27,8 @@ resource "aws_db_subnet_group" "default" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DB subnet group.
+* `name` - (Optional, Forces new resource) The name of the DB subnet group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `description` - (Optional) The description of the DB subnet group. Defaults to "Managed by Terraform".
 * `subnet_ids` - (Required) A list of VPC subnet IDs.
 * `tags` - (Optional) A mapping of tags to assign to the resource.

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -53,8 +53,8 @@ the [AWS official documentation](https://docs.aws.amazon.com/AmazonRDS/latest/Co
 
 The following arguments are supported:
 
-* `cluster_identifier` - (Required) The Cluster Identifier. Must be a lower case
-string.
+* `cluster_identifier` - (Optional, Forces new resources) The cluster identifier. If omitted, Terraform will assign a random, unique identifier.
+* `cluster_identifier_prefix` - (Optional, Forces new resource) Creates a unique cluster identifier beginning with the specified prefix. Conflicts with `cluster_identifer`.
 * `database_name` - (Optional) The name for your database of up to 8 alpha-numeric
   characters. If you do not provide a name, Amazon RDS will not create a
   database in the DB cluster you are creating

--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -47,8 +47,8 @@ the [AWS official documentation](https://docs.aws.amazon.com/AmazonRDS/latest/Co
 
 The following arguments are supported:
 
-* `identifier` - (Optional) The Instance Identifier. Must be a lower case
-string. If omitted, a unique identifier will be generated.
+* `identifier` - (Optional, Forces new resource) The indentifier for the RDS instance, if omitted, Terraform will assign a random, unique identifier.
+* `identifier_prefix` - (Optional, Forces new resource) Creates a unique identifier beginning with the specified prefix. Conflicts with `identifer`.
 * `cluster_identifier` - (Required) The identifier of the [`aws_rds_cluster`](/docs/providers/aws/r/rds_cluster.html) in which to launch this instance.
 * `instance_class` - (Required) The instance class to use. For details on CPU
 and memory, see [Scaling Aurora DB Instances][4]. Aurora currently

--- a/website/source/docs/providers/aws/r/rds_cluster_parameter_group.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_parameter_group.markdown
@@ -32,9 +32,10 @@ resource "aws_rds_cluster_parameter_group" "default" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the DB cluster parameter group.
+* `name` - (Optional, Forces new resource) The name of the DB cluster parameter group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `family` - (Required) The family of the DB cluster parameter group.
-* `description` - (Required) The description of the DB cluster parameter group.
+* `description` - (Optional) The description of the DB cluster parameter group. Defaults to "Managed by Terraform".
 * `parameter` - (Optional) A list of DB parameters to apply.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
Adds `name_prefix` (or, in some cases, `identifier_prefix`) support to all AWS RDS resources.