### PR TITLE
provider/google: Changed network argument in google_compute_instance_group as optional

### DIFF
--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -66,7 +66,9 @@ func resourceComputeInstanceGroup() *schema.Resource {
 
 			"network": &schema.Schema{
 				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"project": &schema.Schema{
@@ -126,6 +128,10 @@ func resourceComputeInstanceGroupCreate(d *schema.ResourceData, meta interface{}
 
 	if v, ok := d.GetOk("named_port"); ok {
 		instanceGroup.NamedPorts = getNamedPorts(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("network"); ok {
+		instanceGroup.Network = v.(string)
 	}
 
 	log.Printf("[DEBUG] InstanceGroup insert request: %#v", instanceGroup)

--- a/builtin/providers/google/resource_compute_instance_group_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_test.go
@@ -227,32 +227,32 @@ func testAccComputeInstanceGroup_named_ports(n string, np map[string]int64, inst
 	}
 }
 
-func testAccComputeInstanceGroup_hasCorrectNetwork(n_ig string, n_nw string, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
+func testAccComputeInstanceGroup_hasCorrectNetwork(nInstanceGroup string, nNetwork string, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 
-		rs_ig, ok := s.RootModule().Resources[n_ig]
+		rsInstanceGroup, ok := s.RootModule().Resources[nInstanceGroup]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n_ig)
+			return fmt.Errorf("Not found: %s", nInstanceGroup)
 		}
-		if rs_ig.Primary.ID == "" {
+		if rsInstanceGroup.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
 		instanceGroup, err := config.clientCompute.InstanceGroups.Get(
-			config.Project, rs_ig.Primary.Attributes["zone"], rs_ig.Primary.ID).Do()
+			config.Project, rsInstanceGroup.Primary.Attributes["zone"], rsInstanceGroup.Primary.ID).Do()
 		if err != nil {
 			return err
 		}
 
-		rs_nw, ok := s.RootModule().Resources[n_nw]
+		rsNetwork, ok := s.RootModule().Resources[nNetwork]
 		if !ok {
-			return fmt.Errorf("Not found: %s", n_nw)
+			return fmt.Errorf("Not found: %s", nNetwork)
 		}
-		if rs_nw.Primary.ID == "" {
+		if rsNetwork.Primary.ID == "" {
 			return fmt.Errorf("No ID is set")
 		}
 		network, err := config.clientCompute.Networks.Get(
-			config.Project, rs_nw.Primary.ID).Do()
+			config.Project, rsNetwork.Primary.ID).Do()
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/google/resource_compute_instance_group_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_test.go
@@ -35,7 +35,7 @@ func TestAccComputeInstanceGroup_basic(t *testing.T) {
 						"google_compute_instance_group.empty", &instanceGroup),
 					testAccComputeInstanceGroup_exists(
 						"google_compute_instance_group.empty-with-network", &instanceGroup),
-					testAccComputeInstanceGroup_network(
+					testAccComputeInstanceGroup_hasCorrectNetwork(
 						"google_compute_instance_group.empty-with-network", network, &instanceGroup),
 				),
 			},
@@ -211,7 +211,7 @@ func testAccComputeInstanceGroup_named_ports(n string, np map[string]int64, inst
 	}
 }
 
-func testAccComputeInstanceGroup_network(n string, network string, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
+func testAccComputeInstanceGroup_hasCorrectNetwork(n string, network string, instanceGroup *compute.InstanceGroup) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {

--- a/builtin/providers/google/resource_compute_instance_group_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_test.go
@@ -454,14 +454,14 @@ func testAccComputeInstanceGroup_network(instance string) string {
 
 	resource "google_compute_instance_group" "with_instance" {
 		description = "Terraform test instance group"
-		name = "%[1]s-with-insntance"
+		name = "%[1]s-with-instance"
 		zone = "us-central1-c"
 		instances = [ "${google_compute_instance.ig_instance.self_link}" ]
 	}
 
 	resource "google_compute_instance_group" "without_instance" {
 		description = "Terraform test instance group"
-		name = "%[1]s-without-insntance"
+		name = "%[1]s-without-instance"
 		zone = "us-central1-c"
 		network = "${google_compute_network.ig_network.self_link}"
 	}`, instance)

--- a/builtin/providers/google/resource_compute_instance_group_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_test.go
@@ -274,7 +274,7 @@ func testAccComputeInstanceGroup_basic(instance, network string) string {
 		description = "Terraform test instance group empty"
 		name = "%s-empty"
 		zone = "us-central1-c"
-			named_port {
+		named_port {
 			name = "http"
 			port = "8080"
 		}
@@ -289,7 +289,7 @@ func testAccComputeInstanceGroup_basic(instance, network string) string {
 		name = "%s-empty-with-network"
 		network = "%s"
 		zone = "us-central1-c"
-			named_port {
+		named_port {
 			name = "http"
 			port = "8080"
 		}

--- a/website/source/docs/providers/google/r/compute_instance_group.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance_group.html.markdown
@@ -21,6 +21,7 @@ resource "google_compute_instance_group" "test" {
   name        = "terraform-test"
   description = "Terraform test instance group"
   zone        = "us-central1-a"
+  network     = "${google_compute_network.default.self_link}"
 }
 ```
 
@@ -75,6 +76,11 @@ The following arguments are supported:
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.
 
+* `network` - (Optional) The URL of the network the instance group is in. If
+    this is different from the network where the instances are in, the creation
+    fails. Defaults to the network where the instances are in (if neither
+    `network` nor `instances` is specified, this field will be blank).
+
 The `named_port` block supports:
 
 * `name` - (Required) The name which the port will be mapped to.
@@ -85,8 +91,6 @@ The `named_port` block supports:
 
 In addition to the arguments listed above, the following computed attributes are
 exported:
-
-* `network` - The network the instance group is in.
 
 * `self_link` - The URI of the created resource.
 


### PR DESCRIPTION
If you want to add an instance group to a backend service, the `network` filed of the instance group must be set.
Formerly this field is set based on the network where instances are in (this is computed by Google API). It means; if you create the empty instance group, the `network` field will be empty, and you cannot add it to a backend service.

In this PR, I changed `network` field in `google_compute_instance_group` from the computed attribute to the configurable optional argument.
Now user can specify network the group is in and add it to a backend service.