### PR TITLE
provider/aws: Add support for aws_dms_replication_task available states

### DIFF
--- a/builtin/providers/aws/resource_aws_dms_replication_task.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_task.go
@@ -226,7 +226,7 @@ func resourceAwsDmsReplicationTaskUpdate(d *schema.ResourceData, meta interface{
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"modifying"},
-			Target:     []string{"ready"},
+			Target:     []string{"ready", "stopped", "failed"},
 			Refresh:    resourceAwsDmsReplicationTaskStateRefreshFunc(d, meta),
 			Timeout:    d.Timeout(schema.TimeoutCreate),
 			MinTimeout: 10 * time.Second,


### PR DESCRIPTION
This supersedes the work in #12406

We have moved away from the AWS waiters - it wasn't fair to ask the origin submitter to update their code when I took so long to merge it

Paul