### PR TITLE
provider/aws: Fix DynamoDB issues about GSIs indexes

### DIFF
--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -533,9 +533,8 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 
 			table := tableDescription.Table
 
-			updates := []*dynamodb.GlobalSecondaryIndexUpdate{}
-
 			for _, updatedgsidata := range gsiSet.List() {
+				updates := []*dynamodb.GlobalSecondaryIndexUpdate{}
 				gsidata := updatedgsidata.(map[string]interface{})
 				gsiName := gsidata["name"].(string)
 				gsiWriteCapacity := gsidata["write_capacity"].(int)
@@ -583,6 +582,10 @@ func resourceAwsDynamoDbTableUpdate(d *schema.ResourceData, meta interface{}) er
 					if err != nil {
 						log.Printf("[DEBUG] Error updating table: %s", err)
 						return err
+					}
+
+					if err := waitForGSIToBeActive(d.Id(), gsiName, meta); err != nil {
+						return errwrap.Wrapf("Error waiting for Dynamo DB GSI to be active: {{err}}", err)
 					}
 				}
 			}

--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -39,6 +39,9 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsDynamoDbTableMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"arn": {
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_dynamodb_table.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table.go
@@ -157,15 +157,6 @@ func resourceAwsDynamoDbTable() *schema.Resource {
 						},
 					},
 				},
-				// GSI names are the uniqueness constraint
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-					m := v.(map[string]interface{})
-					buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-					buf.WriteString(fmt.Sprintf("%d-", m["write_capacity"].(int)))
-					buf.WriteString(fmt.Sprintf("%d-", m["read_capacity"].(int)))
-					return hashcode.String(buf.String())
-				},
 			},
 			"stream_enabled": {
 				Type:     schema.TypeBool,

--- a/builtin/providers/aws/resource_aws_dynamodb_table_migrate.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table_migrate.go
@@ -1,0 +1,70 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"strings"
+)
+
+func resourceAwsDynamoDbTableMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS DynamoDB Table State v0; migrating to v1")
+		return migrateDynamoDBStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateDynamoDBStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] DynamoDB Table Attributes before Migration: %#v", is.Attributes)
+
+	prefix := "global_secondary_index"
+	entity := resourceAwsDynamoDbTable()
+
+	// Read old keys
+	reader := &schema.MapFieldReader{
+		Schema: entity.Schema,
+		Map:    schema.BasicMapReader(is.Attributes),
+	}
+	result, err := reader.ReadField([]string{prefix})
+	if err != nil {
+		return nil, err
+	}
+
+	oldKeys, ok := result.Value.(*schema.Set)
+	if !ok {
+		return nil, fmt.Errorf("Got unexpected value from state: %#v", result.Value)
+	}
+
+	// Delete old keys
+	for k := range is.Attributes {
+		if strings.HasPrefix(k, fmt.Sprintf("%s.", prefix)) {
+			delete(is.Attributes, k)
+		}
+	}
+
+	// Write new keys
+	writer := schema.MapFieldWriter{
+		Schema: entity.Schema,
+	}
+	if err := writer.WriteField([]string{prefix}, oldKeys); err != nil {
+		return is, err
+	}
+	for k, v := range writer.Map() {
+		is.Attributes[k] = v
+	}
+
+	log.Printf("[DEBUG] DynamoDB Table Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}


### PR DESCRIPTION
## Description
This fixes 2 DynamoDB issues about GSI indexes. The first one is represented by the first two linked issues and is about the update of multiple GSIs.

The second one is about a diff that was really big. In fact, the `Set` attribute on the `global_secondary_indexes` was using the read/write capacity. When this capacity was changed on the table, it has to be changed on indexes also, which generates the diff.

Couldn't do separate PRs for that, since the second one was impacting the resolution of the first one with this error:

    testing.go:273: Step 1 error: After applying this step, the plan was not empty:
		UPDATE: aws_dynamodb_table.test
		  global_secondary_index.1396769947.hash_key:             "att1" => ""
		  global_secondary_index.1396769947.name:                 "att1-index" => ""
		  global_secondary_index.1396769947.non_key_attributes.#: "0" => "0"
		  global_secondary_index.1396769947.projection_type:      "ALL" => ""
		  global_secondary_index.1396769947.range_key:            "" => ""
		  global_secondary_index.1396769947.read_capacity:        "10" => "0"
		  global_secondary_index.1396769947.write_capacity:       "10" => "0"
		  global_secondary_index.2884824503.hash_key:             "" => "att2"
		  global_secondary_index.2884824503.name:                 "" => "att2-index"
		  global_secondary_index.2884824503.non_key_attributes.#: "0" => "0"
		  global_secondary_index.2884824503.projection_type:      "" => "ALL"
		  global_secondary_index.2884824503.range_key:            "" => ""
		  global_secondary_index.2884824503.read_capacity:        "" => "20"
		  global_secondary_index.2884824503.write_capacity:       "" => "20"
		  global_secondary_index.2989473846.hash_key:             "att3" => ""
		  global_secondary_index.2989473846.name:                 "att3-index" => ""
		  global_secondary_index.2989473846.non_key_attributes.#: "0" => "0"
		  global_secondary_index.2989473846.projection_type:      "ALL" => ""
		  global_secondary_index.2989473846.range_key:            "" => ""
		  global_secondary_index.2989473846.read_capacity:        "10" => "0"
		  global_secondary_index.2989473846.write_capacity:       "10" => "0"
		  global_secondary_index.3616786540.hash_key:             "" => "att1"
		  global_secondary_index.3616786540.name:                 "" => "att1-index"
		  global_secondary_index.3616786540.non_key_attributes.#: "0" => "0"
		  global_secondary_index.3616786540.projection_type:      "" => "ALL"
		  global_secondary_index.3616786540.range_key:            "" => ""
		  global_secondary_index.3616786540.read_capacity:        "" => "20"
		  global_secondary_index.3616786540.write_capacity:       "" => "20"
		  global_secondary_index.790634816.hash_key:              "att2" => ""
		  global_secondary_index.790634816.name:                  "att2-index" => ""
		  global_secondary_index.790634816.non_key_attributes.#:  "0" => "0"
		  global_secondary_index.790634816.projection_type:       "ALL" => ""
		  global_secondary_index.790634816.range_key:             "" => ""
		  global_secondary_index.790634816.read_capacity:         "10" => "0"
		  global_secondary_index.790634816.write_capacity:        "10" => "0"
		  global_secondary_index.922553537.hash_key:              "" => "att3"
		  global_secondary_index.922553537.name:                  "" => "att3-index"
		  global_secondary_index.922553537.non_key_attributes.#:  "0" => "0"
		  global_secondary_index.922553537.projection_type:       "" => "ALL"
		  global_secondary_index.922553537.range_key:             "" => ""
		  global_secondary_index.922553537.read_capacity:         "" => "20"
		  global_secondary_index.922553537.write_capacity:        "" => "20"

I also cleaned & normalized acc tests.

## Related issues
* Closes https://github.com/hashicorp/terraform/issues/13243
* Closes https://github.com/hashicorp/terraform/issues/9559
* Closes https://github.com/hashicorp/terraform/issues/3911

## Tests
```bash
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDynamoDbTable_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/06 19:53:26 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDynamoDbTable_ -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_importBasic
--- PASS: TestAccAWSDynamoDbTable_importBasic (46.04s)
=== RUN   TestAccAWSDynamoDbTable_importTags
--- PASS: TestAccAWSDynamoDbTable_importTags (45.03s)
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (79.78s)
=== RUN   TestAccAWSDynamoDbTable_streamSpecification
--- PASS: TestAccAWSDynamoDbTable_streamSpecification (51.41s)
=== RUN   TestAccAWSDynamoDbTable_tags
--- PASS: TestAccAWSDynamoDbTable_tags (49.15s)
=== RUN   TestAccAWSDynamoDbTable_gsiUpdate
--- PASS: TestAccAWSDynamoDbTable_gsiUpdate (130.87s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	402.306s
```