### PR TITLE
provider/aws Add support for updating SSM documents

### DIFF
--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -414,8 +414,9 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 	name := d.Get("name").(string)
 
 	params := &ssm.UpdateDocumentInput{
-		Name:    aws.String(name),
-		Content: aws.String(d.Get("content").(string)),
+		Name:            aws.String(name),
+		Content:         aws.String(d.Get("content").(string)),
+		DocumentVersion: aws.String(d.Get("default_version").(string)),
 	}
 
 	newDefaultVersion := d.Get("default_version").(string)

--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -413,7 +413,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 
 	name := d.Get("name").(string)
 
-	params := &ssm.UpdateDocumentInput{
+	updateDocInput := &ssm.UpdateDocumentInput{
 		Name:            aws.String(name),
 		Content:         aws.String(d.Get("content").(string)),
 		DocumentVersion: aws.String(d.Get("default_version").(string)),
@@ -422,7 +422,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 	newDefaultVersion := d.Get("default_version").(string)
 
 	ssmconn := meta.(*AWSClient).ssmconn
-	updated, err := ssmconn.UpdateDocument(params)
+	updated, err := ssmconn.UpdateDocument(updateDocInput)
 
 	if isAWSErr(err, "DuplicateDocumentContent", "") {
 		log.Printf("[DEBUG] Content is a duplicate of the latest version so update is not necessary: %s", d.Id())
@@ -436,12 +436,12 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 		newDefaultVersion = *updated.DocumentDescription.DocumentVersion
 	}
 
-	updateVersionParams := &ssm.UpdateDocumentDefaultVersionInput{
+	updateDefaultInput := &ssm.UpdateDocumentDefaultVersionInput{
 		Name:            aws.String(name),
 		DocumentVersion: aws.String(newDefaultVersion),
 	}
 
-	_, err = ssmconn.UpdateDocumentDefaultVersion(updateVersionParams)
+	_, err = ssmconn.UpdateDocumentDefaultVersion(updateDefaultInput)
 
 	if err != nil {
 		return errwrap.Wrapf("Error updating the default document version to that of the updated document: {{err}}", err)

--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -35,6 +35,10 @@ func resourceAwsSsmDocument() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validateAwsSSMDocumentType,
 			},
+			"schema_version": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"created_date": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -173,6 +177,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("created_date", doc.CreatedDate)
 	d.Set("default_version", doc.DefaultVersion)
 	d.Set("description", doc.Description)
+	d.Set("schema_version", doc.SchemaVersion)
 
 	if _, ok := d.GetOk("document_type"); ok {
 		d.Set("document_type", doc.DocumentType)

--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -430,7 +430,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 
 		newDefaultVersion = d.Get("latest_version").(string)
 	} else if err != nil {
-		return fmt.Errorf("Error updating SSM document %s: %s", name, err)
+		return errwrap.Wrapf("Error updating SSM document: {{err}}", err)
 	} else {
 		log.Printf("[INFO] Updating the default version to the new version %s: %s", newDefaultVersion, d.Id())
 		newDefaultVersion = *updated.DocumentDescription.DocumentVersion
@@ -444,7 +444,7 @@ func updateAwsSSMDocument(d *schema.ResourceData, meta interface{}) error {
 	_, err = ssmconn.UpdateDocumentDefaultVersion(updateVersionParams)
 
 	if err != nil {
-		return fmt.Errorf("Error updating the default document version to that of the updated document %s: %s", name, err)
+		return errwrap.Wrapf("Error updating the default document version to that of the updated document: {{err}}", err)
 	}
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_ssm_document_test.go
+++ b/builtin/providers/aws/resource_aws_ssm_document_test.go
@@ -29,6 +29,39 @@ func TestAccAWSSSMDocument_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSSSMDocument_update(t *testing.T) {
+	name := acctest.RandString(10)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSSMDocumentDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSSSMDocument20Config(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "schema_version", "2.0"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "latest_version", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "default_version", "1"),
+				),
+			},
+			resource.TestStep{
+				Config: testAccAWSSSMDocument20UpdatedConfig(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSSMDocumentExists("aws_ssm_document.foo"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "latest_version", "2"),
+					resource.TestCheckResourceAttr(
+						"aws_ssm_document.foo", "default_version", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSSSMDocument_permission(t *testing.T) {
 	name := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
@@ -183,6 +216,66 @@ resource "aws_ssm_document" "foo" {
 DOC
 }
 
+`, rName)
+}
+
+func testAccAWSSSMDocument20Config(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "foo" {
+  name = "test_document-%s"
+         document_type = "Command"
+
+  content = <<DOC
+    {
+       "schemaVersion": "2.0",
+       "description": "Sample version 2.0 document v2",
+       "parameters": {
+
+       },
+       "mainSteps": [
+          {
+             "action": "aws:runPowerShellScript",
+             "name": "runPowerShellScript",
+             "inputs": {
+                "runCommand": [
+                   "Get-Process"
+                ]
+             }
+          }
+       ]
+    }
+DOC
+}
+`, rName)
+}
+
+func testAccAWSSSMDocument20UpdatedConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_ssm_document" "foo" {
+  name = "test_document-%s"
+         document_type = "Command"
+
+  content = <<DOC
+    {
+       "schemaVersion": "2.0",
+       "description": "Sample version 2.0 document v2",
+       "parameters": {
+
+       },
+       "mainSteps": [
+          {
+             "action": "aws:runPowerShellScript",
+             "name": "runPowerShellScript",
+             "inputs": {
+                "runCommand": [
+                   "Get-Process -Verbose"
+                ]
+             }
+          }
+       ]
+    }
+DOC
+}
 `, rName)
 }
 

--- a/website/source/docs/providers/aws/r/ssm_document.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_document.html.markdown
@@ -10,6 +10,10 @@ description: |-
 
 Provides an SSM Document resource
 
+~> **NOTE on updating SSM documents:** Only documents with a schema version of 2.0
+or greater can update their content once created, see [SSM Schema Features][1]. To update a document with an older
+schema version you must recreate the resource.
+
 ## Example Usage
 
 ```
@@ -56,6 +60,7 @@ The following attributes are exported:
 * `content` -  The json content of the document.
 * `created_date` - The date the document was created.
 * `description` - The description of the document.
+* `schema_version` - The schema version of the document.
 * `document_type` - The type of document created.
 * `default_version` - The default version of the document.
 * `hash` - The sha1 or sha256 of the document content
@@ -66,6 +71,8 @@ The following attributes are exported:
 * `parameter` - The parameters that are available to this document.
 * `permissions` - The permissions of how this document should be shared.
 * `platform_types` - A list of OS platforms compatible with this SSM document, either "Windows" or "Linux".
+
+[1]: http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-ssm-docs.html#document-schemas-features
 
 ## Permissions
 


### PR DESCRIPTION
Fixes #12007 

- [x] Adds `schema_version` attribute to `aws_ssm_document`. 
- [x] Adds support for updating SSM documents with a schema_version >= 2.0 
- [x] Update the default_version of the document to the latest_version when document is updated
- [x] Docs site update
- ~Prune the versions to under 1000 (apparently the limit for number of versions of a single document)~ Looks like this would [take 20 or so api calls to figure out](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_ListDocumentVersions.html) so maybe not. 