### PR TITLE
Remove duplicate entries from resource Dependencies

### DIFF
--- a/terraform/node_resource_abstract.go
+++ b/terraform/node_resource_abstract.go
@@ -102,7 +102,7 @@ func (n *NodeAbstractResource) References() []string {
 			}
 		}
 
-		return result
+		return uniqueStrings(result)
 	}
 
 	// If we have state, that is our next source

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -1163,6 +1163,8 @@ func (m *ModuleState) prune() {
 			delete(m.Outputs, k)
 		}
 	}
+
+	m.Dependencies = uniqueStrings(m.Dependencies)
 }
 
 func (m *ModuleState) sort() {
@@ -1526,8 +1528,9 @@ func (s *ResourceState) prune() {
 			i--
 		}
 	}
-
 	s.Deposed = s.Deposed[:n]
+
+	s.Dependencies = uniqueStrings(s.Dependencies)
 }
 
 func (s *ResourceState) sort() {

--- a/terraform/test-fixtures/apply-multi-ref/main.tf
+++ b/terraform/test-fixtures/apply-multi-ref/main.tf
@@ -1,0 +1,8 @@
+resource "aws_instance" "create" {
+	bar = "abc"
+}
+
+resource "aws_instance" "other" {
+	var = "${aws_instance.create.id}"
+    foo = "${aws_instance.create.bar}"
+}

--- a/terraform/util.go
+++ b/terraform/util.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"sort"
 	"strings"
 )
 
@@ -72,4 +73,21 @@ func strSliceContains(haystack []string, needle string) bool {
 		}
 	}
 	return false
+}
+
+// deduplicate a slice of strings
+func uniqueStrings(s []string) []string {
+	if len(s) < 2 {
+		return s
+	}
+
+	sort.Strings(s)
+	result := make([]string, 1, len(s))
+	result[0] = s[0]
+	for i := 1; i < len(s); i++ {
+		if s[i] != result[len(result)-1] {
+			result = append(result, s[i])
+		}
+	}
+	return result
 }

--- a/terraform/util_test.go
+++ b/terraform/util_test.go
@@ -1,6 +1,8 @@
 package terraform
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -94,5 +96,46 @@ func TestUtilResourceProvider(t *testing.T) {
 				test.Expected,
 			)
 		}
+	}
+}
+
+func TestUniqueStrings(t *testing.T) {
+	cases := []struct {
+		Input    []string
+		Expected []string
+	}{
+		{
+			[]string{},
+			[]string{},
+		},
+		{
+			[]string{"x"},
+			[]string{"x"},
+		},
+		{
+			[]string{"a", "b", "c"},
+			[]string{"a", "b", "c"},
+		},
+		{
+			[]string{"a", "a", "a"},
+			[]string{"a"},
+		},
+		{
+			[]string{"a", "b", "a", "b", "a", "a"},
+			[]string{"a", "b"},
+		},
+		{
+			[]string{"c", "b", "a", "c", "b"},
+			[]string{"a", "b", "c"},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("unique-%d", i), func(t *testing.T) {
+			actual := uniqueStrings(tc.Input)
+			if !reflect.DeepEqual(tc.Expected, actual) {
+				t.Fatalf("Expected: %q\nGot: %q", tc.Expected, actual)
+			}
+		})
 	}
 }


### PR DESCRIPTION
This cleans duplicate Dependencies from resources, and from "depends_on" in the state.

While duplicates are mostly harmless, there could be a situation where equivalent states fail to evaluate as equal. 

Closes #13361