### PR TITLE
Refresh AWS security groups faster

### DIFF
--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
@@ -114,14 +114,15 @@ type Config struct {
 	SkipRequestingAccountId bool
 	SkipMetadataApiCheck    bool
 	S3ForcePathStyle        bool
+	BatchSecurityGroups     bool
 }
 
-type Cache struct {
+type SecurityGroupsCache struct {
 	SecurityGroups *ec2.DescribeSecurityGroupsOutput
 }
 
 type AWSClient struct {
-	cache                 *Cache
+	securitygroupscache   *SecurityGroupsCache
 	cfconn                *cloudformation.CloudFormation
 	cloudfrontconn        *cloudfront.CloudFront
 	cloudtrailconn        *cloudtrail.CloudTrail
@@ -181,11 +182,8 @@ type AWSClient struct {
 	wafregionalconn       *wafregional.WAFRegional
 }
 
-func (c *AWSClient) Cache() *Cache {
-	if c.cache == nil {
-		c.cache = &Cache{}
-	}
-	return c.cache
+func (c *AWSClient) SecurityGroupsCache() *SecurityGroupsCache {
+	return c.securitygroupscache
 }
 
 func (c *AWSClient) S3() *s3.S3 {

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
@@ -344,6 +344,10 @@ func (c *Config) Client() (interface{}, error) {
 		}
 	}
 
+	if c.BatchSecurityGroups {
+		client.securitygroupscache = &SecurityGroupsCache{}
+	}
+
 	client.acmconn = acm.New(sess)
 	client.apigateway = apigateway.New(sess)
 	client.appautoscalingconn = applicationautoscaling.New(sess)

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
@@ -116,7 +116,12 @@ type Config struct {
 	S3ForcePathStyle        bool
 }
 
+type Cache struct {
+	SecurityGroups  *ec2.DescribeSecurityGroupsOutput
+}
+
 type AWSClient struct {
+	cache                 *Cache
 	cfconn                *cloudformation.CloudFormation
 	cloudfrontconn        *cloudfront.CloudFront
 	cloudtrailconn        *cloudtrail.CloudTrail
@@ -174,6 +179,13 @@ type AWSClient struct {
 	ssmconn               *ssm.SSM
 	wafconn               *waf.WAF
 	wafregionalconn       *wafregional.WAFRegional
+}
+
+func (c *AWSClient) Cache() *Cache {
+	if (c.cache == nil) {
+		c.cache = &Cache{}
+	}
+	return c.cache
 }
 
 func (c *AWSClient) S3() *s3.S3 {

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/config.go
@@ -117,7 +117,7 @@ type Config struct {
 }
 
 type Cache struct {
-	SecurityGroups  *ec2.DescribeSecurityGroupsOutput
+	SecurityGroups *ec2.DescribeSecurityGroupsOutput
 }
 
 type AWSClient struct {
@@ -182,7 +182,7 @@ type AWSClient struct {
 }
 
 func (c *AWSClient) Cache() *Cache {
-	if (c.cache == nil) {
+	if c.cache == nil {
 		c.cache = &Cache{}
 	}
 	return c.cache

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/import_aws_security_group.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/import_aws_security_group.go
@@ -15,9 +15,10 @@ func resourceAwsSecurityGroupImportState(
 	d *schema.ResourceData,
 	meta interface{}) ([]*schema.ResourceData, error) {
 	conn := meta.(*AWSClient).ec2conn
+	cache := meta.(*AWSClient).Cache()
 
 	// First query the security group
-	sgRaw, _, err := SGStateRefreshFunc(conn, d.Id())()
+	sgRaw, _, err := SGStateRefreshFunc(conn, cache, d.Id())()
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/import_aws_security_group.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/import_aws_security_group.go
@@ -15,7 +15,7 @@ func resourceAwsSecurityGroupImportState(
 	d *schema.ResourceData,
 	meta interface{}) ([]*schema.ResourceData, error) {
 	conn := meta.(*AWSClient).ec2conn
-	cache := meta.(*AWSClient).Cache()
+	cache := meta.(*AWSClient).SecurityGroupsCache()
 
 	// First query the security group
 	sgRaw, _, err := SGStateRefreshFunc(conn, cache, d.Id())()

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/provider.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/provider.go
@@ -156,6 +156,13 @@ func Provider() terraform.ResourceProvider {
 				Default:     false,
 				Description: descriptions["s3_force_path_style"],
 			},
+
+			"batch_security_groups": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: descriptions["batch_security_groups"],
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -558,6 +565,9 @@ func init() {
 			"use virtual hosted bucket addressing when possible\n" +
 			"(http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.",
 
+		"batch_security_groups": "Set this to batch refreshes EC2 security groups." +
+			" Speeds up refreshes when you have large numbers of security groups.",
+
 		"assume_role_role_arn": "The ARN of an IAM role to assume prior to making API calls.",
 
 		"assume_role_session_name": "The session name to use when assuming the role. If omitted," +
@@ -588,6 +598,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SkipRequestingAccountId: d.Get("skip_requesting_account_id").(bool),
 		SkipMetadataApiCheck:    d.Get("skip_metadata_api_check").(bool),
 		S3ForcePathStyle:        d.Get("s3_force_path_style").(bool),
+		BatchSecurityGroups:     d.Get("batch_security_groups").(bool),
 	}
 
 	assumeRoleList := d.Get("assume_role").(*schema.Set).List()

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/provider.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/provider.go
@@ -565,7 +565,7 @@ func init() {
 			"use virtual hosted bucket addressing when possible\n" +
 			"(http://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.",
 
-		"batch_security_groups": "Set this to batch refreshes EC2 security groups." +
+		"batch_security_groups": "Set this to batch refresh EC2 security groups. Experimental feature." +
 			" Speeds up refreshes when you have large numbers of security groups.",
 
 		"assume_role_role_arn": "The ARN of an IAM role to assume prior to making API calls.",

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
@@ -709,6 +709,7 @@ func resourceAwsSecurityGroupUpdateRules(
 func updateSecurityGroupCache(conn *ec2.EC2, cache *Cache) error {
 	mtKey := "security_groups_cache"
 	awsMutexKV.Lock(mtKey)
+	defer awsMutexKV.Unlock(mtKey)
 	if cache.SecurityGroups == nil {
 		req := &ec2.DescribeSecurityGroupsInput{}
 		resp, err := conn.DescribeSecurityGroups(req)
@@ -720,7 +721,6 @@ func updateSecurityGroupCache(conn *ec2.EC2, cache *Cache) error {
 
 		cache.SecurityGroups = resp
 	}
-	awsMutexKV.Unlock(mtKey)
 	return nil
 }
 

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
@@ -739,7 +739,7 @@ func updateSecurityGroupCache(conn *ec2.EC2, cache *SecurityGroupsCache) error {
 // a security group.
 func SGStateRefreshFunc(conn *ec2.EC2, cache *SecurityGroupsCache, id string) resource.StateRefreshFunc {
 	return func() (interface{}, string, error) {
-		group, err := RefreshSG(conn, cache, id)
+		group, err := refreshSG(conn, cache, id)
 		switch {
 		case group != nil:
 			return group, "exists", nil
@@ -751,18 +751,18 @@ func SGStateRefreshFunc(conn *ec2.EC2, cache *SecurityGroupsCache, id string) re
 	}
 }
 
-func RefreshSG(conn *ec2.EC2, cache *SecurityGroupsCache, id string) (*ec2.SecurityGroup, error) {
+func refreshSG(conn *ec2.EC2, cache *SecurityGroupsCache, id string) (*ec2.SecurityGroup, error) {
 	// If batch_security_groups is set to true on the AWS provider, we make a
 	// single batch call to fetch all SGs and cache it.
 	// Otherwise, just fetch the single security group from the AWS API
 	if cache != nil {
-		return RefreshSGFromCache(conn, cache, id)
+		return refreshSGFromCache(conn, cache, id)
 	} else {
-		return RefreshSGFromAPI(conn, id)
+		return refreshSGFromAPI(conn, id)
 	}
 }
 
-func RefreshSGFromCache(conn *ec2.EC2, cache *SecurityGroupsCache, id string) (*ec2.SecurityGroup, error) {
+func refreshSGFromCache(conn *ec2.EC2, cache *SecurityGroupsCache, id string) (*ec2.SecurityGroup, error) {
 	err := updateSecurityGroupCache(conn, cache)
 	if err != nil {
 		return nil, err
@@ -780,7 +780,7 @@ func RefreshSGFromCache(conn *ec2.EC2, cache *SecurityGroupsCache, id string) (*
 	return nil, nil
 }
 
-func RefreshSGFromAPI(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
+func refreshSGFromAPI(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
 	req := &ec2.DescribeSecurityGroupsInput{
 		GroupIds: []*string{aws.String(id)},
 	}

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
@@ -17,6 +17,8 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
+const SecurityGroupKey = "56e2e112-ef69-4461-af19-01064bdd44d6"
+
 func resourceAwsSecurityGroup() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceAwsSecurityGroupCreate,
@@ -711,16 +713,14 @@ func resourceAwsSecurityGroupUpdateRules(
 }
 
 func clearSecurityGroupCache(cache *SecurityGroupsCache) {
-	mtKey := "security_groups_cache"
-	awsMutexKV.Lock(mtKey)
-	defer awsMutexKV.Unlock(mtKey)
+	awsMutexKV.Lock(SecurityGroupKey)
+	defer awsMutexKV.Unlock(SecurityGroupKey)
 	cache.SecurityGroups = nil
 }
 
 func updateSecurityGroupCache(conn *ec2.EC2, cache *SecurityGroupsCache) error {
-	mtKey := "security_groups_cache"
-	awsMutexKV.Lock(mtKey)
-	defer awsMutexKV.Unlock(mtKey)
+	awsMutexKV.Lock(SecurityGroupKey)
+	defer awsMutexKV.Unlock(SecurityGroupKey)
 	if cache.SecurityGroups == nil {
 		req := &ec2.DescribeSecurityGroupsInput{}
 		resp, err := conn.DescribeSecurityGroups(req)

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group.go
@@ -707,6 +707,8 @@ func resourceAwsSecurityGroupUpdateRules(
 }
 
 func updateSecurityGroupCache(conn *ec2.EC2, cache *Cache) error {
+	mtKey := "security_groups_cache"
+	awsMutexKV.Lock(mtKey)
 	if cache.SecurityGroups == nil {
 		req := &ec2.DescribeSecurityGroupsInput{}
 		resp, err := conn.DescribeSecurityGroups(req)
@@ -718,6 +720,7 @@ func updateSecurityGroupCache(conn *ec2.EC2, cache *Cache) error {
 
 		cache.SecurityGroups = resp
 	}
+	awsMutexKV.Unlock(mtKey)
 	return nil
 }
 

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group_rule.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group_rule.go
@@ -340,7 +340,7 @@ func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}
 }
 
 func findResourceSecurityGroup(conn *ec2.EC2, cache *SecurityGroupsCache, id string) (*ec2.SecurityGroup, error) {
-	group, err := RefreshSG(conn, cache, id)
+	group, err := refreshSG(conn, cache, id)
 
 	if err != nil {
 		return nil, err

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group_rule.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group_rule.go
@@ -108,12 +108,13 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 
 func resourceAwsSecurityGroupRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
+	cache := meta.(*AWSClient).Cache()
 	sg_id := d.Get("security_group_id").(string)
 
 	awsMutexKV.Lock(sg_id)
 	defer awsMutexKV.Unlock(sg_id)
 
-	sg, err := findResourceSecurityGroup(conn, sg_id)
+	sg, err := findResourceSecurityGroup(conn, cache, sg_id)
 	if err != nil {
 		return err
 	}
@@ -187,7 +188,7 @@ information and instructions for recovery. Error message: %s`, sg_id, awsErr.Mes
 	log.Printf("[DEBUG] Computed group rule ID %s", id)
 
 	retErr := resource.Retry(5*time.Minute, func() *resource.RetryError {
-		sg, err := findResourceSecurityGroup(conn, sg_id)
+		sg, err := findResourceSecurityGroup(conn, cache, sg_id)
 
 		if err != nil {
 			log.Printf("[DEBUG] Error finding Security Group (%s) for Rule (%s): %s", sg_id, id, err)
@@ -225,8 +226,9 @@ information and instructions for recovery. Error message: %s`, sg_id, awsErr.Mes
 
 func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
+	cache := meta.(*AWSClient).Cache()
 	sg_id := d.Get("security_group_id").(string)
-	sg, err := findResourceSecurityGroup(conn, sg_id)
+	sg, err := findResourceSecurityGroup(conn, cache, sg_id)
 	if _, notFound := err.(securityGroupNotFound); notFound {
 		// The security group containing this rule no longer exists.
 		d.SetId("")
@@ -280,12 +282,13 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 
 func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
+	cache := meta.(*AWSClient).Cache()
 	sg_id := d.Get("security_group_id").(string)
 
 	awsMutexKV.Lock(sg_id)
 	defer awsMutexKV.Unlock(sg_id)
 
-	sg, err := findResourceSecurityGroup(conn, sg_id)
+	sg, err := findResourceSecurityGroup(conn, cache, sg_id)
 	if err != nil {
 		return err
 	}
@@ -334,25 +337,25 @@ func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}
 	return nil
 }
 
-func findResourceSecurityGroup(conn *ec2.EC2, id string) (*ec2.SecurityGroup, error) {
-	req := &ec2.DescribeSecurityGroupsInput{
-		GroupIds: []*string{aws.String(id)},
-	}
-	resp, err := conn.DescribeSecurityGroups(req)
-	if err, ok := err.(awserr.Error); ok && err.Code() == "InvalidGroup.NotFound" {
-		return nil, securityGroupNotFound{id, nil}
-	}
+func findResourceSecurityGroup(conn *ec2.EC2, cache *Cache, id string) (*ec2.SecurityGroup, error) {
+	var group *ec2.SecurityGroup
+	err := updateSecurityGroupCache(conn, cache)
+
 	if err != nil {
 		return nil, err
 	}
-	if resp == nil {
-		return nil, securityGroupNotFound{id, nil}
-	}
-	if len(resp.SecurityGroups) != 1 || resp.SecurityGroups[0] == nil {
-		return nil, securityGroupNotFound{id, resp.SecurityGroups}
+
+	for _, sg := range cache.SecurityGroups.SecurityGroups {
+		if id == *sg.GroupId {
+			group = sg
+		}
 	}
 
-	return resp.SecurityGroups[0], nil
+	if group == nil {
+		return nil, securityGroupNotFound{id, nil}
+	}
+
+	return group, nil
 }
 
 type securityGroupNotFound struct {

--- a/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group_rule.go
+++ b/vendor/github.com/terraform-providers/terraform-provider-aws/aws/resource_aws_security_group_rule.go
@@ -109,6 +109,7 @@ func resourceAwsSecurityGroupRule() *schema.Resource {
 func resourceAwsSecurityGroupRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	cache := meta.(*AWSClient).Cache()
+	clearSecurityGroupCache(cache)
 	sg_id := d.Get("security_group_id").(string)
 
 	awsMutexKV.Lock(sg_id)
@@ -283,6 +284,7 @@ func resourceAwsSecurityGroupRuleRead(d *schema.ResourceData, meta interface{}) 
 func resourceAwsSecurityGroupRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	cache := meta.(*AWSClient).Cache()
+	clearSecurityGroupCache(cache)
 	sg_id := d.Get("security_group_id").(string)
 
 	awsMutexKV.Lock(sg_id)


### PR DESCRIPTION
from https://github.com/hashicorp/terraform/issues/13837

This changes the way AWS security groups are refreshed: instead of loading them one by one, it loads them all at once at the beginning into a huge list, and then when an individual SG needs to be refreshed, we just search the list in Go for the security group ID. This is a lot faster when many security groups need to be refreshed because we only need to do one AWS API call instead of potentially dozens or hundreds.

This is still pretty rough but I wanted to submit it early to get some feedback. It would also make sense to potentially refresh security groups rules resources in the same way. (since they use the same source of truth as security groups)

### performance implications / tradeoffs

This makes reloading single security groups slower. In my testing on my laptop, it adds about 1 second to the time to reload one security group.

Reloading large amounts of security groups, however, gets dramatically faster. This lets you refresh hundreds of security groups in just a few seconds instead of minutes.

### problems I'd like help with (mostly safety)

Right now I'm pretty sure there are safety problems with this PR -- it loads the list of security groups once into a global variable at the beginning, and then assumes that that stays valid forever. I know that Terraform sometimes changes resources and then refreshes them from the AWS API after. I'd love ideas for how to address this, since I'm still not that familiar with the Terraform codebase.

I haven't thought about EC2 classic security groups at all yet so that's likely broken.