### PR TITLE
[Documentation][fix][minor] Update aws_iam_server_certificate Resource Documentation

### DIFF
--- a/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_server_certificate.html.markdown
@@ -49,7 +49,7 @@ EOF
   private_key = <<EOF
 -----BEGIN RSA PRIVATE KEY-----
 [......] # cert contents
------END CERTIFICATE-----
+-----END RSA PRIVATE KEY-----
 EOF
 }
 ```


### PR DESCRIPTION
I noticed that the example inline redacted private key on the [aws_iam_server_certificate  documentation page](https://www.terraform.io/docs/providers/aws/r/iam_server_certificate.html) appears to have an incongruent/incorrect PEM footer. This PR fixes that.

The header is `-----BEGIN RSA PRIVATE KEY-----`, but the footer is `------END CERTIFICATE-----` (?). I can image the possibility of chaining certificates and keys together, but I have not actually seen that before (I have only seen chained certificates by themselves), so this appears to be an error in the documentation.

Thank you for the fantastic product!