### PR TITLE
Fix validation of the `name_prefix` parameter of the `aws_alb` resource

### DIFF
--- a/builtin/providers/aws/resource_aws_alb.go
+++ b/builtin/providers/aws/resource_aws_alb.go
@@ -48,7 +48,7 @@ func resourceAwsAlb() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateElbName,
+				ValidateFunc: validateElbNamePrefix,
 			},
 
 			"internal": {

--- a/builtin/providers/aws/resource_aws_alb_test.go
+++ b/builtin/providers/aws/resource_aws_alb_test.go
@@ -112,7 +112,7 @@ func TestAccAWSALB_namePrefix(t *testing.T) {
 					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
 					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "name"),
 					resource.TestMatchResourceAttr("aws_alb.alb_test", "name",
-						regexp.MustCompile("^tf-lb")),
+						regexp.MustCompile("^tf-lb-")),
 				),
 			},
 		},
@@ -600,7 +600,7 @@ resource "aws_security_group" "alb_test" {
 func testAccAWSALBConfig_namePrefix() string {
 	return fmt.Sprintf(`
 resource "aws_alb" "alb_test" {
-  name_prefix     = "tf-lb"
+  name_prefix     = "tf-lb-"
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]


### PR DESCRIPTION
This parameter is being validated using the wrong validation function, which means that we are incorrectly disallowing a `name_prefix` value ending with a dash.