### PR TITLE
provider/aws: Expose invoke ARN from Lambda function (for API Gateway)

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -146,6 +146,10 @@ func resourceAwsLambdaFunction() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"invoke_arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -405,6 +409,8 @@ func resourceAwsLambdaFunctionRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("version", lastVersion)
 	d.Set("qualified_arn", lastQualifiedArn)
+
+	d.Set("invoke_arn", buildLambdaInvokeArn(*function.FunctionArn, meta.(*AWSClient).region))
 
 	return nil
 }

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1997,3 +1997,9 @@ func flattenCognitoIdentityProviders(ips []*cognitoidentity.Provider) []map[stri
 
 	return values
 }
+
+func buildLambdaInvokeArn(lambdaArn, region string) string {
+	apiVersion := "2015-03-31"
+	return fmt.Sprintf("arn:aws:apigateway:%s:lambda:path/%s/functions/%s/invocations",
+		region, apiVersion, lambdaArn)
+}

--- a/website/source/docs/providers/aws/r/lambda_function.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_function.html.markdown
@@ -108,6 +108,7 @@ For **environment** the following attributes are supported:
 * `arn` - The Amazon Resource Name (ARN) identifying your Lambda Function.
 * `qualified_arn` - The Amazon Resource Name (ARN) identifying your Lambda Function Version
   (if versioning is enabled via `publish = true`).
+* `invoke_arn` - The ARN to be used for invoking Lambda Function from API Gateway - to be used in [`aws_api_gateway_integration`](/docs/providers/aws/r/api_gateway_integration.html)'s `uri`
 * `version` - Latest published version of your Lambda Function.
 * `last_modified` - The date this resource was last modified.
 * `kms_key_arn` - (Optional) The ARN for the KMS encryption key.


### PR DESCRIPTION
### Before

```hcl
resource "aws_api_gateway_integration" "demo" {
  rest_api_id = "${aws_api_gateway_rest_api.demo.id}"
  resource_id = "${aws_api_gateway_rest_api.demo.root_resource_id}"
  http_method = "${aws_api_gateway_method.demo.http_method}"
  integration_http_method = "POST"
  type        = "AWS"
  uri         = "arn:aws:apigateway:eu-west-2:lambda:path/2015-03-31/functions/${aws_lambda_function.lambda.arn}/invocations"
}
```

### After

```hcl
resource "aws_api_gateway_integration" "demo" {
  rest_api_id = "${aws_api_gateway_rest_api.demo.id}"
  resource_id = "${aws_api_gateway_rest_api.demo.root_resource_id}"
  http_method = "${aws_api_gateway_method.demo.http_method}"
  integration_http_method = "POST"
  type        = "AWS"
  uri         = "${aws_lambda_function.lambda.invoke_arn}"
}
```