### PR TITLE
Update resource_aws_route53_zone_association_test.go

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_zone_association_test.go
+++ b/builtin/providers/aws/resource_aws_route53_zone_association_test.go
@@ -207,6 +207,7 @@ resource "aws_route53_zone" "foo" {
 	provider = "aws.west"
 	name = "foo.com"
 	vpc_id = "${aws_vpc.foo.id}"
+	vpc_region = "us-west-2"
 }
 
 resource "aws_route53_zone_association" "foobar" {


### PR DESCRIPTION
This test fixes `TestAccAWSRoute53ZoneAssociation_region`

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSRoute53ZoneAssociation_region'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/13 09:03:58 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSRoute53ZoneAssociation_region -timeout 120m
=== RUN   TestAccAWSRoute53ZoneAssociation_region
--- PASS: TestAccAWSRoute53ZoneAssociation_region (100.46s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	100.494s
```