### PR TITLE
provider/aws: Add IPv6 outputs to aws_subnet datasource

### DIFF
--- a/builtin/providers/aws/data_source_aws_subnet_test.go
+++ b/builtin/providers/aws/data_source_aws_subnet_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
+func TestAccDataSourceAwsSubnet(t *testing.T) {
 	rInt := acctest.RandIntRange(0, 256)
 
 	resource.Test(t, resource.TestCase{
@@ -17,7 +17,7 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckVpcDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourceAwsSubnetConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_id", rInt),
@@ -25,6 +25,48 @@ func TestAccDataSourceAwsSubnet_basic(t *testing.T) {
 					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_tag", rInt),
 					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_vpc", rInt),
 					testAccDataSourceAwsSubnetCheck("data.aws_subnet.by_filter", rInt),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsSubnetIpv6ByIpv6Filter(t *testing.T) {
+	rInt := acctest.RandIntRange(0, 256)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsSubnetConfigIpv6(rInt),
+			},
+			{
+				Config: testAccDataSourceAwsSubnetConfigIpv6WithDataSourceFilter(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
+					resource.TestCheckResourceAttrSet(
+						"data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccDataSourceAwsSubnetIpv6ByIpv6CidrBlock(t *testing.T) {
+	rInt := acctest.RandIntRange(0, 256)
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceAwsSubnetConfigIpv6(rInt),
+			},
+			{
+				Config: testAccDataSourceAwsSubnetConfigIpv6WithDataSourceIpv6CidrBlock(rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet(
+						"data.aws_subnet.by_ipv6_cidr", "ipv6_cidr_block_association_id"),
 				),
 			},
 		},
@@ -103,6 +145,7 @@ func testAccDataSourceAwsSubnetConfig(rInt int) string {
 		  }
 		}
 
+
 		data "aws_subnet" "by_id" {
 		  id = "${aws_subnet.test.id}"
 		}
@@ -128,4 +171,87 @@ func testAccDataSourceAwsSubnetConfig(rInt int) string {
 		  }
 		}
 		`, rInt, rInt, rInt)
+}
+
+func testAccDataSourceAwsSubnetConfigIpv6(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.%d.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags {
+    Name = "terraform-testacc-subnet-data-source-ipv6"
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block        = "172.%d.123.0/24"
+  availability_zone = "us-west-2a"
+  ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
+
+  tags {
+    Name = "terraform-testacc-subnet-data-sourceipv6-%d"
+  }
+}
+`, rInt, rInt, rInt)
+}
+
+func testAccDataSourceAwsSubnetConfigIpv6WithDataSourceFilter(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.%d.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags {
+    Name = "terraform-testacc-subnet-data-source-ipv6"
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block        = "172.%d.123.0/24"
+  availability_zone = "us-west-2a"
+  ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
+
+  tags {
+    Name = "terraform-testacc-subnet-data-sourceipv6-%d"
+  }
+}
+
+data "aws_subnet" "by_ipv6_cidr" {
+  filter {
+    name = "ipv6-cidr-block-association.ipv6-cidr-block"
+    values = ["${aws_subnet.test.ipv6_cidr_block}"]
+  }
+}
+`, rInt, rInt, rInt)
+}
+
+func testAccDataSourceAwsSubnetConfigIpv6WithDataSourceIpv6CidrBlock(rInt int) string {
+	return fmt.Sprintf(`
+resource "aws_vpc" "test" {
+  cidr_block = "172.%d.0.0/16"
+  assign_generated_ipv6_cidr_block = true
+
+  tags {
+    Name = "terraform-testacc-subnet-data-source-ipv6"
+  }
+}
+
+resource "aws_subnet" "test" {
+  vpc_id            = "${aws_vpc.test.id}"
+  cidr_block        = "172.%d.123.0/24"
+  availability_zone = "us-west-2a"
+  ipv6_cidr_block = "${cidrsubnet(aws_vpc.test.ipv6_cidr_block, 8, 1)}"
+
+  tags {
+    Name = "terraform-testacc-subnet-data-sourceipv6-%d"
+  }
+}
+
+data "aws_subnet" "by_ipv6_cidr" {
+  ipv6_cidr_block = "${aws_subnet.test.ipv6_cidr_block}"
+}
+`, rInt, rInt, rInt)
 }

--- a/builtin/providers/aws/ec2_filters.go
+++ b/builtin/providers/aws/ec2_filters.go
@@ -111,11 +111,11 @@ func ec2CustomFiltersSchema() *schema.Schema {
 		Optional: true,
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
-				"name": &schema.Schema{
+				"name": {
 					Type:     schema.TypeString,
 					Required: true,
 				},
-				"values": &schema.Schema{
+				"values": {
 					Type:     schema.TypeSet,
 					Required: true,
 					Elem: &schema.Schema{

--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -141,9 +141,14 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("cidr_block", subnet.CidrBlock)
 	d.Set("map_public_ip_on_launch", subnet.MapPublicIpOnLaunch)
 	d.Set("assign_ipv6_address_on_creation", subnet.AssignIpv6AddressOnCreation)
-	if subnet.Ipv6CidrBlockAssociationSet != nil {
-		d.Set("ipv6_cidr_block", subnet.Ipv6CidrBlockAssociationSet[0].Ipv6CidrBlock)
-		d.Set("ipv6_cidr_block_association_id", subnet.Ipv6CidrBlockAssociationSet[0].AssociationId)
+	for _, a := range subnet.Ipv6CidrBlockAssociationSet {
+		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
+			d.Set("ipv6_cidr_block_association_id", a.AssociationId)
+			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
+		} else {
+			d.Set("ipv6_cidr_block_association_id", "") // we blank these out to remove old entries
+			d.Set("ipv6_cidr_block", "")
+		}
 	}
 	d.Set("tags", tagsToMap(subnet.Tags))
 

--- a/website/source/docs/providers/aws/d/subnet.html.markdown
+++ b/website/source/docs/providers/aws/d/subnet.html.markdown
@@ -50,6 +50,8 @@ subnet whose data will be exported as attributes.
 
 * `cidr_block` - (Optional) The cidr block of the desired subnet.
 
+* `ipv6_cidr_block` - (Optional) The Ipv6 cidr block of the desired subnet
+
 * `default_for_az` - (Optional) Boolean constraint for whether the desired
   subnet must be the default subnet for its associated availability zone.
 

--- a/website/source/docs/providers/aws/r/subnet.html.markdown
+++ b/website/source/docs/providers/aws/r/subnet.html.markdown
@@ -48,6 +48,8 @@ The following attributes are exported:
 * `availability_zone`- The AZ for the subnet.
 * `cidr_block` - The CIDR block for the subnet.
 * `vpc_id` - The VPC ID.
+* `ipv6_association_id` - The association ID for the IPv6 CIDR block.
+* `ipv6_cidr_block` - The IPv6 CIDR block.
 
 ## Import
 


### PR DESCRIPTION
Fixes: #13595

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccDataSourceAwsSubnet'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/21 13:52:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccDataSourceAwsSubnet -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs
--- PASS: TestAccDataSourceAwsSubnetIDs (81.05s)
=== RUN   TestAccDataSourceAwsSubnet
--- PASS: TestAccDataSourceAwsSubnet (57.48s)
=== RUN   TestAccDataSourceAwsSubnetIpv6ByIpv6Filter
--- PASS: TestAccDataSourceAwsSubnetIpv6ByIpv6Filter (82.63s)
=== RUN   TestAccDataSourceAwsSubnetIpv6ByIpv6CidrBlock
--- PASS: TestAccDataSourceAwsSubnetIpv6ByIpv6CidrBlock (82.43s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	303.625s
```