### PR TITLE
[WIP] remove maps with empty counts during expand

### DIFF
--- a/flatmap/expand.go
+++ b/flatmap/expand.go
@@ -114,6 +114,12 @@ func expandArray(m map[string]string, prefix string) []interface{} {
 }
 
 func expandMap(m map[string]string, prefix string) map[string]interface{} {
+	// Submaps may not have a '%' key, so we can't count on this value being
+	// here. If we don't have a count, just procede as if we have have a map.
+	if count, ok := m[prefix+"%"]; ok && count == "0" {
+		return map[string]interface{}{}
+	}
+
 	result := make(map[string]interface{})
 	for k := range m {
 		if !strings.HasPrefix(k, prefix) {

--- a/flatmap/expand_test.go
+++ b/flatmap/expand_test.go
@@ -163,17 +163,29 @@ func TestExpand(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			Map: map[string]string{
+				"empty_map_of_sets.%":         "0",
+				"empty_map_of_sets.set1.#":    "0",
+				"empty_map_of_sets.set1.1234": "x",
+			},
+			Key:    "empty_map_of_sets",
+			Output: map[string]interface{}{},
+		},
 	}
 
 	for _, tc := range cases {
-		actual := Expand(tc.Map, tc.Key)
-		if !reflect.DeepEqual(actual, tc.Output) {
-			t.Errorf(
-				"Key: %v\nMap:\n\n%#v\n\nOutput:\n\n%#v\n\nExpected:\n\n%#v\n",
-				tc.Key,
-				tc.Map,
-				actual,
-				tc.Output)
-		}
+		t.Run(tc.Key, func(t *testing.T) {
+			actual := Expand(tc.Map, tc.Key)
+			if !reflect.DeepEqual(actual, tc.Output) {
+				t.Errorf(
+					"Key: %v\nMap:\n\n%#v\n\nOutput:\n\n%#v\n\nExpected:\n\n%#v\n",
+					tc.Key,
+					tc.Map,
+					actual,
+					tc.Output)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Addition to #13541

When we encounter maps with empty counts, remove them from the expansion
to prevent already empty sub-elements from being retained.

Convert TestExpand to subtests for easier debugging.

Fix test fixtures with maps that were missing the "%" key. These were
passing because the maps were being inferred by the absence of a "#"
key. These should not happen in practice with properly structured
values.