### PR TITLE
provider/openstack: Ignore fixed_ip when importing ports

### DIFF
--- a/builtin/providers/openstack/import_openstack_networking_port_v2_test.go
+++ b/builtin/providers/openstack/import_openstack_networking_port_v2_test.go
@@ -22,6 +22,9 @@ func TestAccNetworkingV2Port_importBasic(t *testing.T) {
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"fixed_ip",
+				},
 			},
 		},
 	})


### PR DESCRIPTION
I missed this one in the logs when fixing up the import test fails from yesterday.

@stack72 Does this make sense to do? `fixed_ip` is meant to be declared by the user and not meant to be set by the API at all. I tested doing an actual import then making the relevant configuration to match the state and it worked fine.