### PR TITLE
Resolve Sporadic Error with Terraform get with NTFS errors due to relative path

### DIFF
--- a/command/get.go
+++ b/command/get.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"strings"
+	"path/filepath"
 
 	"github.com/hashicorp/terraform/config/module"
 )
@@ -79,7 +80,7 @@ func getModules(m *Meta, path string, mode module.GetMode) error {
 		return fmt.Errorf("Error loading configuration: %s", err)
 	}
 
-	err = mod.Load(m.moduleStorage(m.DataDir()), mode)
+	err = mod.Load(m.moduleStorage(filepath.Abs(m.DataDir())), mode)
 	if err != nil {
 		return fmt.Errorf("Error loading modules: %s", err)
 	}

--- a/command/get.go
+++ b/command/get.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"strings"
-	"path/filepath"
 
 	"github.com/hashicorp/terraform/config/module"
 )
@@ -80,7 +79,7 @@ func getModules(m *Meta, path string, mode module.GetMode) error {
 		return fmt.Errorf("Error loading configuration: %s", err)
 	}
 
-	err = mod.Load(m.moduleStorage(filepath.Abs(m.DataDir())), mode)
+	err = mod.Load(m.moduleStorage(m.DataDirAbs()), mode)
 	if err != nil {
 		return fmt.Errorf("Error loading modules: %s", err)
 	}

--- a/command/meta.go
+++ b/command/meta.go
@@ -47,9 +47,6 @@ type Meta struct {
 	// Modify the data directory location. Defaults to DefaultDataDir
 	dataDir string
 
-	// Fully Qualified version of DataDir
-	dataDirAbs string
-
 	//----------------------------------------------------------
 	// Private: do not set these
 	//----------------------------------------------------------
@@ -150,7 +147,7 @@ func (m *Meta) DataDir() string {
 
 // DataDirAbs returns the DataDir as an absolute path
 func (m *Meta) DataDirAbs() string {
-	dataDirAbs, _ := filepath.Abs(m.dataDir)
+	dataDirAbs, _ := filepath.Abs(m.DataDir())
 	return dataDirAbs
 }
 

--- a/command/meta.go
+++ b/command/meta.go
@@ -14,7 +14,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"path/filepath"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/backend"

--- a/command/meta.go
+++ b/command/meta.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"path/filepath"
 
 	"github.com/hashicorp/go-getter"
 	"github.com/hashicorp/terraform/backend"
@@ -45,6 +46,9 @@ type Meta struct {
 
 	// Modify the data directory location. Defaults to DefaultDataDir
 	dataDir string
+
+	// Fully Qualified version of DataDir
+	dataDirAbs string
 
 	//----------------------------------------------------------
 	// Private: do not set these
@@ -142,6 +146,12 @@ func (m *Meta) DataDir() string {
 	}
 
 	return dataDir
+}
+
+// DataDirAbs returns the DataDir as an absolute path
+func (m *Meta) DataDirAbs() string {
+	dataDirAbs, _ := filepath.Abs(m.dataDir)
+	return dataDirAbs
 }
 
 const (


### PR DESCRIPTION
Terraform Get now passes a full Path, rather than Relative Path, to the Go-Getter application when referencing local terraform modules. This resolves issue seen in #13460 .