### PR TITLE
Add a `kubernetes_service` resource

### DIFF
--- a/builtin/providers/kubernetes/resource_kubernetes_service.go
+++ b/builtin/providers/kubernetes/resource_kubernetes_service.go
@@ -1,0 +1,121 @@
+package kubernetes
+
+import (
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"k8s.io/kubernetes/pkg/api/errors"
+	api "k8s.io/kubernetes/pkg/api/v1"
+	kubernetes "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_5"
+)
+
+func resourceKubernetesService() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceKubernetesServiceCreate,
+		Read:   resourceKubernetesServiceRead,
+		Exists: resourceKubernetesServiceExists,
+		Delete: resourceKubernetesServiceDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"metadata": namespacedMetadataSchema("service", true),
+
+			"spec": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"selector": {
+							Type:        schema.TypeMap,
+							Description: "Route service traffic to pods with label keys and values matching this selector. If empty or not present, the service is assumed to have an external process managing its endpoints, which Kubernetes will not modify. Only applies to types ClusterIP, NodePort, and LoadBalancer. Ignored if type is ExternalName.",
+							Optional:    true,
+						},
+
+						"externalName": &schema.Schema{
+							Type:        schema.TypeString,
+							Description: "The external reference that kubedns or equivalent will return as a CNAME record for this service. No proxying will be involved. Must be a valid DNS name and requires Type to be ExternalName.",
+							Optional:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceKubernetesServiceCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	metadata := expandMetadata(d.Get("metadata").([]interface{}))
+	spec := d.Get("spec").(map[string]interface{})
+
+	cfgMap := api.Service{
+		ObjectMeta: metadata,
+		Spec: api.ServiceSpec{
+			Selector:     expandStringMap(spec["selector"].(map[string]interface{})),
+			ExternalName: spec["selector"].(string),
+		},
+	}
+	log.Printf("[INFO] Creating new service: %#v", cfgMap)
+	out, err := conn.CoreV1().Services(metadata.Namespace).Create(&cfgMap)
+	if err != nil {
+		return err
+	}
+	log.Printf("[INFO] Submitted new service: %#v", out)
+	d.SetId(buildId(out.ObjectMeta))
+
+	return resourceKubernetesServiceRead(d, meta)
+}
+
+func resourceKubernetesServiceRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name := idParts(d.Id())
+	log.Printf("[INFO] Reading service %s", name)
+	cfgMap, err := conn.CoreV1().Services(namespace).Get(name)
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return err
+	}
+	log.Printf("[INFO] Received service: %#v", cfgMap)
+	err = d.Set("metadata", flattenMetadata(cfgMap.ObjectMeta))
+	if err != nil {
+		return err
+	}
+	d.Set("spec", cfgMap.Spec)
+
+	return nil
+}
+
+func resourceKubernetesServiceDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name := idParts(d.Id())
+	log.Printf("[INFO] Deleting service: %#v", name)
+	err := conn.CoreV1().Services(namespace).Delete(name, &api.DeleteOptions{})
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[INFO] service %s deleted", name)
+
+	d.SetId("")
+	return nil
+}
+
+func resourceKubernetesServiceExists(d *schema.ResourceData, meta interface{}) (bool, error) {
+	conn := meta.(*kubernetes.Clientset)
+
+	namespace, name := idParts(d.Id())
+	log.Printf("[INFO] Checking service %s", name)
+	_, err := conn.CoreV1().Services(namespace).Get(name)
+	if err != nil {
+		if statusErr, ok := err.(*errors.StatusError); ok && statusErr.ErrStatus.Code == 404 {
+			return false, nil
+		}
+		log.Printf("[DEBUG] Received error: %#v", err)
+	}
+	return true, err
+}


### PR DESCRIPTION
This is an attempt at implementing part of https://github.com/hashicorp/terraform/issues/13420. Note that this is the very first time I write Go code, so the quality may not live up to your standards. Help is much appreciated.

Adds a `kubernetes_service` resource with the most basic schema. If this is the right direction to go in, I can add more stuff to the schema.