### PR TITLE
provider/opc: Remove 'model' from instance networking

### DIFF
--- a/builtin/providers/opc/resource_instance_test.go
+++ b/builtin/providers/opc/resource_instance_test.go
@@ -67,7 +67,6 @@ func TestAccOPCInstance_sharedNetworking(t *testing.T) {
 					// Check Data Source to validate networking attributes
 					resource.TestCheckResourceAttr(dataName, "shared_network", "true"),
 					resource.TestCheckResourceAttr(dataName, "nat.#", "1"),
-					resource.TestCheckResourceAttr(dataName, "model", "e1000"),
 					resource.TestCheckResourceAttr(dataName, "sec_lists.#", "1"),
 					resource.TestCheckResourceAttr(dataName, "name_servers.#", "0"),
 					resource.TestCheckResourceAttr(dataName, "vnic_sets.#", "0"),
@@ -205,7 +204,6 @@ resource "opc_compute_instance" "test" {
   tags = ["tag1", "tag2"]
   networking_info {
     index = 0
-    model = "e1000"
     nat = ["ippool:/oracle/public/ippool"]
     shared_network = true
   }

--- a/website/source/docs/providers/opc/r/opc_compute_ip_reservation.html.markdown
+++ b/website/source/docs/providers/opc/r/opc_compute_ip_reservation.html.markdown
@@ -30,6 +30,8 @@ The following arguments are supported:
 (if true), or may be returned to the pool and replaced with a different IP address when an instance is restarted, or
 deleted and recreated (if false).
 
+* `name` - (Optional) Name of the IP Reservation. Will be generated if unspecified.
+
 * `tags` - (Optional) List of tags that may be applied to the IP reservation.
 
 ## Import


### PR DESCRIPTION
Removes `model` as a configurable attribute in instance networking.

Also adds missing `name` attribute from `ip_reservation` docs

```
$ make testacc TEST=./builtin/providers/opc TESTARGS="-run=TestAccOPCInstance_ipNetwork"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/06 12:53:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/opc -v -run=TestAccOPCInstance_ipNetwork -timeout 120m
=== RUN   TestAccOPCInstance_ipNetwork
--- PASS: TestAccOPCInstance_ipNetwork (258.69s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/opc    258.721s
```

```
$ make testacc TEST=./builtin/providers/opc TESTARGS="-run=TestAccOPCInstance_sharedNetworking"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/06 12:58:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/opc -v -run=TestAccOPCInstance_sharedNetworking -timeout 120m
=== RUN   TestAccOPCInstance_sharedNetworking
--- PASS: TestAccOPCInstance_sharedNetworking (253.15s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/opc    253.180s
```