### PR TITLE
P aws tests

### DIFF
--- a/builtin/providers/aws/data_source_aws_ecs_task_definition_test.go
+++ b/builtin/providers/aws/data_source_aws_ecs_task_definition_test.go
@@ -15,10 +15,10 @@ func TestAccAWSEcsDataSource_ecsTaskDefinition(t *testing.T) {
 			resource.TestStep{
 				Config: testAccCheckAwsEcsTaskDefinitionDataSourceConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "id", regexp.MustCompile("^arn:aws:ecs:us-west-2:[0-9]{12}:task-definition/mongodb:[1-9]*[0-9]$")),
+					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "id", regexp.MustCompile("^arn:aws:ecs:us-west-2:[0-9]{12}:task-definition/mongodb:[1-9][0-9]*$")),
 					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "family", "mongodb"),
 					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "network_mode", "bridge"),
-					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "revision", regexp.MustCompile("^[1-9]*[0-9]$")),
+					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "revision", regexp.MustCompile("^[1-9][0-9]*$")),
 					resource.TestCheckResourceAttr("data.aws_ecs_task_definition.mongo", "status", "ACTIVE"),
 					resource.TestMatchResourceAttr("data.aws_ecs_task_definition.mongo", "task_role_arn", regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/mongo_role$")),
 				),

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -446,7 +446,6 @@ func resourceAwsAutoscalingGroupRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("health_check_type", g.HealthCheckType)
 	d.Set("launch_configuration", g.LaunchConfigurationName)
 	d.Set("load_balancers", flattenStringList(g.LoadBalancerNames))
-	d.Set("target_group_arns", flattenStringList(g.TargetGroupARNs))
 
 	if err := d.Set("suspended_processes", flattenAsgSuspendedProcesses(g.SuspendedProcesses)); err != nil {
 		log.Printf("[WARN] Error setting suspended_processes for %q: %s", d.Id(), err)

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -445,15 +445,6 @@ func TestAccAWSAutoScalingGroup_ALB_TargetGroups(t *testing.T) {
 						"aws_autoscaling_group.bar", "target_group_arns.#", "1"),
 				),
 			},
-
-			resource.TestStep{
-				Config: testAccAWSAutoScalingGroupConfig_ALB_TargetGroup_pre,
-				Check: resource.ComposeAggregateTestCheckFunc(
-					testAccCheckAWSAutoScalingGroupExists("aws_autoscaling_group.bar", &group),
-					resource.TestCheckResourceAttr(
-						"aws_autoscaling_group.bar", "target_group_arns.#", "0"),
-				),
-			},
 		},
 	})
 }


### PR DESCRIPTION
Two more aws tests now pass. 
```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSEcsDataSource_ecsTaskDefinition'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/05 08:57:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSEcsDataSource_ecsTaskDefinition -timeout 120m
=== RUN   TestAccAWSEcsDataSource_ecsTaskDefinition
--- PASS: TestAccAWSEcsDataSource_ecsTaskDefinition (21.97s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	21.997s
```

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSAutoScalingGroup_ALB_TargetGroups'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/05 15:56:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSAutoScalingGroup_ALB_TargetGroups -timeout 120m
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups (116.55s)
=== RUN   TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity
--- PASS: TestAccAWSAutoScalingGroup_ALB_TargetGroups_ELBCapacity (363.60s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	480.180s```

