### PR TITLE
provider/aws: Updated documentation for Cloudfront

### DIFF
--- a/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudfront_distribution.html.markdown
@@ -368,6 +368,8 @@ The following attributes are exported:
 
   * `id` - The identifier for the distribution. For example: `EDFDVBD632BHDS5`.
 
+  * `arn` - The ARN (Amazon Resource Name) for the distribution. For example: arn:aws:cloudfront::123456789012:distribution/EDFDVBD632BHDS5, where 123456789012 is your AWS account ID.
+
   * `caller_reference` - Internal value used by CloudFront to allow future
     updates to the distribution configuration.
 


### PR DESCRIPTION
This adds the missing exported attribute named `ARN`, as exposed [in the code](https://github.com/hashicorp/terraform/blob/master/builtin/providers/aws/resource_aws_cloudfront_distribution.go#L592).

Closes https://github.com/hashicorp/terraform/issues/13816