### PR TITLE
provider/openstack: Fixing names for import tests

### DIFF
--- a/builtin/providers/openstack/import_openstack_blockstorage_volume_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_blockstorage_volume_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackBlockStorageV1Volume_importBasic(t *testing.T) {
+func TestAccBlockStorageV1Volume_importBasic(t *testing.T) {
 	resourceName := "openstack_blockstorage_volume_v1.volume_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_blockstorage_volume_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_blockstorage_volume_v2_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackBlockStorageV2Volume_importBasic(t *testing.T) {
+func TestAccBlockStorageV2Volume_importBasic(t *testing.T) {
 	resourceName := "openstack_blockstorage_volume_v2.volume_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_compute_floatingip_associate_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_compute_floatingip_associate_v2_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
+func TestAccComputeV2FloatingIPAssociate_importBasic(t *testing.T) {
 	resourceName := "openstack_compute_floatingip_associate_v2.fip_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_compute_keypair_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_compute_keypair_v2_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackComputeV2Keypair_importBasic(t *testing.T) {
-	resourceName := "openstack_compute_keypair_v2.foo"
+func TestAccComputeV2Keypair_importBasic(t *testing.T) {
+	resourceName := "openstack_compute_keypair_v2.kp_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/import_openstack_fw_firewall_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_fw_firewall_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackFWFirewallV1_importBasic(t *testing.T) {
+func TestAccFWFirewallV1_importBasic(t *testing.T) {
 	resourceName := "openstack_fw_firewall_v1.fw_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_fw_policy_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_fw_policy_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackFWPolicyV1_importBasic(t *testing.T) {
+func TestAccFWPolicyV1_importBasic(t *testing.T) {
 	resourceName := "openstack_fw_policy_v1.policy_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_fw_rule_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_fw_rule_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackFWRuleV1_importBasic(t *testing.T) {
+func TestAccFWRuleV1_importBasic(t *testing.T) {
 	resourceName := "openstack_fw_rule_v1.rule_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_lb_member_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_lb_member_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackLBMemberV1_importBasic(t *testing.T) {
+func TestAccLBV1Member_importBasic(t *testing.T) {
 	resourceName := "openstack_lb_member_v1.member_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_lb_monitor_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_lb_monitor_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackLBMonitorV1_importBasic(t *testing.T) {
+func TestAccLBV1Monitor_importBasic(t *testing.T) {
 	resourceName := "openstack_lb_monitor_v1.monitor_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_lb_pool_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_lb_pool_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackLBPoolV1_importBasic(t *testing.T) {
+func TestAccLBV1Pool_importBasic(t *testing.T) {
 	resourceName := "openstack_lb_pool_v1.pool_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_lb_vip_v1_test.go
+++ b/builtin/providers/openstack/import_openstack_lb_vip_v1_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackLBVIPV1_importBasic(t *testing.T) {
+func TestAccLBV1VIP_importBasic(t *testing.T) {
 	resourceName := "openstack_lb_vip_v1.vip_1"
 
 	resource.Test(t, resource.TestCase{

--- a/builtin/providers/openstack/import_openstack_networking_floatingip_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_networking_floatingip_v2_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackNetworkingFloatingIPV2_importBasic(t *testing.T) {
-	resourceName := "openstack_networking_floatingip_v2.foo"
+func TestAccNetworkingV2FloatingIP_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_floatingip_v2.fip_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/import_openstack_networking_network_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_networking_network_v2_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackNetworkingNetworkV2_importBasic(t *testing.T) {
-	resourceName := "openstack_networking_network_v2.foo"
+func TestAccNetworkingV2Network_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_network_v2.network_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/import_openstack_networking_port_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_networking_port_v2_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackNetworkingPortV2_importBasic(t *testing.T) {
-	resourceName := "openstack_networking_port_v2.foo"
+func TestAccNetworkingV2Port_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_port_v2.port_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/import_openstack_networking_secgroup_rule_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_networking_secgroup_rule_v2_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackNetworkingSecGroupRuleV2_importBasic(t *testing.T) {
-	resourceName := "openstack_networking_secgroup_rule_v2.sr_foo"
+func TestAccNetworkingV2SecGroupRule_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_secgroup_rule_v2.secgroup_rule_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/import_openstack_networking_secgroup_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_networking_secgroup_v2_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackNetworkingSecGroupV2_importBasic(t *testing.T) {
-	resourceName := "openstack_networking_secgroup_v2.foo"
+func TestAccNetworkingV2SecGroup_importBasic(t *testing.T) {
+	resourceName := "openstack_networking_secgroup_v2.secgroup_1"
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/openstack/import_openstack_networking_subnet_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_networking_subnet_v2_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccOpenStackNetworkingSubnetV2_importBasic(t *testing.T) {
+func TestAccNetworkingV2Subnet_importBasic(t *testing.T) {
 	resourceName := "openstack_networking_subnet_v2.subnet_1"
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
Noticed the names weren't following the same pattern as the other tests, so they weren't being included when I would run a group-by-group test run.

Fixed and all pass.