### PR TITLE
Fixes kubernetes namespace name to have valid format

### DIFF
--- a/website/source/docs/providers/kubernetes/r/namespace.html.markdown
+++ b/website/source/docs/providers/kubernetes/r/namespace.html.markdown
@@ -24,7 +24,7 @@ resource "kubernetes_namespace" "example" {
       mylabel = "label-value"
     }
 
-    name = "TerraformExampleNamespace"
+    name = "terraform-example-namespace"
   }
 }
 
@@ -59,5 +59,5 @@ The following arguments are supported:
 Namespaces can be imported using their name, e.g.
 
 ```
-$ terraform import kubernetes_namespace.n TerraformExampleNamespace
+$ terraform import kubernetes_namespace.n terraform-example-namespace
 ```


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/13597

__Reasoning for docs update__:
Kubernetes convention does not allow namespace name to have upper case letters

__Relevant Terraform version__:
The kubernetes namespace name should be corrected, irrespective of the version of terraform, as the naming convention is specific to kubernetes.