### PR TITLE
Fix govet errors

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -334,11 +334,11 @@ func testAccCheckDigitalOceanDropletAttributes(droplet *godo.Droplet) resource.T
 		}
 
 		if droplet.Size.PriceHourly != 0.00744 {
-			return fmt.Errorf("Bad price_hourly: %s", droplet.Size.PriceHourly)
+			return fmt.Errorf("Bad price_hourly: %v", droplet.Size.PriceHourly)
 		}
 
 		if droplet.Size.PriceMonthly != 5.0 {
-			return fmt.Errorf("Bad price_monthly: %s", droplet.Size.PriceMonthly)
+			return fmt.Errorf("Bad price_monthly: %v", droplet.Size.PriceMonthly)
 		}
 
 		if droplet.Region.Slug != "nyc3" {

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -1664,7 +1664,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		// validate version
-		log.Printf("[DEBUG] Validating Fastly Service (%s), Version (%s)", d.Id(), latestVersion)
+		log.Printf("[DEBUG] Validating Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
 		valid, msg, err := conn.ValidateVersion(&gofastly.ValidateVersionInput{
 			Service: d.Id(),
 			Version: latestVersion,
@@ -1678,7 +1678,7 @@ func resourceServiceV1Update(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("[ERR] Invalid configuration for Fastly Service (%s): %s", d.Id(), msg)
 		}
 
-		log.Printf("[DEBUG] Activating Fastly Service (%s), Version (%s)", d.Id(), latestVersion)
+		log.Printf("[DEBUG] Activating Fastly Service (%s), Version (%v)", d.Id(), latestVersion)
 		_, err = conn.ActivateVersion(&gofastly.ActivateVersionInput{
 			Service: d.Id(),
 			Version: latestVersion,
@@ -1735,7 +1735,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			d.Set("default_host", settings.DefaultHost)
 			d.Set("default_ttl", settings.DefaultTTL)
 		} else {
-			return fmt.Errorf("[ERR] Error looking up Version settings for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Version settings for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		// TODO: update go-fastly to support an ActiveVersion struct, which contains
@@ -1748,7 +1748,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Domains for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Domains for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		// Refresh Domains
@@ -1766,7 +1766,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Backends for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Backends for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		bl := flattenBackends(backendList)
@@ -1783,7 +1783,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Headers for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Headers for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		hl := flattenHeaders(headerList)
@@ -1800,7 +1800,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Gzips for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Gzips for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		gl := flattenGzips(gzipsList)
@@ -1817,7 +1817,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Healthcheck for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Healthcheck for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		hcl := flattenHealthchecks(healthcheckList)
@@ -1834,7 +1834,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up S3 Logging for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up S3 Logging for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		sl := flattenS3s(s3List)
@@ -1851,7 +1851,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Papertrail for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Papertrail for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		pl := flattenPapertrails(papertrailList)
@@ -1868,7 +1868,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Sumologic for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Sumologic for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		sul := flattenSumologics(sumologicList)
@@ -1884,7 +1884,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Response Object for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Response Object for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		rol := flattenResponseObjects(responseObjectList)
@@ -1901,7 +1901,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Conditions for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Conditions for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		cl := flattenConditions(conditionList)
@@ -1918,7 +1918,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Request Settings for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Request Settings for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		rl := flattenRequestSettings(rsList)
@@ -1934,7 +1934,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			Version: s.ActiveVersion.Number,
 		})
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up VCLs for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up VCLs for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		vl := flattenVCLs(vclList)
@@ -1950,7 +1950,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 			Version: s.ActiveVersion.Number,
 		})
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Cache Settings for (%s), version (%d): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Cache Settings for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		csl := flattenCacheSettings(cslList)


### PR DESCRIPTION
More vet errors as #13122 is still an issue :(

---
```
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go:337: arg droplet.Size.PriceHourly for printf verb %s of wrong type: float64
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go:341: arg droplet.Size.PriceMonthly for printf verb %s of wrong type: float64
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1667: arg latestVersion for printf verb %s of wrong type: int
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1681: arg latestVersion for printf verb %s of wrong type: int
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1738: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1751: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1769: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1786: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1803: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1820: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1837: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1854: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1871: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1887: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1904: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1921: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1937: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
/opt/gopath/src/github.com/hashicorp/terraform/builtin/providers/fastly/resource_fastly_service_v1.go:1953: arg s.ActiveVersion.Number for printf verb %d of wrong type: string
```