### PR TITLE
provider/aws: Fix security group rule import

### DIFF
--- a/builtin/providers/aws/import_aws_security_group_test.go
+++ b/builtin/providers/aws/import_aws_security_group_test.go
@@ -101,3 +101,59 @@ func TestAccAWSSecurityGroup_importSourceSecurityGroup(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		// Expect 4: group, 3 rules
+		if len(s) != 4 {
+			return fmt.Errorf("expected 4 states: %#v", s)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupConfig_importIPRangeAndSecurityGroupWithSameRules,
+			},
+
+			{
+				ResourceName:     "aws_security_group.test_group_1",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}
+
+func TestAccAWSSecurityGroup_importIPRangesWithSameRules(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		// Expect 4: group, 2 rules
+		if len(s) != 3 {
+			return fmt.Errorf("expected 3 states: %#v", s)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupConfig_importIPRangesWithSameRules,
+			},
+
+			{
+				ResourceName:     "aws_security_group.test_group_1",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_security_group_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_test.go
@@ -1995,6 +1995,91 @@ resource "aws_security_group_rule" "allow_test_group_3" {
 }
 `
 
+const testAccAWSSecurityGroupConfig_importIPRangeAndSecurityGroupWithSameRules = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "tf_sg_import_test"
+  }
+}
+
+resource "aws_security_group" "test_group_1" {
+  name        = "test group 1"
+  vpc_id      = "${aws_vpc.foo.id}"
+}
+
+resource "aws_security_group" "test_group_2" {
+  name        = "test group 2"
+  vpc_id      = "${aws_vpc.foo.id}"
+}
+
+resource "aws_security_group_rule" "allow_security_group" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "tcp"
+
+  source_security_group_id = "${aws_security_group.test_group_2.id}"
+  security_group_id = "${aws_security_group.test_group_1.id}"
+}
+
+resource "aws_security_group_rule" "allow_cidr_block" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "tcp"
+
+  cidr_blocks = ["10.0.0.0/32"]
+  security_group_id = "${aws_security_group.test_group_1.id}"
+}
+
+resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "tcp"
+
+  ipv6_cidr_blocks = ["::/0"]
+  security_group_id = "${aws_security_group.test_group_1.id}"
+}
+`
+
+const testAccAWSSecurityGroupConfig_importIPRangesWithSameRules = `
+resource "aws_vpc" "foo" {
+  cidr_block = "10.1.0.0/16"
+
+  tags {
+    Name = "tf_sg_import_test"
+  }
+}
+
+resource "aws_security_group" "test_group_1" {
+  name        = "test group 1"
+  vpc_id      = "${aws_vpc.foo.id}"
+}
+
+resource "aws_security_group_rule" "allow_cidr_block" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "tcp"
+
+  cidr_blocks = ["10.0.0.0/32"]
+  security_group_id = "${aws_security_group.test_group_1.id}"
+}
+
+resource "aws_security_group_rule" "allow_ipv6_cidr_block" {
+  type      = "ingress"
+  from_port = 0
+  to_port   = 0
+  protocol  = "tcp"
+
+  ipv6_cidr_blocks = ["::/0"]
+  security_group_id = "${aws_security_group.test_group_1.id}"
+}
+`
+
 const testAccAWSSecurityGroupConfigPrefixListEgress = `
 resource "aws_vpc" "tf_sg_prefix_list_egress_test" {
     cidr_block = "10.0.0.0/16"


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/8166 and https://github.com/hashicorp/terraform/issues/8827

The issue was being caused when the same rules were applied to both IP ranges and security groups. The previous implementation would combine them into a single rule, which [according to the docs](https://www.terraform.io/docs/providers/aws/r/security_group_rule.html) is not allowed. This fix creates a separate rule for each case.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSecurityGroup_import'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/13 10:33:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSecurityGroup_import -timeout 120m
=== RUN   TestAccAWSSecurityGroup_importBasic
--- PASS: TestAccAWSSecurityGroup_importBasic (19.55s)
=== RUN   TestAccAWSSecurityGroup_importIpv6
--- PASS: TestAccAWSSecurityGroup_importIpv6 (19.48s)
=== RUN   TestAccAWSSecurityGroup_importSelf
--- PASS: TestAccAWSSecurityGroup_importSelf (23.05s)
=== RUN   TestAccAWSSecurityGroup_importSourceSecurityGroup
--- PASS: TestAccAWSSecurityGroup_importSourceSecurityGroup (22.80s)
=== RUN   TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangeAndSecurityGroupWithSameRules (24.14s)
=== RUN   TestAccAWSSecurityGroup_importIPRangesWithSameRules
--- PASS: TestAccAWSSecurityGroup_importIPRangesWithSameRules (22.49s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	131.525s
```