### PR TITLE
Add `name_prefix` to `aws_alb_target_group`

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_target_group.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
@@ -37,10 +38,18 @@ func resourceAwsAlbTargetGroup() *schema.Resource {
 			},
 
 			"name": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"name_prefix"},
+				ValidateFunc:  validateAwsAlbTargetGroupName,
+			},
+			"name_prefix": {
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
-				ValidateFunc: validateAwsAlbTargetGroupName,
+				ValidateFunc: validateAwsAlbTargetGroupNamePrefix,
 			},
 
 			"port": {
@@ -172,8 +181,17 @@ func resourceAwsAlbTargetGroup() *schema.Resource {
 func resourceAwsAlbTargetGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	elbconn := meta.(*AWSClient).elbv2conn
 
+	var groupName string
+	if v, ok := d.GetOk("name"); ok {
+		groupName = v.(string)
+	} else if v, ok := d.GetOk("name_prefix"); ok {
+		groupName = resource.PrefixedUniqueId(v.(string))
+	} else {
+		groupName = resource.PrefixedUniqueId("tf-")
+	}
+
 	params := &elbv2.CreateTargetGroupInput{
-		Name:     aws.String(d.Get("name").(string)),
+		Name:     aws.String(groupName),
 		Port:     aws.Int64(int64(d.Get("port").(int))),
 		Protocol: aws.String(d.Get("protocol").(string)),
 		VpcId:    aws.String(d.Get("vpc_id").(string)),
@@ -460,14 +478,6 @@ func validateAwsAlbTargetGroupHealthCheckProtocol(v interface{}, k string) (ws [
 	}
 
 	errors = append(errors, fmt.Errorf("%q must be either %q or %q", k, "HTTP", "HTTPS"))
-	return
-}
-
-func validateAwsAlbTargetGroupName(v interface{}, k string) (ws []string, errors []error) {
-	name := v.(string)
-	if len(name) > 32 {
-		errors = append(errors, fmt.Errorf("%q (%q) cannot be longer than '32' characters", k, name))
-	}
 	return
 }
 

--- a/builtin/providers/aws/resource_aws_alb_target_group_test.go
+++ b/builtin/providers/aws/resource_aws_alb_target_group_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -79,6 +80,45 @@ func TestAccAWSALBTargetGroup_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "health_check.0.matcher", "200-299"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.%", "1"),
 					resource.TestCheckResourceAttr("aws_alb_target_group.test", "tags.TestName", "TestAccAWSALBTargetGroup_basic"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_namePrefix(t *testing.T) {
+	var conf elbv2.TargetGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_namePrefix,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
+					resource.TestMatchResourceAttr("aws_alb_target_group.test", "name", regexp.MustCompile("^tf-")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSALBTargetGroup_generatedName(t *testing.T) {
+	var conf elbv2.TargetGroup
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb_target_group.test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBTargetGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBTargetGroupConfig_generatedName,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSALBTargetGroupExists("aws_alb_target_group.test", &conf),
 				),
 			},
 		},
@@ -715,3 +755,28 @@ resource "aws_vpc" "test" {
   }
 }`, targetGroupName, stickinessBlock)
 }
+
+const testAccAWSALBTargetGroupConfig_namePrefix = `
+resource "aws_alb_target_group" "test" {
+  name_prefix = "tf-"
+  port = 80
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+`
+
+const testAccAWSALBTargetGroupConfig_generatedName = `
+resource "aws_alb_target_group" "test" {
+  port = 80
+  protocol = "HTTP"
+  vpc_id = "${aws_vpc.test.id}"
+}
+
+resource "aws_vpc" "test" {
+  cidr_block = "10.0.0.0/16"
+}
+`

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -1154,3 +1154,19 @@ func validateDbOptionGroupNamePrefix(v interface{}, k string) (ws []string, erro
 	}
 	return
 }
+
+func validateAwsAlbTargetGroupName(v interface{}, k string) (ws []string, errors []error) {
+	name := v.(string)
+	if len(name) > 32 {
+		errors = append(errors, fmt.Errorf("%q (%q) cannot be longer than '32' characters", k, name))
+	}
+	return
+}
+
+func validateAwsAlbTargetGroupNamePrefix(v interface{}, k string) (ws []string, errors []error) {
+	name := v.(string)
+	if len(name) > 32 {
+		errors = append(errors, fmt.Errorf("%q (%q) cannot be longer than '6' characters", k, name))
+	}
+	return
+}

--- a/website/source/docs/providers/aws/r/alb_target_group.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_target_group.html.markdown
@@ -31,7 +31,8 @@ resource "aws_vpc" "main" {
 
 The following arguments are supported:
 
-* `name` - (Required) The name of the target group.
+* `name` - (Optional, Forces new resource) The name of the target group. If omitted, Terraform will assign a random, unique name.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
 * `port` - (Required) The port on which targets receive traffic, unless overridden when registering a specific target.
 * `protocol` - (Required) The protocol to use for routing traffic to the targets.
 * `vpc_id` - (Required) The identifier of the VPC in which to create the target group.


### PR DESCRIPTION
Adds the `name_prefix` parameter to the `aws_alb_target_group` resource.