### PR TITLE
provider/aws: Changing aws_opsworks_instance should ForceNew

### DIFF
--- a/builtin/providers/aws/resource_aws_opsworks_instance.go
+++ b/builtin/providers/aws/resource_aws_opsworks_instance.go
@@ -111,6 +111,7 @@ func resourceAwsOpsworksInstance() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
+				ForceNew: true,
 			},
 
 			"infrastructure_class": {

--- a/builtin/providers/aws/resource_aws_opsworks_instance_test.go
+++ b/builtin/providers/aws/resource_aws_opsworks_instance_test.go
@@ -108,6 +108,44 @@ func TestAccAWSOpsworksInstance(t *testing.T) {
 	})
 }
 
+func TestAccAWSOpsworksInstance_UpdateHostNameForceNew(t *testing.T) {
+	stackName := fmt.Sprintf("tf-%d", acctest.RandInt())
+
+	var before, after opsworks.Instance
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAwsOpsworksInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAwsOpsworksInstanceConfigCreate(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksInstanceExists("aws_opsworks_instance.tf-acc", &before),
+					resource.TestCheckResourceAttr("aws_opsworks_instance.tf-acc", "hostname", "tf-acc1"),
+				),
+			},
+			{
+				Config: testAccAwsOpsworksInstanceConfigUpdateHostName(stackName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSOpsworksInstanceExists("aws_opsworks_instance.tf-acc", &after),
+					resource.TestCheckResourceAttr("aws_opsworks_instance.tf-acc", "hostname", "tf-acc2"),
+					testAccCheckAwsOpsworksInstanceRecreated(t, &before, &after),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAwsOpsworksInstanceRecreated(t *testing.T,
+	before, after *opsworks.Instance) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before.InstanceId == *after.InstanceId {
+			t.Fatalf("Expected change of OpsWorks Instance IDs, but both were %s", *before.InstanceId)
+		}
+		return nil
+	}
+}
+
 func testAccCheckAWSOpsworksInstanceExists(
 	n string, opsinst *opsworks.Instance) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -195,6 +233,59 @@ func testAccCheckAwsOpsworksInstanceDestroy(s *terraform.State) error {
 	}
 
 	return fmt.Errorf("Fall through error on OpsWorks instance test")
+}
+
+func testAccAwsOpsworksInstanceConfigUpdateHostName(name string) string {
+	return fmt.Sprintf(`
+resource "aws_security_group" "tf-ops-acc-web" {
+  name = "%s-web"
+  ingress {
+    from_port = 80
+    to_port = 80
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "tf-ops-acc-php" {
+  name = "%s-php"
+  ingress {
+    from_port = 8080
+    to_port = 8080
+    protocol = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_opsworks_static_web_layer" "tf-acc" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-web.id}",
+  ]
+}
+
+resource "aws_opsworks_php_app_layer" "tf-acc" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+
+  custom_security_group_ids = [
+    "${aws_security_group.tf-ops-acc-php.id}",
+  ]
+}
+
+resource "aws_opsworks_instance" "tf-acc" {
+  stack_id = "${aws_opsworks_stack.tf-acc.id}"
+  layer_ids = [
+    "${aws_opsworks_static_web_layer.tf-acc.id}",
+  ]
+  instance_type = "t2.micro"
+  state = "stopped"
+  hostname = "tf-acc2"
+}
+
+%s
+
+`, name, name, testAccAwsOpsworksStackConfigVpcCreate(name))
 }
 
 func testAccAwsOpsworksInstanceConfigCreate(name string) string {


### PR DESCRIPTION
Fixes: #13838

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSOpsworksInstance_UpdateHostNameForceNew'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/21 13:11:08 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSOpsworksInstance_UpdateHostNameForceNew -timeout 120m
=== RUN   TestAccAWSOpsworksInstance_UpdateHostNameForceNew
--- PASS: TestAccAWSOpsworksInstance_UpdateHostNameForceNew (114.27s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	114.294s
```