### PR TITLE
provider/aws: Make iam_role_attachment example not throw any errors

### DIFF
--- a/website/source/docs/providers/aws/r/iam_role_policy_attachment.markdown
+++ b/website/source/docs/providers/aws/r/iam_role_policy_attachment.markdown
@@ -13,12 +13,40 @@ Attaches a Managed IAM Policy to an IAM role
 ```hcl
 resource "aws_iam_role" "role" {
     name = "test-role"
+    assume_role_policy = <<EOF
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Action": "sts:AssumeRole",
+          "Principal": {
+            "Service": "ec2.amazonaws.com"
+          },
+          "Effect": "Allow",
+          "Sid": ""
+        }
+      ]
+    }
+EOF
 }
 
 resource "aws_iam_policy" "policy" {
     name        = "test-policy"
     description = "A test policy"
-    policy      = # omitted
+    policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
 }
 
 resource "aws_iam_role_policy_attachment" "test-attach" {


### PR DESCRIPTION
Fixes: #13398