### PR TITLE
provider/aws: Fix overly-restrictive AWS tag rules

### DIFF
--- a/builtin/providers/aws/autoscaling_tags.go
+++ b/builtin/providers/aws/autoscaling_tags.go
@@ -190,7 +190,7 @@ func setToMapByKey(s *schema.Set, key string) map[string]interface{} {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredAutoscaling(t *autoscaling.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/s3_tags.go
+++ b/builtin/providers/aws/s3_tags.go
@@ -121,7 +121,7 @@ func getTagSetS3(s3conn *s3.S3, bucket string) ([]*s3.Tag, error) {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredS3(t *s3.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tags.go
+++ b/builtin/providers/aws/tags.go
@@ -225,7 +225,7 @@ func tagsFromMapELBv2(m map[string]interface{}) []*elbv2.Tag {
 // tagIgnored compares a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnored(t *ec2.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {
@@ -238,7 +238,7 @@ func tagIgnored(t *ec2.Tag) bool {
 
 // and for ELBv2 as well
 func tagIgnoredELBv2(t *elbv2.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsBeanstalk.go
+++ b/builtin/providers/aws/tagsBeanstalk.go
@@ -62,7 +62,7 @@ func tagsToMapBeanstalk(ts []*elasticbeanstalk.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredBeanstalk(t *elasticbeanstalk.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsCloudtrail.go
+++ b/builtin/providers/aws/tagsCloudtrail.go
@@ -100,7 +100,7 @@ func tagsToMapCloudtrail(ts []*cloudtrail.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredCloudtrail(t *cloudtrail.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsCodeBuild.go
+++ b/builtin/providers/aws/tagsCodeBuild.go
@@ -55,7 +55,7 @@ func tagsToMapCodeBuild(ts []*codebuild.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredCodeBuild(t *codebuild.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsEC.go
+++ b/builtin/providers/aws/tagsEC.go
@@ -103,7 +103,7 @@ func tagsToMapEC(ts []*elasticache.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredEC(t *elasticache.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsEFS.go
+++ b/builtin/providers/aws/tagsEFS.go
@@ -102,7 +102,7 @@ func tagsToMapEFS(ts []*efs.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredEFS(t *efs.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsELB.go
+++ b/builtin/providers/aws/tagsELB.go
@@ -102,7 +102,7 @@ func tagsToMapELB(ts []*elb.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredELB(t *elb.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsInspector.go
+++ b/builtin/providers/aws/tagsInspector.go
@@ -62,7 +62,7 @@ func tagsToMapInspector(ts []*inspector.ResourceGroupTag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredInspector(t *inspector.ResourceGroupTag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsKMS.go
+++ b/builtin/providers/aws/tagsKMS.go
@@ -103,7 +103,7 @@ func tagsToMapKMS(ts []*kms.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredKMS(t *kms.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.TagKey)
 		if r, _ := regexp.MatchString(v, *t.TagKey); r == true {

--- a/builtin/providers/aws/tagsRDS.go
+++ b/builtin/providers/aws/tagsRDS.go
@@ -121,7 +121,7 @@ func saveTagsRDS(conn *rds.RDS, d *schema.ResourceData, arn string) error {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredRDS(t *rds.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tagsRedshift.go
+++ b/builtin/providers/aws/tagsRedshift.go
@@ -96,7 +96,7 @@ func tagsToMapRedshift(ts []*redshift.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredRedshift(t *redshift.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tags_elasticsearchservice.go
+++ b/builtin/providers/aws/tags_elasticsearchservice.go
@@ -102,7 +102,7 @@ func tagsToMapElasticsearchService(ts []*elasticsearch.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredElasticsearchService(t *elasticsearch.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tags_kinesis.go
+++ b/builtin/providers/aws/tags_kinesis.go
@@ -113,7 +113,7 @@ func tagsToMapKinesis(ts []*kinesis.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredKinesis(t *kinesis.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tags_route53.go
+++ b/builtin/providers/aws/tags_route53.go
@@ -99,7 +99,7 @@ func tagsToMapR53(ts []*route53.Tag) map[string]string {
 // compare a tag against a list of strings and checks if it should
 // be ignored or not
 func tagIgnoredRoute53(t *route53.Tag) bool {
-	filter := []string{"^aws:*"}
+	filter := []string{"^aws:.*"}
 	for _, v := range filter {
 		log.Printf("[DEBUG] Matching %v with %v\n", v, *t.Key)
 		if r, _ := regexp.MatchString(v, *t.Key); r == true {

--- a/builtin/providers/aws/tags_test.go
+++ b/builtin/providers/aws/tags_test.go
@@ -80,6 +80,24 @@ func TestIgnoringTags(t *testing.T) {
 	}
 }
 
+func TestAcceptableTags(t *testing.T) {
+	var ignoredTags []*ec2.Tag
+	ignoredTags = append(ignoredTags, &ec2.Tag{
+
+		Key:   aws.String("aws_allowedtag"),
+		Value: aws.String("foo"),
+	})
+	ignoredTags = append(ignoredTags, &ec2.Tag{
+		Key:   aws.String("awsome"),
+		Value: aws.String("baz"),
+	})
+	for _, tag := range ignoredTags {
+		if tagIgnored(tag) {
+			t.Fatalf("Tag %v with value %v ignored, but should not be!", *tag.Key, *tag.Value)
+		}
+	}
+}
+
 // testAccCheckTags can be used to check the tags on a resource.
 func testAccCheckTags(
 	ts *[]*ec2.Tag, key string, value string) resource.TestCheckFunc {


### PR DESCRIPTION
Per http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions,
the only restricted tags start with "aws:". This probably applies to many other AWS
services as well, yet the copy-pasted verification function's regex would reject
legitimate tags like aws_something or awssomething.