### PR TITLE
P aws test fixes

### DIFF
--- a/builtin/providers/aws/import_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/import_aws_dynamodb_table_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestAccAWSDynamoDbTable_importBasic(t *testing.T) {
 	resourceName := "aws_dynamodb_table.basic-dynamodb-table"]
+	
 	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/aws/import_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/import_aws_dynamodb_table_test.go
@@ -3,19 +3,20 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSDynamoDbTable_importBasic(t *testing.T) {
 	resourceName := "aws_dynamodb_table.basic-dynamodb-table"
-
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDynamoDbConfigInitialState(),
+				Config: testAccAWSDynamoDbConfigInitialState(rInt),
 			},
 
 			{

--- a/builtin/providers/aws/import_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/import_aws_dynamodb_table_test.go
@@ -8,8 +8,7 @@ import (
 )
 
 func TestAccAWSDynamoDbTable_importBasic(t *testing.T) {
-	resourceName := "aws_dynamodb_table.basic-dynamodb-table"]
-	
+	resourceName := "aws_dynamodb_table.basic-dynamodb-table"
 	rName := acctest.RandomWithPrefix("TerraformTestTable-")
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/aws/resource_aws_dynamodb_table_test.go
+++ b/builtin/providers/aws/resource_aws_dynamodb_table_test.go
@@ -15,6 +15,7 @@ import (
 
 func TestAccAWSDynamoDbTable_basic(t *testing.T) {
 	var conf dynamodb.DescribeTableOutput
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -22,14 +23,14 @@ func TestAccAWSDynamoDbTable_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSDynamoDbTableDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSDynamoDbConfigInitialState(),
+				Config: testAccAWSDynamoDbConfigInitialState(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInitialAWSDynamoDbTableExists("aws_dynamodb_table.basic-dynamodb-table", &conf),
 					testAccCheckInitialAWSDynamoDbTableConf("aws_dynamodb_table.basic-dynamodb-table"),
 				),
 			},
 			{
-				Config: testAccAWSDynamoDbConfigAddSecondaryGSI,
+				Config: testAccAWSDynamoDbConfigAddSecondaryGSI(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckDynamoDbTableWasUpdated("aws_dynamodb_table.basic-dynamodb-table"),
 				),
@@ -363,7 +364,7 @@ func dynamoDbAttributesToMap(attributes *[]*dynamodb.AttributeDefinition) map[st
 	return attrmap
 }
 
-func testAccAWSDynamoDbConfigInitialState() string {
+func testAccAWSDynamoDbConfigInitialState(rInt int) string {
 	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
   name = "TerraformTestTable-%d"
@@ -407,12 +408,13 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     projection_type = "KEYS_ONLY"
   }
 }
-`, acctest.RandInt())
+`, rInt)
 }
 
-const testAccAWSDynamoDbConfigAddSecondaryGSI = `
+func testAccAWSDynamoDbConfigAddSecondaryGSI(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
-  name = "TerraformTestTable"
+  name = "TerraformTestTable-%d"
   read_capacity = 20
   write_capacity = 20
   hash_key = "TestTableHashKey"
@@ -454,7 +456,8 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     non_key_attributes = ["TestNonKeyAttribute"]
   }
 }
-`
+`, rInt)
+}
 
 func testAccAWSDynamoDbConfigStreamSpecification() string {
 	return fmt.Sprintf(`

--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -207,6 +207,7 @@ resource "aws_route53_zone" "foo" {
 	provider = "aws.west"
 	name = "foo.com"
 	vpc_id = "${aws_vpc.foo.id}"
+	vpc_region = "us-west-2"
 }
 
 resource "aws_route53_zone_association" "foobar" {


### PR DESCRIPTION
This PR should fix `TestAccAWSDynamoDbTable_basic` and `TestAccAWSRoute53ZoneAssociation_region'`

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSDynamoDbTable_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/12 08:17:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSDynamoDbTable_basic -timeout 120m
=== RUN   TestAccAWSDynamoDbTable_basic
--- PASS: TestAccAWSDynamoDbTable_basic (134.34s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	134.382s
```

```
 make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSRoute53ZoneAssociation_region'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/13 09:03:58 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSRoute53ZoneAssociation_region -timeout 120m
=== RUN   TestAccAWSRoute53ZoneAssociation_region
--- PASS: TestAccAWSRoute53ZoneAssociation_region (100.46s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	100.494s
```