### PR TITLE
[provider/aws] check that we actually have NodeGroupMembers

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -223,6 +223,10 @@ func resourceAwsElasticacheReplicationGroupRead(d *schema.ResourceData, meta int
 	d.Set("replication_group_id", rgp.ReplicationGroupId)
 
 	if rgp.NodeGroups != nil {
+		if len(rgp.NodeGroups[0].NodeGroupMembers) == 0 {
+			return nil
+		}
+
 		cacheCluster := *rgp.NodeGroups[0].NodeGroupMembers[0]
 
 		res, err := conn.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{


### PR DESCRIPTION
This fixes the crash I reported in #13487 but I don't quite understand why (other than the fact that the array obviously was empty but we try to access element 0 of it... but terraform plan does complete successfully after this change. Unclear if this is leaving the system in a weird state though.