### PR TITLE
provider/aws: Use mutex & retry for WAF change operations

### DIFF
--- a/builtin/providers/aws/resource_aws_waf_ipset.go
+++ b/builtin/providers/aws/resource_aws_waf_ipset.go
@@ -46,23 +46,18 @@ func resourceAwsWafIPSet() *schema.Resource {
 func resourceAwsWafIPSetCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	// ChangeToken
-	var ct *waf.GetChangeTokenInput
-
-	res, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return fmt.Errorf("Error getting change token: %s", err)
-	}
-
-	params := &waf.CreateIPSetInput{
-		ChangeToken: res.ChangeToken,
-		Name:        aws.String(d.Get("name").(string)),
-	}
-
-	resp, err := conn.CreateIPSet(params)
+	wr := newWafRetryer(conn, "global")
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateIPSetInput{
+			ChangeToken: token,
+			Name:        aws.String(d.Get("name").(string)),
+		}
+		return conn.CreateIPSet(params)
+	})
 	if err != nil {
 		return err
 	}
+	resp := out.(*waf.CreateIPSetOutput)
 	d.SetId(*resp.IPSet.IPSetId)
 	return resourceAwsWafIPSetUpdate(d, meta)
 }
@@ -117,18 +112,15 @@ func resourceAwsWafIPSetDelete(d *schema.ResourceData, meta interface{}) error {
 		return fmt.Errorf("Error Removing IPSetDescriptors: %s", err)
 	}
 
-	// ChangeToken
-	var ct *waf.GetChangeTokenInput
-
-	resp, err := conn.GetChangeToken(ct)
-
-	req := &waf.DeleteIPSetInput{
-		ChangeToken: resp.ChangeToken,
-		IPSetId:     aws.String(d.Id()),
-	}
-	log.Printf("[INFO] Deleting WAF IPSet")
-	_, err = conn.DeleteIPSet(req)
-
+	wr := newWafRetryer(conn, "global")
+	_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteIPSetInput{
+			ChangeToken: token,
+			IPSetId:     aws.String(d.Id()),
+		}
+		log.Printf("[INFO] Deleting WAF IPSet")
+		return conn.DeleteIPSet(req)
+	})
 	if err != nil {
 		return fmt.Errorf("Error Deleting WAF IPSet: %s", err)
 	}
@@ -139,33 +131,28 @@ func resourceAwsWafIPSetDelete(d *schema.ResourceData, meta interface{}) error {
 func updateIPSetResource(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
 	conn := meta.(*AWSClient).wafconn
 
-	// ChangeToken
-	var ct *waf.GetChangeTokenInput
-
-	resp, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return fmt.Errorf("Error getting change token: %s", err)
-	}
-
-	req := &waf.UpdateIPSetInput{
-		ChangeToken: resp.ChangeToken,
-		IPSetId:     aws.String(d.Id()),
-	}
-
-	IPSetDescriptors := d.Get("ip_set_descriptors").(*schema.Set)
-	for _, IPSetDescriptor := range IPSetDescriptors.List() {
-		IPSet := IPSetDescriptor.(map[string]interface{})
-		IPSetUpdate := &waf.IPSetUpdate{
-			Action: aws.String(ChangeAction),
-			IPSetDescriptor: &waf.IPSetDescriptor{
-				Type:  aws.String(IPSet["type"].(string)),
-				Value: aws.String(IPSet["value"].(string)),
-			},
+	wr := newWafRetryer(conn, "global")
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateIPSetInput{
+			ChangeToken: token,
+			IPSetId:     aws.String(d.Id()),
 		}
-		req.Updates = append(req.Updates, IPSetUpdate)
-	}
 
-	_, err = conn.UpdateIPSet(req)
+		IPSetDescriptors := d.Get("ip_set_descriptors").(*schema.Set)
+		for _, IPSetDescriptor := range IPSetDescriptors.List() {
+			IPSet := IPSetDescriptor.(map[string]interface{})
+			IPSetUpdate := &waf.IPSetUpdate{
+				Action: aws.String(ChangeAction),
+				IPSetDescriptor: &waf.IPSetDescriptor{
+					Type:  aws.String(IPSet["type"].(string)),
+					Value: aws.String(IPSet["value"].(string)),
+				},
+			}
+			req.Updates = append(req.Updates, IPSetUpdate)
+		}
+
+		return conn.UpdateIPSet(req)
+	})
 	if err != nil {
 		return fmt.Errorf("Error Updating WAF IPSet: %s", err)
 	}

--- a/builtin/providers/aws/resource_aws_waf_ipset_test.go
+++ b/builtin/providers/aws/resource_aws_waf_ipset_test.go
@@ -100,46 +100,39 @@ func testAccCheckAWSWafIPSetDisappears(v *waf.IPSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		// ChangeToken
-		var ct *waf.GetChangeTokenInput
-
-		resp, err := conn.GetChangeToken(ct)
-		if err != nil {
-			return fmt.Errorf("Error getting change token: %s", err)
-		}
-
-		req := &waf.UpdateIPSetInput{
-			ChangeToken: resp.ChangeToken,
-			IPSetId:     v.IPSetId,
-		}
-
-		for _, IPSetDescriptor := range v.IPSetDescriptors {
-			IPSetUpdate := &waf.IPSetUpdate{
-				Action: aws.String("DELETE"),
-				IPSetDescriptor: &waf.IPSetDescriptor{
-					Type:  IPSetDescriptor.Type,
-					Value: IPSetDescriptor.Value,
-				},
+		wr := newWafRetryer(conn, "global")
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateIPSetInput{
+				ChangeToken: token,
+				IPSetId:     v.IPSetId,
 			}
-			req.Updates = append(req.Updates, IPSetUpdate)
-		}
 
-		_, err = conn.UpdateIPSet(req)
+			for _, IPSetDescriptor := range v.IPSetDescriptors {
+				IPSetUpdate := &waf.IPSetUpdate{
+					Action: aws.String("DELETE"),
+					IPSetDescriptor: &waf.IPSetDescriptor{
+						Type:  IPSetDescriptor.Type,
+						Value: IPSetDescriptor.Value,
+					},
+				}
+				req.Updates = append(req.Updates, IPSetUpdate)
+			}
+
+			return conn.UpdateIPSet(req)
+		})
 		if err != nil {
 			return fmt.Errorf("Error Updating WAF IPSet: %s", err)
 		}
 
-		resp, err = conn.GetChangeToken(ct)
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteIPSetInput{
+				ChangeToken: token,
+				IPSetId:     v.IPSetId,
+			}
+			return conn.DeleteIPSet(opts)
+		})
 		if err != nil {
-			return fmt.Errorf("Error getting change token for waf IPSet: %s", err)
-		}
-
-		opts := &waf.DeleteIPSetInput{
-			ChangeToken: resp.ChangeToken,
-			IPSetId:     v.IPSetId,
-		}
-		if _, err := conn.DeleteIPSet(opts); err != nil {
-			return err
+			return fmt.Errorf("Error Deleting WAF IPSet: %s", err)
 		}
 		return nil
 	}

--- a/builtin/providers/aws/resource_aws_waf_size_constraint_set.go
+++ b/builtin/providers/aws/resource_aws_waf_size_constraint_set.go
@@ -69,24 +69,19 @@ func resourceAwsWafSizeConstraintSetCreate(d *schema.ResourceData, meta interfac
 
 	log.Printf("[INFO] Creating SizeConstraintSet: %s", d.Get("name").(string))
 
-	// ChangeToken
-	var ct *waf.GetChangeTokenInput
+	wr := newWafRetryer(conn, "global")
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateSizeConstraintSetInput{
+			ChangeToken: token,
+			Name:        aws.String(d.Get("name").(string)),
+		}
 
-	res, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
-	}
-
-	params := &waf.CreateSizeConstraintSetInput{
-		ChangeToken: res.ChangeToken,
-		Name:        aws.String(d.Get("name").(string)),
-	}
-
-	resp, err := conn.CreateSizeConstraintSet(params)
-
+		return conn.CreateSizeConstraintSet(params)
+	})
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error creating SizeConstraintSet: {{err}}", err)
 	}
+	resp := out.(*waf.CreateSizeConstraintSetOutput)
 
 	d.SetId(*resp.SizeConstraintSet.SizeConstraintSetId)
 
@@ -134,17 +129,14 @@ func resourceAwsWafSizeConstraintSetDelete(d *schema.ResourceData, meta interfac
 		return errwrap.Wrapf("[ERROR] Error deleting SizeConstraintSet: {{err}}", err)
 	}
 
-	var ct *waf.GetChangeTokenInput
-
-	resp, err := conn.GetChangeToken(ct)
-
-	req := &waf.DeleteSizeConstraintSetInput{
-		ChangeToken:         resp.ChangeToken,
-		SizeConstraintSetId: aws.String(d.Id()),
-	}
-
-	_, err = conn.DeleteSizeConstraintSet(req)
-
+	wr := newWafRetryer(conn, "global")
+	_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteSizeConstraintSetInput{
+			ChangeToken:         token,
+			SizeConstraintSetId: aws.String(d.Id()),
+		}
+		return conn.DeleteSizeConstraintSet(req)
+	})
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error deleting SizeConstraintSet: {{err}}", err)
 	}
@@ -155,34 +147,30 @@ func resourceAwsWafSizeConstraintSetDelete(d *schema.ResourceData, meta interfac
 func updateSizeConstraintSetResource(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
 	conn := meta.(*AWSClient).wafconn
 
-	var ct *waf.GetChangeTokenInput
-
-	resp, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
-	}
-
-	req := &waf.UpdateSizeConstraintSetInput{
-		ChangeToken:         resp.ChangeToken,
-		SizeConstraintSetId: aws.String(d.Id()),
-	}
-
-	sizeConstraints := d.Get("size_constraints").(*schema.Set)
-	for _, sizeConstraint := range sizeConstraints.List() {
-		sc := sizeConstraint.(map[string]interface{})
-		sizeConstraintUpdate := &waf.SizeConstraintSetUpdate{
-			Action: aws.String(ChangeAction),
-			SizeConstraint: &waf.SizeConstraint{
-				FieldToMatch:       expandFieldToMatch(sc["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
-				ComparisonOperator: aws.String(sc["comparison_operator"].(string)),
-				Size:               aws.Int64(int64(sc["size"].(int))),
-				TextTransformation: aws.String(sc["text_transformation"].(string)),
-			},
+	wr := newWafRetryer(conn, "global")
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateSizeConstraintSetInput{
+			ChangeToken:         token,
+			SizeConstraintSetId: aws.String(d.Id()),
 		}
-		req.Updates = append(req.Updates, sizeConstraintUpdate)
-	}
 
-	_, err = conn.UpdateSizeConstraintSet(req)
+		sizeConstraints := d.Get("size_constraints").(*schema.Set)
+		for _, sizeConstraint := range sizeConstraints.List() {
+			sc := sizeConstraint.(map[string]interface{})
+			sizeConstraintUpdate := &waf.SizeConstraintSetUpdate{
+				Action: aws.String(ChangeAction),
+				SizeConstraint: &waf.SizeConstraint{
+					FieldToMatch:       expandFieldToMatch(sc["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+					ComparisonOperator: aws.String(sc["comparison_operator"].(string)),
+					Size:               aws.Int64(int64(sc["size"].(int))),
+					TextTransformation: aws.String(sc["text_transformation"].(string)),
+				},
+			}
+			req.Updates = append(req.Updates, sizeConstraintUpdate)
+		}
+
+		return conn.UpdateSizeConstraintSet(req)
+	})
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
 	}

--- a/builtin/providers/aws/resource_aws_waf_size_constraint_set_test.go
+++ b/builtin/providers/aws/resource_aws_waf_size_constraint_set_test.go
@@ -96,45 +96,39 @@ func testAccCheckAWSWafSizeConstraintSetDisappears(v *waf.SizeConstraintSet) res
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		var ct *waf.GetChangeTokenInput
-
-		resp, err := conn.GetChangeToken(ct)
-		if err != nil {
-			return fmt.Errorf("Error getting change token: %s", err)
-		}
-
-		req := &waf.UpdateSizeConstraintSetInput{
-			ChangeToken:         resp.ChangeToken,
-			SizeConstraintSetId: v.SizeConstraintSetId,
-		}
-
-		for _, sizeConstraint := range v.SizeConstraints {
-			sizeConstraintUpdate := &waf.SizeConstraintSetUpdate{
-				Action: aws.String("DELETE"),
-				SizeConstraint: &waf.SizeConstraint{
-					FieldToMatch:       sizeConstraint.FieldToMatch,
-					ComparisonOperator: sizeConstraint.ComparisonOperator,
-					Size:               sizeConstraint.Size,
-					TextTransformation: sizeConstraint.TextTransformation,
-				},
+		wr := newWafRetryer(conn, "global")
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateSizeConstraintSetInput{
+				ChangeToken:         token,
+				SizeConstraintSetId: v.SizeConstraintSetId,
 			}
-			req.Updates = append(req.Updates, sizeConstraintUpdate)
-		}
-		_, err = conn.UpdateSizeConstraintSet(req)
+
+			for _, sizeConstraint := range v.SizeConstraints {
+				sizeConstraintUpdate := &waf.SizeConstraintSetUpdate{
+					Action: aws.String("DELETE"),
+					SizeConstraint: &waf.SizeConstraint{
+						FieldToMatch:       sizeConstraint.FieldToMatch,
+						ComparisonOperator: sizeConstraint.ComparisonOperator,
+						Size:               sizeConstraint.Size,
+						TextTransformation: sizeConstraint.TextTransformation,
+					},
+				}
+				req.Updates = append(req.Updates, sizeConstraintUpdate)
+			}
+			return conn.UpdateSizeConstraintSet(req)
+		})
 		if err != nil {
 			return errwrap.Wrapf("[ERROR] Error updating SizeConstraintSet: {{err}}", err)
 		}
 
-		resp, err = conn.GetChangeToken(ct)
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteSizeConstraintSetInput{
+				ChangeToken:         token,
+				SizeConstraintSetId: v.SizeConstraintSetId,
+			}
+			return conn.DeleteSizeConstraintSet(opts)
+		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
-		}
-
-		opts := &waf.DeleteSizeConstraintSetInput{
-			ChangeToken:         resp.ChangeToken,
-			SizeConstraintSetId: v.SizeConstraintSetId,
-		}
-		if _, err := conn.DeleteSizeConstraintSet(opts); err != nil {
 			return err
 		}
 		return nil

--- a/builtin/providers/aws/resource_aws_waf_web_acl.go
+++ b/builtin/providers/aws/resource_aws_waf_web_acl.go
@@ -77,25 +77,21 @@ func resourceAwsWafWebAcl() *schema.Resource {
 func resourceAwsWafWebAclCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	// ChangeToken
-	var ct *waf.GetChangeTokenInput
+	wr := newWafRetryer(conn, "global")
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateWebACLInput{
+			ChangeToken:   token,
+			DefaultAction: expandDefaultAction(d),
+			MetricName:    aws.String(d.Get("metric_name").(string)),
+			Name:          aws.String(d.Get("name").(string)),
+		}
 
-	res, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return fmt.Errorf("Error getting change token: %s", err)
-	}
-
-	params := &waf.CreateWebACLInput{
-		ChangeToken:   res.ChangeToken,
-		DefaultAction: expandDefaultAction(d),
-		MetricName:    aws.String(d.Get("metric_name").(string)),
-		Name:          aws.String(d.Get("name").(string)),
-	}
-
-	resp, err := conn.CreateWebACL(params)
+		return conn.CreateWebACL(params)
+	})
 	if err != nil {
 		return err
 	}
+	resp := out.(*waf.CreateWebACLOutput)
 	d.SetId(*resp.WebACL.WebACLId)
 	return resourceAwsWafWebAclUpdate(d, meta)
 }
@@ -144,18 +140,16 @@ func resourceAwsWafWebAclDelete(d *schema.ResourceData, meta interface{}) error 
 		return fmt.Errorf("Error Removing WAF ACL Rules: %s", err)
 	}
 
-	var ct *waf.GetChangeTokenInput
+	wr := newWafRetryer(conn, "global")
+	_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteWebACLInput{
+			ChangeToken: token,
+			WebACLId:    aws.String(d.Id()),
+		}
 
-	resp, err := conn.GetChangeToken(ct)
-
-	req := &waf.DeleteWebACLInput{
-		ChangeToken: resp.ChangeToken,
-		WebACLId:    aws.String(d.Id()),
-	}
-
-	log.Printf("[INFO] Deleting WAF ACL")
-	_, err = conn.DeleteWebACL(req)
-
+		log.Printf("[INFO] Deleting WAF ACL")
+		return conn.DeleteWebACL(req)
+	})
 	if err != nil {
 		return fmt.Errorf("Error Deleting WAF ACL: %s", err)
 	}
@@ -164,38 +158,34 @@ func resourceAwsWafWebAclDelete(d *schema.ResourceData, meta interface{}) error 
 
 func updateWebAclResource(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
 	conn := meta.(*AWSClient).wafconn
-	// ChangeToken
-	var ct *waf.GetChangeTokenInput
 
-	resp, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return fmt.Errorf("Error getting change token: %s", err)
-	}
-
-	req := &waf.UpdateWebACLInput{
-		ChangeToken: resp.ChangeToken,
-		WebACLId:    aws.String(d.Id()),
-	}
-
-	if d.HasChange("default_action") {
-		req.DefaultAction = expandDefaultAction(d)
-	}
-
-	rules := d.Get("rules").(*schema.Set)
-	for _, rule := range rules.List() {
-		aclRule := rule.(map[string]interface{})
-		action := aclRule["action"].(*schema.Set).List()[0].(map[string]interface{})
-		aclRuleUpdate := &waf.WebACLUpdate{
-			Action: aws.String(ChangeAction),
-			ActivatedRule: &waf.ActivatedRule{
-				Priority: aws.Int64(int64(aclRule["priority"].(int))),
-				RuleId:   aws.String(aclRule["rule_id"].(string)),
-				Action:   &waf.WafAction{Type: aws.String(action["type"].(string))},
-			},
+	wr := newWafRetryer(conn, "global")
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateWebACLInput{
+			ChangeToken: token,
+			WebACLId:    aws.String(d.Id()),
 		}
-		req.Updates = append(req.Updates, aclRuleUpdate)
-	}
-	_, err = conn.UpdateWebACL(req)
+
+		if d.HasChange("default_action") {
+			req.DefaultAction = expandDefaultAction(d)
+		}
+
+		rules := d.Get("rules").(*schema.Set)
+		for _, rule := range rules.List() {
+			aclRule := rule.(map[string]interface{})
+			action := aclRule["action"].(*schema.Set).List()[0].(map[string]interface{})
+			aclRuleUpdate := &waf.WebACLUpdate{
+				Action: aws.String(ChangeAction),
+				ActivatedRule: &waf.ActivatedRule{
+					Priority: aws.Int64(int64(aclRule["priority"].(int))),
+					RuleId:   aws.String(aclRule["rule_id"].(string)),
+					Action:   &waf.WafAction{Type: aws.String(action["type"].(string))},
+				},
+			}
+			req.Updates = append(req.Updates, aclRuleUpdate)
+		}
+		return conn.UpdateWebACL(req)
+	})
 	if err != nil {
 		return fmt.Errorf("Error Updating WAF ACL: %s", err)
 	}

--- a/builtin/providers/aws/resource_aws_waf_xss_match_set.go
+++ b/builtin/providers/aws/resource_aws_waf_xss_match_set.go
@@ -61,24 +61,19 @@ func resourceAwsWafXssMatchSetCreate(d *schema.ResourceData, meta interface{}) e
 
 	log.Printf("[INFO] Creating XssMatchSet: %s", d.Get("name").(string))
 
-	// ChangeToken
-	var ct *waf.GetChangeTokenInput
+	wr := newWafRetryer(conn, "global")
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateXssMatchSetInput{
+			ChangeToken: token,
+			Name:        aws.String(d.Get("name").(string)),
+		}
 
-	res, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
-	}
-
-	params := &waf.CreateXssMatchSetInput{
-		ChangeToken: res.ChangeToken,
-		Name:        aws.String(d.Get("name").(string)),
-	}
-
-	resp, err := conn.CreateXssMatchSet(params)
-
+		return conn.CreateXssMatchSet(params)
+	})
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error creating XssMatchSet: {{err}}", err)
 	}
+	resp := out.(*waf.CreateXssMatchSetOutput)
 
 	d.SetId(*resp.XssMatchSet.XssMatchSetId)
 
@@ -126,17 +121,15 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 		return errwrap.Wrapf("[ERROR] Error deleting XssMatchSet: {{err}}", err)
 	}
 
-	var ct *waf.GetChangeTokenInput
+	wr := newWafRetryer(conn, "global")
+	_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteXssMatchSetInput{
+			ChangeToken:   token,
+			XssMatchSetId: aws.String(d.Id()),
+		}
 
-	resp, err := conn.GetChangeToken(ct)
-
-	req := &waf.DeleteXssMatchSetInput{
-		ChangeToken:   resp.ChangeToken,
-		XssMatchSetId: aws.String(d.Id()),
-	}
-
-	_, err = conn.DeleteXssMatchSet(req)
-
+		return conn.DeleteXssMatchSet(req)
+	})
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error deleting XssMatchSet: {{err}}", err)
 	}
@@ -147,32 +140,28 @@ func resourceAwsWafXssMatchSetDelete(d *schema.ResourceData, meta interface{}) e
 func updateXssMatchSetResource(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
 	conn := meta.(*AWSClient).wafconn
 
-	var ct *waf.GetChangeTokenInput
-
-	resp, err := conn.GetChangeToken(ct)
-	if err != nil {
-		return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
-	}
-
-	req := &waf.UpdateXssMatchSetInput{
-		ChangeToken:   resp.ChangeToken,
-		XssMatchSetId: aws.String(d.Id()),
-	}
-
-	xssMatchTuples := d.Get("xss_match_tuples").(*schema.Set)
-	for _, xssMatchTuple := range xssMatchTuples.List() {
-		xmt := xssMatchTuple.(map[string]interface{})
-		xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
-			Action: aws.String(ChangeAction),
-			XssMatchTuple: &waf.XssMatchTuple{
-				FieldToMatch:       expandFieldToMatch(xmt["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
-				TextTransformation: aws.String(xmt["text_transformation"].(string)),
-			},
+	wr := newWafRetryer(conn, "global")
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateXssMatchSetInput{
+			ChangeToken:   token,
+			XssMatchSetId: aws.String(d.Id()),
 		}
-		req.Updates = append(req.Updates, xssMatchTupleUpdate)
-	}
 
-	_, err = conn.UpdateXssMatchSet(req)
+		xssMatchTuples := d.Get("xss_match_tuples").(*schema.Set)
+		for _, xssMatchTuple := range xssMatchTuples.List() {
+			xmt := xssMatchTuple.(map[string]interface{})
+			xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
+				Action: aws.String(ChangeAction),
+				XssMatchTuple: &waf.XssMatchTuple{
+					FieldToMatch:       expandFieldToMatch(xmt["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+					TextTransformation: aws.String(xmt["text_transformation"].(string)),
+				},
+			}
+			req.Updates = append(req.Updates, xssMatchTupleUpdate)
+		}
+
+		return conn.UpdateXssMatchSet(req)
+	})
 	if err != nil {
 		return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
 	}

--- a/builtin/providers/aws/resource_aws_waf_xss_match_set_test.go
+++ b/builtin/providers/aws/resource_aws_waf_xss_match_set_test.go
@@ -96,44 +96,38 @@ func testAccCheckAWSWafXssMatchSetDisappears(v *waf.XssMatchSet) resource.TestCh
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
 
-		var ct *waf.GetChangeTokenInput
-
-		resp, err := conn.GetChangeToken(ct)
-		if err != nil {
-			return fmt.Errorf("Error getting change token: %s", err)
-		}
-
-		req := &waf.UpdateXssMatchSetInput{
-			ChangeToken:   resp.ChangeToken,
-			XssMatchSetId: v.XssMatchSetId,
-		}
-
-		for _, xssMatchTuple := range v.XssMatchTuples {
-			xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
-				Action: aws.String("DELETE"),
-				XssMatchTuple: &waf.XssMatchTuple{
-					FieldToMatch:       xssMatchTuple.FieldToMatch,
-					TextTransformation: xssMatchTuple.TextTransformation,
-				},
+		wr := newWafRetryer(conn, "global")
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateXssMatchSetInput{
+				ChangeToken:   token,
+				XssMatchSetId: v.XssMatchSetId,
 			}
-			req.Updates = append(req.Updates, xssMatchTupleUpdate)
-		}
-		_, err = conn.UpdateXssMatchSet(req)
+
+			for _, xssMatchTuple := range v.XssMatchTuples {
+				xssMatchTupleUpdate := &waf.XssMatchSetUpdate{
+					Action: aws.String("DELETE"),
+					XssMatchTuple: &waf.XssMatchTuple{
+						FieldToMatch:       xssMatchTuple.FieldToMatch,
+						TextTransformation: xssMatchTuple.TextTransformation,
+					},
+				}
+				req.Updates = append(req.Updates, xssMatchTupleUpdate)
+			}
+			return conn.UpdateXssMatchSet(req)
+		})
 		if err != nil {
 			return errwrap.Wrapf("[ERROR] Error updating XssMatchSet: {{err}}", err)
 		}
 
-		resp, err = conn.GetChangeToken(ct)
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteXssMatchSetInput{
+				ChangeToken:   token,
+				XssMatchSetId: v.XssMatchSetId,
+			}
+			return conn.DeleteXssMatchSet(opts)
+		})
 		if err != nil {
-			return errwrap.Wrapf("[ERROR] Error getting change token: {{err}}", err)
-		}
-
-		opts := &waf.DeleteXssMatchSetInput{
-			ChangeToken:   resp.ChangeToken,
-			XssMatchSetId: v.XssMatchSetId,
-		}
-		if _, err := conn.DeleteXssMatchSet(opts); err != nil {
-			return err
+			return errwrap.Wrapf("[ERROR] Error deleting XssMatchSet: {{err}}", err)
 		}
 		return nil
 	}

--- a/builtin/providers/aws/waf_token_handlers.go
+++ b/builtin/providers/aws/waf_token_handlers.go
@@ -1,0 +1,49 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+type WafRetryer struct {
+	Connection *waf.WAF
+	Region     string
+}
+
+type withTokenFunc func(token *string) (interface{}, error)
+
+func (t *WafRetryer) RetryWithToken(f withTokenFunc) (interface{}, error) {
+	awsMutexKV.Lock(t.Region)
+	defer awsMutexKV.Unlock(t.Region)
+
+	var out interface{}
+	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
+		var err error
+		var tokenOut *waf.GetChangeTokenOutput
+
+		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
+		if err != nil {
+			return resource.NonRetryableError(errwrap.Wrapf("Failed to acquire change token: {{err}}", err))
+		}
+
+		out, err = f(tokenOut.ChangeToken)
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "WAFStaleDataException" {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	return out, err
+}
+
+func newWafRetryer(conn *waf.WAF, region string) *WafRetryer {
+	return &WafRetryer{Connection: conn, Region: region}
+}


### PR DESCRIPTION
This is to address the following long term WAF test failures:

```
=== RUN   TestAccAWSWafByteMatchSet_changeNameForceNew
--- FAIL: TestAccAWSWafByteMatchSet_changeNameForceNew (17.11s)
    testing.go:280: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_waf_byte_match_set.byte_set (destroy): 1 error(s) occurred:
        
        * aws_waf_byte_match_set.byte_set: [ERROR] Error deleting ByteMatchSet: [ERROR] Error updating ByteMatchSet: WAFStaleDataException: The input token is no longer current.
            status code: 400, request id: 2ea7dc97-20e2-11e7-b79e-d1acbf1c3f7f
    testing.go:344: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
```

Closes https://github.com/hashicorp/terraform/issues/10335

### Test plan

```
=== RUN   TestAccAWSWafByteMatchSet_disappears
--- PASS: TestAccAWSWafByteMatchSet_disappears (29.46s)
=== RUN   TestAccAWSWafIPSet_basic
--- PASS: TestAccAWSWafIPSet_basic (44.91s)
=== RUN   TestAccAWSWafIPSet_disappears
--- PASS: TestAccAWSWafIPSet_disappears (65.57s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafSqlInjectionMatchSet_basic (83.43s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_disappears
--- PASS: TestAccAWSWafSqlInjectionMatchSet_disappears (111.31s)
=== RUN   TestAccAWSWafXssMatchSet_disappears
--- PASS: TestAccAWSWafXssMatchSet_disappears (67.50s)
=== RUN   TestAccAWSWafSizeConstraintSet_changeNameForceNew
--- PASS: TestAccAWSWafSizeConstraintSet_changeNameForceNew (115.84s)
=== RUN   TestAccAWSWafSizeConstraintSet_basic
--- PASS: TestAccAWSWafSizeConstraintSet_basic (138.74s)
=== RUN   TestAccAWSWafSizeConstraintSet_disappears
--- PASS: TestAccAWSWafSizeConstraintSet_disappears (160.11s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (171.16s)
=== RUN   TestAccAWSWafRule_disappears
--- PASS: TestAccAWSWafRule_disappears (199.93s)
=== RUN   TestAccAWSWafByteMatchSet_basic
--- PASS: TestAccAWSWafByteMatchSet_basic (209.15s)
=== RUN   TestAccAWSWafByteMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafByteMatchSet_changeNameForceNew (228.33s)
=== RUN   TestAccAWSWafRule_changeNameForceNew
--- PASS: TestAccAWSWafRule_changeNameForceNew (271.58s)
=== RUN   TestAccAWSWafWebAcl_changeDefaultAction
--- PASS: TestAccAWSWafWebAcl_changeDefaultAction (282.30s)
=== RUN   TestAccAWSWafIPSet_changeNameForceNew
--- PASS: TestAccAWSWafIPSet_changeNameForceNew (293.37s)
=== RUN   TestAccAWSWafXssMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafXssMatchSet_changeNameForceNew (268.99s)
=== RUN   TestAccAWSWafXssMatchSet_basic
--- PASS: TestAccAWSWafXssMatchSet_basic (300.87s)
=== RUN   TestAccAWSWafWebAcl_basic
--- PASS: TestAccAWSWafWebAcl_basic (309.70s)
=== RUN   TestAccAWSWafWebAcl_disappears
--- PASS: TestAccAWSWafWebAcl_disappears (318.02s)
=== RUN   TestAccAWSWafRule_basic
--- PASS: TestAccAWSWafRule_basic (347.32s)
=== RUN   TestAccAWSWafWebAcl_changeNameForceNew
--- PASS: TestAccAWSWafWebAcl_changeNameForceNew (350.59s)
```
