### PR TITLE
Importability for Google DNS Managed Zone

### DIFF
--- a/builtin/providers/google/import_dns_managed_zone_test.go
+++ b/builtin/providers/google/import_dns_managed_zone_test.go
@@ -1,0 +1,28 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDnsManagedZone_importBasic(t *testing.T) {
+	resourceName := "google_dns_managed_zone.foobar"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsManagedZoneDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDnsManagedZone_basic,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_dns_managed_zone.go
+++ b/builtin/providers/google/resource_dns_managed_zone.go
@@ -14,7 +14,9 @@ func resourceDnsManagedZone() *schema.Resource {
 		Create: resourceDnsManagedZoneCreate,
 		Read:   resourceDnsManagedZoneRead,
 		Delete: resourceDnsManagedZoneDelete,
-
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 		Schema: map[string]*schema.Schema{
 			"dns_name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -109,6 +111,9 @@ func resourceDnsManagedZoneRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	d.Set("name_servers", zone.NameServers)
+	d.Set("name", zone.Name)
+	d.Set("dns_name", zone.DnsName)
+	d.Set("description", zone.Description)
 
 	return nil
 }

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -150,6 +150,7 @@ To make a resource importable, please see the
 * google_compute_instance_group_manager
 * google_compute_instance_template
 * google_compute_target_pool
+* google_dns_managed_zone
 * google_project
 
 ### OpenStack


### PR DESCRIPTION
Requested in #13416.

I removed the default description for the DNS managed zone because when I imported a manually created zone with no description it wanted to recreate it with the default terraform description. Since Description is an optional field I think it's appropriate to make it empty by default.

```
$ make test TEST=./builtin/providers/google/
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/20 17:10:57 Generated command/internal_plugin_list.go
go test -i ./builtin/providers/google/ || exit 1
echo ./builtin/providers/google/ | \
		xargs -t -n4 go test  -timeout=60s -parallel=4
go test -timeout=60s -parallel=4 ./builtin/providers/google/
ok  	github.com/hashicorp/terraform/builtin/providers/google	0.027s
```