### PR TITLE
provider/opc: Import support for IP Networks

### DIFF
--- a/builtin/providers/opc/import_ip_network_test.go
+++ b/builtin/providers/opc/import_ip_network_test.go
@@ -1,0 +1,33 @@
+package opc
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccOPCIPNetwork_importBasic(t *testing.T) {
+	resourceName := "opc_compute_ip_network.test"
+
+	rInt := acctest.RandInt()
+	config := testAccOPCIPNetworkConfig_Basic(rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resourceName, testAccOPCCheckIPNetworkDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/opc/resource_ip_network.go
+++ b/builtin/providers/opc/resource_ip_network.go
@@ -13,6 +13,9 @@ func resourceOPCIPNetwork() *schema.Resource {
 		Read:   resourceOPCIPNetworkRead,
 		Update: resourceOPCIPNetworkUpdate,
 		Delete: resourceOPCIPNetworkDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {

--- a/builtin/providers/opc/resource_ip_network_test.go
+++ b/builtin/providers/opc/resource_ip_network_test.go
@@ -12,7 +12,31 @@ import (
 
 func TestAccOPCIPNetwork_Basic(t *testing.T) {
 	rInt := acctest.RandInt()
-	resName := "opc_compute_ip_network.foo"
+	resName := "opc_compute_ip_network.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: opcResourceCheck(resName, testAccOPCCheckIPNetworkDestroyed),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccOPCIPNetworkConfig_Basic(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					opcResourceCheck(resName, testAccOPCCheckIPNetworkExists),
+					resource.TestCheckResourceAttr(resName, "ip_address_prefix", "10.0.12.0/24"),
+					resource.TestCheckResourceAttr(resName, "public_napt_enabled", "false"),
+					resource.TestCheckResourceAttr(resName, "description", fmt.Sprintf("testing-desc-%d", rInt)),
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("testing-ip-network-%d", rInt)),
+					resource.TestMatchResourceAttr(resName, "uri", regexp.MustCompile("testing-ip-network")),
+				),
+			},
+		},
+	})
+}
+
+func TestAccOPCIPNetwork_Update(t *testing.T) {
+	rInt := acctest.RandInt()
+	resName := "opc_compute_ip_network.test"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -46,7 +70,7 @@ func TestAccOPCIPNetwork_Basic(t *testing.T) {
 
 func testAccOPCIPNetworkConfig_Basic(rInt int) string {
 	return fmt.Sprintf(`
-resource "opc_compute_ip_network" "foo" {
+resource "opc_compute_ip_network" "test" {
   name = "testing-ip-network-%d"
   description = "testing-desc-%d"
   ip_address_prefix = "10.0.12.0/24"
@@ -55,7 +79,7 @@ resource "opc_compute_ip_network" "foo" {
 
 func testAccOPCIPNetworkConfig_BasicUpdate(rInt int) string {
 	return fmt.Sprintf(`
-resource "opc_compute_ip_network" "foo" {
+resource "opc_compute_ip_network" "test" {
   name = "testing-ip-network-%d"
   description = "testing-desc-%d"
   ip_address_prefix = "10.0.12.0/24"


### PR DESCRIPTION
Tests pass:
```
$ envchain oracle make testacc TEST=./builtin/providers/opc/ TESTARGS='-run=TestAccOPCIPNetwork'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/07 10:58:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/opc/ -v -run=TestAccOPCIPNetwork -timeout 120m
=== RUN   TestAccOPCIPNetworkExchange_importBasic
--- PASS: TestAccOPCIPNetworkExchange_importBasic (21.95s)
=== RUN   TestAccOPCIPNetwork_importBasic
--- PASS: TestAccOPCIPNetwork_importBasic (20.05s)
=== RUN   TestAccOPCIPNetworkExchange_Basic
--- PASS: TestAccOPCIPNetworkExchange_Basic (17.10s)
=== RUN   TestAccOPCIPNetwork_Basic
--- PASS: TestAccOPCIPNetwork_Basic (16.90s)
=== RUN   TestAccOPCIPNetwork_Update
--- PASS: TestAccOPCIPNetwork_Update (25.05s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/opc	101.069s
```