### PR TITLE
provider/aws: Added API Gateway integration update

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_integration_test.go
@@ -19,86 +19,78 @@ func TestAccAWSAPIGatewayIntegration_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSAPIGatewayIntegrationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayIntegrationConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
-					testAccCheckAWSAPIGatewayIntegrationAttributes(&conf),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "type", "HTTP"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "integration_http_method", "GET"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "uri", "https://www.google.de"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "request_templates.application/json", ""),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
-					resource.TestCheckNoResourceAttr(
-						"aws_api_gateway_integration.test", "content_handling"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Foo", "'Bar'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSAPIGatewayIntegrationConfigUpdate,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
-					testAccCheckAWSAPIGatewayMockIntegrationAttributes(&conf),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "type", "MOCK"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "integration_http_method", ""),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "uri", ""),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "passthrough_behavior", "NEVER"),
-					resource.TestCheckResourceAttr(
-						"aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_BINARY"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'updated'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-FooBar", "'Baz'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", "{'foobar': 'bar}"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.text/html", "<html>Foo</html>"),
+				),
+			},
+
+			{
+				Config: testAccAWSAPIGatewayIntegrationConfigUpdateNoTemplates,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "0"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "0"),
+				),
+			},
+
+			{
+				Config: testAccAWSAPIGatewayIntegrationConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSAPIGatewayIntegrationExists("aws_api_gateway_integration.test", &conf),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "type", "HTTP"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "integration_http_method", "GET"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "uri", "https://www.google.de"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "passthrough_behavior", "WHEN_NO_MATCH"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "content_handling", "CONVERT_TO_TEXT"),
+					resource.TestCheckNoResourceAttr("aws_api_gateway_integration.test", "credentials"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_parameters.integration.request.header.X-Authorization", "'static'"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.%", "2"),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/json", ""),
+					resource.TestCheckResourceAttr("aws_api_gateway_integration.test", "request_templates.application/xml", "#set($inputRoot = $input.path('$'))\n{ }"),
 				),
 			},
 		},
 	})
-}
-
-func testAccCheckAWSAPIGatewayMockIntegrationAttributes(conf *apigateway.Integration) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *conf.Type != "MOCK" {
-			return fmt.Errorf("Wrong Type: %q", *conf.Type)
-		}
-		if *conf.RequestParameters["integration.request.header.X-Authorization"] != "'updated'" {
-			return fmt.Errorf("wrong updated RequestParameters for header.X-Authorization")
-		}
-		if *conf.ContentHandling != "CONVERT_TO_BINARY" {
-			return fmt.Errorf("wrong ContentHandling: %q", *conf.ContentHandling)
-		}
-		return nil
-	}
-}
-
-func testAccCheckAWSAPIGatewayIntegrationAttributes(conf *apigateway.Integration) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *conf.HttpMethod == "" {
-			return fmt.Errorf("empty HttpMethod")
-		}
-		if *conf.Uri != "https://www.google.de" {
-			return fmt.Errorf("wrong Uri")
-		}
-		if *conf.Type != "HTTP" {
-			return fmt.Errorf("wrong Type")
-		}
-		if conf.RequestTemplates["application/json"] != nil {
-			return fmt.Errorf("wrong RequestTemplate for application/json")
-		}
-		if *conf.RequestTemplates["application/xml"] != "#set($inputRoot = $input.path('$'))\n{ }" {
-			return fmt.Errorf("wrong RequestTemplate for application/xml")
-		}
-		if *conf.RequestParameters["integration.request.header.X-Authorization"] != "'static'" {
-			return fmt.Errorf("wrong RequestParameters for header.X-Authorization")
-		}
-		return nil
-	}
 }
 
 func testAccCheckAWSAPIGatewayIntegrationExists(n string, res *apigateway.Integration) resource.TestCheckFunc {
@@ -196,13 +188,15 @@ resource "aws_api_gateway_integration" "test" {
   }
 
   request_parameters = {
-	  "integration.request.header.X-Authorization" = "'static'"
+    "integration.request.header.X-Authorization" = "'static'"
+    "integration.request.header.X-Foo" = "'Bar'"
   }
 
   type = "HTTP"
   uri = "https://www.google.de"
   integration_http_method = "GET"
   passthrough_behavior = "WHEN_NO_MATCH"
+  content_handling = "CONVERT_TO_TEXT"
 }
 `
 
@@ -233,13 +227,55 @@ resource "aws_api_gateway_integration" "test" {
   resource_id = "${aws_api_gateway_resource.test.id}"
   http_method = "${aws_api_gateway_method.test.http_method}"
 
-  request_parameters = {
-	  "integration.request.header.X-Authorization" = "'updated'"
+  request_templates = {
+    "application/json" = "{'foobar': 'bar}"
+    "text/html" = "<html>Foo</html>"
   }
 
-  type = "MOCK"
-  passthrough_behavior = "NEVER"
-  content_handling = "CONVERT_TO_BINARY"
+  request_parameters = {
+    "integration.request.header.X-Authorization" = "'updated'"
+    "integration.request.header.X-FooBar" = "'Baz'"
+  }
 
+  type = "HTTP"
+  uri = "https://www.google.de"
+  integration_http_method = "GET"
+  passthrough_behavior = "WHEN_NO_MATCH"
+  content_handling = "CONVERT_TO_TEXT"
+}
+`
+
+const testAccAWSAPIGatewayIntegrationConfigUpdateNoTemplates = `
+resource "aws_api_gateway_rest_api" "test" {
+  name = "test"
+}
+
+resource "aws_api_gateway_resource" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  parent_id = "${aws_api_gateway_rest_api.test.root_resource_id}"
+  path_part = "test"
+}
+
+resource "aws_api_gateway_method" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "GET"
+  authorization = "NONE"
+
+  request_models = {
+    "application/json" = "Error"
+  }
+}
+
+resource "aws_api_gateway_integration" "test" {
+  rest_api_id = "${aws_api_gateway_rest_api.test.id}"
+  resource_id = "${aws_api_gateway_resource.test.id}"
+  http_method = "${aws_api_gateway_method.test.http_method}"
+
+  type = "HTTP"
+  uri = "https://www.google.de"
+  integration_http_method = "GET"
+  passthrough_behavior = "WHEN_NO_MATCH"
+  content_handling = "CONVERT_TO_TEXT"
 }
 `

--- a/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_integration.html.markdown
@@ -3,12 +3,12 @@ layout: "aws"
 page_title: "AWS: aws_api_gateway_integration"
 sidebar_current: "docs-aws-resource-api-gateway-integration"
 description: |-
-  Provides an HTTP Method Integration for an API Gateway Resource.
+  Provides an HTTP Method Integration for an API Gateway Integration.
 ---
 
 # aws\_api\_gateway\_integration
 
-Provides an HTTP Method Integration for an API Gateway Resource.
+Provides an HTTP Method Integration for an API Gateway Integration.
 
 ## Example Usage
 
@@ -36,6 +36,10 @@ resource "aws_api_gateway_integration" "MyDemoIntegration" {
   resource_id = "${aws_api_gateway_resource.MyDemoResource.id}"
   http_method = "${aws_api_gateway_method.MyDemoMethod.http_method}"
   type        = "MOCK"
+
+  request_parameters = {
+    "integration.request.header.X-Authorization" = "'static'"
+  }
 
   # Transforms the incoming XML request to JSON
   request_templates {


### PR DESCRIPTION
## Description
This adds the update part to the API Gateway integration. 

As per [the documentation](https://docs.aws.amazon.com/apigateway/api-reference/link-relation/integration-update/#remarks), everything excepted `request_templates` & `request_parameters` can't be added nor removed, for the attributes we have at time.
As they are not marked as `Required`, we need to flag them to be recreated on change, thus using the `ForceNew` attribute.

I reworked the acc tests so that they are clearer and handle this workflow, since the API to Create is different from the Update one (Series of PatchOperations):
1. Creation of resources using the 
2. Update: Removal + Additions + Replaces
3. Removal & state checks

## Related issues
* https://github.com/hashicorp/terraform/issues/12233
* https://github.com/hashicorp/terraform/issues/10223

## Tests
```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSAPIGatewayIntegration_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/03/31 17:51:35 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSAPIGatewayIntegration_basic -timeout 120m
=== RUN   TestAccAWSAPIGatewayIntegration_basic
--- PASS: TestAccAWSAPIGatewayIntegration_basic (96.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	96.913s
```