### PR TITLE
provisioner/local-exec: Allow passing env vars to commands

### DIFF
--- a/builtin/provisioners/local-exec/resource_provisioner.go
+++ b/builtin/provisioners/local-exec/resource_provisioner.go
@@ -28,15 +28,17 @@ func Provisioner() terraform.ResourceProvisioner {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-
 			"interpreter": &schema.Schema{
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
-
 			"working_dir": &schema.Schema{
 				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"environment": &schema.Schema{
+				Type:     schema.TypeMap,
 				Optional: true,
 			},
 		},
@@ -50,9 +52,18 @@ func applyFn(ctx context.Context) error {
 	o := ctx.Value(schema.ProvOutputKey).(terraform.UIOutput)
 
 	command := data.Get("command").(string)
-
 	if command == "" {
 		return fmt.Errorf("local-exec provisioner command must be a non-empty string")
+	}
+
+	// Execute the command with env
+	environment := data.Get("environment").(map[string]interface{})
+
+	var env []string
+	env = make([]string, len(environment))
+	for k := range environment {
+		entry := fmt.Sprintf("%s=%s", k, environment[k].(string))
+		env = append(env, entry)
 	}
 
 	// Execute the command using a shell
@@ -85,6 +96,10 @@ func applyFn(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize pipe for output: %s", err)
 	}
 
+	var cmdEnv []string
+	cmdEnv = os.Environ()
+	cmdEnv = append(cmdEnv, env...)
+
 	// Setup the command
 	cmd := exec.CommandContext(ctx, cmdargs[0], cmdargs[1:]...)
 	cmd.Stderr = pw
@@ -93,6 +108,9 @@ func applyFn(ctx context.Context) error {
 	// If Dir is the empty string (this is default), runs the command
 	// in the calling process's current directory.
 	cmd.Dir = workingdir
+	// Env specifies the environment of the command.
+	// By default will use the calling process's environment
+	cmd.Env = cmdEnv
 
 	output, _ := circbuf.NewBuffer(maxBufSize)
 

--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -174,3 +174,27 @@ func TestResourceProvider_ApplyCustomWorkingDirectory(t *testing.T) {
 		t.Errorf("wrong output\ngot:  %s\nwant: %s", got, want)
 	}
 }
+
+func TestResourceProvider_ApplyCustomEnv(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"command": "echo $FOO $BAR $BAZ",
+		"environment": map[string]interface{}{
+			"FOO": "BAR",
+			"BAR": 1,
+			"BAZ": "true",
+		},
+	})
+
+	output := new(terraform.MockUIOutput)
+	p := Provisioner()
+
+	if err := p.Apply(output, nil, c); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	got := strings.TrimSpace(output.OutputMessage)
+	want := "BAR 1 true"
+	if got != want {
+		t.Errorf("wrong output\ngot:  %s\nwant: %s", got, want)
+	}
+}

--- a/website/docs/provisioners/local-exec.html.markdown
+++ b/website/docs/provisioners/local-exec.html.markdown
@@ -51,6 +51,9 @@ The following arguments are supported:
   form "/bin/bash", "-c", "echo foo". If `interpreter` is unspecified,
   sensible defaults will be chosen based on the system OS.
 
+* `environment` - (Optional) block of key value pairs representing the
+  environment of the executed command. inherits the current process environment.
+
 ### Interpreter Examples
 
 ```hcl
@@ -67,6 +70,22 @@ resource "null_resource" "example2" {
   provisioner "local-exec" {
     command = "Get-Date > completed.txt"
     interpreter = ["PowerShell", "-Command"]
+  }
+}
+```
+
+```hcl
+resource "aws_instance" "web" {
+  # ...
+
+  provisioner "local-exec" {
+    command = "echo $FOO $BAR $BAZ >> env_vars.txt"
+
+    environment {
+      FOO = "bar"
+      BAR = 1
+      BAZ = "true"
+    }
   }
 }
 ```


### PR DESCRIPTION
Fixes #13860 