### PR TITLE
provider/google: bump container cluster version in tests.

### DIFF
--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -345,7 +345,7 @@ var testAccContainerCluster_withVersion = fmt.Sprintf(`
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	node_version = "1.5.2"
+	node_version = "1.6.0"
 	initial_node_count = 1
 
 	master_auth {


### PR DESCRIPTION
The version we were using has been deprecated and is no longer
available, making the withVersion test no longer pass. I've bumped it to
the latest available version.