### PR TITLE
[MS] provider/azurerm: fixes for bug #8227 and bug #11226

### DIFF
--- a/builtin/providers/azurerm/import_arm_subnet_test.go
+++ b/builtin/providers/azurerm/import_arm_subnet_test.go
@@ -1,7 +1,6 @@
 package azurerm
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -12,7 +11,7 @@ func TestAccAzureRMSubnet_importBasic(t *testing.T) {
 	resourceName := "azurerm_subnet.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri, ri, ri)
+	config := testAccAzureRMSubnet_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -36,7 +35,7 @@ func TestAccAzureRMSubnet_importWithRouteTable(t *testing.T) {
 	resourceName := "azurerm_subnet.test"
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSubnet_routeTable, ri, ri, ri)
+	config := testAccAzureRMSubnet_routeTable(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },

--- a/builtin/providers/azurerm/import_arm_subnet_test.go
+++ b/builtin/providers/azurerm/import_arm_subnet_test.go
@@ -31,3 +31,27 @@ func TestAccAzureRMSubnet_importBasic(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAzureRMSubnet_importWithRouteTable(t *testing.T) {
+	resourceName := "azurerm_subnet.test"
+
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMSubnet_routeTable, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccAzureRMSubnet_basic(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri, ri, ri)
+	config := testAccAzureRMSubnet_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -35,8 +35,8 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 
 	ri := acctest.RandInt()
-	initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable, ri, ri, ri)
-	updatedConfig := fmt.Sprintf(testAccAzureRMSubnet_updatedRouteTable, ri, ri, ri)
+	initConfig := testAccAzureRMSubnet_routeTable(ri)
+	updatedConfig := testAccAzureRMSubnet_updatedRouteTable(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -53,7 +53,7 @@ func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 			resource.TestStep{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.test", "test-RT"),
+					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.test", fmt.Sprintf("acctest-%d", ri)),
 				),
 			},
 		},
@@ -63,7 +63,7 @@ func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 func TestAccAzureRMSubnet_disappears(t *testing.T) {
 
 	ri := acctest.RandInt()
-	config := fmt.Sprintf(testAccAzureRMSubnet_basic, ri, ri, ri, ri, ri)
+	config := testAccAzureRMSubnet_basic(ri)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -220,7 +220,8 @@ func testCheckAzureRMSubnetDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAzureRMSubnet_basic = `
+func testAccAzureRMSubnet_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -256,9 +257,11 @@ resource "azurerm_route" "test" {
 	next_hop_type = "VirtualAppliance" 
 	next_hop_in_ip_address = "10.10.1.1" 
 }
-`
+`, rInt, rInt, rInt, rInt, rInt)
+}
 
-var testAccAzureRMSubnet_routeTable = `
+func testAccAzureRMSubnet_routeTable(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -280,22 +283,24 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_route_table" "test" {
-  name                = "test-RT"
+  name                = "acctest-%d"
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_route" "route_a" {
-  name                = "TestRouteA"
+  name                = "acctest-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   route_table_name    = "${azurerm_route_table.test.name}"
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"
   next_hop_in_ip_address = "10.10.1.1"
-}`
+}`, rInt, rInt, rInt, rInt, rInt)
+}
 
-var testAccAzureRMSubnet_updatedRouteTable = `
+func testAccAzureRMSubnet_updatedRouteTable(rInt int) string {
+	return fmt.Sprintf(`
 resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
@@ -305,12 +310,12 @@ resource "azurerm_resource_group" "test" {
 }
 
 resource "azurerm_network_security_group" "test_secgroup" {
-    name = "acceptanceTestSecurityGroup1"
+    name = "acctest-%d"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
 
     security_rule {
-        name = "test123"
+        name = "acctest-%d"
         priority = 100
         direction = "Inbound"
         access = "Allow"
@@ -345,7 +350,7 @@ resource "azurerm_subnet" "test" {
 }
 
 resource "azurerm_route_table" "test" {
-  name                = "test-RT"
+  name                = "acctest-%d"
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
   tags {
@@ -354,11 +359,12 @@ resource "azurerm_route_table" "test" {
 }
 
 resource "azurerm_route" "route_a" {
-  name                = "TestRouteA"
+  name                = "acctest-%d"
   resource_group_name = "${azurerm_resource_group.test.name}"
   route_table_name    = "${azurerm_route_table.test.name}"
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"
   next_hop_in_ip_address = "10.10.1.1"
-}`
+}`, rInt, rInt, rInt, rInt, rInt, rInt, rInt)
+}

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -32,7 +32,11 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
+<<<<<<< HEAD
 func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
+=======
+func TestAccAzureRMSubnet_routeTable(t *testing.T) {
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
 	ri := acctest.RandInt()
 	initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable, ri, ri, ri)
@@ -46,14 +50,43 @@ func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 			resource.TestStep{
 				Config: initConfig,
 				Check: resource.ComposeTestCheckFunc(
+<<<<<<< HEAD
 					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+=======
+					testCheckAzureRMSubnetExists("azurerm_subnet.rtTable2"),
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 				),
 			},
 
 			resource.TestStep{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
+<<<<<<< HEAD
 					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.test", "test-RT"),
+=======
+					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMSubnet_routeTable_subnetInline(t *testing.T) {
+
+	ri := acctest.RandInt()
+	//initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable_subnetInline, ri, ri, ri)
+	updatedConfig := fmt.Sprintf(testAccAzureRMSubnet_updatedRouteTable, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 				),
 			},
 		},
@@ -259,11 +292,16 @@ resource "azurerm_route" "test" {
 `
 
 var testAccAzureRMSubnet_routeTable = `
+<<<<<<< HEAD
 resource "azurerm_resource_group" "test" {
+=======
+resource "azurerm_resource_group" "rtTable2" {
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
     name = "acctestRG-%d"
     location = "West US"
 }
 
+<<<<<<< HEAD
 resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
@@ -283,12 +321,75 @@ resource "azurerm_route_table" "test" {
   name                = "test-RT"
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
+=======
+resource "azurerm_virtual_network" "rtTable2" {
+    name = "acctestvirtnet%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+}
+
+resource "azurerm_subnet" "rtTable2" {
+    name = "acctestsubnet%d"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
+    address_prefix = "10.0.2.0/24"
+	route_table_id       = "${azurerm_route_table.rtTable2.id}"
+}
+
+resource "azurerm_route_table" "rtTable2" {
+  name                = "rtTable2-RT"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 }
 
 resource "azurerm_route" "route_a" {
   name                = "TestRouteA"
+<<<<<<< HEAD
   resource_group_name = "${azurerm_resource_group.test.name}"
   route_table_name    = "${azurerm_route_table.test.name}"
+=======
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+
+  address_prefix         = "10.100.0.0/14"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = "10.10.1.1"
+}`
+
+var testAccAzureRMSubnet_routeTable_subnetInline = `
+resource "azurerm_resource_group" "rtTable2" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "rtTable2" {
+    name = "acctestvirtnet%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+ 	subnet {
+    	name           = "rtTable2"
+    	address_prefix = "10.0.3.0/24"
+		route_table    = "${azurerm_route_table.rtTable2.id}"
+  	}
+	tags {
+		environment = "Testing"
+	}
+}
+
+resource "azurerm_route_table" "rtTable2" {
+  name                = "rtTable2-RT"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+}
+
+resource "azurerm_route" "route_a" {
+  name                = "TestRouteA"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"
@@ -296,7 +397,11 @@ resource "azurerm_route" "route_a" {
 }`
 
 var testAccAzureRMSubnet_updatedRouteTable = `
+<<<<<<< HEAD
 resource "azurerm_resource_group" "test" {
+=======
+resource "azurerm_resource_group" "rtTable2" {
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
     name = "acctestRG-%d"
     location = "West US"
 	tags {
@@ -304,10 +409,17 @@ resource "azurerm_resource_group" "test" {
 	}
 }
 
+<<<<<<< HEAD
 resource "azurerm_network_security_group" "test_secgroup" {
     name = "acceptanceTestSecurityGroup1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
+=======
+resource "azurerm_network_security_group" "rtTable2_secgroup" {
+    name = "acceptanceTestSecurityGroup1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
     security_rule {
         name = "test123"
@@ -326,16 +438,25 @@ resource "azurerm_network_security_group" "test_secgroup" {
     }
 }
 
+<<<<<<< HEAD
 resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
+=======
+resource "azurerm_virtual_network" "rtTable2" {
+    name = "acctestvirtnet%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 	tags {
 		environment = "Testing"
 	}
 }
 
+<<<<<<< HEAD
 resource "azurerm_subnet" "test" {
     name = "acctestsubnet%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -348,6 +469,20 @@ resource "azurerm_route_table" "test" {
   name                = "test-RT"
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
+=======
+resource "azurerm_subnet" "rtTable2" {
+    name = "acctestsubnet%d"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
+    address_prefix = "10.0.2.0/24"
+	route_table_id       = "${azurerm_route_table.rtTable2.id}"
+}
+
+resource "azurerm_route_table" "rtTable2" {
+  name                = "rtTable2-RT"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
   tags {
     environment = "Testing"
   }
@@ -355,8 +490,13 @@ resource "azurerm_route_table" "test" {
 
 resource "azurerm_route" "route_a" {
   name                = "TestRouteA"
+<<<<<<< HEAD
   resource_group_name = "${azurerm_resource_group.test.name}"
   route_table_name    = "${azurerm_route_table.test.name}"
+=======
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+>>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -2,7 +2,9 @@ package azurerm
 
 import (
 	"fmt"
+	"log"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -24,6 +26,55 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMSubnet_routeTable(t *testing.T) {
+
+	ri := acctest.RandInt()
+	initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable, ri, ri, ri)
+	updatedConfig := fmt.Sprintf(testAccAzureRMSubnet_updatedRouteTable, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: initConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetExists("azurerm_subnet.rtTable2"),
+				),
+			},
+
+			resource.TestStep{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMSubnet_routeTable_subnetInline(t *testing.T) {
+
+	ri := acctest.RandInt()
+	//initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable_subnetInline, ri, ri, ri)
+	updatedConfig := fmt.Sprintf(testAccAzureRMSubnet_updatedRouteTable, ri, ri, ri)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMSubnetDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
 				),
 			},
 		},
@@ -60,6 +111,8 @@ func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
 			return fmt.Errorf("Not found: %s", name)
 		}
 
+		log.Printf("[INFO] Checking Subnet addition.")
+
 		name := rs.Primary.Attributes["name"]
 		vnetName := rs.Primary.Attributes["virtual_network_name"]
 		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
@@ -76,6 +129,60 @@ func testCheckAzureRMSubnetExists(name string) resource.TestCheckFunc {
 
 		if resp.StatusCode == http.StatusNotFound {
 			return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not exist", name, resourceGroup)
+		}
+
+		if resp.RouteTable == nil {
+			return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not contain route tables after add", name, resourceGroup)
+		}
+
+		return nil
+	}
+}
+
+func testCheckAzureRMSubnetRouteTableExists(subnetName string, routeTableId string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		// Ensure we have enough information in state to look up in API
+		rs, ok := s.RootModule().Resources[subnetName]
+		if !ok {
+			return fmt.Errorf("Not found: %s", subnetName)
+		}
+
+		log.Printf("[INFO] Checking Subnet update.")
+
+		name := rs.Primary.Attributes["name"]
+		vnetName := rs.Primary.Attributes["virtual_network_name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for subnet: %s", name)
+		}
+
+		vnetConn := testAccProvider.Meta().(*ArmClient).vnetClient
+		vnetResp, vnetErr := vnetConn.Get(resourceGroup, vnetName, "")
+		if vnetErr != nil {
+			return fmt.Errorf("Bad: Get on vnetClient: %s", vnetErr)
+		}
+
+		if vnetResp.Subnets == nil {
+			return fmt.Errorf("Bad: Vnet %q (resource group: %q) does not have subnets after update", vnetName, resourceGroup)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).subnetClient
+
+		resp, err := conn.Get(resourceGroup, vnetName, name, "")
+		if err != nil {
+			return fmt.Errorf("Bad: Get on subnetClient: %s", err)
+		}
+
+		if resp.StatusCode == http.StatusNotFound {
+			return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not exist", subnetName, resourceGroup)
+		}
+
+		if resp.RouteTable == nil {
+			return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not contain route tables after update", subnetName, resourceGroup)
+		}
+
+		if !strings.Contains(*resp.RouteTable.ID, routeTableId) {
+			return fmt.Errorf("Bad: Subnet %q (resource group: %q) does not have route table %q", subnetName, resourceGroup, routeTableId)
 		}
 
 		return nil
@@ -171,3 +278,145 @@ resource "azurerm_route" "test" {
 	next_hop_in_ip_address = "10.10.1.1" 
 }
 `
+
+var testAccAzureRMSubnet_routeTable = `
+resource "azurerm_resource_group" "rtTable2" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "rtTable2" {
+    name = "acctestvirtnet%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+}
+
+resource "azurerm_subnet" "rtTable2" {
+    name = "acctestsubnet%d"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
+    address_prefix = "10.0.2.0/24"
+	route_table_id       = "${azurerm_route_table.rtTable2.id}"
+}
+
+resource "azurerm_route_table" "rtTable2" {
+  name                = "rtTable2-RT"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+}
+
+resource "azurerm_route" "route_a" {
+  name                = "TestRouteA"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+
+  address_prefix         = "10.100.0.0/14"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = "10.10.1.1"
+}`
+
+var testAccAzureRMSubnet_routeTable_subnetInline = `
+resource "azurerm_resource_group" "rtTable2" {
+    name = "acctestRG-%d"
+    location = "West US"
+}
+
+resource "azurerm_virtual_network" "rtTable2" {
+    name = "acctestvirtnet%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+ 	subnet {
+    	name           = "rtTable2"
+    	address_prefix = "10.0.3.0/24"
+		route_table    = "${azurerm_route_table.rtTable2.id}"
+  	}
+	tags {
+		environment = "Testing"
+	}
+}
+
+resource "azurerm_route_table" "rtTable2" {
+  name                = "rtTable2-RT"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+}
+
+resource "azurerm_route" "route_a" {
+  name                = "TestRouteA"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+
+  address_prefix         = "10.100.0.0/14"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = "10.10.1.1"
+}`
+
+var testAccAzureRMSubnet_updatedRouteTable = `
+resource "azurerm_resource_group" "rtTable2" {
+    name = "acctestRG-%d"
+    location = "West US"
+	tags {
+		environment = "Testing"
+	}
+}
+
+resource "azurerm_network_security_group" "rtTable2_secgroup" {
+    name = "acceptanceTestSecurityGroup1"
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+
+    security_rule {
+        name = "test123"
+        priority = 100
+        direction = "Inbound"
+        access = "Allow"
+        protocol = "Tcp"
+        source_port_range = "*"
+        destination_port_range = "*"
+        source_address_prefix = "*"
+        destination_address_prefix = "*"
+    }
+
+    tags {
+        environment = "Testing"
+    }
+}
+
+resource "azurerm_virtual_network" "rtTable2" {
+    name = "acctestvirtnet%d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+	tags {
+		environment = "Testing"
+	}
+}
+
+resource "azurerm_subnet" "rtTable2" {
+    name = "acctestsubnet%d"
+    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
+    address_prefix = "10.0.2.0/24"
+	route_table_id       = "${azurerm_route_table.rtTable2.id}"
+}
+
+resource "azurerm_route_table" "rtTable2" {
+  name                = "rtTable2-RT"
+  location            = "West US"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  tags {
+    environment = "Testing"
+  }
+}
+
+resource "azurerm_route" "route_a" {
+  name                = "TestRouteA"
+  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+
+  address_prefix         = "10.100.0.0/14"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = "10.10.1.1"
+}`

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -32,7 +32,7 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
-func TestAccAzureRMSubnet_routeTable(t *testing.T) {
+func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
 
 	ri := acctest.RandInt()
 	initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable, ri, ri, ri)
@@ -46,35 +46,14 @@ func TestAccAzureRMSubnet_routeTable(t *testing.T) {
 			resource.TestStep{
 				Config: initConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSubnetExists("azurerm_subnet.rtTable2"),
+					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
 				),
 			},
 
 			resource.TestStep{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMSubnet_routeTable_subnetInline(t *testing.T) {
-
-	ri := acctest.RandInt()
-	//initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable_subnetInline, ri, ri, ri)
-	updatedConfig := fmt.Sprintf(testAccAzureRMSubnet_updatedRouteTable, ri, ri, ri)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSubnetDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: updatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
+					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.test", "test-RT"),
 				),
 			},
 		},
@@ -280,73 +259,36 @@ resource "azurerm_route" "test" {
 `
 
 var testAccAzureRMSubnet_routeTable = `
-resource "azurerm_resource_group" "rtTable2" {
+resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 }
 
-resource "azurerm_virtual_network" "rtTable2" {
+resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
-resource "azurerm_subnet" "rtTable2" {
+resource "azurerm_subnet" "test" {
     name = "acctestsubnet%d"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
     address_prefix = "10.0.2.0/24"
-	route_table_id       = "${azurerm_route_table.rtTable2.id}"
+	route_table_id       = "${azurerm_route_table.test.id}"
 }
 
-resource "azurerm_route_table" "rtTable2" {
-  name                = "rtTable2-RT"
+resource "azurerm_route_table" "test" {
+  name                = "test-RT"
   location            = "West US"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
 }
 
 resource "azurerm_route" "route_a" {
   name                = "TestRouteA"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-  route_table_name    = "${azurerm_route_table.rtTable2.name}"
-
-  address_prefix         = "10.100.0.0/14"
-  next_hop_type          = "VirtualAppliance"
-  next_hop_in_ip_address = "10.10.1.1"
-}`
-
-var testAccAzureRMSubnet_routeTable_subnetInline = `
-resource "azurerm_resource_group" "rtTable2" {
-    name = "acctestRG-%d"
-    location = "West US"
-}
-
-resource "azurerm_virtual_network" "rtTable2" {
-    name = "acctestvirtnet%d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
- 	subnet {
-    	name           = "rtTable2"
-    	address_prefix = "10.0.3.0/24"
-		route_table    = "${azurerm_route_table.rtTable2.id}"
-  	}
-	tags {
-		environment = "Testing"
-	}
-}
-
-resource "azurerm_route_table" "rtTable2" {
-  name                = "rtTable2-RT"
-  location            = "West US"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-}
-
-resource "azurerm_route" "route_a" {
-  name                = "TestRouteA"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  route_table_name    = "${azurerm_route_table.test.name}"
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"
@@ -354,7 +296,7 @@ resource "azurerm_route" "route_a" {
 }`
 
 var testAccAzureRMSubnet_updatedRouteTable = `
-resource "azurerm_resource_group" "rtTable2" {
+resource "azurerm_resource_group" "test" {
     name = "acctestRG-%d"
     location = "West US"
 	tags {
@@ -362,10 +304,10 @@ resource "azurerm_resource_group" "rtTable2" {
 	}
 }
 
-resource "azurerm_network_security_group" "rtTable2_secgroup" {
+resource "azurerm_network_security_group" "test_secgroup" {
     name = "acceptanceTestSecurityGroup1"
     location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
 
     security_rule {
         name = "test123"
@@ -384,28 +326,28 @@ resource "azurerm_network_security_group" "rtTable2_secgroup" {
     }
 }
 
-resource "azurerm_virtual_network" "rtTable2" {
+resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
 	tags {
 		environment = "Testing"
 	}
 }
 
-resource "azurerm_subnet" "rtTable2" {
+resource "azurerm_subnet" "test" {
     name = "acctestsubnet%d"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
     address_prefix = "10.0.2.0/24"
-	route_table_id       = "${azurerm_route_table.rtTable2.id}"
+	route_table_id       = "${azurerm_route_table.test.id}"
 }
 
-resource "azurerm_route_table" "rtTable2" {
-  name                = "rtTable2-RT"
+resource "azurerm_route_table" "test" {
+  name                = "test-RT"
   location            = "West US"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
   tags {
     environment = "Testing"
   }
@@ -413,8 +355,8 @@ resource "azurerm_route_table" "rtTable2" {
 
 resource "azurerm_route" "route_a" {
   name                = "TestRouteA"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-  route_table_name    = "${azurerm_route_table.rtTable2.name}"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  route_table_name    = "${azurerm_route_table.test.name}"
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"

--- a/builtin/providers/azurerm/resource_arm_subnet_test.go
+++ b/builtin/providers/azurerm/resource_arm_subnet_test.go
@@ -32,11 +32,7 @@ func TestAccAzureRMSubnet_basic(t *testing.T) {
 	})
 }
 
-<<<<<<< HEAD
 func TestAccAzureRMSubnet_routeTableUpdate(t *testing.T) {
-=======
-func TestAccAzureRMSubnet_routeTable(t *testing.T) {
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
 	ri := acctest.RandInt()
 	initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable, ri, ri, ri)
@@ -50,43 +46,14 @@ func TestAccAzureRMSubnet_routeTable(t *testing.T) {
 			resource.TestStep{
 				Config: initConfig,
 				Check: resource.ComposeTestCheckFunc(
-<<<<<<< HEAD
 					testCheckAzureRMSubnetExists("azurerm_subnet.test"),
-=======
-					testCheckAzureRMSubnetExists("azurerm_subnet.rtTable2"),
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 				),
 			},
 
 			resource.TestStep{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-<<<<<<< HEAD
 					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.test", "test-RT"),
-=======
-					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
-				),
-			},
-		},
-	})
-}
-
-func TestAccAzureRMSubnet_routeTable_subnetInline(t *testing.T) {
-
-	ri := acctest.RandInt()
-	//initConfig := fmt.Sprintf(testAccAzureRMSubnet_routeTable_subnetInline, ri, ri, ri)
-	updatedConfig := fmt.Sprintf(testAccAzureRMSubnet_updatedRouteTable, ri, ri, ri)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testCheckAzureRMSubnetDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: updatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					testCheckAzureRMSubnetRouteTableExists("azurerm_subnet.rtTable2", "rtTable2-RT"),
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 				),
 			},
 		},
@@ -292,16 +259,11 @@ resource "azurerm_route" "test" {
 `
 
 var testAccAzureRMSubnet_routeTable = `
-<<<<<<< HEAD
 resource "azurerm_resource_group" "test" {
-=======
-resource "azurerm_resource_group" "rtTable2" {
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
     name = "acctestRG-%d"
     location = "West US"
 }
 
-<<<<<<< HEAD
 resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
@@ -321,75 +283,12 @@ resource "azurerm_route_table" "test" {
   name                = "test-RT"
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
-=======
-resource "azurerm_virtual_network" "rtTable2" {
-    name = "acctestvirtnet%d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-}
-
-resource "azurerm_subnet" "rtTable2" {
-    name = "acctestsubnet%d"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
-    address_prefix = "10.0.2.0/24"
-	route_table_id       = "${azurerm_route_table.rtTable2.id}"
-}
-
-resource "azurerm_route_table" "rtTable2" {
-  name                = "rtTable2-RT"
-  location            = "West US"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 }
 
 resource "azurerm_route" "route_a" {
   name                = "TestRouteA"
-<<<<<<< HEAD
   resource_group_name = "${azurerm_resource_group.test.name}"
   route_table_name    = "${azurerm_route_table.test.name}"
-=======
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-  route_table_name    = "${azurerm_route_table.rtTable2.name}"
-
-  address_prefix         = "10.100.0.0/14"
-  next_hop_type          = "VirtualAppliance"
-  next_hop_in_ip_address = "10.10.1.1"
-}`
-
-var testAccAzureRMSubnet_routeTable_subnetInline = `
-resource "azurerm_resource_group" "rtTable2" {
-    name = "acctestRG-%d"
-    location = "West US"
-}
-
-resource "azurerm_virtual_network" "rtTable2" {
-    name = "acctestvirtnet%d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
- 	subnet {
-    	name           = "rtTable2"
-    	address_prefix = "10.0.3.0/24"
-		route_table    = "${azurerm_route_table.rtTable2.id}"
-  	}
-	tags {
-		environment = "Testing"
-	}
-}
-
-resource "azurerm_route_table" "rtTable2" {
-  name                = "rtTable2-RT"
-  location            = "West US"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-}
-
-resource "azurerm_route" "route_a" {
-  name                = "TestRouteA"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-  route_table_name    = "${azurerm_route_table.rtTable2.name}"
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"
@@ -397,11 +296,7 @@ resource "azurerm_route" "route_a" {
 }`
 
 var testAccAzureRMSubnet_updatedRouteTable = `
-<<<<<<< HEAD
 resource "azurerm_resource_group" "test" {
-=======
-resource "azurerm_resource_group" "rtTable2" {
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
     name = "acctestRG-%d"
     location = "West US"
 	tags {
@@ -409,17 +304,10 @@ resource "azurerm_resource_group" "rtTable2" {
 	}
 }
 
-<<<<<<< HEAD
 resource "azurerm_network_security_group" "test_secgroup" {
     name = "acceptanceTestSecurityGroup1"
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
-=======
-resource "azurerm_network_security_group" "rtTable2_secgroup" {
-    name = "acceptanceTestSecurityGroup1"
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
     security_rule {
         name = "test123"
@@ -438,25 +326,16 @@ resource "azurerm_network_security_group" "rtTable2_secgroup" {
     }
 }
 
-<<<<<<< HEAD
 resource "azurerm_virtual_network" "test" {
     name = "acctestvirtnet%d"
     address_space = ["10.0.0.0/16"]
     location = "West US"
     resource_group_name = "${azurerm_resource_group.test.name}"
-=======
-resource "azurerm_virtual_network" "rtTable2" {
-    name = "acctestvirtnet%d"
-    address_space = ["10.0.0.0/16"]
-    location = "West US"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 	tags {
 		environment = "Testing"
 	}
 }
 
-<<<<<<< HEAD
 resource "azurerm_subnet" "test" {
     name = "acctestsubnet%d"
     resource_group_name = "${azurerm_resource_group.test.name}"
@@ -469,20 +348,6 @@ resource "azurerm_route_table" "test" {
   name                = "test-RT"
   location            = "West US"
   resource_group_name = "${azurerm_resource_group.test.name}"
-=======
-resource "azurerm_subnet" "rtTable2" {
-    name = "acctestsubnet%d"
-    resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-    virtual_network_name = "${azurerm_virtual_network.rtTable2.name}"
-    address_prefix = "10.0.2.0/24"
-	route_table_id       = "${azurerm_route_table.rtTable2.id}"
-}
-
-resource "azurerm_route_table" "rtTable2" {
-  name                = "rtTable2-RT"
-  location            = "West US"
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
   tags {
     environment = "Testing"
   }
@@ -490,13 +355,8 @@ resource "azurerm_route_table" "rtTable2" {
 
 resource "azurerm_route" "route_a" {
   name                = "TestRouteA"
-<<<<<<< HEAD
   resource_group_name = "${azurerm_resource_group.test.name}"
   route_table_name    = "${azurerm_route_table.test.name}"
-=======
-  resource_group_name = "${azurerm_resource_group.rtTable2.name}"
-  route_table_name    = "${azurerm_route_table.rtTable2.name}"
->>>>>>> 772fac7a1... Changes to vNet and subnet files to allow subnet updates without losing routing table references
 
   address_prefix         = "10.100.0.0/14"
   next_hop_type          = "VirtualAppliance"

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -269,8 +269,7 @@ func getVirtualNetworkProperties(d *schema.ResourceData, meta interface{}) (*net
 		}
 	}
 
-	// finally; return the struct:
-	return &network.VirtualNetworkPropertiesFormat{
+	properties := &network.VirtualNetworkPropertiesFormat{
 		AddressSpace: &network.AddressSpace{
 			AddressPrefixes: &prefixes,
 		},
@@ -278,16 +277,18 @@ func getVirtualNetworkProperties(d *schema.ResourceData, meta interface{}) (*net
 			DNSServers: &dnses,
 		},
 		Subnets: &subnets,
-	}, nil
+	}
+	// finally; return the struct:
+	return properties, nil
 }
 
 func resourceAzureSubnetHash(v interface{}) int {
 	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
-	buf.WriteString(fmt.Sprintf("%s-", m["address_prefix"].(string)))
-	if m["security_group"] != nil {
-		buf.WriteString(fmt.Sprintf("%s-", m["security_group"].(string)))
+	buf.WriteString(fmt.Sprintf("%s", m["name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s", m["address_prefix"].(string)))
+	if v, ok := m["security_group"]; ok {
+		buf.WriteString(v.(string))
 	}
 	return hashcode.String(buf.String())
 }

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -114,8 +114,8 @@ func resourceArmVirtualNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	azureRMLockMultiple(&nsgNames)
-	defer azureRMUnlockMultiple(&nsgNames)
+	azureRMLockMultiple(&networkSecurityGroupNames)
+	defer azureRMUnlockMultiple(&networkSecurityGroupNames)
 
 	_, err := vnetClient.CreateOrUpdate(resGroup, name, vnet, make(chan struct{}))
 	if err != nil {

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -114,8 +114,8 @@ func resourceArmVirtualNetworkCreate(d *schema.ResourceData, meta interface{}) e
 		}
 	}
 
-	azureRMLockMultiple(&networkSecurityGroupNames)
-	defer azureRMUnlockMultiple(&networkSecurityGroupNames)
+	azureRMLockMultiple(&nsgNames)
+	defer azureRMUnlockMultiple(&nsgNames)
 
 	_, err := vnetClient.CreateOrUpdate(resGroup, name, vnet, make(chan struct{}))
 	if err != nil {

--- a/builtin/providers/azurerm/resource_arm_virtual_network.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network.go
@@ -1,6 +1,7 @@
 package azurerm
 
 import (
+	"bytes"
 	"fmt"
 	"log"
 	"net/http"
@@ -89,11 +90,15 @@ func resourceArmVirtualNetworkCreate(d *schema.ResourceData, meta interface{}) e
 	location := d.Get("location").(string)
 	resGroup := d.Get("resource_group_name").(string)
 	tags := d.Get("tags").(map[string]interface{})
+	vnetProperties, vnetPropsErr := getVirtualNetworkProperties(d, meta)
+	if vnetPropsErr != nil {
+		return vnetPropsErr
+	}
 
 	vnet := network.VirtualNetwork{
 		Name:                           &name,
 		Location:                       &location,
-		VirtualNetworkPropertiesFormat: getVirtualNetworkProperties(d),
+		VirtualNetworkPropertiesFormat: vnetProperties,
 		Tags: expandTags(tags),
 	}
 
@@ -210,7 +215,7 @@ func resourceArmVirtualNetworkDelete(d *schema.ResourceData, meta interface{}) e
 	return err
 }
 
-func getVirtualNetworkProperties(d *schema.ResourceData) *network.VirtualNetworkPropertiesFormat {
+func getVirtualNetworkProperties(d *schema.ResourceData, meta interface{}) (*network.VirtualNetworkPropertiesFormat, error) {
 	// first; get address space prefixes:
 	prefixes := []string{}
 	for _, prefix := range d.Get("address_space").([]interface{}) {
@@ -230,21 +235,37 @@ func getVirtualNetworkProperties(d *schema.ResourceData) *network.VirtualNetwork
 			subnet := subnet.(map[string]interface{})
 
 			name := subnet["name"].(string)
+			log.Printf("[INFO] setting subnets inside vNet, processing %q", name)
+			//since subnets can also be created outside of vNet definition (as root objects)
+			// do a GET on subnet properties from the server before setting them
+			resGroup := d.Get("resource_group_name").(string)
+			vnetName := d.Get("name").(string)
+			subnetObj, err := getExistingSubnet(resGroup, vnetName, name, meta)
+			if err != nil {
+				return nil, err
+			}
+			log.Printf("[INFO] Completed GET of Subnet props ")
+
 			prefix := subnet["address_prefix"].(string)
 			secGroup := subnet["security_group"].(string)
 
-			var subnetObj network.Subnet
+			//set the props from config and leave the rest intact
 			subnetObj.Name = &name
-			subnetObj.SubnetPropertiesFormat = &network.SubnetPropertiesFormat{}
+			if subnetObj.SubnetPropertiesFormat == nil {
+				subnetObj.SubnetPropertiesFormat = &network.SubnetPropertiesFormat{}
+			}
+
 			subnetObj.SubnetPropertiesFormat.AddressPrefix = &prefix
 
 			if secGroup != "" {
 				subnetObj.SubnetPropertiesFormat.NetworkSecurityGroup = &network.SecurityGroup{
 					ID: &secGroup,
 				}
+			} else {
+				subnetObj.SubnetPropertiesFormat.NetworkSecurityGroup = nil
 			}
 
-			subnets = append(subnets, subnetObj)
+			subnets = append(subnets, *subnetObj)
 		}
 	}
 
@@ -257,16 +278,55 @@ func getVirtualNetworkProperties(d *schema.ResourceData) *network.VirtualNetwork
 			DNSServers: &dnses,
 		},
 		Subnets: &subnets,
-	}
+	}, nil
 }
 
 func resourceAzureSubnetHash(v interface{}) int {
+	var buf bytes.Buffer
 	m := v.(map[string]interface{})
-	subnet := m["name"].(string) + m["address_prefix"].(string)
-	if securityGroup, present := m["security_group"]; present {
-		subnet = subnet + securityGroup.(string)
+	buf.WriteString(fmt.Sprintf("%s-", m["name"].(string)))
+	buf.WriteString(fmt.Sprintf("%s-", m["address_prefix"].(string)))
+	if m["security_group"] != nil {
+		buf.WriteString(fmt.Sprintf("%s-", m["security_group"].(string)))
 	}
-	return hashcode.String(subnet)
+	return hashcode.String(buf.String())
+}
+
+func getExistingSubnet(resGroup string, vnetName string, subnetName string, meta interface{}) (*network.Subnet, error) {
+	//attempt to retrieve existing subnet from the server
+	existingSubnet := network.Subnet{}
+	subnetClient := meta.(*ArmClient).subnetClient
+	resp, err := subnetClient.Get(resGroup, vnetName, subnetName, "")
+
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return &existingSubnet, nil
+		}
+		//raise an error if there was an issue other than 404 in getting subnet properties
+		return nil, err
+	}
+
+	existingSubnet.SubnetPropertiesFormat = &network.SubnetPropertiesFormat{}
+	existingSubnet.SubnetPropertiesFormat.AddressPrefix = resp.SubnetPropertiesFormat.AddressPrefix
+
+	if resp.SubnetPropertiesFormat.NetworkSecurityGroup != nil {
+		existingSubnet.SubnetPropertiesFormat.NetworkSecurityGroup = resp.SubnetPropertiesFormat.NetworkSecurityGroup
+	}
+
+	if resp.SubnetPropertiesFormat.RouteTable != nil {
+		existingSubnet.SubnetPropertiesFormat.RouteTable = resp.SubnetPropertiesFormat.RouteTable
+	}
+
+	if resp.SubnetPropertiesFormat.IPConfigurations != nil {
+		ips := make([]string, 0, len(*resp.SubnetPropertiesFormat.IPConfigurations))
+		for _, ip := range *resp.SubnetPropertiesFormat.IPConfigurations {
+			ips = append(ips, *ip.ID)
+		}
+
+		existingSubnet.SubnetPropertiesFormat.IPConfigurations = resp.SubnetPropertiesFormat.IPConfigurations
+	}
+
+	return &existingSubnet, nil
 }
 
 func expandAzureRmVirtualNetworkVirtualNetworkSecurityGroupNames(d *schema.ResourceData) ([]string, error) {

--- a/builtin/providers/azurerm/resource_arm_virtual_network_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_network_test.go
@@ -208,8 +208,8 @@ resource "azurerm_virtual_network" "test" {
     }
 
     tags {
-	environment = "Production"
-	cost_center = "MSFT"
+		environment = "Production"
+		cost_center = "MSFT"
     }
 }
 `
@@ -232,7 +232,7 @@ resource "azurerm_virtual_network" "test" {
     }
 
     tags {
-	environment = "staging"
+		environment = "staging"
     }
 }
 `


### PR DESCRIPTION
This PR should partially fix #8227 and #11226 which I believe is a duplicate of #8227. The fix should preserve all of the subnet properties, including routeTable association, on vNet update.