### PR TITLE
Add support for StatusCake TriggerRate field

### DIFF
--- a/builtin/providers/statuscake/resource_statuscaketest.go
+++ b/builtin/providers/statuscake/resource_statuscaketest.go
@@ -70,6 +70,12 @@ func resourceStatusCakeTest() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+
+			"trigger_rate": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  5,
+			},
 		},
 	}
 }
@@ -87,6 +93,7 @@ func CreateTest(d *schema.ResourceData, meta interface{}) error {
 		ContactID:    d.Get("contact_id").(int),
 		Confirmation: d.Get("confirmations").(int),
 		Port:         d.Get("port").(int),
+		TriggerRate:  d.Get("trigger_rate").(int),
 	}
 
 	log.Printf("[DEBUG] Creating new StatusCake Test: %s", d.Get("website_name").(string))
@@ -151,6 +158,7 @@ func ReadTest(d *schema.ResourceData, meta interface{}) error {
 	d.Set("contact_id", testResp.ContactID)
 	d.Set("confirmations", testResp.Confirmation)
 	d.Set("port", testResp.Port)
+	d.Set("trigger_rate", testResp.TriggerRate)
 
 	return nil
 }
@@ -192,6 +200,9 @@ func getStatusCakeTestInput(d *schema.ResourceData) *statuscake.Test {
 	}
 	if v, ok := d.GetOk("port"); ok {
 		test.Port = v.(int)
+	}
+	if v, ok := d.GetOk("trigger_rate"); ok {
+		test.TriggerRate = v.(int)
 	}
 
 	defaultStatusCodes := "204, 205, 206, 303, 400, 401, 403, 404, 405, 406, " +

--- a/builtin/providers/statuscake/resource_statuscaketest_test.go
+++ b/builtin/providers/statuscake/resource_statuscaketest_test.go
@@ -73,6 +73,7 @@ func TestAccStatusCake_withUpdate(t *testing.T) {
 					resource.TestCheckResourceAttr("statuscake_test.google", "timeout", "40"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "contact_id", "0"),
 					resource.TestCheckResourceAttr("statuscake_test.google", "confirmations", "0"),
+					resource.TestCheckResourceAttr("statuscake_test.google", "trigger_rate", "20"),
 				),
 			},
 		},
@@ -139,6 +140,8 @@ func testAccTestCheckAttributes(rn string, test *statuscake.Test) resource.TestC
 				err = check(key, value, strconv.Itoa(test.ContactID))
 			case "confirmations":
 				err = check(key, value, strconv.Itoa(test.Confirmation))
+			case "trigger_rate":
+				err = check(key, value, strconv.Itoa(test.TriggerRate))
 			}
 
 			if err != nil {
@@ -170,6 +173,7 @@ resource "statuscake_test" "google" {
 	timeout = 10
 	contact_id = 43402
 	confirmations = 1
+	trigger_rate = 10
 }
 `
 
@@ -180,6 +184,7 @@ resource "statuscake_test" "google" {
 	test_type = "HTTP"
 	check_rate = 500
 	paused = true
+	trigger_rate = 20
 }
 `
 


### PR DESCRIPTION
This PR adds a new "TriggerRate" field to statuscake_test so that it can be passed to the StatusCake API.
