### PR TITLE
Add support for remote port fowarding for SSH connections used by Provisioners

### DIFF
--- a/communicator/ssh/provisioner_test.go
+++ b/communicator/ssh/provisioner_test.go
@@ -127,3 +127,89 @@ func TestProvisioner_connInfoHostname(t *testing.T) {
 		t.Fatalf("bad %v", conf)
 	}
 }
+
+func TestProvisioner_connInfoRemoteForward(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":        "ssh",
+				"user":        "root",
+				"password":    "supersecret",
+				"private_key": "someprivatekeycontents",
+				"host":        "example.com",
+				"port":        "22",
+				"timeout":     "30s",
+
+				"bastion_host":   "example.com",
+				"remote_forward": "127.0.1.1:8080:127.0.0.1:80,8081:host:8081",
+			},
+		},
+	}
+
+	conf, err := parseConnectionInfo(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(conf.RemoteForwardVal) != 2 {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.RemoteForwardVal[0].BindPort != 8080 {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.RemoteForwardVal[0].BindHost != "127.0.1.1" {
+		t.Fatalf("bad %v", conf)
+	}
+
+	if conf.RemoteForwardVal[0].Port != 80 {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.RemoteForwardVal[0].Host != "127.0.0.1" {
+		t.Fatalf("bad %v", conf)
+	}
+
+	if conf.RemoteForwardVal[1].BindPort != 8081 {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.RemoteForwardVal[1].BindHost != "localhost" {
+		t.Fatalf("bad %v", conf)
+	}
+
+	if conf.RemoteForwardVal[1].Port != 8081 {
+		t.Fatalf("bad: %v", conf)
+	}
+
+	if conf.RemoteForwardVal[1].Host != "host" {
+		t.Fatalf("bad %v", conf)
+	}
+
+}
+
+func TestProvisioner_connInfoRemoteForwardNone(t *testing.T) {
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":        "ssh",
+				"user":        "root",
+				"password":    "supersecret",
+				"private_key": "someprivatekeycontents",
+				"host":        "example.com",
+				"port":        "22",
+				"timeout":     "30s",
+			},
+		},
+	}
+
+	conf, err := parseConnectionInfo(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if len(conf.RemoteForwardVal) != 0 {
+		t.Fatalf("bad: %v", conf)
+	}
+}

--- a/website/source/docs/provisioners/connection.html.markdown
+++ b/website/source/docs/provisioners/connection.html.markdown
@@ -80,6 +80,20 @@ provisioner "file" {
   only supported SSH authentication agent is
   [Pageant](http://the.earth.li/~sgtatham/putty/0.66/htmldoc/Chapter9.html#pageant).
 
+* `remote_forward` - The set of ports to forward from the remote host (the host
+  being provisioned) to a given host on the local side of the SSH connection (the side
+  running Terraform). The format is a comma separated list of
+  forward instructions similar to `ssh -R`, i.e. `[bind_address]:port:host:hostport`.
+  `bind_address` is the address to bind on the remote host. It is optional and defaults
+  to `localhost`. `port` is the listen port on the remote side of the SSH connection.
+  `host` is the host to connect to on the local side of the SSH connection.
+  `hostport` is the port to connect to on the local side of the SSH connection.
+  For example `localhost:8080:chef.example.com:80` will forward the port 8080 on the
+  remote host (the host being provisioned) to port 80 of `chef.example.com` on the
+  local side of the SSH connection (the host running Terraform). The feature is
+  useful during bootstrapping if the host being provisioned
+  does not yet have direct network access to required resources, e.g. a Chef Server.
+
 **Additional arguments only supported by the `winrm` connection type:**
 
 * `https` - Set to `true` to connect using HTTPS instead of HTTP.


### PR DESCRIPTION
During the bootstrapping phase the instances you are provisioning might not yet have
direct network connectivity to resources required for provisioning. If the node used
for provisioning has the required access, then by using SSH remote port forwarding
we can give the node being provisioned network access to the required resources.

This PR adds that capability for provisioners when using an SSH connection.

A new parameter is added to connection type for SSH connections only. The
parameter is used to specify a list of ports forward from host being
provisioned to the local side of the SSH connection (the side running Terraform).

The remote port forwarding is established when the SSH connection is made to
the host being provisioned and it torn down when the SSH connection terminates.

Failure to establish the remote port forwarding does not abort the provisioner,
but does generate a log warning message.