### PR TITLE
provider/aws: Increase AMI retry timeouts

### DIFF
--- a/builtin/providers/aws/resource_aws_ami.go
+++ b/builtin/providers/aws/resource_aws_ami.go
@@ -18,8 +18,8 @@ import (
 )
 
 const (
-	AWSAMIRetryTimeout       = 20 * time.Minute
-	AWSAMIDeleteRetryTimeout = 20 * time.Minute
+	AWSAMIRetryTimeout       = 40 * time.Minute
+	AWSAMIDeleteRetryTimeout = 90 * time.Minute
 	AWSAMIRetryDelay         = 5 * time.Second
 	AWSAMIRetryMinTimeout    = 3 * time.Second
 )


### PR DESCRIPTION
This is to address the following test failures:

```
=== RUN   TestAccAWSAMIFromInstance
--- FAIL: TestAccAWSAMIFromInstance (1472.25s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_ami_from_instance.test: 1 error(s) occurred:
        
        * aws_ami_from_instance.test: Error waiting for AMI (ami-0e880918) to be ready: timeout while waiting for state to become 'available' (last state: 'pending', timeout: 20m0s)
    testing.go:344: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
```
```
=== RUN   TestAccAWSAMI_snapshotSize
--- FAIL: TestAccAWSAMI_snapshotSize (1236.76s)
    testing.go:344: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_ami.foo (destroy): 1 error(s) occurred:
        
        * aws_ami.foo: Error waiting for AMI (ami-0ff3656f) to be deleted: timeout while waiting for state to become 'destroyed' (last state: 'available', timeout: 20m0s)
```

### Acceptance test results

```
=== RUN   TestAccAWSAMI_basic
--- PASS: TestAccAWSAMI_basic (41.94s)
=== RUN   TestAccAWSAMI_snapshotSize
--- PASS: TestAccAWSAMI_snapshotSize (42.29s)
=== RUN   TestAccAWSAMIFromInstance
--- PASS: TestAccAWSAMIFromInstance (104.61s)
=== RUN   TestAccAWSAMILaunchPermission_Basic
--- PASS: TestAccAWSAMILaunchPermission_Basic (342.25s)
=== RUN   TestAccAWSAMICopy
--- PASS: TestAccAWSAMICopy (472.55s)
```

https://ci.hashicorp.engineering/viewLog.html?buildId=29868&buildTypeId=Terraform_ProviderAws&tab=buildLog