### PR TITLE
provider/aws: add an option to skip getting the EC2 platforms

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -97,6 +97,7 @@ type Config struct {
 	Insecure         bool
 
 	SkipCredsValidation     bool
+	SkipGetEC2Platforms     bool
 	SkipRegionValidation    bool
 	SkipRequestingAccountId bool
 	SkipMetadataApiCheck    bool
@@ -280,13 +281,15 @@ func (c *Config) Client() (interface{}, error) {
 
 	client.ec2conn = ec2.New(awsEc2Sess)
 
-	supportedPlatforms, err := GetSupportedEC2Platforms(client.ec2conn)
-	if err != nil {
-		// We intentionally fail *silently* because there's a chance
-		// user just doesn't have ec2:DescribeAccountAttributes permissions
-		log.Printf("[WARN] Unable to get supported EC2 platforms: %s", err)
-	} else {
-		client.supportedplatforms = supportedPlatforms
+	if !c.SkipGetEC2Platforms {
+		supportedPlatforms, err := GetSupportedEC2Platforms(client.ec2conn)
+		if err != nil {
+			// We intentionally fail *silently* because there's a chance
+			// user just doesn't have ec2:DescribeAccountAttributes permissions
+			log.Printf("[WARN] Unable to get supported EC2 platforms: %s", err)
+		} else {
+			client.supportedplatforms = supportedPlatforms
+		}
 	}
 
 	client.acmconn = acm.New(sess)

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -122,6 +122,13 @@ func Provider() terraform.ResourceProvider {
 				Description: descriptions["skip_credentials_validation"],
 			},
 
+			"skip_get_ec2_platforms": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["skip_get_ec2_platforms"],
+			},
+
 			"skip_region_validation": {
 				Type:        schema.TypeBool,
 				Optional:    true,
@@ -489,6 +496,9 @@ func init() {
 		"skip_credentials_validation": "Skip the credentials validation via STS API. " +
 			"Used for AWS API implementations that do not have STS available/implemented.",
 
+		"skip_get_ec2_platforms": "Skip getting the supported EC2 platforms. " +
+			"Used by users that don't have ec2:DescribeAccountAttributes permissions.",
+
 		"skip_region_validation": "Skip static validation of region name. " +
 			"Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).",
 
@@ -528,6 +538,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		MaxRetries:              d.Get("max_retries").(int),
 		Insecure:                d.Get("insecure").(bool),
 		SkipCredsValidation:     d.Get("skip_credentials_validation").(bool),
+		SkipGetEC2Platforms:     d.Get("skip_get_ec2_platforms").(bool),
 		SkipRegionValidation:    d.Get("skip_region_validation").(bool),
 		SkipRequestingAccountId: d.Get("skip_requesting_account_id").(bool),
 		SkipMetadataApiCheck:    d.Get("skip_metadata_api_check").(bool),

--- a/website/source/docs/providers/aws/index.html.markdown
+++ b/website/source/docs/providers/aws/index.html.markdown
@@ -180,6 +180,10 @@ The following arguments are supported in the `provider` block:
   validation via the STS API. Useful for AWS API implementations that do
   not have STS available or implemented.
 
+* `skip_get_ec2_platforms` - (Optional) Skip getting the supported EC2
+  platforms. Used by users that don't have ec2:DescribeAccountAttributes
+  permissions.
+
 * `skip_region_validation` - (Optional) Skip validation of provided region name.
   Useful for AWS-like implementations that use their own region names
   or to bypass the validation for regions that aren't publicly available yet.


### PR DESCRIPTION
Even through this call fails silently in case of an error (usually lack of rights), it’s still a pretty extensive call.

In our region (eu-west-1) this can take up to 3 seconds. And since we have a system that involves doing much planning with the option `-refresh=false` these additional 3 seconds are really very annoying and totally not needed.

So being able to choose to skip them would make our lives a little better :wink: