### PR TITLE
[WIP] provider/azurerm: Fixes to `azurerm_network_security_rule`

### DIFF
--- a/builtin/providers/azurerm/resource_arm_network_security_rule.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_rule.go
@@ -34,6 +34,7 @@ func resourceArmNetworkSecurityRule() *schema.Resource {
 			"network_security_group_name": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 
 			"description": {

--- a/builtin/providers/azurerm/resource_arm_network_security_rule.go
+++ b/builtin/providers/azurerm/resource_arm_network_security_rule.go
@@ -20,9 +20,10 @@ func resourceArmNetworkSecurityRule() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
 			},
 
 			"resource_group_name": {

--- a/builtin/providers/azurerm/validators.go
+++ b/builtin/providers/azurerm/validators.go
@@ -4,7 +4,16 @@ import (
 	"fmt"
 
 	"github.com/satori/uuid"
+	"regexp"
 )
+
+func validateName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !regexp.MustCompile(`^[0-9A-Za-z_-]$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf("Only alphanumeric characters, `_` or `-` are allowed in %q: %q", k, value))
+	}
+	return
+}
 
 func validateUUID(v interface{}, k string) (ws []string, errors []error) {
 	if _, err := uuid.FromString(v.(string)); err != nil {

--- a/builtin/providers/azurerm/validators.go
+++ b/builtin/providers/azurerm/validators.go
@@ -9,7 +9,7 @@ import (
 
 func validateName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z_-]$`).MatchString(value) {
+	if !regexp.MustCompile(`^[\dA-Za-z_-]{1,}$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf("Only alphanumeric characters, `_` or `-` are allowed in %q: %q", k, value))
 	}
 	return

--- a/builtin/providers/azurerm/validators_test.go
+++ b/builtin/providers/azurerm/validators_test.go
@@ -1,0 +1,69 @@
+package azurerm
+
+import "testing"
+
+func TestValidateName_invalid(t *testing.T) {
+	type testCases struct {
+		Value    string
+		ErrCount int
+	}
+
+	invalidCases := []testCases{
+		{
+			Value:    "",
+			ErrCount: 1,
+		},
+		{
+			Value:    " ",
+			ErrCount: 1,
+		},
+		{
+			Value:    "abc 123",
+			ErrCount: 1,
+		},
+		{
+			Value:    "abc123!",
+			ErrCount: 1,
+		},
+		{
+			Value:    "{invalid}",
+			ErrCount: 1,
+		},
+	}
+
+	for _, tc := range invalidCases {
+		_, errors := validateName(tc.Value, "json")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q to trigger a validation error.", tc.Value)
+		}
+	}
+}
+
+func TestValidateName_valid(t *testing.T) {
+	type testCases struct {
+		Value    string
+		ErrCount int
+	}
+
+	validCases := []testCases{
+		{
+			Value:    "abc123",
+			ErrCount: 0,
+		},
+		{
+			Value:    "abc-123",
+			ErrCount: 0,
+		},
+		{
+			Value:    "abc_123",
+			ErrCount: 0,
+		},
+	}
+
+	for _, tc := range validCases {
+		_, errors := validateName(tc.Value, "json")
+		if len(errors) != tc.ErrCount {
+			t.Fatalf("Expected %q not to trigger a validation error.", tc.Value)
+		}
+	}
+}

--- a/website/source/docs/providers/azurerm/r/network_security_rule.html.markdown
+++ b/website/source/docs/providers/azurerm/r/network_security_rule.html.markdown
@@ -48,7 +48,7 @@ The following arguments are supported:
 * `resource_group_name` - (Required) The name of the resource group in which to
     create the Network Security Rule.
 
-* `network_security_group_name` - (Required) The name of the Network Security Group that we want to attach the rule to.
+* `network_security_group_name` - (Required) The name of the Network Security Group that we want to attach the rule to. Changing this forces a new resource to be created.
 
 * `description` - (Optional) A description for this rule. Restricted to 140 characters.
 


### PR DESCRIPTION
Issue #13773 has identified a number of shortcomings in the `azurerm_network_security_rule` resource. In this case:

 - Changing the `network_security_group_name` should currently copies the rule, leaving the original in-place. It looks like this should be a `ForceNew` (see fig 1 / 2 below)
 - The `name` can currently be an empty string (which causes an error in the API) - this fixes that

Fig 1:
<img width="831" alt="screen shot 2017-04-24 at 13 42 17" src="https://cloud.githubusercontent.com/assets/666005/25337485/ef469c46-28f3-11e7-89b4-6531896f1a75.png">

Then after changing the NSG Name and applying, Fig 2 is created but Fig 1 remains:

Fig 2:
<img width="813" alt="screen shot 2017-04-24 at 13 42 44" src="https://cloud.githubusercontent.com/assets/666005/25337487/f2a1f9b2-28f3-11e7-9f38-ed7aa8902643.png">

