### PR TITLE
provider/azurerm: fixing a bug refreshing the `azurerm_redis_cache`

### DIFF
--- a/builtin/providers/azurerm/resource_arm_redis_cache.go
+++ b/builtin/providers/azurerm/resource_arm_redis_cache.go
@@ -281,12 +281,13 @@ func resourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 	name := id.Path["Redis"]
 
 	resp, err := client.Get(resGroup, name)
-	if err != nil {
-		return fmt.Errorf("Error making Read request on Azure Redis Cache %s: %s", name, err)
-	}
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error making Read request on Azure Redis Cache %s: %s", name, err)
 	}
 
 	keysResp, err := client.ListKeys(resGroup, name)

--- a/builtin/providers/azurerm/resource_arm_redis_cache.go
+++ b/builtin/providers/azurerm/resource_arm_redis_cache.go
@@ -281,6 +281,8 @@ func resourceArmRedisCacheRead(d *schema.ResourceData, meta interface{}) error {
 	name := id.Path["Redis"]
 
 	resp, err := client.Get(resGroup, name)
+
+	// covers if the resource has been deleted outside of TF, but is still in the state
 	if resp.StatusCode == http.StatusNotFound {
 		d.SetId("")
 		return nil


### PR DESCRIPTION
Currently, attempting to plan when an `azurerm_redis_cache` resource has been deleted in the portal - Terraform returns an error:
```
$ envchain azurerm terraform plan -refresh
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_resource_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tharvey-devrg)
azurerm_redis_cache.redis: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...providers/Microsoft.Cache/Redis/redis0)
Error refreshing state: 1 error(s) occurred:

* azurerm_redis_cache.redis: azurerm_redis_cache.redis: Error making Read request on Azure Redis Cache redis0: redis.GroupClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceNotFound" Message="The Resource 'Microsoft.Cache/Redis/redis0' under resource group 'tharvey-devrg' was not found.
```

This PR checks for a HTTP Not Found result - and removes it from the state if it doesn't exist:

```
$ envchain azurerm terraform plan -refresh
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_resource_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/tharvey-devrg)
azurerm_redis_cache.redis: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...providers/Microsoft.Cache/Redis/redis0)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

+ azurerm_redis_cache.redis
    capacity:                                 "1"
    enable_non_ssl_port:                      "false"
    family:                                   "C"
    hostname:                                 "<computed>"
    location:                                 "westeurope"
    name:                                     "redis0"
    port:                                     "<computed>"
    primary_access_key:                       "<computed>"
    redis_configuration.#:                    "1"
    redis_configuration.0.maxclients:         "1000"
    redis_configuration.0.maxmemory_delta:    "<computed>"
    redis_configuration.0.maxmemory_policy:   "volatile-lru"
    redis_configuration.0.maxmemory_reserved: "<computed>"
    resource_group_name:                      "tharvey-devrg"
    secondary_access_key:                     "<computed>"
    sku_name:                                 "Standard"
    ssl_port:                                 "<computed>"
    tags.%:                                   "2"
    tags.environment:                         "production"
    tags.role:                                "redis"


Plan: 1 to add, 0 to change, 0 to destroy.
```

Fixes #13896