### PR TITLE
Representation of Provider Dependencies

### DIFF
--- a/moduledeps/dependencies.go
+++ b/moduledeps/dependencies.go
@@ -1,0 +1,43 @@
+package moduledeps
+
+import (
+	"github.com/hashicorp/terraform/plugin/discovery"
+)
+
+// Providers describes a set of provider dependencies for a given module.
+//
+// Each named provider instance can have one version constraint.
+type Providers map[ProviderInstance]ProviderDependency
+
+// ProviderDependency describes the dependency for a particular provider
+// instance, including both the set of allowed versions and the reason for
+// the dependency.
+type ProviderDependency struct {
+	Versions discovery.VersionSet
+	Reason   ProviderDependencyReason
+}
+
+// ProviderDependencyReason is an enumeration of reasons why a dependency might be
+// present.
+type ProviderDependencyReason int
+
+const (
+	// ProviderDependencyExplicit means that there is an explicit "provider"
+	// block in the configuration for this module.
+	ProviderDependencyExplicit ProviderDependencyReason = iota
+
+	// ProviderDependencyImplicit means that there is no explicit "provider"
+	// block but there is at least one resource that uses this provider.
+	ProviderDependencyImplicit
+
+	// ProviderDependencyInherited is a special case of
+	// ProviderDependencyImplicit where a parent module has defined a
+	// configuration for the provider that has been inherited by at least one
+	// resource in this module.
+	ProviderDependencyInherited
+
+	// ProviderDependencyFromState means that this provider is not currently
+	// referenced by configuration at all, but some existing instances in
+	// the state still depend on it.
+	ProviderDependencyFromState
+)

--- a/moduledeps/doc.go
+++ b/moduledeps/doc.go
@@ -1,0 +1,7 @@
+// Package moduledeps contains types that can be used to describe the
+// providers required for all of the modules in a module tree.
+//
+// It does not itself contain the functionality for populating such
+// data structures; that's in Terraform core, since this package intentionally
+// does not depend on terraform core to avoid package dependency cycles.
+package moduledeps

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -1,0 +1,135 @@
+package moduledeps
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/plugin/discovery"
+)
+
+// Module represents the dependencies of a single module, as well being
+// a node in a tree of such structures representing the dependencies of
+// an entire configuration.
+type Module struct {
+	Name      string
+	Providers Providers
+	Children  []*Module
+}
+
+// WalkFunc is a callback type for use with Module.WalkTree
+type WalkFunc func(path []string, parent *Module, current *Module) error
+
+// WalkTree calls the given callback once for the receiver and then
+// once for each descendent, in an order such that parents are called
+// before their children and siblings are called in the order they
+// appear in the Children slice.
+//
+// When calling the callback, parent will be nil for the first call
+// for the receiving module, and then set to the direct parent of
+// each module for the subsequent calls.
+//
+// The path given to the callback is valid only until the callback
+// returns, after which it will be mutated and reused. Callbacks must
+// therefore copy the path slice if they wish to retain it.
+//
+// If the given callback returns an error, the walk will be aborted at
+// that point and that error returned to the caller.
+//
+// This function is not thread-safe for concurrent modifications of the
+// data structure, so it's the caller's responsibility to arrange for that
+// should it be needed.
+//
+// It is safe for a callback to modify the descendents of the "current"
+// module, including the ordering of the Children slice itself, but the
+// callback MUST NOT modify the parent module.
+func (m *Module) WalkTree(cb WalkFunc) error {
+	return walkModuleTree(make([]string, 0, 1), nil, m, cb)
+}
+
+func walkModuleTree(path []string, parent *Module, current *Module, cb WalkFunc) error {
+	path = append(path, current.Name)
+	err := cb(path, parent, current)
+	if err != nil {
+		return err
+	}
+
+	for _, child := range current.Children {
+		err := walkModuleTree(path, current, child, cb)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SortChildren sorts the Children slice into lexicographic order by
+// name, in-place.
+//
+// This is primarily useful prior to calling WalkTree so that the walk
+// will proceed in a consistent order.
+func (m *Module) SortChildren() {
+	sort.Sort(sortModules{m.Children})
+}
+
+// SortDescendents is a convenience wrapper for calling SortChildren on
+// the receiver and all of its descendent modules.
+func (m *Module) SortDescendents() {
+	m.WalkTree(func(path []string, parent *Module, current *Module) error {
+		current.SortChildren()
+		return nil
+	})
+}
+
+type sortModules struct {
+	modules []*Module
+}
+
+func (s sortModules) Len() int {
+	return len(s.modules)
+}
+
+func (s sortModules) Less(i, j int) bool {
+	cmp := strings.Compare(s.modules[i].Name, s.modules[j].Name)
+	return cmp < 0
+}
+
+func (s sortModules) Swap(i, j int) {
+	s.modules[i], s.modules[j] = s.modules[j], s.modules[i]
+}
+
+// PluginRequirements produces a PluginRequirements structure that can
+// be used with discovery.PluginMetaSet.ConstrainVersions to identify
+// suitable plugins to satisfy the module's provider dependencies.
+//
+// This method only considers the direct requirements of the receiver.
+// Use AllPluginRequirements to flatten the dependencies for the
+// entire tree of modules.
+func (m *Module) PluginRequirements() discovery.PluginRequirements {
+	ret := make(discovery.PluginRequirements)
+	for inst, dep := range m.Providers {
+		// m.Providers is keyed on provider names, such as "aws.foo".
+		// a PluginRequirements wants keys to be provider *types*, such
+		// as "aws". If there are multiple aliases for the same
+		// provider then we will flatten them into a single requirement
+		// by using Intersection to merge the version sets.
+		pty := inst.Type()
+		if existing, exists := ret[pty]; exists {
+			ret[pty] = existing.Intersection(dep.Versions)
+		} else {
+			ret[pty] = dep.Versions
+		}
+	}
+	return ret
+}
+
+// AllPluginRequirements calls PluginRequirements for the receiver and all
+// of its descendents, and merges the result into a single PluginRequirements
+// structure that would satisfy all of the modules together.
+func (m *Module) AllPluginRequirements() discovery.PluginRequirements {
+	var ret discovery.PluginRequirements
+	m.WalkTree(func(path []string, parent *Module, current *Module) error {
+		ret = ret.Merge(current.PluginRequirements())
+		return nil
+	})
+	return ret
+}

--- a/moduledeps/module_test.go
+++ b/moduledeps/module_test.go
@@ -1,0 +1,216 @@
+package moduledeps
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/hashicorp/terraform/plugin/discovery"
+)
+
+func TestModuleWalkTree(t *testing.T) {
+	type walkStep struct {
+		Path       []string
+		ParentName string
+	}
+
+	tests := []struct {
+		Root      *Module
+		WalkOrder []walkStep
+	}{
+		{
+			&Module{
+				Name:     "root",
+				Children: nil,
+			},
+			[]walkStep{
+				{
+					Path:       []string{"root"},
+					ParentName: "",
+				},
+			},
+		},
+		{
+			&Module{
+				Name: "root",
+				Children: []*Module{
+					{
+						Name: "child",
+					},
+				},
+			},
+			[]walkStep{
+				{
+					Path:       []string{"root"},
+					ParentName: "",
+				},
+				{
+					Path:       []string{"root", "child"},
+					ParentName: "root",
+				},
+			},
+		},
+		{
+			&Module{
+				Name: "root",
+				Children: []*Module{
+					{
+						Name: "child",
+						Children: []*Module{
+							{
+								Name: "grandchild",
+							},
+						},
+					},
+				},
+			},
+			[]walkStep{
+				{
+					Path:       []string{"root"},
+					ParentName: "",
+				},
+				{
+					Path:       []string{"root", "child"},
+					ParentName: "root",
+				},
+				{
+					Path:       []string{"root", "child", "grandchild"},
+					ParentName: "child",
+				},
+			},
+		},
+		{
+			&Module{
+				Name: "root",
+				Children: []*Module{
+					{
+						Name: "child1",
+						Children: []*Module{
+							{
+								Name: "grandchild1",
+							},
+						},
+					},
+					{
+						Name: "child2",
+						Children: []*Module{
+							{
+								Name: "grandchild2",
+							},
+						},
+					},
+				},
+			},
+			[]walkStep{
+				{
+					Path:       []string{"root"},
+					ParentName: "",
+				},
+				{
+					Path:       []string{"root", "child1"},
+					ParentName: "root",
+				},
+				{
+					Path:       []string{"root", "child1", "grandchild1"},
+					ParentName: "child1",
+				},
+				{
+					Path:       []string{"root", "child2"},
+					ParentName: "root",
+				},
+				{
+					Path:       []string{"root", "child2", "grandchild2"},
+					ParentName: "child2",
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			wo := test.WalkOrder
+			test.Root.WalkTree(func(path []string, parent *Module, current *Module) error {
+				if len(wo) == 0 {
+					t.Fatalf("ran out of walk steps while expecting one for %#v", path)
+				}
+				step := wo[0]
+				wo = wo[1:]
+				if got, want := path, step.Path; !reflect.DeepEqual(got, want) {
+					t.Errorf("wrong path %#v; want %#v", got, want)
+				}
+				parentName := ""
+				if parent != nil {
+					parentName = parent.Name
+				}
+				if got, want := parentName, step.ParentName; got != want {
+					t.Errorf("wrong parent name %q; want %q", got, want)
+				}
+
+				if got, want := current.Name, path[len(path)-1]; got != want {
+					t.Errorf("mismatching current.Name %q and final path element %q", got, want)
+				}
+				return nil
+			})
+		})
+	}
+}
+
+func TestModuleSortChildren(t *testing.T) {
+	m := &Module{
+		Name: "root",
+		Children: []*Module{
+			{
+				Name: "apple",
+			},
+			{
+				Name: "zebra",
+			},
+			{
+				Name: "xylophone",
+			},
+			{
+				Name: "pig",
+			},
+		},
+	}
+
+	m.SortChildren()
+
+	want := []string{"apple", "pig", "xylophone", "zebra"}
+	var got []string
+	for _, c := range m.Children {
+		got = append(got, c.Name)
+	}
+
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("wrong order %#v; want %#v", want, got)
+	}
+}
+
+func TestModulePluginRequirements(t *testing.T) {
+	m := &Module{
+		Name: "root",
+		Providers: Providers{
+			"foo": ProviderDependency{
+				Versions: discovery.ConstraintStr(">=1.0.0").MustParse(),
+			},
+			"foo.bar": ProviderDependency{
+				Versions: discovery.ConstraintStr(">=2.0.0").MustParse(),
+			},
+			"baz": ProviderDependency{
+				Versions: discovery.ConstraintStr(">=3.0.0").MustParse(),
+			},
+		},
+	}
+
+	reqd := m.PluginRequirements()
+	if len(reqd) != 2 {
+		t.Errorf("wrong number of elements in %#v; want 2", reqd)
+	}
+	if got, want := reqd["foo"].String(), ">=1.0.0,>=2.0.0"; got != want {
+		t.Errorf("wrong combination of versions for 'foo' %q; want %q", got, want)
+	}
+	if got, want := reqd["baz"].String(), ">=3.0.0"; got != want {
+		t.Errorf("wrong combination of versions for 'baz' %q; want %q", got, want)
+	}
+}

--- a/moduledeps/provider.go
+++ b/moduledeps/provider.go
@@ -1,0 +1,30 @@
+package moduledeps
+
+import (
+	"strings"
+)
+
+// ProviderInstance describes a particular provider instance by its full name,
+// like "null" or "aws.foo".
+type ProviderInstance string
+
+// Type returns the provider type of this instance. For example, for an instance
+// named "aws.foo" the type is "aws".
+func (p ProviderInstance) Type() string {
+	t := string(p)
+	if dotPos := strings.Index(t, "."); dotPos != -1 {
+		t = t[:dotPos]
+	}
+	return t
+}
+
+// Alias returns the alias of this provider, if any. An instance named "aws.foo"
+// has the alias "foo", while an instance named just "docker" has no alias,
+// so the empty string would be returned.
+func (p ProviderInstance) Alias() string {
+	t := string(p)
+	if dotPos := strings.Index(t, "."); dotPos != -1 {
+		return t[dotPos+1:]
+	}
+	return ""
+}

--- a/moduledeps/provider_test.go
+++ b/moduledeps/provider_test.go
@@ -1,0 +1,36 @@
+package moduledeps
+
+import (
+	"testing"
+)
+
+func TestProviderInstance(t *testing.T) {
+	tests := []struct {
+		Name      string
+		WantType  string
+		WantAlias string
+	}{
+		{
+			Name:      "aws",
+			WantType:  "aws",
+			WantAlias: "",
+		},
+		{
+			Name:      "aws.foo",
+			WantType:  "aws",
+			WantAlias: "foo",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			inst := ProviderInstance(test.Name)
+			if got, want := inst.Type(), test.WantType; got != want {
+				t.Errorf("got type %q; want %q", got, want)
+			}
+			if got, want := inst.Alias(), test.WantAlias; got != want {
+				t.Errorf("got alias %q; want %q", got, want)
+			}
+		})
+	}
+}

--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -157,7 +157,7 @@ func ResolvePluginPaths(paths []string) PluginMetaSet {
 
 		s.Add(PluginMeta{
 			Name:    name,
-			Version: version,
+			Version: VersionStr(version),
 			Path:    path,
 		})
 		found[nameVersion{name, version}] = struct{}{}

--- a/plugin/discovery/meta.go
+++ b/plugin/discovery/meta.go
@@ -4,8 +4,6 @@ import (
 	"crypto/sha256"
 	"io"
 	"os"
-
-	"github.com/blang/semver"
 )
 
 // PluginMeta is metadata about a plugin, useful for launching the plugin
@@ -16,19 +14,12 @@ type PluginMeta struct {
 	Name string
 
 	// Version is the semver version of the plugin, expressed as a string
-	// that might not be semver-valid. (Call VersionObj to attempt to
-	// parse it and thus detect if it is invalid.)
-	Version string
+	// that might not be semver-valid.
+	Version VersionStr
 
 	// Path is the absolute path of the executable that can be launched
 	// to provide the RPC server for this plugin.
 	Path string
-}
-
-// VersionObj returns the semver version of the plugin as an object, or
-// an error if the version string is not semver-syntax-compliant.
-func (m PluginMeta) VersionObj() (semver.Version, error) {
-	return semver.Make(m.Version)
 }
 
 // SHA256 returns a SHA256 hash of the content of the referenced executable

--- a/plugin/discovery/meta_set_test.go
+++ b/plugin/discovery/meta_set_test.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"testing"
-
-	"github.com/blang/semver"
 )
 
 func TestPluginMetaSetManipulation(t *testing.T) {
@@ -264,13 +262,13 @@ func TestPluginMetaSetNewest(t *testing.T) {
 			for _, version := range test.versions {
 				s.Add(PluginMeta{
 					Name:    "foo",
-					Version: version,
+					Version: VersionStr(version),
 					Path:    "foo-V" + version,
 				})
 			}
 
 			newest := s.Newest()
-			if newest.Version != test.want {
+			if newest.Version != VersionStr(test.want) {
 				t.Errorf("version is %q; want %q", newest.Version, test.want)
 			}
 		})
@@ -311,11 +309,11 @@ func TestPluginMetaSetConstrainVersions(t *testing.T) {
 		s.Add(p)
 	}
 
-	byName := s.ConstrainVersions(map[string]semver.Range{
-		"foo": semver.MustParseRange(">=2.0.0"),
-		"bar": semver.MustParseRange(">=0.0.0"),
-		"baz": semver.MustParseRange(">=1.0.0"),
-		"fun": semver.MustParseRange(">5.0.0"),
+	byName := s.ConstrainVersions(PluginRequirements{
+		"foo": ConstraintStr(">=2.0.0").MustParse(),
+		"bar": ConstraintStr(">=0.0.0").MustParse(),
+		"baz": ConstraintStr(">=1.0.0").MustParse(),
+		"fun": ConstraintStr(">5.0.0").MustParse(),
 	})
 	if got, want := len(byName), 3; got != want {
 		t.Errorf("%d keys in map; want %d", got, want)

--- a/plugin/discovery/requirements.go
+++ b/plugin/discovery/requirements.go
@@ -1,0 +1,26 @@
+package discovery
+
+// PluginRequirements describes a set of plugins (assumed to be of a consistent
+// kind) that are required to exist and have versions within the given
+// corresponding sets.
+//
+// PluginRequirements is a map from plugin name to VersionSet.
+type PluginRequirements map[string]VersionSet
+
+// Merge takes the contents of the receiver and the other given requirements
+// object and merges them together into a single requirements structure
+// that satisfies both sets of requirements.
+func (r PluginRequirements) Merge(other PluginRequirements) PluginRequirements {
+	ret := make(PluginRequirements)
+	for n, vs := range r {
+		ret[n] = vs
+	}
+	for n, vs := range other {
+		if existing, exists := ret[n]; exists {
+			ret[n] = existing.Intersection(vs)
+		} else {
+			ret[n] = vs
+		}
+	}
+	return ret
+}

--- a/plugin/discovery/version.go
+++ b/plugin/discovery/version.go
@@ -1,0 +1,37 @@
+package discovery
+
+import (
+	version "github.com/hashicorp/go-version"
+)
+
+// A VersionStr is a string containing a possibly-invalid representation
+// of a semver version number. Call Parse on it to obtain a real Version
+// object, or discover that it is invalid.
+type VersionStr string
+
+// Parse transforms a VersionStr into a Version if it is
+// syntactically valid. If it isn't then an error is returned instead.
+func (s VersionStr) Parse() (Version, error) {
+	raw, err := version.NewVersion(string(s))
+	if err != nil {
+		return Version{}, err
+	}
+	return Version{raw}, nil
+}
+
+// Version represents a version number that has been parsed from
+// a semver string and known to be valid.
+type Version struct {
+	// We wrap this here just because it avoids a proliferation of
+	// direct go-version imports all over the place, and keeps the
+	// version-processing details within this package.
+	raw *version.Version
+}
+
+func (v Version) String() string {
+	return v.raw.String()
+}
+
+func (v Version) newerThan(other Version) bool {
+	return v.raw.GreaterThan(other.raw)
+}

--- a/plugin/discovery/version_set.go
+++ b/plugin/discovery/version_set.go
@@ -1,0 +1,64 @@
+package discovery
+
+import (
+	version "github.com/hashicorp/go-version"
+)
+
+// A ConstraintStr is a string containing a possibly-invalid representation
+// of a version constraint provided in configuration. Call Parse on it to
+// obtain a real Constraint object, or discover that it is invalid.
+type ConstraintStr string
+
+// Parse transforms a ConstraintStr into a VersionSet if it is
+// syntactically valid. If it isn't then an error is returned instead.
+func (s ConstraintStr) Parse() (VersionSet, error) {
+	raw, err := version.NewConstraint(string(s))
+	if err != nil {
+		return VersionSet{}, err
+	}
+	return VersionSet{raw}, nil
+}
+
+// MustParse is like Parse but it panics if the constraint string is invalid.
+func (s ConstraintStr) MustParse() VersionSet {
+	ret, err := s.Parse()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+// VersionSet represents a set of versions which any given Version is either
+// a member of or not.
+type VersionSet struct {
+	// Internally a version set is actually a list of constraints that
+	// *remove* versions from the set. Thus a VersionSet with an empty
+	// Constraints list would be one that contains *all* versions.
+	raw version.Constraints
+}
+
+// Has returns true if the given version is in the receiving set.
+func (s VersionSet) Has(v Version) bool {
+	return s.raw.Check(v.raw)
+}
+
+// Intersection combines the receving set with the given other set to produce a
+// set that is the intersection of both sets, which is to say that it contains
+// only the versions that are members of both sets.
+func (s VersionSet) Intersection(other VersionSet) VersionSet {
+	raw := make(version.Constraints, 0, len(s.raw)+len(other.raw))
+
+	// Since "raw" is a list of constraints that remove versions from the set,
+	// "Intersection" is implemented by concatenating together those lists,
+	// thus leaving behind only the versions not removed by either list.
+	raw = append(raw, s.raw...)
+	raw = append(raw, other.raw...)
+
+	return VersionSet{raw}
+}
+
+// String returns a string representation of the set members as a set
+// of range constraints.
+func (s VersionSet) String() string {
+	return s.raw.String()
+}

--- a/plugin/discovery/version_set_test.go
+++ b/plugin/discovery/version_set_test.go
@@ -1,0 +1,64 @@
+package discovery
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestVersionSet(t *testing.T) {
+	tests := []struct {
+		ConstraintStr string
+		VersionStr    string
+		ShouldHave    bool
+	}{
+		// These test cases are not exhaustive since the underlying go-version
+		// library is well-tested. This is mainly here just to exercise our
+		// wrapper code, but also used as an opportunity to cover some basic
+		// but important cases such as the ~> constraint so that we'll be more
+		// likely to catch any accidental breaking behavior changes in the
+		// underlying library.
+		{
+			">=1.0.0",
+			"1.0.0",
+			true,
+		},
+		{
+			">=1.0.0",
+			"0.0.0",
+			false,
+		},
+		{
+			">=1.0.0",
+			"1.1.0-beta1",
+			true,
+		},
+		{
+			"~>1.1.0",
+			"1.1.2-beta1",
+			true,
+		},
+		{
+			"~>1.1.0",
+			"1.2.0",
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s has %s", test.ConstraintStr, test.VersionStr), func(t *testing.T) {
+			accepted, err := ConstraintStr(test.ConstraintStr).Parse()
+			if err != nil {
+				t.Fatalf("unwanted error parsing constraints string %q: %s", test.ConstraintStr, err)
+			}
+
+			version, err := VersionStr(test.VersionStr).Parse()
+			if err != nil {
+				t.Fatalf("unwanted error parsing version string %q: %s", test.VersionStr, err)
+			}
+
+			if got, want := accepted.Has(version), test.ShouldHave; got != want {
+				t.Errorf("Has returned %#v; want %#v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
While working on the refactoring of how we think about provider dependencies in core I decided to hoist a bunch of model-level code out into a separate package called `moduledeps` to make it easier to understand rather than it getting lost inside all the other complexity of the `terraform` package. (It's called `moduledeps` under the assumption that modules might get to depend on other things later, such as provisioners, and this package would grow to represent those dependencies too.)

The goal of representing the dependencies in this much detail (even though we ultimately just need the flattened map from plugin to constraint) is to allow us to give good, contextual feedback to the user when dependencies cannot be resolved due to conflicts. That's not used yet by anything I'm working on, but I expect it will be useful in the auto-install code in `terraform init` when we want to explain to a user -- in an actionable way -- why a given situation is not resolvable.

As part of doing this I also reorganized `plugin/discovery` to use `go-version` rather than `semver` so that we can support pessimistic dependencies (`~>`). After seeing how much package dependency noise was being created by the use of the `semver` types before, I also took this opportunity to wrap the `go-version` types in local types to present a lighter interface to callers of this package, hiding the implementation details.

These two parts are split into separate commits, so it may prove easier to review them both separately.

I have some other code, *not* included in this PR, that produces a dependency tree like this given a `module.Tree` and a `terraform.InstanceState`. The result is then used to resolve provider plugins using the version information. I've left this out of here because I've not yet finished reworking it for `moduledeps` being a separate package; I will continue with that tomorrow.
