### PR TITLE
config: add "version" argument to provider blocks, disabled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type Module struct {
 type ProviderConfig struct {
 	Name      string
 	Alias     string
+	Version   string
 	RawConfig *RawConfig
 }
 
@@ -349,7 +350,8 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Check that providers aren't declared multiple times.
+	// Check that providers aren't declared multiple times, and that versions
+	// aren't used yet since they aren't properly supported.
 	providerSet := make(map[string]struct{})
 	for _, p := range c.ProviderConfigs {
 		name := p.FullName()
@@ -358,6 +360,13 @@ func (c *Config) Validate() error {
 				"provider.%s: declared multiple times, you can only declare a provider once",
 				name))
 			continue
+		}
+
+		if p.Version != "" {
+			errs = append(errs, fmt.Errorf(
+				"provider.%s: version constraints are not yet supported; remove the 'version' argument from configuration",
+				name,
+			))
 		}
 
 		providerSet[name] = struct{}{}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -207,6 +207,12 @@ func TestConfigValidate_table(t *testing.T) {
 			false,
 			"",
 		},
+		{
+			"provider with version constraint",
+			"provider-version",
+			true,
+			"version constraints are not yet supported",
+		},
 	}
 
 	for i, tc := range cases {
@@ -685,5 +691,26 @@ func TestConfigDataCount(t *testing.T) {
 	// it's not a real key and won't validate.
 	if _, ok := c.Resources[0].RawConfig.Raw["count"]; ok {
 		t.Fatal("count key still exists in RawConfig")
+	}
+}
+
+func TestConfigProviderVersion(t *testing.T) {
+	c := testConfig(t, "provider-version")
+
+	if len(c.ProviderConfigs) != 1 {
+		t.Fatal("expected 1 provider")
+	}
+
+	p := c.ProviderConfigs[0]
+	if p.Name != "aws" {
+		t.Fatalf("expected provider name 'aws', got %q", p.Name)
+	}
+
+	if p.Version != "0.0.1" {
+		t.Fatalf("expected providers version '0.0.1', got %q", p.Version)
+	}
+
+	if _, ok := p.RawConfig.Raw["version"]; ok {
+		t.Fatal("'version' should not exist in raw config")
 	}
 }

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -554,6 +554,7 @@ func loadProvidersHcl(list *ast.ObjectList) ([]*ProviderConfig, error) {
 		}
 
 		delete(config, "alias")
+		delete(config, "version")
 
 		rawConfig, err := NewRawConfig(config)
 		if err != nil {
@@ -575,9 +576,22 @@ func loadProvidersHcl(list *ast.ObjectList) ([]*ProviderConfig, error) {
 			}
 		}
 
+		// If we have a version field then extract it
+		var version string
+		if a := listVal.Filter("version"); len(a.Items) > 0 {
+			err := hcl.DecodeObject(&version, a.Items[0].Val)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Error reading version for provider[%s]: %s",
+					n,
+					err)
+			}
+		}
+
 		result = append(result, &ProviderConfig{
 			Name:      n,
 			Alias:     alias,
+			Version:   version,
 			RawConfig: rawConfig,
 		})
 	}

--- a/config/test-fixtures/provider-version/main.tf
+++ b/config/test-fixtures/provider-version/main.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+	version = "0.0.1"
+	a = "a"
+	b = "b"
+}
+


### PR DESCRIPTION
In future we will support version constraints on providers, so we're reserving this attribute name that is currently not used by any builtin providers.

For now using this will produce an error, since the rest of Terraform (outside of the config parser) doesn't currently have this notion and we don't want people to start trying to use it until its behavior is fully defined and implemented.

It may be used by third-party providers, so this is a breaking change worth warning about in `CHANGELOG` but one whose impact should be small. Any third-party providers using this name should migrate to using a new attribute name instead moving forward.
