### PR TITLE
helper/schema: Disallow validation+diff suppression on computed fields

### DIFF
--- a/builtin/providers/circonus/resource_circonus_metric_cluster.go
+++ b/builtin/providers/circonus/resource_circonus_metric_cluster.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/circonus-labs/circonus-gometrics/api"
-	"github.com/circonus-labs/circonus-gometrics/api/config"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -85,9 +84,8 @@ func resourceMetricCluster() *schema.Resource {
 
 			// Out parameters
 			metricClusterIDAttr: &schema.Schema{
-				Computed:     true,
-				Type:         schema.TypeString,
-				ValidateFunc: validateRegexp(metricClusterIDAttr, config.MetricClusterCIDRegex),
+				Computed: true,
+				Type:     schema.TypeString,
 			},
 		}),
 	}

--- a/builtin/providers/consul/data_source_consul_agent_self.go
+++ b/builtin/providers/consul/data_source_consul_agent_self.go
@@ -181,9 +181,6 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 			agentSelfACLDisabledTTL: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfACLDisabledTTL, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfACLDownPolicy: {
 				Computed: true,
@@ -196,9 +193,6 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 			agentSelfACLTTL: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfACLTTL, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfAddresses: {
 				Computed: true,
@@ -275,23 +269,14 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 			agentSelfCheckDeregisterIntervalMin: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfCheckDeregisterIntervalMin, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfCheckReapInterval: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfCheckReapInterval, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfCheckUpdateInterval: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfCheckUpdateInterval, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfClientAddr: {
 				Computed: true,
@@ -317,16 +302,10 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 						agentSelfDNSMaxStale: {
 							Computed: true,
 							Type:     schema.TypeString,
-							ValidateFunc: makeValidationFunc(agentSelfDNSMaxStale, validatorInputs{
-								validateDurationMin("0ns"),
-							}),
 						},
 						agentSelfDNSNodeTTL: {
 							Computed: true,
 							Type:     schema.TypeString,
-							ValidateFunc: makeValidationFunc(agentSelfDNSNodeTTL, validatorInputs{
-								validateDurationMin("0ns"),
-							}),
 						},
 						agentSelfDNSOnlyPassing: {
 							Computed: true,
@@ -335,16 +314,10 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 						agentSelfDNSRecursorTimeout: {
 							Computed: true,
 							Type:     schema.TypeString,
-							ValidateFunc: makeValidationFunc(agentSelfDNSRecursorTimeout, validatorInputs{
-								validateDurationMin("0ns"),
-							}),
 						},
 						agentSelfDNSServiceTTL: {
 							Computed: true,
 							Type:     schema.TypeString,
-							ValidateFunc: makeValidationFunc(agentSelfDNSServiceTTL, validatorInputs{
-								validateDurationMin("0ns"),
-							}),
 						},
 						agentSelfDNSUDPAnswerLimit: {
 							Computed: true,
@@ -406,9 +379,6 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 			agentSelfID: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfID, validatorInputs{
-					validateRegexp(`(?i)^[\da-f]{8}-[\da-f]{4}-[\da-f]{4}-[\da-f]{4}-[\da-f]{12}$`),
-				}),
 			},
 			agentSelfLeaveOnInt: {
 				Computed: true,
@@ -434,9 +404,6 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 						agentSelfPerformanceRaftMultiplier: {
 							Computed: true,
 							Type:     schema.TypeString, // FIXME(sean@): should be schema.TypeInt
-							ValidateFunc: makeValidationFunc(agentSelfPerformanceRaftMultiplier, validatorInputs{
-								validateIntMin(0),
-							}),
 						},
 					},
 				},
@@ -453,58 +420,30 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 						agentSelfSchemaPortsDNS: {
 							Computed: true,
 							Type:     schema.TypeInt,
-							ValidateFunc: makeValidationFunc(agentSelfSchemaPortsDNS, validatorInputs{
-								validateIntMin(1),
-								validateIntMax(65535),
-							}),
 						},
 						agentSelfSchemaPortsHTTP: {
 							Computed: true,
 							Type:     schema.TypeInt,
-							ValidateFunc: makeValidationFunc(agentSelfSchemaPortsHTTP, validatorInputs{
-								validateIntMin(1),
-								validateIntMax(65535),
-							}),
 						},
 						agentSelfSchemaPortsHTTPS: {
 							Computed: true,
 							Type:     schema.TypeInt,
-							ValidateFunc: makeValidationFunc(agentSelfSchemaPortsHTTPS, validatorInputs{
-								validateIntMin(1),
-								validateIntMax(65535),
-							}),
 						},
 						agentSelfSchemaPortsRPC: {
 							Computed: true,
 							Type:     schema.TypeInt,
-							ValidateFunc: makeValidationFunc(agentSelfSchemaPortsRPC, validatorInputs{
-								validateIntMin(1),
-								validateIntMax(65535),
-							}),
 						},
 						agentSelfSchemaPortsSerfLAN: {
 							Computed: true,
 							Type:     schema.TypeInt,
-							ValidateFunc: makeValidationFunc(agentSelfSchemaPortsSerfLAN, validatorInputs{
-								validateIntMin(1),
-								validateIntMax(65535),
-							}),
 						},
 						agentSelfSchemaPortsSerfWAN: {
 							Computed: true,
 							Type:     schema.TypeInt,
-							ValidateFunc: makeValidationFunc(agentSelfSchemaPortsSerfWAN, validatorInputs{
-								validateIntMin(1),
-								validateIntMax(65535),
-							}),
 						},
 						agentSelfSchemaPortsServer: {
 							Computed: true,
 							Type:     schema.TypeInt,
-							ValidateFunc: makeValidationFunc(agentSelfSchemaPortsServer, validatorInputs{
-								validateIntMin(1),
-								validateIntMax(65535),
-							}),
 						},
 					},
 				},
@@ -516,16 +455,10 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 			agentSelfReconnectTimeoutLAN: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfReconnectTimeoutLAN, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfReconnectTimeoutWAN: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfReconnectTimeoutWAN, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfRejoinAfterLeave: {
 				Computed: true,
@@ -612,9 +545,6 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 			agentSelfSessionTTLMin: {
 				Computed: true,
 				Type:     schema.TypeString,
-				ValidateFunc: makeValidationFunc(agentSelfSessionTTLMin, validatorInputs{
-					validateDurationMin("0ns"),
-				}),
 			},
 			agentSelfStartJoin: {
 				Computed: true,
@@ -702,9 +632,6 @@ func dataSourceConsulAgentSelf() *schema.Resource {
 						agentSelfTelemetryCirconusSubmissionInterval: &schema.Schema{
 							Type:     schema.TypeString,
 							Computed: true,
-							ValidateFunc: makeValidationFunc(agentSelfTelemetryCirconusSubmissionInterval, validatorInputs{
-								validateDurationMin("0ns"),
-							}),
 						},
 						agentSelfTelemetryEnableHostname: &schema.Schema{
 							Type:     schema.TypeString,

--- a/builtin/providers/consul/data_source_consul_catalog_nodes.go
+++ b/builtin/providers/consul/data_source_consul_catalog_nodes.go
@@ -56,14 +56,12 @@ func dataSourceConsulCatalogNodes() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						catalogNodesNodeID: &schema.Schema{
-							Type:         schema.TypeString,
-							Computed:     true,
-							ValidateFunc: makeValidationFunc(catalogNodesNodeID, []interface{}{validateRegexp(`^[\S]+$`)}),
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						catalogNodesNodeName: &schema.Schema{
-							Type:         schema.TypeString,
-							Computed:     true,
-							ValidateFunc: makeValidationFunc(catalogNodesNodeName, []interface{}{validateRegexp(`^[\S]+$`)}),
+							Type:     schema.TypeString,
+							Computed: true,
 						},
 						catalogNodesNodeAddress: &schema.Schema{
 							Type:     schema.TypeString,

--- a/builtin/providers/rancher/resource_rancher_stack.go
+++ b/builtin/providers/rancher/resource_rancher_stack.go
@@ -76,14 +76,12 @@ func resourceRancherStack() *schema.Resource {
 				Optional: true,
 			},
 			"rendered_docker_compose": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				DiffSuppressFunc: suppressComposeDiff,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 			"rendered_rancher_compose": {
-				Type:             schema.TypeString,
-				Computed:         true,
-				DiffSuppressFunc: suppressComposeDiff,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 		},
 	}

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -645,6 +645,19 @@ func (m schemaMap) InternalValidate(topSchemaMap schemaMap) error {
 			}
 		}
 
+		// Computed-only field
+		if v.Computed && !v.Optional {
+			if v.ValidateFunc != nil {
+				return fmt.Errorf("%s: ValidateFunc is for validating user input, "+
+					"there's nothing to validate on computed-only field", k)
+			}
+			if v.DiffSuppressFunc != nil {
+				return fmt.Errorf("%s: DiffSuppressFunc is for suppressing differences"+
+					" between config and state representation. "+
+					"There is no config for computed-only field, nothing to compare.", k)
+			}
+		}
+
 		if v.ValidateFunc != nil {
 			switch v.Type {
 			case TypeList, TypeSet:


### PR DESCRIPTION
Although we seem to run `ValidateFunc` and `DiffSuppressFunc` for computed-only fields, there is (AFAIK) no value in either validation or diff suppression.

For **validation** - even if the API response contained structures that didn't comply with validation restrictions (and I admit it may happen as some APIs may just change) and we raised that as error there's nothing the user can do about it. They can't change or fix the API. The validation should (IMO) be on the other side - in any fields where we might reference these computed fields.

For **diff suppression** - This feature was designed to suppress differences/drifts between config and state, not between state and state. That is why it has no effect in the context of compute-only field which has no config value to compare the value from state against.

Related https://github.com/hashicorp/terraform/pull/11005

cc @catsby @djosephsen

### Test plan

```
make testacc TEST=./builtin/providers/circonus
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/23 13:13:42 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/circonus -v  -timeout 120m
=== RUN   TestAccDataSourceCirconusAccount
--- PASS: TestAccDataSourceCirconusAccount (6.45s)
=== RUN   TestAccDataSourceCirconusCollector
--- PASS: TestAccDataSourceCirconusCollector (2.82s)
=== RUN   Test_MetricChecksum
--- PASS: Test_MetricChecksum (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccCirconusCheckCAQL_basic
--- PASS: TestAccCirconusCheckCAQL_basic (7.93s)
=== RUN   TestAccCirconusCheckCloudWatch_basic
--- FAIL: TestAccCirconusCheckCloudWatch_basic (0.01s)
	testing.go:280: Step 0 error: Configuration is invalid.

		Warnings: []string(nil)

		Errors: []string{"circonus_check.rds_metrics: Invalid api_key specified (\"\"): regexp failed to match string", "circonus_check.rds_metrics: Invalid api_secret specified (\"\"): regexp failed to match string"}
=== RUN   TestAccCirconusCheckConsul_node
--- PASS: TestAccCirconusCheckConsul_node (8.45s)
=== RUN   TestAccCirconusCheckConsul_service
--- PASS: TestAccCirconusCheckConsul_service (8.04s)
=== RUN   TestAccCirconusCheckConsul_state
--- PASS: TestAccCirconusCheckConsul_state (9.92s)
=== RUN   TestAccCirconusCheckHTTP_basic
--- PASS: TestAccCirconusCheckHTTP_basic (7.67s)
=== RUN   TestAccCirconusCheckHTTPTrap_basic
--- PASS: TestAccCirconusCheckHTTPTrap_basic (7.80s)
=== RUN   TestAccCirconusCheckICMPPing_basic
--- PASS: TestAccCirconusCheckICMPPing_basic (8.95s)
=== RUN   TestAccCirconusCheckJSON_basic
--- PASS: TestAccCirconusCheckJSON_basic (14.39s)
=== RUN   TestAccCirconusCheckMySQL_basic
--- PASS: TestAccCirconusCheckMySQL_basic (7.58s)
=== RUN   TestAccCirconusCheckPostgreSQL_basic
--- PASS: TestAccCirconusCheckPostgreSQL_basic (8.96s)
=== RUN   TestAccCirconusCheckStatsd_basic
--- PASS: TestAccCirconusCheckStatsd_basic (8.98s)
=== RUN   TestAccCirconusCheckTCP_basic
--- PASS: TestAccCirconusCheckTCP_basic (11.33s)
=== RUN   TestAccCirconusContactGroup_basic
--- PASS: TestAccCirconusContactGroup_basic (6.85s)
=== RUN   TestAccCirconusGraph_basic
--- PASS: TestAccCirconusGraph_basic (13.16s)
=== RUN   TestAccCirconusMetricCluster_basic
--- PASS: TestAccCirconusMetricCluster_basic (6.05s)
=== RUN   TestAccCirconusMetric_basic
--- PASS: TestAccCirconusMetric_basic (0.04s)
=== RUN   TestAccCirconusMetric_tagsets
--- PASS: TestAccCirconusMetric_tagsets (0.07s)
=== RUN   TestAccCirconusRuleSet_basic
--- PASS: TestAccCirconusRuleSet_basic (13.52s)
```
That one failure is [a known issue](https://github.com/hashicorp/terraform/issues/12808).

```
make testacc TEST=./builtin/providers/consul
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/23 11:59:24 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/consul -v -timeout 120m
TestAccDataConsulAgentSelf_basic
TestAccDataConsulCatalogNodes_basic
TestAccDataConsulCatalogService_basic
TestAccDataConsulCatalogServices_basic
TestAccDataConsulKeys_basic
TestAccConsulAgentService_basic
TestAccConsulCatalogEntry_basic
TestAccConsulKeyPrefix_basic
TestConsulKeysMigrateState
TestConsulKeysMigrateState_empty
TestAccConsulKeys_basic
TestAccConsulNode_basic
TestAccConsulPreparedQuery_basic
TestAccConsulService_basic
TestResourceProvider
TestResourceProvider_impl
TestResourceProvider_Configure
TestResourceProvider_ConfigureTLS
PASS
ok github.com/hashicorp/terraform/builtin/providers/consul	0.443s
```

We don't have any Rancher environment to test in for the moment.