### PR TITLE
provider/aws: Add IPv6 outputs to aws_subnet datasource

### DIFF
--- a/builtin/providers/aws/ec2_filters.go
+++ b/builtin/providers/aws/ec2_filters.go
@@ -111,11 +111,11 @@ func ec2CustomFiltersSchema() *schema.Schema {
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"name": &schema.Schema{
+				"name": {
 					Type:     schema.TypeString,
 					Required: true,
 				},
-				"values": &schema.Schema{
+				"values": {
 					Type:     schema.TypeSet,
 					Required: true,
 					Elem: &schema.Schema{

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -141,9 +141,14 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", subnet.CidrBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)
-	if subnet.Ipv6CidrBlockAssociationSet != nil {
-		d.Set("ipv6_cidr_block", subnet.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock)
-		d.Set("ipv6_cidr_block_association_id", subnet.Ipv6CidrBlockAssociationSet[0].AssociationId)
+	for _, a := range subnet.Ipv6CidrBlockAssociationSet {
+		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
+			d.Set("ipv6_cidr_block_association_id", a.AssociationId)
+			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
+		} else {
+			d.Set("ipv6_cidr_block_association_id", "") // we blank these out to remove old entries
+			d.Set("ipv6_cidr_block", "")
+		}
 	}
 	d.Set("tags", tagsToMap(subnet.Tags))
 

--- a/website/source/docs/providers/aws/d/subnet.html.markdown
+++ b/website/source/docs/providers/aws/d/subnet.html.markdown
@@ -50,6 +50,8 @@ subnet whose data will be exported as attributes.
 
 * `cidr_block` - (Optional) The cidr block of the desired subnet.
 
+* `ipv6_cidr_block` - (Optional) The Ipv6 cidr block of the desired subnet
+
 * `default_for_az` - (Optional) Boolean constraint for whether the desired
   subnet must be the default subnet for its associated availability zone.
 

--- a/website/source/docs/providers/aws/r/subnet.html.markdown
+++ b/website/source/docs/providers/aws/r/subnet.html.markdown
@@ -48,6 +48,8 @@ The following attributes are exported:
 * `availability_zone`- The AZ for the subnet.
 * `cidr_block` - The CIDR block for the subnet.
 * `vpc_id` - The VPC ID.
+* `ipv6_association_id` - The association ID for the IPv6 CIDR block.
+* `ipv6_cidr_block` - The IPv6 CIDR block.
 
 
 


### PR DESCRIPTION
Fixes: #13595

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccDataSourceAwsSubnet'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/21 13:52:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccDataSourceAwsSubnet -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs
--- PASS: TestAccDataSourceAwsSubnetIDs (81.05s)
=== RUN   TestAccDataSourceAwsSubnet
--- PASS: TestAccDataSourceAwsSubnet (57.48s)
=== RUN   TestAccDataSourceAwsSubnetIpv6ByIpv6Filter
--- PASS: TestAccDataSourceAwsSubnetIpv6ByIpv6Filter (82.63s)
=== RUN   TestAccDataSourceAwsSubnetIpv6ByIpv6CidrBlock
--- PASS: TestAccDataSourceAwsSubnetIpv6ByIpv6CidrBlock (82.43s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	303.625s
```