### PR TITLE
provider/google: Fixed instance group manager to allow 0 instance

### DIFF
--- a/builtin/providers/google/import_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/import_compute_instance_group_manager_test.go
@@ -11,10 +11,12 @@ import (
 func TestAccInstanceGroupManager_importBasic(t *testing.T) {
 	resourceName1 := "google_compute_instance_group_manager.igm-basic"
 	resourceName2 := "google_compute_instance_group_manager.igm-no-tp"
+	resourceName3 := "google_compute_instance_group_manager.igm-size-zero"
 	template := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm3 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,7 +24,7 @@ func TestAccInstanceGroupManager_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccInstanceGroupManager_basic(template, target, igm1, igm2),
+				Config: testAccInstanceGroupManager_basic(template, target, igm1, igm2, igm3),
 			},
 
 			resource.TestStep{
@@ -33,6 +35,12 @@ func TestAccInstanceGroupManager_importBasic(t *testing.T) {
 
 			resource.TestStep{
 				ResourceName:      resourceName2,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName3,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -384,7 +384,7 @@ func resourceComputeInstanceGroupManagerUpdate(d *schema.ResourceData, meta inte
 
 	// If size changes trigger a resize
 	if d.HasChange("target_size") {
-		if v, ok := d.GetOk("target_size"); ok {
+		if v, ok := d.GetOkAllowZero("target_size"); ok {
 			// Only do anything if the new size is set
 			target_size := int64(v.(int))
 

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -134,7 +134,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 
 	// Get group size, default to 1 if not given
 	var target_size int64 = 1
-	if v, ok := d.GetOk("target_size"); ok {
+	if v, ok := d.GetOkAllowZero("target_size"); ok {
 		target_size = int64(v.(int))
 	}
 
@@ -144,6 +144,7 @@ func resourceComputeInstanceGroupManagerCreate(d *schema.ResourceData, meta inte
 		BaseInstanceName: d.Get("base_instance_name").(string),
 		InstanceTemplate: d.Get("instance_template").(string),
 		TargetSize:       target_size,
+		ForceSendFields:  []string{"Name", "BaseInstanceName", "InstanceTemplate", "TargetSize"},
 	}
 
 	// Set optional fields
@@ -256,7 +257,6 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 	d.Set("named_port", flattenNamedPorts(manager.NamedPorts))
 	d.Set("fingerprint", manager.Fingerprint)
 	d.Set("instance_group", manager.InstanceGroup)
-	d.Set("target_size", manager.TargetSize)
 	d.Set("self_link", manager.SelfLink)
 	update_strategy, ok := d.GetOk("update_strategy")
 	if !ok {

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -72,7 +72,7 @@ func TestAccInstanceGroupManager_update(t *testing.T) {
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-update", &manager),
 					testAccCheckInstanceGroupManagerUpdated(
-						"google_compute_instance_group_manager.igm-update", 3,
+						"google_compute_instance_group_manager.igm-update", 0,
 						"google_compute_target_pool.igm-update", template2),
 					testAccCheckInstanceGroupManagerNamedPorts(
 						"google_compute_instance_group_manager.igm-update",
@@ -514,7 +514,7 @@ func testAccInstanceGroupManager_update2(template1, target, template2, igm strin
 		target_pools = ["${google_compute_target_pool.igm-update.self_link}"]
 		base_instance_name = "igm-update"
 		zone = "us-central1-c"
-		target_size = 3
+		target_size = 0
 		named_port {
 			name = "customhttp"
 			port = 8080

--- a/builtin/providers/google/resource_compute_instance_group_manager_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager_test.go
@@ -20,6 +20,7 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 	target := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm1 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 	igm2 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
+	igm3 := fmt.Sprintf("igm-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -27,12 +28,14 @@ func TestAccInstanceGroupManager_basic(t *testing.T) {
 		CheckDestroy: testAccCheckInstanceGroupManagerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccInstanceGroupManager_basic(template, target, igm1, igm2),
+				Config: testAccInstanceGroupManager_basic(template, target, igm1, igm2, igm3),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-basic", &manager),
 					testAccCheckInstanceGroupManagerExists(
 						"google_compute_instance_group_manager.igm-no-tp", &manager),
+					testAccCheckInstanceGroupManagerExists(
+						"google_compute_instance_group_manager.igm-size-zero", &manager),
 				),
 			},
 		},
@@ -334,7 +337,7 @@ func testAccCheckInstanceGroupManagerUpdateStrategy(n, strategy string) resource
 	}
 }
 
-func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) string {
+func testAccInstanceGroupManager_basic(template, target, igm1, igm2, igm3 string) string {
 	return fmt.Sprintf(`
 	resource "google_compute_instance_template" "igm-basic" {
 		name = "%s"
@@ -385,7 +388,16 @@ func testAccInstanceGroupManager_basic(template, target, igm1, igm2 string) stri
 		zone = "us-central1-c"
 		target_size = 2
 	}
-	`, template, target, igm1, igm2)
+
+	resource "google_compute_instance_group_manager" "igm-size-zero" {
+		description = "Terraform test instance group manager"
+		name = "%s"
+		instance_template = "${google_compute_instance_template.igm-basic.self_link}"
+		base_instance_name = "igm-target-zero"
+		zone = "us-central1-c"
+		target_size = 0
+	}
+	`, template, target, igm1, igm2, igm3)
 }
 
 func testAccInstanceGroupManager_update(template, target, igm string) string {

--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -104,6 +104,19 @@ func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	return r.Value, exists
 }
 
+// GetOkAllowZero returns the data for the given key and whether or
+// not the key has been set to some value at some point.
+// This method does not check if the value is non-zero, unlike GetOk.
+//
+// The first result will not necessarilly be nil if the value doesn't exist.
+// The second result should be checked to determine this information.
+func (d *ResourceData) GetOkAllowZero(key string) (interface{}, bool) {
+	r := d.getRaw(key, getSourceSet)
+	exists := r.Exists && !r.Computed
+
+	return r.Value, exists
+}
+
 func (d *ResourceData) getRaw(key string, level getSource) getResult {
 	var parts []string
 	if key != "" {


### PR DESCRIPTION
## Problem solved

As pointed in #5690, even if you configure the `google_compute_instance_group_manager` with `target_size = 0`, that is ignored on the resulting resource (both on first creation or update).

This PR will fix this.

## Discussion point

To fix this, I added `GetOkAllowZero` method to the `ResourceData`, which is wanted in #5694 (note: #993 is also relevant PR).
But actually, I don't understand whole code of the Terraform, so I don't know if this is the good way of achieving it.
Also, naming of the method can be questioned.

