### PR TITLE
provider/aws: Fix some Acc tests by skipping final snaphot in Redshift

### DIFF
--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -487,6 +487,7 @@ resource "aws_redshift_cluster" "test_cluster" {
   master_password = "T3stPass"
   node_type = "dc1.large"
   cluster_type = "single-node"
+	skip_final_snapshot = true
 }`
 
 var testAccKinesisFirehoseDeliveryStreamConfig_RedshiftBasic = testAccKinesisFirehoseDeliveryStreamBaseRedshiftConfig + `

--- a/builtin/providers/aws/resource_aws_redshift_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_redshift_cluster_test.go
@@ -703,6 +703,7 @@ func testAccAWSRedshiftClusterConfig_loggingDisabled(rInt int) string {
 		automated_snapshot_retention_period = 0
 		allow_version_upgrade = false
 		enable_logging = false
+		skip_final_snapshot = true
 	}`, rInt)
 }
 


### PR DESCRIPTION
Redshift was changed to not skip snapshots by default, so our configs
were out of date and causing errors in destroy (thus leaking redshifts)

This changes the configs to skip snapshots, which should at least fix:

- `TestAccAWSKinesisFirehoseDeliveryStream_RedshiftConfigUpdates`
- `TestAccAWSRedshiftCluster_loggingEnabled`

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRedshiftCluster_loggingEnabled -timeout 120m
=== RUN   TestAccAWSRedshiftCluster_loggingEnabled
--- PASS: TestAccAWSRedshiftCluster_loggingEnabled (741.60s)
```