### PR TITLE
Update cloudwatch_log_subscription_filter.html.markdown

### DIFF
--- a/website/source/docs/providers/aws/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_log_subscription_filter.html.markdown
@@ -27,10 +27,10 @@ resource "aws_cloudwatch_log_subscription_filter" "test_lambdafunction_logfilter
 The following arguments are supported:
 
 * `name` - (Required) A name for the subscription filter
-* `destination_arn` - (Required) The ARN of the destination to deliver matching log events to. Currently only Kinesis stream / a logical destination
+* `destination_arn` - (Required) The ARN of the destination to deliver matching log events to. Kinesis stream or Lambda function ARN.
 * `filter_pattern` - (Required) A valid CloudWatch Logs filter pattern for subscribing to a filtered stream of log events.
 * `log_group_name` - (Required) The name of the log group to associate the subscription filter with
-* `role_arn` - (Optional) The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination stream
+* `role_arn` - (Optional) The ARN of an IAM role that grants Amazon CloudWatch Logs permissions to deliver ingested log events to the destination. If you use Lambda as a destination, you should skip this argument and use `aws_lambda_permission` resource for granting access from CloudWatch logs to the destination Lambda function. 
 
 ## Attributes Reference
 


### PR DESCRIPTION
Currently CloudWatch log subscription supports Lambda as a destination. And we can use `aws_cloudwatch_log_subscription_filter` resource for creating subscriptions with Lambda as a destination, but it needs some additional actions. I described them in description, but feel free to improve description if you can say the same better.
This change will help better understand abilities of using this resource.