### PR TITLE
Mitigate race condition leading to orphaned resources being generated

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -400,7 +400,7 @@ func resourceAwsInstanceCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[DEBUG] Run configuration: %s", runOpts)
 
 	var runResp *ec2.Reservation
-	err = resource.Retry(15*time.Second, func() *resource.RetryError {
+	err = resource.RetryWithGrace(15*time.Second, 5*time.Second, func() *resource.RetryError {
 		var err error
 		runResp, err = conn.RunInstances(runOpts)
 		// IAM instance profiles can take ~10 seconds to propagate in AWS:

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -25,6 +25,20 @@ func TestRetry(t *testing.T) {
 	}
 }
 
+func TestRetry_grace(t *testing.T) {
+	t.Parallel()
+
+	f := func() *RetryError {
+		time.Sleep(2 * time.Second)
+		return nil
+	}
+
+	err := RetryWithGrace(1*time.Second, 2*time.Second, f)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestRetry_timeout(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This addresses #13617 by adding the notion of a grace period to `resource.StateChangeConf` which is the amount of time that we wait for a current execution of the refresh function to finish after the timeout expires but before failing on a timeout error. It also sets the grace period for creating EC2 instances to 5 seconds. This combination seems to fix the problems we're experiencing.