### PR TITLE
provider/azurerm: Event Hubs making the Location field idempotent

### DIFF
--- a/builtin/providers/azurerm/resource_arm_eventhub_authorization_rule.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_authorization_rule.go
@@ -144,7 +144,7 @@ func resourceArmEventHubAuthorizationRuleRead(d *schema.ResourceData, meta inter
 
 	resp, err := client.GetAuthorizationRule(resGroup, namespaceName, eventHubName, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule %s: %+v", name, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
@@ -153,7 +153,7 @@ func resourceArmEventHubAuthorizationRuleRead(d *schema.ResourceData, meta inter
 
 	keysResp, err := client.ListKeys(resGroup, namespaceName, eventHubName, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule List Keys %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure EventHub Authorization Rule List Keys %s: %+v", name, err)
 	}
 
 	d.Set("name", name)
@@ -187,7 +187,7 @@ func resourceArmEventHubAuthorizationRuleDelete(d *schema.ResourceData, meta int
 	resp, err := eventhubClient.DeleteAuthorizationRule(resGroup, namespaceName, eventHubName, name)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Authorization Rule '%s': %s", name, err)
+		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Authorization Rule '%s': %+v", name, err)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_eventhub_authorization_rule.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_authorization_rule.go
@@ -45,11 +45,7 @@ func resourceArmEventHubAuthorizationRule() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+			"location": locationSchema(),
 
 			"listen": {
 				Type:     schema.TypeBool,

--- a/builtin/providers/azurerm/resource_arm_eventhub_consumer_group.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_consumer_group.go
@@ -45,11 +45,7 @@ func resourceArmEventHubConsumerGroup() *schema.Resource {
 				ForceNew: true,
 			},
 
-			"location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
+			"location": locationSchema(),
 
 			"user_metadata": {
 				Type:     schema.TypeString,

--- a/builtin/providers/azurerm/resource_arm_eventhub_consumer_group.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_consumer_group.go
@@ -109,7 +109,7 @@ func resourceArmEventHubConsumerGroupRead(d *schema.ResourceData, meta interface
 
 	resp, err := eventhubClient.Get(resGroup, namespaceName, eventHubName, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure EventHub Consumer Group %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure EventHub Consumer Group %s: %+v", name, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
@@ -141,7 +141,7 @@ func resourceArmEventHubConsumerGroupDelete(d *schema.ResourceData, meta interfa
 	resp, err := eventhubClient.Delete(resGroup, namespaceName, eventHubName, name)
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Consumer Group '%s': %s", name, err)
+		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Consumer Group '%s': %+v", name, err)
 	}
 
 	return nil

--- a/builtin/providers/azurerm/resource_arm_eventhub_namespace.go
+++ b/builtin/providers/azurerm/resource_arm_eventhub_namespace.go
@@ -131,7 +131,7 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 
 	resp, err := namespaceClient.Get(resGroup, name)
 	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure EventHub Namespace %s: %s", name, err)
+		return fmt.Errorf("Error making Read request on Azure EventHub Namespace %s: %+v", name, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
@@ -146,7 +146,7 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 
 	keys, err := namespaceClient.ListKeys(resGroup, name, eventHubNamespaceDefaultAuthorizationRule)
 	if err != nil {
-		log.Printf("[ERROR] Unable to List default keys for Namespace %s: %s", name, err)
+		log.Printf("[ERROR] Unable to List default keys for Namespace %s: %+v", name, err)
 	} else {
 		d.Set("default_primary_connection_string", keys.PrimaryConnectionString)
 		d.Set("default_secondary_connection_string", keys.SecondaryConnectionString)
@@ -160,7 +160,6 @@ func resourceArmEventHubNamespaceRead(d *schema.ResourceData, meta interface{}) 
 }
 
 func resourceArmEventHubNamespaceDelete(d *schema.ResourceData, meta interface{}) error {
-
 	namespaceClient := meta.(*ArmClient).eventHubNamespacesClient
 
 	id, err := parseAzureResourceID(d.Id())
@@ -173,7 +172,7 @@ func resourceArmEventHubNamespaceDelete(d *schema.ResourceData, meta interface{}
 	resp, err := namespaceClient.Delete(resGroup, name, make(chan struct{}))
 
 	if resp.StatusCode != http.StatusNotFound {
-		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Namespace'%s': %s", name, err)
+		return fmt.Errorf("Error issuing Azure ARM delete request of EventHub Namespace '%s': %+v", name, err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes a bug where the Location field caused a perpectual diff, with the Read function normalising the location and the Schema not - reported by @lstolyarov at the London HUG for Event Hub Authorization Rules (and Consumer Groups)

Tests pass:
```
$ envchain azurerm make testacc TEST=./builtin/providers/azurerm/ TESTARGS='-run=TestAccAzureRMEventHubConsumerGroup'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/12 11:09:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm/ -v -run=TestAccAzureRMEventHubConsumerGroup -timeout 120m
=== RUN   TestAccAzureRMEventHubConsumerGroup_importBasic
--- PASS: TestAccAzureRMEventHubConsumerGroup_importBasic (356.07s)
=== RUN   TestAccAzureRMEventHubConsumerGroup_importComplete
--- PASS: TestAccAzureRMEventHubConsumerGroup_importComplete (358.80s)
=== RUN   TestAccAzureRMEventHubConsumerGroup_basic
--- PASS: TestAccAzureRMEventHubConsumerGroup_basic (348.86s)
=== RUN   TestAccAzureRMEventHubConsumerGroup_complete
--- PASS: TestAccAzureRMEventHubConsumerGroup_complete (357.12s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	1420.863s
```

```
$ envchain azurerm make testacc TEST=./builtin/providers/azurerm/ TESTARGS='-run=TestAccAzureRMEventHubAuthorization'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/12 11:09:26 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm/ -v -run=TestAccAzureRMEventHubAuthorization -timeout 120m
=== RUN   TestAccAzureRMEventHubAuthorizationRule_importListen
--- PASS: TestAccAzureRMEventHubAuthorizationRule_importListen (340.31s)
=== RUN   TestAccAzureRMEventHubAuthorizationRule_importSend
--- PASS: TestAccAzureRMEventHubAuthorizationRule_importSend (352.71s)
=== RUN   TestAccAzureRMEventHubAuthorizationRule_importReadWrite
--- PASS: TestAccAzureRMEventHubAuthorizationRule_importReadWrite (347.81s)
=== RUN   TestAccAzureRMEventHubAuthorizationRule_importManage
--- PASS: TestAccAzureRMEventHubAuthorizationRule_importManage (374.06s)
=== RUN   TestAccAzureRMEventHubAuthorizationRule_listen
--- PASS: TestAccAzureRMEventHubAuthorizationRule_listen (378.14s)
=== RUN   TestAccAzureRMEventHubAuthorizationRule_send
--- PASS: TestAccAzureRMEventHubAuthorizationRule_send (357.69s)
=== RUN   TestAccAzureRMEventHubAuthorizationRule_readwrite
--- PASS: TestAccAzureRMEventHubAuthorizationRule_readwrite (356.87s)
=== RUN   TestAccAzureRMEventHubAuthorizationRule_manage
--- PASS: TestAccAzureRMEventHubAuthorizationRule_manage (382.39s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	2890.012s
```