### PR TITLE
[WIP] ebs_volumes datasource return multiples

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-set GOPATH=$GOPATH;d:\CSG\dev\github\Terraform\terraform

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "go.gopath": "D:\\CSG\\dev\\github\\Terraform\\terraform\\src;D:\\CSG\\dev\\github\\Terraform\\terraform\\vendor;D:\\CSG\\dev\\github\\Terraform\\terraform\\terraform;D:\\CSG\\dev\\github\\Terraform\\terraform\\builtin\\providers",
-  "go.toolsGopath":"C:\\tools\\go"
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ BUG FIXES:
  * provider/fastly: Fix issue with using 0 for `default_ttl` [GH-13648]
  * provider/fastly: Add ability to associate a healthcheck to a backend [GH-13539]
  * provider/google: Stop setting the id when project creation fails [GH-13644]
+ * provider/google: Make ports in resource_compute_forwarding_rule ForceNew [GH-13833]
  * provider/logentries: Refresh from state when resources not found [GH-13810]
  * provider/newrelic: newrelic_alert_condition - `condition_scope` must be `application` or `instance` [GH-12972]
  * provider/opc: fixed issue with unqualifying nats [GH-13826]

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,6 +69,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "initial-setup", type: "shell", inline: $script
   config.vm.synced_folder '.', '/opt/gopath/src/github.com/hashicorp/terraform'
 
+  config.vm.provider "docker" do |v, override|
+    override.vm.box = "tknerr/baseimage-ubuntu-#{UBUNTUVERSION}"
+  end
 
   ["vmware_fusion", "vmware_workstation"].each do |p|
     config.vm.provider p do |v|


### PR DESCRIPTION
[WIP]  ebs_volumes data source returning multiple rows (similar to availability_zones)

See discussion under #10123 

The AWS usecase is as follows:

**Given** -  a variable defined number of aws_instance(s) with associated ebs_volume(s) (destroy on termination = false)  using terraform apply.  
**When**  - instance is terminated and terraform apply run
**Then** -  Recreate the terminated instance and re-associate the existing volume to the same instance.

One way to implement this is to have terraform manage the ebs_volumes and separate terraform create the instance and query via the aws_ebs_volume data_source.  However,  This implementation is not possible because the data source is limited to returning one match.  


Example:

```
// Terraform 1
provider "aws" {
  region = "${var.aws_region}"
}

data "aws_availability_zones" "available" {}

resource "aws_ebs_volume" "volumes" {
  availability_zone = "${data.aws_availability_zones.available.names[(count.index) % length(data.aws_availability_zones.available.names)]}"
  size              = "${var.size}"
  encrypted         = "${var.encrypted}"
  type              = "${var.volume_type}"
  count             = "${var.instance_count}"

  tags {
    Role= "Log"
  }
}
```

```
// Terraform 2
resource "aws_instance" "instance" {
...
  count                  = "${var.instance_count}"
}

data "aws_ebs_volumes" "log" {
  filter {
    name   = "tag:Role"
    values = ["Log"]
  }
}

resource "aws_volume_attachment" "instance" {
  device_name = "/dev/sde"
  volume_id   = "${element(data.aws_ebs_volumes.log.ids, count.index)}"
  instance_id = "${element(aws_instance.instance.*.id, count.index)}"
  count       = "${var.instance_count}"
}
```

Ideally I would like a way under aws_instance to auto manage and reattach based on a tag value. 







