### PR TITLE
[WIP] provider/aws: AWS WAF Regional SqlInjectionMatchSet support

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -64,6 +64,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-cleanhttp"
@@ -159,6 +160,7 @@ type AWSClient struct {
 	sfnconn               *sfn.SFN
 	ssmconn               *ssm.SSM
 	wafconn               *waf.WAF
+	wafregionalconn       *wafregional.WAFRegional
 }
 
 func (c *AWSClient) S3() *s3.S3 {
@@ -339,6 +341,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.sqsconn = sqs.New(sess)
 	client.ssmconn = ssm.New(sess)
 	client.wafconn = waf.New(sess)
+	client.wafregionalconn = wafregional.New(sess)
 
 	return &client, nil
 }

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -446,6 +446,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_xss_match_set":                    resourceAwsWafXssMatchSet(),
 			"aws_waf_sql_injection_match_set":          resourceAwsWafSqlInjectionMatchSet(),
 			"aws_wafregional_byte_match_set":           resourceAwsWafRegionalByteMatchSet(),
+			"aws_wafregional_sql_injection_match_set":  resourceAwsWafRegionalSqlInjectionMatchSet(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -445,6 +445,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_waf_web_acl":                          resourceAwsWafWebAcl(),
 			"aws_waf_xss_match_set":                    resourceAwsWafXssMatchSet(),
 			"aws_waf_sql_injection_match_set":          resourceAwsWafSqlInjectionMatchSet(),
+			"aws_wafregional_byte_match_set":           resourceAwsWafRegionalByteMatchSet(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/builtin/providers/aws/resource_aws_wafregional_byte_match_set.go
+++ b/builtin/providers/aws/resource_aws_wafregional_byte_match_set.go
@@ -1,0 +1,197 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsWafRegionalByteMatchSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafRegionalByteMatchSetCreate,
+		Read:   resourceAwsWafRegionalByteMatchSetRead,
+		Update: resourceAwsWafRegionalByteMatchSetUpdate,
+		Delete: resourceAwsWafRegionalByteMatchSetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"byte_match_tuples": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_to_match": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"data": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"positional_constraint": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"target_string": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"text_transformation": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsWafRegionalByteMatchSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	log.Printf("[INFO] Creating ByteMatchSet: %s", d.Get("name").(string))
+
+	wr := newWafRegionalRetryer(conn)
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateByteMatchSetInput{
+			ChangeToken: token,
+			Name:        aws.String(d.Get("name").(string)),
+		}
+		return conn.CreateByteMatchSet(params)
+	})
+
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error creating ByteMatchSet: {{err}}", err)
+	}
+	resp := out.(*waf.CreateByteMatchSetOutput)
+
+	d.SetId(*resp.ByteMatchSet.ByteMatchSetId)
+
+	return resourceAwsWafRegionalByteMatchSetUpdate(d, meta)
+}
+
+func resourceAwsWafRegionalByteMatchSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	log.Printf("[INFO] Reading ByteMatchSet: %s", d.Get("name").(string))
+
+	params := &waf.GetByteMatchSetInput{
+		ByteMatchSetId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetByteMatchSet(params)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
+			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.ByteMatchSet.Name)
+
+	return nil
+}
+
+func resourceAwsWafRegionalByteMatchSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating ByteMatchSet: %s", d.Get("name").(string))
+
+	err := updateByteMatchSetResourceWR(d, meta, waf.ChangeActionInsert)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+	}
+	return resourceAwsWafRegionalByteMatchSetRead(d, meta)
+}
+
+func resourceAwsWafRegionalByteMatchSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	log.Printf("[INFO] Deleting ByteMatchSet: %s", d.Get("name").(string))
+
+	err := updateByteMatchSetResourceWR(d, meta, waf.ChangeActionDelete)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+	}
+
+	wr := newWafRegionalRetryer(conn)
+	_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteByteMatchSetInput{
+			ChangeToken:    token,
+			ByteMatchSetId: aws.String(d.Id()),
+		}
+		return conn.DeleteByteMatchSet(req)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+	}
+
+	return nil
+}
+
+func updateByteMatchSetResourceWR(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	wr := newWafRegionalRetryer(conn)
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateByteMatchSetInput{
+			ChangeToken:    token,
+			ByteMatchSetId: aws.String(d.Id()),
+		}
+
+		ByteMatchTuples := d.Get("byte_match_tuples").(*schema.Set)
+		for _, ByteMatchTuple := range ByteMatchTuples.List() {
+			ByteMatch := ByteMatchTuple.(map[string]interface{})
+			ByteMatchUpdate := &waf.ByteMatchSetUpdate{
+				Action: aws.String(ChangeAction),
+				ByteMatchTuple: &waf.ByteMatchTuple{
+					FieldToMatch:         expandFieldToMatch(ByteMatch["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+					PositionalConstraint: aws.String(ByteMatch["positional_constraint"].(string)),
+					TargetString:         []byte(ByteMatch["target_string"].(string)),
+					TextTransformation:   aws.String(ByteMatch["text_transformation"].(string)),
+				},
+			}
+			req.Updates = append(req.Updates, ByteMatchUpdate)
+		}
+
+		return conn.UpdateByteMatchSet(req)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+	}
+
+	return nil
+}
+
+func expandFieldToMatchWR(d map[string]interface{}) *waf.FieldToMatch {
+	return &waf.FieldToMatch{
+		Type: aws.String(d["type"].(string)),
+		Data: aws.String(d["data"].(string)),
+	}
+}
+
+func flattenFieldToMatchWR(fm *waf.FieldToMatch) map[string]interface{} {
+	m := make(map[string]interface{})
+	m["data"] = *fm.Data
+	m["type"] = *fm.Type
+	return m
+}

--- a/builtin/providers/aws/resource_aws_wafregional_byte_match_set_test.go
+++ b/builtin/providers/aws/resource_aws_wafregional_byte_match_set_test.go
@@ -1,0 +1,250 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAWSWafRegionalByteMatchSet_basic(t *testing.T) {
+	var v waf.ByteMatchSet
+	byteMatchSet := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalByteMatchSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafRegionalByteMatchSetConfig(byteMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &v),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalByteMatchSet_changeNameForceNew(t *testing.T) {
+	var before, after waf.ByteMatchSet
+	byteMatchSet := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
+	byteMatchSetNewName := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalByteMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalByteMatchSetConfig(byteMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalByteMatchSetConfigChangeName(byteMatchSetNewName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "name", byteMatchSetNewName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_byte_match_set.byte_set", "byte_match_tuples.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalByteMatchSet_disappears(t *testing.T) {
+	var v waf.ByteMatchSet
+	byteMatchSet := fmt.Sprintf("byteMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalByteMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalByteMatchSetConfig(byteMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalByteMatchSetExists("aws_wafregional_byte_match_set.byte_set", &v),
+					testAccCheckAWSWafRegionalByteMatchSetDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafRegionalByteMatchSetDisappears(v *waf.ByteMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+
+		wr := newWafRegionalRetryer(conn)
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateByteMatchSetInput{
+				ChangeToken:    token,
+				ByteMatchSetId: v.ByteMatchSetId,
+			}
+
+			for _, ByteMatchTuple := range v.ByteMatchTuples {
+				ByteMatchUpdate := &waf.ByteMatchSetUpdate{
+					Action: aws.String("DELETE"),
+					ByteMatchTuple: &waf.ByteMatchTuple{
+						FieldToMatch:         ByteMatchTuple.FieldToMatch,
+						PositionalConstraint: ByteMatchTuple.PositionalConstraint,
+						TargetString:         ByteMatchTuple.TargetString,
+						TextTransformation:   ByteMatchTuple.TextTransformation,
+					},
+				}
+				req.Updates = append(req.Updates, ByteMatchUpdate)
+			}
+
+			return conn.UpdateByteMatchSet(req)
+		})
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error updating ByteMatchSet: {{err}}", err)
+		}
+
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteByteMatchSetInput{
+				ChangeToken:    token,
+				ByteMatchSetId: v.ByteMatchSetId,
+			}
+			return conn.DeleteByteMatchSet(opts)
+		})
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error deleting ByteMatchSet: {{err}}", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAWSWafRegionalByteMatchSetExists(n string, v *waf.ByteMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF ByteMatchSet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetByteMatchSet(&waf.GetByteMatchSetInput{
+			ByteMatchSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.ByteMatchSet.ByteMatchSetId == rs.Primary.ID {
+			*v = *resp.ByteMatchSet
+			return nil
+		}
+
+		return fmt.Errorf("WAF ByteMatchSet (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSWafRegionalByteMatchSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_wafregional_byte_match_set" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetByteMatchSet(
+			&waf.GetByteMatchSetInput{
+				ByteMatchSetId: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if *resp.ByteMatchSet.ByteMatchSetId == rs.Primary.ID {
+				return fmt.Errorf("WAF ByteMatchSet %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the ByteMatchSet is already destroyed
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "WAFNonexistentItemException" {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSWafRegionalByteMatchSetConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_byte_match_set" "byte_set" {
+  name = "%s"
+  byte_match_tuples {
+    text_transformation = "NONE"
+    target_string = "badrefer1"
+    positional_constraint = "CONTAINS"
+    field_to_match {
+      type = "HEADER"
+      data = "referer"
+    }
+  }
+
+  byte_match_tuples {
+    text_transformation = "NONE"
+    target_string = "badrefer2"
+    positional_constraint = "CONTAINS"
+    field_to_match {
+      type = "HEADER"
+      data = "referer"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafRegionalByteMatchSetConfigChangeName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_byte_match_set" "byte_set" {
+  name = "%s"
+  byte_match_tuples {
+    text_transformation = "NONE"
+    target_string = "badrefer1"
+    positional_constraint = "CONTAINS"
+    field_to_match {
+      type = "HEADER"
+      data = "referer"
+    }
+  }
+
+  byte_match_tuples {
+    text_transformation = "NONE"
+    target_string = "badrefer2"
+    positional_constraint = "CONTAINS"
+    field_to_match {
+      type = "HEADER"
+      data = "referer"
+    }
+  }
+}`, name)
+}

--- a/builtin/providers/aws/resource_aws_wafregional_sql_injection_match_set.go
+++ b/builtin/providers/aws/resource_aws_wafregional_sql_injection_match_set.go
@@ -1,0 +1,169 @@
+package aws
+
+import (
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsWafRegionalSqlInjectionMatchSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsWafRegionalSqlInjectionMatchSetCreate,
+		Read:   resourceAwsWafRegionalSqlInjectionMatchSetRead,
+		Update: resourceAwsWafRegionalSqlInjectionMatchSetUpdate,
+		Delete: resourceAwsWafRegionalSqlInjectionMatchSetDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"sql_injection_match_tuples": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"field_to_match": {
+							Type:     schema.TypeSet,
+							Required: true,
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"data": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
+									"type": {
+										Type:     schema.TypeString,
+										Required: true,
+									},
+								},
+							},
+						},
+						"text_transformation": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceAwsWafRegionalSqlInjectionMatchSetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	log.Printf("[INFO] Creating SqlInjectionMatchSet: %s", d.Get("name").(string))
+
+	wr := newWafRegionalRetryer(conn)
+	out, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		params := &waf.CreateSqlInjectionMatchSetInput{
+			ChangeToken: token,
+			Name:        aws.String(d.Get("name").(string)),
+		}
+
+		return conn.CreateSqlInjectionMatchSet(params)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error creating SqlInjectionMatchSet: {{err}}", err)
+	}
+	resp := out.(*waf.CreateSqlInjectionMatchSetOutput)
+	d.SetId(*resp.SqlInjectionMatchSet.SqlInjectionMatchSetId)
+
+	return resourceAwsWafRegionalSqlInjectionMatchSetUpdate(d, meta)
+}
+
+func resourceAwsWafRegionalSqlInjectionMatchSetRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+	log.Printf("[INFO] Reading SqlInjectionMatchSet: %s", d.Get("name").(string))
+	params := &waf.GetSqlInjectionMatchSetInput{
+		SqlInjectionMatchSetId: aws.String(d.Id()),
+	}
+
+	resp, err := conn.GetSqlInjectionMatchSet(params)
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "WAFNonexistentItemException" {
+			log.Printf("[WARN] WAF IPSet (%s) not found, error code (404)", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", resp.SqlInjectionMatchSet.Name)
+
+	return nil
+}
+
+func resourceAwsWafRegionalSqlInjectionMatchSetUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Updating SqlInjectionMatchSet: %s", d.Get("name").(string))
+	err := updateSqlInjectionMatchSetResourceWR(d, meta, waf.ChangeActionInsert)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating SqlInjectionMatchSet: {{err}}", err)
+	}
+	return resourceAwsWafRegionalSqlInjectionMatchSetRead(d, meta)
+}
+
+func resourceAwsWafRegionalSqlInjectionMatchSetDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	log.Printf("[INFO] Deleting SqlInjectionMatchSet: %s", d.Get("name").(string))
+	err := updateSqlInjectionMatchSetResourceWR(d, meta, waf.ChangeActionDelete)
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting SqlInjectionMatchSet: {{err}}", err)
+	}
+
+	wr := newWafRegionalRetryer(conn)
+	_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.DeleteSqlInjectionMatchSetInput{
+			ChangeToken:            token,
+			SqlInjectionMatchSetId: aws.String(d.Id()),
+		}
+
+		return conn.DeleteSqlInjectionMatchSet(req)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error deleting SqlInjectionMatchSet: {{err}}", err)
+	}
+
+	return nil
+}
+
+func updateSqlInjectionMatchSetResourceWR(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
+	conn := meta.(*AWSClient).wafregionalconn
+
+	wr := newWafRegionalRetryer(conn)
+	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+		req := &waf.UpdateSqlInjectionMatchSetInput{
+			ChangeToken:            token,
+			SqlInjectionMatchSetId: aws.String(d.Id()),
+		}
+
+		sqlInjectionMatchTuples := d.Get("sql_injection_match_tuples").(*schema.Set)
+		for _, sqlInjectionMatchTuple := range sqlInjectionMatchTuples.List() {
+			simt := sqlInjectionMatchTuple.(map[string]interface{})
+			sizeConstraintUpdate := &waf.SqlInjectionMatchSetUpdate{
+				Action: aws.String(ChangeAction),
+				SqlInjectionMatchTuple: &waf.SqlInjectionMatchTuple{
+					FieldToMatch:       expandFieldToMatch(simt["field_to_match"].(*schema.Set).List()[0].(map[string]interface{})),
+					TextTransformation: aws.String(simt["text_transformation"].(string)),
+				},
+			}
+			req.Updates = append(req.Updates, sizeConstraintUpdate)
+		}
+
+		return conn.UpdateSqlInjectionMatchSet(req)
+	})
+	if err != nil {
+		return errwrap.Wrapf("[ERROR] Error updating SqlInjectionMatchSet: {{err}}", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_wafregional_sql_injection_match_set_test.go
+++ b/builtin/providers/aws/resource_aws_wafregional_sql_injection_match_set_test.go
@@ -1,0 +1,220 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/acctest"
+)
+
+func TestAccAWSWafRegionalSqlInjectionMatchSet_basic(t *testing.T) {
+	var v waf.SqlInjectionMatchSet
+	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSqlInjectionMatchSetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &v),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalSqlInjectionMatchSet_changeNameForceNew(t *testing.T) {
+	var before, after waf.SqlInjectionMatchSet
+	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+	sqlInjectionMatchSetNewName := fmt.Sprintf("sqlInjectionMatchSetNewName-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSqlInjectionMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+				),
+			},
+			{
+				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfigChangeName(sqlInjectionMatchSetNewName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSetNewName),
+					resource.TestCheckResourceAttr(
+						"aws_wafregional_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSWafRegionalSqlInjectionMatchSet_disappears(t *testing.T) {
+	var v waf.SqlInjectionMatchSet
+	sqlInjectionMatchSet := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRegionalSqlInjectionMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRegionalSqlInjectionMatchSetConfig(sqlInjectionMatchSet),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetExists("aws_wafregional_sql_injection_match_set.sql_injection_match_set", &v),
+					testAccCheckAWSWafRegionalSqlInjectionMatchSetDisappears(&v),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func testAccCheckAWSWafRegionalSqlInjectionMatchSetDisappears(v *waf.SqlInjectionMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+
+		wr := newWafRegionalRetryer(conn)
+		_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
+			req := &waf.UpdateSqlInjectionMatchSetInput{
+				ChangeToken:            token,
+				SqlInjectionMatchSetId: v.SqlInjectionMatchSetId,
+			}
+
+			for _, sqlInjectionMatchTuple := range v.SqlInjectionMatchTuples {
+				sqlInjectionMatchTupleUpdate := &waf.SqlInjectionMatchSetUpdate{
+					Action: aws.String("DELETE"),
+					SqlInjectionMatchTuple: &waf.SqlInjectionMatchTuple{
+						FieldToMatch:       sqlInjectionMatchTuple.FieldToMatch,
+						TextTransformation: sqlInjectionMatchTuple.TextTransformation,
+					},
+				}
+				req.Updates = append(req.Updates, sqlInjectionMatchTupleUpdate)
+			}
+			return conn.UpdateSqlInjectionMatchSet(req)
+		})
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error updating SqlInjectionMatchSet: {{err}}", err)
+		}
+
+		_, err = wr.RetryWithToken(func(token *string) (interface{}, error) {
+			opts := &waf.DeleteSqlInjectionMatchSetInput{
+				ChangeToken:            token,
+				SqlInjectionMatchSetId: v.SqlInjectionMatchSetId,
+			}
+			return conn.DeleteSqlInjectionMatchSet(opts)
+		})
+		if err != nil {
+			return errwrap.Wrapf("[ERROR] Error deleting SqlInjectionMatchSet: {{err}}", err)
+		}
+		return nil
+	}
+}
+
+func testAccCheckAWSWafRegionalSqlInjectionMatchSetExists(n string, v *waf.SqlInjectionMatchSet) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No WAF SqlInjectionMatchSet ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetSqlInjectionMatchSet(&waf.GetSqlInjectionMatchSetInput{
+			SqlInjectionMatchSetId: aws.String(rs.Primary.ID),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		if *resp.SqlInjectionMatchSet.SqlInjectionMatchSetId == rs.Primary.ID {
+			*v = *resp.SqlInjectionMatchSet
+			return nil
+		}
+
+		return fmt.Errorf("WAF SqlInjectionMatchSet (%s) not found", rs.Primary.ID)
+	}
+}
+
+func testAccCheckAWSWafRegionalSqlInjectionMatchSetDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aws_wafregional_byte_match_set" {
+			continue
+		}
+
+		conn := testAccProvider.Meta().(*AWSClient).wafregionalconn
+		resp, err := conn.GetSqlInjectionMatchSet(
+			&waf.GetSqlInjectionMatchSetInput{
+				SqlInjectionMatchSetId: aws.String(rs.Primary.ID),
+			})
+
+		if err == nil {
+			if *resp.SqlInjectionMatchSet.SqlInjectionMatchSetId == rs.Primary.ID {
+				return fmt.Errorf("WAF SqlInjectionMatchSet %s still exists", rs.Primary.ID)
+			}
+		}
+
+		// Return nil if the SqlInjectionMatchSet is already destroyed
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "WAFNonexistentItemException" {
+				return nil
+			}
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func testAccAWSWafRegionalSqlInjectionMatchSetConfig(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
+  name = "%s"
+  sql_injection_match_tuples {
+    text_transformation = "URL_DECODE"
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafRegionalSqlInjectionMatchSetConfigChangeName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
+  name = "%s"
+  sql_injection_match_tuples {
+    text_transformation = "URL_DECODE"
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+}`, name)
+}

--- a/builtin/providers/aws/wafregionl_token_handlers.go
+++ b/builtin/providers/aws/wafregionl_token_handlers.go
@@ -1,0 +1,50 @@
+package aws
+
+import (
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafregional"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+type WafRegionalRetryer struct {
+	Connection *wafregional.WAFRegional
+	Region     string
+}
+
+type withRegionalTokenFunc func(token *string) (interface{}, error)
+
+func (t *WafRegionalRetryer) RetryWithToken(f withRegionalTokenFunc) (interface{}, error) {
+	awsMutexKV.Lock(t.Region)
+	defer awsMutexKV.Unlock(t.Region)
+
+	var out interface{}
+	err := resource.Retry(15*time.Minute, func() *resource.RetryError {
+		var err error
+		var tokenOut *waf.GetChangeTokenOutput
+
+		tokenOut, err = t.Connection.GetChangeToken(&waf.GetChangeTokenInput{})
+		if err != nil {
+			return resource.NonRetryableError(errwrap.Wrapf("Failed to acquire change token: {{err}}", err))
+		}
+
+		out, err = f(tokenOut.ChangeToken)
+		if err != nil {
+			awsErr, ok := err.(awserr.Error)
+			if ok && awsErr.Code() == "WAFStaleDataException" {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
+	return out, err
+}
+
+func newWafRegionalRetryer(conn *wafregional.WAFRegional) *WafRegionalRetryer {
+	return &WafRegionalRetryer{Connection: conn}
+}

--- a/website/source/docs/providers/aws/r/wafregional_byte_match_set.html.markdown
+++ b/website/source/docs/providers/aws/r/wafregional_byte_match_set.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "aws"
+page_title: "AWS: wafregional_byte_match_set"
+sidebar_current: "docs-aws-resource-wafregional-bytematchset"
+description: |-
+  Provides a AWS WAF Regional ByteMatchSet resource for use with ALB.
+---
+
+# aws\_wafregional\_byte\_match\_set
+
+Provides a WAF Regional Byte Match Set Resource for use with Application Load Balancer.
+
+## Example Usage
+
+```
+resource "aws_wafregional_byte_match_set" "byte_set" {
+  name = "tf_waf_byte_match_set"
+  byte_match_tuples {
+    text_transformation = "NONE"
+    target_string = "badrefer1"
+    positional_constraint = "CONTAINS"
+    field_to_match {
+      type = "HEADER"
+      data = "referer"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or description of the ByteMatchSet.
+* `byte_match_tuples` - Settings for the ByteMatchSet, such as the bytes (typically a string that corresponds with ASCII characters) that you want AWS WAF to search for in web requests. 
+
+## Remarks
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF ByteMatchSet.

--- a/website/source/docs/providers/aws/r/wafregional_sql_injection_match_set.html.markdown
+++ b/website/source/docs/providers/aws/r/wafregional_sql_injection_match_set.html.markdown
@@ -1,0 +1,40 @@
+---
+layout: "aws"
+page_title: "AWS: wafregional_sql_injection_match_set"
+sidebar_current: "docs-aws-resource-wafregional-sql-injection-match-set"
+description: |-
+  Provides a AWS WAF Regional SqlInjectionMatchSet resource for use with ALB.
+---
+
+# aws\_wafregional\_sql\_injection\_match\_set
+
+Provides a WAF Regional SQL Injection Match Set Resource for use with Application Load Balancer.
+
+## Example Usage
+
+```
+resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
+  name = "tf-sql_injection_match_set"
+  sql_injection_match_tuples {
+    text_transformation = "URL_DECODE"
+    field_to_match {
+      type = "QUERY_STRING"
+    }
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name or description of the SizeConstraintSet.
+* `sql_injection_match_tuples` - The parts of web requests that you want AWS WAF to inspect for malicious SQL code and, if you want AWS WAF to inspect a header, the name of the header.
+
+## Remarks
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the WAF SqlInjectionMatchSet.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1088,6 +1088,10 @@
                     <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
                   </li>
 
+                  <li<%= sidebar_current("docs-aws-resource-wafregional-sql-injection-match-set") %>>
+                    <a href="/docs/providers/aws/r/wafregional_sql_injection_match_set.html">aws_wafregional_sql_injection_match_set</a>
+                  </li>
+
                 </ul>
               </li>
 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1080,6 +1080,17 @@
                 </ul>
               </li>
 
+              <li<%= sidebar_current(/^docs-aws-resource-wafregional/) %>>
+                <a href="#">WAF Regional Resources</a>
+                <ul class="nav nav-visible">
+
+                  <li<%= sidebar_current("docs-aws-resource-wafregional-bytematchset") %>>
+                    <a href="/docs/providers/aws/r/wafregional_byte_match_set.html">aws_wafregional_byte_match_set</a>
+                  </li>
+
+                </ul>
+              </li>
+
 
                 <li<%= sidebar_current("docs-aws-resource-route53") %>>
                     <a href="#">Route53 Resources</a>


### PR DESCRIPTION
This PR is from #13676.

test
```
resource "aws_wafregional_sql_injection_match_set" "sql_injection_match_set" {
  name = "tf-sql_injection_match_set"
  sql_injection_match_tuples {
    text_transformation = "URL_DECODE"
    field_to_match {
      type = "QUERY_STRING"
    }
  }
}
```

exec
```
aws_wafregional_sql_injection_match_set.sql_injection_match_set: Creating...
  name:                                                                 "" => "tf-sql_injection_match_set"
  sql_injection_match_tuples.#:                                         "" => "1"
  sql_injection_match_tuples.3367958210.field_to_match.#:               "" => "1"
  sql_injection_match_tuples.3367958210.field_to_match.2316364334.data: "" => ""
  sql_injection_match_tuples.3367958210.field_to_match.2316364334.type: "" => "QUERY_STRING"
  sql_injection_match_tuples.3367958210.text_transformation:            "" => "URL_DECODE"
aws_wafregional_sql_injection_match_set.sql_injection_match_set: Creation complete (ID: c480b0b8-f5c1-4dae-b04f-f46b79961481)
```