### PR TITLE
`roles` deprecated in examples

### DIFF
--- a/examples/aws-ecs-alb/main.tf
+++ b/examples/aws-ecs-alb/main.tf
@@ -249,7 +249,7 @@ EOF
 
 resource "aws_iam_instance_profile" "app" {
   name  = "tf-ecs-instprofile"
-  roles = ["${aws_iam_role.app_instance.name}"]
+  role = "${aws_iam_role.app_instance.name}"
 }
 
 resource "aws_iam_role" "app_instance" {


### PR DESCRIPTION
`roles` deprecated in examples/aws-ecs-alb/main.tf.