### PR TITLE
provider/openstack: Add support for 'value_specs' options to...

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_servergroup_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_servergroup_v2.go
@@ -41,6 +41,11 @@ func resourceComputeServerGroupV2() *schema.Resource {
 				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 			},
+			"value_specs": &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -52,10 +57,14 @@ func resourceComputeServerGroupV2Create(d *schema.ResourceData, meta interface{}
 		return fmt.Errorf("Error creating OpenStack compute client: %s", err)
 	}
 
-	createOpts := &servergroups.CreateOpts{
-		Name:     d.Get("name").(string),
-		Policies: resourceServerGroupPoliciesV2(d),
+	createOpts := ServerGroupCreateOpts{
+		servergroups.CreateOpts{
+			Name:     d.Get("name").(string),
+			Policies: resourceServerGroupPoliciesV2(d),
+		},
+		MapValueSpecs(d),
 	}
+
 	log.Printf("[DEBUG] Create Options: %#v", createOpts)
 	newSG, err := servergroups.Create(computeClient, createOpts).Extract()
 	if err != nil {

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/keypairs"
+	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/servergroups"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/firewalls"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/policies"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/extensions/fwaas/rules"
@@ -248,6 +249,18 @@ func (opts RuleCreateOpts) ToRuleCreateMap() (map[string]interface{}, error) {
 	}
 
 	return b, nil
+}
+
+// ServerGroupCreateOpts represents the attributes used when creating a new router.
+type ServerGroupCreateOpts struct {
+	servergroups.CreateOpts
+	ValueSpecs map[string]string `json:"value_specs,omitempty"`
+}
+
+// ToServerGroupCreateMap casts a CreateOpts struct to a map.
+// It overrides routers.ToServerGroupCreateMap to add the ValueSpecs field.
+func (opts ServerGroupCreateOpts) ToServerGroupCreateMap() (map[string]interface{}, error) {
+	return BuildRequest(opts, "server_group")
 }
 
 // SubnetCreateOpts represents the attributes used when creating a new subnet.

--- a/website/source/docs/providers/openstack/r/compute_servergroup_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/compute_servergroup_v2.html.markdown
@@ -35,6 +35,8 @@ The following arguments are supported:
     the Policies section for more information. Changing this creates a new
     server group.
 
+* `value_specs` - (Optional) Map of additional options.
+
 ## Policies
 
 * `affinity` - All instances/servers launched in this group will be hosted on


### PR DESCRIPTION
... `openstack_compute_servergroup_v2`
Refactor to use common `types.go` and `MapValueSpecs function`.
Added supporting website documentation.