### PR TITLE
provider/rabbitmq: Allow users without tags

### DIFF
--- a/website/source/docs/providers/rabbitmq/r/user.html.markdown
+++ b/website/source/docs/providers/rabbitmq/r/user.html.markdown
@@ -32,7 +32,7 @@ The following arguments are supported:
 * `password` - (Required) The password of the user. The value of this argument
   is plain-text so make sure to secure where this is defined.
 
-* `tags` - (Required) Which permission model to apply to the user. Valid
+* `tags` - (Optional) Which permission model to apply to the user. Valid
   options are: management, policymaker, monitoring, and administrator.
 
 ## Attributes Reference


### PR DESCRIPTION
This commit makes the tags attribute optional for users. It also
handles cases when a user defines a tag as an empty string ("").

Fixes #12296