### PR TITLE
provider/aws: Quoting the title for the iam_role data source

### DIFF
--- a/website/source/docs/providers/aws/d/iam_role.html.markdown
+++ b/website/source/docs/providers/aws/d/iam_role.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "aws"
-page_title: AWS: aws_iam_role
+page_title: "AWS: aws_iam_role"
 sidebar_current: docs-aws-datasource-iam-role
 description: |-
   Get information on a Amazon IAM role


### PR DESCRIPTION
Fixes #13613