### PR TITLE
helper/schema: Clarify the expectations for DefaultFunc

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -62,10 +62,20 @@ type Schema struct {
 	DiffSuppressFunc SchemaDiffSuppressFunc
 
 	// If this is non-nil, then this will be a default value that is used
-	// when this item is not set in the configuration/state.
+	// when this item is not set in the configuration.
 	//
-	// DefaultFunc can be specified if you want a dynamic default value.
-	// Only one of Default or DefaultFunc can be set.
+	// DefaultFunc can be specified to compute a dynamic default.
+	// Only one of Default or DefaultFunc can be set. If DefaultFunc is
+	// used then its return value should be stable to avoid generating
+	// confusing/perpetual diffs.
+	//
+	// Changing either Default or the return value of DefaultFunc can be
+	// a breaking change, especially if the attribute in question has
+	// ForceNew set. If a default needs to change to align with changing
+	// assumptions in an upstream API then it may be necessary to also use
+	// the MigrateState function on the resource to change the state to match,
+	// or have the Read function adjust the state value to align with the
+	// new default.
 	//
 	// If Required is true above, then Default cannot be set. DefaultFunc
 	// can be set with Required. If the DefaultFunc returns nil, then there


### PR DESCRIPTION
Discussion in #9512 revealed that some of the comments here were inaccurate and that the comments here did not paint a complete enough picture of the behavior and expectations of `Default` and `DefaultFunc`.

This is a comments-only change that aims to clarify the situation and call attention to the fact that the defaults only affect the handling of the configuration and that changes to defaults may require migration of
existing resource states.

This closes #9512.