### PR TITLE
Bump Statuscake deps to support TriggerRate

### DIFF
--- a/vendor/github.com/DreamItGetIT/statuscake/responses.go
+++ b/vendor/github.com/DreamItGetIT/statuscake/responses.go
@@ -43,6 +43,7 @@ type detailResponse struct {
 	ProcessingOn    string   `json:"ProcessingOn"`
 	DownTimes       int      `json:"DownTimes,string"`
 	Sensitive       bool     `json:"Sensitive"`
+	TriggerRate     int      `json:"string,TriggerRate"`
 }
 
 func (d *detailResponse) test() *Test {
@@ -64,5 +65,6 @@ func (d *detailResponse) test() *Test {
 		FindString:    d.FindString,
 		DoNotFind:     d.DoNotFind,
 		Port:          d.Port,
+		TriggerRate:   d.TriggerRate,
 	}
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -367,10 +367,10 @@
 			"revision": "edd0930276e7f1a5f2cf3e7835b5dc42a3217669"
 		},
 		{
-			"checksumSHA1": "oHtkxzPF9DIWqua2uA5MiVFRq+Q=",
+			"checksumSHA1": "jtSV16UIYcS+MTy2bor1Nd+6tM8=",
 			"path": "github.com/DreamItGetIT/statuscake",
-			"revision": "93fe653ce590267167708b20d7f49e0cc7021d99",
-			"revisionTime": "2017-02-15T23:13:05Z"
+			"revision": "2eaa583e3badecb05ab0e963ed19f3d7f1a23273",
+			"revisionTime": "2017-04-07T12:51:49Z"
 		},
 		{
 			"checksumSHA1": "nomT+8bvze/Qmc0tK0r0mwgHV6M=",


### PR DESCRIPTION
Results of the tests:

```
% make testacc TEST=./builtin/providers/statuscake
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/07 15:59:55 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/statuscake -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccStatusCake_basic
--- PASS: TestAccStatusCake_basic (2.85s)
=== RUN   TestAccStatusCake_tcp
--- PASS: TestAccStatusCake_tcp (2.32s)
=== RUN   TestAccStatusCake_withUpdate
--- PASS: TestAccStatusCake_withUpdate (6.90s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/statuscake	12.078s
```