### PR TITLE
provider/google: Make ports in resource_compute_forwarding_rule ForceNew

### DIFF
--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -88,6 +88,7 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
+				ForceNew: true,
 				Set:      schema.HashString,
 			},
 


### PR DESCRIPTION
There's no way to change this field in the API currently, so `ForceNew` is correct.

Fixes #13820 and #13821.