### PR TITLE
provider/aws: Validate WAF metric names

### DIFF
--- a/builtin/providers/aws/resource_aws_waf_rule.go
+++ b/builtin/providers/aws/resource_aws_waf_rule.go
@@ -24,9 +24,10 @@ func resourceAwsWafRule() *schema.Resource {
 				ForceNew: true,
 			},
 			"metric_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateWafMetricName,
 			},
 			"predicates": &schema.Schema{
 				Type:     schema.TypeSet,

--- a/builtin/providers/aws/resource_aws_waf_web_acl.go
+++ b/builtin/providers/aws/resource_aws_waf_web_acl.go
@@ -37,9 +37,10 @@ func resourceAwsWafWebAcl() *schema.Resource {
 				},
 			},
 			"metric_name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateWafMetricName,
 			},
 			"rules": &schema.Schema{
 				Type:     schema.TypeSet,

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -1291,3 +1291,13 @@ func validateCognitoIdentityProvidersProviderName(v interface{}, k string) (ws [
 
 	return
 }
+
+func validateWafMetricName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"Only alphanumeric characters allowed in %q: %q",
+			k, value))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -2178,3 +2178,34 @@ func TestValidateCognitoIdentityProvidersProviderName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateWafMetricName(t *testing.T) {
+	validNames := []string{
+		"testrule",
+		"testRule",
+		"testRule123",
+	}
+	for _, v := range validNames {
+		_, errors := validateWafMetricName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid WAF metric name: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"!",
+		"/",
+		" ",
+		":",
+		";",
+		"white space",
+		"/slash-at-the-beginning",
+		"slash-at-the-end/",
+	}
+	for _, v := range invalidNames {
+		_, errors := validateWafMetricName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid WAF metric name", v)
+		}
+	}
+}


### PR DESCRIPTION
WAF metric names must be alphanumeric only and it would be useful to have this validated during a plan rather than fail on apply.

This bit us recently when I merged some code to master that used underscores for the metric name when the plan looked fine. Not a huge issue but should have been caught on the plan.

See http://docs.aws.amazon.com/waf/latest/developerguide/web-acl-rules.html#web-acl-rules-creating and
http://docs.aws.amazon.com/waf/latest/developerguide/web-acl-working-with.html#web-acl-creating