### PR TITLE
docs: Update AWS Data Source docs to have HCL formatted examples

### DIFF
--- a/website/source/docs/providers/aws/d/acm_certificate.html.markdown
+++ b/website/source/docs/providers/aws/d/acm_certificate.html.markdown
@@ -16,7 +16,7 @@ them by domain without having to hard code the ARNs as input.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_acm_certificate" "example" {
   domain   = "tf.example.com"
   statuses = ["ISSUED"]

--- a/website/source/docs/providers/aws/d/alb.html.markdown
+++ b/website/source/docs/providers/aws/d/alb.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_alb"
-sidebar_current: "docs-aws-datasource-alb"
+sidebar_current: "docs-aws-datasource-alb-x"
 description: |-
   Provides an Application Load Balancer data source.
 ---
@@ -16,7 +16,7 @@ with it, etc.
 
 ## Example Usage
 
-```
+```hcl
 variable "alb_arn" {
   type    = "string"
   default = ""

--- a/website/source/docs/providers/aws/d/alb_listener.html.markdown
+++ b/website/source/docs/providers/aws/d/alb_listener.html.markdown
@@ -16,7 +16,7 @@ information specific to the listener in question.
 
 ## Example Usage
 
-```
+```hcl
 variable "listener_arn" {
   type = "string"
 }

--- a/website/source/docs/providers/aws/d/ami.html.markdown
+++ b/website/source/docs/providers/aws/d/ami.html.markdown
@@ -13,7 +13,7 @@ resources.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_ami" "nat_ami" {
   most_recent      = true
   executable_users = ["self"]

--- a/website/source/docs/providers/aws/d/autoscaling_groups.html.markdown
+++ b/website/source/docs/providers/aws/d/autoscaling_groups.html.markdown
@@ -13,7 +13,7 @@ ASGs within a specific region. This will allow you to pass a list of AutoScaling
 
 ## Example Usage
 
-```
+```hcl
 data "aws_autoscaling_groups" "groups" {}
 
 resource "aws_autoscaling_notification" "slack_notifications" {

--- a/website/source/docs/providers/aws/d/availability_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/availability_zone.html.markdown
@@ -25,7 +25,7 @@ which provides a list of the available zones.
 The following example shows how this data source might be used to derive
 VPC and subnet CIDR prefixes systematically for an availability zone.
 
-```
+```hcl
 variable "region_number" {
   # Arbitrary mapping of region name to number to use in
   # a VPC's CIDR prefix.

--- a/website/source/docs/providers/aws/d/availability_zones.html.markdown
+++ b/website/source/docs/providers/aws/d/availability_zones.html.markdown
@@ -17,7 +17,7 @@ which provides some details about a specific availability zone.
 
 ## Example Usage
 
-```
+```hcl
 # Declare the data source
 data "aws_availability_zones" "available" {}
 

--- a/website/source/docs/providers/aws/d/caller_identity.html.markdown
+++ b/website/source/docs/providers/aws/d/caller_identity.html.markdown
@@ -14,7 +14,7 @@ which Terraform is authorized.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_caller_identity" "current" {}
 
 output "account_id" {

--- a/website/source/docs/providers/aws/d/canonical_user_id.html.markdown
+++ b/website/source/docs/providers/aws/d/canonical_user_id.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_canonical_user_id"
-sidebar_current: "docs-aws-canonical-user-id"
+sidebar_current: "docs-aws-datasource-canonical-user-id"
 description: |-
   Provides the canonical user ID for the AWS account associated with the provider
   connection to AWS.
@@ -14,7 +14,7 @@ for the effective account in which Terraform is working.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_canonical_user_id" "current" {}
 
 output "canonical_user_id" {

--- a/website/source/docs/providers/aws/d/cloudformation_stack.html.markdown
+++ b/website/source/docs/providers/aws/d/cloudformation_stack.html.markdown
@@ -13,7 +13,7 @@ outputs and other useful data including the template body.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_cloudformation_stack" "network" {
   name = "my-network-stack"
 }

--- a/website/source/docs/providers/aws/d/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/d/db_instance.html.markdown
@@ -12,7 +12,7 @@ Use this data source to get information about an RDS instance
 
 ## Example Usage
 
-```
+```hcl
 data "aws_db_instance" "database" {
   db_instance_identifier = "my-test-database"
 }

--- a/website/source/docs/providers/aws/d/ebs_snapshot.html.markdown
+++ b/website/source/docs/providers/aws/d/ebs_snapshot.html.markdown
@@ -12,7 +12,7 @@ Use this data source to get information about an EBS Snapshot for use when provi
 
 ## Example Usage
 
-```
+```hcl
 data "aws_ebs_snapshot" "ebs_volume" {
   most_recent = true
   owners      = ["self"]

--- a/website/source/docs/providers/aws/d/ebs_volume.html.markdown
+++ b/website/source/docs/providers/aws/d/ebs_volume.html.markdown
@@ -13,7 +13,7 @@ resources.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_ebs_volume" "ebs_volume" {
   most_recent = true
 

--- a/website/source/docs/providers/aws/d/ecs_cluster.html.markdown
+++ b/website/source/docs/providers/aws/d/ecs_cluster.html.markdown
@@ -13,7 +13,7 @@ cluster within an AWS ECS service.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_ecs_cluster" "ecs-mongo" {
   cluster_name = "ecs-mongo-production"
 }

--- a/website/source/docs/providers/aws/d/ecs_container_definition.html.markdown
+++ b/website/source/docs/providers/aws/d/ecs_container_definition.html.markdown
@@ -13,7 +13,7 @@ a specific container within an AWS ECS service.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_ecs_container_definition" "ecs-mongo" {
   task_definition = "${aws_ecs_task_definition.mongo.id}"
   container_name  = "mongodb"

--- a/website/source/docs/providers/aws/d/ecs_task_definition.html.markdown
+++ b/website/source/docs/providers/aws/d/ecs_task_definition.html.markdown
@@ -14,7 +14,7 @@ a specific AWS ECS task definition.
 
 ## Example Usage
 
-```
+```hcl
 # Simply specify the family to find the latest ACTIVE revision in that family.
 data "aws_ecs_task_definition" "mongo" {
   task_definition = "${aws_ecs_task_definition.mongo.family}"

--- a/website/source/docs/providers/aws/d/elb_hosted_zone_id.html.markdown
+++ b/website/source/docs/providers/aws/d/elb_hosted_zone_id.html.markdown
@@ -13,7 +13,7 @@ in a given region for the purpose of using in an AWS Route53 Alias.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_elb_hosted_zone_id" "main" {}
 
 resource "aws_route53_record" "www" {

--- a/website/source/docs/providers/aws/d/elb_service_account.html.markdown
+++ b/website/source/docs/providers/aws/d/elb_service_account.html.markdown
@@ -13,7 +13,7 @@ in a given region for the purpose of whitelisting in S3 bucket policy.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_elb_service_account" "main" {}
 
 resource "aws_s3_bucket" "elb_logs" {

--- a/website/source/docs/providers/aws/d/iam_account_alias.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_account_alias.html.markdown
@@ -14,7 +14,7 @@ for the effective account in which Terraform is working.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_iam_account_alias" "current" {}
 
 output "account_id" {

--- a/website/source/docs/providers/aws/d/iam_policy_document.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_policy_document.html.markdown
@@ -14,7 +14,7 @@ This is a data source which can be used to construct a JSON representation of
 an IAM policy document, for use with resources which expect policy documents,
 such as the `aws_iam_policy` resource.
 
-```
+```hcl
 data "aws_iam_policy_document" "example" {
   statement {
     sid = "1"
@@ -149,7 +149,7 @@ The following attribute is exported:
 
 Showing how you can use this as an assume role policy as well as showing how you can specify multiple principal blocks with different types.
 
-```
+```hcl
 data "aws_iam_policy_document" "event_stream_bucket_role_assume_role_policy" {
   statement {
     actions = ["sts:AssumeRole"]

--- a/website/source/docs/providers/aws/d/iam_role.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_role.html.markdown
@@ -14,7 +14,7 @@ properties without having to hard code ARNs as input.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_iam_role" "example" {
   role_name = "an_example_role_name"
 }

--- a/website/source/docs/providers/aws/d/iam_role.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_role.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: "AWS: aws_iam_role
+page_title: "AWS: aws_iam_role"
 sidebar_current: "docs-aws-datasource-iam-role"
 description: |-
   Get information on a Amazon IAM role

--- a/website/source/docs/providers/aws/d/iam_server_certificate.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_server_certificate.html.markdown
@@ -12,7 +12,7 @@ Use this data source to lookup information about IAM Server Certificates.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_iam_server_certificate" "my-domain" {
   name_prefix = "my-domain.org"
   latest      = true

--- a/website/source/docs/providers/aws/d/instance.html.markdown
+++ b/website/source/docs/providers/aws/d/instance.html.markdown
@@ -13,7 +13,7 @@ resources.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_instance" "foo" {
   instance_id = "i-instanceid"
 

--- a/website/source/docs/providers/aws/d/ip_ranges.html.markdown
+++ b/website/source/docs/providers/aws/d/ip_ranges.html.markdown
@@ -12,7 +12,7 @@ Use this data source to get the [IP ranges][1] of various AWS products and servi
 
 ## Example Usage
 
-```
+```hcl
 data "aws_ip_ranges" "european_ec2" {
   regions  = ["eu-west-1", "eu-central-1"]
   services = ["ec2"]

--- a/website/source/docs/providers/aws/d/kms_secret.html.markdown
+++ b/website/source/docs/providers/aws/d/kms_secret.html.markdown
@@ -36,7 +36,7 @@ AQECAHgaPa0J8WadplGCqqVAr4HNvDaFSQ+NaiwIBhmm6qDSFwAAAGIwYAYJKoZIhvcNAQcGoFMwUQIB
 
 Now, take that output and add it to your resource definitions.
 
-```
+```hcl
 data "aws_kms_secret" "db" {
   secret {
     name    = "master_password"

--- a/website/source/docs/providers/aws/d/partition.html.markdown
+++ b/website/source/docs/providers/aws/d/partition.html.markdown
@@ -12,7 +12,7 @@ Use this data source to lookup current AWS partition in which Terraform is worki
 
 ## Example Usage
 
-```
+```hcl
 data "aws_partition" "current" {}
 
 data "aws_iam_policy_document" "s3_policy" {

--- a/website/source/docs/providers/aws/d/prefix_list.html.markdown
+++ b/website/source/docs/providers/aws/d/prefix_list.html.markdown
@@ -18,7 +18,7 @@ rules.
 
 ## Example Usage
 
-```
+```hcl
 resource "aws_vpc_endpoint" "private_s3" {
   vpc_id       = "${aws_vpc.foo.id}"
   service_name = "com.amazonaws.us-west-2.s3"

--- a/website/source/docs/providers/aws/d/redshift_service_account.html.markdown
+++ b/website/source/docs/providers/aws/d/redshift_service_account.html.markdown
@@ -13,7 +13,7 @@ in a given region for the purpose of allowing Redshift to store audit data in S3
 
 ## Example Usage
 
-```
+```hcl
 data "aws_redshift_service_account" "main" {}
 
 resource "aws_s3_bucket" "bucket" {

--- a/website/source/docs/providers/aws/d/region.html.markdown
+++ b/website/source/docs/providers/aws/d/region.html.markdown
@@ -20,7 +20,7 @@ which is inheriting an AWS provider configuration from its parent module.
 The following example shows how the resource might be used to obtain
 the name of the AWS region configured on the provider.
 
-```
+```hcl
 data "aws_region" "current" {
   current = true
 }

--- a/website/source/docs/providers/aws/d/route53_zone.html.markdown
+++ b/website/source/docs/providers/aws/d/route53_zone.html.markdown
@@ -17,7 +17,7 @@ This data source allows to find a Hosted Zone ID given Hosted Zone name and cert
 The following example shows how to get a Hosted Zone from it's name and from this data how to create a Record Set.
 
 
-```
+```hcl
 data "aws_route53_zone" "selected" {
   name         = "test.com."
   private_zone = true

--- a/website/source/docs/providers/aws/d/route_table.html.markdown
+++ b/website/source/docs/providers/aws/d/route_table.html.markdown
@@ -19,7 +19,7 @@ the Route Table.
 The following example shows how one might accept a Route Table id as a variable
 and use this data source to obtain the data necessary to create a route.
 
-```
+```hcl
 variable "subnet_id" {}
 
 data "aws_route_table" "selected" {

--- a/website/source/docs/providers/aws/d/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/d/s3_bucket_object.html.markdown
@@ -15,7 +15,7 @@ _optionally_ (see below) content of an object stored inside S3 bucket.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_s3_bucket_object" "lambda" {
   bucket = "my-lambda-functions"
   key    = "hello-world.zip"

--- a/website/source/docs/providers/aws/d/security_group.html.markdown
+++ b/website/source/docs/providers/aws/d/security_group.html.markdown
@@ -19,7 +19,7 @@ VPC that the security group belongs to.
 The following example shows how one might accept a Security Group id as a variable
 and use this data source to obtain the data necessary to create a subnet.
 
-```
+```hcl
 variable "security_group_id" {}
 
 data "aws_security_group" "selected" {

--- a/website/source/docs/providers/aws/d/sns_topic.html.markdown
+++ b/website/source/docs/providers/aws/d/sns_topic.html.markdown
@@ -14,7 +14,7 @@ without having to hard code the ARNs as input.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_sns_topic" "example" {
   name = "an_example_topic"
 }

--- a/website/source/docs/providers/aws/d/subnet.html.markdown
+++ b/website/source/docs/providers/aws/d/subnet.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_subnet"
-sidebar_current: "docs-aws-datasource-subnet"
+sidebar_current: "docs-aws-datasource-subnet-x"
 description: |-
     Provides details about a specific VPC subnet
 ---
@@ -20,7 +20,7 @@ The following example shows how one might accept a subnet id as a variable
 and use this data source to obtain the data necessary to create a security
 group that allows connections from hosts in that subnet.
 
-```
+```hcl
 variable "subnet_id" {}
 
 data "aws_subnet" "selected" {

--- a/website/source/docs/providers/aws/d/subnet_ids.html.markdown
+++ b/website/source/docs/providers/aws/d/subnet_ids.html.markdown
@@ -16,7 +16,7 @@ This resource can be useful for getting back a list of subnet ids for a vpc.
 
 The following shows outputing all cidr blocks for every subnet id in a vpc.
 
-```
+```hcl
 data "aws_subnet_ids" "example" {
   vpc_id = "${var.vpc_id}"
 }

--- a/website/source/docs/providers/aws/d/vpc.html.markdown
+++ b/website/source/docs/providers/aws/d/vpc.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_vpc"
-sidebar_current: "docs-aws-datasource-vpc"
+sidebar_current: "docs-aws-datasource-vpc-x"
 description: |-
     Provides details about a specific VPC
 ---
@@ -20,7 +20,7 @@ The following example shows how one might accept a VPC id as a variable
 and use this data source to obtain the data necessary to create a subnet
 within it.
 
-```
+```hcl
 variable "vpc_id" {}
 
 data "aws_vpc" "selected" {

--- a/website/source/docs/providers/aws/d/vpc_endpoint.html.markdown
+++ b/website/source/docs/providers/aws/d/vpc_endpoint.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "aws"
 page_title: "AWS: aws_vpc_endpoint"
-sidebar_current: "docs-aws-datasource-vpc-endpoint"
+sidebar_current: "docs-aws-datasource-vpc-endpoint-x"
 description: |-
     Provides details about a specific VPC endpoint.
 ---
@@ -13,7 +13,7 @@ a specific VPC endpoint.
 
 ## Example Usage
 
-```
+```hcl
 # Declare the data source
 data "aws_vpc_endpoint" "s3" {
   vpc_id       = "${aws_vpc.foo.id}"

--- a/website/source/docs/providers/aws/d/vpc_endpoint_service.html.markdown
+++ b/website/source/docs/providers/aws/d/vpc_endpoint_service.html.markdown
@@ -14,7 +14,7 @@ configured in the provider.
 
 ## Example Usage
 
-```
+```hcl
 # Declare the data source
 data "aws_vpc_endpoint_service" "s3" {
   service = "s3"

--- a/website/source/docs/providers/aws/d/vpc_peering_connection.html.markdown
+++ b/website/source/docs/providers/aws/d/vpc_peering_connection.html.markdown
@@ -13,7 +13,7 @@ a specific VPC peering connection.
 
 ## Example Usage
 
-```
+```hcl
 # Declare the data source
 data "aws_vpc_peering_connection" "pc" {
   vpc_id          = "${aws_vpc.foo.id}"

--- a/website/source/docs/providers/aws/d/vpn_gateway.html.markdown
+++ b/website/source/docs/providers/aws/d/vpn_gateway.html.markdown
@@ -13,7 +13,7 @@ a specific VPN gateway.
 
 ## Example Usage
 
-```
+```hcl
 data "aws_vpn_gateway" "selected" {
   filter {
     name = "tag:Name"

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -16,7 +16,7 @@ Use the navigation to the left to read about the available resources.
 
 ## Example Usage
 
-```
+```hcl
 # Configure the AWS Provider
 provider "aws" {
   access_key = "${var.aws_access_key}"
@@ -64,13 +64,13 @@ Access Key and AWS Secret Key, respectively.  The `AWS_DEFAULT_REGION`
 and `AWS_SESSION_TOKEN` environment variables are also used, if
 applicable:
 
-```
+```hcl
 provider "aws" {}
 ```
 
 Usage:
 
-```
+```hcl
 $ export AWS_ACCESS_KEY_ID="anaccesskey"
 $ export AWS_SECRET_ACCESS_KEY="asecretkey"
 $ export AWS_DEFAULT_REGION="us-west-2"
@@ -91,7 +91,7 @@ method also supports a `profile` configuration and matching
 
 Usage:
 
-```
+```hcl
 provider "aws" {
   region                  = "us-west-2"
   shared_credentials_file = "/Users/tf_user/.aws/creds"
@@ -120,7 +120,7 @@ using the supplied credentials.
 
 Usage:
 
-```
+```hcl
 provider "aws" {
   assume_role {
     role_arn     = "arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME"

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -17,7 +17,7 @@
                         <li<%= sidebar_current("docs-aws-datasource-acm-certificate") %>>
                             <a href="/docs/providers/aws/d/acm_certificate.html">aws_acm_certificate</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-alb") %>>
+                        <li<%= sidebar_current("docs-aws-datasource-alb-x") %>>
                             <a href="/docs/providers/aws/d/alb.html">aws_alb</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-alb-listener") %>>

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -116,16 +116,16 @@
                         <li<%= sidebar_current("docs-aws-datasource-sns-topic") %>>
                          <a href="/docs/providers/aws/d/sns_topic.html">aws_sns_topic</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-subnet") %>>
+                        <li<%= sidebar_current("docs-aws-datasource-subnet-x") %>>
                             <a href="/docs/providers/aws/d/subnet.html">aws_subnet</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-subnet-ids") %>>
                             <a href="/docs/providers/aws/d/subnet_ids.html">aws_subnet_ids</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-vpc") %>>
+                        <li<%= sidebar_current("docs-aws-datasource-vpc-x") %>>
                             <a href="/docs/providers/aws/d/vpc.html">aws_vpc</a>
                         </li>
-                        <li<%= sidebar_current("docs-aws-datasource-vpc-endpoint") %>>
+                        <li<%= sidebar_current("docs-aws-datasource-vpc-endpoint-x") %>>
                             <a href="/docs/providers/aws/d/vpc_endpoint.html">aws_vpc_endpoint</a>
                         </li>
                         <li<%= sidebar_current("docs-aws-datasource-vpc-endpoint-service") %>>


### PR DESCRIPTION
I went through the Data Sources on https://www.terraform.io/docs/providers/aws/ and added HCL syntax highlights to the examples. I also fixed some layout issues along the way. 