### PR TITLE
Implement matchkeys interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -69,7 +69,7 @@ func Funcs() map[string]ast.Function {
 		"distinct":     interpolationFuncDistinct(),
 		"element":      interpolationFuncElement(),
 		"file":         interpolationFuncFile(),
-		"filter":       interpolationFuncFilter(),
+		"matchkeys":    interpolationFuncMatchKeys(),
 		"floor":        interpolationFuncFloor(),
 		"format":       interpolationFuncFormat(),
 		"formatlist":   interpolationFuncFormatList(),
@@ -669,41 +669,54 @@ func appendIfMissing(slice []string, element string) []string {
 	return append(slice, element)
 }
 
-// interpolationFuncFilter implements the "filter" function that
-// removes elements from a list
-func interpolationFuncFilter() ast.Function {
+// for two lists `keys` and `values` of equal length, returns all elements
+// from `values` where the corresponding element from `keys` is in `searchset`.
+func interpolationFuncMatchKeys() ast.Function {
 	return ast.Function{
-		ArgTypes:   []ast.Type{ast.TypeList, ast.TypeList, ast.TypeString},
+		ArgTypes:   []ast.Type{ast.TypeList, ast.TypeList, ast.TypeList},
 		ReturnType: ast.TypeList,
 		Callback: func(args []interface{}) (interface{}, error) {
-			var list []string
+			output := make([]ast.Variable, 0)
 
-			argument, _ := args[0].([]ast.Variable)
+			values, _ := args[0].([]ast.Variable)
 			keys, _ := args[1].([]ast.Variable)
-			searchkey, _ := args[2].(string)
+			searchset, _ := args[2].([]ast.Variable)
 
-			if len(argument) != len(keys) {
-				return nil, fmt.Errorf("length of lists should be equal")
+			if len(keys) != len(values) {
+				return nil, fmt.Errorf("length of keys and values should be equal")
 			}
 
-			for i, element := range argument {
-				if element.Type != ast.TypeString {
-					return nil, fmt.Errorf(
-						"only works for flat lists, this list contains elements of %s",
-						element.Type.Printable())
-				}
-				if keys[i].Type != ast.TypeString {
-					return nil, fmt.Errorf(
-						"only works for flat lists, this list contains elements of %s",
-						keys[i].Type.Printable())
-				}
-				if keys[i].Value.(string) == searchkey {
-					list = append(list, element.Value.(string))
+			for i, key := range keys {
+				for _, search := range searchset {
+					if res, err := compareSimpleVariables(key, search); err != nil {
+						return nil, err
+					} else if res == true {
+						output = append(output, values[i])
+						break
+					}
 				}
 			}
-
-			return stringSliceToVariableValue(list), nil
+			// if searchset is empty, then output is an empty list as well.
+			// if we haven't matched any key, then output is an empty list.
+			return output, nil
 		},
+	}
+}
+
+// compare two variables of the same type, i.e. non complex one, such as TypeList or TypeMap
+func compareSimpleVariables(a, b ast.Variable) (bool, error) {
+	if a.Type != b.Type {
+		return false, fmt.Errorf(
+			"won't compare items of different types %s and %s",
+			a.Type.Printable(), b.Type.Printable())
+	}
+	switch a.Type {
+	case ast.TypeString:
+		return a.Value.(string) == b.Value.(string), nil
+	default:
+		return false, fmt.Errorf(
+			"can't compare items of type %s",
+			a.Type.Printable())
 	}
 }
 

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -964,6 +964,43 @@ func TestInterpolateFuncDistinct(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncFilter(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			// normal usage
+			{
+				`${filter(list("a", "b", "c"), list("ref1", "ref2", "ref3"), "ref2")}`,
+				[]interface{}{"b"},
+				false,
+			},
+			// zero case
+			{
+				`${filter(list(), list(), "nope")}`,
+				[]interface{}{},
+				false,
+			},
+			// non-string list is an error
+			{
+				`${filter(list(list("a"), list("a")), list("a"), "a")}`,
+				nil,
+				true,
+			},
+			// non-string keys list is an error
+			{
+				`${filter(list("a"), list(list("a"), list("a")), "a")}`,
+				nil,
+				true,
+			},
+			// lists of different length is an error
+			{
+				`${filter(list("a"), list("a", "b"), "a")}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncFile(t *testing.T) {
 	tf, err := ioutil.TempFile("", "tf")
 	if err != nil {

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -964,36 +964,67 @@ func TestInterpolateFuncDistinct(t *testing.T) {
 	})
 }
 
-func TestInterpolateFuncFilter(t *testing.T) {
+func TestInterpolateFuncMatchKeys(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
 			// normal usage
 			{
-				`${filter(list("a", "b", "c"), list("ref1", "ref2", "ref3"), "ref2")}`,
+				`${matchkeys(list("a", "b", "c"), list("ref1", "ref2", "ref3"), list("ref2"))}`,
 				[]interface{}{"b"},
+				false,
+			},
+			// normal usage 2, check the order
+			{
+				`${matchkeys(list("a", "b", "c"), list("ref1", "ref2", "ref3"), list("ref2", "ref1"))}`,
+				[]interface{}{"a", "b"},
+				false,
+			},
+			// duplicate item in searchset
+			{
+				`${matchkeys(list("a", "b", "c"), list("ref1", "ref2", "ref3"), list("ref2", "ref2"))}`,
+				[]interface{}{"b"},
+				false,
+			},
+			// no matches
+			{
+				`${matchkeys(list("a", "b", "c"), list("ref1", "ref2", "ref3"), list("ref4"))}`,
+				[]interface{}{},
+				false,
+			},
+			// no matches 2
+			{
+				`${matchkeys(list("a", "b", "c"), list("ref1", "ref2", "ref3"), list())}`,
+				[]interface{}{},
 				false,
 			},
 			// zero case
 			{
-				`${filter(list(), list(), "nope")}`,
+				`${matchkeys(list(), list(), list("nope"))}`,
 				[]interface{}{},
 				false,
 			},
-			// non-string list is an error
+			// complex values
 			{
-				`${filter(list(list("a"), list("a")), list("a"), "a")}`,
+				`${matchkeys(list(list("a", "a")), list("a"), list("a"))}`,
+				[]interface{}{[]interface{}{"a", "a"}},
+				false,
+			},
+			// errors
+			// different types
+			{
+				`${matchkeys(list("a"), list(1), list("a"))}`,
 				nil,
 				true,
 			},
-			// non-string keys list is an error
+			// different types
 			{
-				`${filter(list("a"), list(list("a"), list("a")), "a")}`,
+				`${matchkeys(list("a"), list(list("a"), list("a")), list("a"))}`,
 				nil,
 				true,
 			},
 			// lists of different length is an error
 			{
-				`${filter(list("a"), list("a", "b"), "a")}`,
+				`${matchkeys(list("a"), list("a", "b"), list("a"))}`,
 				nil,
 				true,
 			},

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -208,13 +208,14 @@ The supported built-in functions are:
       module, you generally want to make the path relative to the module base,
       like this: `file("${path.module}/file")`.
 
-  * `filter(list, keys, searchkey)` - For two lists `list` and `keys` of
-      equal length, returns all elements from `list` where the corresponding
-      element from `keys` is equal to `searchkey`.  E.g.
-      `filter(aws_instance.example.*.id,
-      aws_instance.example.*.availability_zone, "us-west-2a")` will return a
+  * `matchkeys(values, keys, searchset)` - For two lists `values` and `keys` of
+      equal length, returns all elements from `values` where the corresponding
+      element from `keys` exists in the `searchset` list.  E.g.
+      `matchkeys(aws_instance.example.*.id,
+      aws_instance.example.*.availability_zone, list("us-west-2a"))` will return a
       list of the instance IDs of the `aws_instance.example` instances in
-      `"us-west-2a"`.
+      `"us-west-2a"`. No match will result in empty list. Items of `keys` are
+      processed sequentially, so the order of returned `values` is preserved.
 
   * `floor(float)` - Returns the greatest integer value less than or equal to
       the argument.

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -208,6 +208,14 @@ The supported built-in functions are:
       module, you generally want to make the path relative to the module base,
       like this: `file("${path.module}/file")`.
 
+  * `filter(list, keys, searchkey)` - For two lists `list` and `keys` of
+      equal length, returns all elements from `list` where the corresponding
+      element from `keys` is equal to `searchkey`.  E.g.
+      `filter(aws_instance.example.*.id,
+      aws_instance.example.*.availability_zone, "us-west-2a")` will return a
+      list of the instance IDs of the `aws_instance.example` instances in
+      `"us-west-2a"`.
+
   * `floor(float)` - Returns the greatest integer value less than or equal to
       the argument.
 


### PR DESCRIPTION
This is a followup for https://github.com/hashicorp/terraform/pull/12389. The PR implements `matchkeys` function:

`matchkeys(values, keys, searchset)` - For two lists `values` and `keys` of equal length, returns all elements from `values` where the corresponding element from `keys` exists in the `searchset` list. For example

 ```
matchkeys(aws_instance.example.*.id, 
           aws_instance.example.*.availability_zone,
           list("us-west-2a"))
```

will return a list of the instance IDs of the `aws_instance.example` instances in `"us-west-2a"`. No match will result in empty list. Items of `keys` are processed sequentially, so the order of returned `values` is preserved.
