### PR TITLE
Update Azure DNS CNAME documentation to reflect reality

### DIFF
--- a/website/source/docs/providers/azurerm/r/dns_cname_record.html.markdown
+++ b/website/source/docs/providers/azurerm/r/dns_cname_record.html.markdown
@@ -28,7 +28,7 @@ resource "azurerm_dns_cname_record" "test" {
   zone_name           = "${azurerm_dns_zone.test.name}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   ttl                 = "300"
-  records             = ["contoso.com"]
+  record              = "contoso.com"
 }
 ```
 ## Argument Reference
@@ -43,7 +43,7 @@ The following arguments are supported:
 
 * `TTL` - (Required) The Time To Live (TTL) of the DNS record.
 
-* `records` - (Required) The target of the CNAME. Must be a single value.
+* `record` - (Required) The target of the CNAME.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 


### PR DESCRIPTION
From the code:

			"records": &schema.Schema{
				Type:     schema.TypeString,
				Optional: true,
				Elem:     &schema.Schema{Type: schema.TypeString},
				Set:      schema.HashString,
				Removed:  "Use `record` instead. This attribute will be removed in a future version",
			},

			"record": &schema.Schema{
				Type:     schema.TypeString,
				Required: true,