### PR TITLE
helper/schema: Allow specifying Name + Description for a resource

### DIFF
--- a/builtin/providers/kubernetes/resource_kubernetes_config_map.go
+++ b/builtin/providers/kubernetes/resource_kubernetes_config_map.go
@@ -21,6 +21,8 @@ func resourceKubernetesConfigMap() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		Name:        "Config Map",
+		Description: "The resource provides mechanisms to inject containers with configuration data while keeping containers agnostic of Kubernetes. Config Map can be used to store fine-grained information like individual properties or coarse-grained information like entire config files or JSON blobs.",
 
 		Schema: map[string]*schema.Schema{
 			"metadata": namespacedMetadataSchema("config map", true),

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -20,6 +20,13 @@ import (
 // but also for data sources. In the case of data sources, the Create,
 // Update and Delete functions must not be provided.
 type Resource struct {
+	// Name is used as the name for docs.
+	Name string
+
+	// Description is used as the description for docs.
+	// It should be relatively short (a few sentences max)
+	Description string
+
 	// Schema is the schema for the configuration of this resource.
 	//
 	// The keys of this map are the configuration keys, and the values


### PR DESCRIPTION
We eventually want to be able to generate documentation from the schema and there's a few missing bits that we currently have to specify manually as these aren't specify-able in the schema.

I don't know if there's any benefit to `Name` or `Description` for the UI input, probably not, but I noticed these would be useful in this specific context:

```markdown
---
layout: "kubernetes"
page_title: "Kubernetes: kubernetes_config_map"
sidebar_current: "docs-kubernetes-config-map"
description: |-
  <RESOURCE DESCRIPTION HERE>
---

# kubernetes_config_map

<RESOURCE DESCRIPTION HERE>


## Example Usage

...

## Import

<RESOURCE NAME HERE> can be imported using the ..., e.g.
...
```