### PR TITLE
provider/aws: Fix KMS Key reading with Exists method

### DIFF
--- a/builtin/providers/aws/resource_aws_kms_key.go
+++ b/builtin/providers/aws/resource_aws_kms_key.go
@@ -136,13 +136,6 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	resp, err := conn.DescribeKey(req)
 	if err != nil {
-		if awsErr, ok := err.(awserr.Error); ok {
-			if awsErr.Code() == "NotFoundException" {
-				log.Printf("[WARN] Removing KMS key %s: Key not found", d.Id())
-				d.SetId("")
-				return nil
-			}
-		}
 		return err
 	}
 	metadata := resp.KeyMetadata

--- a/builtin/providers/aws/resource_aws_kms_key.go
+++ b/builtin/providers/aws/resource_aws_kms_key.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -18,6 +19,7 @@ func resourceAwsKmsKey() *schema.Resource {
 		Read:   resourceAwsKmsKeyRead,
 		Update: resourceAwsKmsKeyUpdate,
 		Delete: resourceAwsKmsKeyDelete,
+		Exists: resourceAwsKmsKeyExists,
 
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -134,6 +136,13 @@ func resourceAwsKmsKeyRead(d *schema.ResourceData, meta interface{}) error {
 	}
 	resp, err := conn.DescribeKey(req)
 	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				log.Printf("[WARN] Removing KMS key %s: Key not found", d.Id())
+				d.SetId("")
+				return nil
+			}
+		}
 		return err
 	}
 	metadata := resp.KeyMetadata
@@ -366,6 +375,30 @@ func updateKmsKeyRotationStatus(conn *kms.KMS, d *schema.ResourceData) error {
 	}
 
 	return nil
+}
+
+func resourceAwsKmsKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*AWSClient).kmsconn
+
+	req := &kms.DescribeKeyInput{
+		KeyId: aws.String(d.Id()),
+	}
+	resp, err := conn.DescribeKey(req)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NotFoundException" {
+				return false, nil
+			}
+		}
+		return false, err
+	}
+	metadata := resp.KeyMetadata
+
+	if *metadata.KeyState == "PendingDeletion" {
+		return false, nil
+	}
+
+	return true, nil
 }
 
 func resourceAwsKmsKeyDelete(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Fixes #13322 by checking if the key Exists and offering to recreate if
not found, or pending delete