### PR TITLE
enable security configurations to be attached to EMR clusters

### DIFF
--- a/builtin/providers/aws/resource_aws_emr_cluster.go
+++ b/builtin/providers/aws/resource_aws_emr_cluster.go
@@ -157,6 +157,11 @@ func resourceAwsEMRCluster() *schema.Resource {
 				ForceNew: true,
 				Required: true,
 			},
+			"security_configuration": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Optional: true,
+			},
 			"autoscaling_role": &schema.Schema{
 				Type:     schema.TypeString,
 				ForceNew: true,
@@ -268,6 +273,10 @@ func resourceAwsEMRClusterCreate(d *schema.ResourceData, meta interface{}) error
 		params.AutoScalingRole = aws.String(v.(string))
 	}
 
+	if v, ok := d.GetOk("security_configuration"); ok {
+		params.SecurityConfiguration = aws.String(v.(string))
+	}
+
 	if instanceProfile != "" {
 		params.JobFlowRole = aws.String(instanceProfile)
 	}
@@ -361,6 +370,7 @@ func resourceAwsEMRClusterRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", cluster.Name)
 	d.Set("service_role", cluster.ServiceRole)
+	d.Set("security_configuration", cluster.SecurityConfiguration)
 	d.Set("autoscaling_role", cluster.AutoScalingRole)
 	d.Set("release_label", cluster.ReleaseLabel)
 	d.Set("log_uri", cluster.LogUri)

--- a/website/source/docs/providers/aws/r/emr_cluster.html.md
+++ b/website/source/docs/providers/aws/r/emr_cluster.html.md
@@ -67,6 +67,7 @@ The following arguments are supported:
 * `release_label` - (Required) The release label for the Amazon EMR release
 * `master_instance_type` - (Required) The EC2 instance type of the master node
 * `service_role` - (Required) IAM role that will be assumed by the Amazon EMR service to access AWS resources
+* `security_configuration` - (Optional) The security configuration name to attach to the EMR cluster, the security configuration cannot be created through Terraform
 * `core_instance_type` - (Optional) The EC2 instance type of the slave nodes
 * `core_instance_count` - (Optional) Number of Amazon EC2 instances used to execute the job flow. EMR will use one node as the cluster's master node and use the remainder of the nodes (`core_instance_count`-1) as core nodes. Default `1`
 * `log_uri` - (Optional) S3 bucket to write the log files of the job flow. If a value


### PR DESCRIPTION
Security configurations that have been created in the web console or through another API can be attached to EMR cluster.  There are three possible.

1. do not include argument: behaves as is
2. attache security conf. that exists in VPC: successfully attaches during build
3. attache security conf. that does not exist in VPC: produces error 
ValidationException: Security configuration with name '****' does not exist.

Resolves issue #11830  