### PR TITLE
improve resource.WaitForState and add refreshGracePeriod

### DIFF
--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -114,20 +114,19 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 
 			// If we're waiting for the absence of a thing, then return
 			if res == nil && len(conf.Target) == 0 {
-				targetOccurence += 1
+				targetOccurence++
 				if conf.ContinuousTargetOccurence == targetOccurence {
 					result.Done = true
 					resCh <- result
 					return
-				} else {
-					continue
 				}
+				continue
 			}
 
 			if res == nil {
 				// If we didn't find the resource, check if we have been
 				// not finding it for awhile, and if so, report an error.
-				notfoundTick += 1
+				notfoundTick++
 				if notfoundTick > conf.NotFoundChecks {
 					result.Error = &NotFoundError{
 						LastError: err,
@@ -144,14 +143,13 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 				for _, allowed := range conf.Target {
 					if currentState == allowed {
 						found = true
-						targetOccurence += 1
+						targetOccurence++
 						if conf.ContinuousTargetOccurence == targetOccurence {
 							result.Done = true
 							resCh <- result
 							return
-						} else {
-							continue
 						}
+						continue
 					}
 				}
 
@@ -237,7 +235,7 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 					}
 
 					if !ok {
-						// the the goroutine returned
+						// the goroutine returned
 						break forSelect
 					}
 

--- a/helper/resource/state_test.go
+++ b/helper/resource/state_test.go
@@ -147,6 +147,12 @@ func TestWaitForState_inconsistent_negative(t *testing.T) {
 }
 
 func TestWaitForState_timeout(t *testing.T) {
+	old := refreshGracePeriod
+	refreshGracePeriod = 5 * time.Millisecond
+	defer func() {
+		refreshGracePeriod = old
+	}()
+
 	conf := &StateChangeConf{
 		Pending: []string{"pending", "incomplete"},
 		Target:  []string{"running"},

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -25,6 +25,21 @@ func TestRetry(t *testing.T) {
 	}
 }
 
+// make sure a slow StateRefreshFunc is allowed to complete after timeout
+func TestRetry_grace(t *testing.T) {
+	t.Parallel()
+
+	f := func() *RetryError {
+		time.Sleep(1 * time.Second)
+		return nil
+	}
+
+	err := Retry(10*time.Millisecond, f)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestRetry_timeout(t *testing.T) {
 	t.Parallel()
 

--- a/helper/resource/wait_test.go
+++ b/helper/resource/wait_test.go
@@ -54,14 +54,18 @@ func TestRetry_timeout(t *testing.T) {
 }
 
 func TestRetry_hang(t *testing.T) {
-	t.Parallel()
+	old := refreshGracePeriod
+	refreshGracePeriod = 50 * time.Millisecond
+	defer func() {
+		refreshGracePeriod = old
+	}()
 
 	f := func() *RetryError {
 		time.Sleep(2 * time.Second)
 		return nil
 	}
 
-	err := Retry(1*time.Second, f)
+	err := Retry(50*time.Millisecond, f)
 	if err == nil {
 		t.Fatal("should error")
 	}


### PR DESCRIPTION
The Refresh goroutine in WaitForState was never being canceled, and could end up running until the entire process exited. Because of this situation, successful calls to refresh could happen long after the timeout is reached. This can be a serious problem when the Refresh call has side effects that need to be recorded (as is often the case when called through `resource.Retry`).

Start by making the goroutine properly cancellable, returning immediately during the wait period. 

Once the refresh goroutine can be cancelled, the case where there is a Refresh still in-flight needs to be taken care of. Because Refresh can't be cancelled directly, all we can do is wait and hope it returns in a reasonable amount of time.

Add a grace period after the timeout elapses, to wait for the function to return. 

Fixes #13617