### PR TITLE
Doc fixes for azurerm - deployment template and virtual machine

### DIFF
--- a/website/source/docs/providers/azurerm/r/template_deployment.html.markdown
+++ b/website/source/docs/providers/azurerm/r/template_deployment.html.markdown
@@ -74,7 +74,7 @@ resource "azurerm_template_deployment" "test" {
 }
 DEPLOY
 
-  deployment_mode = "Complete"
+  deployment_mode = "Incremental"
 }
 ```
 

--- a/website/source/docs/providers/azurerm/r/template_deployment.html.markdown
+++ b/website/source/docs/providers/azurerm/r/template_deployment.html.markdown
@@ -98,3 +98,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Template Deployment ID.
+
+## Note
+
+Terraform does not know about the individual resources created by Azure using a deployment template and therefore cannot delete these resources during a destroy. Destroying a template deployment removes the associated deployment operations, but will not delete the Azure resources created by the deployment. In order to delete these resources, the containing resource group must also be destroyed. [More information](https://docs.microsoft.com/en-us/rest/api/resources/deployments#Deployments_Delete).

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -176,7 +176,7 @@ resource "azurerm_virtual_machine" "test" {
     name          = "datadisk0"
     vhd_uri       = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/datadisk0.vhd"
     disk_size_gb  = "1023"
-    create_option = "empty"
+    create_option = "Empty"
     lun           = 0
   }
 
@@ -345,7 +345,7 @@ For more information on the different example configurations, please check out t
 * `vhd_uri` - (Optional) Specifies the vhd uri. Changing this forces a new resource to be created. Cannot be used with managed disks.
 * `managed_disk_type` - (Optional) Specifies the type of managed disk to create. Value you must be either `Standard_LRS` or `Premium_LRS`. Cannot be used when `vhd_uri` is specified.
 * `managed_disk_id` - (Optional) Specifies an existing managed disk to use by id. Can only be used when `create_option` is `Attach`. Cannot be used when `vhd_uri` is specified.
-* `create_option` - (Required) Specifies how the virtual machine should be created. Possible values are `attach` and `FromImage`.
+* `create_option` - (Required) Specifies how the virtual machine should be created. Possible values are `Attach` and `FromImage`.
 * `caching` - (Optional) Specifies the caching requirements.
 * `image_uri` - (Optional) Specifies the image_uri in the form publisherName:offer:skus:version. `image_uri` can also specify the [VHD uri](https://azure.microsoft.com/en-us/documentation/articles/virtual-machines-linux-cli-deploy-templates/#create-a-custom-vm-image) of a custom VM image to clone. When cloning a custom disk image the `os_type` documented below becomes required.
 * `os_type` - (Optional) Specifies the operating system Type, valid values are windows, linux.
@@ -357,7 +357,7 @@ For more information on the different example configurations, please check out t
 * `vhd_uri` - (Optional) Specifies the uri of the location in storage where the vhd for the virtual machine should be placed. Cannot be used with managed disks.
 * `managed_disk_type` - (Optional) Specifies the type of managed disk to create. Value you must be either `Standard_LRS` or `Premium_LRS`. Cannot be used when `vhd_uri` is specified.
 * `managed_disk_id` - (Optional) Specifies an existing managed disk to use by id. Can only be used when `create_option` is `Attach`. Cannot be used when `vhd_uri` is specified.
-* `create_option` - (Required) Specifies how the data disk should be created.
+* `create_option` - (Required) Specifies how the data disk should be created. Possible values are `Attach`, `FromImage` and `Empty`.
 * `disk_size_gb` - (Required) Specifies the size of the data disk in gigabytes.
 * `caching` - (Optional) Specifies the caching requirements.
 * `lun` - (Required) Specifies the logical unit number of the data disk.


### PR DESCRIPTION
Docs says you should almost always use Incremental mode, so change the sample to use it.
Fix casing.
Empty should be allowed for data disks.
Note behavior of destroying deployment templates.

Test results N/A