### PR TITLE
provisioner/chef: make sure we add new Chef-Vault clients as clients

### DIFF
--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -579,7 +579,7 @@ func (p *Provisioner) configureVaultsFunc(
 
 		for vault, items := range p.vaults {
 			for _, item := range items {
-				updateCmd := fmt.Sprintf("%s vault update %s %s -A %s -M client %s",
+				updateCmd := fmt.Sprintf("%s vault update %s %s -C %s -M client %s",
 					knifeCmd,
 					vault,
 					item,

--- a/builtin/provisioners/chef/resource_provisioner_test.go
+++ b/builtin/provisioners/chef/resource_provisioner_test.go
@@ -269,7 +269,7 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", linuxGemCmd): true,
-				fmt.Sprintf("%s vault update vault1 item1 -A nodename1 -M client -c %s/client.rb "+
+				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 			},
 		},
@@ -292,9 +292,9 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", linuxGemCmd): true,
-				fmt.Sprintf("%s vault update vault1 item1 -A nodename1 -M client -c %s/client.rb "+
+				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
-				fmt.Sprintf("%s vault update vault1 item2 -A nodename1 -M client -c %s/client.rb "+
+				fmt.Sprintf("%s vault update vault1 item2 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 			},
 		},
@@ -316,7 +316,7 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", windowsGemCmd): true,
-				fmt.Sprintf("%s vault update vault1 item1 -A nodename1 -M client -c %s/client.rb "+
+				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 			},
 		},
@@ -339,9 +339,9 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", windowsGemCmd): true,
-				fmt.Sprintf("%s vault update vault1 item1 -A nodename1 -M client -c %s/client.rb "+
+				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
-				fmt.Sprintf("%s vault update vault1 item2 -A nodename1 -M client -c %s/client.rb "+
+				fmt.Sprintf("%s vault update vault1 item2 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 			},
 		},


### PR DESCRIPTION
This is possible using the newly released Chef-Vault 3.0 gem. Before we could only add new clients as admins.

Fixes #9137