### PR TITLE
providers/aws: add tags for resource_aws_autoscaling_group

### DIFF
--- a/builtin/providers/aws/autoscaling_tags.go
+++ b/builtin/providers/aws/autoscaling_tags.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
@@ -12,8 +13,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-// tagsSchema returns the schema to use for tags.
-func autoscalingTagsSchema() *schema.Schema {
+// autoscalingTagSchema returns the schema to use for the tag element.
+func autoscalingTagSchema() *schema.Schema {
 	return &schema.Schema{
 		Type:     schema.TypeSet,
 		Optional: true,
@@ -35,11 +36,11 @@ func autoscalingTagsSchema() *schema.Schema {
 				},
 			},
 		},
-		Set: autoscalingTagsToHash,
+		Set: autoscalingTagToHash,
 	}
 }
 
-func autoscalingTagsToHash(v interface{}) int {
+func autoscalingTagToHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
 	buf.WriteString(fmt.Sprintf("%s-", m["key"].(string)))
@@ -52,35 +53,74 @@ func autoscalingTagsToHash(v interface{}) int {
 // setTags is a helper to set the tags for a resource. It expects the
 // tags field to be named "tag"
 func setAutoscalingTags(conn *autoscaling.AutoScaling, d *schema.ResourceData) error {
-	if d.HasChange("tag") {
+	resourceID := d.Get("name").(string)
+	var createTags, removeTags []*autoscaling.Tag
+
+	if d.HasChange("tag") || d.HasChange("tags") {
 		oraw, nraw := d.GetChange("tag")
 		o := setToMapByKey(oraw.(*schema.Set), "key")
 		n := setToMapByKey(nraw.(*schema.Set), "key")
 
-		resourceID := d.Get("name").(string)
-		c, r := diffAutoscalingTags(
-			autoscalingTagsFromMap(o, resourceID),
-			autoscalingTagsFromMap(n, resourceID),
-			resourceID)
-		create := autoscaling.CreateOrUpdateTagsInput{
-			Tags: c,
-		}
-		remove := autoscaling.DeleteTagsInput{
-			Tags: r,
+		old, err := autoscalingTagsFromMap(o, resourceID)
+		if err != nil {
+			return err
 		}
 
-		// Set tags
-		if len(r) > 0 {
-			log.Printf("[DEBUG] Removing autoscaling tags: %#v", r)
-			if _, err := conn.DeleteTags(&remove); err != nil {
-				return err
-			}
+		new, err := autoscalingTagsFromMap(n, resourceID)
+		if err != nil {
+			return err
 		}
-		if len(c) > 0 {
-			log.Printf("[DEBUG] Creating autoscaling tags: %#v", c)
-			if _, err := conn.CreateOrUpdateTags(&create); err != nil {
-				return err
-			}
+
+		c, r, err := diffAutoscalingTags(old, new, resourceID)
+		if err != nil {
+			return err
+		}
+
+		createTags = append(createTags, c...)
+		removeTags = append(removeTags, r...)
+
+		oraw, nraw = d.GetChange("tags")
+		old, err = autoscalingTagsFromList(oraw.([]interface{}), resourceID)
+		if err != nil {
+			return err
+		}
+
+		new, err = autoscalingTagsFromList(nraw.([]interface{}), resourceID)
+		if err != nil {
+			return err
+		}
+
+		c, r, err = diffAutoscalingTags(old, new, resourceID)
+		if err != nil {
+			return err
+		}
+
+		createTags = append(createTags, c...)
+		removeTags = append(removeTags, r...)
+	}
+
+	// Set tags
+	if len(removeTags) > 0 {
+		log.Printf("[DEBUG] Removing autoscaling tags: %#v", removeTags)
+
+		remove := autoscaling.DeleteTagsInput{
+			Tags: removeTags,
+		}
+
+		if _, err := conn.DeleteTags(&remove); err != nil {
+			return err
+		}
+	}
+
+	if len(createTags) > 0 {
+		log.Printf("[DEBUG] Creating autoscaling tags: %#v", createTags)
+
+		create := autoscaling.CreateOrUpdateTagsInput{
+			Tags: createTags,
+		}
+
+		if _, err := conn.CreateOrUpdateTags(&create); err != nil {
+			return err
 		}
 	}
 
@@ -90,11 +130,12 @@ func setAutoscalingTags(conn *autoscaling.AutoScaling, d *schema.ResourceData) e
 // diffTags takes our tags locally and the ones remotely and returns
 // the set of tags that must be created, and the set of tags that must
 // be destroyed.
-func diffAutoscalingTags(oldTags, newTags []*autoscaling.Tag, resourceID string) ([]*autoscaling.Tag, []*autoscaling.Tag) {
+func diffAutoscalingTags(oldTags, newTags []*autoscaling.Tag, resourceID string) ([]*autoscaling.Tag, []*autoscaling.Tag, error) {
 	// First, we're creating everything we have
 	create := make(map[string]interface{})
 	for _, t := range newTags {
 		tag := map[string]interface{}{
+			"key":                 *t.Key,
 			"value":               *t.Value,
 			"propagate_at_launch": *t.PropagateAtLaunch,
 		}
@@ -112,27 +153,99 @@ func diffAutoscalingTags(oldTags, newTags []*autoscaling.Tag, resourceID string)
 		}
 	}
 
-	return autoscalingTagsFromMap(create, resourceID), remove
+	createTags, err := autoscalingTagsFromMap(create, resourceID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return createTags, remove, nil
+}
+
+func autoscalingTagsFromList(vs []interface{}, resourceID string) ([]*autoscaling.Tag, error) {
+	result := make([]*autoscaling.Tag, 0, len(vs))
+	for _, tag := range vs {
+		attr, ok := tag.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		t, err := autoscalingTagFromMap(attr, resourceID)
+		if err != nil {
+			return nil, err
+		}
+
+		if t != nil {
+			result = append(result, t)
+		}
+	}
+	return result, nil
 }
 
 // tagsFromMap returns the tags for the given map of data.
-func autoscalingTagsFromMap(m map[string]interface{}, resourceID string) []*autoscaling.Tag {
+func autoscalingTagsFromMap(m map[string]interface{}, resourceID string) ([]*autoscaling.Tag, error) {
 	result := make([]*autoscaling.Tag, 0, len(m))
-	for k, v := range m {
-		attr := v.(map[string]interface{})
-		t := &autoscaling.Tag{
-			Key:               aws.String(k),
-			Value:             aws.String(attr["value"].(string)),
-			PropagateAtLaunch: aws.Bool(attr["propagate_at_launch"].(bool)),
-			ResourceId:        aws.String(resourceID),
-			ResourceType:      aws.String("auto-scaling-group"),
+	for _, v := range m {
+		attr, ok := v.(map[string]interface{})
+		if !ok {
+			continue
 		}
-		if !tagIgnoredAutoscaling(t) {
+
+		t, err := autoscalingTagFromMap(attr, resourceID)
+		if err != nil {
+			return nil, err
+		}
+
+		if t != nil {
 			result = append(result, t)
 		}
 	}
 
-	return result
+	return result, nil
+}
+
+func autoscalingTagFromMap(attr map[string]interface{}, resourceID string) (*autoscaling.Tag, error) {
+	if _, ok := attr["key"]; !ok {
+		return nil, fmt.Errorf("%s: invalid tag attributes: key missing", resourceID)
+	}
+
+	if _, ok := attr["value"]; !ok {
+		return nil, fmt.Errorf("%s: invalid tag attributes: value missing", resourceID)
+	}
+
+	if _, ok := attr["propagate_at_launch"]; !ok {
+		return nil, fmt.Errorf("%s: invalid tag attributes: propagate_at_launch missing", resourceID)
+	}
+
+	var propagateAtLaunch bool
+	var err error
+
+	if v, ok := attr["propagate_at_launch"].(bool); ok {
+		propagateAtLaunch = v
+	}
+
+	if v, ok := attr["propagate_at_launch"].(string); ok {
+		if propagateAtLaunch, err = strconv.ParseBool(v); err != nil {
+			return nil, fmt.Errorf(
+				"%s: invalid tag attribute: invalid value for propagate_at_launch: %s",
+				resourceID,
+				v,
+			)
+		}
+	}
+
+	t := &autoscaling.Tag{
+		Key:               aws.String(attr["key"].(string)),
+		Value:             aws.String(attr["value"].(string)),
+		PropagateAtLaunch: aws.Bool(propagateAtLaunch),
+		ResourceId:        aws.String(resourceID),
+		ResourceType:      aws.String("auto-scaling-group"),
+	}
+
+	if tagIgnoredAutoscaling(t) {
+		return nil, nil
+	}
+
+	return t, nil
 }
 
 // autoscalingTagsToMap turns the list of tags into a map.
@@ -140,6 +253,7 @@ func autoscalingTagsToMap(ts []*autoscaling.Tag) map[string]interface{} {
 	tags := make(map[string]interface{})
 	for _, t := range ts {
 		tag := map[string]interface{}{
+			"key":                 *t.Key,
 			"value":               *t.Value,
 			"propagate_at_launch": *t.PropagateAtLaunch,
 		}
@@ -154,6 +268,7 @@ func autoscalingTagDescriptionsToMap(ts *[]*autoscaling.TagDescription) map[stri
 	tags := make(map[string]map[string]interface{})
 	for _, t := range *ts {
 		tag := map[string]interface{}{
+			"key":                 *t.Key,
 			"value":               *t.Value,
 			"propagate_at_launch": *t.PropagateAtLaunch,
 		}

--- a/builtin/providers/aws/autoscaling_tags_test.go
+++ b/builtin/providers/aws/autoscaling_tags_test.go
@@ -20,24 +20,28 @@ func TestDiffAutoscalingTags(t *testing.T) {
 		{
 			Old: map[string]interface{}{
 				"Name": map[string]interface{}{
+					"key":                 "Name",
 					"value":               "bar",
 					"propagate_at_launch": true,
 				},
 			},
 			New: map[string]interface{}{
 				"DifferentTag": map[string]interface{}{
+					"key":                 "DifferentTag",
 					"value":               "baz",
 					"propagate_at_launch": true,
 				},
 			},
 			Create: map[string]interface{}{
 				"DifferentTag": map[string]interface{}{
+					"key":                 "DifferentTag",
 					"value":               "baz",
 					"propagate_at_launch": true,
 				},
 			},
 			Remove: map[string]interface{}{
 				"Name": map[string]interface{}{
+					"key":                 "Name",
 					"value":               "bar",
 					"propagate_at_launch": true,
 				},
@@ -48,24 +52,28 @@ func TestDiffAutoscalingTags(t *testing.T) {
 		{
 			Old: map[string]interface{}{
 				"Name": map[string]interface{}{
+					"key":                 "Name",
 					"value":               "bar",
 					"propagate_at_launch": true,
 				},
 			},
 			New: map[string]interface{}{
 				"Name": map[string]interface{}{
+					"key":                 "Name",
 					"value":               "baz",
 					"propagate_at_launch": false,
 				},
 			},
 			Create: map[string]interface{}{
 				"Name": map[string]interface{}{
+					"key":                 "Name",
 					"value":               "baz",
 					"propagate_at_launch": false,
 				},
 			},
 			Remove: map[string]interface{}{
 				"Name": map[string]interface{}{
+					"key":                 "Name",
 					"value":               "bar",
 					"propagate_at_launch": true,
 				},
@@ -76,10 +84,20 @@ func TestDiffAutoscalingTags(t *testing.T) {
 	var resourceID = "sample"
 
 	for i, tc := range cases {
-		awsTagsOld := autoscalingTagsFromMap(tc.Old, resourceID)
-		awsTagsNew := autoscalingTagsFromMap(tc.New, resourceID)
+		awsTagsOld, err := autoscalingTagsFromMap(tc.Old, resourceID)
+		if err != nil {
+			t.Fatalf("%d: unexpected error convertig old tags: %v", i, err)
+		}
 
-		c, r := diffAutoscalingTags(awsTagsOld, awsTagsNew, resourceID)
+		awsTagsNew, err := autoscalingTagsFromMap(tc.New, resourceID)
+		if err != nil {
+			t.Fatalf("%d: unexpected error convertig new tags: %v", i, err)
+		}
+
+		c, r, err := diffAutoscalingTags(awsTagsOld, awsTagsNew, resourceID)
+		if err != nil {
+			t.Fatalf("%d: unexpected error diff'ing tags: %v", i, err)
+		}
 
 		cm := autoscalingTagsToMap(c)
 		rm := autoscalingTagsToMap(r)

--- a/builtin/providers/aws/import_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/import_aws_autoscaling_group_test.go
@@ -18,7 +18,7 @@ func TestAccAWSAutoScalingGroup_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSAutoScalingGroupDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSAutoScalingGroupConfig(randName),
+				Config: testAccAWSAutoScalingGroupImport(randName),
 			},
 
 			resource.TestStep{

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -60,6 +60,54 @@ EOF
 }
 ```
 
+## Interpolated tags
+
+```
+variable extra_tags {
+  default = [
+    {
+      key = "Foo"
+      value = "Bar"
+      propagate_at_launch = true
+    },
+    {
+      key = "Baz"
+      value = "Bam"
+      propagate_at_launch = true
+    },
+  ]
+}
+
+resource "aws_autoscaling_group" "bar" {
+  availability_zones        = ["us-east-1a"]
+  name                      = "foobar3-terraform-test"
+  max_size                  = 5
+  min_size                  = 2
+  launch_configuration      = "${aws_launch_configuration.foobar.name}"
+
+  tags = [
+    {
+      key                 = "explicit1"
+      value               = "value1"
+      propagate_at_launch = true
+    },
+    {
+      key                 = "explicit2"
+      value               = "value2"
+      propagate_at_launch = true
+    },
+  ]
+
+  tags = ["${concat(
+    list(
+      map("key", "interpolation1", "value", "value3", "propagate_at_launch", true),
+      map("key", "interpolation2", "value", "value4", "propagate_at_launch", true)
+    ),
+    var.extra_tags)
+  }"]
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -100,6 +148,7 @@ Application Load Balancing
 * `suspended_processes` - (Optional) A list of processes to suspend for the AutoScaling Group. The allowed values are `Launch`, `Terminate`, `HealthCheck`, `ReplaceUnhealthy`, `AZRebalance`, `AlarmNotification`, `ScheduledActions`, `AddToLoadBalancer`.
 Note that if you suspend either the `Launch` or `Terminate` process types, it can prevent your autoscaling group from functioning properly.
 * `tag` (Optional) A list of tag blocks. Tags documented below.
+* `tags` (Optional) A list of tag blocks (maps). Tags documented below.
 * `placement_group` (Optional) The name of the placement group into which you'll launch your instances, if any.
 * `metrics_granularity` - (Optional) The granularity to associate with the metrics to collect. The only valid value is `1Minute`. Default is `1Minute`.
 * `enabled_metrics` - (Optional) A list of metrics to collect. The allowed values are `GroupMinSize`, `GroupMaxSize`, `GroupDesiredCapacity`, `GroupInServiceInstances`, `GroupPendingInstances`, `GroupStandbyInstances`, `GroupTerminatingInstances`, `GroupTotalInstances`.
@@ -123,10 +172,17 @@ Note that if you suspend either the `Launch` or `Terminate` process types, it ca
 
 Tags support the following:
 
+The `tag` attribute accepts exactly one tag declaration with the following fields:
+
 * `key` - (Required) Key
 * `value` - (Required) Value
 * `propagate_at_launch` - (Required) Enables propagation of the tag to
    Amazon EC2 instances launched via this ASG
+
+To declare multiple tags additional `tag` blocks can be specified.
+Alternatively the `tags` attributes can be used, which accepts a list of maps containing the above field names as keys and their respective values.
+This allows the construction of dynamic lists of tags which is not possible using the single `tag` attribute.
+`tag` and `tags` are mutually exclusive, only one of them can be specified.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The existing "tag" field on autoscaling groups is very limited in that it
is unable to accept a dynamic list of tag entries.

Other AWS resources don't have this restriction on tags because they work
directly on the map type.

AWS autoscaling groups on the other hand have an additional field
"propagate_at_launch" which is not usable with a pure map type.

This fixes it by introducing an additional field called "tags" which
allows specifying a list of maps. This preserves the possibility to
declare tags as with the "tag" field but additionally allows to
construct lists of maps using interpolation syntax.

/cc @philips @Quentin-M @sym3tri @alexsomesan