### PR TITLE
provider/opc: Fix Instance Label / Update Docs

### DIFF
--- a/builtin/providers/opc/resource_instance.go
+++ b/builtin/providers/opc/resource_instance.go
@@ -80,6 +80,7 @@ func resourceInstance() *schema.Resource {
 			"label": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 				ForceNew: true,
 			},
 

--- a/builtin/providers/opc/resource_instance_test.go
+++ b/builtin/providers/opc/resource_instance_test.go
@@ -136,6 +136,27 @@ func TestAccOPCInstance_storage(t *testing.T) {
 	})
 }
 
+func TestAccOPCInstance_emptyLabel(t *testing.T) {
+	resName := "opc_compute_instance.test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccOPCCheckInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccInstanceEmptyLabel(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccOPCCheckInstanceExists,
+					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("acc-test-instance-%d", rInt)),
+					resource.TestCheckResourceAttrSet(resName, "label"),
+				),
+			},
+		},
+	})
+}
+
 func testAccOPCCheckInstanceExists(s *terraform.State) error {
 	client := testAccProvider.Meta().(*compute.Client).Instances()
 
@@ -270,4 +291,18 @@ resource "opc_compute_instance" "test" {
 	  index = 2
 	}
 }`, rInt, rInt, rInt)
+}
+
+func testAccInstanceEmptyLabel(rInt int) string {
+	return fmt.Sprintf(`
+resource "opc_compute_instance" "test" {
+	name = "acc-test-instance-%d"
+	shape = "oc3"
+	image_list = "/oracle/public/oel_6.7_apaas_16.4.5_1610211300"
+	instance_attributes = <<JSON
+{
+  "foo": "bar"
+}
+JSON
+}`, rInt)
 }

--- a/website/source/docs/providers/opc/r/opc_compute_security_list.html.markdown
+++ b/website/source/docs/providers/opc/r/opc_compute_security_list.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Creates and manages a security list in an OPC identity domain.
 ---
 
-# opc\_compute\_ip\_reservation
+# opc\_compute\_security\_list
 
 The ``opc_compute_security_list`` resource creates and manages a security list in an OPC identity domain.
 


### PR DESCRIPTION
Fix issue with an instances label causing a ForceNew if omitted.

Also updates mistyped docs for the `opc_compute_security_list` resource.

```
$ make testacc TEST=./builtin/providers/opc TESTARGS="-run=TestAccOPCInstance_emptyLabel"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/21 09:57:48 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/opc -v -run=TestAccOPCInstance_emptyLabel -timeout 120m
=== RUN   TestAccOPCInstance_emptyLabel
--- PASS: TestAccOPCInstance_emptyLabel (574.79s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/opc    574.835s
```