### PR TITLE
provider/aws: Increase subnet deletion timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -215,7 +215,7 @@ func resourceAwsSubnetDelete(d *schema.ResourceData, meta interface{}) error {
 	wait := resource.StateChangeConf{
 		Pending:    []string{"pending"},
 		Target:     []string{"destroyed"},
-		Timeout:    5 * time.Minute,
+		Timeout:    10 * time.Minute,
 		MinTimeout: 1 * time.Second,
 		Refresh: func() (interface{}, string, error) {
 			_, err := conn.DeleteSubnet(req)


### PR DESCRIPTION
This is to address the following test failure:
```
=== RUN   TestAccAWSALBListener_basic
--- FAIL: TestAccAWSALBListener_basic (487.90s)
    testing.go:344: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_subnet.alb_test[1] (destroy): 1 error(s) occurred:
        
        * aws_subnet.alb_test.1: Error deleting subnet: timeout while waiting for state to become 'destroyed' (last state: 'pending', timeout: 5m0s)
```