### PR TITLE
command: Add flag for updating modules on init.

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -221,31 +221,34 @@ Usage: terraform init [options] [SOURCE] [PATH]
 
 Options:
 
-  -backend=true        Configure the backend for this environment.
+  -backend=true         Configure the backend for this environment.
 
-  -backend-config=path This can be either a path to an HCL file with key/value
-                       assignments (same format as terraform.tfvars) or a
-                       'key=value' format. This is merged with what is in the
-                       configuration file. This can be specified multiple
-                       times. The backend type must be in the configuration
-                       itself.
+  -backend-config=path  This can be either a path to an HCL file with key/value
+                        assignments (same format as terraform.tfvars) or a
+                        'key=value' format. This is merged with what is in the
+                        configuration file. This can be specified multiple
+                        times. The backend type must be in the configuration
+                        itself.
 
-  -force-copy          Suppress prompts about copying state data. This is
-                       equivalent to providing a "yes" to all confirmation
-                       prompts.
+  -force-copy           Suppress prompts about copying state data. This is
+                        equivalent to providing a "yes" to all confirmation
+                        prompts.
 
-  -get=true            Download any modules for this configuration.
+  -get=true             Download any modules for this configuration.
 
-  -input=true          Ask for input if necessary. If false, will error if
-                       input was required.
+  -input=true           Ask for input if necessary. If false, will error if
+                        input was required.
 
-  -lock=true           Lock the state file when locking is supported.
+  -lock=true            Lock the state file when locking is supported.
 
-  -lock-timeout=0s     Duration to retry a state lock.
+  -lock-timeout=0s      Duration to retry a state lock.
 
-  -no-color            If specified, output won't contain any color.
+  -no-color             If specified, output won't contain any color.
 
   -reconfigure          Reconfigure the backend, ignoring any saved configuration.
+
+  -update-modules=false If true, modules already downloaded will be checked
+                        for updates and updated if necessary.
 `
 	return strings.TrimSpace(helpText)
 }

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -212,6 +212,37 @@ func TestInit_copyGet(t *testing.T) {
 	}
 }
 
+func TestInit_getUpdate(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	os.MkdirAll(td, 0755)
+	// copy.CopyDir(testFixturePath("init-get"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	c := &InitCommand{
+		Meta: Meta{
+			ContextOpts: testCtxConfig(testProvider()),
+			Ui:          ui,
+		},
+	}
+
+	args := []string{
+		"-update-modules=true",
+		testFixturePath("init-get"),
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
+	}
+
+	// Check output
+	output := ui.OutputWriter.String()
+	if !strings.Contains(output, "(update)") {
+		t.Fatalf("doesn't look like get: %s", output)
+	}
+}
+
 func TestInit_backend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := tempDir(t)

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -229,7 +229,7 @@ func TestInit_getUpdate(t *testing.T) {
 	}
 
 	args := []string{
-		"-update-modules=true",
+		"-update-modules",
 		testFixturePath("init-get"),
 	}
 	if code := c.Run(args); code != 0 {

--- a/website/source/docs/commands/init.html.markdown
+++ b/website/source/docs/commands/init.html.markdown
@@ -65,6 +65,8 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-reconfigure` - Reconfigure the backend, ignoring any saved configuration.
 
+* `-update-modules` - Update any existing downloaded modules for this configuration.
+
 ## Backend Config
 
 The `-backend-config` can take a path or `key=value` pair to specify additional


### PR DESCRIPTION
Add a flag `update-modules` to enable updating modules as part of a `terraform init`, and supporting test case.

The justification behind this is to enable the use of `terraform init` as part of a Jenkins CI pipeline, whereby we are running a `terraform init` on every build. Currently, after the modules are initially downloaded they'll never be updated, unless either:
* The workspace is cleared 
-or-
* A `terraform get -update` is run