### PR TITLE
provider/azurerm: Crash in Virtual Machines on an empty Windows Config block

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -354,7 +354,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"provision_vm_agent": {
 							Type:     schema.TypeBool,
 							Optional: true,
-							Default:  false,
+							Default:  true,
 						},
 						"enable_automatic_upgrades": {
 							Type:     schema.TypeBool,

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -354,11 +354,13 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"provision_vm_agent": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 							Default:  true,
 						},
 						"enable_automatic_upgrades": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							ForceNew: true,
 							Default:  false,
 						},
 						"winrm": {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -865,13 +865,16 @@ func resourceArmVirtualMachineStorageOsProfileLinuxConfigHash(v interface{}) int
 
 func resourceArmVirtualMachineStorageOsProfileWindowsConfigHash(v interface{}) int {
 	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	if m["provision_vm_agent"] != nil {
-		buf.WriteString(fmt.Sprintf("%t-", m["provision_vm_agent"].(bool)))
+
+	if m, ok := v.(map[string]interface{}); ok {
+		if m["provision_vm_agent"] != nil {
+			buf.WriteString(fmt.Sprintf("%t-", m["provision_vm_agent"].(bool)))
+		}
+		if m["enable_automatic_upgrades"] != nil {
+			buf.WriteString(fmt.Sprintf("%t-", m["enable_automatic_upgrades"].(bool)))
+		}
 	}
-	if m["enable_automatic_upgrades"] != nil {
-		buf.WriteString(fmt.Sprintf("%t-", m["enable_automatic_upgrades"].(bool)))
-	}
+
 	return hashcode.String(buf.String())
 }
 

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -354,10 +354,12 @@ func resourceArmVirtualMachine() *schema.Resource {
 						"provision_vm_agent": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"enable_automatic_upgrades": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Default:  false,
 						},
 						"winrm": {
 							Type:     schema.TypeList,

--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -24,6 +24,8 @@ func resourceArmVirtualMachine() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		SchemaVersion: 1,
+		MigrateState:  resourceAzureRMVirtualMachineMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -361,7 +363,7 @@ func resourceArmVirtualMachine() *schema.Resource {
 							Type:     schema.TypeBool,
 							Optional: true,
 							ForceNew: true,
-							Default:  false,
+							Default:  true,
 						},
 						"winrm": {
 							Type:     schema.TypeList,

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_migration.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_migration.go
@@ -1,0 +1,81 @@
+package azurerm
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAzureRMVirtualMachineMigrateState(v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AzureRM Virtual Machine State v0; migrating to v1")
+		return migrateAzureRMVirtualMachineStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateAzureRMVirtualMachineStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] AzureRM Virtual Machine Attributes before migration: %#v", is.Attributes)
+	prefix := "os_profile_windows_config"
+	entity := resourceArmVirtualMachine()
+
+	// Read old keys
+	reader := &schema.MapFieldReader{
+		Schema: entity.Schema,
+		Map:    schema.BasicMapReader(is.Attributes),
+	}
+	result, err := reader.ReadField([]string{prefix})
+	if err != nil {
+		return nil, err
+	}
+
+	oldKeys, ok := result.Value.(*schema.Set)
+	if !ok {
+		return nil, fmt.Errorf("Got unexpected value from state: %#v", result.Value)
+	}
+
+	for _, value := range oldKeys.List() {
+		value := value.(map[string]interface{})
+		_, exists := value["provision_vm_agent"]
+		if !exists {
+			value["provision_vm_agent"] = "true"
+		}
+
+		_, exists = value["enable_automatic_upgrades"]
+		if !exists {
+			value["enable_automatic_upgrades"] = "true"
+		}
+	}
+
+	// Delete old keys
+	for k := range is.Attributes {
+		if strings.HasPrefix(k, fmt.Sprintf("%s.", prefix)) {
+			delete(is.Attributes, k)
+		}
+	}
+
+	// Write new keys
+	writer := schema.MapFieldWriter{
+		Schema: entity.Schema,
+	}
+	if err := writer.WriteField([]string{prefix}, oldKeys); err != nil {
+		return is, err
+	}
+	for k, v := range writer.Map() {
+		is.Attributes[k] = v
+	}
+
+	log.Printf("[DEBUG] AzureRM Virtual Machine Attributes after State Migration: %#v", is.Attributes)
+
+	return is, nil
+}

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_migration_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_migration_test.go
@@ -1,0 +1,76 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAzureRMVirtualMachineMigrateStateV0ToV1(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+	}{
+		"v0_1_set_default": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"os_profile_windows_config.#":                                       "1",
+				"os_profile_windows_config.2256145325.additional_unattend_config.#": "0",
+				"os_profile_windows_config.2256145325.enable_automatic_upgrades":    "true",
+				"os_profile_windows_config.2256145325.provision_vm_agent":           "true",
+				"os_profile_windows_config.2256145325.winrm.#":                      "0",
+			},
+			Expected: map[string]string{
+				"os_profile_windows_config.#":                                       "1",
+				"os_profile_windows_config.2256145325.additional_unattend_config.#": "0",
+				"os_profile_windows_config.2256145325.enable_automatic_upgrades":    "true",
+				"os_profile_windows_config.2256145325.provision_vm_agent":           "true",
+				"os_profile_windows_config.2256145325.winrm.#":                      "0",
+			},
+		},
+		"v0_1_set_other": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"os_profile_windows_config.#":                                      "1",
+				"os_profile_windows_config.429474957.additional_unattend_config.#": "0",
+				"os_profile_windows_config.429474957.enable_automatic_upgrades":    "false",
+				"os_profile_windows_config.429474957.provision_vm_agent":           "false",
+				"os_profile_windows_config.429474957.winrm.#":                      "0",
+			},
+			Expected: map[string]string{
+				"os_profile_windows_config.#":                                      "1",
+				"os_profile_windows_config.429474957.additional_unattend_config.#": "0",
+				"os_profile_windows_config.429474957.enable_automatic_upgrades":    "false",
+				"os_profile_windows_config.429474957.provision_vm_agent":           "false",
+				"os_profile_windows_config.429474957.winrm.#":                      "0",
+			},
+		},
+		"v0_1_empty": {
+			StateVersion: 0,
+			Attributes:   map[string]string{},
+			Expected:     map[string]string{},
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         "azurerm_virtual_machine",
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceArmVirtualMachine().MigrateState(tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_test.go
@@ -261,6 +261,25 @@ func TestAccAzureRMVirtualMachine_basicWindowsMachine(t *testing.T) {
 	})
 }
 
+func TestAccAzureRMVirtualMachine_basicWindowsMachineEmptyConfigBlock(t *testing.T) {
+	var vm compute.VirtualMachine
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachine_basicWindowsMachineEmptyConfigBlock, ri, ri, ri, ri, ri, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineExists("azurerm_virtual_machine.test", &vm),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAzureRMVirtualMachine_windowsUnattendedConfig(t *testing.T) {
 	var vm compute.VirtualMachine
 	ri := acctest.RandInt()
@@ -2144,6 +2163,87 @@ resource "azurerm_virtual_machine" "test" {
 	enable_automatic_upgrades = false
 	provision_vm_agent = true
     }
+}
+`
+
+var testAccAzureRMVirtualMachine_basicWindowsMachineEmptyConfigBlock = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%d"
+    location = "West US 2"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US 2"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%d"
+    location = "West US 2"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accsa%d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US 2"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine" "test" {
+    name = "acctvm-%d"
+    location = "West US 2"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    network_interface_ids = ["${azurerm_network_interface.test.id}"]
+    vm_size = "Standard_D1_v2"
+
+    storage_image_reference {
+	publisher = "MicrosoftWindowsServer"
+	offer = "WindowsServer"
+	sku = "2012-Datacenter"
+	version = "latest"
+    }
+
+    storage_os_disk {
+        name = "myosdisk1"
+        vhd_uri = "${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}/myosdisk1.vhd"
+        caching = "ReadWrite"
+        create_option = "FromImage"
+    }
+
+    os_profile {
+	computer_name = "winhost01"
+	admin_username = "testadmin"
+	admin_password = "Password1234!"
+    }
+
+    os_profile_windows_config {}
 }
 `
 

--- a/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine.html.markdown
@@ -377,8 +377,8 @@ For more information on the different example configurations, please check out t
 
 `os_profile_windows_config` supports the following:
 
-* `provision_vm_agent` - (Optional)
-* `enable_automatic_upgrades` - (Optional)
+* `provision_vm_agent` - (Optional) Should the Azure Agent be Provisioned on the VM? This is needed for some Azure functionality, such as VM Extensions. Changing this forces a new resource to be created.
+* `enable_automatic_upgrades` - (Optional) Should updates be installed through Microsoft Update automatically? Changing this forces a new resource to be created.
 * `winrm` - (Optional) A collection of WinRM configuration blocks as documented below.
 * `additional_unattend_config` - (Optional) An Additional Unattended Config block as documented below.
 
@@ -411,10 +411,10 @@ For more information on the different example configurations, please check out t
 * `certificate_url` - (Required) Specifies the URI of the key vault secrets in the format of `https://<vaultEndpoint>/secrets/<secretName>/<secretVersion>`. Stored secret is the Base64 encoding of a JSON Object that which is encoded in UTF-8 of which the contents need to be
 
 ```json
-{ 
-  "data":"<Base64-encoded-certificate>", 
+{
+  "data":"<Base64-encoded-certificate>",
   "dataType":"pfx",
-  "password":"<pfx-file-password>" 
+  "password":"<pfx-file-password>"
 }
 ```
 


### PR DESCRIPTION
Currently Terraform crashes with the following stack trace when specifying an empty `os_profile_windows_config` block in an `azurerm_virtual_machine` resource (full details in #10744):

```
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: panic: interface conversion: interface {} is nil, not map[string]interface {}
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: goroutine 76 [running]:
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/builtin/providers/azurerm.resourceArmVirtualMachineStorageOsProfileWindowsConfigHash(0x0, 0x0, 0xc4203cb798)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/builtin/providers/azurerm/resource_arm_virtual_machine.go:868 +0x3b9
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*Set).hash(0xc4203cb780, 0x0, 0x0, 0x1965f40, 0xc4201cb2c0)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/set.go:180 +0x3d
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*Set).add(0xc4203cb780, 0x0, 0x0, 0xc42037fc00, 0x0, 0xc4203cbae0)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/set.go:167 +0x81
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*ConfigFieldReader).readSet(0xc420481920, 0xc4204ab500, 0x1, 0x1, 0xc42037fc20, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/field_reader_config.go:289 +0x3b0
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*ConfigFieldReader).readField(0xc420481920, 0xc4204ab500, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/field_reader_config.go:115 +0x93c
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*ConfigFieldReader).ReadField(0xc420481920, 0xc4204ab500, 0x1, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0x20, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/field_reader_config.go:27 +0xe3
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*MultiLevelFieldReader).ReadFieldExact(0xc420495b60, 0xc4204ab500, 0x1, 0x1, 0x1a6210d, 0x6, 0x0, 0x0, 0x0, 0x0, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/field_reader_multi.go:31 +0xef
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*ResourceData).get(0xc420108930, 0xc4204ab500, 0x1, 0x1, 0xc4204ab512, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/resource_data.go:475 +0x13a
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*ResourceData).getChange(0xc420108930, 0x1a7531e, 0x19, 0xc420451201, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/resource_data.go:451 +0x135
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*ResourceData).diffChange(0xc420108930, 0x1a7531e, 0x19, 0xc42037b860, 0xc4206dd618, 0xc420108930, 0x1, 0x0)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/resource_data.go:428 +0x61
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.schemaMap.diffSet(0xc4201cb3b0, 0x1a7531e, 0x19, 0xc42037fc20, 0xc4206dd618, 0xc420108930, 0x1a19a00, 0x0, 0x0)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/schema.go:915 +0x5d
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.schemaMap.diff(0xc4201cb3b0, 0x1a7531e, 0x19, 0xc42037fc20, 0xc420495960, 0xc420108930, 0x111a400, 0x0, 0x0)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/schema.go:678 +0x4b1
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.schemaMap.Diff(0xc4201cb3b0, 0xc420016500, 0xc420481380, 0x0, 0x0, 0xa)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/schema.go:389 +0x1c2
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*Resource).Diff(0xc4201dbd40, 0xc420016500, 0xc420481380, 0x17, 0xc420392178, 0x1)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/resource.go:211 +0x15b
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/helper/schema.(*Provider).Diff(0xc4201d60e0, 0xc420016370, 0xc420016500, 0xc420481380, 0x23004b0, 0x0, 0xc42001f300)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/helper/schema/provider.go:255 +0x84
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: github.com/hashicorp/terraform/plugin.(*ResourceProviderServer).Diff(0xc4201c63a0, 0xc420495040, 0xc4204c3040, 0x0, 0x0)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/Users/tharvey/code/src/github.com/hashicorp/terraform/plugin/resource_provider.go:499 +0x57
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: reflect.Value.call(0xc42027f0e0, 0xc42024e750, 0x13, 0x1a6033d, 0x4, 0xc420233f20, 0x3, 0x3, 0x0, 0xc4204a66c0, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8/libexec/src/reflect/value.go:434 +0x91f
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: reflect.Value.Call(0xc42027f0e0, 0xc42024e750, 0x13, 0xc420211f20, 0x3, 0x3, 0xc4203421e0, 0xc420211f48, 0xc420211f48)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8/libexec/src/reflect/value.go:302 +0xa4
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: net/rpc.(*service).call(0xc420353880, 0xc420353840, 0xc420359a48, 0xc42029f700, 0xc42028e800, 0x18ed440, 0xc420495040, 0x16, 0x18ed480, 0xc4204c3040, ...)
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8/libexec/src/net/rpc/server.go:387 +0x144
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: created by net/rpc.(*Server).ServeCodec
2017/04/18 20:41:06 [DEBUG] plugin: terraform-provider-azurerm: 	/usr/local/Cellar/go/1.8/libexec/src/net/rpc/server.go:481 +0x404
```

Fixes #10744