### PR TITLE
Add `min_size` and `max_size` ASG fields

### DIFF
--- a/website/source/docs/providers/aws/r/launch_configuration.html.markdown
+++ b/website/source/docs/providers/aws/r/launch_configuration.html.markdown
@@ -76,6 +76,8 @@ resource "aws_launch_configuration" "as_conf" {
 resource "aws_autoscaling_group" "bar" {
   name                 = "terraform-asg-example"
   launch_configuration = "${aws_launch_configuration.as_conf.name}"
+  min_size             = 1
+  max_size             = 2
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
These are required fields
```
$ terraform plan
2 error(s) occurred:

* aws_autoscaling_group.bar: "max_size": required field is not set
* aws_autoscaling_group.bar: "min_size": required field is not set
```