### PR TITLE
Changed cidrhost() to accept negative host number

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -542,7 +542,22 @@ func TestInterpolateFuncCidrHost(t *testing.T) {
 				false,
 			},
 			{
+				`${cidrhost("192.168.1.0/24", -5)}`,
+				"192.168.1.251",
+				false,
+			},
+			{
+				`${cidrhost("192.168.1.0/24", -256)}`,
+				"192.168.1.0",
+				false,
+			},
+			{
 				`${cidrhost("192.168.1.0/30", 255)}`,
+				nil,
+				true, // 255 doesn't fit in two bits
+			},
+			{
+				`${cidrhost("192.168.1.0/30", -255)}`,
 				nil,
 				true, // 255 doesn't fit in two bits
 			},

--- a/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
+++ b/vendor/github.com/apparentlymart/go-cidr/cidr/cidr.go
@@ -61,7 +61,14 @@ func Host(base *net.IPNet, num int) (net.IP, error) {
 	hostLen := addrLen - parentLen
 
 	maxHostNum := uint64(1<<uint64(hostLen)) - 1
-	if uint64(num) > maxHostNum {
+
+	numUint64 := uint64(num)
+	if num < 0 {
+		numUint64 = uint64(-num) - 1
+		num = int(maxHostNum - numUint64)
+	}
+
+	if numUint64 > maxHostNum {
 		return nil, fmt.Errorf("prefix of %d does not accommodate a host numbered %d", parentLen, num)
 	}
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -446,9 +446,10 @@
 			"revisionTime": "2016-08-22T23:00:20Z"
 		},
 		{
-			"checksumSHA1": "kn+zdUr5TNsoAX8BgjOaWYtMT5U=",
+			"checksumSHA1": "FIL83loX9V9APvGQIjJpbxq53F0=",
 			"path": "github.com/apparentlymart/go-cidr/cidr",
-			"revision": "a3ebdb999b831ecb6ab8a226e31b07b2b9061c47"
+			"revision": "7e4b007599d4e2076d9a81be723b3912852dda2c",
+			"revisionTime": "2017-04-18T07:21:50Z"
 		},
 		{
 			"checksumSHA1": "yicZ9OtLcy3iCgraWO015yeoO5E=",

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -157,8 +157,10 @@ The supported built-in functions are:
   * `chomp(string)` - Removes trailing newlines from the given string.
 
   * `cidrhost(iprange, hostnum)` - Takes an IP address range in CIDR notation
-    and creates an IP address with the given host number. For example,
-    `cidrhost("10.0.0.0/8", 2)` returns `10.0.0.2`.
+    and creates an IP address with the given host number. If given host
+    number is negative, the count starts from the end of the range.
+    For example, `cidrhost("10.0.0.0/8", 2)` returns `10.0.0.2` and
+    `cidrhost("10.0.0.0/8", -2)` returns `10.255.255.254`.
 
   * `cidrnetmask(iprange)` - Takes an IP address range in CIDR notation
     and returns the address-formatted subnet mask format that some


### PR DESCRIPTION
Changed the interpolation function `cidrhost()`.

The expected behavior, which is also demonstrated in the test code, is as follows:
Given CIDR range and a negative number, get IP address from the end of the range.

Say the CIDR range is `168.192.0.0/24`.
`-1` will gives you `168.192.0.255` (the last address), or `-256` will `168.192.0.0`. In this sense, giving `-257` will be an error because it's out of the range.

| num | num from end | IP            |
|----:|-------------:|:--------------|
|   0 |          256 | 168.192.0.0   |
|   1 |          255 | 168.192.0.1   |
| ... |          ... | ...           |
| 254 |            2 | 168.192.0.254 |
| 255 |            1 | 168.192.0.255 |

C.f.; https://github.com/apparentlymart/go-cidr/pull/2