### PR TITLE
Changed output type of ips variable of ip_block ProfitBricks resource

### DIFF
--- a/builtin/providers/profitbricks/resource_profitbricks_ipblock.go
+++ b/builtin/providers/profitbricks/resource_profitbricks_ipblock.go
@@ -26,7 +26,8 @@ func resourceProfitBricksIPBlock() *schema.Resource {
 				ForceNew: true,
 			},
 			"ips": {
-				Type:     schema.TypeString,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
 		},
@@ -68,7 +69,7 @@ func resourceProfitBricksIPBlockRead(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] IPS: %s", strings.Join(ipblock.Properties.Ips, ","))
 
-	d.Set("ips", strings.Join(ipblock.Properties.Ips, ","))
+	d.Set("ips", ipblock.Properties.Ips)
 	d.Set("location", ipblock.Properties.Location)
 	d.Set("size", ipblock.Properties.Size)
 


### PR DESCRIPTION
ProfitBricks `ip_block` property `ips` now returns a list of strings instead of just a string.