### PR TITLE
provider/aws: Fix WAF IPSet descriptors removal on update

### DIFF
--- a/builtin/providers/aws/resource_aws_waf_ipset.go
+++ b/builtin/providers/aws/resource_aws_waf_ipset.go
@@ -80,17 +80,17 @@ func resourceAwsWafIPSetRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	var IPSetDescriptors []map[string]interface{}
+	var descriptors []map[string]interface{}
 
-	for _, IPSetDescriptor := range resp.IPSet.IPSetDescriptors {
-		IPSet := map[string]interface{}{
-			"type":  *IPSetDescriptor.Type,
-			"value": *IPSetDescriptor.Value,
+	for _, descriptor := range resp.IPSet.IPSetDescriptors {
+		d := map[string]interface{}{
+			"type":  *descriptor.Type,
+			"value": *descriptor.Value,
 		}
-		IPSetDescriptors = append(IPSetDescriptors, IPSet)
+		descriptors = append(descriptors, d)
 	}
 
-	d.Set("ip_set_descriptors", IPSetDescriptors)
+	d.Set("ip_set_descriptors", descriptors)
 
 	d.Set("name", resp.IPSet.Name)
 
@@ -98,7 +98,12 @@ func resourceAwsWafIPSetRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceAwsWafIPSetUpdate(d *schema.ResourceData, meta interface{}) error {
-	err := updateIPSetResource(d, meta, waf.ChangeActionInsert)
+	conn := meta.(*AWSClient).wafconn
+
+	o, n := d.GetChange("ip_set_descriptors")
+	oldD, newD := o.(*schema.Set).List(), n.(*schema.Set).List()
+
+	err := updateWafIpSetDescriptors(d.Id(), oldD, newD, conn)
 	if err != nil {
 		return fmt.Errorf("Error Updating WAF IPSet: %s", err)
 	}
@@ -107,9 +112,13 @@ func resourceAwsWafIPSetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceAwsWafIPSetDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
-	err := updateIPSetResource(d, meta, waf.ChangeActionDelete)
+
+	oldDescriptors := d.Get("ip_set_descriptors").(*schema.Set).List()
+	noDescriptors := []interface{}{}
+
+	err := updateWafIpSetDescriptors(d.Id(), oldDescriptors, noDescriptors, conn)
 	if err != nil {
-		return fmt.Errorf("Error Removing IPSetDescriptors: %s", err)
+		return fmt.Errorf("Error updating IPSetDescriptors: %s", err)
 	}
 
 	wr := newWafRetryer(conn, "global")
@@ -128,29 +137,15 @@ func resourceAwsWafIPSetDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func updateIPSetResource(d *schema.ResourceData, meta interface{}, ChangeAction string) error {
-	conn := meta.(*AWSClient).wafconn
-
+func updateWafIpSetDescriptors(id string, oldD, newD []interface{}, conn *waf.WAF) error {
 	wr := newWafRetryer(conn, "global")
 	_, err := wr.RetryWithToken(func(token *string) (interface{}, error) {
 		req := &waf.UpdateIPSetInput{
 			ChangeToken: token,
-			IPSetId:     aws.String(d.Id()),
+			IPSetId:     aws.String(id),
+			Updates:     diffWafIpSetDescriptors(oldD, newD),
 		}
-
-		IPSetDescriptors := d.Get("ip_set_descriptors").(*schema.Set)
-		for _, IPSetDescriptor := range IPSetDescriptors.List() {
-			IPSet := IPSetDescriptor.(map[string]interface{})
-			IPSetUpdate := &waf.IPSetUpdate{
-				Action: aws.String(ChangeAction),
-				IPSetDescriptor: &waf.IPSetDescriptor{
-					Type:  aws.String(IPSet["type"].(string)),
-					Value: aws.String(IPSet["value"].(string)),
-				},
-			}
-			req.Updates = append(req.Updates, IPSetUpdate)
-		}
-
+		log.Printf("[INFO] Updating IPSet descriptors: %s", req)
 		return conn.UpdateIPSet(req)
 	})
 	if err != nil {
@@ -158,4 +153,38 @@ func updateIPSetResource(d *schema.ResourceData, meta interface{}, ChangeAction 
 	}
 
 	return nil
+}
+
+func diffWafIpSetDescriptors(oldD, newD []interface{}) []*waf.IPSetUpdate {
+	updates := make([]*waf.IPSetUpdate, 0)
+
+	for _, od := range oldD {
+		descriptor := od.(map[string]interface{})
+
+		if idx, contains := sliceContainsMap(newD, descriptor); contains {
+			newD = append(newD[:idx], newD[idx+1:]...)
+			continue
+		}
+
+		updates = append(updates, &waf.IPSetUpdate{
+			Action: aws.String(waf.ChangeActionDelete),
+			IPSetDescriptor: &waf.IPSetDescriptor{
+				Type:  aws.String(descriptor["type"].(string)),
+				Value: aws.String(descriptor["value"].(string)),
+			},
+		})
+	}
+
+	for _, nd := range newD {
+		descriptor := nd.(map[string]interface{})
+
+		updates = append(updates, &waf.IPSetUpdate{
+			Action: aws.String(waf.ChangeActionInsert),
+			IPSetDescriptor: &waf.IPSetDescriptor{
+				Type:  aws.String(descriptor["type"].(string)),
+				Value: aws.String(descriptor["value"].(string)),
+			},
+		})
+	}
+	return updates
 }

--- a/builtin/providers/aws/resource_aws_waf_ipset_test.go
+++ b/builtin/providers/aws/resource_aws_waf_ipset_test.go
@@ -138,6 +138,29 @@ func TestAccAWSWafIPSet_changeDescriptors(t *testing.T) {
 	})
 }
 
+func TestAccAWSWafIPSet_noDescriptors(t *testing.T) {
+	var ipset waf.IPSet
+	ipsetName := fmt.Sprintf("ip-set-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafIPSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafIPSetConfig_noDescriptors(ipsetName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafIPSetExists("aws_waf_ipset.ipset", &ipset),
+					resource.TestCheckResourceAttr(
+						"aws_waf_ipset.ipset", "name", ipsetName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_ipset.ipset", "ip_set_descriptors.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestDiffWafIpSetDescriptors(t *testing.T) {
 	testCases := []struct {
 		Old             []interface{}
@@ -367,5 +390,11 @@ func testAccAWSWafIPSetConfigChangeIPSetDescriptors(name string) string {
     type = "IPV4"
     value = "192.0.8.0/24"
   }
+}`, name)
+}
+
+func testAccAWSWafIPSetConfig_noDescriptors(name string) string {
+	return fmt.Sprintf(`resource "aws_waf_ipset" "ipset" {
+  name = "%s"
 }`, name)
 }

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -2017,3 +2017,13 @@ func buildLambdaInvokeArn(lambdaArn, region string) string {
 	return fmt.Sprintf("arn:aws:apigateway:%s:lambda:path/%s/functions/%s/invocations",
 		region, apiVersion, lambdaArn)
 }
+
+func sliceContainsMap(l []interface{}, m map[string]interface{}) (int, bool) {
+	for i, t := range l {
+		if reflect.DeepEqual(m, t.(map[string]interface{})) {
+			return i, true
+		}
+	}
+
+	return -1, false
+}


### PR DESCRIPTION
Closes https://github.com/hashicorp/terraform/issues/10403
Closes https://github.com/hashicorp/terraform/issues/10914

Before this patch we were never deleting descriptors from the IPSet except when deleting the whole IPSet. We were always just inserting more.

Fortunately because the `Read()` is implemented correctly we keep track of all descriptors, including the ones that user wanted to delete, but weren't deleted. That is how users can recover from the buggy state as we can just delete descriptors we know about.

TL;DR It should be sufficient to just re-apply after the bugfix was released to recover.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSWafIPSet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/19 14:05:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSWafIPSet_ -timeout 120m
=== RUN   TestAccAWSWafIPSet_basic
--- PASS: TestAccAWSWafIPSet_basic (58.86s)
=== RUN   TestAccAWSWafIPSet_disappears
--- PASS: TestAccAWSWafIPSet_disappears (60.86s)
=== RUN   TestAccAWSWafIPSet_changeNameForceNew
--- PASS: TestAccAWSWafIPSet_changeNameForceNew (119.98s)
=== RUN   TestAccAWSWafIPSet_changeDescriptors
--- PASS: TestAccAWSWafIPSet_changeDescriptors (97.32s)
=== RUN   TestAccAWSWafIPSet_noDescriptors
--- PASS: TestAccAWSWafIPSet_noDescriptors (36.35s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	373.406s
```

cc @yusukegoto I think the same bugs exists in [your PR](https://github.com/hashicorp/terraform/pull/13705) too, so feel free to cherry-pick from here.

btw. I believe there's very similar bug affecting byte match set which I plan to fix too.