### PR TITLE
provider/aws: Add support for CustomOrigin timeouts to aws_cloudfront_distribution

### DIFF
--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure.go
@@ -773,21 +773,31 @@ func originCustomHeaderHash(v interface{}) int {
 }
 
 func expandCustomOriginConfig(m map[string]interface{}) *cloudfront.CustomOriginConfig {
-	return &cloudfront.CustomOriginConfig{
-		OriginProtocolPolicy: aws.String(m["origin_protocol_policy"].(string)),
-		HTTPPort:             aws.Int64(int64(m["http_port"].(int))),
-		HTTPSPort:            aws.Int64(int64(m["https_port"].(int))),
-		OriginSslProtocols:   expandCustomOriginConfigSSL(m["origin_ssl_protocols"].([]interface{})),
+
+	customOrigin := &cloudfront.CustomOriginConfig{
+		OriginProtocolPolicy:   aws.String(m["origin_protocol_policy"].(string)),
+		HTTPPort:               aws.Int64(int64(m["http_port"].(int))),
+		HTTPSPort:              aws.Int64(int64(m["https_port"].(int))),
+		OriginSslProtocols:     expandCustomOriginConfigSSL(m["origin_ssl_protocols"].([]interface{})),
+		OriginReadTimeout:      aws.Int64(int64(m["origin_read_timeout"].(int))),
+		OriginKeepaliveTimeout: aws.Int64(int64(m["origin_keepalive_timeout"].(int))),
 	}
+
+	return customOrigin
 }
 
 func flattenCustomOriginConfig(cor *cloudfront.CustomOriginConfig) map[string]interface{} {
-	return map[string]interface{}{
-		"origin_protocol_policy": *cor.OriginProtocolPolicy,
-		"http_port":              int(*cor.HTTPPort),
-		"https_port":             int(*cor.HTTPSPort),
-		"origin_ssl_protocols":   flattenCustomOriginConfigSSL(cor.OriginSslProtocols),
+
+	customOrigin := map[string]interface{}{
+		"origin_protocol_policy":   *cor.OriginProtocolPolicy,
+		"http_port":                int(*cor.HTTPPort),
+		"https_port":               int(*cor.HTTPSPort),
+		"origin_ssl_protocols":     flattenCustomOriginConfigSSL(cor.OriginSslProtocols),
+		"origin_read_timeout":      int(*cor.OriginReadTimeout),
+		"origin_keepalive_timeout": int(*cor.OriginKeepaliveTimeout),
 	}
+
+	return customOrigin
 }
 
 // Assemble the hash for the aws_cloudfront_distribution custom_origin_config
@@ -801,6 +811,9 @@ func customOriginConfigHash(v interface{}) int {
 	for _, v := range sortInterfaceSlice(m["origin_ssl_protocols"].([]interface{})) {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))
 	}
+	buf.WriteString(fmt.Sprintf("%d-", m["origin_keepalive_timeout"].(int)))
+	buf.WriteString(fmt.Sprintf("%d-", m["origin_read_timeout"].(int)))
+
 	return hashcode.String(buf.String())
 }
 

--- a/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
+++ b/builtin/providers/aws/cloudfront_distribution_configuration_structure_test.go
@@ -117,10 +117,12 @@ func originCustomHeaderConf2() map[string]interface{} {
 
 func customOriginConf() map[string]interface{} {
 	return map[string]interface{}{
-		"origin_protocol_policy": "http-only",
-		"http_port":              80,
-		"https_port":             443,
-		"origin_ssl_protocols":   customOriginSslProtocolsConf(),
+		"origin_protocol_policy":   "http-only",
+		"http_port":                80,
+		"https_port":               443,
+		"origin_ssl_protocols":     customOriginSslProtocolsConf(),
+		"origin_read_timeout":      30,
+		"origin_keepalive_timeout": 5,
 	}
 }
 
@@ -784,6 +786,12 @@ func TestCloudFrontStructure_expandCustomOriginConfig(t *testing.T) {
 	}
 	if *co.HTTPSPort != 443 {
 		t.Fatalf("Expected HTTPSPort to be 443, got %v", *co.HTTPSPort)
+	}
+	if *co.OriginReadTimeout != 30 {
+		t.Fatalf("Expected Origin Read Timeout to be 30, got %v", *co.OriginReadTimeout)
+	}
+	if *co.OriginKeepaliveTimeout != 5 {
+		t.Fatalf("Expected Origin Keepalive Timeout to be 5, got %v", *co.OriginKeepaliveTimeout)
 	}
 }
 

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceAwsCloudFrontDistribution() *schema.Resource {
@@ -355,6 +356,18 @@ func resourceAwsCloudFrontDistribution() *schema.Resource {
 									"https_port": {
 										Type:     schema.TypeInt,
 										Required: true,
+									},
+									"origin_keepalive_timeout": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      5,
+										ValidateFunc: validation.IntBetween(1, 60),
+									},
+									"origin_read_timeout": {
+										Type:         schema.TypeInt,
+										Optional:     true,
+										Default:      30,
+										ValidateFunc: validation.IntBetween(4, 60),
 									},
 									"origin_protocol_policy": {
 										Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
+++ b/builtin/providers/aws/resource_aws_cloudfront_distribution_test.go
@@ -27,7 +27,7 @@ func TestAccAWSCloudFrontDistribution_S3Origin(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
@@ -95,7 +95,7 @@ func TestAccAWSCloudFrontDistribution_customOrigin(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFrontDistributionCustomConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
@@ -118,7 +118,7 @@ func TestAccAWSCloudFrontDistribution_multiOrigin(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFrontDistributionMultiOriginConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
@@ -141,7 +141,7 @@ func TestAccAWSCloudFrontDistribution_noOptionalItemsConfig(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFrontDistributionNoOptionalItemsConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
@@ -165,7 +165,7 @@ func TestAccAWSCloudFrontDistribution_HTTP11Config(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFrontDistributionHTTP11Config,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
@@ -183,7 +183,7 @@ func TestAccAWSCloudFrontDistribution_IsIPV6EnabledConfig(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFrontDistributionIsIPV6EnabledConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
@@ -203,7 +203,7 @@ func TestAccAWSCloudFrontDistribution_noCustomErrorResponseConfig(t *testing.T) 
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCloudFrontDistributionDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudFrontDistributionNoCustomErroResponseInfo,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFrontDistributionExistence(
@@ -477,6 +477,8 @@ resource "aws_cloudfront_distribution" "custom_distribution" {
 			https_port = 443
 			origin_protocol_policy = "http-only"
 			origin_ssl_protocols = [ "SSLv3", "TLSv1" ]
+			origin_read_timeout = 30
+			origin_keepalive_timeout = 5
 		}
 	}
 	enabled = true
@@ -542,6 +544,7 @@ resource "aws_cloudfront_distribution" "multi_origin_distribution" {
 			https_port = 443
 			origin_protocol_policy = "http-only"
 			origin_ssl_protocols = [ "SSLv3", "TLSv1" ]
+			origin_keepalive_timeout = 45
 		}
 	}
 	enabled = true

--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -316,6 +316,10 @@ argument is not required.
     CloudFront to use when communicating with your origin over HTTPS. A list of
     one or more of `SSLv3`, `TLSv1`, `TLSv1.1`, and `TLSv1.2`.
 
+  * `origin_keepalive_timeout` - (Optional) The Custom KeepAlive timeout, in seconds. Value must be between `1` and `60`.
+
+  * `origin_read_timeout` - (Optional) The Custom Read timeout, in seconds. Value must be between `4` and `60`.
+
 ##### S3 Origin Config Arguments
 
 * `origin_access_identity` (Optional) - The [CloudFront origin access


### PR DESCRIPTION
Currently, any changes / deletions to aws_cloudfront resources with a custom_origin are completely broken

```
aws_cloudfront_distribution.custom_distribution: Destroying... (ID: EC5N584ZA1U1D)
Error applying plan:

1 error(s) occurred:

* aws_cloudfront_distribution.custom_distribution (destroy): 1 error(s) occurred:

* aws_cloudfront_distribution.custom_distribution: IllegalUpdate: OriginReadTimeout is required for updates.
	status code: 400, request id: dff72b5b-2a2a-11e7-8c7e-b353bd2f7989

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
```

I have decided that it is better to fix the error and let the users see the change than to hide it via a state migration

<img width="777" alt="screen shot 2017-04-11 at 00 55 15" src="https://cloud.githubusercontent.com/assets/227823/24884329/8f1622b2-1e51-11e7-8509-f6056db67661.png">
