### PR TITLE
Fixing TestAccAWSInstance_multipleRegions

### DIFF
--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -367,7 +367,10 @@ func testProviderFactories(c TestCase) (map[string]terraform.ResourceProviderFac
 	for k, pf := range ctxProviders {
 		// we can ignore any errors here, if we don't have a provider to reset
 		// the error will be handled later
-		p, _ := pf()
+		p, err := pf()
+		if err != nil {
+			return nil, err
+		}
 		if p, ok := p.(TestProvider); ok {
 			err := p.TestReset()
 			if err != nil {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -354,19 +354,13 @@ func Test(t TestT, c TestCase) {
 // Any errors are stored so that they can be returned by the factory in
 // terraform to match non-test behavior.
 func testProviderFactories(c TestCase) (map[string]terraform.ResourceProviderFactory, error) {
-	ctxProviders := make(map[string]terraform.ResourceProviderFactory)
-
+	ctxProviders := c.ProviderFactories // make(map[string]terraform.ResourceProviderFactory)
+	if ctxProviders == nil {
+		ctxProviders = make(map[string]terraform.ResourceProviderFactory)
+	}
 	// add any fixed providers
 	for k, p := range c.Providers {
 		ctxProviders[k] = terraform.ResourceProviderFactoryFixed(p)
-	}
-
-	// call any factory functions and store the result.
-	for k, pf := range c.ProviderFactories {
-		p, err := pf()
-		ctxProviders[k] = func() (terraform.ResourceProvider, error) {
-			return p, err
-		}
 	}
 
 	// reset the providers if needed


### PR DESCRIPTION
This PR fixes `TestAccAWSInstance_multipleRegions`

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSInstance_multipleRegions'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/19 09:12:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSInstance_multipleRegions -timeout 120m
=== RUN   TestAccAWSInstance_multipleRegions
--- PASS: TestAccAWSInstance_multipleRegions (122.17s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	122.215s
```