### PR TITLE
Fix `aws_s3_bucket` diff of logging options

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -728,8 +728,8 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	log.Printf("[DEBUG] S3 Bucket: %s, logging: %v", d.Id(), logging)
+	lcl := make([]map[string]interface{}, 0, 1)
 	if v := logging.LoggingEnabled; v != nil {
-		lcl := make([]map[string]interface{}, 0, 1)
 		lc := make(map[string]interface{})
 		if *v.TargetBucket != "" {
 			lc["target_bucket"] = *v.TargetBucket
@@ -738,9 +738,9 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 			lc["target_prefix"] = *v.TargetPrefix
 		}
 		lcl = append(lcl, lc)
-		if err := d.Set("logging", lcl); err != nil {
-			return err
-		}
+	}
+	if err := d.Set("logging", lcl); err != nil {
+		return err
 	}
 
 	// Read the lifecycle configuration


### PR DESCRIPTION
If `aws_s3_bucket` logging options are cleared on the AWS side, Terraform does not detect this, and changes must be made out-of-band or through a recreation of the resource.  This PR addresses this issue.

Fixes #8576.
