### PR TITLE
provider/aws: Fix wrong config in ES domain acceptance test

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain_test.go
@@ -228,10 +228,6 @@ func testAccESDomainConfig_complex(randInt int) string {
 resource "aws_elasticsearch_domain" "example" {
   domain_name = "tf-test-%d"
 
-  cluster_config {
-    instance_type = "r3.large.elasticsearch"
-  }
-
   advanced_options {
     "indices.fielddata.cache.size" = 80
   }
@@ -243,6 +239,7 @@ resource "aws_elasticsearch_domain" "example" {
   cluster_config {
     instance_count = 2
     zone_awareness_enabled = true
+    instance_type = "r3.large.elasticsearch"
   }
 
   snapshot_options {


### PR DESCRIPTION
This is to address the following test failure:
```
=== RUN   TestAccAWSElasticSearchDomain_complex
--- FAIL: TestAccAWSElasticSearchDomain_complex (1.64s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_elasticsearch_domain.example: 1 error(s) occurred:
        
        * aws_elasticsearch_domain.example: Only a single cluster_config block is expected
```

### After fix
```
=== RUN   TestAccAWSElasticSearchDomain_complex
--- PASS: TestAccAWSElasticSearchDomain_complex (1413.41s)
PASS
```