### PR TITLE
provider/aws: Fix some acc tests (more, again)

### DIFF
--- a/builtin/providers/aws/data_source_aws_subnet_ids_test.go
+++ b/builtin/providers/aws/data_source_aws_subnet_ids_test.go
@@ -11,8 +11,9 @@ import (
 func TestAccDataSourceAwsSubnetIDs(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			{
 				Config: testAccDataSourceAwsSubnetIDsConfig(rInt),

--- a/builtin/providers/aws/data_source_aws_subnet_test.go
+++ b/builtin/providers/aws/data_source_aws_subnet_test.go
@@ -9,12 +9,13 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDataSourceAwsSubnet(t *testing.T) {
+func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
 				Config: testAccDataSourceAwsSubnetConfig(rInt),

--- a/builtin/providers/aws/resource_aws_elasticache_cluster.go
+++ b/builtin/providers/aws/resource_aws_elasticache_cluster.go
@@ -311,7 +311,7 @@ func resourceAwsElasticacheClusterCreate(d *schema.ResourceData, meta interface{
 	// name contained uppercase characters.
 	d.SetId(strings.ToLower(*resp.CacheCluster.CacheClusterId))
 
-	pending := []string{"creating", "modifying", "restoring"}
+	pending := []string{"creating", "modifying", "restoring", "snapshotting"}
 	stateConf := &resource.StateChangeConf{
 		Pending:    pending,
 		Target:     []string{"available"},

--- a/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
+++ b/builtin/providers/aws/resource_aws_kinesis_firehose_delivery_stream_test.go
@@ -534,6 +534,9 @@ resource "aws_kinesis_firehose_delivery_stream" "test_stream" {
 var testAccKinesisFirehoseDeliveryStreamBaseElasticsearchConfig = testAccKinesisFirehoseDeliveryStreamBaseConfig + `
 resource "aws_elasticsearch_domain" "test_cluster" {
   domain_name = "es-test-%d"
+  cluster_config {
+    instance_type = "r3.large.elasticsearch"
+  }
 
   access_policies = <<CONFIG
 {

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -267,7 +267,7 @@ func testAccCheckAWSClusterSnapshot(rInt int) resource.TestCheckFunc {
 			}
 
 			// Try and delete the snapshot before we check for the cluster not found
-			snapshot_identifier := fmt.Sprintf("foobarbaz-test-terraform-final-snapshot-%d", rInt)
+			snapshot_identifier := fmt.Sprintf("tf-acctest-rdscluster-snapshot-%d", rInt)
 
 			awsClient := testAccProvider.Meta().(*AWSClient)
 			conn := awsClient.rdsconn
@@ -436,7 +436,6 @@ resource "aws_rds_cluster" "default" {
   master_username = "foo"
   master_password = "mustbeeightcharaters"
   db_cluster_parameter_group_name = "default.aurora5.6"
-  skip_final_snapshot = true
   final_snapshot_identifier = "tf-acctest-rdscluster-snapshot-%d"
   tags {
     Environment = "production"


### PR DESCRIPTION
Fixes 

- `TestAccAWSKinesisFirehoseDeliveryStream_ElasticsearchConfigUpdates`
- `TestAccAWSElasticacheCluster_snapshotsWithUpdates`
- `TestAccAWSRDSCluster_takeFinalSnapshot`

Adds:

- `testAccCheckVpcDestroy` method to check that we've destroyed the VPC (and included subnet) that's created in that test