### PR TITLE
provider/google: Add node_pool field in resource_container_cluster

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"regexp"
 
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/googleapi"
@@ -23,12 +24,6 @@ func resourceContainerCluster() *schema.Resource {
 		Delete: resourceContainerClusterDelete,
 
 		Schema: map[string]*schema.Schema{
-			"initial_node_count": &schema.Schema{
-				Type:     schema.TypeInt,
-				Required: true,
-				ForceNew: true,
-			},
-
 			"master_auth": &schema.Schema{
 				Type:     schema.TypeList,
 				Required: true,
@@ -93,6 +88,12 @@ func resourceContainerCluster() *schema.Resource {
 			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
+			},
+
+			"initial_node_count": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -292,6 +293,36 @@ func resourceContainerCluster() *schema.Resource {
 				Computed: true,
 			},
 
+			"node_pool": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				ForceNew: true, // TODO(danawillow): Add ability to add/remove nodePools
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"initial_node_count": &schema.Schema{
+							Type:     schema.TypeInt,
+							Required: true,
+							ForceNew: true,
+						},
+
+						"name": &schema.Schema{
+							Type:          schema.TypeString,
+							Optional:      true,
+							Computed:      true,
+							ConflictsWith: []string{"node_pool.name_prefix"},
+							ForceNew:      true,
+						},
+
+						"name_prefix": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+
 			"project": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -439,6 +470,33 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		}
 	}
 
+	nodePoolsCount := d.Get("node_pool.#").(int)
+	if nodePoolsCount > 0 {
+		nodePools := make([]*container.NodePool, 0, nodePoolsCount)
+		for i := 0; i < nodePoolsCount; i++ {
+			prefix := fmt.Sprintf("node_pool.%d", i)
+
+			nodeCount := d.Get(prefix + ".initial_node_count").(int)
+
+			var name string
+			if v, ok := d.GetOk(prefix + ".name"); ok {
+				name = v.(string)
+			} else if v, ok := d.GetOk(prefix + ".name_prefix"); ok {
+				name = resource.PrefixedUniqueId(v.(string))
+			} else {
+				name = resource.UniqueId()
+			}
+
+			nodePool := &container.NodePool{
+				Name:             name,
+				InitialNodeCount: int64(nodeCount),
+			}
+
+			nodePools = append(nodePools, nodePool)
+		}
+		cluster.NodePools = nodePools
+	}
+
 	req := &container.CreateClusterRequest{
 		Cluster: cluster,
 	}
@@ -523,6 +581,7 @@ func resourceContainerClusterRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("network", d.Get("network").(string))
 	d.Set("subnetwork", cluster.Subnetwork)
 	d.Set("node_config", flattenClusterNodeConfig(cluster.NodeConfig))
+	d.Set("node_pool", flattenClusterNodePools(d, cluster.NodePools))
 
 	if igUrls, err := getInstanceGroupUrlsFromManagerUrls(config, cluster.InstanceGroupUrls); err != nil {
 		return err
@@ -640,4 +699,21 @@ func flattenClusterNodeConfig(c *container.NodeConfig) []map[string]interface{} 
 	}
 
 	return config
+}
+
+func flattenClusterNodePools(d *schema.ResourceData, c []*container.NodePool) []map[string]interface{} {
+	count := len(c)
+
+	nodePools := make([]map[string]interface{}, 0, count)
+
+	for i, np := range c {
+		nodePool := map[string]interface{}{
+			"name":               np.Name,
+			"name_prefix":        d.Get(fmt.Sprintf("node_pool.%d.name_prefix", i)),
+			"initial_node_count": np.InitialNodeCount,
+		}
+		nodePools = append(nodePools, nodePool)
+	}
+
+	return nodePools
 }

--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -85,6 +85,8 @@ resource "google_container_cluster" "primary" {
 * `node_config` -  (Optional) The machine type and image to use for all nodes in
     this cluster
 
+* `node_pool` - (Optional) List of node pools associated with this cluster.
+
 * `node_version` - (Optional) The Kubernetes version on the nodes. Also affects
     the initial master version on cluster creation. Updates affect nodes only.
     Defaults to the default version set by GKE which is not necessarily the latest
@@ -155,6 +157,16 @@ addons_config {
   }
 }
 ```
+
+**Node Pool** supports the following arguments:
+
+* `initial_node_count` - (Required) The initial node count for the pool.
+
+* `name` - (Optional) The name of the node pool. If left blank, Terraform will
+    auto-generate a unique name.
+
+* `name_prefix` - (Optional) Creates a unique name for the node pool beginning
+    with the specified prefix. Conflicts with `name`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
As @paddyforan and I discussed offline, even though nodepools could be their own resource, it makes more sense to keep track of them inside the cluster resource. Each nodepool belongs to exactly one cluster, some of the update methods on nodepools are actually part of the clusters API, and the creation of a cluster without a specified nodepool will create a default one that we might want terraform to be able to manage.

For this PR, I've just included the minimum functionality. In follow-ups I'll add the ability to add and remove nodepools from a cluster and add more fields to the node_pool schema.