### PR TITLE
Process version constraints in `provider` blocks

### DIFF
--- a/command/plugins.go
+++ b/command/plugins.go
@@ -50,7 +50,7 @@ func (m *Meta) providerFactories() map[string]terraform.ResourceProviderFactory 
 		// by name, we're guaranteed that the metas in our set all have
 		// valid versions and that there's at least one meta.
 		newest := metas.Newest()
-		client := newest.Client()
+		client := tfplugin.Client(newest)
 		factories[name] = providerFactory(client)
 	}
 
@@ -99,7 +99,7 @@ func (m *Meta) provisionerFactories() map[string]terraform.ResourceProvisionerFa
 		// by name, we're guaranteed that the metas in our set all have
 		// valid versions and that there's at least one meta.
 		newest := metas.Newest()
-		client := newest.Client()
+		client := tfplugin.Client(newest)
 		factories[name] = provisionerFactory(client)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -240,6 +240,33 @@ func (r *Resource) Id() string {
 	}
 }
 
+// ProviderFullName returns the full name of the provider for this resource,
+// which may either be specified explicitly using the "provider" meta-argument
+// or implied by the prefix on the resource type name.
+func (r *Resource) ProviderFullName() string {
+	return ResourceProviderFullName(r.Type, r.Provider)
+}
+
+// ResourceProviderFullName returns the full (dependable) name of the
+// provider for a hypothetical resource with the given resource type and
+// explicit provider string. If the explicit provider string is empty then
+// the provider name is inferred from the resource type name.
+func ResourceProviderFullName(resourceType, explicitProvider string) string {
+	if explicitProvider != "" {
+		return explicitProvider
+	}
+
+	idx := strings.IndexRune(resourceType, '_')
+	if idx == -1 {
+		// If no underscores, the resource name is assumed to be
+		// also the provider name, e.g. if the provider exposes
+		// only a single resource of each type.
+		return resourceType
+	}
+
+	return resourceType[:idx]
+}
+
 // Validate does some basic semantic checking of the configuration.
 func (c *Config) Validate() error {
 	if c == nil {

--- a/config/config.go
+++ b/config/config.go
@@ -64,6 +64,7 @@ type Module struct {
 type ProviderConfig struct {
 	Name      string
 	Alias     string
+	Version   string
 	RawConfig *RawConfig
 }
 
@@ -349,7 +350,8 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	// Check that providers aren't declared multiple times.
+	// Check that providers aren't declared multiple times, and that versions
+	// aren't used yet since they aren't properly supported.
 	providerSet := make(map[string]struct{})
 	for _, p := range c.ProviderConfigs {
 		name := p.FullName()
@@ -358,6 +360,13 @@ func (c *Config) Validate() error {
 				"provider.%s: declared multiple times, you can only declare a provider once",
 				name))
 			continue
+		}
+
+		if p.Version != "" {
+			errs = append(errs, fmt.Errorf(
+				"provider.%s: version constraints are not yet supported; remove the 'version' argument from configuration",
+				name,
+			))
 		}
 
 		providerSet[name] = struct{}{}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -208,10 +208,16 @@ func TestConfigValidate_table(t *testing.T) {
 			"",
 		},
 		{
-			"provider with version constraint",
+			"provider with valid version constraint",
 			"provider-version",
+			false,
+			"",
+		},
+		{
+			"provider with invalid version constraint",
+			"provider-version-invalid",
 			true,
-			"version constraints are not yet supported",
+			"invalid version constraint",
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -720,3 +720,53 @@ func TestConfigProviderVersion(t *testing.T) {
 		t.Fatal("'version' should not exist in raw config")
 	}
 }
+
+func TestResourceProviderFullName(t *testing.T) {
+	type testCase struct {
+		ResourceName string
+		Alias        string
+		Expected     string
+	}
+
+	tests := []testCase{
+		{
+			// If no alias is provided, the first underscore-separated segment
+			// is assumed to be the provider name.
+			ResourceName: "aws_thing",
+			Alias:        "",
+			Expected:     "aws",
+		},
+		{
+			// If we have more than one underscore then it's the first one that we'll use.
+			ResourceName: "aws_thingy_thing",
+			Alias:        "",
+			Expected:     "aws",
+		},
+		{
+			// A provider can export a resource whose name is just the bare provider name,
+			// e.g. because the provider only has one resource and so any additional
+			// parts would be redundant.
+			ResourceName: "external",
+			Alias:        "",
+			Expected:     "external",
+		},
+		{
+			// Alias always overrides the default extraction of the name
+			ResourceName: "aws_thing",
+			Alias:        "tls.baz",
+			Expected:     "tls.baz",
+		},
+	}
+
+	for _, test := range tests {
+		got := ResourceProviderFullName(test.ResourceName, test.Alias)
+		if got != test.Expected {
+			t.Errorf(
+				"(%q, %q) produced %q; want %q",
+				test.ResourceName, test.Alias,
+				got,
+				test.Expected,
+			)
+		}
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -207,6 +207,12 @@ func TestConfigValidate_table(t *testing.T) {
 			false,
 			"",
 		},
+		{
+			"provider with version constraint",
+			"provider-version",
+			true,
+			"version constraints are not yet supported",
+		},
 	}
 
 	for i, tc := range cases {
@@ -685,5 +691,26 @@ func TestConfigDataCount(t *testing.T) {
 	// it's not a real key and won't validate.
 	if _, ok := c.Resources[0].RawConfig.Raw["count"]; ok {
 		t.Fatal("count key still exists in RawConfig")
+	}
+}
+
+func TestConfigProviderVersion(t *testing.T) {
+	c := testConfig(t, "provider-version")
+
+	if len(c.ProviderConfigs) != 1 {
+		t.Fatal("expected 1 provider")
+	}
+
+	p := c.ProviderConfigs[0]
+	if p.Name != "aws" {
+		t.Fatalf("expected provider name 'aws', got %q", p.Name)
+	}
+
+	if p.Version != "0.0.1" {
+		t.Fatalf("expected providers version '0.0.1', got %q", p.Version)
+	}
+
+	if _, ok := p.RawConfig.Raw["version"]; ok {
+		t.Fatal("'version' should not exist in raw config")
 	}
 }

--- a/config/loader_hcl.go
+++ b/config/loader_hcl.go
@@ -554,6 +554,7 @@ func loadProvidersHcl(list *ast.ObjectList) ([]*ProviderConfig, error) {
 		}
 
 		delete(config, "alias")
+		delete(config, "version")
 
 		rawConfig, err := NewRawConfig(config)
 		if err != nil {
@@ -575,9 +576,22 @@ func loadProvidersHcl(list *ast.ObjectList) ([]*ProviderConfig, error) {
 			}
 		}
 
+		// If we have a version field then extract it
+		var version string
+		if a := listVal.Filter("version"); len(a.Items) > 0 {
+			err := hcl.DecodeObject(&version, a.Items[0].Val)
+			if err != nil {
+				return nil, fmt.Errorf(
+					"Error reading version for provider[%s]: %s",
+					n,
+					err)
+			}
+		}
+
 		result = append(result, &ProviderConfig{
 			Name:      n,
 			Alias:     alias,
+			Version:   version,
 			RawConfig: rawConfig,
 		})
 	}

--- a/config/module/tree.go
+++ b/config/module/tree.go
@@ -92,6 +92,25 @@ func (t *Tree) Children() map[string]*Tree {
 	return t.children
 }
 
+// DeepEach calls the provided callback for the receiver and then all of
+// its descendents in the tree, allowing an operation to be performed on
+// all modules in the tree.
+//
+// Parents will be visited before their children but otherwise the order is
+// not defined.
+func (t *Tree) DeepEach(cb func(*Tree)) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+	t.deepEach(cb)
+}
+
+func (t *Tree) deepEach(cb func(*Tree)) {
+	cb(t)
+	for _, c := range t.children {
+		c.deepEach(cb)
+	}
+}
+
 // Loaded says whether or not this tree has been loaded or not yet.
 func (t *Tree) Loaded() bool {
 	t.lock.RLock()

--- a/config/providers.go
+++ b/config/providers.go
@@ -1,0 +1,103 @@
+package config
+
+import "github.com/blang/semver"
+
+// ProviderVersionConstraint presents a constraint for a particular
+// provider, identified by its full name.
+type ProviderVersionConstraint struct {
+	Constraint   string
+	ProviderType string
+}
+
+// ProviderVersionConstraints is a map from provider full name to its associated
+// ProviderVersionConstraint, as produced by Config.RequiredProviders.
+type ProviderVersionConstraints map[string]ProviderVersionConstraint
+
+// RequiredProviders returns the ProviderVersionConstraints for this
+// module.
+//
+// This includes both providers that are explicitly requested by provider
+// blocks and those that are used implicitly by instantiating one of their
+// resource types. In the latter case, the returned semver Range will
+// accept any version of the provider.
+func (c *Config) RequiredProviders() ProviderVersionConstraints {
+	ret := make(ProviderVersionConstraints, len(c.ProviderConfigs))
+
+	configs := c.ProviderConfigsByFullName()
+
+	// In order to find the *implied* dependencies (those without explicit
+	// "provider" blocks) we need to walk over all of the resources and
+	// cross-reference with the provider configs.
+	for _, rc := range c.Resources {
+		providerName := rc.ProviderFullName()
+		var providerType string
+
+		// Default to (effectively) no constraint whatsoever, but we might
+		// override if there's an explicit constraint in config.
+		constraint := ">=0.0.0"
+
+		config, ok := configs[providerName]
+		if ok {
+			if config.Version != "" {
+				constraint = config.Version
+			}
+			providerType = config.Name
+		} else {
+			providerType = providerName
+		}
+
+		ret[providerName] = ProviderVersionConstraint{
+			ProviderType: providerType,
+			Constraint:   constraint,
+		}
+	}
+
+	return ret
+}
+
+// RequiredRanges returns a semver.Range for each distinct provider type in
+// the constraint map. If the same provider type appears more than once
+// (e.g. because aliases are in use) then their respective constraints are
+// combined such that they must *all* apply.
+//
+// The result of this method can be passed to the
+// PluginMetaSet.ConstrainVersions method within the plugin/discovery
+// package in order to filter down the available plugins to those which
+// satisfy the given constraints.
+//
+// This function will panic if any of the constraints within cannot be
+// parsed as semver ranges. This is guaranteed to never happen for a
+// constraint set that was built from a configuration that passed validation.
+func (cons ProviderVersionConstraints) RequiredRanges() map[string]semver.Range {
+	ret := make(map[string]semver.Range, len(cons))
+
+	for _, con := range cons {
+		spec := semver.MustParseRange(con.Constraint)
+		if existing, exists := ret[con.ProviderType]; exists {
+			ret[con.ProviderType] = existing.AND(spec)
+		} else {
+			ret[con.ProviderType] = spec
+		}
+	}
+
+	return ret
+}
+
+// ProviderConfigsByFullName returns a map from provider full names (as
+// returned by ProviderConfig.FullName()) to the corresponding provider
+// configs.
+//
+// This function returns no new information than what's already in
+// c.ProviderConfigs, but returns it in a more convenient shape. If there
+// is more than one provider config with the same full name then the result
+// is undefined, but that is guaranteed not to happen for any config that
+// has passed validation.
+func (c *Config) ProviderConfigsByFullName() map[string]*ProviderConfig {
+	ret := make(map[string]*ProviderConfig, len(c.ProviderConfigs))
+
+	for _, pc := range c.ProviderConfigs {
+		ret[pc.FullName()] = pc
+	}
+
+	return ret
+}

--- a/config/test-fixtures/provider-version-invalid/main.tf
+++ b/config/test-fixtures/provider-version-invalid/main.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  version = "bananas"
+  a       = "a"
+  b       = "b"
+}

--- a/config/test-fixtures/provider-version/main.tf
+++ b/config/test-fixtures/provider-version/main.tf
@@ -1,0 +1,6 @@
+provider "aws" {
+	version = "0.0.1"
+	a = "a"
+	b = "b"
+}
+

--- a/plugin/client.go
+++ b/plugin/client.go
@@ -1,0 +1,24 @@
+package plugin
+
+import (
+	"os/exec"
+
+	plugin "github.com/hashicorp/go-plugin"
+	"github.com/hashicorp/terraform/plugin/discovery"
+)
+
+// ClientConfig returns a configuration object that can be used to instantiate
+// a client for the plugin described by the given metadata.
+func ClientConfig(m discovery.PluginMeta) *plugin.ClientConfig {
+	return &plugin.ClientConfig{
+		Cmd:             exec.Command(m.Path),
+		HandshakeConfig: Handshake,
+		Managed:         true,
+		Plugins:         PluginMap,
+	}
+}
+
+// Client returns a plugin client for the plugin described by the given metadata.
+func Client(m discovery.PluginMeta) *plugin.Client {
+	return plugin.NewClient(ClientConfig(m))
+}

--- a/plugin/discovery/meta.go
+++ b/plugin/discovery/meta.go
@@ -4,11 +4,8 @@ import (
 	"crypto/sha256"
 	"io"
 	"os"
-	"os/exec"
 
 	"github.com/blang/semver"
-	plugin "github.com/hashicorp/go-plugin"
-	tfplugin "github.com/hashicorp/terraform/plugin"
 )
 
 // PluginMeta is metadata about a plugin, useful for launching the plugin
@@ -50,20 +47,4 @@ func (m PluginMeta) SHA256() ([]byte, error) {
 	}
 
 	return h.Sum(nil), nil
-}
-
-// ClientConfig returns a configuration object that can be used to instantiate
-// a client for the referenced plugin.
-func (m PluginMeta) ClientConfig() *plugin.ClientConfig {
-	return &plugin.ClientConfig{
-		Cmd:             exec.Command(m.Path),
-		HandshakeConfig: tfplugin.Handshake,
-		Managed:         true,
-		Plugins:         tfplugin.PluginMap,
-	}
-}
-
-// Client returns a plugin client for the referenced plugin.
-func (m PluginMeta) Client() *plugin.Client {
-	return plugin.NewClient(m.ClientConfig())
 }

--- a/terraform/util.go
+++ b/terraform/util.go
@@ -2,7 +2,8 @@ package terraform
 
 import (
 	"sort"
-	"strings"
+
+	"github.com/hashicorp/terraform/config"
 )
 
 // Semaphore is a wrapper around a channel to provide
@@ -47,21 +48,8 @@ func (s Semaphore) Release() {
 	}
 }
 
-// resourceProvider returns the provider name for the given type.
-func resourceProvider(t, alias string) string {
-	if alias != "" {
-		return alias
-	}
-
-	idx := strings.IndexRune(t, '_')
-	if idx == -1 {
-		// If no underscores, the resource name is assumed to be
-		// also the provider name, e.g. if the provider exposes
-		// only a single resource of each type.
-		return t
-	}
-
-	return t[:idx]
+func resourceProvider(resourceType, explicitProvider string) string {
+	return config.ResourceProviderFullName(resourceType, explicitProvider)
 }
 
 // strSliceContains checks if a given string is contained in a slice

--- a/terraform/util_test.go
+++ b/terraform/util_test.go
@@ -49,56 +49,6 @@ func TestStrSliceContains(t *testing.T) {
 	}
 }
 
-func TestUtilResourceProvider(t *testing.T) {
-	type testCase struct {
-		ResourceName string
-		Alias        string
-		Expected     string
-	}
-
-	tests := []testCase{
-		{
-			// If no alias is provided, the first underscore-separated segment
-			// is assumed to be the provider name.
-			ResourceName: "aws_thing",
-			Alias:        "",
-			Expected:     "aws",
-		},
-		{
-			// If we have more than one underscore then it's the first one that we'll use.
-			ResourceName: "aws_thingy_thing",
-			Alias:        "",
-			Expected:     "aws",
-		},
-		{
-			// A provider can export a resource whose name is just the bare provider name,
-			// e.g. because the provider only has one resource and so any additional
-			// parts would be redundant.
-			ResourceName: "external",
-			Alias:        "",
-			Expected:     "external",
-		},
-		{
-			// Alias always overrides the default extraction of the name
-			ResourceName: "aws_thing",
-			Alias:        "tls.baz",
-			Expected:     "tls.baz",
-		},
-	}
-
-	for _, test := range tests {
-		got := resourceProvider(test.ResourceName, test.Alias)
-		if got != test.Expected {
-			t.Errorf(
-				"(%q, %q) produced %q; want %q",
-				test.ResourceName, test.Alias,
-				got,
-				test.Expected,
-			)
-		}
-	}
-}
-
 func TestUniqueStrings(t *testing.T) {
 	cases := []struct {
 		Input    []string


### PR DESCRIPTION
This allows and processes version constraints on providers, like the following:

```
provider "aws" {
  version = "1.0.0"
}
```

This is a checkpoint on the path toward actually *using* these constraints, but it doesn't actually use them yet. Instead, this just includes the logic for building the constraint map that will be passed to the `plugin/discovery` `ConstrainVersions` method in a later commit.

A little more refactoring is required in the `command` package before we can make use of this, because currently we process the providers too early to consider this version information. This refactoring will follow in a subsequent PR.

(There's some supporting changes included in this PR that may make the overall diff hard to read. Each logical change is in its own commit, so it may prove easier to review on a per-commit basis here.)
