### PR TITLE
Removed newline from keybase username

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_user_login_profile_test.go
+++ b/builtin/providers/aws/resource_aws_iam_user_login_profile_test.go
@@ -242,8 +242,7 @@ resource "aws_iam_access_key" "user" {
 resource "aws_iam_user_login_profile" "user" {
         user = "${aws_iam_user.user.name}"
         pgp_key = <<EOF
-%s
-EOF
+%sEOF
 }
 `, r, p, key)
 }


### PR DESCRIPTION
This patch fixes ```TestAccAWSUserLoginProfile_keybase```

It removes the newline that was being added to the username being passed to the keybase getter.

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSUserLoginProfile'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/04 09:27:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSUserLoginProfile -timeout 120m
=== RUN   TestAccAWSUserLoginProfile_basic
--- PASS: TestAccAWSUserLoginProfile_basic (24.32s)
=== RUN   TestAccAWSUserLoginProfile_keybase
--- PASS: TestAccAWSUserLoginProfile_keybase (22.34s)
=== RUN   TestAccAWSUserLoginProfile_keybaseDoesntExist
--- PASS: TestAccAWSUserLoginProfile_keybaseDoesntExist (14.54s)
=== RUN   TestAccAWSUserLoginProfile_notAKey
--- PASS: TestAccAWSUserLoginProfile_notAKey (14.68s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	75.921s
```