### PR TITLE
provider/aws: Run all AWSConfig acc tests sequentially

### DIFF
--- a/builtin/providers/aws/resource_aws_config_config_rule_test.go
+++ b/builtin/providers/aws/resource_aws_config_config_rule_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSConfigConfigRule_basic(t *testing.T) {
+func testAccConfigConfigRule_basic(t *testing.T) {
 	var cr configservice.ConfigRule
 	rInt := acctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
@@ -37,7 +37,7 @@ func TestAccAWSConfigConfigRule_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigRule_ownerAws(t *testing.T) {
+func testAccConfigConfigRule_ownerAws(t *testing.T) {
 	var cr configservice.ConfigRule
 	rInt := acctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
@@ -72,7 +72,7 @@ func TestAccAWSConfigConfigRule_ownerAws(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigRule_customlambda(t *testing.T) {
+func testAccConfigConfigRule_customlambda(t *testing.T) {
 	var cr configservice.ConfigRule
 	rInt := acctest.RandInt()
 
@@ -113,7 +113,7 @@ func TestAccAWSConfigConfigRule_customlambda(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigRule_importAws(t *testing.T) {
+func testAccConfigConfigRule_importAws(t *testing.T) {
 	resourceName := "aws_config_config_rule.foo"
 	rInt := acctest.RandInt()
 
@@ -135,7 +135,7 @@ func TestAccAWSConfigConfigRule_importAws(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigRule_importLambda(t *testing.T) {
+func testAccConfigConfigRule_importLambda(t *testing.T) {
 	resourceName := "aws_config_config_rule.foo"
 	rInt := acctest.RandInt()
 

--- a/builtin/providers/aws/resource_aws_config_configuration_recorder_status_test.go
+++ b/builtin/providers/aws/resource_aws_config_configuration_recorder_status_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSConfigConfigurationRecorderStatus_basic(t *testing.T) {
+func testAccConfigConfigurationRecorderStatus_basic(t *testing.T) {
 	var cr configservice.ConfigurationRecorder
 	var crs configservice.ConfigurationRecorderStatus
 	rInt := acctest.RandInt()
@@ -36,7 +36,7 @@ func TestAccAWSConfigConfigurationRecorderStatus_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigurationRecorderStatus_startEnabled(t *testing.T) {
+func testAccConfigConfigurationRecorderStatus_startEnabled(t *testing.T) {
 	var cr configservice.ConfigurationRecorder
 	var crs configservice.ConfigurationRecorderStatus
 	rInt := acctest.RandInt()
@@ -81,7 +81,7 @@ func TestAccAWSConfigConfigurationRecorderStatus_startEnabled(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigurationRecorderStatus_importBasic(t *testing.T) {
+func testAccConfigConfigurationRecorderStatus_importBasic(t *testing.T) {
 	resourceName := "aws_config_configuration_recorder_status.foo"
 	rInt := acctest.RandInt()
 

--- a/builtin/providers/aws/resource_aws_config_configuration_recorder_test.go
+++ b/builtin/providers/aws/resource_aws_config_configuration_recorder_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSConfigConfigurationRecorder_basic(t *testing.T) {
+func testAccConfigConfigurationRecorder_basic(t *testing.T) {
 	var cr configservice.ConfigurationRecorder
 	rInt := acctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
@@ -39,7 +39,7 @@ func TestAccAWSConfigConfigurationRecorder_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigurationRecorder_allParams(t *testing.T) {
+func testAccConfigConfigurationRecorder_allParams(t *testing.T) {
 	var cr configservice.ConfigurationRecorder
 	rInt := acctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-%d", rInt)
@@ -70,7 +70,7 @@ func TestAccAWSConfigConfigurationRecorder_allParams(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigConfigurationRecorder_importBasic(t *testing.T) {
+func testAccConfigConfigurationRecorder_importBasic(t *testing.T) {
 	resourceName := "aws_config_configuration_recorder.foo"
 	rInt := acctest.RandInt()
 

--- a/builtin/providers/aws/resource_aws_config_delivery_channel_test.go
+++ b/builtin/providers/aws/resource_aws_config_delivery_channel_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccAWSConfigDeliveryChannel_basic(t *testing.T) {
+func testAccConfigDeliveryChannel_basic(t *testing.T) {
 	var dc configservice.DeliveryChannel
 	rInt := acctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-awsconfig-%d", rInt)
@@ -36,7 +36,7 @@ func TestAccAWSConfigDeliveryChannel_basic(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigDeliveryChannel_allParams(t *testing.T) {
+func testAccConfigDeliveryChannel_allParams(t *testing.T) {
 	var dc configservice.DeliveryChannel
 	rInt := acctest.RandInt()
 	expectedName := fmt.Sprintf("tf-acc-test-awsconfig-%d", rInt)
@@ -64,7 +64,7 @@ func TestAccAWSConfigDeliveryChannel_allParams(t *testing.T) {
 	})
 }
 
-func TestAccAWSConfigDeliveryChannel_importBasic(t *testing.T) {
+func testAccConfigDeliveryChannel_importBasic(t *testing.T) {
 	resourceName := "aws_config_delivery_channel.foo"
 	rInt := acctest.RandInt()
 

--- a/builtin/providers/aws/resource_aws_config_test.go
+++ b/builtin/providers/aws/resource_aws_config_test.go
@@ -1,0 +1,44 @@
+package aws
+
+import (
+	"testing"
+)
+
+func TestAccAWSConfig(t *testing.T) {
+	testCases := map[string]map[string]func(t *testing.T){
+		"Config": {
+			"basic":        testAccConfigConfigRule_basic,
+			"ownerAws":     testAccConfigConfigRule_ownerAws,
+			"customlambda": testAccConfigConfigRule_customlambda,
+			"importAws":    testAccConfigConfigRule_importAws,
+			"importLambda": testAccConfigConfigRule_importLambda,
+		},
+		"ConfigurationRecorderStatus": {
+			"basic":        testAccConfigConfigurationRecorderStatus_basic,
+			"startEnabled": testAccConfigConfigurationRecorderStatus_startEnabled,
+			"importBasic":  testAccConfigConfigurationRecorderStatus_importBasic,
+		},
+		"ConfigurationRecorder": {
+			"basic":       testAccConfigConfigurationRecorder_basic,
+			"allParams":   testAccConfigConfigurationRecorder_allParams,
+			"importBasic": testAccConfigConfigurationRecorder_importBasic,
+		},
+		"DeliveryChannel": {
+			"basic":       testAccConfigDeliveryChannel_basic,
+			"allParams":   testAccConfigDeliveryChannel_allParams,
+			"importBasic": testAccConfigDeliveryChannel_importBasic,
+		},
+	}
+
+	for group, m := range testCases {
+		m := m
+		t.Run(group, func(t *testing.T) {
+			for name, tc := range m {
+				tc := tc
+				t.Run(name, func(t *testing.T) {
+					tc(t)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
This is to address the acceptance test failures caused by the limitations of AWSConfig (i.e. only 1 recorder/delivery channel can exist in 1 account/region at a time).

The subtest-based approach has only one downside - that is TC wrapper's inability to read the test results from subtests, so all of AWSConfig is tracked as a single test with all related details (e.g. flakiness).

### Test plan
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSConfig'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/14 10:18:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSConfig -timeout 120m
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/basic
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorder
=== RUN   TestAccAWSConfig/ConfigurationRecorder/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/allParams
=== RUN   TestAccAWSConfig/ConfigurationRecorder/importBasic
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
--- PASS: TestAccAWSConfig (4950.43s)
    --- PASS: TestAccAWSConfig/Config (1614.95s)
        --- PASS: TestAccAWSConfig/Config/basic (242.24s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (237.00s)
        --- PASS: TestAccAWSConfig/Config/customlambda (431.92s)
        --- PASS: TestAccAWSConfig/Config/importAws (262.96s)
        --- PASS: TestAccAWSConfig/Config/importLambda (440.83s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus (1392.67s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/basic (305.05s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled (779.85s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (307.77s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorder (989.80s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/basic (322.94s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/allParams (326.97s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/importBasic (339.89s)
    --- PASS: TestAccAWSConfig/DeliveryChannel (953.02s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/basic (339.02s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/allParams (301.06s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/importBasic (312.93s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	4950.462s
```