### PR TITLE
Hash MySQL passwords

### DIFF
--- a/builtin/providers/mysql/utils.go
+++ b/builtin/providers/mysql/utils.go
@@ -1,0 +1,10 @@
+package mysql
+
+import (
+	"crypto/sha256"
+	"fmt"
+)
+
+func hashSum(contents interface{}) string {
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(contents.(string))))
+}


### PR DESCRIPTION
Instead of storing MySQL passwords in plaintext, hash them first. This implementation is largely based on #12128.