### PR TITLE
provider/aws: Improve logging & docs for caller_identity

### DIFF
--- a/builtin/providers/aws/data_source_aws_caller_identity.go
+++ b/builtin/providers/aws/data_source_aws_caller_identity.go
@@ -40,16 +40,9 @@ func dataSourceAwsCallerIdentityRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error getting Caller Identity: %v", err)
 	}
 
-	log.Printf("[DEBUG] Reading Caller Identity.")
+	log.Printf("[DEBUG] Received Caller Identity: %s", res)
+
 	d.SetId(time.Now().UTC().String())
-
-	if *res.Account == "" {
-		log.Println("[DEBUG] No Account ID available, failing")
-		return fmt.Errorf("No AWS Account ID is available to the provider. Please ensure that\n" +
-			"skip_requesting_account_id is not set on the AWS provider.")
-	}
-
-	log.Printf("[DEBUG] Setting AWS Account ID to %s.", *res.Account)
 	d.Set("account_id", res.Account)
 	d.Set("arn", res.Arn)
 	d.Set("user_id", res.UserId)

--- a/website/source/docs/providers/aws/d/caller_identity.html.markdown
+++ b/website/source/docs/providers/aws/d/caller_identity.html.markdown
@@ -12,10 +12,6 @@ description: |-
 Use this data source to get the access to the effective Account ID, User ID, and ARN in
 which Terraform is authorized.
 
-~> **NOTE on `aws_caller_identity`:** - an Account ID is only available
-if `skip_requesting_account_id` is not set on the AWS provider. In such
-cases, the data source will return an error.
-
 ## Example Usage
 
 ```


### PR DESCRIPTION
This is a follow-up to https://github.com/hashicorp/terraform/pull/13092

I made the log message a bit more useful (also surprised this wasn't caught by `vet` - Printf w/out arguments 😮 ) and removed error handling which is IMO not necessary anymore since we make an explicit call that is not affected by provider configuration like `skip_requesting_account_id`.