### PR TITLE
provider/google: Unset the id for resource_google_project if the create operation fails

### DIFF
--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -100,13 +100,13 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error creating project %s (%s): %s.", project.ProjectId, project.Name, err)
 	}
 
-	d.SetId(pid)
-
 	// Wait for the operation to complete
 	waitErr := resourceManagerOperationWait(config, op, "project to create")
 	if waitErr != nil {
 		return waitErr
 	}
+
+	d.SetId(pid)
 
 	// Set the billing account
 	if v, ok := d.GetOk("billing_account"); ok {

--- a/builtin/providers/google/resource_google_project.go
+++ b/builtin/providers/google/resource_google_project.go
@@ -100,13 +100,15 @@ func resourceGoogleProjectCreate(d *schema.ResourceData, meta interface{}) error
 		return fmt.Errorf("Error creating project %s (%s): %s.", project.ProjectId, project.Name, err)
 	}
 
+	d.SetId(pid)
+
 	// Wait for the operation to complete
 	waitErr := resourceManagerOperationWait(config, op, "project to create")
 	if waitErr != nil {
+		// The resource wasn't actually created
+		d.SetId("")
 		return waitErr
 	}
-
-	d.SetId(pid)
 
 	// Set the billing account
 	if v, ok := d.GetOk("billing_account"); ok {


### PR DESCRIPTION
The current way means that the project creation can fail during the async part (for example, for a quota failure) but terraform thinks it succeeded.