### PR TITLE
Remove Terraform logo from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ Terraform
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 
-![Terraform](https://raw.githubusercontent.com/hashicorp/terraform/master/website/source/assets/images/readme.png)
-
 Terraform is a tool for building, changing, and versioning infrastructure safely and efficiently. Terraform can manage existing and popular service providers as well as custom in-house solutions.
 
 The key features of Terraform are:


### PR DESCRIPTION
The README used to show the Terraform logo, but since the rebrand this
appears to have disappeared. I'm not sure how valuable it is to show the
image in the README, so I've removed the image from the README to stop a
404 rather than create a new image and have to continue to maintain that in future.