### PR TITLE
provider/fastly: upgrade go-fastly to fix #12910

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -108,20 +108,20 @@ func TestAccFastlyServiceV1_gzips_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.Gzip{
-		Version:        "1",
+		Version:        1,
 		Name:           "gzip file types",
 		Extensions:     "js css",
 		CacheCondition: "testing_condition",
 	}
 
 	log2 := gofastly.Gzip{
-		Version:      "1",
+		Version:      1,
 		Name:         "gzip extensions",
 		ContentTypes: "text/css text/html",
 	}
 
 	log3 := gofastly.Gzip{
-		Version:      "1",
+		Version:      1,
 		Name:         "all",
 		Extensions:   "js html css",
 		ContentTypes: "text/javascript application/x-javascript application/javascript text/css text/html",

--- a/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
@@ -81,7 +81,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.Header{
-		Version:     "1",
+		Version:     1,
 		Name:        "remove x-amz-request-id",
 		Destination: "http.x-amz-request-id",
 		Type:        "cache",
@@ -90,7 +90,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 	}
 
 	log2 := gofastly.Header{
-		Version:     "1",
+		Version:     1,
 		Name:        "remove s3 server",
 		Destination: "http.Server",
 		Type:        "cache",
@@ -100,7 +100,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 	}
 
 	log3 := gofastly.Header{
-		Version:     "1",
+		Version:     1,
 		Name:        "DESTROY S3",
 		Destination: "http.Server",
 		Type:        "cache",
@@ -109,7 +109,7 @@ func TestAccFastlyServiceV1_headers_basic(t *testing.T) {
 	}
 
 	log4 := gofastly.Header{
-		Version:           "1",
+		Version:           1,
 		Name:              "Add server name",
 		Destination:       "http.server-name",
 		Type:              "request",

--- a/builtin/providers/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -17,7 +17,7 @@ func TestAccFastlyServiceV1_healthcheck_basic(t *testing.T) {
 	domainName := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.HealthCheck{
-		Version:          "1",
+		Version:          1,
 		Name:             "example-healthcheck1",
 		Host:             "example1.com",
 		Path:             "/test1.txt",
@@ -32,7 +32,7 @@ func TestAccFastlyServiceV1_healthcheck_basic(t *testing.T) {
 	}
 
 	log2 := gofastly.HealthCheck{
-		Version:          "1",
+		Version:          1,
 		Name:             "example-healthcheck2",
 		Host:             "example2.com",
 		Path:             "/test2.txt",

--- a/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -17,7 +17,7 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.Papertrail{
-		Version:           "1",
+		Version:           1,
 		Name:              "papertrailtesting",
 		Address:           "test1.papertrailapp.com",
 		Port:              uint(3600),
@@ -26,7 +26,7 @@ func TestAccFastlyServiceV1_papertrail_basic(t *testing.T) {
 	}
 
 	log2 := gofastly.Papertrail{
-		Version: "1",
+		Version: 1,
 		Name:    "papertrailtesting2",
 		Address: "test2.papertrailapp.com",
 		Port:    uint(8080),

--- a/builtin/providers/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_response_object_test.go
@@ -17,7 +17,7 @@ func TestAccFastlyServiceV1_response_object_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.ResponseObject{
-		Version:          "1",
+		Version:          1,
 		Name:             "responseObjecttesting",
 		Status:           200,
 		Response:         "OK",
@@ -28,7 +28,7 @@ func TestAccFastlyServiceV1_response_object_basic(t *testing.T) {
 	}
 
 	log2 := gofastly.ResponseObject{
-		Version:          "1",
+		Version:          1,
 		Name:             "responseObjecttesting2",
 		Status:           404,
 		Response:         "Not Found",

--- a/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -18,7 +18,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.S3{
-		Version:           "1",
+		Version:           1,
 		Name:              "somebucketlog",
 		BucketName:        "fastlytestlogging",
 		Domain:            "s3-us-west-2.amazonaws.com",
@@ -33,7 +33,7 @@ func TestAccFastlyServiceV1_s3logging_basic(t *testing.T) {
 	}
 
 	log2 := gofastly.S3{
-		Version:         "1",
+		Version:         1,
 		Name:            "someotherbucketlog",
 		BucketName:      "fastlytestlogging2",
 		Domain:          "s3-us-west-2.amazonaws.com",
@@ -89,7 +89,7 @@ func TestAccFastlyServiceV1_s3logging_s3_env(t *testing.T) {
 	defer resetEnv()
 
 	log3 := gofastly.S3{
-		Version:         "1",
+		Version:         1,
 		Name:            "somebucketlog",
 		BucketName:      "fastlytestlogging",
 		Domain:          "s3-us-west-2.amazonaws.com",
@@ -128,7 +128,7 @@ func TestAccFastlyServiceV1_s3logging_formatVersion(t *testing.T) {
 	domainName1 := fmt.Sprintf("%s.notadomain.com", acctest.RandString(10))
 
 	log1 := gofastly.S3{
-		Version:         "1",
+		Version:         1,
 		Name:            "somebucketlog",
 		BucketName:      "fastlytestlogging",
 		Domain:          "s3-us-west-2.amazonaws.com",

--- a/builtin/providers/fastly/resource_fastly_service_v1_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_test.go
@@ -173,7 +173,7 @@ func TestAccFastlyServiceV1_updateBackend(t *testing.T) {
 			},
 
 			resource.TestStep{
-				Config: testAccServiceV1Config_backend_update(name, backendName, backendName2),
+				Config: testAccServiceV1Config_backend_update(name, backendName, backendName2, 3400),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
 					testAccCheckFastlyServiceV1Attributes_backends(&service, name, []string{backendName, backendName2}),
@@ -357,6 +357,52 @@ func testAccCheckFastlyServiceV1Attributes_backends(service *gofastly.ServiceDet
 	}
 }
 
+func TestAccFastlyServiceV1_defaultTTL(t *testing.T) {
+	var service gofastly.ServiceDetail
+	name := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	backendName := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+	backendName2 := fmt.Sprintf("%s.aws.amazon.com", acctest.RandString(3))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckServiceV1Destroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccServiceV1Config_backend(name, backendName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_backends(&service, name, []string{backendName}),
+				),
+			},
+
+			resource.TestStep{
+				Config: testAccServiceV1Config_backend_update(name, backendName, backendName2, 3400),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_backends(&service, name, []string{backendName, backendName2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "default_ttl", "3400"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "active_version", "2"),
+				),
+			},
+			// Now update the default_ttl to 0 and encounter the issue https://github.com/hashicorp/terraform/issues/12910
+			resource.TestStep{
+				Config: testAccServiceV1Config_backend_update(name, backendName, backendName2, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckServiceV1Exists("fastly_service_v1.foo", &service),
+					testAccCheckFastlyServiceV1Attributes_backends(&service, name, []string{backendName, backendName2}),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "default_ttl", "0"),
+					resource.TestCheckResourceAttr(
+						"fastly_service_v1.foo", "active_version", "3"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckServiceV1Destroy(s *terraform.State) error {
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "fastly_service_v1" {
@@ -441,12 +487,12 @@ resource "fastly_service_v1" "foo" {
 }`, name, backend)
 }
 
-func testAccServiceV1Config_backend_update(name, backend, backend2 string) string {
+func testAccServiceV1Config_backend_update(name, backend, backend2 string, ttl uint) string {
 	return fmt.Sprintf(`
 resource "fastly_service_v1" "foo" {
   name = "%s"
 
-	default_ttl = 3400
+	default_ttl = %d
 
   domain {
     name    = "test.notadomain.com"
@@ -464,5 +510,5 @@ resource "fastly_service_v1" "foo" {
   }
 
   force_destroy = true
-}`, name, backend, backend2)
+}`, name, ttl, backend, backend2)
 }

--- a/vendor/github.com/ajg/form/README.md
+++ b/vendor/github.com/ajg/form/README.md
@@ -28,6 +28,7 @@ Usage
 
 ```go
 import "github.com/ajg/form"
+// or: "gopkg.in/ajg/form.v1"
 ```
 
 Given a type like the following...
@@ -125,6 +126,10 @@ While encouraged, it is not necessary to define a type (e.g. a `struct`) in orde
  - Simple values will be treated as a `string`.
  - Composite values will be treated as a `map[string]interface{}`, itself able to contain nested values (both scalar and compound) ad infinitum.
  - However, if there is a value (of any supported type) already present in a map for a given key, then it will be used when possible, rather than being replaced with a generic value as specified above; this makes it possible to handle partially typed, dynamic or schema-less values.
+
+### Zero Values
+
+By default, and without custom marshaling, zero values (also known as empty/default values) are encoded as the empty string. To disable this behavior, meaning to keep zero values in their literal form (e.g. `0` for integral types), `Encoder` offers a `KeepZeros` setter method, which will do just that when set to `true`.
 
 ### Unsupported Values
 

--- a/vendor/github.com/ajg/form/TODO.md
+++ b/vendor/github.com/ajg/form/TODO.md
@@ -2,4 +2,3 @@ TODO
 ====
 
   - Document IgnoreCase and IgnoreUnknownKeys in README.
-  - Fix want/have newlines in tests.

--- a/vendor/github.com/ajg/form/decode.go
+++ b/vendor/github.com/ajg/form/decode.go
@@ -14,13 +14,13 @@ import (
 	"time"
 )
 
-// NewDecoder returns a new form decoder.
-func NewDecoder(r io.Reader) *decoder {
-	return &decoder{r, defaultDelimiter, defaultEscape, false, false}
+// NewDecoder returns a new form Decoder.
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{r, defaultDelimiter, defaultEscape, false, false}
 }
 
-// decoder decodes data from a form (application/x-www-form-urlencoded).
-type decoder struct {
+// Decoder decodes data from a form (application/x-www-form-urlencoded).
+type Decoder struct {
 	r             io.Reader
 	d             rune
 	e             rune
@@ -28,20 +28,20 @@ type decoder struct {
 	ignoreCase    bool
 }
 
-// DelimitWith sets r as the delimiter used for composite keys by decoder d and returns the latter; it is '.' by default.
-func (d *decoder) DelimitWith(r rune) *decoder {
+// DelimitWith sets r as the delimiter used for composite keys by Decoder d and returns the latter; it is '.' by default.
+func (d *Decoder) DelimitWith(r rune) *Decoder {
 	d.d = r
 	return d
 }
 
-// EscapeWith sets r as the escape used for delimiters (and to escape itself) by decoder d and returns the latter; it is '\\' by default.
-func (d *decoder) EscapeWith(r rune) *decoder {
+// EscapeWith sets r as the escape used for delimiters (and to escape itself) by Decoder d and returns the latter; it is '\\' by default.
+func (d *Decoder) EscapeWith(r rune) *Decoder {
 	d.e = r
 	return d
 }
 
 // Decode reads in and decodes form-encoded data into dst.
-func (d decoder) Decode(dst interface{}) error {
+func (d Decoder) Decode(dst interface{}) error {
 	bs, err := ioutil.ReadAll(d.r)
 	if err != nil {
 		return err
@@ -54,20 +54,20 @@ func (d decoder) Decode(dst interface{}) error {
 	return d.decodeNode(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v)))
 }
 
-// IgnoreUnknownKeys if set to true it will make the decoder ignore values
+// IgnoreUnknownKeys if set to true it will make the Decoder ignore values
 // that are not found in the destination object instead of returning an error.
-func (d *decoder) IgnoreUnknownKeys(ignoreUnknown bool) {
+func (d *Decoder) IgnoreUnknownKeys(ignoreUnknown bool) {
 	d.ignoreUnknown = ignoreUnknown
 }
 
-// IgnoreCase if set to true it will make the decoder try to set values in the
+// IgnoreCase if set to true it will make the Decoder try to set values in the
 // destination object even if the case does not match.
-func (d *decoder) IgnoreCase(ignoreCase bool) {
+func (d *Decoder) IgnoreCase(ignoreCase bool) {
 	d.ignoreCase = ignoreCase
 }
 
 // DecodeString decodes src into dst.
-func (d decoder) DecodeString(dst interface{}, src string) error {
+func (d Decoder) DecodeString(dst interface{}, src string) error {
 	vs, err := url.ParseQuery(src)
 	if err != nil {
 		return err
@@ -77,7 +77,7 @@ func (d decoder) DecodeString(dst interface{}, src string) error {
 }
 
 // DecodeValues decodes vs into dst.
-func (d decoder) DecodeValues(dst interface{}, vs url.Values) error {
+func (d Decoder) DecodeValues(dst interface{}, vs url.Values) error {
 	v := reflect.ValueOf(dst)
 	return d.decodeNode(v, parseValues(d.d, d.e, vs, canIndexOrdinally(v)))
 }
@@ -92,7 +92,7 @@ func DecodeValues(dst interface{}, vs url.Values) error {
 	return NewDecoder(nil).DecodeValues(dst, vs)
 }
 
-func (d decoder) decodeNode(v reflect.Value, n node) (err error) {
+func (d Decoder) decodeNode(v reflect.Value, n node) (err error) {
 	defer func() {
 		if e := recover(); e != nil {
 			err = fmt.Errorf("%v", e)
@@ -106,7 +106,7 @@ func (d decoder) decodeNode(v reflect.Value, n node) (err error) {
 	return nil
 }
 
-func (d decoder) decodeValue(v reflect.Value, x interface{}) {
+func (d Decoder) decodeValue(v reflect.Value, x interface{}) {
 	t := v.Type()
 	k := v.Kind()
 
@@ -163,7 +163,7 @@ func (d decoder) decodeValue(v reflect.Value, x interface{}) {
 	}
 }
 
-func (d decoder) decodeStruct(v reflect.Value, x interface{}) {
+func (d Decoder) decodeStruct(v reflect.Value, x interface{}) {
 	t := v.Type()
 	for k, c := range getNode(x) {
 		if f, ok := findField(v, k, d.ignoreCase); !ok && k == "" {
@@ -180,7 +180,7 @@ func (d decoder) decodeStruct(v reflect.Value, x interface{}) {
 	}
 }
 
-func (d decoder) decodeMap(v reflect.Value, x interface{}) {
+func (d Decoder) decodeMap(v reflect.Value, x interface{}) {
 	t := v.Type()
 	if v.IsNil() {
 		v.Set(reflect.MakeMap(t))
@@ -216,7 +216,7 @@ func (d decoder) decodeMap(v reflect.Value, x interface{}) {
 	}
 }
 
-func (d decoder) decodeArray(v reflect.Value, x interface{}) {
+func (d Decoder) decodeArray(v reflect.Value, x interface{}) {
 	t := v.Type()
 	for k, c := range getNode(x) {
 		i, err := strconv.Atoi(k)
@@ -230,7 +230,7 @@ func (d decoder) decodeArray(v reflect.Value, x interface{}) {
 	}
 }
 
-func (d decoder) decodeSlice(v reflect.Value, x interface{}) {
+func (d Decoder) decodeSlice(v reflect.Value, x interface{}) {
 	t := v.Type()
 	if t.Elem().Kind() == reflect.Uint8 {
 		// Allow, but don't require, byte slices to be encoded as a single string.
@@ -265,7 +265,7 @@ func (d decoder) decodeSlice(v reflect.Value, x interface{}) {
 	}
 }
 
-func (d decoder) decodeBasic(v reflect.Value, x interface{}) {
+func (d Decoder) decodeBasic(v reflect.Value, x interface{}) {
 	t := v.Type()
 	switch k, s := t.Kind(), getString(x); k {
 	case reflect.Bool:
@@ -316,7 +316,7 @@ func (d decoder) decodeBasic(v reflect.Value, x interface{}) {
 	}
 }
 
-func (d decoder) decodeTime(v reflect.Value, x interface{}) {
+func (d Decoder) decodeTime(v reflect.Value, x interface{}) {
 	t := v.Type()
 	s := getString(x)
 	// TODO: Find a more efficient way to do this.
@@ -329,7 +329,7 @@ func (d decoder) decodeTime(v reflect.Value, x interface{}) {
 	panic("cannot decode string `" + s + "` as " + t.String())
 }
 
-func (d decoder) decodeURL(v reflect.Value, x interface{}) {
+func (d Decoder) decodeURL(v reflect.Value, x interface{}) {
 	t := v.Type()
 	s := getString(x)
 	if u, err := url.Parse(s); err == nil {

--- a/vendor/github.com/sethvargo/go-fastly/backend.go
+++ b/vendor/github.com/sethvargo/go-fastly/backend.go
@@ -8,7 +8,7 @@ import (
 // Backend represents a backend response from the Fastly API.
 type Backend struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name                string   `mapstructure:"name"`
 	Address             string   `mapstructure:"address"`
@@ -53,7 +53,7 @@ type ListBackendsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListBackends returns the list of backends for the configuration version.
@@ -62,11 +62,11 @@ func (c *Client) ListBackends(i *ListBackendsInput) ([]*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/backend", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -85,7 +85,7 @@ type CreateBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name                string       `form:"name,omitempty"`
 	Address             string       `form:"address,omitempty"`
@@ -119,11 +119,11 @@ func (c *Client) CreateBackend(i *CreateBackendInput) (*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/backend", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -141,7 +141,7 @@ type GetBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the backend to fetch.
 	Name string
@@ -153,7 +153,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -161,7 +161,7 @@ func (c *Client) GetBackend(i *GetBackendInput) (*Backend, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ type UpdateBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the backend to update.
 	Name string
@@ -216,7 +216,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -224,7 +224,7 @@ func (c *Client) UpdateBackend(i *UpdateBackendInput) (*Backend, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -242,7 +242,7 @@ type DeleteBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the backend to delete (required).
 	Name string
@@ -254,7 +254,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -262,7 +262,7 @@ func (c *Client) DeleteBackend(i *DeleteBackendInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/backend/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/backend/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/cache_setting.go
+++ b/vendor/github.com/sethvargo/go-fastly/cache_setting.go
@@ -22,7 +22,7 @@ type CacheSettingAction string
 // CacheSetting represents a response from Fastly's API for cache settings.
 type CacheSetting struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name           string             `mapstructure:"name"`
 	Action         CacheSettingAction `mapstructure:"action"`
@@ -47,7 +47,7 @@ type ListCacheSettingsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListCacheSettings returns the list of cache settings for the configuration
@@ -57,11 +57,11 @@ func (c *Client) ListCacheSettings(i *ListCacheSettingsInput) ([]*CacheSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -80,7 +80,7 @@ type CreateCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name           string             `form:"name,omitempty"`
 	Action         CacheSettingAction `form:"action,omitempty"`
@@ -95,11 +95,11 @@ func (c *Client) CreateCacheSetting(i *CreateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -117,7 +117,7 @@ type GetCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the cache setting to fetch.
 	Name string
@@ -130,7 +130,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -138,7 +138,7 @@ func (c *Client) GetCacheSetting(i *GetCacheSettingInput) (*CacheSetting, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ type UpdateCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the cache setting to update.
 	Name string
@@ -174,7 +174,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -182,7 +182,7 @@ func (c *Client) UpdateCacheSetting(i *UpdateCacheSettingInput) (*CacheSetting, 
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ type DeleteCacheSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the cache setting to delete (required).
 	Name string
@@ -212,7 +212,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -220,7 +220,7 @@ func (c *Client) DeleteCacheSetting(i *DeleteCacheSettingInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/cache_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/cache_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/condition.go
+++ b/vendor/github.com/sethvargo/go-fastly/condition.go
@@ -8,7 +8,7 @@ import (
 // Condition represents a condition response from the Fastly API.
 type Condition struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name      string `mapstructure:"name"`
 	Statement string `mapstructure:"statement"`
@@ -32,7 +32,7 @@ type ListConditionsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListConditions returns the list of conditions for the configuration version.
@@ -41,11 +41,11 @@ func (c *Client) ListConditions(i *ListConditionsInput) ([]*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/condition", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ type CreateConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name      string `form:"name,omitempty"`
 	Statement string `form:"statement,omitempty"`
@@ -78,11 +78,11 @@ func (c *Client) CreateCondition(i *CreateConditionInput) (*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/condition", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ type GetConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the condition to fetch.
 	Name string
@@ -112,7 +112,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -120,7 +120,7 @@ func (c *Client) GetCondition(i *GetConditionInput) (*Condition, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ type UpdateConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the condition to update.
 	Name string
@@ -154,7 +154,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -162,7 +162,7 @@ func (c *Client) UpdateCondition(i *UpdateConditionInput) (*Condition, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ type DeleteConditionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the condition to delete (required).
 	Name string
@@ -192,7 +192,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -200,7 +200,7 @@ func (c *Client) DeleteCondition(i *DeleteConditionInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/condition/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/condition/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/dictionary.go
+++ b/vendor/github.com/sethvargo/go-fastly/dictionary.go
@@ -8,7 +8,7 @@ import (
 // Dictionary represents a dictionary response from the Fastly API.
 type Dictionary struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	ID      string `mapstructure:"id"`
 	Name    string `mapstructure:"name"`
@@ -31,7 +31,7 @@ type ListDictionariesInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListDictionaries returns the list of dictionaries for the configuration version.
@@ -40,11 +40,11 @@ func (c *Client) ListDictionaries(i *ListDictionariesInput) ([]*Dictionary, erro
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ type CreateDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name string `form:"name,omitempty"`
 }
@@ -74,11 +74,11 @@ func (c *Client) CreateDictionary(i *CreateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -96,7 +96,7 @@ type GetDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the dictionary to fetch.
 	Name string
@@ -108,7 +108,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -116,7 +116,7 @@ func (c *Client) GetDictionary(i *GetDictionaryInput) (*Dictionary, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ type UpdateDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the dictionary to update.
 	Name string
@@ -148,7 +148,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -156,7 +156,7 @@ func (c *Client) UpdateDictionary(i *UpdateDictionaryInput) (*Dictionary, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ type DeleteDictionaryInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the dictionary to delete (required).
 	Name string
@@ -186,7 +186,7 @@ func (c *Client) DeleteDictionary(i *DeleteDictionaryInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -194,7 +194,7 @@ func (c *Client) DeleteDictionary(i *DeleteDictionaryInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/dictionary/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/dictionary/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/diff.go
+++ b/vendor/github.com/sethvargo/go-fastly/diff.go
@@ -5,8 +5,8 @@ import "fmt"
 // Diff represents a diff of two versions as a response from the Fastly API.
 type Diff struct {
 	Format string `mapstructure:"format"`
-	From   string `mapstructure:"from"`
-	To     string `mapstructure:"to"`
+	From   int    `mapstructure:"from"`
+	To     int    `mapstructure:"to"`
 	Diff   string `mapstructure:"diff"`
 }
 
@@ -18,10 +18,10 @@ type GetDiffInput struct {
 	// From is the version to diff from. This can either be a string indicating a
 	// positive number (e.g. "1") or a negative number from "-1" down ("-1" is the
 	// latest version).
-	From string
+	From int
 
 	// To is the version to diff up to. The same rules for From apply.
-	To string
+	To int
 
 	// Format is an optional field to specify the format with which the diff will
 	// be returned. Acceptable values are "text" (default), "html", or
@@ -35,15 +35,15 @@ func (c *Client) GetDiff(i *GetDiffInput) (*Diff, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.From == "" {
+	if i.From == 0 {
 		return nil, ErrMissingFrom
 	}
 
-	if i.To == "" {
+	if i.To == 0 {
 		return nil, ErrMissingTo
 	}
 
-	path := fmt.Sprintf("service/%s/diff/from/%s/to/%s", i.Service, i.From, i.To)
+	path := fmt.Sprintf("service/%s/diff/from/%d/to/%d", i.Service, i.From, i.To)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/sethvargo/go-fastly/director.go
+++ b/vendor/github.com/sethvargo/go-fastly/director.go
@@ -25,7 +25,7 @@ type DirectorType uint8
 // Director represents a director response from the Fastly API.
 type Director struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name     string       `mapstructure:"name"`
 	Comment  string       `mapstructure:"comment"`
@@ -51,7 +51,7 @@ type ListDirectorsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListDirectors returns the list of directors for the configuration version.
@@ -60,11 +60,11 @@ func (c *Client) ListDirectors(i *ListDirectorsInput) ([]*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/director", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -83,7 +83,7 @@ type CreateDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name    string       `form:"name,omitempty"`
 	Comment string       `form:"comment,omitempty"`
@@ -98,11 +98,11 @@ func (c *Client) CreateDirector(i *CreateDirectorInput) (*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/director", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -120,7 +120,7 @@ type GetDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the director to fetch.
 	Name string
@@ -132,7 +132,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -140,7 +140,7 @@ func (c *Client) GetDirector(i *GetDirectorInput) (*Director, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ type UpdateDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the director to update.
 	Name string
@@ -175,7 +175,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -183,7 +183,7 @@ func (c *Client) UpdateDirector(i *UpdateDirectorInput) (*Director, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -201,7 +201,7 @@ type DeleteDirectorInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the director to delete (required).
 	Name string
@@ -213,7 +213,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -221,7 +221,7 @@ func (c *Client) DeleteDirector(i *DeleteDirectorInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/director_backend.go
+++ b/vendor/github.com/sethvargo/go-fastly/director_backend.go
@@ -9,7 +9,7 @@ import (
 // Fastly API.
 type DirectorBackend struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Director  string     `mapstructure:"director_name"`
 	Backend   string     `mapstructure:"backend_name"`
@@ -24,7 +24,7 @@ type CreateDirectorBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Director is the name of the director (required).
 	Director string
@@ -39,7 +39,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -51,7 +51,7 @@ func (c *Client) CreateDirectorBackend(i *CreateDirectorBackendInput) (*Director
 		return nil, ErrMissingBackend
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
 		i.Service, i.Version, i.Director, i.Backend)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
@@ -70,7 +70,7 @@ type GetDirectorBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Director is the name of the director (required).
 	Director string
@@ -85,7 +85,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -97,7 +97,7 @@ func (c *Client) GetDirectorBackend(i *GetDirectorBackendInput) (*DirectorBacken
 		return nil, ErrMissingBackend
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
 		i.Service, i.Version, i.Director, i.Backend)
 	resp, err := c.Get(path, nil)
 	if err != nil {
@@ -116,7 +116,7 @@ type DeleteDirectorBackendInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Director is the name of the director (required).
 	Director string
@@ -131,7 +131,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -143,7 +143,7 @@ func (c *Client) DeleteDirectorBackend(i *DeleteDirectorBackendInput) error {
 		return ErrMissingBackend
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/director/%s/backend/%s",
+	path := fmt.Sprintf("/service/%s/version/%d/director/%s/backend/%s",
 		i.Service, i.Version, i.Director, i.Backend)
 	resp, err := c.Delete(path, nil)
 	if err != nil {

--- a/vendor/github.com/sethvargo/go-fastly/domain.go
+++ b/vendor/github.com/sethvargo/go-fastly/domain.go
@@ -8,7 +8,7 @@ import (
 // Domain represents the the domain name Fastly will serve content for.
 type Domain struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name    string `mapstructure:"name"`
 	Comment string `mapstructure:"comment"`
@@ -30,7 +30,7 @@ type ListDomainsInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ListDomains returns the list of domains for this Service.
@@ -39,11 +39,11 @@ func (c *Client) ListDomains(i *ListDomainsInput) ([]*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/domain", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ type CreateDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain that the service will respond to (required).
 	Name string `form:"name"`
@@ -77,11 +77,11 @@ func (c *Client) CreateDomain(i *CreateDomainInput) (*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/domain", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -99,7 +99,7 @@ type GetDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain to fetch.
 	Name string `form:"name"`
@@ -111,7 +111,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -119,7 +119,7 @@ func (c *Client) GetDomain(i *GetDomainInput) (*Domain, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ type UpdateDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain that the service will respond to (required).
 	Name string
@@ -156,7 +156,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -164,7 +164,7 @@ func (c *Client) UpdateDomain(i *UpdateDomainInput) (*Domain, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ type DeleteDomainInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the domain that the service will respond to (required).
 	Name string `form:"name"`
@@ -194,7 +194,7 @@ func (c *Client) DeleteDomain(i *DeleteDomainInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -202,7 +202,7 @@ func (c *Client) DeleteDomain(i *DeleteDomainInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/domain/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/domain/%s", i.Service, i.Version, i.Name)
 	_, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/ftp.go
+++ b/vendor/github.com/sethvargo/go-fastly/ftp.go
@@ -9,7 +9,7 @@ import (
 // FTP represents an FTP logging response from the Fastly API.
 type FTP struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -43,7 +43,7 @@ type ListFTPsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListFTPs returns the list of ftps for the configuration version.
@@ -52,11 +52,11 @@ func (c *Client) ListFTPs(i *ListFTPsInput) ([]*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -75,7 +75,7 @@ type CreateFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string `form:"name,omitempty"`
 	Address           string `form:"address,omitempty"`
@@ -96,11 +96,11 @@ func (c *Client) CreateFTP(i *CreateFTPInput) (*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -118,7 +118,7 @@ type GetFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the FTP to fetch.
 	Name string
@@ -130,7 +130,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -138,7 +138,7 @@ func (c *Client) GetFTP(i *GetFTPInput) (*FTP, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ type UpdateFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the FTP to update.
 	Name string
@@ -180,7 +180,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -188,7 +188,7 @@ func (c *Client) UpdateFTP(i *UpdateFTPInput) (*FTP, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +206,7 @@ type DeleteFTPInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the FTP to delete (required).
 	Name string
@@ -218,7 +218,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -226,7 +226,7 @@ func (c *Client) DeleteFTP(i *DeleteFTPInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/ftp/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/ftp/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/gcs.go
+++ b/vendor/github.com/sethvargo/go-fastly/gcs.go
@@ -8,7 +8,7 @@ import (
 // GCS represents an GCS logging response from the Fastly API.
 type GCS struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string `mapstructure:"name"`
 	Bucket            string `mapstructure:"bucket_name"`
@@ -38,7 +38,7 @@ type ListGCSsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListGCSs returns the list of gcses for the configuration version.
@@ -47,11 +47,11 @@ func (c *Client) ListGCSs(i *ListGCSsInput) ([]*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ type CreateGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string `form:"name,omitempty"`
 	Bucket            string `form:"bucket_name,omitempty"`
@@ -90,11 +90,11 @@ func (c *Client) CreateGCS(i *CreateGCSInput) (*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ type GetGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the GCS to fetch.
 	Name string
@@ -124,7 +124,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -132,7 +132,7 @@ func (c *Client) GetGCS(i *GetGCSInput) (*GCS, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ type UpdateGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the GCS to update.
 	Name string
@@ -173,7 +173,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -181,7 +181,7 @@ func (c *Client) UpdateGCS(i *UpdateGCSInput) (*GCS, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -199,7 +199,7 @@ type DeleteGCSInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the GCS to delete (required).
 	Name string
@@ -211,7 +211,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -219,7 +219,7 @@ func (c *Client) DeleteGCS(i *DeleteGCSInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/gcs/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/gcs/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/gzip.go
+++ b/vendor/github.com/sethvargo/go-fastly/gzip.go
@@ -8,7 +8,7 @@ import (
 // Gzip represents an Gzip logging response from the Fastly API.
 type Gzip struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name           string `mapstructure:"name"`
 	ContentTypes   string `mapstructure:"content_types"`
@@ -32,7 +32,7 @@ type ListGzipsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListGzips returns the list of gzips for the configuration version.
@@ -41,11 +41,11 @@ func (c *Client) ListGzips(i *ListGzipsInput) ([]*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -64,7 +64,7 @@ type CreateGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name           string `form:"name,omitempty"`
 	ContentTypes   string `form:"content_types"`
@@ -78,11 +78,11 @@ func (c *Client) CreateGzip(i *CreateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ type GetGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the Gzip to fetch.
 	Name string
@@ -112,7 +112,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -120,7 +120,7 @@ func (c *Client) GetGzip(i *GetGzipInput) (*Gzip, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ type UpdateGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the Gzip to update.
 	Name string
@@ -155,7 +155,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -163,7 +163,7 @@ func (c *Client) UpdateGzip(i *UpdateGzipInput) (*Gzip, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -181,7 +181,7 @@ type DeleteGzipInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the Gzip to delete (required).
 	Name string
@@ -193,7 +193,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -201,7 +201,7 @@ func (c *Client) DeleteGzip(i *DeleteGzipInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/gzip/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/gzip/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/header.go
+++ b/vendor/github.com/sethvargo/go-fastly/header.go
@@ -51,7 +51,7 @@ type HeaderType string
 // Header represents a header response from the Fastly API.
 type Header struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string       `mapstructure:"name"`
 	Action            HeaderAction `mapstructure:"action"`
@@ -83,7 +83,7 @@ type ListHeadersInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListHeaders returns the list of headers for the configuration version.
@@ -92,11 +92,11 @@ func (c *Client) ListHeaders(i *ListHeadersInput) ([]*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/header", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ type CreateHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	Action            HeaderAction `form:"action,omitempty"`
@@ -137,11 +137,11 @@ func (c *Client) CreateHeader(i *CreateHeaderInput) (*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/header", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ type GetHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the header to fetch.
 	Name string
@@ -171,7 +171,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -179,7 +179,7 @@ func (c *Client) GetHeader(i *GetHeaderInput) (*Header, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ type UpdateHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the header to update.
 	Name string
@@ -222,7 +222,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -230,7 +230,7 @@ func (c *Client) UpdateHeader(i *UpdateHeaderInput) (*Header, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ type DeleteHeaderInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the header to delete (required).
 	Name string
@@ -260,7 +260,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -268,7 +268,7 @@ func (c *Client) DeleteHeader(i *DeleteHeaderInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/header/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/header/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/health_check.go
+++ b/vendor/github.com/sethvargo/go-fastly/health_check.go
@@ -8,7 +8,7 @@ import (
 // HealthCheck represents a health check response from the Fastly API.
 type HealthCheck struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name             string `mapstructure:"name"`
 	Method           string `mapstructure:"method"`
@@ -39,7 +39,7 @@ type ListHealthChecksInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListHealthChecks returns the list of health checks for the configuration
@@ -49,11 +49,11 @@ func (c *Client) ListHealthChecks(i *ListHealthChecksInput) ([]*HealthCheck, err
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -72,7 +72,7 @@ type CreateHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name             string `form:"name,omitempty"`
 	Method           string `form:"method,omitempty"`
@@ -93,11 +93,11 @@ func (c *Client) CreateHealthCheck(i *CreateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ type GetHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the health check to fetch.
 	Name string
@@ -127,7 +127,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -135,7 +135,7 @@ func (c *Client) GetHealthCheck(i *GetHealthCheckInput) (*HealthCheck, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -153,7 +153,7 @@ type UpdateHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the health check to update.
 	Name string
@@ -177,7 +177,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -185,7 +185,7 @@ func (c *Client) UpdateHealthCheck(i *UpdateHealthCheckInput) (*HealthCheck, err
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -203,7 +203,7 @@ type DeleteHealthCheckInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the health check to delete (required).
 	Name string
@@ -215,7 +215,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -223,7 +223,7 @@ func (c *Client) DeleteHealthCheck(i *DeleteHealthCheckInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/healthcheck/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/healthcheck/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/logentries.go
+++ b/vendor/github.com/sethvargo/go-fastly/logentries.go
@@ -9,7 +9,7 @@ import (
 // Logentries represents a logentries response from the Fastly API.
 type Logentries struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Port              uint       `mapstructure:"port"`
@@ -38,7 +38,7 @@ type ListLogentriesInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListLogentries returns the list of logentries for the configuration version.
@@ -47,11 +47,11 @@ func (c *Client) ListLogentries(i *ListLogentriesInput) ([]*Logentries, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ type CreateLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	Port              uint         `form:"port,omitempty"`
@@ -86,11 +86,11 @@ func (c *Client) CreateLogentries(i *CreateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ type GetLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the logentries to fetch.
 	Name string
@@ -120,7 +120,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -128,7 +128,7 @@ func (c *Client) GetLogentries(i *GetLogentriesInput) (*Logentries, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -146,7 +146,7 @@ type UpdateLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the logentries to update.
 	Name string
@@ -165,7 +165,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -173,7 +173,7 @@ func (c *Client) UpdateLogentries(i *UpdateLogentriesInput) (*Logentries, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ type DeleteLogentriesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the logentries to delete (required).
 	Name string
@@ -203,7 +203,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -211,7 +211,7 @@ func (c *Client) DeleteLogentries(i *DeleteLogentriesInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/logentries/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/logentries/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/papertrail.go
+++ b/vendor/github.com/sethvargo/go-fastly/papertrail.go
@@ -9,7 +9,7 @@ import (
 // Papertrail represents a papertrail response from the Fastly API.
 type Papertrail struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -37,7 +37,7 @@ type ListPapertrailsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListPapertrails returns the list of papertrails for the configuration version.
@@ -46,11 +46,11 @@ func (c *Client) ListPapertrails(i *ListPapertrailsInput) ([]*Papertrail, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -69,7 +69,7 @@ type CreatePapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string     `form:"name,omitempty"`
 	Address           string     `form:"address,omitempty"`
@@ -87,11 +87,11 @@ func (c *Client) CreatePapertrail(i *CreatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ type GetPapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the papertrail to fetch.
 	Name string
@@ -121,7 +121,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -129,7 +129,7 @@ func (c *Client) GetPapertrail(i *GetPapertrailInput) (*Papertrail, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ type UpdatePapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the papertrail to update.
 	Name string
@@ -168,7 +168,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -176,7 +176,7 @@ func (c *Client) UpdatePapertrail(i *UpdatePapertrailInput) (*Papertrail, error)
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ type DeletePapertrailInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the papertrail to delete (required).
 	Name string
@@ -206,7 +206,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -214,7 +214,7 @@ func (c *Client) DeletePapertrail(i *DeletePapertrailInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/papertrail/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/papertrail/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/request_setting.go
+++ b/vendor/github.com/sethvargo/go-fastly/request_setting.go
@@ -40,7 +40,7 @@ type RequestSettingXFF string
 // RequestSetting represents a request setting response from the Fastly API.
 type RequestSetting struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name             string               `mapstructure:"name"`
 	ForceMiss        bool                 `mapstructure:"force_miss"`
@@ -73,7 +73,7 @@ type ListRequestSettingsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListRequestSettings returns the list of request settings for the
@@ -83,11 +83,11 @@ func (c *Client) ListRequestSettings(i *ListRequestSettingsInput) ([]*RequestSet
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ type CreateRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name             string               `form:"name,omitempty"`
 	ForceMiss        *Compatibool         `form:"force_miss,omitempty"`
@@ -129,11 +129,11 @@ func (c *Client) CreateRequestSetting(i *CreateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ type GetRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the request settings to fetch.
 	Name string
@@ -164,7 +164,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -172,7 +172,7 @@ func (c *Client) GetRequestSetting(i *GetRequestSettingInput) (*RequestSetting, 
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -191,7 +191,7 @@ type UpdateRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the request settings to update.
 	Name string
@@ -216,7 +216,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -224,7 +224,7 @@ func (c *Client) UpdateRequestSetting(i *UpdateRequestSettingInput) (*RequestSet
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -242,7 +242,7 @@ type DeleteRequestSettingInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the request settings to delete (required).
 	Name string
@@ -254,7 +254,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -262,7 +262,7 @@ func (c *Client) DeleteRequestSetting(i *DeleteRequestSettingInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/request_settings/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/request_settings/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/response_object.go
+++ b/vendor/github.com/sethvargo/go-fastly/response_object.go
@@ -8,7 +8,7 @@ import (
 // ResponseObject represents a response object response from the Fastly API.
 type ResponseObject struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name             string `mapstructure:"name"`
 	Status           uint   `mapstructure:"status"`
@@ -36,7 +36,7 @@ type ListResponseObjectsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListResponseObjects returns the list of response objects for the
@@ -46,11 +46,11 @@ func (c *Client) ListResponseObjects(i *ListResponseObjectsInput) ([]*ResponseOb
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -70,7 +70,7 @@ type CreateResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name             string `form:"name,omitempty"`
 	Status           uint   `form:"status,omitempty"`
@@ -87,11 +87,11 @@ func (c *Client) CreateResponseObject(i *CreateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -109,7 +109,7 @@ type GetResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the response object to fetch.
 	Name string
@@ -122,7 +122,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -130,7 +130,7 @@ func (c *Client) GetResponseObject(i *GetResponseObjectInput) (*ResponseObject, 
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ type UpdateResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the response object to update.
 	Name string
@@ -169,7 +169,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -177,7 +177,7 @@ func (c *Client) UpdateResponseObject(i *UpdateResponseObjectInput) (*ResponseOb
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -195,7 +195,7 @@ type DeleteResponseObjectInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the response object to delete (required).
 	Name string
@@ -207,7 +207,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -215,7 +215,7 @@ func (c *Client) DeleteResponseObject(i *DeleteResponseObjectInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/response_object/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/response_object/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/s3.go
+++ b/vendor/github.com/sethvargo/go-fastly/s3.go
@@ -16,7 +16,7 @@ const (
 // S3 represents a S3 response from the Fastly API.
 type S3 struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string       `mapstructure:"name"`
 	BucketName        string       `mapstructure:"bucket_name"`
@@ -52,7 +52,7 @@ type ListS3sInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListS3s returns the list of S3s for the configuration version.
@@ -61,11 +61,11 @@ func (c *Client) ListS3s(i *ListS3sInput) ([]*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -84,7 +84,7 @@ type CreateS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	BucketName        string       `form:"bucket_name,omitempty"`
@@ -107,11 +107,11 @@ func (c *Client) CreateS3(i *CreateS3Input) (*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -129,7 +129,7 @@ type GetS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the S3 to fetch.
 	Name string
@@ -141,7 +141,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -149,7 +149,7 @@ func (c *Client) GetS3(i *GetS3Input) (*S3, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -167,7 +167,7 @@ type UpdateS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the S3 to update.
 	Name string
@@ -193,7 +193,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -201,7 +201,7 @@ func (c *Client) UpdateS3(i *UpdateS3Input) (*S3, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -219,7 +219,7 @@ type DeleteS3Input struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the S3 to delete (required).
 	Name string
@@ -231,7 +231,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -239,7 +239,7 @@ func (c *Client) DeleteS3(i *DeleteS3Input) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/s3/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/s3/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/settings.go
+++ b/vendor/github.com/sethvargo/go-fastly/settings.go
@@ -5,7 +5,7 @@ import "fmt"
 // Settings represents a backend response from the Fastly API.
 type Settings struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	DefaultTTL  uint   `mapstructure:"general.default_ttl"`
 	DefaultHost string `mapstructure:"general.default_host"`
@@ -16,7 +16,7 @@ type GetSettingsInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // GetSettings gets the backend configuration with the given parameters.
@@ -25,11 +25,11 @@ func (c *Client) GetSettings(i *GetSettingsInput) (*Settings, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/settings", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -47,9 +47,9 @@ type UpdateSettingsInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
-	DefaultTTL  uint   `form:"general.default_ttl,omitempty"`
+	DefaultTTL  uint   `form:"general.default_ttl"`
 	DefaultHost string `form:"general.default_host,omitempty"`
 }
 
@@ -59,11 +59,11 @@ func (c *Client) UpdateSettings(i *UpdateSettingsInput) (*Settings, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/settings", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/settings", i.Service, i.Version)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/sethvargo/go-fastly/sumologic.go
+++ b/vendor/github.com/sethvargo/go-fastly/sumologic.go
@@ -9,7 +9,7 @@ import (
 // Sumologic represents a sumologic response from the Fastly API.
 type Sumologic struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -39,7 +39,7 @@ type ListSumologicsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListSumologics returns the list of sumologics for the configuration version.
@@ -48,11 +48,11 @@ func (c *Client) ListSumologics(i *ListSumologicsInput) ([]*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -71,7 +71,7 @@ type CreateSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string `form:"name,omitempty"`
 	Address           string `form:"address,omitempty"`
@@ -88,11 +88,11 @@ func (c *Client) CreateSumologic(i *CreateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -110,7 +110,7 @@ type GetSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the sumologic to fetch.
 	Name string
@@ -122,7 +122,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -130,7 +130,7 @@ func (c *Client) GetSumologic(i *GetSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -148,7 +148,7 @@ type UpdateSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the sumologic to update.
 	Name string
@@ -168,7 +168,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -176,7 +176,7 @@ func (c *Client) UpdateSumologic(i *UpdateSumologicInput) (*Sumologic, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ type DeleteSumologicInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the sumologic to delete (required).
 	Name string
@@ -206,7 +206,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -214,7 +214,7 @@ func (c *Client) DeleteSumologic(i *DeleteSumologicInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/sumologic/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/sumologic/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/syslog.go
+++ b/vendor/github.com/sethvargo/go-fastly/syslog.go
@@ -9,7 +9,7 @@ import (
 // Syslog represents a syslog response from the Fastly API.
 type Syslog struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name              string     `mapstructure:"name"`
 	Address           string     `mapstructure:"address"`
@@ -41,7 +41,7 @@ type ListSyslogsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListSyslogs returns the list of syslogs for the configuration version.
@@ -50,11 +50,11 @@ func (c *Client) ListSyslogs(i *ListSyslogsInput) ([]*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -73,7 +73,7 @@ type CreateSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name              string       `form:"name,omitempty"`
 	Address           string       `form:"address,omitempty"`
@@ -92,11 +92,11 @@ func (c *Client) CreateSyslog(i *CreateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -114,7 +114,7 @@ type GetSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the syslog to fetch.
 	Name string
@@ -126,7 +126,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -134,7 +134,7 @@ func (c *Client) GetSyslog(i *GetSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -152,7 +152,7 @@ type UpdateSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the syslog to update.
 	Name string
@@ -174,7 +174,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -182,7 +182,7 @@ func (c *Client) UpdateSyslog(i *UpdateSyslogInput) (*Syslog, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ type DeleteSyslogInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the syslog to delete (required).
 	Name string
@@ -212,7 +212,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -220,7 +220,7 @@ func (c *Client) DeleteSyslog(i *DeleteSyslogInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/logging/syslog/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/logging/syslog/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/vcl.go
+++ b/vendor/github.com/sethvargo/go-fastly/vcl.go
@@ -8,7 +8,7 @@ import (
 // VCL represents a response about VCL from the Fastly API.
 type VCL struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name    string `mapstructure:"name"`
 	Main    bool   `mapstructure:"main"`
@@ -31,7 +31,7 @@ type ListVCLsInput struct {
 	Service string
 
 	// Version is the specific configuration version (required).
-	Version string
+	Version int
 }
 
 // ListVCLs returns the list of VCLs for the configuration version.
@@ -40,11 +40,11 @@ func (c *Client) ListVCLs(i *ListVCLsInput) ([]*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ type GetVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to fetch.
 	Name string
@@ -75,7 +75,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -83,7 +83,7 @@ func (c *Client) GetVCL(i *GetVCLInput) (*VCL, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ type GetGeneratedVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // GetGeneratedVCL gets the VCL configuration with the given parameters.
@@ -110,11 +110,11 @@ func (c *Client) GetGeneratedVCL(i *GetGeneratedVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/generated_vcl", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/generated_vcl", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ type CreateVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name    string `form:"name,omitempty"`
 	Content string `form:"content,omitempty"`
@@ -144,11 +144,11 @@ func (c *Client) CreateVCL(i *CreateVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -166,7 +166,7 @@ type UpdateVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to update (required).
 	Name string
@@ -181,7 +181,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -189,7 +189,7 @@ func (c *Client) UpdateVCL(i *UpdateVCLInput) (*VCL, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ type ActivateVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to mark as main (required).
 	Name string
@@ -219,7 +219,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -227,7 +227,7 @@ func (c *Client) ActivateVCL(i *ActivateVCLInput) (*VCL, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s/main", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s/main", i.Service, i.Version, i.Name)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -245,7 +245,7 @@ type DeleteVCLInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the VCL to delete (required).
 	Name string
@@ -257,7 +257,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -265,7 +265,7 @@ func (c *Client) DeleteVCL(i *DeleteVCLInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/vcl/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/vcl/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/github.com/sethvargo/go-fastly/version.go
+++ b/vendor/github.com/sethvargo/go-fastly/version.go
@@ -7,14 +7,14 @@ import (
 
 // Version represents a distinct configuration version.
 type Version struct {
-	Number    string     `mapstructure:"number"`
-	Comment   string     `mapstructure:"comment"`
-	ServiceID string     `mapstructure:"service_id"`
-	Active    bool       `mapstructure:"active"`
-	Locked    bool       `mapstructure:"locked"`
-	Deployed  bool       `mapstructure:"deployed"`
-	Staging   bool       `mapstructure:"staging"`
-	Testing   bool       `mapstructure:"testing"`
+	Number    int    `mapstructure:"number"`
+	Comment   string `mapstructure:"comment"`
+	ServiceID string `mapstructure:"service_id"`
+	Active    bool   `mapstructure:"active"`
+	Locked    bool   `mapstructure:"locked"`
+	Deployed  bool   `mapstructure:"deployed"`
+	Staging   bool   `mapstructure:"staging"`
+	Testing   bool   `mapstructure:"testing"`
 }
 
 // versionsByNumber is a sortable list of versions. This is used by the version
@@ -114,7 +114,7 @@ type GetVersionInput struct {
 	Service string
 
 	// Version is the version number to fetch (required).
-	Version string
+	Version int
 }
 
 // GetVersion fetches a version with the given information.
@@ -123,11 +123,11 @@ func (c *Client) GetVersion(i *GetVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -145,7 +145,7 @@ type UpdateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Comment string `form:"comment,omitempty"`
 }
@@ -156,11 +156,11 @@ func (c *Client) UpdateVersion(i *UpdateVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d", i.Service, i.Version)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ type ActivateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ActivateVersion activates the given version.
@@ -187,11 +187,11 @@ func (c *Client) ActivateVersion(i *ActivateVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/activate", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/activate", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ type DeactivateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // DeactivateVersion deactivates the given version.
@@ -218,11 +218,11 @@ func (c *Client) DeactivateVersion(i *DeactivateVersionInput) (*Version, error) 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/deactivate", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/deactivate", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -240,7 +240,7 @@ type CloneVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // CloneVersion creates a clone of the version with and returns a new
@@ -251,11 +251,11 @@ func (c *Client) CloneVersion(i *CloneVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/clone", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/clone", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err
@@ -273,7 +273,7 @@ type ValidateVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ValidateVersion validates if the given version is okay.
@@ -284,11 +284,11 @@ func (c *Client) ValidateVersion(i *ValidateVersionInput) (bool, string, error) 
 		return false, msg, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return false, msg, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/validate", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/validate", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return false, msg, err
@@ -308,7 +308,7 @@ type LockVersionInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // LockVersion locks the specified version.
@@ -317,11 +317,11 @@ func (c *Client) LockVersion(i *LockVersionInput) (*Version, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/lock", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/lock", i.Service, i.Version)
 	resp, err := c.Put(path, nil)
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/sethvargo/go-fastly/wordpress.go
+++ b/vendor/github.com/sethvargo/go-fastly/wordpress.go
@@ -8,7 +8,7 @@ import (
 // Wordpress represents a wordpress response from the Fastly API.
 type Wordpress struct {
 	ServiceID string `mapstructure:"service_id"`
-	Version   string `mapstructure:"version"`
+	Version   int    `mapstructure:"version"`
 
 	Name    string `mapstructure:"name"`
 	Path    string `mapstructure:"path"`
@@ -30,7 +30,7 @@ type ListWordpressesInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 }
 
 // ListWordpresses returns the list of wordpresses for the configuration version.
@@ -39,11 +39,11 @@ func (c *Client) ListWordpresses(i *ListWordpressesInput) ([]*Wordpress, error) 
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress", i.Service, i.Version)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ type CreateWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	Name    string `form:"name,omitempty"`
 	Path    string `form:"path,omitempty"`
@@ -75,11 +75,11 @@ func (c *Client) CreateWordpress(i *CreateWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress", i.Service, i.Version)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress", i.Service, i.Version)
 	resp, err := c.PostForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ type GetWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the wordpress to fetch.
 	Name string
@@ -109,7 +109,7 @@ func (c *Client) GetWordpress(i *GetWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -117,7 +117,7 @@ func (c *Client) GetWordpress(i *GetWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Get(path, nil)
 	if err != nil {
 		return nil, err
@@ -135,7 +135,7 @@ type UpdateWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the wordpress to update.
 	Name string
@@ -151,7 +151,7 @@ func (c *Client) UpdateWordpress(i *UpdateWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return nil, ErrMissingVersion
 	}
 
@@ -159,7 +159,7 @@ func (c *Client) UpdateWordpress(i *UpdateWordpressInput) (*Wordpress, error) {
 		return nil, ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress/%s", i.Service, i.Version, i.Name)
 	resp, err := c.PutForm(path, i, nil)
 	if err != nil {
 		return nil, err
@@ -177,7 +177,7 @@ type DeleteWordpressInput struct {
 	// Service is the ID of the service. Version is the specific configuration
 	// version. Both fields are required.
 	Service string
-	Version string
+	Version int
 
 	// Name is the name of the wordpress to delete (required).
 	Name string
@@ -189,7 +189,7 @@ func (c *Client) DeleteWordpress(i *DeleteWordpressInput) error {
 		return ErrMissingService
 	}
 
-	if i.Version == "" {
+	if i.Version == 0 {
 		return ErrMissingVersion
 	}
 
@@ -197,7 +197,7 @@ func (c *Client) DeleteWordpress(i *DeleteWordpressInput) error {
 		return ErrMissingName
 	}
 
-	path := fmt.Sprintf("/service/%s/version/%s/wordpress/%s", i.Service, i.Version, i.Name)
+	path := fmt.Sprintf("/service/%s/version/%d/wordpress/%s", i.Service, i.Version, i.Name)
 	resp, err := c.Delete(path, nil)
 	if err != nil {
 		return err

--- a/vendor/gopkg.in/yaml.v2/decode.go
+++ b/vendor/gopkg.in/yaml.v2/decode.go
@@ -120,7 +120,6 @@ func (p *parser) parse() *node {
 	default:
 		panic("attempted to parse unknown event: " + strconv.Itoa(int(p.event.typ)))
 	}
-	panic("unreachable")
 }
 
 func (p *parser) node(kind int) *node {

--- a/vendor/gopkg.in/yaml.v2/emitterc.go
+++ b/vendor/gopkg.in/yaml.v2/emitterc.go
@@ -666,7 +666,6 @@ func yaml_emitter_emit_node(emitter *yaml_emitter_t, event *yaml_event_t,
 		return yaml_emitter_set_emitter_error(emitter,
 			"expected SCALAR, SEQUENCE-START, MAPPING-START, or ALIAS")
 	}
-	return false
 }
 
 // Expect ALIAS.

--- a/vendor/gopkg.in/yaml.v2/parserc.go
+++ b/vendor/gopkg.in/yaml.v2/parserc.go
@@ -166,7 +166,6 @@ func yaml_parser_state_machine(parser *yaml_parser_t, event *yaml_event_t) bool 
 	default:
 		panic("invalid parser state")
 	}
-	return false
 }
 
 // Parse the production:

--- a/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/vendor/gopkg.in/yaml.v2/resolve.go
@@ -3,6 +3,7 @@ package yaml
 import (
 	"encoding/base64"
 	"math"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -80,6 +81,8 @@ func resolvableTag(tag string) bool {
 	return false
 }
 
+var yamlStyleFloat = regexp.MustCompile(`^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)?$`)
+
 func resolve(tag string, in string) (rtag string, out interface{}) {
 	if !resolvableTag(tag) {
 		return tag, in
@@ -135,9 +138,11 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 			if err == nil {
 				return yaml_INT_TAG, uintv
 			}
-			floatv, err := strconv.ParseFloat(plain, 64)
-			if err == nil {
-				return yaml_FLOAT_TAG, floatv
+			if yamlStyleFloat.MatchString(plain) {
+				floatv, err := strconv.ParseFloat(plain, 64)
+				if err == nil {
+					return yaml_FLOAT_TAG, floatv
+				}
 			}
 			if strings.HasPrefix(plain, "0b") {
 				intv, err := strconv.ParseInt(plain[2:], 2, 64)

--- a/vendor/gopkg.in/yaml.v2/scannerc.go
+++ b/vendor/gopkg.in/yaml.v2/scannerc.go
@@ -9,7 +9,7 @@ import (
 // ************
 //
 // The following notes assume that you are familiar with the YAML specification
-// (http://yaml.org/spec/cvs/current.html).  We mostly follow it, although in
+// (http://yaml.org/spec/1.2/spec.html).  We mostly follow it, although in
 // some cases we are less restrictive that it requires.
 //
 // The process of transforming a YAML stream into a sequence of events is

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -440,10 +440,10 @@
 			"revisionTime": "2015-08-30T18:26:16Z"
 		},
 		{
-			"checksumSHA1": "csR8njyJfkweB0RCtfnLwgXNeqQ=",
+			"checksumSHA1": "kMfAFLobZymMrCOm/Xi/g9gnJOU=",
 			"path": "github.com/ajg/form",
-			"revision": "7ff89c75808766205bfa4411abb436c98c33eb5e",
-			"revisionTime": "2016-06-29T21:43:12Z"
+			"revision": "523a5da1a92f01b01f840b61689c0340a0243532",
+			"revisionTime": "2016-08-22T23:00:20Z"
 		},
 		{
 			"checksumSHA1": "kn+zdUr5TNsoAX8BgjOaWYtMT5U=",
@@ -2858,10 +2858,10 @@
 			"revisionTime": "2017-03-13T16:33:22Z"
 		},
 		{
-			"checksumSHA1": "bCpL8ZdY+y7OGwiN3hZzbQI5oM0=",
+			"checksumSHA1": "Je4BagkuoS2e+IlNJOf0+6JoB1g=",
 			"path": "github.com/sethvargo/go-fastly",
-			"revision": "43b7f97296d6c8e3a7bc083ab91101fbbc8c2f94",
-			"revisionTime": "2017-02-28T16:12:19Z"
+			"revision": "6e883a4c1524445805f33ddb1ab2a09a49ce4b1c",
+			"revisionTime": "2017-04-17T16:09:14Z"
 		},
 		{
 			"checksumSHA1": "8tEiK6vhVXuUbnWME5XNWLgvtSo=",
@@ -3495,10 +3495,10 @@
 			"revisionTime": "2016-11-01T17:03:53Z"
 		},
 		{
-			"checksumSHA1": "12GqsW8PiRPnezDDy0v4brZrndM=",
+			"checksumSHA1": "fALlQNY1fM99NesfLJ50KguWsio=",
 			"path": "gopkg.in/yaml.v2",
-			"revision": "a5b47d31c556af34a302ce5d659e6fea44d90de0",
-			"revisionTime": "2016-09-28T15:37:09Z"
+			"revision": "cd8b52f8269e0feb286dfeef29f8fe4d5b397e0b",
+			"revisionTime": "2017-04-07T17:21:22Z"
 		},
 		{
 			"checksumSHA1": "OcJdNALtPXoFOieAZjznhm7ufuU=",


### PR DESCRIPTION
Fixes: #12910
- [X] Added acceptance tests that reproduce the issue
- [x] Fix the issue

The current acceptance test reveals that error which matches the explanation provided in the issue:
```
$ TF_ACC=1 go test ./builtin/providers/fastly -v  -timeout 120m -run TestAccFastlyServiceV1_defaultTTL
=== RUN   TestAccFastlyServiceV1_defaultTTL
--- FAIL: TestAccFastlyServiceV1_defaultTTL (52.79s)
	testing.go:280: Step 2 error: Check failed: Check 3/4 error: fastly_service_v1.foo: Attribute 'default_ttl' expected "0", got "3400"
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/fastly	53.310s
```