### PR TITLE
provider/aws: fix parsing instance blockDeviceMapping

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -887,7 +887,7 @@ func readBlockDevicesFromInstance(instance *ec2.Instance, conn *ec2.EC2) (map[st
 
 	instanceBlockDevices := make(map[string]*ec2.InstanceBlockDeviceMapping)
 	for _, bd := range instance.BlockDeviceMappings {
-		if bd.Ebs != nil {
+		if bd.Ebs != nil && bd.Ebs.VolumeId != nil {
 			instanceBlockDevices[*bd.Ebs.VolumeId] = bd
 		}
 	}


### PR DESCRIPTION
According to [AWS API Reference](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_EbsInstanceBlockDevice.html#API_EbsInstanceBlockDevice_Contents), EBS field `VolumeId` is not required in `blockDeviceMapping` type.

Also, if `VolumeId` field doesn't exist in `blockDeviceMapping.EBS`, command `terraform apply` will crash after creating the instance:
```sh
2017/04/12 18:37:58 [DEBUG] plugin: terraform: Error applying plan:

1 error(s) occurred:

* aws_instance.test_instance: 1 error(s) occurred:

* aws_instance.test_instance: unexpected EOF

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
panic: runtime error: invalid memory address or nil pointer dereference
2017/04/12 18:37:58 [DEBUG] plugin: terraform: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16b1182]
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 
2017/04/12 18:37:58 [DEBUG] plugin: terraform: goroutine 61 [running]:
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/aws.readBlockDevicesFromInstance(0xc420da4300, 0xc4204d7340, 0xc420b71b40, 0xc420b45930, 0x1)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_instance.go:891 +0xfb2
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/aws.readBlockDevices(0xc4202d9180, 0xc420da4300, 0xc4204d7340, 0x0, 0xc420ac3b30)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_instance.go:857 +0x42
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsInstanceRead(0xc4202d9180, 0x3f2cca0, 0xc4204c65a0, 0x0, 0x0)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_instance.go:570 +0xb37
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsInstanceUpdate(0xc4202d9180, 0x3f2cca0, 0xc4204c65a0, 0xc421150758, 0xc4211b74a0)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_instance.go:814 +0x820
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsInstanceCreate(0xc4202d9180, 0x3f2cca0, 0xc4204c65a0, 0x0, 0x0)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_instance.go:476 +0xe15
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*Resource).Apply(0xc420e8b320, 0xc420b18730, 0xc420b719c0, 0x3f2cca0, 0xc4204c65a0, 0x1, 0x28, 0xc420f453e0)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/helper/schema/resource.go:186 +0x48d
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/helper/schema.(*Provider).Apply(0xc4202bc540, 0xc420b186e0, 0xc420b18730, 0xc420b719c0, 0x7fc1ada17e10, 0x0, 0xc420971860)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/helper/schema/provider.go:242 +0x9b
2017/04/12 18:37:58 [DEBUG] plugin: terraform: github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Apply(0xc420aa3a20, 0xc420b71940, 0xc420b3d4e0, 0x0, 0x0)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/gopath/src/github.com/hashicorp/terraform/plugin/resource_provider.go:488 +0x57
2017/04/12 18:37:58 [DEBUG] plugin: terraform: reflect.Value.call(0xc4207983c0, 0xc4204d6ad8, 0x13, 0x4cac114, 0x4, 0xc420fd8f20, 0x3, 0x3, 0x0, 0xc420396601, ...)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/go/src/reflect/value.go:434 +0x91f
2017/04/12 18:37:58 [DEBUG] plugin: terraform: reflect.Value.Call(0xc4207983c0, 0xc4204d6ad8, 0x13, 0xc420396720, 0x3, 0x3, 0xc420396768, 0x5f8063, 0xc42105c700)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/go/src/reflect/value.go:302 +0xa4
2017/04/12 18:37:58 [DEBUG] plugin: terraform: net/rpc.(*service).call(0xc420c50200, 0xc420c50180, 0xc420a890b8, 0xc4204dc300, 0xc420aa3b00, 0x3f2f5e0, 0xc420b71940, 0x16, 0x3f2f620, 0xc420b3d4e0, ...)
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/go/src/net/rpc/server.go:387 +0x144
2017/04/12 18:37:58 [DEBUG] plugin: terraform: created by net/rpc.(*Server).ServeCodec
2017/04/12 18:37:58 [DEBUG] plugin: terraform: 	/opt/go/src/net/rpc/server.go:481 +0x404
2017/04/12 18:37:58 [DEBUG] root: eval: *terraform.EvalWriteState
2017/04/12 18:37:58 [DEBUG] plugin: /home/miushanov/Downloads/terraform/terraform: plugin process exited
2017/04/12 18:37:58 [DEBUG] root: eval: *terraform.EvalApplyProvisioners
2017/04/12 18:37:58 [DEBUG] root: eval: *terraform.EvalIf
2017/04/12 18:37:58 [DEBUG] root: eval: *terraform.EvalWriteState
2017/04/12 18:37:58 [DEBUG] root: eval: *terraform.EvalWriteDiff
2017/04/12 18:37:58 [DEBUG] root: eval: *terraform.EvalApplyPost
2017/04/12 18:37:58 [ERROR] root: eval: *terraform.EvalApplyPost, err: 1 error(s) occurred:

* aws_instance.test_instance: unexpected EOF
```