### PR TITLE
provider/aws: Expose execution ARN + invoke URL for APIG deployment

### DIFF
--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1927,6 +1927,20 @@ func flattenApiGatewayUsagePlanQuota(s *apigateway.QuotaSettings) []map[string]i
 	return []map[string]interface{}{settings}
 }
 
+func buildApiGatewayInvokeURL(restApiId, region, stageName string) string {
+	return fmt.Sprintf("https://%s.execute-api.%s.amazonaws.com/%s",
+		restApiId, region, stageName)
+}
+
+func buildApiGatewayExecutionARN(restApiId, region, accountId string) (string, error) {
+	if accountId == "" {
+		return "", fmt.Errorf("Unable to build execution ARN for %s as account ID is missing",
+			restApiId)
+	}
+	return fmt.Sprintf("arn:aws:execute-api:%s:%s:%s",
+		region, accountId, restApiId), nil
+}
+
 func expandCognitoSupportedLoginProviders(config map[string]interface{}) map[string]*string {
 	m := map[string]*string{}
 	for k, v := range config {

--- a/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_deployment.html.markdown
@@ -68,4 +68,9 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The ID of the deployment
+* `invoke_url` - The URL to invoke the API pointing to the stage,
+  e.g. `https://z4675bid1j.execute-api.eu-west-2.amazonaws.com/prod`
+* `execution_arn` - The execution ARN to be used in [`lambda_permission`](/docs/providers/aws/r/lambda_permission.html)'s `source_arn`
+  when allowing API Gateway to invoke a Lambda function,
+  e.g. `arn:aws:execute-api:eu-west-2:123456789012:z4675bid1j/prod`
 * `created_date` - The creation date of the deployment


### PR DESCRIPTION
The URL is useful for humans wanting to call the URL easily straight away and ARN for Lambda Permission.

### Before

```hcl
resource "aws_lambda_permission" "apigw_lambda" {
  statement_id  = "AllowExecutionFromAPIGateway"
  action        = "lambda:InvokeFunction"
  function_name = "${aws_lambda_function.lambda.arn}"
  principal     = "apigateway.amazonaws.com"

  source_arn = "arn:aws:execute-api:${var.region}:${var.account_id}:${aws_api_gateway_rest_api.demo.id}/${var.stage_name}/*"
}

output "invoke_url" {
  value = "https://${aws_api_gateway_rest_api.demo.id}.execute-api.${var.region}.amazonaws.com/${var.stage_name}"
}
```

### After

```hcl
resource "aws_lambda_permission" "apigw_lambda" {
  statement_id  = "AllowExecutionFromAPIGateway"
  action        = "lambda:InvokeFunction"
  function_name = "${aws_lambda_function.lambda.arn}"
  principal     = "apigateway.amazonaws.com"

  source_arn = "${aws_api_gateway_deployment.demo.execution_arn}/*"
}

output "invoke_url" {
  value = "${aws_api_gateway_deployment.demo.invoke_url}"
}
```