### PR TITLE
ip_set_descriptors is no longer a required parameter.

### DIFF
--- a/website/source/docs/providers/aws/r/waf_ipset.html.markdown
+++ b/website/source/docs/providers/aws/r/waf_ipset.html.markdown
@@ -28,7 +28,7 @@ resource "aws_waf_ipset" "ipset" {
 The following arguments are supported:
 
 * `name` - (Required) The name or description of the IPSet.
-* `ip_set_descriptors` - (Required) The IP address type and IP address range (in CIDR notation) from which web requests originate.
+* `ip_set_descriptors` - (Optional) The IP address type and IP address range (in CIDR notation) from which web requests originate.
 
 ## Remarks
 


### PR DESCRIPTION
The `ip_set_descriptors` option is no longer required. IP sets can be created without this parameter, allowing the creation of empty IP-based blacklists.