### PR TITLE
provider/digitalocean: prevent new resources when using ID's of image…

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet.go
@@ -260,10 +260,13 @@ func resourceDigitalOceanDropletRead(d *schema.ResourceData, meta interface{}) e
 		return fmt.Errorf("Error retrieving droplet: %s", err)
 	}
 
-	if droplet.Image.Slug != "" {
-		d.Set("image", droplet.Image.Slug)
-	} else {
+	_, err = strconv.Atoi(d.Get("image").(string))
+	if err == nil || droplet.Image.Slug == "" {
+		// The image field is provided as an ID (number), or
+		// the image bash no slug. In both cases we store it as an ID.
 		d.Set("image", droplet.Image.ID)
+	} else {
+		d.Set("image", droplet.Image.Slug)
 	}
 
 	d.Set("name", droplet.Name)

--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -46,6 +46,26 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 	})
 }
 
+func TestAccDigitalOceanDroplet_WithID(t *testing.T) {
+	var droplet godo.Droplet
+	rInt := acctest.RandInt()
+	// TODO: not hardcode this as it will change over time
+	centosID := 22995941
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDigitalOceanDropletDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckDigitalOceanDropletConfig_withID(centosID, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDigitalOceanDropletExists("digitalocean_droplet.foobar", &droplet),
+				),
+			},
+		},
+	})
+}
 func TestAccDigitalOceanDroplet_withSSH(t *testing.T) {
 	var droplet godo.Droplet
 	rInt := acctest.RandInt()
@@ -497,6 +517,17 @@ resource "digitalocean_droplet" "foobar" {
   region    = "nyc3"
   user_data = "foobar"
 }`, rInt)
+}
+
+func testAccCheckDigitalOceanDropletConfig_withID(imageID, rInt int) string {
+	return fmt.Sprintf(`
+resource "digitalocean_droplet" "foobar" {
+  name      = "foo-%d"
+  size      = "512mb"
+  image     = "%d"
+  region    = "nyc3"
+  user_data = "foobar"
+}`, rInt, imageID)
 }
 
 func testAccCheckDigitalOceanDropletConfig_withSSH(rInt int) string {


### PR DESCRIPTION
…s with slugs

When you specify the ID of an image that has a slug, terraform would
store its slug to the state, hence it would always recreate the image.

This commit fixes it by storing the image as an ID when it is specified
by and ID by the user, ignoring the slug.

Closes #12751.
Fixes #12255.


Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>