### PR TITLE
azurerm_redis_cache resource missing hostname

### DIFF
--- a/builtin/providers/azurerm/resource_arm_redis_cache.go
+++ b/builtin/providers/azurerm/resource_arm_redis_cache.go
@@ -298,7 +298,7 @@ func resourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("resource_group_name", resGroup)
 	d.Set("location", azureRMNormalizeLocation(*resp.Location))
 	d.Set("ssl_port", resp.SslPort)
-	d.Set("host_name", resp.HostName)
+	d.Set("hostname", resp.HostName)
 	d.Set("port", resp.Port)
 	d.Set("enable_non_ssl_port", resp.EnableNonSslPort)
 	d.Set("capacity", resp.Sku.Capacity)

--- a/website/source/docs/providers/azurerm/r/redis_cache.html.markdown
+++ b/website/source/docs/providers/azurerm/r/redis_cache.html.markdown
@@ -132,9 +132,9 @@ The following attributes are exported:
 
 * `hostname` - The Hostname of the Redis Instance
 
-* `ssl_port` - The non-SSL Port of the Redis Instance
+* `ssl_port` - The SSL Port of the Redis Instance
 
-* `port` - The SSL Port of the Redis Instance
+* `port` - The non-SSL Port of the Redis Instance
 
 * `primary_access_key` - The Primary Access Key for the Redis Instance
 


### PR DESCRIPTION
The documentation states that an ``azurerm_redis_cache`` resource has a ``hostname`` attribute, but no such attribute is available. This fixes a typo to expose the hostname as expected. Another typo in the documentation for this resource is also fixed.