### PR TITLE
fix integration between ALB and ECS

### DIFF
--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -510,6 +510,8 @@ func resourceAwsEcsServiceDelete(d *schema.ResourceData, meta interface{}) error
 func resourceAwsEcsLoadBalancerHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
+
+	buf.WriteString(fmt.Sprintf("%s-", m["target_group_arn"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["elb_name"].(string)))
 	buf.WriteString(fmt.Sprintf("%s-", m["container_name"].(string)))
 	buf.WriteString(fmt.Sprintf("%d-", m["container_port"].(int)))

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -511,6 +511,8 @@ func resourceAwsEcsLoadBalancerHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
+	// There are 2 types of load balancers: ELB/ALB
+	// In case of ELB `elb_name` is expected and for ALB `target_group_arn` is.
 	optionalLoadBalancerParams := []string{"target_group_arn", "elb_name"}
 
 	for i := range optionalLoadBalancerParams {

--- a/builtin/providers/aws/resource_aws_ecs_service.go
+++ b/builtin/providers/aws/resource_aws_ecs_service.go
@@ -511,8 +511,16 @@ func resourceAwsEcsLoadBalancerHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 
-	buf.WriteString(fmt.Sprintf("%s-", m["target_group_arn"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["elb_name"].(string)))
+	optionalLoadBalancerParams := []string{"target_group_arn", "elb_name"}
+
+	for i := range optionalLoadBalancerParams {
+		paramName := optionalLoadBalancerParams[i]
+
+		if m[paramName] != nil {
+			buf.WriteString(fmt.Sprintf("%s-", m[paramName].(string)))
+		}
+	}
+
 	buf.WriteString(fmt.Sprintf("%s-", m["container_name"].(string)))
 	buf.WriteString(fmt.Sprintf("%d-", m["container_port"].(int)))
 


### PR DESCRIPTION
For our ECS service definition we have this snippet at the
`load_balancer`.

The `target_group_arn` is being pupulated by an external service that
returns the arn based on a simple string from our microservices list.

If the arn changed, this would not cause a recreation of the service and
leaving a dangling pointer to an arn that does not exist anymore.

```
  load_balancer {
    target_group_arn  = "${lookup(var.target_group_mapping, element(values(var.microservices), count.index))}"
    container_name    = "${element(values(var.microservices), count.index)}"
    container_port    = "${var.container_port}"
  }
```

The fix is adding another field to the set that's creating the ELB/ALB
definition. From looking into the git history seems this code was
created prior to ALB thus not having this field available at the time.

Service is being recreated as expected, no other services are affected
(expected behavior)