### PR TITLE
Make the external test work on more environments

### DIFF
--- a/builtin/providers/external/data_source_test.go
+++ b/builtin/providers/external/data_source_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"regexp"
 	"testing"
 
@@ -117,8 +118,13 @@ func buildDataSourceTestProgram() (string, error) {
 		return "", fmt.Errorf("failed to build test stub program: %s", err)
 	}
 
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		gopath = filepath.Join(os.Getenv("HOME") + "/go")
+	}
+
 	programPath := path.Join(
-		os.Getenv("GOPATH"), "bin", "tf-acc-external-data-source",
+		filepath.SplitList(gopath)[0], "bin", "tf-acc-external-data-source",
 	)
 	return programPath, nil
 }


### PR DESCRIPTION
GOPATH is actually a list of path and doesn't necessarily have to be
set. If unset it will default to $GOPATH/go in go 1.9+.

Assume that go install will install to the first path in the list.

Can be applied on 0.9.2 as well.