### PR TITLE
provider/aws: Increase Beanstalk env 'ready' timeout

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment.go
@@ -125,7 +125,7 @@ func resourceAwsElasticBeanstalkEnvironment() *schema.Resource {
 			"wait_for_ready_timeout": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "10m",
+				Default:  "20m",
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
 					value := v.(string)
 					duration, err := time.ParseDuration(value)


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSBeanstalkEnv_basic
--- FAIL: TestAccAWSBeanstalkEnv_basic (606.92s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_environment.tfenvtest: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_environment.tfenvtest: Error waiting for Elastic Beanstalk Environment (e-jpqtfzywmh) to become ready: timeout while waiting for state to become 'Ready' (last state: 'Launching', timeout: 10m0s)
    testing.go:344: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_environment.tfenvtest (destroy): 1 error(s) occurred:
        
        * aws_elastic_beanstalk_environment.tfenvtest: InvalidParameterValue: Cannot terminate environment named tf-test-name-311080929528815735. It is currently pending creation.
            status code: 400, request id: 97ccb1b9-19c7-11e7-88cf-1b6eb6271a09
        
```