### PR TITLE
Host based routing on ALB possible

### DIFF
--- a/website/source/docs/providers/aws/r/alb_listener_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/alb_listener_rule.html.markdown
@@ -36,6 +36,22 @@ resource "aws_alb_listener_rule" "static" {
     values = ["/static/*"]
   }
 }
+
+resource "aws_alb_listener_rule" "host_based_routing" {
+  listener_arn = "${aws_alb_listener.front_end.arn}"
+  priority     = 99
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_alb_target_group.static.arn}"
+  }
+
+  condition {
+    field  = "host-header"
+    values = ["my-service.*.terraform.io"]
+  }
+}
+
 ```
 
 ## Argument Reference
@@ -54,7 +70,7 @@ Action Blocks (for `default_action`) support the following:
 
 Condition Blocks (for `default_condition`) support the following:
 
-* `field` - (Required) The name of the field. The only valid value is `path-pattern`.
+* `field` - (Required) The name of the field. Must be one of `path-pattern` for path based routing or `host-header` for host based routing.
 * `values` - (Required) The path patterns to match. A maximum of 1 can be defined.
 
 ## Attributes Reference


### PR DESCRIPTION
Tried to use the Host based routing feature of the ALB (ELB v2.0) with Terraform 0.9.2. Worked perfectly, so updating the documentation.