### PR TITLE
Added chomp interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -462,11 +462,12 @@ func interpolationFuncCeil() ast.Function {
 
 // interpolationFuncChomp removes trailing newlines from the given string
 func interpolationFuncChomp() ast.Function {
+	newlines := regexp.MustCompile(`(?:\r\n?|\n)*\z`)
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeString},
 		ReturnType: ast.TypeString,
 		Callback: func(args []interface{}) (interface{}, error) {
-			return strings.TrimRight(args[0].(string), "\n"), nil
+			return newlines.ReplaceAllString(args[0].(string), ""), nil
 		},
 	}
 }

--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -58,6 +58,7 @@ func Funcs() map[string]ast.Function {
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64sha256": interpolationFuncBase64Sha256(),
 		"ceil":         interpolationFuncCeil(),
+		"chomp":        interpolationFuncChomp(),
 		"cidrhost":     interpolationFuncCidrHost(),
 		"cidrnetmask":  interpolationFuncCidrNetmask(),
 		"cidrsubnet":   interpolationFuncCidrSubnet(),
@@ -455,6 +456,17 @@ func interpolationFuncCeil() ast.Function {
 		ReturnType: ast.TypeInt,
 		Callback: func(args []interface{}) (interface{}, error) {
 			return int(math.Ceil(args[0].(float64))), nil
+		},
+	}
+}
+
+// interpolationFuncChomp removes trailing newlines from the given string
+func interpolationFuncChomp() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			return strings.TrimRight(args[0].(string), "\n"), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -370,6 +370,32 @@ func TestInterpolateFuncCeil(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncChomp(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${chomp()}`,
+				nil,
+				true,
+			},
+
+			{
+				`${chomp("hello world")}`,
+				"hello world",
+				false,
+			},
+
+			{
+				`${chomp("goodbye\ncruel\nworld\n")}`,
+				`goodbye
+cruel
+world`,
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncMap(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -386,10 +386,38 @@ func TestInterpolateFuncChomp(t *testing.T) {
 			},
 
 			{
-				`${chomp("goodbye\ncruel\nworld\n")}`,
-				`goodbye
-cruel
-world`,
+				fmt.Sprintf(`${chomp("%s")}`, "goodbye\ncruel\nworld"),
+				"goodbye\ncruel\nworld",
+				false,
+			},
+
+			{
+				fmt.Sprintf(`${chomp("%s")}`, "goodbye\r\nwindows\r\nworld"),
+				"goodbye\r\nwindows\r\nworld",
+				false,
+			},
+
+			{
+				fmt.Sprintf(`${chomp("%s")}`, "goodbye\ncruel\nworld\n"),
+				"goodbye\ncruel\nworld",
+				false,
+			},
+
+			{
+				fmt.Sprintf(`${chomp("%s")}`, "goodbye\ncruel\nworld\n\n\n\n"),
+				"goodbye\ncruel\nworld",
+				false,
+			},
+
+			{
+				fmt.Sprintf(`${chomp("%s")}`, "goodbye\r\nwindows\r\nworld\r\n"),
+				"goodbye\r\nwindows\r\nworld",
+				false,
+			},
+
+			{
+				fmt.Sprintf(`${chomp("%s")}`, "goodbye\r\nwindows\r\nworld\r\n\r\n\r\n\r\n"),
+				"goodbye\r\nwindows\r\nworld",
 				false,
 			},
 		},

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -156,6 +156,8 @@ The supported built-in functions are:
   * `ceil(float)` - Returns the least integer value greater than or equal
       to the argument.
 
+  * `chomp(string)` - Removes trailing newlines from the given string.
+
   * `cidrhost(iprange, hostnum)` - Takes an IP address range in CIDR notation
     and creates an IP address with the given host number. For example,
     `cidrhost("10.0.0.0/8", 2)` returns `10.0.0.2`.


### PR DESCRIPTION
This PR adds an interpolation function to remove trailing newline(s). This is useful for including inline configuration from files maintained by editors that add a final trailing newline (a reasonable default).

Example (untested in real HCL):

```
api_key = "${chomp(file($var.api_key_file))}"
```