### PR TITLE
provider/logentries: Refresh from state when resources not found

### DIFF
--- a/builtin/providers/logentries/resource_logentries_log.go
+++ b/builtin/providers/logentries/resource_logentries_log.go
@@ -2,9 +2,12 @@ package logentries
 
 import (
 	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	logentries "github.com/logentries/le_goclient"
-	"strconv"
 )
 
 func resourceLogentriesLog() *schema.Resource {
@@ -16,25 +19,25 @@ func resourceLogentriesLog() *schema.Resource {
 		Delete: resourceLogentriesLogDelete,
 
 		Schema: map[string]*schema.Schema{
-			"token": &schema.Schema{
+			"token": {
 				Type:     schema.TypeString,
 				Computed: true,
 				ForceNew: true,
 			},
-			"logset_id": &schema.Schema{
+			"logset_id": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"filename": &schema.Schema{
+			"filename": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"retention_period": &schema.Schema{
+			"retention_period": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "ACCOUNT_DEFAULT",
@@ -47,7 +50,7 @@ func resourceLogentriesLog() *schema.Resource {
 					return
 				},
 			},
-			"source": &schema.Schema{
+			"source": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Default:  "token",
@@ -60,7 +63,7 @@ func resourceLogentriesLog() *schema.Resource {
 					return
 				},
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Default:  "",
 				Optional: true,
@@ -100,6 +103,11 @@ func resourceLogentriesLogRead(d *schema.ResourceData, meta interface{}) error {
 		Key:       d.Id(),
 	})
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			log.Printf("Logentries Log Not Found - Refreshing from State")
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 

--- a/builtin/providers/logentries/resource_logentries_logset.go
+++ b/builtin/providers/logentries/resource_logentries_logset.go
@@ -1,8 +1,11 @@
 package logentries
 
 import (
+	"log"
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/schema"
-	"github.com/logentries/le_goclient"
+	logentries "github.com/logentries/le_goclient"
 )
 
 func resourceLogentriesLogSet() *schema.Resource {
@@ -49,6 +52,11 @@ func resourceLogentriesLogSetRead(d *schema.ResourceData, meta interface{}) erro
 		Key: d.Id(),
 	})
 	if err != nil {
+		if strings.Contains(err.Error(), "No such log set") {
+			log.Printf("Logentries LogSet Not Found - Refreshing from State")
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Fixes: #13805

Before the fix:

```
Error refreshing state: 1 error(s) occurred:

* logentries_logset.logset: logentries_logset.logset: No such log set with key 278e7344-1201-43ba-9804-77b9a72fe7d6
```

After the fix:

```
% terraform plan                                                                                  ✚ ✭
[WARN] /Users/stacko/Code/go/bin/terraform-provider-logentries overrides an internal plugin for logentries-provider.
  If you did not expect to see this message you will need to remove the old plugin.
  See https://www.terraform.io/docs/internals/internal-plugins.html
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

logentries_logset.logset: Refreshing state... (ID: 278e7344-...a72fe7d6)
logentries_log.log: Refreshing state... (ID: 2ae1e8ae-...e932d25c)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ logentries_log.log
    logset_id:        "${logentries_logset.logset.id}"
    name:             "test-log"
    retention_period: "ACCOUNT_DEFAULT"
    source:           "token"
    token:            "<computed>"

+ logentries_logset.logset
    location: "nonlocation"
    name:     "testing-terraform-destroy"

Plan: 2 to add, 0 to change, 0 to destroy.
```

Test Run:

```
% make testacc TEST=./builtin/providers/logentries                                                ✚ ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/20 20:36:20 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/logentries -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccLogentriesLog_Token
--- PASS: TestAccLogentriesLog_Token (39.03s)
=== RUN   TestAccLogentriesLog_SourceApi
--- PASS: TestAccLogentriesLog_SourceApi (28.46s)
=== RUN   TestAccLogentriesLog_SourceAgent
--- PASS: TestAccLogentriesLog_SourceAgent (6.19s)
=== RUN   TestAccLogentriesLog_RetentionPeriod1M
--- PASS: TestAccLogentriesLog_RetentionPeriod1M (3.04s)
=== RUN   TestAccLogentriesLog_RetentionPeriodAccountDefault
--- PASS: TestAccLogentriesLog_RetentionPeriodAccountDefault (2.71s)
=== RUN   TestAccLogentriesLog_RetentionPeriodAccountUnlimited
--- PASS: TestAccLogentriesLog_RetentionPeriodAccountUnlimited (2.65s)
=== RUN   TestAccLogentriesLogSet_Basic
--- PASS: TestAccLogentriesLogSet_Basic (1.54s)
=== RUN   TestAccLogentriesLogSet_NoLocation
--- PASS: TestAccLogentriesLogSet_NoLocation (1.54s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/logentries	85.177s
```