### PR TITLE
provider/aws: Support lifecycle tags filter in aws_s3_bucket

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_test.go
@@ -560,6 +560,14 @@ func TestAccAWSS3Bucket_Lifecycle(t *testing.T) {
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.expiration.2855832418.days", "0"),
 					resource.TestCheckResourceAttr(
 						"aws_s3_bucket.bucket", "lifecycle_rule.1.expiration.2855832418.expired_object_delete_marker", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.id", "id3"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.prefix", "path3/"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.tags.tagKey", "tagValue"),
+					resource.TestCheckResourceAttr(
+						"aws_s3_bucket.bucket", "lifecycle_rule.2.tags.terraform", "hashicorp"),
 				),
 			},
 			{
@@ -1390,6 +1398,19 @@ resource "aws_s3_bucket" "bucket" {
 	lifecycle_rule {
 		id = "id2"
 		prefix = "path2/"
+		enabled = true
+
+		expiration {
+			date = "2016-01-12"
+		}
+	}
+	lifecycle_rule {
+		id = "id3"
+		prefix = "path3/"
+		tags {
+			"tagKey" = "tagValue"
+			"terraform" = "hashicorp"
+		}
 		enabled = true
 
 		expiration {

--- a/website/source/docs/providers/aws/r/s3_bucket.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket.html.markdown
@@ -110,8 +110,13 @@ resource "aws_s3_bucket" "bucket" {
 
   lifecycle_rule {
     id      = "log"
-    prefix  = "log/"
     enabled = true
+
+    prefix  = "log/"
+    tags {
+      "rule"      = "log"
+      "autoclean" = "true"
+    }
 
     transition {
       days          = 30
@@ -338,7 +343,8 @@ The `logging` object supports the following:
 The `lifecycle_rule` object supports the following:
 
 * `id` - (Optional) Unique identifier for the rule.
-* `prefix` - (Required) Object key prefix identifying one or more objects to which the rule applies.
+* `prefix` - (Optional) Object key prefix identifying one or more objects to which the rule applies.
+* `tags` - (Optional) Specifies object tags key and value.
 * `enabled` - (Required) Specifies lifecycle rule status.
 * `abort_incomplete_multipart_upload_days` (Optional) Specifies the number of days after initiating a multipart upload when the multipart upload must be completed.
 * `expiration` - (Optional) Specifies a period in the object's expire (documented below).


### PR DESCRIPTION
Enhance aws_s3_bucket resource, lifecycle_rule.

* Add `tags` filter in lifecycle_rule
* Change `prefix` filter to optional

https://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketPUTlifecycle.html

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSS3Bucket_Lifecycle'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/16 02:40:19 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSS3Bucket_Lifecycle -timeout 120m
=== RUN   TestAccAWSS3Bucket_Lifecycle
--- PASS: TestAccAWSS3Bucket_Lifecycle (124.24s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    124.255s
```

Link #13473, #12830