### PR TITLE
Allow Windows Docker containers to map volumes

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -189,7 +189,7 @@ func resourceDockerContainer() *schema.Resource {
 							ForceNew: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 								value := v.(string)
-								if !regexp.MustCompile(`^[a-zA-Z]:\|^/`).MatchString(value) {
+								if !regexp.MustCompile(`^[a-zA-Z]:\\|^/`).MatchString(value) {
 									es = append(es, fmt.Errorf(
 										"%q must be an absolute path", k))
 								}

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -189,7 +189,7 @@ func resourceDockerContainer() *schema.Resource {
 							ForceNew: true,
 							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
 								value := v.(string)
-								if !regexp.MustCompile(`^/`).MatchString(value) {
+								if !regexp.MustCompile(`^[a-zA-Z]:\|^/`).MatchString(value) {
 									es = append(es, fmt.Errorf(
 										"%q must be an absolute path", k))
 								}

--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -184,17 +184,10 @@ func resourceDockerContainer() *schema.Resource {
 						},
 
 						"host_path": &schema.Schema{
-							Type:     schema.TypeString,
-							Optional: true,
-							ForceNew: true,
-							ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-								value := v.(string)
-								if !regexp.MustCompile(`^[a-zA-Z]:\\|^/`).MatchString(value) {
-									es = append(es, fmt.Errorf(
-										"%q must be an absolute path", k))
-								}
-								return
-							},
+							Type:         schema.TypeString,
+							Optional:     true,
+							ForceNew:     true,
+							ValidateFunc: validateDockerContainerPath,
 						},
 
 						"volume_name": &schema.Schema{
@@ -514,4 +507,14 @@ func resourceDockerUploadHash(v interface{}) int {
 	}
 
 	return hashcode.String(buf.String())
+}
+
+func validateDockerContainerPath(v interface{}, k string) (ws []string, errors []error) {
+
+	value := v.(string)
+	if !regexp.MustCompile(`^[a-zA-Z]:\\|^/`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("%q must be an absolute path", k))
+	}
+
+	return
 }

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -27,6 +27,29 @@ func TestAccDockerContainer_basic(t *testing.T) {
 	})
 }
 
+func TestAccDockerContainerPath_validation(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{Value: "/var/log", ErrCount: 0},
+		{Value: "/tmp", ErrCount: 0},
+		{Value: "C:\\Windows\\System32", ErrCount: 0},
+		{Value: "C:\\Program Files\\MSBuild", ErrCount: 0},
+		{Value: "test", ErrCount: 1},
+		{Value: "C:Test", ErrCount: 1},
+		{Value: "", ErrCount: 1},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateDockerContainerPath(tc.Value, "docker_container")
+
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected the Docker Container Path to trigger a validation error")
+		}
+	}
+}
+
 func TestAccDockerContainer_volume(t *testing.T) {
 	var c dc.Container
 


### PR DESCRIPTION
As windows is also support for Docker now we made our first testes and noticed that the notation "C:\.." is not accepted yet.
The current code is requiring absolute paths for volume mounts in the Linux notation ("/etc..."). 
To correct this behavior I changed the regex to accept also the Windows pattern.

- [x] Unit tests: Not affected
- [x] Documentation updates: Not affected
- [x] Well-formed Code: Not affected
