### PR TITLE
core: fix crash when computed nested map given in module block

### DIFF
--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -174,9 +174,15 @@ func (n *EvalVariableBlock) setUnknownVariableValueForPath(path string) error {
 	// Otherwise find the correct point in the tree and then set to unknown
 	var current interface{} = n.VariableValues[pathComponents[0]]
 	for i := 1; i < len(pathComponents); i++ {
-		switch current.(type) {
-		case []interface{}, []map[string]interface{}:
-			tCurrent := current.([]interface{})
+		switch tCurrent := current.(type) {
+		case []interface{}:
+			index, err := strconv.Atoi(pathComponents[i])
+			if err != nil {
+				return fmt.Errorf("Cannot convert %s to slice index in path %s",
+					pathComponents[i], path)
+			}
+			current = tCurrent[index]
+		case []map[string]interface{}:
 			index, err := strconv.Atoi(pathComponents[i])
 			if err != nil {
 				return fmt.Errorf("Cannot convert %s to slice index in path %s",
@@ -184,7 +190,6 @@ func (n *EvalVariableBlock) setUnknownVariableValueForPath(path string) error {
 			}
 			current = tCurrent[index]
 		case map[string]interface{}:
-			tCurrent := current.(map[string]interface{})
 			if val, hasVal := tCurrent[pathComponents[i]]; hasVal {
 				current = val
 				continue

--- a/terraform/eval_variable.go
+++ b/terraform/eval_variable.go
@@ -114,7 +114,6 @@ type EvalVariableBlock struct {
 	VariableValues map[string]interface{}
 }
 
-// TODO: test
 func (n *EvalVariableBlock) Eval(ctx EvalContext) (interface{}, error) {
 	// Clear out the existing mapping
 	for k, _ := range n.VariableValues {


### PR DESCRIPTION
This crash resulted because the type switch checked for either of two types but the type assertion within it assumed only one of them.
    
A straightforward (if inelegant) fix is to simply duplicate the relevant case block and change the type assertion, thus allowing the types to match up in all cases.
    
This fixes #13297.

(Also includes a basic test for this eval type, since it entirely lacked one before.)