### PR TITLE
TestAccAWSAutoscalingLifecycleHook_omitDefaultResult

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_lifecycle_hook_test.go
@@ -202,7 +202,7 @@ resource "aws_launch_configuration" "foobar" {
 }
 
 resource "aws_sqs_queue" "foobar" {
-  name                      = "foobar"
+  name                      = "foobar-%d"
   delay_seconds             = 90
   max_message_size          = 2048
   message_retention_seconds = 86400
@@ -225,7 +225,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "foobar" {
-  name = "foobar"
+  name = "foobar-%d"
   role = "${aws_iam_role.foobar.id}"
 
   policy = <<EOF
@@ -265,7 +265,7 @@ resource "aws_autoscaling_group" "foobar" {
 }
 
 resource "aws_autoscaling_lifecycle_hook" "foobar" {
-  name                   = "foobar"
+  name                   = "foobar-%d"
   autoscaling_group_name = "${aws_autoscaling_group.foobar.name}"
   heartbeat_timeout      = 2000
   lifecycle_transition   = "autoscaling:EC2_INSTANCE_LAUNCHING"
@@ -278,5 +278,5 @@ EOF
 
   notification_target_arn = "${aws_sqs_queue.foobar.arn}"
   role_arn                = "${aws_iam_role.foobar.arn}"
-}`, name, rInt, name)
+}`, name, rInt, rInt, rInt, name, rInt)
 }


### PR DESCRIPTION
This test fixes TestAccAWSAutoscalingLifecycleHook_omitDefaultResult

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSAutoscalingLifecycleHook_omitDefaultResult'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/17 09:04:47 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSAutoscalingLifecycleHook_omitDefaultResult -timeout 120m
=== RUN   TestAccAWSAutoscalingLifecycleHook_omitDefaultResult
--- PASS: TestAccAWSAutoscalingLifecycleHook_omitDefaultResult (225.67s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	225.700s
```