### PR TITLE
provider/aws: Fix panic on nil route configs

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -452,7 +452,10 @@ func resourceAwsRouteTableDelete(d *schema.ResourceData, meta interface{}) error
 
 func resourceAwsRouteTableHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
+	m, castOk := v.(map[string]interface{})
+	if !castOk {
+		return 0
+	}
 
 	if v, ok := m["ipv6_cidr_block"]; ok {
 		buf.WriteString(fmt.Sprintf("%s-", v.(string)))

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -178,6 +179,21 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 					testAccCheckTags(&route_table.Tags, "foo", ""),
 					testAccCheckTags(&route_table.Tags, "bar", "baz"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRouteTable_panic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_route_table.foo",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckRouteTableDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccRouteTableConfigPanic,
+				ExpectError: regexp.MustCompile("The request must contain the parameter destinationCidrBlock or destinationIpv6CidrBlock"),
 			},
 		},
 	})
@@ -495,5 +511,18 @@ resource "aws_route_table" "foo" {
 	vpc_id = "${aws_vpc.foo.id}"
 
 	propagating_vgws = ["${aws_vpn_gateway.foo.id}"]
+}
+`
+
+const testAccRouteTableConfigPanic = `
+resource "aws_vpc" "foo" {
+	cidr_block = "10.2.0.0/16"
+}
+
+resource "aws_route_table" "foo" {
+	vpc_id = "${aws_vpc.foo.id}"
+
+  route {
+  }
 }
 `

--- a/builtin/providers/aws/resource_aws_route_table_test.go
+++ b/builtin/providers/aws/resource_aws_route_table_test.go
@@ -184,7 +184,8 @@ func TestAccAWSRouteTable_tags(t *testing.T) {
 	})
 }
 
-func TestAccAWSRouteTable_panic(t *testing.T) {
+// For GH-13545, Fixes panic on an empty route config block
+func TestAccAWSRouteTable_panicEmptyRoute(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_route_table.foo",
@@ -192,7 +193,7 @@ func TestAccAWSRouteTable_panic(t *testing.T) {
 		CheckDestroy:  testAccCheckRouteTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccRouteTableConfigPanic,
+				Config:      testAccRouteTableConfigPanicEmptyRoute,
 				ExpectError: regexp.MustCompile("The request must contain the parameter destinationCidrBlock or destinationIpv6CidrBlock"),
 			},
 		},
@@ -514,7 +515,8 @@ resource "aws_route_table" "foo" {
 }
 `
 
-const testAccRouteTableConfigPanic = `
+// For GH-13545
+const testAccRouteTableConfigPanicEmptyRoute = `
 resource "aws_vpc" "foo" {
 	cidr_block = "10.2.0.0/16"
 }


### PR DESCRIPTION
When creating an `aws_route_table`, if a `route` configuration block is left `nil`, Terraform would previously panic. This allows Terraform to catch a faulty interface conversion during the resource create. The resource will still fail to apply, however, since every item in the `route` element is `Optional` we cannot currently catch this error during plan time, via validation.

Fixes: #13545