### PR TITLE
Fix invalid MIME formatting in multipart cloudinit userdata

### DIFF
--- a/builtin/providers/template/datasource_cloudinit_config.go
+++ b/builtin/providers/template/datasource_cloudinit_config.go
@@ -140,7 +140,7 @@ func renderPartsToWriter(parts cloudInitParts, writer io.Writer) error {
 	}
 
 	writer.Write([]byte(fmt.Sprintf("Content-Type: multipart/mixed; boundary=\"%s\"\n", mimeWriter.Boundary())))
-	writer.Write([]byte("MIME-Version: 1.0\r\n"))
+	writer.Write([]byte("MIME-Version: 1.0\r\n\r\n"))
 
 	for _, part := range parts {
 		header := textproto.MIMEHeader{}

--- a/builtin/providers/template/datasource_cloudinit_config_test.go
+++ b/builtin/providers/template/datasource_cloudinit_config_test.go
@@ -22,7 +22,7 @@ func TestRender(t *testing.T) {
 					content = "baz"
 				}
 			}`,
-			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n",
+			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n",
 		},
 		{
 			`data "template_cloudinit_config" "foo" {
@@ -35,7 +35,7 @@ func TestRender(t *testing.T) {
 					filename = "foobar.sh"
 				}
 			}`,
-			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Disposition: attachment; filename=\"foobar.sh\"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n",
+			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n\r\n--MIMEBOUNDARY\r\nContent-Disposition: attachment; filename=\"foobar.sh\"\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY--\r\n",
 		},
 		{
 			`data "template_cloudinit_config" "foo" {
@@ -51,7 +51,7 @@ func TestRender(t *testing.T) {
 					content = "ffbaz"
 				}
 			}`,
-			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDARY--\r\n",
+			"Content-Type: multipart/mixed; boundary=\"MIMEBOUNDARY\"\nMIME-Version: 1.0\r\n\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nbaz\r\n--MIMEBOUNDARY\r\nContent-Transfer-Encoding: 7bit\r\nContent-Type: text/x-shellscript\r\nMime-Version: 1.0\r\n\r\nffbaz\r\n--MIMEBOUNDARY--\r\n",
 		},
 	}
 


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc822#appendix-B.2, MIME headers and Body need to be separated by two new lines (or CRLFs in this case). 

The email parser in python can handle this which is what cloud-init uses but this bug causes problems if you try to parse the multipart message by languages other than python.