### PR TITLE
provider/opc: Bootable Storage Volumes

### DIFF
--- a/builtin/providers/opc/import_storage_volume_test.go
+++ b/builtin/providers/opc/import_storage_volume_test.go
@@ -118,6 +118,28 @@ func TestAccOPCStorageVolume_importImageListEntry(t *testing.T) {
 	})
 }
 
+func TestAccOPCStorageVolume_importLowLatency(t *testing.T) {
+	resourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	config := testAccStorageVolumeLowLatency(rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccOPCStorageVolume_importFromSnapshot(t *testing.T) {
 	resourceName := "opc_compute_storage_volume.test"
 	rInt := acctest.RandInt()

--- a/builtin/providers/opc/import_storage_volume_test.go
+++ b/builtin/providers/opc/import_storage_volume_test.go
@@ -1,0 +1,141 @@
+package opc
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOPCStorageVolume_importBasic(t *testing.T) {
+	resourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	config := fmt.Sprintf(testAccStorageVolumeBasic, rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageVolume_importComplete(t *testing.T) {
+	resourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	config := fmt.Sprintf(testAccStorageVolumeComplete, rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageVolume_importMaxSize(t *testing.T) {
+	resourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	config := fmt.Sprintf(testAccStorageVolumeBasicMaxSize, rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageVolume_importBootable(t *testing.T) {
+	resourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	config := fmt.Sprintf(testAccStorageVolumeBootable, rInt, rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageVolume_importImageListEntry(t *testing.T) {
+	resourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	config := fmt.Sprintf(testAccStorageVolumeBootable, rInt, rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccOPCStorageVolume_importFromSnapshot(t *testing.T) {
+	resourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	config := testAccStorageVolumeFromSnapshot(rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/opc/resource_storage_volume.go
+++ b/builtin/providers/opc/resource_storage_volume.go
@@ -15,6 +15,9 @@ func resourceOPCStorageVolume() *schema.Resource {
 		Read:   resourceOPCStorageVolumeRead,
 		Update: resourceOPCStorageVolumeUpdate,
 		Delete: resourceOPCStorageVolumeDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -232,7 +235,7 @@ func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) erro
 
 	d.Set("name", result.Name)
 	d.Set("description", result.Description)
-	d.Set("storage", result.Properties[0])
+	d.Set("storage_type", result.Properties[0])
 	size, err := strconv.Atoi(result.Size)
 	if err != nil {
 		return err

--- a/builtin/providers/opc/resource_storage_volume.go
+++ b/builtin/providers/opc/resource_storage_volume.go
@@ -42,47 +42,24 @@ func resourceOPCStorageVolume() *schema.Resource {
 				}, true),
 			},
 
-			"snapshot": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-				Computed: true,
-			},
-
-			"snapshot_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				Computed: true,
-				ForceNew: true,
-			},
-
-			"snapshot_account": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
-
 			"bootable": {
-				Type:     schema.TypeList,
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+
+			"image_list": {
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				MaxItems: 1,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						"image_list": {
-							Type:     schema.TypeString,
-							Required: true,
-							ForceNew: true,
-						},
+			},
 
-						"image_list_entry": {
-							Type:     schema.TypeInt,
-							Optional: true,
-							ForceNew: true,
-							Default:  -1,
-						},
-					},
-				},
+			"image_list_entry": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  -1,
 			},
 
 			"tags": tagsOptionalSchema(),
@@ -139,27 +116,29 @@ func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) er
 	description := d.Get("description").(string)
 	size := d.Get("size").(int)
 	storageType := d.Get("storage_type").(string)
+	bootable := d.Get("bootable").(bool)
+	imageList := d.Get("image_list").(string)
+	imageListEntry := d.Get("image_list_entry").(int)
+
+	if bootable == true {
+		if imageList == "" {
+			return fmt.Errorf("Error: A Bootable Volume must have an Image List!")
+		}
+
+		if imageListEntry == -1 {
+			return fmt.Errorf("Error: A Bootable Volume must have an Image List Entry!")
+		}
+	}
 
 	input := compute.CreateStorageVolumeInput{
-		Name:        name,
-		Description: description,
-		Size:        strconv.Itoa(size),
-		Properties:  []string{storageType},
-		Tags:        getStringList(d, "tags"),
-	}
-
-	expandOPCStorageVolumeOptionalFields(d, &input)
-
-	if v, ok := d.GetOk("snapshot"); ok {
-		input.Snapshot = v.(string)
-	}
-
-	if v, ok := d.GetOk("snapshot_account"); ok {
-		input.SnapshotAccount = v.(string)
-	}
-
-	if v, ok := d.GetOk("snapshot_id"); ok {
-		input.SnapshotID = v.(string)
+		Name:           name,
+		Description:    description,
+		Size:           strconv.Itoa(size),
+		Properties:     []string{storageType},
+		Bootable:       bootable,
+		ImageList:      imageList,
+		ImageListEntry: imageListEntry,
+		Tags:           getStringList(d, "tags"),
 	}
 
 	info, err := client.CreateStorageVolume(&input)
@@ -178,13 +157,17 @@ func resourceOPCStorageVolumeUpdate(d *schema.ResourceData, meta interface{}) er
 	description := d.Get("description").(string)
 	size := d.Get("size").(int)
 	storageType := d.Get("storage_type").(string)
+	imageList := d.Get("image_list").(string)
+	imageListEntry := d.Get("image_list_entry").(int)
 
 	input := compute.UpdateStorageVolumeInput{
-		Name:        name,
-		Description: description,
-		Size:        strconv.Itoa(size),
-		Properties:  []string{storageType},
-		Tags:        getStringList(d, "tags"),
+		Name:           name,
+		Description:    description,
+		Size:           strconv.Itoa(size),
+		Properties:     []string{storageType},
+		ImageList:      imageList,
+		ImageListEntry: imageListEntry,
+		Tags:           getStringList(d, "tags"),
 	}
 	_, err := client.UpdateStorageVolume(&input)
 	if err != nil {
@@ -220,20 +203,18 @@ func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", result.Name)
 	d.Set("description", result.Description)
 	d.Set("storage", result.Properties[0])
-	d.Set("snapshot", result.Snapshot)
-	d.Set("snapshot_id", result.SnapshotID)
-	d.Set("snapshot_account", result.SnapshotAccount)
 	size, err := strconv.Atoi(result.Size)
 	if err != nil {
 		return err
 	}
 	d.Set("size", size)
+	d.Set("bootable", result.Bootable)
+	d.Set("image_list", result.ImageList)
+	d.Set("image_list_entry", result.ImageListEntry)
 
 	if err := setStringList(d, "tags", result.Tags); err != nil {
 		return err
 	}
-
-	flattenOPCStorageVolumeOptionalFields(d, result)
 
 	flattenOPCStorageVolumeComputedFields(d, result)
 
@@ -253,24 +234,6 @@ func resourceOPCStorageVolumeDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	return nil
-}
-
-func expandOPCStorageVolumeOptionalFields(d *schema.ResourceData, input *compute.CreateStorageVolumeInput) {
-	bootValue, bootExists := d.GetOk("bootable")
-	input.Bootable = bootExists
-	if bootExists {
-		configs := bootValue.([]interface{})
-		config := configs[0].(map[string]interface{})
-
-		input.ImageList = config["image_list"].(string)
-		input.ImageListEntry = config["image_list_entry"].(int)
-	}
-}
-
-func flattenOPCStorageVolumeOptionalFields(d *schema.ResourceData, result *compute.StorageVolumeInfo) {
-	d.Set("bootable", result.Bootable)
-	d.Set("image_list", result.ImageList)
-	d.Set("image_list_entry", result.ImageListEntry)
 }
 
 func flattenOPCStorageVolumeComputedFields(d *schema.ResourceData, result *compute.StorageVolumeInfo) {

--- a/builtin/providers/opc/resource_storage_volume.go
+++ b/builtin/providers/opc/resource_storage_volume.go
@@ -42,6 +42,26 @@ func resourceOPCStorageVolume() *schema.Resource {
 				}, true),
 			},
 
+			"snapshot": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+				Computed: true,
+			},
+
+			"snapshot_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+
+			"snapshot_account": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"bootable": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -141,6 +161,16 @@ func resourceOPCStorageVolumeCreate(d *schema.ResourceData, meta interface{}) er
 		Tags:           getStringList(d, "tags"),
 	}
 
+	if v, ok := d.GetOk("snapshot"); ok {
+		input.Snapshot = v.(string)
+	}
+	if v, ok := d.GetOk("snapshot_account"); ok {
+		input.SnapshotAccount = v.(string)
+	}
+	if v, ok := d.GetOk("snapshot_id"); ok {
+		input.SnapshotID = v.(string)
+	}
+
 	info, err := client.CreateStorageVolume(&input)
 	if err != nil {
 		return fmt.Errorf("Error creating storage volume %s: %s", name, err)
@@ -211,6 +241,10 @@ func resourceOPCStorageVolumeRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("bootable", result.Bootable)
 	d.Set("image_list", result.ImageList)
 	d.Set("image_list_entry", result.ImageListEntry)
+
+	d.Set("snapshot", result.Snapshot)
+	d.Set("snapshot_id", result.SnapshotID)
+	d.Set("snapshot_account", result.SnapshotAccount)
 
 	if err := setStringList(d, "tags", result.Tags); err != nil {
 		return err

--- a/builtin/providers/opc/resource_storage_volume_test.go
+++ b/builtin/providers/opc/resource_storage_volume_test.go
@@ -136,6 +136,27 @@ func TestAccOPCStorageVolume_ImageListEntry(t *testing.T) {
 	})
 }
 
+func TestAccOPCStorageVolume_LowLatency(t *testing.T) {
+	volumeResourceName := "opc_compute_storage_volume.test"
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(volumeResourceName, testAccCheckStorageVolumeDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccStorageVolumeLowLatency(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					opcResourceCheck(volumeResourceName, testAccCheckStorageVolumeExists),
+					resource.TestCheckResourceAttr(volumeResourceName, "storage_type", "/oracle/public/storage/latency"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccOPCStorageVolume_FromSnapshot(t *testing.T) {
 	volumeResourceName := "opc_compute_storage_volume.test"
 	rInt := acctest.RandInt()
@@ -159,8 +180,6 @@ func TestAccOPCStorageVolume_FromSnapshot(t *testing.T) {
 		},
 	})
 }
-
-// TODO: test Premium storage
 
 func testAccCheckStorageVolumeExists(state *OPCResourceState) error {
 	sv := state.Client.StorageVolumes()
@@ -301,4 +320,14 @@ func testAccStorageVolumeFromSnapshot(rInt int) string {
     size        = 5
     snapshot_id = "${opc_compute_storage_volume_snapshot.foo.snapshot_id}"
   }`, rInt, rInt, rInt)
+}
+
+func testAccStorageVolumeLowLatency(rInt int) string {
+	return fmt.Sprintf(`
+  resource "opc_compute_storage_volume" "test" {
+    name         = "test-acc-stor-vol-ll-%d"
+    description  = "Acc Test Storage Volume Low Latency"
+    storage_type = "/oracle/public/storage/latency"
+    size         = 5
+  }`, rInt)
 }

--- a/builtin/providers/opc/resource_storage_volume_test.go
+++ b/builtin/providers/opc/resource_storage_volume_test.go
@@ -160,6 +160,8 @@ func TestAccOPCStorageVolume_FromSnapshot(t *testing.T) {
 	})
 }
 
+// TODO: test Premium storage
+
 func testAccCheckStorageVolumeExists(state *OPCResourceState) error {
 	sv := state.Client.StorageVolumes()
 	volumeName := state.Attributes["name"]
@@ -270,9 +272,9 @@ resource "opc_compute_storage_volume" "test" {
 
 const testAccStorageVolumeBasicMaxSize = `
 resource "opc_compute_storage_volume" "test" {
-  name = "test-acc-stor-vol-%d"
+  name        = "test-acc-stor-vol-%d"
   description = "Provider Acceptance Tests Storage Volume Max Size"
-  size = 2048
+  size        = 2048
 }
 `
 
@@ -280,23 +282,23 @@ func testAccStorageVolumeFromSnapshot(rInt int) string {
 	return fmt.Sprintf(`
   // Initial Storage Volume to create snapshot with
   resource "opc_compute_storage_volume" "foo" {
-    name = "test-acc-stor-vol-%d"
+    name        = "test-acc-stor-vol-%d"
     description = "Acc Test intermediary storage volume for snapshot"
-    size = 5
+    size        = 5
   }
 
   resource "opc_compute_storage_volume_snapshot" "foo" {
     description = "testing-acc"
-    name = "test-acc-stor-snapshot-%d"
-    collocated = true
+    name        = "test-acc-stor-snapshot-%d"
+    collocated  = true
     volume_name = "${opc_compute_storage_volume.foo.name}"
   }
 
   // Create storage volume from snapshot
   resource "opc_compute_storage_volume" "test" {
-    name = "test-acc-stor-vol-final-%d"
+    name        = "test-acc-stor-vol-final-%d"
     description = "storage volume from snapshot"
-    size = 5
+    size        = 5
     snapshot_id = "${opc_compute_storage_volume_snapshot.foo.snapshot_id}"
   }`, rInt, rInt, rInt)
 }

--- a/builtin/providers/opc/resource_storage_volume_test.go
+++ b/builtin/providers/opc/resource_storage_volume_test.go
@@ -116,9 +116,10 @@ func TestAccOPCStorageVolume_Bootable(t *testing.T) {
 	})
 }
 
-func TestAccOPCStorageVolume_FromSnapshot(t *testing.T) {
+func TestAccOPCStorageVolume_ImageListEntry(t *testing.T) {
 	volumeResourceName := "opc_compute_storage_volume.test"
-	rInt := acctest.RandInt()
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccStorageVolumeImageListEntry, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -126,13 +127,9 @@ func TestAccOPCStorageVolume_FromSnapshot(t *testing.T) {
 		CheckDestroy: opcResourceCheck(volumeResourceName, testAccCheckStorageVolumeDestroyed),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccStorageVolumeFromSnapshot(rInt),
+				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					opcResourceCheck(volumeResourceName, testAccCheckStorageVolumeExists),
-					resource.TestCheckResourceAttr(volumeResourceName, "name", fmt.Sprintf("test-acc-stor-vol-final-%d", rInt)),
-					resource.TestCheckResourceAttrSet(volumeResourceName, "snapshot"),
-					resource.TestCheckResourceAttrSet(volumeResourceName, "snapshot_id"),
-					resource.TestCheckResourceAttr(volumeResourceName, "size", "5"),
 				),
 			},
 		},
@@ -206,17 +203,44 @@ resource "opc_compute_storage_volume" "test" {
 const testAccStorageVolumeBootable = `
 resource "opc_compute_image_list" "test" {
   name        = "test-acc-stor-vol-bootable-image-list-%d"
-  description = "Provider Acceptance Tests Storage Volume"
+  description = "Provider Acceptance Tests Storage Volume Bootable"
+}
+
+resource "opc_compute_image_list_entry" "test" {
+  name           = "${opc_compute_image_list.test.name}"
+  machine_images = [ "/oracle/public/oel_6.7_apaas_16.4.5_1610211300" ]
+  version        = 1
 }
 
 resource "opc_compute_storage_volume" "test" {
-  name        = "test-acc-stor-vol-bootable-%d"
-  description = "Provider Acceptance Tests Storage Volume"
-  size        = 2
-  tags        = ["bar", "foo"]
-  bootable {
-  	image_list = "${opc_compute_image_list.test.name}"
-  }
+  name             = "test-acc-stor-vol-bootable-%d"
+  description      = "Provider Acceptance Tests Storage Volume Bootable"
+  size             = 20
+  tags             = ["bar", "foo"]
+  bootable         = true
+  image_list       = "${opc_compute_image_list.test.name}"
+  image_list_entry = "${opc_compute_image_list_entry.test.version}"
+}
+`
+
+const testAccStorageVolumeImageListEntry = `
+resource "opc_compute_image_list" "test" {
+  name        = "test-acc-stor-vol-bootable-image-list-%d"
+  description = "Provider Acceptance Tests Storage Volume Image List Entry"
+}
+
+resource "opc_compute_image_list_entry" "test" {
+  name           = "${opc_compute_image_list.test.name}"
+  machine_images = [ "/oracle/public/oel_6.7_apaas_16.4.5_1610211300" ]
+  version        = 1
+}
+
+resource "opc_compute_storage_volume" "test" {
+  name             = "test-acc-stor-vol-bootable-%d"
+  description      = "Provider Acceptance Tests Storage Volume Image List Entry"
+  size             = 20
+  tags             = ["bar", "foo"]
+  image_list_entry = "${opc_compute_image_list_entry.test.version}"
 }
 `
 
@@ -227,29 +251,3 @@ resource "opc_compute_storage_volume" "test" {
   size = 2048
 }
 `
-
-func testAccStorageVolumeFromSnapshot(rInt int) string {
-	return fmt.Sprintf(`
-// Initial Storage Volume to create snapshot with
-resource "opc_compute_storage_volume" "foo" {
-  name = "test-acc-stor-vol-%d"
-  description = "Acc Test intermediary storage volume for snapshot"
-  size = 5
-}
-
-resource "opc_compute_storage_volume_snapshot" "foo" {
-  description = "testing-acc"
-  name = "test-acc-stor-snapshot-%d"
-  collocated = true
-  volume_name = "${opc_compute_storage_volume.foo.name}"
-}
-
-// Create storage volume from snapshot
-resource "opc_compute_storage_volume" "test" {
-  name = "test-acc-stor-vol-final-%d"
-  description = "storage volume from snapshot"
-  size = 5
-  snapshot_id = "${opc_compute_storage_volume_snapshot.foo.snapshot_id}"
-}
-`, rInt, rInt, rInt)
-}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1976,16 +1976,14 @@
 			"revisionTime": "2017-04-06T17:51:51Z"
 		},
 		{
-			"checksumSHA1": "DzK7lYwHt5Isq5Zf73cnQqBO2LI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/helper",
-			"revision": "98fdaf3c4bde245e21947487ba722c3d0abaccb2",
-			"revisionTime": "2017-03-29T21:19:34Z"
+			"revision": "5508daed82ecd55b71d45e8a149e99d24825e5bb",
+			"revisionTime": "2017-04-06T17:51:51Z"
 		},
 		{
-			"checksumSHA1": "AyNRs19Es9pDw2VMxVKWuLx3Afg=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
-			"revision": "98fdaf3c4bde245e21947487ba722c3d0abaccb2",
-			"revisionTime": "2017-03-29T21:19:34Z"
+			"revision": "5508daed82ecd55b71d45e8a149e99d24825e5bb",
+			"revisionTime": "2017-04-06T17:51:51Z"
 		},
 		{
 			"checksumSHA1": "b0nQutPMJHeUmz4SjpreotAo6Yk=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1976,11 +1976,13 @@
 			"revisionTime": "2017-04-06T17:51:51Z"
 		},
 		{
+			"checksumSHA1": "DzK7lYwHt5Isq5Zf73cnQqBO2LI=",
 			"path": "github.com/hashicorp/go-oracle-terraform/helper",
 			"revision": "5508daed82ecd55b71d45e8a149e99d24825e5bb",
 			"revisionTime": "2017-04-06T17:51:51Z"
 		},
 		{
+			"checksumSHA1": "AyNRs19Es9pDw2VMxVKWuLx3Afg=",
 			"path": "github.com/hashicorp/go-oracle-terraform/opc",
 			"revision": "5508daed82ecd55b71d45e8a149e99d24825e5bb",
 			"revisionTime": "2017-04-06T17:51:51Z"

--- a/website/source/docs/providers/opc/r/opc_compute_storage_volume.html.markdown
+++ b/website/source/docs/providers/opc/r/opc_compute_storage_volume.html.markdown
@@ -30,14 +30,20 @@ resource "opc_compute_image_list" "test" {
   description = "Description for the Image List"
 }
 
+resource "opc_compute_image_list_entry" "test" {
+  name           = "${opc_compute_image_list.test.name}"
+  machine_images = [ "/oracle/public/oel_6.7_apaas_16.4.5_1610211300" ]
+  version        = 1
+}
+
 resource "opc_compute_storage_volume" "test" {
-  name        = "storageVolume1"
-  description = "Description for the Bootable Storage Volume"
-  size        = 30
-  tags        = ["first", "second"]
-  bootable {
-  	image_list = "${opc_compute_image_list.test.name}"
-  }
+  name             = "storageVolume1"
+  description      = "Description for the Bootable Storage Volume"
+  size             = 30
+  tags             = ["first", "second"]
+  bootable         = true
+	image_list       = "${opc_compute_image_list.test.name}"
+  image_list_entry = "${opc_compute_image_list_entry.test.version}"
 }
 ```
 
@@ -49,15 +55,10 @@ The following arguments are supported:
 * `description` (Optional) The description of the storage volume.
 * `size` (Required) The size of this storage volume in GB. The allowed range is from 1 GB to 2 TB (2048 GB).
 * `storage_type` - (Optional) - The Type of Storage to provision. Possible values are `/oracle/public/storage/latency` or `/oracle/public/storage/default`. Defaults to `/oracle/public/storage/default`.
-* `bootable` - (Optional) A `bootable` block as defined below.
+* `bootable` - (Optional) Is the Volume Bootable? Defaults to `false`.
+* `image_list` - (Required) Defines an image list. Required if `bootable` is set to `true`.
+* `image_list_entry` - (Optional) Defines an image list entry. Required if `bootable` is set to `true`.
 * `tags` - (Optional) Comma-separated strings that tag the storage volume.
-* `snapshot` - (Optional) Name of the storage volume snapshot if this storage volume is a clone.
-* `snapshot_account` - (Optional) Account of the parent snapshot from which the storage volume is restored.
-* `snapshot_id` - (Optional) Id of the parent snapshot from which the storage volume is restored or cloned.
-
-`bootable` supports the following:
-* `image_list` - (Required) Defines an image list.
-* `image_list_entry` - (Optional) Defines an image list entry.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/opc/r/opc_compute_storage_volume.html.markdown
+++ b/website/source/docs/providers/opc/r/opc_compute_storage_volume.html.markdown
@@ -42,7 +42,7 @@ resource "opc_compute_storage_volume" "test" {
   size             = 30
   tags             = ["first", "second"]
   bootable         = true
-	image_list       = "${opc_compute_image_list.test.name}"
+  image_list       = "${opc_compute_image_list.test.name}"
   image_list_entry = "${opc_compute_image_list_entry.test.version}"
 }
 ```
@@ -56,8 +56,8 @@ The following arguments are supported:
 * `size` (Required) The size of this storage volume in GB. The allowed range is from 1 GB to 2 TB (2048 GB).
 * `storage_type` - (Optional) - The Type of Storage to provision. Possible values are `/oracle/public/storage/latency` or `/oracle/public/storage/default`. Defaults to `/oracle/public/storage/default`.
 * `bootable` - (Optional) Is the Volume Bootable? Defaults to `false`.
-* `image_list` - (Required) Defines an image list. Required if `bootable` is set to `true`.
-* `image_list_entry` - (Optional) Defines an image list entry. Required if `bootable` is set to `true`.
+* `image_list` - (Optional) Defines an image list. Required if `bootable` is set to `true`, optional if set to `false`.
+* `image_list_entry` - (Optional) Defines an image list entry. Required if `bootable` is set to `true`, optional if set to `false`.
 * `tags` - (Optional) Comma-separated strings that tag the storage volume.
 
 ## Attributes Reference


### PR DESCRIPTION
Tests pass:

```
$ envchain oracle make testacc TEST=./builtin/providers/opc/ TESTARGS='-run=TestAccOPCStorageVolume_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/06 19:41:33 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/opc/ -v -run=TestAccOPCStorageVolume_ -timeout 120m
=== RUN   TestAccOPCStorageVolume_Basic
--- PASS: TestAccOPCStorageVolume_Basic (24.21s)
=== RUN   TestAccOPCStorageVolume_Complete
--- PASS: TestAccOPCStorageVolume_Complete (20.74s)
=== RUN   TestAccOPCStorageVolume_MaxSize
--- PASS: TestAccOPCStorageVolume_MaxSize (22.76s)
=== RUN   TestAccOPCStorageVolume_Update
--- PASS: TestAccOPCStorageVolume_Update (31.46s)
=== RUN   TestAccOPCStorageVolume_Bootable
--- PASS: TestAccOPCStorageVolume_Bootable (31.51s)
=== RUN   TestAccOPCStorageVolume_ImageListEntry
--- PASS: TestAccOPCStorageVolume_ImageListEntry (26.96s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/opc	157.654s
```