### PR TITLE
provider/digitalocean: Add monitoring option to digitalocean droplets

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -107,6 +107,11 @@ func resourceDigitalOceanDroplet() *schema.Resource {
 				Optional: true,
 			},
 
+			"monitoring": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+
 			"ipv4_address": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -167,6 +172,10 @@ func resourceDigitalOceanDropletCreate(d *schema.ResourceData, meta interface{})
 
 	if attr, ok := d.GetOk("private_networking"); ok {
 		opts.PrivateNetworking = attr.(bool)
+	}
+
+	if attr, ok := d.GetOk("monitoring"); ok {
+		opts.Monitoring = attr.(bool)
 	}
 
 	if attr, ok := d.GetOk("user_data"); ok {

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -294,6 +294,27 @@ func TestAccDigitalOceanDroplet_PrivateNetworkingIpv6(t *testing.T) {
 	})
 }
 
+func testAccDigitalOceanDroplet_Monitoring(t *testing.T) {
+	var droplet godo.Droplet
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_Monitoring(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
+					resource.TestCheckResourceAttr(
+						"digitalocean_droplet.foobar", "monitoring", "true"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckDigitalOceanDropletDestroy(s *terraform.State) error {
 	client := testAccProvider.Meta().(*godo.Client)
 
@@ -580,6 +601,18 @@ resource "digitalocean_droplet" "foobar" {
   region             = "sgp1"
   ipv6               = true
   private_networking = true
+}
+`, rInt)
+}
+
+func testAccCheckDigitalOceanDropletConfig_Monitoring(rInt int) string {
+	return fmt.Sprintf(`
+resource "digitalocean_droplet" "foobar" {
+  name       = "foo-%d"
+  size       = "1gb"
+  image      = "centos-7-x64"
+  region     = "nyc3"
+  monitoring = true
 }
 `, rInt)
 }

--- a/website/source/docs/providers/do/r/droplet.html.markdown
+++ b/website/source/docs/providers/do/r/droplet.html.markdown
@@ -34,6 +34,8 @@ The following arguments are supported:
 * `size` - (Required) The instance size to start
 * `backups` - (Optional) Boolean controlling if backups are made. Defaults to
    false.
+* `monitoring` - (Optional) Boolean controlling whether monitoring agent is installed.
+   Defaults to false.
 * `ipv6` - (Optional) Boolean controlling if IPv6 is enabled. Defaults to false.
 * `private_networking` - (Optional) Boolean controlling if private networks are
    enabled. Defaults to false.


### PR DESCRIPTION
This adds the monitoring option described [in the DO API](https://developers.digitalocean.com/documentation/v2/#create-a-new-droplet) which was added to `godo` on [this commit](https://github.com/digitalocean/godo/commit/7c9bf156916c9a1bf90936231549388231dd5d4e).

Caveats:
As far as I can tell, the current DO API doesn't allow you to turn off monitoring or read the monitoring state. 

Due to this, I wasn't able to come up with a way to properly confirm that the option was applied on the other end after state is read. 

Also, I assumed forcing new on a new option would be a bad idea in this case, so reverting the flag to false will have no effect on existing resources.

I'm new to go-- feel free to let me know if this needs some work.