### PR TITLE
Add auto_minor_version_upgrade document

### DIFF
--- a/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster_instance.html.markdown
@@ -75,6 +75,7 @@ what IAM permissions are needed to allow Enhanced Monitoring for RDS Instances.
   Eg: "04:00-09:00"
 * `preferred_maintenance_window` - (Optional) The window to perform maintenance in.
   Syntax: "ddd:hh24:mi-ddd:hh24:mi". Eg: "Mon:00:00-Mon:03:00".
+* `auto_minor_version_upgrade` - (Optional) Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window. Default `true`.
 * `tags` - (Optional) A mapping of tags to assign to the instance.
 
 ## Attributes Reference


### PR DESCRIPTION
`auto_minor_version_upgrade` argument in `aws_rds_cluster_instance` is already implemented but document does not exist.

https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_rds_cluster_instance.go#L106

Contents are the same as `aws_db_instance`
https://github.com/hashicorp/terraform/blob/master/website/source/docs/providers/aws/r/db_instance.html.markdown
