### PR TITLE
Fix context key types in schema

### DIFF
--- a/helper/schema/backend.go
+++ b/helper/schema/backend.go
@@ -28,8 +28,8 @@ type Backend struct {
 	config *ResourceData
 }
 
-const (
-	backendConfigKey = iota
+var (
+	backendConfigKey = contextKey("data")
 )
 
 // FromContextBackendConfig extracts a ResourceData with the configuration

--- a/helper/schema/backend.go
+++ b/helper/schema/backend.go
@@ -29,7 +29,7 @@ type Backend struct {
 }
 
 var (
-	backendConfigKey = contextKey("data")
+	backendConfigKey = contextKey("backend config")
 )
 
 // FromContextBackendConfig extracts a ResourceData with the configuration

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -46,25 +46,25 @@ type Provisioner struct {
 	stopOnce      sync.Once
 }
 
-// These constants are the keys that can be used to access data in
-// the context parameters for Provisioners.
-const (
-	connDataInvalid int = iota
+// Keys that can be used to access data in the context parameters for
+// Provisioners.
+var (
+	connDataInvalid = contextKey("data invalid")
 
 	// This returns a *ResourceData for the connection information.
 	// Guaranteed to never be nil.
-	ProvConnDataKey
+	ProvConnDataKey = contextKey("provider conn data")
 
 	// This returns a *ResourceData for the config information.
 	// Guaranteed to never be nil.
-	ProvConfigDataKey
+	ProvConfigDataKey = contextKey("provider config data")
 
 	// This returns a terraform.UIOutput. Guaranteed to never be nil.
-	ProvOutputKey
+	ProvOutputKey = contextKey("provider output")
 
 	// This returns the raw InstanceState passed to Apply. Guaranteed to
 	// be set, but may be nil.
-	ProvRawStateKey
+	ProvRawStateKey = contextKey("provider raw state")
 )
 
 // InternalValidate should be called to validate the structure

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -23,6 +23,9 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// type used for schema package context keys
+type contextKey string
+
 // Schema is used to describe the structure of a value.
 //
 // Read the documentation of the struct elements for important details.


### PR DESCRIPTION
helper/schema uses `context.WithValue` in a couple places with a primitive key type.

Primitive types should be avoided as keys, because without a namespaced type, packages could have colliding key values (`golint` warns on this, but we are far from being able to run that globally)