### PR TITLE
providers/aws: Update ElasticTranscoderPreset to have default for MaxFrameRate

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_transcoder_preset.go
+++ b/builtin/providers/aws/resource_aws_elastic_transcoder_preset.go
@@ -213,6 +213,7 @@ func resourceAwsElasticTranscoderPreset() *schema.Resource {
 						"max_frame_rate": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Default:  "30",
 							ForceNew: true,
 						},
 						"max_height": &schema.Schema{


### PR DESCRIPTION
Updates `video.max_frame_rate` attribute to supply a default of `30`, matching our Docs and AWS docs:

- http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/create-preset.html

Fixes test `TestAccAWSElasticTranscoderPreset_basic`
