### PR TITLE
vcd provider: adds support for setting OVF guest properties in vcd_vapp resource

### DIFF
--- a/builtin/providers/vcd/provider_test.go
+++ b/builtin/providers/vcd/provider_test.go
@@ -47,4 +47,13 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("VCD_VDC"); v == "" {
 		t.Fatal("VCD_VDC must be set for acceptance tests")
 	}
+	if v := os.Getenv("VCD_TEMPLATE"); v == "" {
+		t.Fatal("VCD_TEMPLATE must be set for acceptance tests")
+	}
+	if v := os.Getenv("VCD_CATALOG"); v == "" {
+		t.Fatal("VCD_CATALOG must be set for acceptance tests")
+	}
+	if v := os.Getenv("VCD_NET"); v == "" {
+		t.Fatal("VCD_NET must be set for acceptance tests")
+	}
 }

--- a/builtin/providers/vcd/resource_vcd_vapp.go
+++ b/builtin/providers/vcd/resource_vcd_vapp.go
@@ -213,9 +213,8 @@ func resourceVcdVAppUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("guest_properties") {
 		_, nraw := d.GetChange("guest_properties")
-		tmp := nraw.(map[string]interface{})
 		guest_properties := make(map[string]string)
-		for k, v := range tmp {
+		for k, v := range nraw.(map[string]interface{}) {
 			guest_properties[k] = v.(string)
 		}
 		task, err := vapp.SetOvf(guest_properties)

--- a/builtin/providers/vcd/resource_vcd_vapp_test.go
+++ b/builtin/providers/vcd/resource_vcd_vapp_test.go
@@ -48,6 +48,30 @@ func TestAccVcdVApp_PowerOff(t *testing.T) {
 	})
 }
 
+func TestAccVcdVApp_GuestProperties(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVcdVAppDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(testAccCheckVcdVApp_guestProperties,
+					os.Getenv("VCD_TEMPLATE"),
+					os.Getenv("VCD_CATALOG"),
+					os.Getenv("VCD_NET")),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"vcd_vapp.foobar", "name", "foobar"),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp.foobar", "guest_properties.role", "bazbox"),
+					resource.TestCheckResourceAttr(
+						"vcd_vapp.foobar", "guest_properties.team", "TeamFoo"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckVcdVAppExists(n string, vapp *govcd.VApp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -176,5 +200,20 @@ resource "vcd_vapp" "foobar" {
 	cpus = 1
 	ip = "10.10.102.160"
 	power_on = false
+}
+`
+
+const testAccCheckVcdVApp_guestProperties = `
+resource "vcd_vapp" "foobar" {
+  name = "foobar"
+  template_name = "%s"
+  catalog_name = "%s"
+  network_name = "%s"
+  memory = 1024
+  cpus = 1
+  guest_properties = {
+	  role="bazbox"
+	  team="TeamFoo"
+  }
 }
 `

--- a/website/source/docs/providers/vcd/r/vapp.html.markdown
+++ b/website/source/docs/providers/vcd/r/vapp.html.markdown
@@ -34,6 +34,10 @@ resource "vcd_vapp" "web" {
     env     = "staging"
     version = "v1"
   }
+
+  guest_properties {
+    role     = "web"
+  }
 }
 ```
 
@@ -57,4 +61,7 @@ The following arguments are supported:
   `dhcp_pool` set with at least one available IP then this will be set with
   DHCP.
 * `metadata` - (Optional) Key value map of metadata to assign to this vApp
+* `guest_properties` - (Optional) Key value map of properties to pass into the
+  OVF environment of the virtual machine in this vApp. Useful for driving
+  configuration management.
 * `power_on` - (Optional) A boolean value stating if this vApp should be powered on. Default to `true`


### PR DESCRIPTION
In VMware, virtual machines can have properties set at create-time which are queryable from within the VM. These properties can be queried by tools within a VM to automate configuration, e.g. automatically applying a specific role manifest within Puppet.

This pull request includes updated documentation and acceptance tests.