### PR TITLE
provider/azurerm: VM Scale Sets - import support + fixes

### DIFF
--- a/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
@@ -31,6 +31,29 @@ func TestAccAzureRMVirtualMachineScaleSet_importBasic(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineScaleSet_importLinux(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set.test"
+
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualMachineScaleSet_linux(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineScaleSet_importLoadBalancer(t *testing.T) {
 	resourceName := "azurerm_virtual_machine_scale_set.test"
 

--- a/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
@@ -26,7 +26,6 @@ func TestAccAzureRMVirtualMachineScaleSet_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				//ImportStateVerifyIgnore: []string{"os_profile.XXXXXXXXX.custom_data"},
 			},
 		},
 	})
@@ -50,7 +49,6 @@ func TestAccAzureRMVirtualMachineScaleSet_importLoadBalancer(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
-				//ImportStateVerifyIgnore: []string{"os_profile.XXXXXXXXX.custom_data"},
 			},
 		},
 	})

--- a/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
@@ -1,0 +1,114 @@
+package azurerm
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMVirtualMachineScaleSet_importBasic(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basicLinux, ri, ri, ri, ri, ri, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				//ImportStateVerifyIgnore: []string{"os_profile.XXXXXXXXX.custom_data"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSet_importLoadBalancer(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSetLoadbalancerTemplate, ri, ri, ri, ri, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				//ImportStateVerifyIgnore: []string{"os_profile.XXXXXXXXX.custom_data"},
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSet_importOverProvision(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSetOverprovisionTemplate, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+					testCheckAzureRMVirtualMachineScaleSetOverprovision("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSet_importExtension(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSetExtensionTemplate, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+					testCheckAzureRMVirtualMachineScaleSetExtension("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSet_importMultipleExtensions(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSetMultipleExtensionsTemplate, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+					testCheckAzureRMVirtualMachineScaleSetExtension("azurerm_virtual_machine_scale_set.test"),
+				),
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/import_arm_virtual_machine_scale_set_test.go
@@ -12,7 +12,7 @@ func TestAccAzureRMVirtualMachineScaleSet_importBasic(t *testing.T) {
 	resourceName := "azurerm_virtual_machine_scale_set.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basicLinux, ri, ri, ri, ri, ri, ri, ri, ri)
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basic, ri, ri, ri, ri, ri, ri, ri, ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -346,7 +346,7 @@ func userDataStateFunc(v interface{}) string {
 	}
 }
 
-// Base64Encode encodes data if the input isn't already encoded using
+// base64Encode encodes data if the input isn't already encoded using
 // base64.StdEncoding.EncodeToString. If the input is already base64 encoded,
 // return the original input unchanged.
 func base64Encode(data string) string {
@@ -356,6 +356,21 @@ func base64Encode(data string) string {
 	}
 	// data has not been encoded encode and return
 	return base64.StdEncoding.EncodeToString([]byte(data))
+}
+
+// base64Decode decodes data if the input isn't already decoded using base64
+// If the input is already decoded, returns the original input unchanged.
+func base64Decode(data string) (string, error) {
+	// Check whether the data is already Base64 encoded; don't double-encode
+	if !isBase64Encoded(data) {
+		return data, nil
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(data)
+	if err != nil {
+		return "", err
+	}
+	return string(decoded), nil
 }
 
 func isBase64Encoded(data string) bool {

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -358,21 +358,6 @@ func base64Encode(data string) string {
 	return base64.StdEncoding.EncodeToString([]byte(data))
 }
 
-// base64Decode decodes data if the input isn't already decoded using base64
-// If the input is already decoded, returns the original input unchanged.
-func base64Decode(data string) (string, error) {
-	// Check whether the data is already Base64 encoded; don't double-encode
-	if !isBase64Encoded(data) {
-		return data, nil
-	}
-
-	decoded, err := base64.StdEncoding.DecodeString(data)
-	if err != nil {
-		return "", err
-	}
-	return string(decoded), nil
-}
-
 func isBase64Encoded(data string) bool {
 	_, err := base64.StdEncoding.DecodeString(data)
 	return err == nil

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -19,6 +19,9 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 		Read:   resourceArmVirtualMachineScaleSetRead,
 		Update: resourceArmVirtualMachineScaleSetCreate,
 		Delete: resourceArmVirtualMachineScaleSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -497,8 +500,9 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 		return fmt.Errorf("Error making Read request on Azure Virtual Machine Scale Set %s: %s", name, err)
 	}
 
-	d.Set("location", resp.Location)
 	d.Set("name", resp.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 
 	if err := d.Set("sku", flattenAzureRmVirtualMachineScaleSetSku(resp.Sku)); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting Virtual Machine Scale Set Sku error: %#v", err)

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -509,7 +509,12 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 	d.Set("upgrade_policy_mode", properties.UpgradePolicy.Mode)
 	d.Set("overprovision", properties.Overprovision)
 
-	if err := d.Set("os_profile", flattenAzureRMVirtualMachineScaleSetOsProfile(properties.VirtualMachineProfile.OsProfile)); err != nil {
+	osProfile, err := flattenAzureRMVirtualMachineScaleSetOsProfile(properties.VirtualMachineProfile.OsProfile)
+	if err != nil {
+		return fmt.Errorf("[DEBUG] Error flattening Virtual Machine Scale Set OS Profile. Error: %#v", err)
+	}
+
+	if err := d.Set("os_profile", osProfile); err != nil {
 		return fmt.Errorf("[DEBUG] Error setting Virtual Machine Scale Set OS Profile error: %#v", err)
 	}
 
@@ -710,17 +715,22 @@ func flattenAzureRmVirtualMachineScaleSetNetworkProfile(profile *compute.Virtual
 	return result
 }
 
-func flattenAzureRMVirtualMachineScaleSetOsProfile(profile *compute.VirtualMachineScaleSetOSProfile) []interface{} {
+func flattenAzureRMVirtualMachineScaleSetOsProfile(profile *compute.VirtualMachineScaleSetOSProfile) ([]interface{}, error) {
 	result := make(map[string]interface{})
 
 	result["computer_name_prefix"] = *profile.ComputerNamePrefix
 	result["admin_username"] = *profile.AdminUsername
 
 	if profile.CustomData != nil {
-		result["custom_data"] = *profile.CustomData
+		data, err := base64Decode(*profile.CustomData)
+		if err != nil {
+			return nil, err
+		}
+		result["custom_data"] = data
+
 	}
 
-	return []interface{}{result}
+	return []interface{}{result}, nil
 }
 
 func flattenAzureRmVirtualMachineScaleSetStorageProfileOSDisk(profile *compute.VirtualMachineScaleSetOSDisk) []interface{} {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAzureRMVirtualMachineScaleSet_basicLinux(t *testing.T) {
+func TestAccAzureRMVirtualMachineScaleSet_basic(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basicLinux, ri, ri, ri, ri, ri, ri, ri, ri)
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basic, ri, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -28,9 +28,36 @@ func TestAccAzureRMVirtualMachineScaleSet_basicLinux(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachineScaleSet_linuxUpdated(t *testing.T) {
+	resourceName := "azurerm_virtual_machine_scale_set.test"
+	ri := acctest.RandInt()
+	config := testAccAzureRMVirtualMachineScaleSet_linux(ri)
+	updatedConfig := testAccAzureRMVirtualMachineScaleSet_linuxUpdated(ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists(resourceName),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists(resourceName),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachineScaleSet_basicLinux_disappears(t *testing.T) {
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basicLinux, ri, ri, ri, ri, ri, ri, ri, ri)
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_basic, ri, ri, ri, ri, ri, ri, ri, ri)
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
@@ -311,87 +338,88 @@ func testCheckAzureRMVirtualMachineScaleSetExtension(name string) resource.TestC
 	}
 }
 
-var testAccAzureRMVirtualMachineScaleSet_basicLinux = `
+var testAccAzureRMVirtualMachineScaleSet_basic = `
 resource "azurerm_resource_group" "test" {
-    name = "acctestRG-%d"
-    location = "West US"
+  name     = "acctestRG-%d"
+  location = "West US"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name = "acctvn-%d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name = "acctsub-%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_network_interface" "test" {
-    name = "acctni-%d"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctni-%d"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 
-    ip_configuration {
-    	name = "testconfiguration1"
-    	subnet_id = "${azurerm_subnet.test.id}"
-    	private_ip_address_allocation = "dynamic"
-    }
+  ip_configuration {
+    name                          = "testconfiguration1"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "dynamic"
+  }
 }
 
 resource "azurerm_storage_account" "test" {
-    name = "accsa%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location = "westus"
-    account_type = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "westus"
+  account_type        = "Standard_LRS"
 
-    tags {
-        environment = "staging"
-    }
+  tags {
+    environment = "staging"
+  }
 }
 
 resource "azurerm_storage_container" "test" {
-    name = "vhds"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    storage_account_name = "${azurerm_storage_account.test.name}"
-    container_access_type = "private"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
 }
 
 resource "azurerm_virtual_machine_scale_set" "test" {
-  name = "acctvmss-%d"
-  location = "West US"
+  name                = "acctvmss-%d"
+  location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   upgrade_policy_mode = "Manual"
 
   sku {
-    name = "Standard_A0"
-    tier = "Standard"
+    name     = "Standard_A0"
+    tier     = "Standard"
     capacity = 2
   }
 
   os_profile {
     computer_name_prefix = "testvm-%d"
-    admin_username = "myadmin"
-    admin_password = "Passwword1234"
+    admin_username       = "myadmin"
+    admin_password       = "Passwword1234"
   }
 
   network_profile {
-      name = "TestNetworkProfile-%d"
-      primary = true
-      ip_configuration {
-        name = "TestIPConfiguration"
-        subnet_id = "${azurerm_subnet.test.id}"
-      }
+    name    = "TestNetworkProfile-%d"
+    primary = true
+
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      subnet_id = "${azurerm_subnet.test.id}"
+    }
   }
 
   storage_profile_os_disk {
-    name = "osDiskProfile"
-    caching       = "ReadWrite"
-    create_option = "FromImage"
+    name           = "osDiskProfile"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
     vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
   }
 
@@ -404,381 +432,626 @@ resource "azurerm_virtual_machine_scale_set" "test" {
 }
 `
 
-var testAccAzureRMVirtualMachineScaleSetLoadbalancerTemplate = `
-resource "azurerm_resource_group" "test" {
-    name 	 = "acctestrg-%d"
-    location = "southcentralus"
+func testAccAzureRMVirtualMachineScaleSet_linux(rInt int) string {
+	return fmt.Sprintf(`
+	resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "West Europe"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name 		        = "acctvn-%d"
-    address_space       = ["10.0.0.0/16"]
-    location            = "southcentralus"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestvn-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  address_space       = ["10.0.0.0/8"]
 }
 
 resource "azurerm_subnet" "test" {
-    name                 = "acctsub-%d"
-    resource_group_name  = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix       = "10.0.2.0/24"
+  name                 = "acctestsn-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.1.0/24"
 }
 
 resource "azurerm_storage_account" "test" {
-    name                = "accsa%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location            = "southcentralus"
-    account_type        = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  account_type        = "Standard_LRS"
 }
 
 resource "azurerm_storage_container" "test" {
-    name                  = "vhds"
-    resource_group_name   = "${azurerm_resource_group.test.name}"
-    storage_account_name  = "${azurerm_storage_account.test.name}"
-    container_access_type = "private"
+  name                  = "acctestsc-%d"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "acctestpip-%d"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  location                     = "${azurerm_resource_group.test.location}"
+  public_ip_address_allocation = "static"
 }
 
 resource "azurerm_lb" "test" {
-    name                = "acctestlb-%d"
-    location            = "southcentralus"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctestlb-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
 
-    frontend_ip_configuration {
-        name                          = "default"
-        subnet_id                     = "${azurerm_subnet.test.id}"
-        private_ip_address_allocation = "Dynamic"
-    }
+  frontend_ip_configuration {
+    name                 = "ip-address"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
 }
 
 resource "azurerm_lb_backend_address_pool" "test" {
-    name                = "test"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location            = "southcentralus"
-    loadbalancer_id     = "${azurerm_lb.test.id}"
+  name                = "acctestbap-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id     = "${azurerm_lb.test.id}"
 }
 
 resource "azurerm_virtual_machine_scale_set" "test" {
-  	name                = "acctvmss-%d"
-  	location            = "southcentralus"
-  	resource_group_name = "${azurerm_resource_group.test.name}"
-  	upgrade_policy_mode = "Manual"
+  name                = "acctestvmss-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  upgrade_policy_mode = "Automatic"
 
-  	sku {
-		name     = "Standard_A0"
-    	tier     = "Standard"
-    	capacity = 1
-	}
+  sku {
+    name     = "Standard_A0"
+    tier     = "Standard"
+    capacity = "1"
+  }
 
-  	os_profile {
-    	computer_name_prefix = "testvm-%d"
-    	admin_username = "myadmin"
-    	admin_password = "Passwword1234"
-  	}
+  os_profile {
+    computer_name_prefix = "prefix"
+    admin_username       = "ubuntu"
+    admin_password       = "password"
+    custom_data          = "custom data!"
+  }
 
-  	network_profile {
-      	name    = "TestNetworkProfile"
-      	primary = true
-      	ip_configuration {
-        	name                                   = "TestIPConfiguration"
-        	subnet_id                              = "${azurerm_subnet.test.id}"
-			load_balancer_backend_address_pool_ids = [ "${azurerm_lb_backend_address_pool.test.id}" ]
-      	}
-  	}
+  os_profile_linux_config {
+    disable_password_authentication = true
 
-  	storage_profile_os_disk {
-    	name 		   = "os-disk"
-    	caching        = "ReadWrite"
-    	create_option  = "FromImage"
-    	vhd_containers = [ "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}" ]
-  	}
+    ssh_keys {
+      path     = "/home/ubuntu/.ssh/authorized_keys"
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
+    }
+  }
 
-  	storage_profile_image_reference {
-    	publisher = "Canonical"
-    	offer     = "UbuntuServer"
-    	sku       = "14.04.2-LTS"
-    	version   = "latest"
-  	}
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name                                   = "TestIPConfiguration"
+      subnet_id                              = "${azurerm_subnet.test.id}"
+      load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.test.id}"]
+    }
+  }
+
+  storage_profile_os_disk {
+    name           = "osDiskProfile"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    os_type        = "linux"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "14.04.2-LTS"
+    version   = "latest"
+  }
+}
+
+`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccAzureRMVirtualMachineScaleSet_linuxUpdated(rInt int) string {
+	return fmt.Sprintf(`
+	resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "West Europe"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctestvn-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  address_space       = ["10.0.0.0/8"]
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctestsn-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.1.0/24"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  account_type        = "Standard_LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "acctestsc-%d"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_public_ip" "test" {
+  name                         = "acctestpip-%d"
+  resource_group_name          = "${azurerm_resource_group.test.name}"
+  location                     = "${azurerm_resource_group.test.location}"
+  public_ip_address_allocation = "static"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "acctestlb-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+
+  frontend_ip_configuration {
+    name                 = "ip-address"
+    public_ip_address_id = "${azurerm_public_ip.test.id}"
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name                = "acctestbap-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name                = "acctestvmss-%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "${azurerm_resource_group.test.location}"
+  upgrade_policy_mode = "Automatic"
+
+  sku {
+    name     = "Standard_A0"
+    tier     = "Standard"
+    capacity = "1"
+  }
+
+  os_profile {
+    computer_name_prefix = "prefix"
+    admin_username       = "ubuntu"
+    admin_password       = "password"
+    custom_data          = "custom data!"
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/ubuntu/.ssh/authorized_keys"
+      key_data = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDCsTcryUl51Q2VSEHqDRNmceUFo55ZtcIwxl2QITbN1RREti5ml/VTytC0yeBOvnZA4x4CFpdw/lCDPk0yrH9Ei5vVkXmOrExdTlT3qI7YaAzj1tUVlBd4S6LX1F7y6VLActvdHuDDuXZXzCDd/97420jrDfWZqJMlUK/EmCE5ParCeHIRIvmBxcEnGfFIsw8xQZl0HphxWOtJil8qsUWSdMyCiJYYQpMoMliO99X40AUc4/AlsyPyT5ddbKk08YrZ+rKDVHF7o29rh4vi5MmHkVgVQHKiKybWlHq+b71gIAUQk9wrJxD+dqt4igrmDSpIjfjwnd+l5UIn5fJSO5DYV4YT/4hwK7OKmuo7OFHD0WyY5YnkYEMtFgzemnRBdE8ulcT60DQpVgRMXFWHvhyCWy0L6sgj1QWDZlLpvsIvNfHsyhKFMG1frLnMt/nP0+YCcfg+v1JYeCKjeoJxB8DWcRBsjzItY0CGmzP8UYZiYKl/2u+2TgFS5r7NWH11bxoUzjKdaa1NLw+ieA8GlBFfCbfWe6YVB9ggUte4VtYFMZGxOjS2bAiYtfgTKFJv+XqORAwExG6+G2eDxIDyo80/OA9IG7Xv/jwQr7D6KDjDuULFcN/iTxuttoKrHeYz1hf5ZQlBdllwJHYx6fK2g8kha6r2JIQKocvsAXiiONqSfw== hello@world.com"
+    }
+  }
+
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name                                   = "TestIPConfiguration"
+      subnet_id                              = "${azurerm_subnet.test.id}"
+      load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.test.id}"]
+    }
+  }
+
+  storage_profile_os_disk {
+    name           = "osDiskProfile"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    os_type        = "linux"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "14.04.2-LTS"
+    version   = "latest"
+  }
+
+  tags {
+    ThisIs = "a test"
+  }
+}
+
+`, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}
+
+var testAccAzureRMVirtualMachineScaleSetLoadbalancerTemplate = `
+resource "azurerm_resource_group" "test" {
+  name     = "acctestrg-%d"
+  location = "southcentralus"
+}
+
+resource "azurerm_virtual_network" "test" {
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
+}
+
+resource "azurerm_storage_account" "test" {
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "southcentralus"
+  account_type        = "Standard_LRS"
+}
+
+resource "azurerm_storage_container" "test" {
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
+}
+
+resource "azurerm_lb" "test" {
+  name                = "acctestlb-%d"
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+
+  frontend_ip_configuration {
+    name                          = "default"
+    subnet_id                     = "${azurerm_subnet.test.id}"
+    private_ip_address_allocation = "Dynamic"
+  }
+}
+
+resource "azurerm_lb_backend_address_pool" "test" {
+  name                = "test"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "southcentralus"
+  loadbalancer_id     = "${azurerm_lb.test.id}"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name                = "acctvmss-%d"
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+
+  sku {
+    name     = "Standard_A0"
+    tier     = "Standard"
+    capacity = 1
+  }
+
+  os_profile {
+    computer_name_prefix = "testvm-%d"
+    admin_username       = "myadmin"
+    admin_password       = "Passwword1234"
+  }
+
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
+
+    ip_configuration {
+      name                                   = "TestIPConfiguration"
+      subnet_id                              = "${azurerm_subnet.test.id}"
+      load_balancer_backend_address_pool_ids = ["${azurerm_lb_backend_address_pool.test.id}"]
+    }
+  }
+
+  storage_profile_os_disk {
+    name           = "os-disk"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "14.04.2-LTS"
+    version   = "latest"
+  }
 }
 `
 
 var testAccAzureRMVirtualMachineScaleSetOverprovisionTemplate = `
 resource "azurerm_resource_group" "test" {
-    name 	 = "acctestrg-%d"
-    location = "southcentralus"
+  name     = "acctestrg-%d"
+  location = "southcentralus"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name 		        = "acctvn-%d"
-    address_space       = ["10.0.0.0/16"]
-    location            = "southcentralus"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name                 = "acctsub-%d"
-    resource_group_name  = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix       = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_storage_account" "test" {
-    name                = "accsa%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location            = "southcentralus"
-    account_type        = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "southcentralus"
+  account_type        = "Standard_LRS"
 }
 
 resource "azurerm_storage_container" "test" {
-    name                  = "vhds"
-    resource_group_name   = "${azurerm_resource_group.test.name}"
-    storage_account_name  = "${azurerm_storage_account.test.name}"
-    container_access_type = "private"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
 }
 
 resource "azurerm_virtual_machine_scale_set" "test" {
-  	name                = "acctvmss-%d"
-  	location            = "southcentralus"
-  	resource_group_name = "${azurerm_resource_group.test.name}"
-  	upgrade_policy_mode = "Manual"
-	overprovision       = false
+  name                = "acctvmss-%d"
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+  overprovision       = false
 
-  	sku {
-		name     = "Standard_A0"
-    	tier     = "Standard"
-    	capacity = 1
-	}
+  sku {
+    name     = "Standard_A0"
+    tier     = "Standard"
+    capacity = 1
+  }
 
-  	os_profile {
-    	computer_name_prefix = "testvm-%d"
-    	admin_username = "myadmin"
-    	admin_password = "Passwword1234"
-  	}
+  os_profile {
+    computer_name_prefix = "testvm-%d"
+    admin_username       = "myadmin"
+    admin_password       = "Passwword1234"
+  }
 
-  	network_profile {
-      	name    = "TestNetworkProfile"
-      	primary = true
-      	ip_configuration {
-        	name	  = "TestIPConfiguration"
-        	subnet_id = "${azurerm_subnet.test.id}"
-      	}
-  	}
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
 
-  	storage_profile_os_disk {
-    	name 		   = "os-disk"
-    	caching        = "ReadWrite"
-    	create_option  = "FromImage"
-    	vhd_containers = [ "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}" ]
-  	}
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      subnet_id = "${azurerm_subnet.test.id}"
+    }
+  }
 
-  	storage_profile_image_reference {
-    	publisher = "Canonical"
-    	offer     = "UbuntuServer"
-    	sku       = "14.04.2-LTS"
-    	version   = "latest"
-  	}
+  storage_profile_os_disk {
+    name           = "os-disk"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "14.04.2-LTS"
+    version   = "latest"
+  }
 }
 `
 
 var testAccAzureRMVirtualMachineScaleSetExtensionTemplate = `
 resource "azurerm_resource_group" "test" {
-    name 	 = "acctestrg-%d"
-    location = "southcentralus"
+  name     = "acctestrg-%d"
+  location = "southcentralus"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name 		        = "acctvn-%d"
-    address_space       = ["10.0.0.0/16"]
-    location            = "southcentralus"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name                 = "acctsub-%d"
-    resource_group_name  = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix       = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_storage_account" "test" {
-    name                = "accsa%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location            = "southcentralus"
-    account_type        = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "southcentralus"
+  account_type        = "Standard_LRS"
 }
 
 resource "azurerm_storage_container" "test" {
-    name                  = "vhds"
-    resource_group_name   = "${azurerm_resource_group.test.name}"
-    storage_account_name  = "${azurerm_storage_account.test.name}"
-    container_access_type = "private"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
 }
 
 resource "azurerm_virtual_machine_scale_set" "test" {
-  	name                = "acctvmss-%d"
-  	location            = "southcentralus"
-  	resource_group_name = "${azurerm_resource_group.test.name}"
-  	upgrade_policy_mode = "Manual"
-	overprovision       = false
+  name                = "acctvmss-%d"
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+  overprovision       = false
 
-  	sku {
-		name     = "Standard_A0"
-    	tier     = "Standard"
-    	capacity = 1
-	}
+  sku {
+    name     = "Standard_A0"
+    tier     = "Standard"
+    capacity = 1
+  }
 
-  	os_profile {
-    	computer_name_prefix = "testvm-%d"
-    	admin_username = "myadmin"
-    	admin_password = "Passwword1234"
-  	}
+  os_profile {
+    computer_name_prefix = "testvm-%d"
+    admin_username       = "myadmin"
+    admin_password       = "Passwword1234"
+  }
 
-  	network_profile {
-      	name    = "TestNetworkProfile"
-      	primary = true
-      	ip_configuration {
-        	name	  = "TestIPConfiguration"
-        	subnet_id = "${azurerm_subnet.test.id}"
-      	}
-  	}
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
 
-  	storage_profile_os_disk {
-    	name 		   = "os-disk"
-    	caching        = "ReadWrite"
-    	create_option  = "FromImage"
-    	vhd_containers = [ "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}" ]
-  	}
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      subnet_id = "${azurerm_subnet.test.id}"
+    }
+  }
 
-  	storage_profile_image_reference {
-    	publisher = "Canonical"
-    	offer     = "UbuntuServer"
-    	sku       = "14.04.2-LTS"
-    	version   = "latest"
-  	}
+  storage_profile_os_disk {
+    name           = "os-disk"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
 
-	extension {
-		name                       = "CustomScript"
-		publisher                  = "Microsoft.Azure.Extensions"
-		type                       = "CustomScript"
-		type_handler_version       = "2.0"
-		auto_upgrade_minor_version = true
-		settings                   = <<SETTINGS
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "14.04.2-LTS"
+    version   = "latest"
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = <<SETTINGS
 		{
 			"commandToExecute": "echo $HOSTNAME"
 		}
 SETTINGS
 
-		protected_settings         = <<SETTINGS
+    protected_settings = <<SETTINGS
 		{
 			"storageAccountName": "${azurerm_storage_account.test.name}",
 			"storageAccountKey": "${azurerm_storage_account.test.primary_access_key}"
 		}
 SETTINGS
-	}
+  }
 }
+
 `
 
 var testAccAzureRMVirtualMachineScaleSetMultipleExtensionsTemplate = `
 resource "azurerm_resource_group" "test" {
-    name 	 = "acctestrg-%d"
-    location = "southcentralus"
+  name     = "acctestrg-%d"
+  location = "southcentralus"
 }
 
 resource "azurerm_virtual_network" "test" {
-    name 		        = "acctvn-%d"
-    address_space       = ["10.0.0.0/16"]
-    location            = "southcentralus"
-    resource_group_name = "${azurerm_resource_group.test.name}"
+  name                = "acctvn-%d"
+  address_space       = ["10.0.0.0/16"]
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_subnet" "test" {
-    name                 = "acctsub-%d"
-    resource_group_name  = "${azurerm_resource_group.test.name}"
-    virtual_network_name = "${azurerm_virtual_network.test.name}"
-    address_prefix       = "10.0.2.0/24"
+  name                 = "acctsub-%d"
+  resource_group_name  = "${azurerm_resource_group.test.name}"
+  virtual_network_name = "${azurerm_virtual_network.test.name}"
+  address_prefix       = "10.0.2.0/24"
 }
 
 resource "azurerm_storage_account" "test" {
-    name                = "accsa%d"
-    resource_group_name = "${azurerm_resource_group.test.name}"
-    location            = "southcentralus"
-    account_type        = "Standard_LRS"
+  name                = "accsa%d"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  location            = "southcentralus"
+  account_type        = "Standard_LRS"
 }
 
 resource "azurerm_storage_container" "test" {
-    name                  = "vhds"
-    resource_group_name   = "${azurerm_resource_group.test.name}"
-    storage_account_name  = "${azurerm_storage_account.test.name}"
-    container_access_type = "private"
+  name                  = "vhds"
+  resource_group_name   = "${azurerm_resource_group.test.name}"
+  storage_account_name  = "${azurerm_storage_account.test.name}"
+  container_access_type = "private"
 }
 
 resource "azurerm_virtual_machine_scale_set" "test" {
-  	name                = "acctvmss-%d"
-  	location            = "southcentralus"
-  	resource_group_name = "${azurerm_resource_group.test.name}"
-  	upgrade_policy_mode = "Manual"
-	overprovision       = false
+  name                = "acctvmss-%d"
+  location            = "southcentralus"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+  overprovision       = false
 
-  	sku {
-		name     = "Standard_A0"
-    	tier     = "Standard"
-    	capacity = 1
-	}
+  sku {
+    name     = "Standard_A0"
+    tier     = "Standard"
+    capacity = 1
+  }
 
-  	os_profile {
-    	computer_name_prefix = "testvm-%d"
-    	admin_username = "myadmin"
-    	admin_password = "Passwword1234"
-  	}
+  os_profile {
+    computer_name_prefix = "testvm-%d"
+    admin_username       = "myadmin"
+    admin_password       = "Passwword1234"
+  }
 
-  	network_profile {
-      	name    = "TestNetworkProfile"
-      	primary = true
-      	ip_configuration {
-        	name	  = "TestIPConfiguration"
-        	subnet_id = "${azurerm_subnet.test.id}"
-      	}
-  	}
+  network_profile {
+    name    = "TestNetworkProfile"
+    primary = true
 
-  	storage_profile_os_disk {
-    	name 		   = "os-disk"
-    	caching        = "ReadWrite"
-    	create_option  = "FromImage"
-    	vhd_containers = [ "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}" ]
-  	}
+    ip_configuration {
+      name      = "TestIPConfiguration"
+      subnet_id = "${azurerm_subnet.test.id}"
+    }
+  }
 
-  	storage_profile_image_reference {
-    	publisher = "Canonical"
-    	offer     = "UbuntuServer"
-    	sku       = "14.04.2-LTS"
-    	version   = "latest"
-  	}
+  storage_profile_os_disk {
+    name           = "os-disk"
+    caching        = "ReadWrite"
+    create_option  = "FromImage"
+    vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
 
-	extension {
-		name                       = "CustomScript"
-		publisher                  = "Microsoft.Azure.Extensions"
-		type                       = "CustomScript"
-		type_handler_version       = "2.0"
-		auto_upgrade_minor_version = true
-		settings                   = <<SETTINGS
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "14.04.2-LTS"
+    version   = "latest"
+  }
+
+  extension {
+    name                       = "CustomScript"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "CustomScript"
+    type_handler_version       = "2.0"
+    auto_upgrade_minor_version = true
+
+    settings = <<SETTINGS
 		{
 			"commandToExecute": "echo $HOSTNAME"
 		}
 SETTINGS
 
-		protected_settings         = <<SETTINGS
+    protected_settings = <<SETTINGS
 		{
 			"storageAccountName": "${azurerm_storage_account.test.name}",
 			"storageAccountKey": "${azurerm_storage_account.test.primary_access_key}"
 		}
 SETTINGS
-	}
+  }
 
-	extension {
-		name                       = "Docker"
-		publisher                  = "Microsoft.Azure.Extensions"
-		type                       = "DockerExtension"
-		type_handler_version       = "1.0"
-		auto_upgrade_minor_version = true
-	}
+  extension {
+    name                       = "Docker"
+    publisher                  = "Microsoft.Azure.Extensions"
+    type                       = "DockerExtension"
+    type_handler_version       = "1.0"
+    auto_upgrade_minor_version = true
+  }
 }
 `

--- a/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
@@ -177,7 +177,7 @@ The following arguments are supported:
 * `disable_password_authentication` - (Required) Specifies whether password authentication should be disabled.
 * `ssh_keys` - (Optional) Specifies a collection of `path` and `key_data` to be placed on the virtual machine.
 
-~> **Note:** Please note that the only allowed `path` is `/home/<username>/.ssh/authorized_keys` due to a limitation of Azure_
+~> _**Note:** Please note that the only allowed `path` is `/home/<username>/.ssh/authorized_keys` due to a limitation of Azure_
 
 
 `network_profile` supports the following:
@@ -225,3 +225,12 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The virtual machine scale set ID.
+
+
+## Import
+
+Virtual Machine Scale Sets can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_virtual_machine_scale_set.scaleset1 /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Compute/virtualMachineScaleSets/scaleset1
+```

--- a/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
@@ -140,7 +140,7 @@ The following arguments are supported:
 * `computer_name_prefix` - (Required) Specifies the computer name prefix for all of the virtual machines in the scale set. Computer name prefixes must be 1 to 15 characters long.
 * `admin_username` - (Required) Specifies the administrator account name to use for all the instances of virtual machines in the scale set.
 * `admin_password` - (Required) Specifies the administrator password to use for all the instances of virtual machines in a scale set..
-* `custom_data` - (Optional) Specifies custom data to supply to the machine. On linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes.
+* `custom_data` - (Optional) Specifies custom data to supply to the machine. On linux-based systems, this can be used as a cloud-init script. On other systems, this will be copied as a file on disk. Internally, Terraform will base64 encode this value before sending it to the API. The maximum length of the binary array is 65535 bytes. Changing this forces a new resource to be created.
 
 `os_profile_secrets` supports the following:
 


### PR DESCRIPTION
Fixes several issues with VM Scale Sets:
 - Adds import support
 - Fixing a bug where a null value was appended to the `ssh_keys` state field, causing a crash on the next apply, which fixes: #13094 #13009
 - Storing `custom_data` in the state file as base64
 - Making `custom_data` ForceNew, since it's not possible to update it