### PR TITLE
provider/ns1: No splitting answer on spf records.

### DIFF
--- a/builtin/providers/ns1/resource_record.go
+++ b/builtin/providers/ns1/resource_record.go
@@ -236,7 +236,7 @@ func resourceDataToRecord(r *dns.Record, d *schema.ResourceData) error {
 			var a *dns.Answer
 			v := answer["answer"].(string)
 			switch d.Get("type") {
-			case "TXT":
+			case "TXT", "SPF":
 				a = dns.NewTXTAnswer(v)
 			default:
 				a = dns.NewAnswer(strings.Split(v, " "))


### PR DESCRIPTION
References https://github.com/hashicorp/terraform/issues/12758

Previously, provider was incorrectly splitting spf answers by spaces. 

Tested via `host -t SPF terraform.example dns1.p03.nsone.net` and received the expected output