### PR TITLE
vendor: update github.com/hashicorp/go-retryablehttp

### DIFF
--- a/vendor/github.com/hashicorp/go-retryablehttp/client.go
+++ b/vendor/github.com/hashicorp/go-retryablehttp/client.go
@@ -32,8 +32,8 @@ import (
 var (
 	// Default retry configuration
 	defaultRetryWaitMin = 1 * time.Second
-	defaultRetryWaitMax = 5 * time.Minute
-	defaultRetryMax     = 32
+	defaultRetryWaitMax = 30 * time.Second
+	defaultRetryMax     = 4
 
 	// defaultClient is used for performing requests without explicitly making
 	// a new client. It is purposely private to avoid modifications.

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2023,10 +2023,10 @@
 			"revisionTime": "2017-02-17T16:27:05Z"
 		},
 		{
-			"checksumSHA1": "GBDE1KDl/7c5hlRPYRZ7+C0WQ0g=",
+			"checksumSHA1": "ErJHGU6AVPZM9yoY/xV11TwSjQs=",
 			"path": "github.com/hashicorp/go-retryablehttp",
-			"revision": "f4ed9b0fa01a2ac614afe7c897ed2e3d8208f3e8",
-			"revisionTime": "2016-08-10T17:22:55Z"
+			"revision": "6e85be8fee1dcaa02c0eaaac2df5a8fbecf94145",
+			"revisionTime": "2016-09-30T03:51:02Z"
 		},
 		{
 			"checksumSHA1": "A1PcINvF3UiwHRKn8UcgARgvGRs=",


### PR DESCRIPTION
Updates the default retry settings for go-retryablehttp from upstream. Helps avoid retrying for very long periods of time.