### PR TITLE
Detect and reject unknown attributes in "connection" blocks

### DIFF
--- a/terraform/node_resource_validate.go
+++ b/terraform/node_resource_validate.go
@@ -129,17 +129,29 @@ func (n *NodeValidatableResourceInstance) EvalTree() EvalNode {
 	// Validate all the provisioners
 	for _, p := range n.Config.Provisioners {
 		var provisioner ResourceProvisioner
-		seq.Nodes = append(seq.Nodes, &EvalGetProvisioner{
-			Name:   p.Type,
-			Output: &provisioner,
-		}, &EvalInterpolate{
-			Config:   p.RawConfig.Copy(),
-			Resource: resource,
-			Output:   &config,
-		}, &EvalValidateProvisioner{
-			Provisioner: &provisioner,
-			Config:      &config,
-		})
+		var connConfig *ResourceConfig
+		seq.Nodes = append(
+			seq.Nodes,
+			&EvalGetProvisioner{
+				Name:   p.Type,
+				Output: &provisioner,
+			},
+			&EvalInterpolate{
+				Config:   p.RawConfig.Copy(),
+				Resource: resource,
+				Output:   &config,
+			},
+			&EvalInterpolate{
+				Config:   p.ConnInfo.Copy(),
+				Resource: resource,
+				Output:   &connConfig,
+			},
+			&EvalValidateProvisioner{
+				Provisioner: &provisioner,
+				Config:      &config,
+				ConnConfig:  &connConfig,
+			},
+		)
 	}
 
 	return seq


### PR DESCRIPTION
Since the validation of connection blocks is delegated to the communicator selected by `type`, we were not previously doing any validation of the attribute names in these blocks until running provisioners during apply.

Proper validation here requires us to already have the instance state, since the final connection info is a merge of values provided in config with values assigned automatically by the resource. However, we can do some basic name validation to catch typos during the validation pass, even though semantic validation and checking for missing attributes will still wait until the provisioner is instantiated.

This fixes #6582 as much as we reasonably can.