### PR TITLE
kubernetes PatchOperations tests reliability

### DIFF
--- a/builtin/providers/kubernetes/patch_operations_test.go
+++ b/builtin/providers/kubernetes/patch_operations_test.go
@@ -117,7 +117,7 @@ func TestDiffStringMap(t *testing.T) {
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			ops := diffStringMap(tc.Path, tc.Old, tc.New)
-			if !tc.ExpectedOps.Equal(ops) {
+			if !ops.Equal(tc.ExpectedOps) {
 				t.Fatalf("Operations don't match.\nExpected: %v\nGiven:    %v\n", tc.ExpectedOps, ops)
 			}
 		})


### PR DESCRIPTION
This fixes a flakey test where a map is turned into a list but doesn't
always produce the same result because go maps don't guarantee
predictable ordering.

PatchOperations.Equal sorts the left-hand side before applying the
comparison.

Can be applied against 0.9.2 as well