### PR TITLE
aws: Increase default number of retries to 25 (fix APIG acc tests)

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -70,7 +70,7 @@ func Provider() terraform.ResourceProvider {
 			"max_retries": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     11,
+				Default:     25,
 				Description: descriptions["max_retries"],
 			},
 


### PR DESCRIPTION
This is to address the following API Gateway acceptance test failures:

```
=== RUN   TestAccAWSAPIGatewayEmptyBasePath_basic
--- FAIL: TestAccAWSAPIGatewayEmptyBasePath_basic (778.08s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_rest_api.test: 1 error(s) occurred:
        
        * aws_api_gateway_rest_api.test: Error creating API Gateway: TooManyRequestsException: Too Many Requests
            status code: 429, request id: f45e04ee-214d-11e7-bf42-89449489f501
=== RUN   TestAccAWSAPIGatewayMethod_basic
--- FAIL: TestAccAWSAPIGatewayMethod_basic (611.76s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_rest_api.test: 1 error(s) occurred:
        
        * aws_api_gateway_rest_api.test: Error creating API Gateway: TooManyRequestsException: Too Many Requests
            status code: 429, request id: 9252ae7f-214d-11e7-a740-7f562ac7bfc6
```

The error code [is already treated as "retryable" in the upstream AWS SDK](https://github.com/aws/aws-sdk-go/blob/master/aws/request/retryer.go#L42), we just don't retry enough.

This should not affect users in terms of diffs, since we don't store provider configuration in the state, unlike for resources and data sources.