### PR TITLE
website: Add sidebar links to GitHub webhook resource pages

### DIFF
--- a/website/source/layouts/github.erb
+++ b/website/source/layouts/github.erb
@@ -16,11 +16,17 @@
           <li<%= sidebar_current("docs-github-resource-membership") %>>
           <a href="/docs/providers/github/r/membership.html">github_membership</a>
           </li>
+          <li<%= sidebar_current("docs-github-resource-organization-webhook") %>>
+            <a href="/docs/providers/github/r/organization_webhook.html">github_organization_webhook</a>
+          </li>
           <li<%= sidebar_current("docs-github-resource-repository") %>>
             <a href="/docs/providers/github/r/repository.html">github_repository</a>
           </li>
           <li<%= sidebar_current("docs-github-resource-repository-collaborator") %>>
             <a href="/docs/providers/github/r/repository_collaborator.html">github_repository_collaborator</a>
+          </li>
+          <li<%= sidebar_current("docs-github-resource-repository-webhook") %>>
+            <a href="/docs/providers/github/r/repository_webhook.html">github_repository_webhook</a>
           </li>
           <li<%= sidebar_current("docs-github-resource-team") %>>
             <a href="/docs/providers/github/r/team.html">github_team</a>


### PR DESCRIPTION
These resources and their documentation were added in https://github.com/hashicorp/terraform/pull/12924. Add sidebar links to the docs pages to make them easier to find.