### PR TITLE
[WIP] Support AWS S3 ACL policies

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -580,20 +580,23 @@ func resourceAwsS3BucketRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	// Read the ACL policy
-	pol, err := s3conn.GetBucketAcl(&s3.GetBucketAclInput{
-		Bucket: aws.String(d.Id()),
-	})
-	log.Printf("[DEBUG] S3 bucket: %s, read ACL policy: %+v", d.Id(), pol)
-	if err != nil {
-		return err
-	}
+	// Do not evaluate if `acl` is set.
+	if _, ok := d.GetOk("acl"); !ok {
+		pol, err := s3conn.GetBucketAcl(&s3.GetBucketAclInput{
+			Bucket: aws.String(d.Id()),
+		})
+		log.Printf("[DEBUG] S3 bucket: %s, read ACL policy: %+v", d.Id(), pol)
+		if err != nil {
+			return err
+		}
 
-	b, err := json.Marshal(pol)
-	if err != nil {
-		return err
-	}
-	if err := d.Set("acl_policy", string(b)); err != nil {
-		return err
+		b, err := json.Marshal(pol)
+		if err != nil {
+			return err
+		}
+		if err := d.Set("acl_policy", string(b)); err != nil {
+			return err
+		}
 	}
 
 	// Read the CORS

--- a/builtin/providers/aws/resource_aws_s3_bucket.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket.go
@@ -397,13 +397,16 @@ func resourceAwsS3BucketCreate(d *schema.ResourceData, meta interface{}) error {
 
 	// Get the bucket and acl
 	bucket := d.Get("bucket").(string)
-	acl := d.Get("acl").(string)
-
-	log.Printf("[DEBUG] S3 bucket create: %s, ACL: %s", bucket, acl)
+	log.Printf("[DEBUG] S3 bucket create: %s", bucket)
 
 	req := &s3.CreateBucketInput{
 		Bucket: aws.String(bucket),
-		ACL:    aws.String(acl),
+	}
+
+	if acl, ok := d.GetOk("acl"); ok {
+		acl := acl.(string)
+		req.ACL = aws.String(acl)
+		log.Printf("[DEBUG] S3 bucket %s has canned ACL %s", bucket, acl)
 	}
 
 	var awsRegion string

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -289,7 +289,8 @@ resource "aws_s3_bucket" "bucket" {
 The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket.
-* `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply. Defaults to "private".
+* `acl` - (Optional) The [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl) to apply.
+* `acl_policy` - (Optional) The JSON-formatted [ACL policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#sample-acl) to apply. This is the same format described [here](http://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-acl.html).
 * `policy` - (Optional) A valid [bucket policy](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-bucket-policies.html) JSON document. Note that if the policy document is not specific enough (but still valid), Terraform may view the policy as constantly changing in a `terraform plan`. In this case, please make sure you use the verbose/specific version of the policy.
 
 * `tags` - (Optional) A mapping of tags to assign to the bucket.


### PR DESCRIPTION
This PR allows for the importing and management of S3 ACL policies.  This allows for finer control than canned ACLs, including more complex policies.  More information on ACLs is available at https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html .

This changes `acl` in that it no longer provides a default of `private`.

I have begun to write tests, but got stuck due to a) knowing almost nothing about Go or the testing flow, and b) the ACL policy in the template needing to have a canonical ID that must be looked up via API.  I kept getting errors when trying to do so [1].  I did not push my tests, but can do so if desired.

If you have any questions or feedback, please let me know.

[1]:
```=== RUN   TestAccAWSS3Bucket_AclPolicy
--- FAIL: TestAccAWSS3Bucket_AclPolicy (0.00s)
panic: interface conversion: interface {} is nil, not *aws.AWSClient [recovered]
	panic: interface conversion: interface {} is nil, not *aws.AWSClient
```