### PR TITLE
provider/aws: Raise timeout for deleting APIG REST API

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_rest_api.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_rest_api.go
@@ -172,7 +172,7 @@ func resourceAwsApiGatewayRestApiDelete(d *schema.ResourceData, meta interface{}
 	conn := meta.(*AWSClient).apigateway
 	log.Printf("[DEBUG] Deleting API Gateway: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteRestApi(&apigateway.DeleteRestApiInput{
 			RestApiId: aws.String(d.Id()),
 		})


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSAPIGatewayMethod_basic
--- FAIL: TestAccAWSAPIGatewayMethod_basic (668.06s)
    testing.go:344: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_rest_api.test (destroy): 1 error(s) occurred:
        
        * aws_api_gateway_rest_api.test: timeout while waiting for state to become 'success' (timeout: 5m0s)
        
        State: aws_api_gateway_rest_api.test:
          ID = vun0yge9i3
          binary_media_types.# = 0
          created_date = 2017-04-06T05:34:23Z
          description = 
          name = tf-acc-test-apig-method-664371681136790516
          root_resource_id = egvg409hn4
```