### PR TITLE
Added set_identifier to route53 import e.g.

### DIFF
--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -144,5 +144,5 @@ Weighted routing policies support the following:
 Route53 Records can be imported using ID of the record, e.g.
 
 ```
-$ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS
+$ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS_dev
 ```


### PR DESCRIPTION
Added set_identifier example for import, maybe it should be added to error in resourceAwsRoute53RecordRead import