### PR TITLE
Randomize aws tests

### DIFF
--- a/builtin/providers/aws/data_source_aws_subnet_ids_test.go
+++ b/builtin/providers/aws/data_source_aws_subnet_ids_test.go
@@ -1,21 +1,24 @@
 package aws
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDataSourceAwsSubnetIDs(t *testing.T) {
+	rInt := acctest.RandIntRange(0, 256)
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccDataSourceAwsSubnetIDsConfig,
+				Config: testAccDataSourceAwsSubnetIDsConfig(rInt),
 			},
 			{
-				Config: testAccDataSourceAwsSubnetIDsConfigWithDataSource,
+				Config: testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.aws_subnet_ids.selected", "ids.#", "1"),
 				),
@@ -24,45 +27,51 @@ func TestAccDataSourceAwsSubnetIDs(t *testing.T) {
 	})
 }
 
-const testAccDataSourceAwsSubnetIDsConfigWithDataSource = `
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
+func testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt int) string {
+	return fmt.Sprintf(
+		`
+	resource "aws_vpc" "test" {
+	  cidr_block = "172.%d.0.0/16"
 
-  tags {
-    Name = "terraform-testacc-subnet-ids-data-source"
-  }
+	  tags {
+	    Name = "terraform-testacc-subnet-ids-data-source"
+	  }
+	}
+
+	resource "aws_subnet" "test" {
+	  vpc_id            = "${aws_vpc.test.id}"
+	  cidr_block        = "172.%d.123.0/24"
+	  availability_zone = "us-west-2a"
+
+	  tags {
+	    Name = "terraform-testacc-subnet-ids-data-source"
+	  }
+	}
+
+	data "aws_subnet_ids" "selected" {
+	  vpc_id = "${aws_vpc.test.id}"
+	}
+	`, rInt, rInt)
 }
 
-resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  cidr_block        = "172.16.123.0/24"
-  availability_zone = "us-west-2a"
+func testAccDataSourceAwsSubnetIDsConfig(rInt int) string {
+	return fmt.Sprintf(`
+		resource "aws_vpc" "test" {
+		  cidr_block = "172.%d.0.0/16"
 
-  tags {
-    Name = "terraform-testacc-subnet-ids-data-source"
-  }
+		  tags {
+		    Name = "terraform-testacc-subnet-ids-data-source"
+		  }
+		}
+
+		resource "aws_subnet" "test" {
+		  vpc_id            = "${aws_vpc.test.id}"
+		  cidr_block        = "172.%d.123.0/24"
+		  availability_zone = "us-west-2a"
+
+		  tags {
+		    Name = "terraform-testacc-subnet-ids-data-source"
+		  }
+		}
+		`, rInt, rInt)
 }
-
-data "aws_subnet_ids" "selected" {
-  vpc_id = "${aws_vpc.test.id}"
-}
-`
-const testAccDataSourceAwsSubnetIDsConfig = `
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-
-  tags {
-    Name = "terraform-testacc-subnet-ids-data-source"
-  }
-}
-
-resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  cidr_block        = "172.16.123.0/24"
-  availability_zone = "us-west-2a"
-
-  tags {
-    Name = "terraform-testacc-subnet-ids-data-source"
-  }
-}
-`

--- a/builtin/providers/aws/data_source_aws_subnet_test.go
+++ b/builtin/providers/aws/data_source_aws_subnet_test.go
@@ -4,30 +4,33 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccDataSourceAwsSubnet(t *testing.T) {
+	rInt := acctest.RandIntRange(0, 256)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourceAwsSubnetConfig,
+				Config: testAccDataSourceAwsSubnetConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_id"),
-					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_cidr"),
-					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_tag"),
-					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_vpc"),
-					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_filter"),
+					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_id", rInt),
+					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_cidr", rInt),
+					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_tag", rInt),
+					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_vpc", rInt),
+					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_filter", rInt),
 				),
 			},
 		},
 	})
 }
 
-func testAccDataSourceAwsSubnetCheck(name string) resource.TestCheckFunc {
+func testAccDataSourceAwsSubnetCheck(name string, rInt int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -61,13 +64,13 @@ func testAccDataSourceAwsSubnetCheck(name string) resource.TestCheckFunc {
 			)
 		}
 
-		if attr["cidr_block"] != "172.16.123.0/24" {
+		if attr["cidr_block"] != fmt.Sprintf("172.%d.123.0/24", rInt) {
 			return fmt.Errorf("bad cidr_block %s", attr["cidr_block"])
 		}
 		if attr["availability_zone"] != "us-west-2a" {
 			return fmt.Errorf("bad availability_zone %s", attr["availability_zone"])
 		}
-		if attr["tags.Name"] != "terraform-testacc-subnet-data-source" {
+		if attr["tags.Name"] != fmt.Sprintf("terraform-testacc-subnet-data-source-%d", rInt) {
 			return fmt.Errorf("bad Name tag %s", attr["tags.Name"])
 		}
 
@@ -75,51 +78,53 @@ func testAccDataSourceAwsSubnetCheck(name string) resource.TestCheckFunc {
 	}
 }
 
-const testAccDataSourceAwsSubnetConfig = `
-provider "aws" {
-  region = "us-west-2"
+func testAccDataSourceAwsSubnetConfig(rInt int) string {
+	return fmt.Sprintf(`
+		provider "aws" {
+		  region = "us-west-2"
+		}
+
+		resource "aws_vpc" "test" {
+		  cidr_block = "172.%d.0.0/16"
+
+		  tags {
+		    Name = "terraform-testacc-subnet-data-source"
+		  }
+		}
+
+		resource "aws_subnet" "test" {
+		  vpc_id            = "${aws_vpc.test.id}"
+		  cidr_block        = "172.%d.123.0/24"
+		  availability_zone = "us-west-2a"
+
+		  tags {
+		    Name = "terraform-testacc-subnet-data-source-%d"
+		  }
+		}
+
+		data "aws_subnet" "by_id" {
+		  id = "${aws_subnet.test.id}"
+		}
+
+		data "aws_subnet" "by_cidr" {
+		  cidr_block = "${aws_subnet.test.cidr_block}"
+		}
+
+		data "aws_subnet" "by_tag" {
+		  tags {
+		    Name = "${aws_subnet.test.tags["Name"]}"
+		  }
+		}
+
+		data "aws_subnet" "by_vpc" {
+		  vpc_id = "${aws_subnet.test.vpc_id}"
+		}
+
+		data "aws_subnet" "by_filter" {
+		  filter {
+		    name = "vpc-id"
+		    values = ["${aws_subnet.test.vpc_id}"]
+		  }
+		}
+		`, rInt, rInt, rInt)
 }
-
-resource "aws_vpc" "test" {
-  cidr_block = "172.16.0.0/16"
-
-  tags {
-    Name = "terraform-testacc-subnet-data-source"
-  }
-}
-
-resource "aws_subnet" "test" {
-  vpc_id            = "${aws_vpc.test.id}"
-  cidr_block        = "172.16.123.0/24"
-  availability_zone = "us-west-2a"
-
-  tags {
-    Name = "terraform-testacc-subnet-data-source"
-  }
-}
-
-data "aws_subnet" "by_id" {
-  id = "${aws_subnet.test.id}"
-}
-
-data "aws_subnet" "by_cidr" {
-  cidr_block = "${aws_subnet.test.cidr_block}"
-}
-
-data "aws_subnet" "by_tag" {
-  tags {
-    Name = "${aws_subnet.test.tags["Name"]}"
-  }
-}
-
-data "aws_subnet" "by_vpc" {
-  vpc_id = "${aws_subnet.test.vpc_id}"
-}
-
-data "aws_subnet" "by_filter" {
-  filter {
-    name = "vpc-id"
-    values = ["${aws_subnet.test.vpc_id}"]
-  }
-}
-`

--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -439,7 +439,7 @@ resource "aws_cloudwatch_log_stream" "test" {
 
 resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
   depends_on = ["aws_iam_role_policy.firehose"]
-  name = "terraform-kinesis-firehose-basictest-cloudwatch"
+  name = "terraform-kinesis-firehose-cloudwatch-%d"
   destination = "s3"
   s3_configuration {
     role_arn = "${aws_iam_role.firehose.arn}"
@@ -451,7 +451,7 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
     }
   }
 }
-`, rInt, accountId, rInt, rInt, rInt, rInt)
+`, rInt, accountId, rInt, rInt, rInt, rInt, rInt)
 }
 
 var testAccKinesisFirehoseDeliveryStreamConfig_s3basic = testAccKinesisFirehoseDeliveryStreamBaseConfig + `


### PR DESCRIPTION
This PR fixes `TestAccAWSEcsService_withAlb`, `TestAccAWSKinesisFirehoseDeliveryStream_s3WithCloudwatchLogging`, and `	Fixes TestAccDataSourceAwsSubnet`

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSEcsService_withAlb'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/11 10:45:56 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSEcsService_withAlb -timeout 120m
=== RUN   TestAccAWSEcsService_withAlb
--- PASS: TestAccAWSEcsService_withAlb (281.06s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	281.093s
```

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccDataSourceAwsSubnet'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/11 13:40:17 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccDataSourceAwsSubnet -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs
--- PASS: TestAccDataSourceAwsSubnetIDs (38.93s)
=== RUN   TestAccDataSourceAwsSubnet
--- PASS: TestAccDataSourceAwsSubnet (29.30s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	68.264s
```