### PR TITLE
fix a few races in the context tests

### DIFF
--- a/terraform/context_apply_test.go
+++ b/terraform/context_apply_test.go
@@ -4430,6 +4430,7 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 	p.ApplyFn = testApplyFn
 	p.DiffFn = testDiffFn
 
+	var l sync.Mutex
 	var calls []string
 	pr.ApplyFn = func(rs *InstanceState, c *ResourceConfig) error {
 		val, ok := c.Config["foo"]
@@ -4437,6 +4438,8 @@ func TestContext2Apply_provisionerDestroyFailContinue(t *testing.T) {
 			t.Fatalf("bad value for foo: %v %#v", val, c)
 		}
 
+		l.Lock()
+		defer l.Unlock()
 		calls = append(calls, val.(string))
 		return fmt.Errorf("provisioner error")
 	}
@@ -4501,6 +4504,7 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 	p.ApplyFn = testApplyFn
 	p.DiffFn = testDiffFn
 
+	var l sync.Mutex
 	var calls []string
 	pr.ApplyFn = func(rs *InstanceState, c *ResourceConfig) error {
 		val, ok := c.Config["foo"]
@@ -4508,6 +4512,8 @@ func TestContext2Apply_provisionerDestroyFailContinueFail(t *testing.T) {
 			t.Fatalf("bad value for foo: %v %#v", val, c)
 		}
 
+		l.Lock()
+		defer l.Unlock()
 		calls = append(calls, val.(string))
 		return fmt.Errorf("provisioner error")
 	}

--- a/terraform/context_plan_test.go
+++ b/terraform/context_plan_test.go
@@ -532,6 +532,9 @@ func TestContext2Plan_moduleProviderInherit(t *testing.T) {
 					state *InstanceState,
 					c *ResourceConfig) (*InstanceDiff, error) {
 					v, _ := c.Get("from")
+
+					l.Lock()
+					defer l.Unlock()
 					calls = append(calls, v.(string))
 					return testDiffFn(info, state, c)
 				}
@@ -628,6 +631,9 @@ func TestContext2Plan_moduleProviderDefaults(t *testing.T) {
 					state *InstanceState,
 					c *ResourceConfig) (*InstanceDiff, error) {
 					v, _ := c.Get("from")
+
+					l.Lock()
+					defer l.Unlock()
 					calls = append(calls, v.(string))
 					return testDiffFn(info, state, c)
 				}
@@ -677,6 +683,8 @@ func TestContext2Plan_moduleProviderDefaultsVar(t *testing.T) {
 						buf.WriteString(v.(string) + "\n")
 					}
 
+					l.Lock()
+					defer l.Unlock()
 					calls = append(calls, buf.String())
 					return nil
 				}


### PR DESCRIPTION
these were so infrequent that the race detector couldn't catch them
either, but on a heavily loaded CI host they occasionally fail.