### PR TITLE
provider/aws: Add import to codecommit_repository

### DIFF
--- a/builtin/providers/aws/import_aws_codecommit_repository_test.go
+++ b/builtin/providers/aws/import_aws_codecommit_repository_test.go
@@ -1,0 +1,29 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCodeCommitRepository_importBasic(t *testing.T) {
+	resName := "aws_codecommit_repository.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckCodeCommitRepositoryDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCodeCommitRepository_basic(rInt),
+			},
+			{
+				ResourceName:      resName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_codecommit_repository.go
+++ b/builtin/providers/aws/resource_aws_codecommit_repository.go
@@ -15,9 +15,12 @@ func resourceAwsCodeCommitRepository() *schema.Resource {
 		Update: resourceAwsCodeCommitRepositoryUpdate,
 		Read:   resourceAwsCodeCommitRepositoryRead,
 		Delete: resourceAwsCodeCommitRepositoryDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"repository_name": &schema.Schema{
+			"repository_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -31,7 +34,7 @@ func resourceAwsCodeCommitRepository() *schema.Resource {
 				},
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ValidateFunc: func(v interface{}, k string) (ws []string, errors []error) {
@@ -44,27 +47,27 @@ func resourceAwsCodeCommitRepository() *schema.Resource {
 				},
 			},
 
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"repository_id": &schema.Schema{
+			"repository_id": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"clone_url_http": &schema.Schema{
+			"clone_url_http": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"clone_url_ssh": &schema.Schema{
+			"clone_url_ssh": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"default_branch": &schema.Schema{
+			"default_branch": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
@@ -130,6 +133,8 @@ func resourceAwsCodeCommitRepositoryRead(d *schema.ResourceData, meta interface{
 	d.Set("arn", out.RepositoryMetadata.Arn)
 	d.Set("clone_url_http", out.RepositoryMetadata.CloneUrlHttp)
 	d.Set("clone_url_ssh", out.RepositoryMetadata.CloneUrlSsh)
+	d.Set("description", out.RepositoryMetadata.RepositoryDescription)
+	d.Set("repository_name", out.RepositoryMetadata.RepositoryName)
 
 	if _, ok := d.GetOk("default_branch"); ok {
 		if out.RepositoryMetadata.DefaultBranch != nil {

--- a/builtin/providers/aws/resource_aws_codecommit_repository_test.go
+++ b/builtin/providers/aws/resource_aws_codecommit_repository_test.go
@@ -19,7 +19,7 @@ func TestAccAWSCodeCommitRepository_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCodeCommitRepositoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCodeCommitRepository_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
@@ -36,7 +36,7 @@ func TestAccAWSCodeCommitRepository_withChanges(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCodeCommitRepositoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCodeCommitRepository_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
@@ -44,7 +44,7 @@ func TestAccAWSCodeCommitRepository_withChanges(t *testing.T) {
 						"aws_codecommit_repository.test", "description", "This is a test description"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCodeCommitRepository_withChanges(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
@@ -63,7 +63,7 @@ func TestAccAWSCodeCommitRepository_create_default_branch(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCodeCommitRepositoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCodeCommitRepository_with_default_branch(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
@@ -82,7 +82,7 @@ func TestAccAWSCodeCommitRepository_create_and_update_default_branch(t *testing.
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckCodeCommitRepositoryDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCodeCommitRepository_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),
@@ -90,7 +90,7 @@ func TestAccAWSCodeCommitRepository_create_and_update_default_branch(t *testing.
 						"aws_codecommit_repository.test", "default_branch"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCodeCommitRepository_with_default_branch(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCodeCommitRepositoryExists("aws_codecommit_repository.test"),


### PR DESCRIPTION
Adds import capability to the `aws_codecommit_repository` resource.

Also fixes an issue in the Read function where both `description` and `resource_name` attributes weren't being updated and set in the Schema.

Fixes: #13559

```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run=TestAccAWSCodeCommitRepository"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/12 10:14:44 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCodeCommitRepository -timeout 120m
=== RUN   TestAccAWSCodeCommitRepository_importBasic
--- PASS: TestAccAWSCodeCommitRepository_importBasic (16.11s)
=== RUN   TestAccAWSCodeCommitRepository_basic
--- PASS: TestAccAWSCodeCommitRepository_basic (14.97s)
=== RUN   TestAccAWSCodeCommitRepository_withChanges
--- PASS: TestAccAWSCodeCommitRepository_withChanges (26.71s)
=== RUN   TestAccAWSCodeCommitRepository_create_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_default_branch (14.34s)
=== RUN   TestAccAWSCodeCommitRepository_create_and_update_default_branch
--- PASS: TestAccAWSCodeCommitRepository_create_and_update_default_branch (27.90s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    100.071s
```