### PR TITLE
state/remote/swift: Support Openstack request logging

### DIFF
--- a/builtin/providers/openstack/config.go
+++ b/builtin/providers/openstack/config.go
@@ -113,8 +113,8 @@ func (c *Config) loadAndValidate() error {
 	transport := &http.Transport{Proxy: http.ProxyFromEnvironment, TLSClientConfig: config}
 	client.HTTPClient = http.Client{
 		Transport: &LogRoundTripper{
-			rt:      transport,
-			osDebug: osDebug,
+			Rt:      transport,
+			OsDebug: osDebug,
 		},
 	}
 

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -3,7 +3,6 @@ package openstack
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -76,15 +75,7 @@ func (lrt *LogRoundTripper) logRequest(original io.ReadCloser, headers http.Head
 		return nil, err
 	}
 
-	// Log request headers
-	var requestHeaders []string
-	for name, header := range headers {
-		name = strings.ToLower(name)
-		for _, h := range header {
-			requestHeaders = append(requestHeaders, fmt.Sprintf("%v: %v", name, h))
-		}
-	}
-	log.Printf("[DEBUG] Openstack Request headers:\n%s", strings.Join(requestHeaders, "\n"))
+	log.Printf("[DEBUG] Openstack Request headers:\n%s", strings.Join(RedactHeaders(headers), "\n"))
 
 	// Handle request contentType
 	contentType := headers.Get("Content-Type")
@@ -101,15 +92,7 @@ func (lrt *LogRoundTripper) logRequest(original io.ReadCloser, headers http.Head
 // logResponse will log the HTTP Response details.
 // If the body is JSON, it will attempt to be pretty-formatted.
 func (lrt *LogRoundTripper) logResponse(original io.ReadCloser, headers http.Header) (io.ReadCloser, error) {
-	// Log response headers
-	var responseHeaders []string
-	for name, header := range headers {
-		name = strings.ToLower(name)
-		for _, h := range header {
-			responseHeaders = append(responseHeaders, fmt.Sprintf("%v: %v", name, h))
-		}
-	}
-	log.Printf("[DEBUG] Openstack Response headers:\n%s", strings.Join(responseHeaders, "\n"))
+	log.Printf("[DEBUG] Openstack Response headers:\n%s", strings.Join(RedactHeaders(headers), "\n"))
 
 	contentType := headers.Get("Content-Type")
 	if strings.HasPrefix(contentType, "application/json") {

--- a/builtin/providers/openstack/types.go
+++ b/builtin/providers/openstack/types.go
@@ -24,8 +24,8 @@ import (
 // LogRoundTripper satisfies the http.RoundTripper interface and is used to
 // customize the default http client RoundTripper to allow for logging.
 type LogRoundTripper struct {
-	rt      http.RoundTripper
-	osDebug bool
+	Rt      http.RoundTripper
+	OsDebug bool
 }
 
 // RoundTrip performs a round-trip HTTP request and logs relevant information about it.
@@ -37,11 +37,11 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 	}()
 
 	// for future reference, this is how to access the Transport struct:
-	//tlsconfig := lrt.rt.(*http.Transport).TLSClientConfig
+	//tlsconfig := lrt.Rt.(*http.Transport).TLSClientConfig
 
 	var err error
 
-	if lrt.osDebug {
+	if lrt.OsDebug {
 		log.Printf("[DEBUG] OpenStack Request URL: %s %s", request.Method, request.URL)
 
 		if request.Body != nil {
@@ -52,12 +52,12 @@ func (lrt *LogRoundTripper) RoundTrip(request *http.Request) (*http.Response, er
 		}
 	}
 
-	response, err := lrt.rt.RoundTrip(request)
+	response, err := lrt.Rt.RoundTrip(request)
 	if response == nil {
 		return nil, err
 	}
 
-	if lrt.osDebug {
+	if lrt.OsDebug {
 		response.Body, err = lrt.logResponseBody(response.Body, response.Header)
 	}
 

--- a/builtin/providers/openstack/util.go
+++ b/builtin/providers/openstack/util.go
@@ -2,8 +2,10 @@ package openstack
 
 import (
 	"fmt"
+	"net/http"
 	"os"
 
+	"github.com/Unknwon/com"
 	"github.com/gophercloud/gophercloud"
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -57,4 +59,24 @@ func MapValueSpecs(d *schema.ResourceData) map[string]string {
 		m[key] = val.(string)
 	}
 	return m
+}
+
+// List of headers that need to be redacted
+var REDACT_HEADERS = []string{"x-auth-token", "x-auth-key", "x-service-token",
+	"x-storage-token", "x-account-meta-temp-url-key", "x-account-meta-temp-url-key-2",
+	"x-container-meta-temp-url-key", "x-container-meta-temp-url-key-2", "set-cookie",
+	"x-subject-token"}
+
+// RedactHeaders processes a headers object, returning a redacted list
+func RedactHeaders(headers http.Header) (processedHeaders []string) {
+	for name, header := range headers {
+		for _, v := range header {
+			if com.IsSliceContainsStr(REDACT_HEADERS, name) {
+				processedHeaders = append(processedHeaders, fmt.Sprintf("%v: %v", name, "***"))
+			} else {
+				processedHeaders = append(processedHeaders, fmt.Sprintf("%v: %v", name, v))
+			}
+		}
+	}
+	return
 }


### PR DESCRIPTION
PR #12089 added support for logging request and response bodies to Openstack resource requests. 
This PR extends that to the swift remote state backend. 

In order to support this, had to modify the `LogRoundTripper` struct to use uppercase field names so that they are exposed externally of the package. 

Also extended `LogRoundTripper` to log the request/response headers, as they are useful when working with Swift and container archiving/expiration which uses headers to specify, rather than the request body. 