### PR TITLE
provider/aws: Increase launch_configuration creation timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -473,7 +473,7 @@ func resourceAwsLaunchConfigurationCreate(d *schema.ResourceData, meta interface
 
 	// IAM profiles can take ~10 seconds to propagate in AWS:
 	// http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#launch-instance-with-role-console
-	err = resource.Retry(30*time.Second, func() *resource.RetryError {
+	err = resource.Retry(90*time.Second, func() *resource.RetryError {
 		_, err := autoscalingconn.CreateLaunchConfiguration(&createLaunchConfigurationOpts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSAutoscalingPolicy_upgrade
--- FAIL: TestAccAWSAutoscalingPolicy_upgrade (31.56s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_launch_configuration.foobar: 1 error(s) occurred:
        
        * aws_launch_configuration.foobar: Error creating launch configuration: timeout while waiting for state to become 'success' (timeout: 30s)
```