### PR TITLE
provider/aws: Add support for iam_openid_connect_provider

### DIFF
--- a/builtin/providers/aws/diff_suppress_funcs.go
+++ b/builtin/providers/aws/diff_suppress_funcs.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"log"
+	"net/url"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -57,4 +58,20 @@ func suppressEquivalentJsonDiffs(k, old, new string, d *schema.ResourceData) boo
 	}
 
 	return jsonBytesEqual(ob.Bytes(), nb.Bytes())
+}
+
+func suppressOpenIdURL(k, old, new string, d *schema.ResourceData) bool {
+	oldUrl, err := url.Parse(old)
+	if err != nil {
+		return false
+	}
+
+	newUrl, err := url.Parse(new)
+	if err != nil {
+		return false
+	}
+
+	oldUrl.Scheme = "https"
+
+	return oldUrl.String() == newUrl.String()
 }

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -309,6 +309,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_group_membership":                     resourceAwsIamGroupMembership(),
 			"aws_iam_group_policy_attachment":              resourceAwsIamGroupPolicyAttachment(),
 			"aws_iam_instance_profile":                     resourceAwsIamInstanceProfile(),
+			"aws_iam_openid_connect_provider":              resourceAwsIamOpenIDConnectProvider(),
 			"aws_iam_policy":                               resourceAwsIamPolicy(),
 			"aws_iam_policy_attachment":                    resourceAwsIamPolicyAttachment(),
 			"aws_iam_role_policy_attachment":               resourceAwsIamRolePolicyAttachment(),

--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
@@ -1,0 +1,125 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsIamOpenIDConnectProvider() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsIamOpenIDConnectProviderCreate,
+		Read:   resourceAwsIamOpenIDConnectProviderRead,
+		Update: resourceAwsIamOpenIDConnectProviderUpdate,
+		Delete: resourceAwsIamOpenIDConnectProviderDelete,
+
+		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: false,
+				Required: true,
+				ForceNew: true,
+			},
+			"client-id-list": &schema.Schema{
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Required: true,
+				ForceNew: true,
+			},
+			"thumbprint-list": &schema.Schema{
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Type:     schema.TypeList,
+				Required: true,
+			},
+		},
+	}
+}
+
+func stringListToStringSlice(stringList []interface{}) []string {
+	ret := []string{}
+	for _, v := range stringList {
+		ret = append(ret, v.(string))
+	}
+	return ret
+}
+
+func resourceAwsIamOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	input := &iam.CreateOpenIDConnectProviderInput{
+		Url:            aws.String(d.Get("url").(string)),
+		ClientIDList:   aws.StringSlice(stringListToStringSlice(d.Get("client-id-list").([]interface{}))),
+		ThumbprintList: aws.StringSlice(stringListToStringSlice(d.Get("thumbprint-list").([]interface{}))),
+	}
+
+	out, err := iamconn.CreateOpenIDConnectProvider(input)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*out.OpenIDConnectProviderArn)
+
+	return resourceAwsIamOpenIDConnectProviderRead(d, meta)
+}
+
+func resourceAwsIamOpenIDConnectProviderRead(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	input := &iam.GetOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: aws.String(d.Id()),
+	}
+	out, err := iamconn.GetOpenIDConnectProvider(input)
+	if err != nil {
+		return err
+	}
+
+	d.Set("arn", d.Id())
+	d.Set("url", *out.Url)
+	d.Set("client-id-list", out.ClientIDList)
+	d.Set("thumbprint-list", out.ThumbprintList)
+
+	return nil
+}
+
+func resourceAwsIamOpenIDConnectProviderUpdate(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	if d.HasChange("thumbprint-list") {
+		input := &iam.UpdateOpenIDConnectProviderThumbprintInput{
+			OpenIDConnectProviderArn: aws.String(d.Id()),
+		}
+
+		_, err := iamconn.UpdateOpenIDConnectProviderThumbprint(input)
+		if err != nil {
+			return err
+		}
+	}
+
+	return resourceAwsIamOpenIDConnectProviderRead(d, meta)
+}
+
+func resourceAwsIamOpenIDConnectProviderDelete(d *schema.ResourceData, meta interface{}) error {
+	iamconn := meta.(*AWSClient).iamconn
+
+	input := &iam.DeleteOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: aws.String(d.Id()),
+	}
+	_, err := iamconn.DeleteOpenIDConnectProvider(input)
+
+	if err != nil {
+		if err, ok := err.(awserr.Error); ok && err.Code() == "NotFound" {
+			return nil
+		}
+		return fmt.Errorf("Error deleting platform application %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
@@ -30,13 +30,13 @@ func resourceAwsIamOpenIDConnectProvider() *schema.Resource {
 				ValidateFunc:     validateOpenIdURL,
 				DiffSuppressFunc: suppressOpenIdURL,
 			},
-			"client-id-list": &schema.Schema{
+			"client_id_list": &schema.Schema{
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Type:     schema.TypeList,
 				Required: true,
 				ForceNew: true,
 			},
-			"thumbprint-list": &schema.Schema{
+			"thumbprint_list": &schema.Schema{
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Type:     schema.TypeList,
 				Required: true,
@@ -58,8 +58,8 @@ func resourceAwsIamOpenIDConnectProviderCreate(d *schema.ResourceData, meta inte
 
 	input := &iam.CreateOpenIDConnectProviderInput{
 		Url:            aws.String(d.Get("url").(string)),
-		ClientIDList:   aws.StringSlice(stringListToStringSlice(d.Get("client-id-list").([]interface{}))),
-		ThumbprintList: aws.StringSlice(stringListToStringSlice(d.Get("thumbprint-list").([]interface{}))),
+		ClientIDList:   aws.StringSlice(stringListToStringSlice(d.Get("client_id_list").([]interface{}))),
+		ThumbprintList: aws.StringSlice(stringListToStringSlice(d.Get("thumbprint_list").([]interface{}))),
 	}
 
 	out, err := iamconn.CreateOpenIDConnectProvider(input)
@@ -84,9 +84,9 @@ func resourceAwsIamOpenIDConnectProviderRead(d *schema.ResourceData, meta interf
 	}
 
 	d.Set("arn", d.Id())
-	d.Set("url", *out.Url)
-	d.Set("client-id-list", out.ClientIDList)
-	d.Set("thumbprint-list", out.ThumbprintList)
+	d.Set("url", out.Url)
+	d.Set("client_id_list", out.ClientIDList)
+	d.Set("thumbprint_list", out.ThumbprintList)
 
 	return nil
 }
@@ -94,7 +94,7 @@ func resourceAwsIamOpenIDConnectProviderRead(d *schema.ResourceData, meta interf
 func resourceAwsIamOpenIDConnectProviderUpdate(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
-	if d.HasChange("thumbprint-list") {
+	if d.HasChange("thumbprint_list") {
 		input := &iam.UpdateOpenIDConnectProviderThumbprintInput{
 			OpenIDConnectProviderArn: aws.String(d.Id()),
 		}

--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
@@ -45,21 +45,13 @@ func resourceAwsIamOpenIDConnectProvider() *schema.Resource {
 	}
 }
 
-func stringListToStringSlice(stringList []interface{}) []string {
-	ret := []string{}
-	for _, v := range stringList {
-		ret = append(ret, v.(string))
-	}
-	return ret
-}
-
 func resourceAwsIamOpenIDConnectProviderCreate(d *schema.ResourceData, meta interface{}) error {
 	iamconn := meta.(*AWSClient).iamconn
 
 	input := &iam.CreateOpenIDConnectProviderInput{
 		Url:            aws.String(d.Get("url").(string)),
-		ClientIDList:   aws.StringSlice(stringListToStringSlice(d.Get("client_id_list").([]interface{}))),
-		ThumbprintList: aws.StringSlice(stringListToStringSlice(d.Get("thumbprint_list").([]interface{}))),
+		ClientIDList:   expandStringList(d.Get("client_id_list").([]interface{})),
+		ThumbprintList: expandStringList(d.Get("thumbprint_list").([]interface{})),
 	}
 
 	out, err := iamconn.CreateOpenIDConnectProvider(input)
@@ -97,6 +89,7 @@ func resourceAwsIamOpenIDConnectProviderUpdate(d *schema.ResourceData, meta inte
 	if d.HasChange("thumbprint_list") {
 		input := &iam.UpdateOpenIDConnectProviderThumbprintInput{
 			OpenIDConnectProviderArn: aws.String(d.Id()),
+			ThumbprintList:           expandStringList(d.Get("thumbprint_list").([]interface{})),
 		}
 
 		_, err := iamconn.UpdateOpenIDConnectProviderThumbprint(input)

--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider.go
@@ -23,10 +23,12 @@ func resourceAwsIamOpenIDConnectProvider() *schema.Resource {
 				Computed: true,
 			},
 			"url": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: false,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Computed:         false,
+				Required:         true,
+				ForceNew:         true,
+				ValidateFunc:     validateOpenIdURL,
+				DiffSuppressFunc: suppressOpenIdURL,
 			},
 			"client-id-list": &schema.Schema{
 				Elem:     &schema.Schema{Type: schema.TypeString},

--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider_test.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider_test.go
@@ -82,9 +82,9 @@ func testAccCheckIAMOpenIDConnectProvider(id string) resource.TestCheckFunc {
 const testAccIAMOpenIDConnectProviderConfig = `
 resource "aws_iam_openid_connect_provider" "goog" {
   url="https://accounts.google.com"
-  client-id-list = [
+  client_id_list = [
      "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.googleusercontent.com"
   ]
-  thumbprint-list = []
+  thumbprint_list = []
 }
 `

--- a/builtin/providers/aws/resource_aws_iam_openid_connect_provider_test.go
+++ b/builtin/providers/aws/resource_aws_iam_openid_connect_provider_test.go
@@ -1,0 +1,90 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSIAMOpenIDConnectProvider_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckIAMOpenIDConnectProviderDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIAMOpenIDConnectProviderConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckIAMOpenIDConnectProvider("aws_iam_openid_connect_provider.goog"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckIAMOpenIDConnectProviderDestroy(s *terraform.State) error {
+	iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_iam_openid_connect_provider" {
+			continue
+		}
+
+		input := &iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(rs.Primary.ID),
+		}
+		out, err := iamconn.GetOpenIDConnectProvider(input)
+		if err != nil {
+			if iamerr, ok := err.(awserr.Error); ok && iamerr.Code() == "NoSuchEntity" {
+				// none found, that's good
+				return nil
+			}
+			return fmt.Errorf("Error reading IAM OpenID Connect Provider, out: %s, err: %s", out, err)
+		}
+
+		if out != nil {
+			return fmt.Errorf("Found IAM OpenID Connect Provider, expected none: %s", out)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckIAMOpenIDConnectProvider(id string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[id]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", id)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		iamconn := testAccProvider.Meta().(*AWSClient).iamconn
+		_, err := iamconn.GetOpenIDConnectProvider(&iam.GetOpenIDConnectProviderInput{
+			OpenIDConnectProviderArn: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+}
+
+const testAccIAMOpenIDConnectProviderConfig = `
+resource "aws_iam_openid_connect_provider" "goog" {
+  url="https://accounts.google.com"
+  client-id-list = [
+     "266362248691-re108qaeld573ia0l6clj2i5ac7r7291.apps.googleusercontent.com"
+  ]
+  thumbprint-list = []
+}
+`

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"regexp"
 	"strings"
 	"time"
@@ -1167,6 +1168,22 @@ func validateAwsAlbTargetGroupNamePrefix(v interface{}, k string) (ws []string, 
 	name := v.(string)
 	if len(name) > 32 {
 		errors = append(errors, fmt.Errorf("%q (%q) cannot be longer than '6' characters", k, name))
+	}
+	return
+}
+
+func validateOpenIdURL(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	u, err := url.Parse(value)
+	if err != nil {
+		errors = append(errors, fmt.Errorf("%q has to be a valid URL", k))
+		return
+	}
+	if u.Scheme != "https" {
+		errors = append(errors, fmt.Errorf("%q has to use HTTPS scheme (i.e. begin with https://)", k))
+	}
+	if len(u.Query()) > 0 {
+		errors = append(errors, fmt.Errorf("%q cannot contain query parameters per the OIDC standard", k))
 	}
 	return
 }

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1913,3 +1913,35 @@ func TestValidateDbOptionGroupNamePrefix(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateOpenIdURL(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "http://wrong.scheme.com",
+			ErrCount: 1,
+		},
+		{
+			Value:    "ftp://wrong.scheme.co.uk",
+			ErrCount: 1,
+		},
+		{
+			Value:    "%@invalidUrl",
+			ErrCount: 1,
+		},
+		{
+			Value:    "https://example.com/?query=param",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateOpenIdURL(tc.Value, "url")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %d of OpenID URL validation errors, got %d", tc.ErrCount, len(errors))
+		}
+	}
+}

--- a/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
@@ -15,10 +15,10 @@ Provides an IAM OpenID Connect provider.
 ```
 resource "aws_iam_openid_connect_provider" "default" {
     url = "https://accounts.google.com"
-    client-id-list = [
+    client_id_list = [
      "266362248691-342342xasdasdasda-apps.googleusercontent.com"
     ]
-    thumbprint-list = []
+    thumbprint_list = []
 }
 ```
 
@@ -27,8 +27,8 @@ resource "aws_iam_openid_connect_provider" "default" {
 The following arguments are supported:
 
 * `url` - (Required) The URL of the identity provider. Corresponds to the _iss_ claim.
-* `client-id-list` - (Required) A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)
-* `thumbprint-list` - (Required) A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s). 
+* `client_id_list` - (Required) A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)
+* `thumbprint_list` - (Required) A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s). 
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
@@ -35,3 +35,11 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `arn` - The ARN assigned by AWS for this provider.
+
+## Import
+
+IAM OpenID Connect Providers can be imported using the `arn`, e.g.
+
+```
+$ terraform import aws_iam_openid_connect_provider.default arn:aws:iam::123456789012:oidc-provider/accounts.google.com
+```

--- a/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_openid_connect_provider.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "aws"
+page_title: "AWS: aws_iam_openid_connect_provider"
+sidebar_current: "docs-aws-resource-iam-openid-connect-provider"
+description: |-
+  Provides an IAM OpenID Connect provider.
+---
+
+# aws\_iam\_openid\_connect\_provider
+
+Provides an IAM OpenID Connect provider.
+
+## Example Usage
+
+```
+resource "aws_iam_openid_connect_provider" "default" {
+    url = "https://accounts.google.com"
+    client-id-list = [
+     "266362248691-342342xasdasdasda-apps.googleusercontent.com"
+    ]
+    thumbprint-list = []
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `url` - (Required) The URL of the identity provider. Corresponds to the _iss_ claim.
+* `client-id-list` - (Required) A list of client IDs (also known as audiences). When a mobile or web app registers with an OpenID Connect provider, they establish a value that identifies the application. (This is the value that's sent as the client_id parameter on OAuth requests.)
+* `thumbprint-list` - (Required) A list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s). 
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `arn` - The ARN assigned by AWS for this provider.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -745,6 +745,10 @@
                             <a href="/docs/providers/aws/r/iam_instance_profile.html">aws_iam_instance_profile</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-iam-openid-connect-provider") %>>
+                            <a href="/docs/providers/aws/r/iam_openid_connect_provider.html">aws_iam_openid_connect_provider</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-iam-policy") %>>
                             <a href="/docs/providers/aws/r/iam_policy.html">aws_iam_policy</a>
                         </li>


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/pull/6137

In the spirit of reducing number of old, stale PRs and to speed things up a bit I took the liberty to make changes to the original PR and resubmitted.

@ryansroberts I hope you don't mind. Your contribution is still included (and still credited to you), with the appropriate modifications.

Feel free to ask about any of the changes.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSIAMOpenIDConnectProvider_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/06 12:14:51 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSIAMOpenIDConnectProvider_ -timeout 120m
=== RUN   TestAccAWSIAMOpenIDConnectProvider_basic
--- PASS: TestAccAWSIAMOpenIDConnectProvider_basic (68.43s)
=== RUN   TestAccAWSIAMOpenIDConnectProvider_importBasic
--- PASS: TestAccAWSIAMOpenIDConnectProvider_importBasic (38.50s)
=== RUN   TestAccAWSIAMOpenIDConnectProvider_disappears
--- PASS: TestAccAWSIAMOpenIDConnectProvider_disappears (54.81s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	161.773s
```