### PR TITLE
Fix DB parameter group name property

### DIFF
--- a/builtin/providers/aws/resource_aws_db_parameter_group.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group.go
@@ -98,6 +98,7 @@ func resourceAwsDbParameterGroupCreate(d *schema.ResourceData, meta interface{})
 	} else {
 		groupName = resource.UniqueId()
 	}
+	d.Set("name", groupName)
 
 	createOpts := rds.CreateDBParameterGroupInput{
 		DBParameterGroupName:   aws.String(groupName),

--- a/builtin/providers/aws/resource_aws_db_parameter_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_parameter_group_test.go
@@ -715,11 +715,21 @@ const testAccDBParameterGroupConfig_namePrefix = `
 resource "aws_db_parameter_group" "test" {
 	name_prefix = "tf-test-"
 	family = "mysql5.6"
+
+	parameter {
+		name = "sync_binlog"
+		value = 0
+	}
 }
 `
 
 const testAccDBParameterGroupConfig_generatedName = `
 resource "aws_db_parameter_group" "test" {
 	family = "mysql5.6"
+
+	parameter {
+		name = "sync_binlog"
+		value = 0
+	}
 }
 `


### PR DESCRIPTION
It appears that #13232 doesn't work properly if you actually try to set any `parameter`s. Specifically, I was getting the following error:

```
* aws_db_parameter_group.test: 1 error(s) occurred:

* aws_db_parameter_group.test: Error modifying DB Parameter Group: InvalidParameterValue: The parameter DBParameterGroupName must be provided and must not be blank.
	status code: 400, request id: 5783e396-17ff-11e7-87d5-e3fd4c7025ce
```