### PR TITLE
provider/aws: Raise timeout for attaching/detaching VPN GW

### DIFF
--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -205,7 +205,7 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"detached", "attaching"},
 		Target:  []string{"attached"},
 		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "available"),
-		Timeout: 1 * time.Minute,
+		Timeout: 5 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(
@@ -266,7 +266,7 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"attached", "detaching", "available"},
 		Target:  []string{"detached"},
 		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "detached"),
-		Timeout: 1 * time.Minute,
+		Timeout: 5 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSVpnGateway_importBasic
--- FAIL: TestAccAWSVpnGateway_importBasic (78.33s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_vpn_gateway.foo: 1 error(s) occurred:
        
        * aws_vpn_gateway.foo: Error waiting for VPN gateway (vgw-91805b8f) to attach: timeout while waiting for state to become 'attached' (last state: 'detached', timeout: 1m0s)
```

### Test results
```
=== RUN   TestAccAWSVpnGateway_importBasic
--- PASS: TestAccAWSVpnGateway_importBasic (52.14s)
=== RUN   TestAccAWSVpnGateway_disappears
--- PASS: TestAccAWSVpnGateway_disappears (52.76s)
=== RUN   TestAccAWSVpnGateway_withAvailabilityZoneSetToState
--- PASS: TestAccAWSVpnGateway_withAvailabilityZoneSetToState (62.91s)
=== RUN   TestAccAWSVpnGateway_tags
--- PASS: TestAccAWSVpnGateway_tags (73.82s)
=== RUN   TestAccAWSVpnGateway_basic
--- PASS: TestAccAWSVpnGateway_basic (88.03s)
=== RUN   TestAccAWSVpnGateway_reattach
--- PASS: TestAccAWSVpnGateway_reattach (96.34s)
=== RUN   TestAccAWSVpnGateway_delete
--- PASS: TestAccAWSVpnGateway_delete (96.95s)
```