### PR TITLE
config: Add 'list' to variable type error message

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1017,7 +1017,7 @@ func (v *Variable) ValidateTypeAndDefault() error {
 	// If an explicit type is declared, ensure it is valid
 	if v.DeclaredType != "" {
 		if _, ok := typeStringMap[v.DeclaredType]; !ok {
-			return fmt.Errorf("Variable '%s' must be of type string or map - '%s' is not a valid type", v.Name, v.DeclaredType)
+			return fmt.Errorf("Variable '%s' must be of type string, map, or list - '%s' is not a valid type", v.Name, v.DeclaredType)
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -1017,7 +1017,16 @@ func (v *Variable) ValidateTypeAndDefault() error {
 	// If an explicit type is declared, ensure it is valid
 	if v.DeclaredType != "" {
 		if _, ok := typeStringMap[v.DeclaredType]; !ok {
-			return fmt.Errorf("Variable '%s' must be of type string, map, or list - '%s' is not a valid type", v.Name, v.DeclaredType)
+			validTypes := []string{}
+			for k := range typeStringMap {
+				validTypes = append(validTypes, k)
+			}
+			return fmt.Errorf(
+				"Variable '%s' type must be one of [%s] - '%s' is not a valid type",
+				v.Name,
+				strings.Join(validTypes, ", "),
+				v.DeclaredType,
+			)
 		}
 	}
 

--- a/config/loader_test.go
+++ b/config/loader_test.go
@@ -684,7 +684,7 @@ func TestLoadFile_badVariableTypes(t *testing.T) {
 	}
 
 	errorStr := err.Error()
-	if !strings.Contains(errorStr, "'bad_type' must be of type string") {
+	if !strings.Contains(errorStr, "'bad_type' type must be one of") {
 		t.Fatalf("bad: expected error has wrong text: %s", errorStr)
 	}
 }


### PR DESCRIPTION
Given the following:

```tf
variable "things" {
  type = "array"
}
```

`terraform plan` displays this error message:

```tf
Variable 'things' must be of type string or map - 'array' is not a valid type
```

But `list` is what I wanted.

With this PR, it now renders as:

```
Variable 'things' type must be one of [string, map, list] - 'array' is not a valid type
```