### PR TITLE
Autoload *.tfvars in the same way as *.tf (allow inheritance)

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -296,8 +296,8 @@ Options:
                          flag can be set multiple times.
 
   -var-file=foo          Set variables in the Terraform configuration from
-                         a file. If "terraform.tfvars" is present, it will be
-                         automatically loaded if this flag is not specified.
+                         a file. If "terraform.tfvars" or any ".auto.tfvars"
+                         files are present, they will be automatically loaded.
 
 
 `
@@ -345,8 +345,8 @@ Options:
                          flag can be set multiple times.
 
   -var-file=foo          Set variables in the Terraform configuration from
-                         a file. If "terraform.tfvars" is present, it will be
-                         automatically loaded if this flag is not specified.
+                         a file. If "terraform.tfvars" or any ".auto.tfvars"
+                         files are present, they will be automatically loaded.
 
 
 `

--- a/command/apply.go
+++ b/command/apply.go
@@ -30,7 +30,10 @@ type ApplyCommand struct {
 
 func (c *ApplyCommand) Run(args []string) int {
 	var destroyForce, refresh, autoApprove bool
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdName := "apply"
 	if c.Destroy {

--- a/command/console.go
+++ b/command/console.go
@@ -146,8 +146,8 @@ Options:
                          flag can be set multiple times.
 
   -var-file=foo          Set variables in the Terraform configuration from
-                         a file. If "terraform.tfvars" is present, it will be
-                         automatically loaded if this flag is not specified.
+                         a file. If "terraform.tfvars" or any ".auto.tfvars"
+                         files are present, they will be automatically loaded.
 
 
 `

--- a/command/console.go
+++ b/command/console.go
@@ -23,7 +23,11 @@ type ConsoleCommand struct {
 }
 
 func (c *ConsoleCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
+
 	cmdFlags := c.Meta.flagSet("console")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }

--- a/command/debug_json2dot.go
+++ b/command/debug_json2dot.go
@@ -16,7 +16,10 @@ type DebugJSON2DotCommand struct {
 }
 
 func (c *DebugJSON2DotCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 	cmdFlags := c.Meta.flagSet("debug json2dot")
 
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/fmt.go
+++ b/command/fmt.go
@@ -29,7 +29,10 @@ func (c *FmtCommand) Run(args []string) int {
 		c.input = os.Stdin
 	}
 
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := flag.NewFlagSet("fmt", flag.ContinueOnError)
 	cmdFlags.BoolVar(&c.opts.List, "list", true, "list")
@@ -59,7 +62,7 @@ func (c *FmtCommand) Run(args []string) int {
 	}
 
 	output := &cli.UiWriter{Ui: c.Ui}
-	err := fmtcmd.Run(dirs, []string{fileExtension}, c.input, output, c.opts)
+	err = fmtcmd.Run(dirs, []string{fileExtension}, c.input, output, c.opts)
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Error running fmt: %s", err))
 		return 2

--- a/command/get.go
+++ b/command/get.go
@@ -17,7 +17,10 @@ type GetCommand struct {
 func (c *GetCommand) Run(args []string) int {
 	var update bool
 
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := flag.NewFlagSet("get", flag.ContinueOnError)
 	cmdFlags.BoolVar(&update, "update", false, "update")
@@ -26,7 +29,6 @@ func (c *GetCommand) Run(args []string) int {
 		return 1
 	}
 
-	var path string
 	path, err := ModulePath(cmdFlags.Args())
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/graph.go
+++ b/command/graph.go
@@ -24,7 +24,10 @@ func (c *GraphCommand) Run(args []string) int {
 	var drawCycles bool
 	var graphTypeStr string
 
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := flag.NewFlagSet("graph", flag.ContinueOnError)
 	c.addModuleDepthFlag(cmdFlags, &moduleDepth)

--- a/command/import.go
+++ b/command/import.go
@@ -27,7 +27,10 @@ func (c *ImportCommand) Run(args []string) int {
 	}
 
 	var configPath string
-	args = c.Meta.process(args, true)
+	args, err = c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("import")
 	cmdFlags.IntVar(&c.Meta.parallelism, "parallelism", 0, "parallelism")

--- a/command/import.go
+++ b/command/import.go
@@ -243,8 +243,8 @@ Options:
                       with the "-config" flag.
 
   -var-file=foo       Set variables in the Terraform configuration from
-                      a file. If "terraform.tfvars" is present, it will be
-                      automatically loaded if this flag is not specified.
+                      a file. If "terraform.tfvars" or any ".auto.tfvars"
+                      files are present, they will be automatically loaded.
 
 
 `

--- a/command/init.go
+++ b/command/init.go
@@ -38,7 +38,10 @@ func (c *InitCommand) Run(args []string) int {
 	var flagPluginPath FlagStringSlice
 	var flagVerifyPlugins bool
 
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 	cmdFlags := c.flagSet("init")
 	cmdFlags.BoolVar(&flagBackend, "backend", true, "")
 	cmdFlags.Var((*variables.FlagAny)(&flagConfigExtra), "backend-config", "")

--- a/command/meta.go
+++ b/command/meta.go
@@ -400,8 +400,19 @@ func (m *Meta) process(args []string, vars bool) ([]string, error) {
 			return nil, err
 		}
 
-		err = nil
 		var preArgs []string
+
+		if _, err = os.Stat(DefaultVarsFilename); err == nil {
+			m.autoKey = "var-file-default"
+			preArgs = append(preArgs, "-"+m.autoKey, DefaultVarsFilename)
+		}
+
+		if _, err = os.Stat(DefaultVarsFilename + ".json"); err == nil {
+			m.autoKey = "var-file-default"
+			preArgs = append(preArgs, "-"+m.autoKey, DefaultVarsFilename+".json")
+		}
+
+		err = nil
 		for err != io.EOF {
 			var fis []os.FileInfo
 			fis, err = f.Readdir(128)
@@ -412,7 +423,7 @@ func (m *Meta) process(args []string, vars bool) ([]string, error) {
 			for _, fi := range fis {
 				name := fi.Name()
 				// Ignore directories, non-var-files, and ignored files
-				if fi.IsDir() || !isVarFile(name) || config.IsIgnoredFile(name) {
+				if fi.IsDir() || !isAutoVarFile(name) || config.IsIgnoredFile(name) {
 					continue
 				}
 
@@ -570,8 +581,8 @@ func (m *Meta) SetWorkspace(name string) error {
 	return nil
 }
 
-// isVarFile determines if the file ends with .tfvars or .tfvars.json
-func isVarFile(path string) bool {
-	return strings.HasSuffix(path, ".tfvars") ||
-		strings.HasSuffix(path, ".tfvars.json")
+// isAutoVarFile determines if the file ends with .auto.tfvars or .auto.tfvars.json
+func isAutoVarFile(path string) bool {
+	return strings.HasSuffix(path, ".auto.tfvars") ||
+		strings.HasSuffix(path, ".auto.tfvars.json")
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -18,6 +18,7 @@ import (
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/backend/local"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/experiment"
 	"github.com/hashicorp/terraform/helper/variables"
 	"github.com/hashicorp/terraform/helper/wrappedstreams"
@@ -348,7 +349,7 @@ func (m *Meta) moduleStorage(root string) getter.Storage {
 // slice.
 //
 // vars says whether or not we support variables.
-func (m *Meta) process(args []string, vars bool) []string {
+func (m *Meta) process(args []string, vars bool) ([]string, error) {
 	// We do this so that we retain the ability to technically call
 	// process multiple times, even if we have no plans to do so
 	if m.oldUi != nil {
@@ -381,24 +382,49 @@ func (m *Meta) process(args []string, vars bool) []string {
 	// the args...
 	m.autoKey = ""
 	if vars {
-		if _, err := os.Stat(DefaultVarsFilename); err == nil {
-			m.autoKey = "var-file-default"
-			args = append(args, "", "")
-			copy(args[2:], args[0:])
-			args[0] = "-" + m.autoKey
-			args[1] = DefaultVarsFilename
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		f, err := os.Open(wd)
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		fi, err := f.Stat()
+		if err != nil {
+			return nil, err
+		}
+		if !fi.IsDir() {
+			return nil, err
 		}
 
-		if _, err := os.Stat(DefaultVarsFilename + ".json"); err == nil {
-			m.autoKey = "var-file-default"
-			args = append(args, "", "")
-			copy(args[2:], args[0:])
-			args[0] = "-" + m.autoKey
-			args[1] = DefaultVarsFilename + ".json"
+		err = nil
+		var preArgs []string
+		for err != io.EOF {
+			var fis []os.FileInfo
+			fis, err = f.Readdir(128)
+			if err != nil && err != io.EOF {
+				return nil, err
+			}
+
+			for _, fi := range fis {
+				name := fi.Name()
+				// Ignore directories, non-var-files, and ignored files
+				if fi.IsDir() || !isVarFile(name) || config.IsIgnoredFile(name) {
+					continue
+				}
+
+				m.autoKey = "var-file-default"
+				preArgs = append(preArgs, "-"+m.autoKey, name)
+			}
 		}
+
+		args = append(preArgs, args...)
 	}
 
-	return args
+	return args, nil
 }
 
 // uiHook returns the UiHook to use with the context.
@@ -542,4 +568,10 @@ func (m *Meta) SetWorkspace(name string) error {
 		return err
 	}
 	return nil
+}
+
+// isVarFile determines if the file ends with .tfvars or .tfvars.json
+func isVarFile(path string) bool {
+	return strings.HasSuffix(path, ".tfvars") ||
+		strings.HasSuffix(path, ".tfvars.json")
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -382,6 +382,18 @@ func (m *Meta) process(args []string, vars bool) ([]string, error) {
 	// the args...
 	m.autoKey = ""
 	if vars {
+		var preArgs []string
+
+		if _, err := os.Stat(DefaultVarsFilename); err == nil {
+			m.autoKey = "var-file-default"
+			preArgs = append(preArgs, "-"+m.autoKey, DefaultVarsFilename)
+		}
+
+		if _, err := os.Stat(DefaultVarsFilename + ".json"); err == nil {
+			m.autoKey = "var-file-default"
+			preArgs = append(preArgs, "-"+m.autoKey, DefaultVarsFilename+".json")
+		}
+
 		wd, err := os.Getwd()
 		if err != nil {
 			return nil, err
@@ -398,18 +410,6 @@ func (m *Meta) process(args []string, vars bool) ([]string, error) {
 		}
 		if !fi.IsDir() {
 			return nil, err
-		}
-
-		var preArgs []string
-
-		if _, err = os.Stat(DefaultVarsFilename); err == nil {
-			m.autoKey = "var-file-default"
-			preArgs = append(preArgs, "-"+m.autoKey, DefaultVarsFilename)
-		}
-
-		if _, err = os.Stat(DefaultVarsFilename + ".json"); err == nil {
-			m.autoKey = "var-file-default"
-			preArgs = append(preArgs, "-"+m.autoKey, DefaultVarsFilename+".json")
 		}
 
 		err = nil

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -21,7 +21,10 @@ func TestMetaColorize(t *testing.T) {
 	m.Color = true
 	args = []string{"foo", "bar"}
 	args2 = []string{"foo", "bar"}
-	args = m.process(args, false)
+	args, err := m.process(args, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 	if !reflect.DeepEqual(args, args2) {
 		t.Fatalf("bad: %#v", args)
 	}
@@ -33,7 +36,10 @@ func TestMetaColorize(t *testing.T) {
 	m = new(Meta)
 	args = []string{"foo", "bar"}
 	args2 = []string{"foo", "bar"}
-	args = m.process(args, false)
+	args, err = m.process(args, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 	if !reflect.DeepEqual(args, args2) {
 		t.Fatalf("bad: %#v", args)
 	}
@@ -46,7 +52,10 @@ func TestMetaColorize(t *testing.T) {
 	m.Color = true
 	args = []string{"foo", "-no-color", "bar"}
 	args2 = []string{"foo", "bar"}
-	args = m.process(args, false)
+	args, err = m.process(args, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 	if !reflect.DeepEqual(args, args2) {
 		t.Fatalf("bad: %#v", args)
 	}
@@ -152,7 +161,10 @@ func TestMetaInputMode_defaultVars(t *testing.T) {
 
 	m := new(Meta)
 	args := []string{}
-	args = m.process(args, true)
+	args, err = m.process(args, false)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
 	fs := m.flagSet("foo")
 	if err := fs.Parse(args); err != nil {
@@ -305,5 +317,62 @@ func TestMeta_Env(t *testing.T) {
 	env = m.Workspace()
 	if env != backend.DefaultStateName {
 		t.Fatalf("expected env %q, got env %q", backend.DefaultStateName, env)
+	}
+}
+
+func TestMeta_process(t *testing.T) {
+	test = false
+	defer func() { test = true }()
+
+	// Create a temporary directory for our cwd
+	d := tempDir(t)
+	if err := os.MkdirAll(d, 0755); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.Chdir(d); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Chdir(cwd)
+
+	// Create two vars files
+	file1 := "file1.tfvars"
+	err = ioutil.WriteFile(
+		filepath.Join(d, file1),
+		[]byte(""),
+		0644)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	file2 := "file2.tfvars"
+	err = ioutil.WriteFile(
+		filepath.Join(d, file2),
+		[]byte(""),
+		0644)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	m := new(Meta)
+	args := []string{}
+	args, err = m.process(args, true)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if args[0] != "-var-file-default" {
+		t.Fatalf("expected %q, got %q", "-var-file-default", args[0])
+	}
+	if args[1] != file1 {
+		t.Fatalf("expected %q, got %q", file1, args[1])
+	}
+	if args[2] != "-var-file-default" {
+		t.Fatalf("expected %q, got %q", "-var-file-default", args[0])
+	}
+	if args[3] != file2 {
+		t.Fatalf("expected %q, got %q", file2, args[3])
 	}
 }

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -339,17 +339,25 @@ func TestMeta_process(t *testing.T) {
 	defer os.Chdir(cwd)
 
 	// Create two vars files
-	file1 := "file1.tfvars"
+	defaultVarsfile := "terraform.tfvars"
 	err = ioutil.WriteFile(
-		filepath.Join(d, file1),
+		filepath.Join(d, defaultVarsfile),
 		[]byte(""),
 		0644)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
-	file2 := "file2.tfvars"
+	fileFirstAlphabetical := "a-file.auto.tfvars"
 	err = ioutil.WriteFile(
-		filepath.Join(d, file2),
+		filepath.Join(d, fileFirstAlphabetical),
+		[]byte(""),
+		0644)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	fileLastAlphabetical := "z-file.auto.tfvars"
+	err = ioutil.WriteFile(
+		filepath.Join(d, fileLastAlphabetical),
 		[]byte(""),
 		0644)
 	if err != nil {
@@ -366,13 +374,19 @@ func TestMeta_process(t *testing.T) {
 	if args[0] != "-var-file-default" {
 		t.Fatalf("expected %q, got %q", "-var-file-default", args[0])
 	}
-	if args[1] != file1 {
-		t.Fatalf("expected %q, got %q", file1, args[1])
+	if args[1] != defaultVarsfile {
+		t.Fatalf("expected %q, got %q", defaultVarsfile, args[3])
 	}
 	if args[2] != "-var-file-default" {
 		t.Fatalf("expected %q, got %q", "-var-file-default", args[0])
 	}
-	if args[3] != file2 {
-		t.Fatalf("expected %q, got %q", file2, args[3])
+	if args[3] != fileFirstAlphabetical {
+		t.Fatalf("expected %q, got %q", fileFirstAlphabetical, args[1])
+	}
+	if args[4] != "-var-file-default" {
+		t.Fatalf("expected %q, got %q", "-var-file-default", args[0])
+	}
+	if args[5] != fileLastAlphabetical {
+		t.Fatalf("expected %q, got %q", fileLastAlphabetical, args[3])
 	}
 }

--- a/command/meta_test.go
+++ b/command/meta_test.go
@@ -363,12 +363,25 @@ func TestMeta_process(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	// Regular tfvars files will not be autoloaded
+	fileIgnored := "ignored.tfvars"
+	err = ioutil.WriteFile(
+		filepath.Join(d, fileIgnored),
+		[]byte(""),
+		0644)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
 	m := new(Meta)
 	args := []string{}
 	args, err = m.process(args, true)
 	if err != nil {
 		t.Fatalf("err: %s", err)
+	}
+
+	if len(args) != 6 {
+		t.Fatalf("expected 6 args, got %v", args)
 	}
 
 	if args[0] != "-var-file-default" {

--- a/command/output.go
+++ b/command/output.go
@@ -16,7 +16,10 @@ type OutputCommand struct {
 }
 
 func (c *OutputCommand) Run(args []string) int {
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	var module string
 	var jsonOutput bool

--- a/command/plan.go
+++ b/command/plan.go
@@ -186,8 +186,8 @@ Options:
                       flag can be set multiple times.
 
   -var-file=foo       Set variables in the Terraform configuration from
-                      a file. If "terraform.tfvars" is present, it will be
-                      automatically loaded if this flag is not specified.
+                      a file. If "terraform.tfvars" or any ".auto.tfvars"
+                      files are present, they will be automatically loaded.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/plan.go
+++ b/command/plan.go
@@ -21,7 +21,10 @@ func (c *PlanCommand) Run(args []string) int {
 	var outPath string
 	var moduleDepth int
 
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("plan")
 	cmdFlags.BoolVar(&destroy, "destroy", false, "destroy")

--- a/command/push.go
+++ b/command/push.go
@@ -381,8 +381,8 @@ Options:
                        flag can be set multiple times.
 
   -var-file=foo        Set variables in the Terraform configuration from
-                       a file. If "terraform.tfvars" is present, it will be
-                       automatically loaded if this flag is not specified.
+                       a file. If "terraform.tfvars" or any ".auto.tfvars"
+                       files are present, they will be automatically loaded.
 
   -vcs=true            If true (default), push will upload only files
                        committed to your VCS, if detected.

--- a/command/push.go
+++ b/command/push.go
@@ -29,7 +29,10 @@ func (c *PushCommand) Run(args []string) int {
 	var archiveVCS, moduleUpload bool
 	var name string
 	var overwrite []string
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 	cmdFlags := c.Meta.flagSet("push")
 	cmdFlags.StringVar(&atlasAddress, "atlas-address", "", "")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -17,7 +17,10 @@ type RefreshCommand struct {
 }
 
 func (c *RefreshCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("refresh")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -133,8 +133,8 @@ Options:
                       flag can be set multiple times.
 
   -var-file=foo       Set variables in the Terraform configuration from
-                      a file. If "terraform.tfvars" is present, it will be
-                      automatically loaded if this flag is not specified.
+                      a file. If "terraform.tfvars" or any ".auto.tfvars"
+                      files are present, they will be automatically loaded.
 
 `
 	return strings.TrimSpace(helpText)

--- a/command/show.go
+++ b/command/show.go
@@ -19,7 +19,10 @@ type ShowCommand struct {
 func (c *ShowCommand) Run(args []string) int {
 	var moduleDepth int
 
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := flag.NewFlagSet("show", flag.ContinueOnError)
 	c.addModuleDepthFlag(cmdFlags, &moduleDepth)

--- a/command/state_list.go
+++ b/command/state_list.go
@@ -16,7 +16,10 @@ type StateListCommand struct {
 }
 
 func (c *StateListCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("state list")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")

--- a/command/state_mv.go
+++ b/command/state_mv.go
@@ -15,7 +15,10 @@ type StateMvCommand struct {
 }
 
 func (c *StateMvCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	// We create two metas to track the two states
 	var meta1, meta2 Meta

--- a/command/state_pull.go
+++ b/command/state_pull.go
@@ -16,7 +16,10 @@ type StatePullCommand struct {
 }
 
 func (c *StatePullCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("state pull")
 	if err := cmdFlags.Parse(args); err != nil {

--- a/command/state_push.go
+++ b/command/state_push.go
@@ -17,7 +17,10 @@ type StatePushCommand struct {
 }
 
 func (c *StatePushCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	var flagForce bool
 	cmdFlags := c.Meta.flagSet("state push")

--- a/command/state_rm.go
+++ b/command/state_rm.go
@@ -14,7 +14,10 @@ type StateRmCommand struct {
 }
 
 func (c *StateRmCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("state show")
 	cmdFlags.StringVar(&c.Meta.backupPath, "backup", "-", "backup")

--- a/command/state_show.go
+++ b/command/state_show.go
@@ -17,7 +17,10 @@ type StateShowCommand struct {
 }
 
 func (c *StateShowCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("state show")
 	cmdFlags.StringVar(&c.Meta.statePath, "state", DefaultStateFilename, "path")

--- a/command/taint.go
+++ b/command/taint.go
@@ -18,7 +18,10 @@ type TaintCommand struct {
 }
 
 func (c *TaintCommand) Run(args []string) int {
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	var allowMissing bool
 	var module string

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -16,7 +16,10 @@ type UnlockCommand struct {
 }
 
 func (c *UnlockCommand) Run(args []string) int {
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	force := false
 	cmdFlags := c.Meta.flagSet("force-unlock")

--- a/command/untaint.go
+++ b/command/untaint.go
@@ -17,7 +17,10 @@ type UntaintCommand struct {
 }
 
 func (c *UntaintCommand) Run(args []string) int {
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	var allowMissing bool
 	var module string

--- a/command/validate.go
+++ b/command/validate.go
@@ -17,7 +17,10 @@ type ValidateCommand struct {
 const defaultPath = "."
 
 func (c *ValidateCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 	var checkVars bool
 
 	cmdFlags := c.Meta.flagSet("validate")

--- a/command/version.go
+++ b/command/version.go
@@ -34,7 +34,10 @@ func (c *VersionCommand) Help() string {
 
 func (c *VersionCommand) Run(args []string) int {
 	var versionString bytes.Buffer
-	args = c.Meta.process(args, false)
+	args, err := c.Meta.process(args, false)
+	if err != nil {
+		return 1
+	}
 
 	fmt.Fprintf(&versionString, "Terraform v%s", c.Version)
 	if c.VersionPrerelease != "" {

--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -15,7 +15,10 @@ type WorkspaceCommand struct {
 }
 
 func (c *WorkspaceCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 

--- a/command/workspace_delete.go
+++ b/command/workspace_delete.go
@@ -16,7 +16,10 @@ type WorkspaceDeleteCommand struct {
 }
 
 func (c *WorkspaceDeleteCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 

--- a/command/workspace_list.go
+++ b/command/workspace_list.go
@@ -12,7 +12,10 @@ type WorkspaceListCommand struct {
 }
 
 func (c *WorkspaceListCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 

--- a/command/workspace_new.go
+++ b/command/workspace_new.go
@@ -18,7 +18,10 @@ type WorkspaceNewCommand struct {
 }
 
 func (c *WorkspaceNewCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 

--- a/command/workspace_select.go
+++ b/command/workspace_select.go
@@ -13,7 +13,10 @@ type WorkspaceSelectCommand struct {
 }
 
 func (c *WorkspaceSelectCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	envCommandShowWarning(c.Ui, c.LegacyName)
 

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -9,7 +9,10 @@ type WorkspaceShowCommand struct {
 }
 
 func (c *WorkspaceShowCommand) Run(args []string) int {
-	args = c.Meta.process(args, true)
+	args, err := c.Meta.process(args, true)
+	if err != nil {
+		return 1
+	}
 
 	cmdFlags := c.Meta.flagSet("workspace show")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }

--- a/config/loader.go
+++ b/config/loader.go
@@ -194,7 +194,7 @@ func dirFiles(dir string) ([]string, []string, error) {
 			// Only care about files that are valid to load
 			name := fi.Name()
 			extValue := ext(name)
-			if extValue == "" || isIgnoredFile(name) {
+			if extValue == "" || IsIgnoredFile(name) {
 				continue
 			}
 
@@ -215,9 +215,9 @@ func dirFiles(dir string) ([]string, []string, error) {
 	return files, overrides, nil
 }
 
-// isIgnoredFile returns true or false depending on whether the
+// IsIgnoredFile returns true or false depending on whether the
 // provided file name is a file that should be ignored.
-func isIgnoredFile(name string) bool {
+func IsIgnoredFile(name string) bool {
 	return strings.HasPrefix(name, ".") || // Unix-like hidden files
 		strings.HasSuffix(name, "~") || // vim
 		strings.HasPrefix(name, "#") && strings.HasSuffix(name, "#") // emacs

--- a/contrib/zsh-completion/_terraform
+++ b/contrib/zsh-completion/_terraform
@@ -27,7 +27,7 @@ __apply() {
         '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]' \
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __destroy() {
@@ -39,7 +39,7 @@ __destroy() {
         '-state=[Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]' \
         '-state-out=[Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __get() {
@@ -77,7 +77,7 @@ __plan() {
         '-refresh=[(true) Update state prior to checking for differences.]' \
         '-state=[(statefile) Path to a Terraform state file to use to look up Terraform-managed resources. By default it will use the state "terraform.tfstate" if it exists.]' \
         '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __push() {
@@ -93,7 +93,7 @@ __refresh() {
         '-state=[(path) Path to read and save state (unless state-out is specified). Defaults to "terraform.tfstate".]' \
         '-state-out=[(path) Path to write state to that is different than "-state". This can be used to preserve the old state.]' \
         '-var[("foo=bar") Set a variable in the Terraform configuration. This flag can be set multiple times.]' \
-        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" is present, it will be automatically loaded if this flag is not specified.]'
+        '-var-file=[(path) Set variables in the Terraform configuration from a file. If "terraform.tfvars" or any ".auto.tfvars" files are present, they will be automatically loaded.]'
 }
 
 __taint() {

--- a/examples/azure-2-vms-loadbalancer-lbrules/README.md
+++ b/examples/azure-2-vms-loadbalancer-lbrules/README.md
@@ -14,7 +14,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your .gitignore file.
 

--- a/examples/azure-cdn-with-storage-account/README.md
+++ b/examples/azure-cdn-with-storage-account/README.md
@@ -20,7 +20,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/examples/azure-encrypt-running-linux-vm/README.md
+++ b/examples/azure-encrypt-running-linux-vm/README.md
@@ -34,7 +34,7 @@ You may leave the provider block in the `main.tf`, as it is in this template, or
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your .gitignore file.
 

--- a/examples/azure-search-create/README.md
+++ b/examples/azure-search-create/README.md
@@ -18,7 +18,7 @@ You may leave the provider block in the `main.tf`, as it is in this template, or
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/examples/azure-servicebus-create-topic-and-subscription/README.md
+++ b/examples/azure-servicebus-create-topic-and-subscription/README.md
@@ -12,7 +12,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/examples/azure-spark-and-cassandra-on-centos/README.md
+++ b/examples/azure-spark-and-cassandra-on-centos/README.md
@@ -52,7 +52,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/examples/azure-sql-database/README.md
+++ b/examples/azure-sql-database/README.md
@@ -14,7 +14,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 ## variables.tf
 The `variables.tf` file contains all of the input parameters that the user can specify when deploying this Terraform template.

--- a/examples/azure-traffic-manager-vm/README.md
+++ b/examples/azure-traffic-manager-vm/README.md
@@ -19,7 +19,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/examples/azure-vm-from-user-image/README.md
+++ b/examples/azure-vm-from-user-image/README.md
@@ -16,7 +16,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/examples/azure-vm-simple-linux-managed-disk/README.md
+++ b/examples/azure-vm-simple-linux-managed-disk/README.md
@@ -14,7 +14,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 ## variables.tf
 The `variables.tf` file contains all of the input parameters that the user can specify when deploying this Terraform template.

--- a/examples/azure-vm-specialized-vhd-existing-vnet/README.md
+++ b/examples/azure-vm-specialized-vhd-existing-vnet/README.md
@@ -27,7 +27,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 ## variables.tf
 The `variables.tf` file contains all of the input parameters that the user can specify when deploying this Terraform template.

--- a/examples/azure-vmss-ubuntu/README.md
+++ b/examples/azure-vmss-ubuntu/README.md
@@ -14,7 +14,7 @@ You may leave the provider block in the `main.tf`, as it is in this template, or
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 ## variables.tf
 The `variables.tf` file contains all of the input parameters that the user can specify when deploying this Terraform template.

--- a/examples/azure-vnet-to-vnet-peering/README.md
+++ b/examples/azure-vnet-to-vnet-peering/README.md
@@ -14,7 +14,7 @@ You may leave the provider block in the `main.tf`, as it is in this template, or
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/examples/azure-vnet-two-subnets/README.md
+++ b/examples/azure-vnet-two-subnets/README.md
@@ -12,7 +12,7 @@ This data is outputted when `terraform apply` is called, and can be queried usin
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 ## variables.tf
 The `variables.tf` file contains all of the input parameters that the user can specify when deploying this Terraform template.

--- a/examples/azure-wordpress-mysql-replication/README.md
+++ b/examples/azure-wordpress-mysql-replication/README.md
@@ -33,7 +33,7 @@ You may leave the provider block in the `main.tf`, as it is in this template, or
 Azure requires that an application is added to Azure Active Directory to generate the `client_id`, `client_secret`, and `tenant_id` needed by Terraform (`subscription_id` can be recovered from your Azure account details). Please go [here](https://www.terraform.io/docs/providers/azurerm/) for full instructions on how to create this to populate your `provider.tf` file.
 
 ## terraform.tfvars
-If a `terraform.tfvars` file is present in the current directory, Terraform automatically loads it to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use `-var-file` to load it.
+If a `terraform.tfvars` or any `.auto.tfvars` files are present in the current directory, Terraform automatically loads them to populate variables. We don't recommend saving usernames and password to version control, but you can create a local secret variables file and use the `-var-file` flag or the `.auto.tfvars` extension to load it.
 
 If you are committing this template to source control, please insure that you add this file to your `.gitignore` file.
 

--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -68,6 +68,7 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
    a [variable file](/docs/configuration/variables.html#variable-files). If
-  "terraform.tfvars" is present, it will be automatically loaded first. Any
-  files specified by `-var-file` override any values in a "terraform.tfvars".
-  This flag can be used multiple times.
+  any files matching "*.tfvars" are present, they will be automatically loaded
+  in alphabetical order. Any files specified by `-var-file` override any values
+  set automatically from files in the working directory. This flag can be used
+  multiple times.

--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -67,8 +67,9 @@ The command-line flags are all optional. The list of available flags are:
   specified via this flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-   a [variable file](/docs/configuration/variables.html#variable-files). If
-  any files matching "*.tfvars" are present, they will be automatically loaded
-  in alphabetical order. Any files specified by `-var-file` override any values
-  set automatically from files in the working directory. This flag can be used
-  multiple times.
+  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
+  directory, they will be automatically loaded. `terraform.tfvars` is loaded
+  first and the `.auto.tfvars` files after in alphabetical order. Any files
+  specified by `-var-file` override any values set automatically from files in
+  the working directory. This flag can be used multiple times.

--- a/website/docs/commands/import.html.md
+++ b/website/docs/commands/import.html.md
@@ -67,10 +67,10 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
    a [variable file](/docs/configuration/variables.html#variable-files). If
-  "terraform.tfvars" is present, it will be automatically loaded first. Any
-  files specified by `-var-file` override any values in a "terraform.tfvars".
-  This flag can be used multiple times. This is only useful with the `-config`
-  flag.
+  any file matching "*.tfvars" are present, they will be automatically loaded
+  in alphabetical order. Any files specified by `-var-file` override any values
+  set automatically from files in the working directory. This flag can be used
+  multiple times. This is only useful with the `-config` flag.
 
 ## Provider Configuration
 

--- a/website/docs/commands/import.html.md
+++ b/website/docs/commands/import.html.md
@@ -66,11 +66,13 @@ The command-line flags are all optional. The list of available flags are:
   specified via this flag. This is only useful with the `-config` flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-   a [variable file](/docs/configuration/variables.html#variable-files). If
-  any file matching "*.tfvars" are present, they will be automatically loaded
-  in alphabetical order. Any files specified by `-var-file` override any values
-  set automatically from files in the working directory. This flag can be used
-  multiple times. This is only useful with the `-config` flag.
+  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
+  directory, they will be automatically loaded. `terraform.tfvars` is loaded
+  first and the `.auto.tfvars` files after in alphabetical order. Any files
+  specified by `-var-file` override any values set automatically from files in
+  the working directory. This flag can be used multiple times. This is only
+  useful with the `-config` flag.
 
 ## Provider Configuration
 

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -73,9 +73,10 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
    a [variable file](/docs/configuration/variables.html#variable-files). If
-  "terraform.tfvars" is present, it will be automatically loaded first. Any
-  files specified by `-var-file` override any values in a "terraform.tfvars".
-  This flag can be used multiple times.
+   any files matching "*.tfvars" are present, they will be automatically loaded
+   in alphabetical order. Any files specified by `-var-file` override any values
+   set automatically from files in the working directory. This flag can be used
+   multiple times.
 
 ## Resource Targeting
 

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -72,11 +72,12 @@ The command-line flags are all optional. The list of available flags are:
   specified via this flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-   a [variable file](/docs/configuration/variables.html#variable-files). If
-   any files matching "*.tfvars" are present, they will be automatically loaded
-   in alphabetical order. Any files specified by `-var-file` override any values
-   set automatically from files in the working directory. This flag can be used
-   multiple times.
+  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
+  directory, they will be automatically loaded. `terraform.tfvars` is loaded
+  first and the `.auto.tfvars` files after in alphabetical order. Any files
+  specified by `-var-file` override any values set automatically from files in
+  the working directory. This flag can be used multiple times.
 
 ## Resource Targeting
 

--- a/website/docs/commands/refresh.html.markdown
+++ b/website/docs/commands/refresh.html.markdown
@@ -55,8 +55,9 @@ The command-line flags are all optional. The list of available flags are:
   specified via this flag.
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
-   a [variable file](/docs/configuration/variables.html#variable-files). If
-   any files matching "*.tfvars" are present, they will be automatically loaded
-   in alphabetical order. Any files specified by `-var-file` override any values
-   set automatically from files in the working directory. This flag can be used
-   multiple times.
+  a [variable file](/docs/configuration/variables.html#variable-files). If
+  a `terraform.tfvars` or any `.auto.tfvars` files are present in the current
+  directory, they will be automatically loaded. `terraform.tfvars` is loaded
+  first and the `.auto.tfvars` files after in alphabetical order. Any files
+  specified by `-var-file` override any values set automatically from files in
+  the working directory. This flag can be used multiple times.

--- a/website/docs/commands/refresh.html.markdown
+++ b/website/docs/commands/refresh.html.markdown
@@ -56,6 +56,7 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-var-file=foo` - Set variables in the Terraform configuration from
    a [variable file](/docs/configuration/variables.html#variable-files). If
-  "terraform.tfvars" is present, it will be automatically loaded first. Any
-  files specified by `-var-file` override any values in a "terraform.tfvars".
-  This flag can be used multiple times.
+   any files matching "*.tfvars" are present, they will be automatically loaded
+   in alphabetical order. Any files specified by `-var-file` override any values
+   set automatically from files in the working directory. This flag can be used
+   multiple times.

--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -256,10 +256,9 @@ $ TF_VAR_somemap='{foo = "bar", baz = "qux"}' terraform plan
 Variables can be collected in files and passed all at once using the
 `-var-file=foo.tfvars` flag.
 
-If a file named `terraform.tfvars` is present in the current directory,
-Terraform automatically loads it to populate variables. If the file is named
-something else, you can pass the path to the file using the `-var-file`
-flag.
+For all files which match `*.tfvars` present in the current directory,
+Terraform automatically loads it to populate variables. If the file is located
+somewhere else, you can pass the path to the file using the `-var-file` flag.
 
 Variables files use HCL or JSON to define variable values. Strings, lists or
 maps may be set in the same manner as the default value in a `variable` block
@@ -338,11 +337,18 @@ _bar.tfvars_
 baz = "bar"
 ```
 
-When they are passed in the following order:
+When they are read directly from the working directory, the files are evaluated
+in alphabetical order. The result will be that baz contains the value `foo`
+because `foo.tfvars` has the last definition loaded.
+
+When they are passed manually in the following order:
 
 ```shell
-$ terraform apply -var-file=foo.tfvars -var-file=bar.tfvars
+$ terraform apply -var-file=path/to/foo.tfvars -var-file=path/to/bar.tfvars
 ```
 
 The result will be that `baz` will contain the value `bar` because `bar.tfvars`
 has the last definition loaded.
+
+Definitions passed using the `-var-file` flag will always be evaluated after
+those in the working directory.

--- a/website/docs/configuration/variables.html.md
+++ b/website/docs/configuration/variables.html.md
@@ -256,9 +256,10 @@ $ TF_VAR_somemap='{foo = "bar", baz = "qux"}' terraform plan
 Variables can be collected in files and passed all at once using the
 `-var-file=foo.tfvars` flag.
 
-For all files which match `*.tfvars` present in the current directory,
-Terraform automatically loads it to populate variables. If the file is located
-somewhere else, you can pass the path to the file using the `-var-file` flag.
+For all files which match `terraform.tfvars` or `*.auto.tfvars` present in the
+current directory, Terraform automatically loads them to populate variables. If
+the file is located somewhere else, you can pass the path to the file using the
+`-var-file` flag.
 
 Variables files use HCL or JSON to define variable values. Strings, lists or
 maps may be set in the same manner as the default value in a `variable` block
@@ -337,14 +338,10 @@ _bar.tfvars_
 baz = "bar"
 ```
 
-When they are read directly from the working directory, the files are evaluated
-in alphabetical order. The result will be that baz contains the value `foo`
-because `foo.tfvars` has the last definition loaded.
-
-When they are passed manually in the following order:
+When they are passed in the following order:
 
 ```shell
-$ terraform apply -var-file=path/to/foo.tfvars -var-file=path/to/bar.tfvars
+$ terraform apply -var-file=foo.tfvars -var-file=bar.tfvars
 ```
 
 The result will be that `baz` will contain the value `bar` because `bar.tfvars`

--- a/website/intro/getting-started/variables.html.md
+++ b/website/intro/getting-started/variables.html.md
@@ -86,9 +86,9 @@ access_key = "foo"
 secret_key = "bar"
 ```
 
-If a `terraform.tfvars` file is present in the current directory,
-Terraform automatically loads it to populate variables. If the file is
-named something else, you can use the `-var-file` flag directly to
+For all files which match `terraform.tfvars` or `*.auto.tfvars` present in the
+current directory, Terraform automatically loads them to populate variables. If
+the file is named something else, you can use the `-var-file` flag directly to
 specify a file. These files are the same syntax as Terraform
 configuration files. And like Terraform configuration files, these files
 can also be JSON.

--- a/website/upgrade-guides/0-7.html.markdown
+++ b/website/upgrade-guides/0-7.html.markdown
@@ -233,4 +233,4 @@ This will give the map the effective value:
 }
 ```
 
-It's also possible to override the values in a variables file, either in any `*.tfvars` file or specified using the `-var-file` flag.
+It's also possible to override the values in a variables file, either in any `terraform.tfvars` file, an `.auto.tfvars` file, or specified using the `-var-file` flag.

--- a/website/upgrade-guides/0-7.html.markdown
+++ b/website/upgrade-guides/0-7.html.markdown
@@ -233,4 +233,4 @@ This will give the map the effective value:
 }
 ```
 
-It's also possible to override the values in a variables file, either in `terraform.tfvars` or specified using the `-var-file` flag.
+It's also possible to override the values in a variables file, either in any `*.tfvars` file or specified using the `-var-file` flag.


### PR DESCRIPTION
Resolves #1084

I based the behavior on the original discussion and mostly borrowed the logic from the loading of `*.tf` files. As for implementation details:
- Files are loaded in alphabetical order, with later files overriding earlier ones
- Any file loaded using a `-var-file` flag will override those loaded from the directory
- Uses the `isIgnoredFile` function from the `config` package (renamed to `IsIgnoredFile`)