### PR TITLE
provider/aws: Adding support for ipv6 to aws_subnets needs migration

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -22,6 +22,9 @@ func resourceAwsSubnet() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		SchemaVersion: 1,
+		MigrateState:  resourceAwsSubnetMigrateState,
+
 		Schema: map[string]*schema.Schema{
 			"vpc_id": {
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_subnet_migrate.go
+++ b/builtin/providers/aws/resource_aws_subnet_migrate.go
@@ -1,0 +1,33 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceAwsSubnetMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	switch v {
+	case 0:
+		log.Println("[INFO] Found AWS Subnet State v0; migrating to v1")
+		return migrateSubnetStateV0toV1(is)
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateSubnetStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	if is.Empty() || is.Attributes == nil {
+		log.Println("[DEBUG] Empty Subnet State; nothing to migrate.")
+		return is, nil
+	}
+
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	is.Attributes["assign_ipv6_address_on_creation"] = "false"
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/aws/resource_aws_subnet_migrate_test.go
+++ b/builtin/providers/aws/resource_aws_subnet_migrate_test.go
@@ -1,0 +1,41 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAWSSubnetMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		ID           string
+		Attributes   map[string]string
+		Expected     string
+		Meta         interface{}
+	}{
+		"v0_1_without_value": {
+			StateVersion: 0,
+			ID:           "some_id",
+			Attributes:   map[string]string{},
+			Expected:     "false",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceAwsSubnetMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.Attributes["assign_ipv6_address_on_creation"] != tc.Expected {
+			t.Fatalf("bad Subnet Migrate: %s\n\n expected: %s", is.Attributes["assign_ipv6_address_on_creation"], tc.Expected)
+		}
+	}
+}


### PR DESCRIPTION
Fixes: #13829

When IPv6 support was added to subnets, we added a new parameter that
had a default value. This means that users are experiencing unexpected
changes in their configuration

We need a schema migration in place to make sure this isn't the case for
the users who have not upgraded yet

```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/23 10:36:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAWSSubnetMigrateState -timeout 120m
=== RUN   TestAWSSubnetMigrateState
2017/04/23 10:37:27 [INFO] Found AWS Subnet State v0; migrating to v1
2017/04/23 10:37:27 [DEBUG] Attributes before migration: map[string]string{}
2017/04/23 10:37:27 [DEBUG] Attributes after migration: map[string]string{"assign_ipv6_address_on_creation":"false"}
--- PASS: TestAWSSubnetMigrateState (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	0.021s
```