### PR TITLE
provider/aws: Add aws_kms_alias datasource

### DIFF
--- a/builtin/providers/aws/data_source_aws_kms_alias.go
+++ b/builtin/providers/aws/data_source_aws_kms_alias.go
@@ -1,0 +1,62 @@
+package aws
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/service/kms"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsKmsAlias() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsKmsAliasRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateAwsKmsName,
+			},
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"target_key_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsKmsAliasRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).kmsconn
+	params := &kms.ListAliasesInput{}
+
+	target := d.Get("name")
+	var alias *kms.AliasListEntry
+	err := conn.ListAliasesPages(params, func(page *kms.ListAliasesOutput, lastPage bool) bool {
+		for _, entity := range page.Aliases {
+			if *entity.AliasName == target {
+				alias = entity
+				return false
+			}
+		}
+
+		return true
+	})
+	if err != nil {
+		return errwrap.Wrapf("Error fetch KMS alias list: {{err}}", err)
+	}
+
+	if alias == nil {
+		return fmt.Errorf("No alias with name %q found in this region.", target)
+	}
+
+	d.SetId(time.Now().UTC().String())
+	d.Set("arn", alias.AliasArn)
+	d.Set("target_key_id", alias.TargetKeyId)
+
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_kms_alias_test.go
+++ b/builtin/providers/aws/data_source_aws_kms_alias_test.go
@@ -1,0 +1,77 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataSourceAwsKmsAlias(t *testing.T) {
+	rInt := acctest.RandInt()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataSourceAwsKmsAlias(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceAwsKmsAliasCheck("data.aws_kms_alias.by_name"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceAwsKmsAliasCheck(name string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("root module has no resource called %s", name)
+		}
+
+		kmsKeyRs, ok := s.RootModule().Resources["aws_kms_alias.single"]
+		if !ok {
+			return fmt.Errorf("can't find aws_kms_alias.single in state")
+		}
+
+		attr := rs.Primary.Attributes
+
+		if attr["arn"] != kmsKeyRs.Primary.Attributes["arn"] {
+			return fmt.Errorf(
+				"arn is %s; want %s",
+				attr["arn"],
+				kmsKeyRs.Primary.Attributes["arn"],
+			)
+		}
+
+		if attr["target_key_id"] != kmsKeyRs.Primary.Attributes["target_key_id"] {
+			return fmt.Errorf(
+				"target_key_id is %s; want %s",
+				attr["target_key_id"],
+				kmsKeyRs.Primary.Attributes["target_key_id"],
+			)
+		}
+
+		return nil
+	}
+}
+
+func testAccDataSourceAwsKmsAlias(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_kms_key" "one" {
+    description = "Terraform acc test"
+    deletion_window_in_days = 7
+}
+
+resource "aws_kms_alias" "single" {
+    name = "alias/tf-acc-key-alias-%d"
+    target_key_id = "${aws_kms_key.one.key_id}"
+}
+
+data "aws_kms_alias" "by_name" {
+  name = "${aws_kms_alias.single.name}"
+}`, rInt)
+}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -178,6 +178,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_iam_server_certificate":   dataSourceAwsIAMServerCertificate(),
 			"aws_instance":                 dataSourceAwsInstance(),
 			"aws_ip_ranges":                dataSourceAwsIPRanges(),
+			"aws_kms_alias":                dataSourceAwsKmsAlias(),
 			"aws_kms_secret":               dataSourceAwsKmsSecret(),
 			"aws_partition":                dataSourceAwsPartition(),
 			"aws_prefix_list":              dataSourceAwsPrefixList(),

--- a/builtin/providers/aws/resource_aws_kms_alias.go
+++ b/builtin/providers/aws/resource_aws_kms_alias.go
@@ -29,14 +29,7 @@ func resourceAwsKmsAlias() *schema.Resource {
 				Optional:      true,
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
-				ValidateFunc: func(v interface{}, k string) (ws []string, es []error) {
-					value := v.(string)
-					if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9:/_-]+$`).MatchString(value) {
-						es = append(es, fmt.Errorf(
-							"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9:/_-]", k))
-					}
-					return
-				},
+				ValidateFunc:  validateAwsKmsName,
 			},
 			"name_prefix": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -1189,3 +1189,12 @@ func validateOpenIdURL(v interface{}, k string) (ws []string, errors []error) {
 	}
 	return
 }
+
+func validateAwsKmsName(v interface{}, k string) (ws []string, es []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^(alias\/)[a-zA-Z0-9:/_-]+$`).MatchString(value) {
+		es = append(es, fmt.Errorf(
+			"%q must begin with 'alias/' and be comprised of only [a-zA-Z0-9:/_-]", k))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -1945,3 +1945,35 @@ func TestValidateOpenIdURL(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateAwsKmsName(t *testing.T) {
+	cases := []struct {
+		Value    string
+		ErrCount int
+	}{
+		{
+			Value:    "alias/aws/s3",
+			ErrCount: 0,
+		},
+		{
+			Value:    "alias/hashicorp",
+			ErrCount: 0,
+		},
+		{
+			Value:    "hashicorp",
+			ErrCount: 1,
+		},
+		{
+			Value:    "hashicorp/terraform",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		_, errors := validateAwsKmsName(tc.Value, "name")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("AWS KMS Alias Name validation failed: %v", errors)
+		}
+	}
+
+}

--- a/website/source/docs/providers/aws/d/kms_alias.html.markdown
+++ b/website/source/docs/providers/aws/d/kms_alias.html.markdown
@@ -1,0 +1,30 @@
+---
+layout: "aws"
+page_title: "AWS: aws_kms_alias"
+sidebar_current: "docs-aws-datasource-kms-alias"
+description: |-
+  Get information on a AWS Key Management Service (KMS) Alias
+---
+
+# aws\_kms\_alias
+
+Use this data source to get the ARN of a KMS key alias.
+By using this data source, you can reference key alias
+without having to hard code the ARN as input.
+
+## Example Usage
+
+```hcl
+data "aws_kms_alias" "s3" {
+  name = "alias/aws/s3"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) The display name of the alias. The name must start with the word "alias" followed by a forward slash (alias/)
+
+## Attributes Reference
+
+* `arn` - The Amazon Resource Name(ARN) of the key alias.
+* `target_key_id` - Key identifier pointed to by the alias.


### PR DESCRIPTION
This datasource can get arn of KMS key alias.

```
$  make test TEST=./builtin/providers/aws/
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/15 03:20:50 Generated command/internal_plugin_list.go
go test -i ./builtin/providers/aws/ || exit 1
echo ./builtin/providers/aws/ | \
        xargs -t -n4 go test  -timeout=60s -parallel=4
go test -timeout=60s -parallel=4 ./builtin/providers/aws/
ok      github.com/hashicorp/terraform/builtin/providers/aws    1.671s

$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccDataSourceAwsKmsAlias'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/15 03:16:14 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccDataSourceAwsKmsAlias -timeout 120m
=== RUN   TestAccDataSourceAwsKmsAlias
--- PASS: TestAccDataSourceAwsKmsAlias (68.02s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    68.031s
```