### PR TITLE
provider/aws: Add support for evaluate_low_sample_count_percentiles to cloudwatch_metric_alarm

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_metric_alarm.go
@@ -105,6 +105,12 @@ func resourceAwsCloudWatchMetricAlarm() *schema.Resource {
 				Default:      "missing",
 				ValidateFunc: validation.StringInSlice([]string{"breaching", "notBreaching", "ignore", "missing"}, true),
 			},
+			"evaluate_low_sample_count_percentiles": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Computed:     true,
+				ValidateFunc: validation.StringInSlice([]string{"evaluate", "ignore"}, true),
+			},
 		},
 	}
 }
@@ -172,6 +178,7 @@ func resourceAwsCloudWatchMetricAlarmRead(d *schema.ResourceData, meta interface
 	d.Set("unit", a.Unit)
 	d.Set("extended_statistic", a.ExtendedStatistic)
 	d.Set("treat_missing_data", a.TreatMissingData)
+	d.Set("evaluate_low_sample_count_percentiles", a.EvaluateLowSampleCountPercentile)
 
 	return nil
 }
@@ -246,6 +253,10 @@ func getAwsCloudWatchPutMetricAlarmInput(d *schema.ResourceData) cloudwatch.PutM
 
 	if v, ok := d.GetOk("extended_statistic"); ok {
 		params.ExtendedStatistic = aws.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("evaluate_low_sample_count_percentiles"); ok {
+		params.EvaluateLowSampleCountPercentile = aws.String(v.(string))
 	}
 
 	var alarmActions []*string

--- a/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_metric_alarm.html.markdown
@@ -85,6 +85,12 @@ The following arguments are supported:
 * `unit` - (Optional) The unit for the alarm's associated metric.
 * `extended_statistic` - (Optional) The percentile statistic for the metric associated with the alarm. Specify a value between p0.0 and p100.
 * `treat_missing_data` - (Optional) Sets how this alarm is to handle missing data points. The following values are supported: `missing`, `ignore`, `breaching` and `notBreaching`. Defaults to `missing`.
+* `evaluate_low_sample_count_percentiles` - (Optional) Used only for alarms
+based on percentiles. If you specify `ignore`, the alarm state will not
+change during periods with too few data points to be statistically significant.
+If you specify `evaluate` or omit this parameter, the alarm will always be
+evaluated and possibly change state no matter how many data points are available.
+The following values are supported: `ignore`, and `evaluate`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
<img width="721" alt="screen shot 2017-04-05 at 15 28 24" src="https://cloud.githubusercontent.com/assets/227823/24705429/8d60eae2-1a14-11e7-8afd-01476d6cfb09.png">
