### PR TITLE
add init -reconfigure flag

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -30,6 +30,7 @@ func (c *InitCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&c.forceInitCopy, "force-copy", false, "suppress prompts about copying state data")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
+	cmdFlags.BoolVar(&c.reconfigure, "reconfigure", false, "reconfigure")
 
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
 	if err := cmdFlags.Parse(args); err != nil {
@@ -223,6 +224,10 @@ Options:
                        times. The backend type must be in the configuration
                        itself.
 
+  -force-copy          Suppress prompts about copying state data. This is
+                       equivalent to providing a "yes" to all confirmation
+                       prompts.
+
   -get=true            Download any modules for this configuration.
 
   -input=true          Ask for input if necessary. If false, will error if
@@ -234,9 +239,7 @@ Options:
 
   -no-color            If specified, output won't contain any color.
 
-  -force-copy          Suppress prompts about copying state data. This is
-                       equivalent to providing a "yes" to all confirmation
-                       prompts.
+  -reconfigure          Reconfigure the backend, ignoring any saved configuration.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -95,6 +95,8 @@ type Meta struct {
 	//
 	// forceInitCopy suppresses confirmation for copying state data during
 	// init.
+	//
+	// reconfigure forces init to ignore any stored configuration.
 	statePath        string
 	stateOutPath     string
 	backupPath       string
@@ -104,6 +106,7 @@ type Meta struct {
 	stateLock        bool
 	stateLockTimeout time.Duration
 	forceInitCopy    bool
+	reconfigure      bool
 }
 
 // initStatePaths is used to initialize the default values for

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -352,6 +352,13 @@ func (m *Meta) backendFromConfig(opts *BackendOpts) (backend.Backend, error) {
 		s = terraform.NewState()
 	}
 
+	// if we want to force reconfiguration of the backend, we set the backend
+	// state to nil on this copy. This will direct us through the correct
+	// configuration path in the switch statement below.
+	if m.reconfigure {
+		s.Backend = nil
+	}
+
 	// Upon return, we want to set the state we're using in-memory so that
 	// we can access it for commands.
 	m.backendState = nil

--- a/website/source/docs/commands/init.html.markdown
+++ b/website/source/docs/commands/init.html.markdown
@@ -49,6 +49,9 @@ The command-line flags are all optional. The list of available flags are:
   for the backend. This can be specified multiple times. Flags specified
   later in the line override those specified earlier if they conflict.
 
+* `-force-copy` -  Suppress prompts about copying state data. This is equivalent
+  to providing a "yes" to all confirmation prompts.
+
 * `-get=true` - Download any modules for this configuration.
 
 * `-input=true` - Ask for input interactively if necessary. If this is false
@@ -60,8 +63,7 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-no-color` - If specified, output won't contain any color.
 
-* `-force-copy` -  Suppress prompts about copying state data. This is equivalent
-  to providing a "yes" to all confirmation prompts.
+* `-reconfigure` - Reconfigure the backend, ignoring any saved configuration.
 
 ## Backend Config
 


### PR DESCRIPTION
The reconfigure flag will force init to ignore any saved backend state.
This is useful when a user does not want any backend migration to
happen, or if the saved configuration can't be loaded at all for some
reason.