### PR TITLE
Fixes issue for cross account iam role with aws_lambda_permission

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_permission.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission.go
@@ -230,7 +230,12 @@ func resourceAwsLambdaPermissionRead(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("action", statement.Action)
-	d.Set("principal", statement.Principal["Service"])
+	// Check if the pricipal is a cross-account IAM role
+	if _, ok := statement.Principal["AWS"]; ok {
+		d.Set("principal", statement.Principal["AWS"])
+	} else {
+		d.Set("principal", statement.Principal["Service"])
+	}
 
 	if stringEquals, ok := statement.Condition["StringEquals"]; ok {
 		d.Set("source_account", stringEquals["AWS:SourceAccount"])


### PR DESCRIPTION
**Background**: We have a large number of AWS accounts where we like to share access to lambda functions to only a certain IAM role in the remote account.  The statement principal appears like so for lambda policies with this type of principal.

```
{
  "Policy": {
    "Version": "2012-10-17",
    "Id": "default",
    "Statement": [
      {
        "Sid": "remote-iam-access",
        "Effect": "Allow",
        "Principal": {
          "AWS": "arn:aws:iam::<remote_account>:role/<remote_role>"
        },
        "Action": "lambda:InvokeFunction",
        "Resource": "arn:aws:lambda:us-east-1:<my_account>:function:<my_function>"
      }
    ]
  }
}
```

Current behavior of terraform was to always try to read from "Service" which will always detect a change for existing unchanged aws_lambda_permission resources using this above pattern.  

This PR fixes this issue.