### PR TITLE
Unify s3 client code

### DIFF
--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -29,16 +29,12 @@ func TestBackend_impl(t *testing.T) {
 }
 
 func TestBackendConfig(t *testing.T) {
-	// This test just instantiates the client. Shouldn't make any actual
-	// requests nor incur any costs.
-
+	testACC(t)
 	config := map[string]interface{}{
 		"region":     "us-west-1",
 		"bucket":     "tf-test",
 		"key":        "state",
 		"encrypt":    true,
-		"access_key": "ACCESS_KEY",
-		"secret_key": "SECRET_KEY",
 		"lock_table": "dynamoTable",
 	}
 
@@ -58,11 +54,11 @@ func TestBackendConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error when requesting credentials")
 	}
-	if credentials.AccessKeyID != "ACCESS_KEY" {
-		t.Fatalf("Incorrect Access Key Id was populated")
+	if credentials.AccessKeyID == "" {
+		t.Fatalf("No Access Key Id was populated")
 	}
-	if credentials.SecretAccessKey != "SECRET_KEY" {
-		t.Fatalf("Incorrect Secret Access Key was populated")
+	if credentials.SecretAccessKey == "" {
+		t.Fatalf("No Secret Access Key was populated")
 	}
 }
 

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -160,6 +160,14 @@ type AWSClient struct {
 	wafconn               *waf.WAF
 }
 
+func (c *AWSClient) S3() *s3.S3 {
+	return c.s3conn
+}
+
+func (c *AWSClient) DynamoDB() *dynamodb.DynamoDB {
+	return c.dynamodbconn
+}
+
 // Client configures and returns a fully initialized AWSClient
 func (c *Config) Client() (interface{}, error) {
 	// Get the auth and region. This can fail if keys/regions were not

--- a/state/state.go
+++ b/state/state.go
@@ -94,9 +94,9 @@ func LockWithContext(ctx context.Context, s State, info *LockInfo) (string, erro
 			return "", err
 		}
 
-		if le.Info.ID == "" {
-			// the lock has no ID, something is wrong so don't keep trying
-			return "", fmt.Errorf("lock error missing ID: %s", err)
+		if le == nil || le.Info == nil || le.Info.ID == "" {
+			// If we dont' have a complete LockError, there's something wrong with the lock
+			return "", err
 		}
 
 		if postLockHook != nil {


### PR DESCRIPTION
Use the aws provider code to create the clients for the s3 backend, so
that all the behavior matches that of the provider.

Add getters for the AWSClient s3.S3 and dynamodb.DynamoDB clients so the
s3 remote-state backend can use all the same initialization code as the
aws provider.