### PR TITLE
provider/aws: Allow AWS Subnet to change IPv6 CIDR Block without ForceNew

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -38,7 +38,6 @@ func resourceAwsSubnet() *schema.Resource {
 			"ipv6_cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
-				ForceNew: true,
 			},
 
 			"availability_zone": {
@@ -145,6 +144,7 @@ func resourceAwsSubnetRead(d *schema.ResourceData, meta interface{}) error {
 		if *a.Ipv6CidrBlockState.State == "associated" { //we can only ever have 1 IPv6 block associated at once
 			d.Set("ipv6_cidr_block_association_id", a.AssociationId)
 			d.Set("ipv6_cidr_block", a.Ipv6CidrBlock)
+			break
 		} else {
 			d.Set("ipv6_cidr_block_association_id", "") // we blank these out to remove old entries
 			d.Set("ipv6_cidr_block", "")
@@ -202,6 +202,73 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 		} else {
 			d.SetPartial("map_public_ip_on_launch")
 		}
+	}
+
+	// We have to be careful here to not go through a change of association if this is a new resource
+	// A New resource here would denote that the Update func is called by the Create func
+	if d.HasChange("ipv6_cidr_block") && !d.IsNewResource() {
+		// We need to handle that we disassociate the IPv6 CIDR block before we try and associate the new one
+		// This could be an issue as, we could error out when we try and add the new one
+		// We may need to roll back the state and reattach the old one if this is the case
+
+		_, new := d.GetChange("ipv6_cidr_block")
+
+		//Firstly we have to disassociate the old IPv6 CIDR Block
+		disassociateOps := &ec2.DisassociateSubnetCidrBlockInput{
+			AssociationId: aws.String(d.Get("ipv6_cidr_block_association_id").(string)),
+		}
+
+		_, err := conn.DisassociateSubnetCidrBlock(disassociateOps)
+		if err != nil {
+			return err
+		}
+
+		// Wait for the CIDR to become disassociated
+		log.Printf(
+			"[DEBUG] Waiting for IPv6 CIDR (%s) to become disassociated",
+			d.Id())
+		stateConf := &resource.StateChangeConf{
+			Pending: []string{"disassociating", "associated"},
+			Target:  []string{"disassociated"},
+			Refresh: SubnetIpv6CidrStateRefreshFunc(conn, d.Id(), d.Get("ipv6_cidr_block_association_id").(string)),
+			Timeout: 1 * time.Minute,
+		}
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf(
+				"Error waiting for IPv6 CIDR (%s) to become disassociated: %s",
+				d.Id(), err)
+		}
+
+		//Now we need to try and associate the new CIDR block
+		associatesOpts := &ec2.AssociateSubnetCidrBlockInput{
+			SubnetId:      aws.String(d.Id()),
+			Ipv6CidrBlock: aws.String(new.(string)),
+		}
+
+		resp, err := conn.AssociateSubnetCidrBlock(associatesOpts)
+		if err != nil {
+			//The big question here is, do we want to try and reassociate the old one??
+			//If we have a failure here, then we may be in a situation that we have nothing associated
+			return err
+		}
+
+		// Wait for the CIDR to become associated
+		log.Printf(
+			"[DEBUG] Waiting for IPv6 CIDR (%s) to become associated",
+			d.Id())
+		stateConf = &resource.StateChangeConf{
+			Pending: []string{"associating", "disassociated"},
+			Target:  []string{"associated"},
+			Refresh: SubnetIpv6CidrStateRefreshFunc(conn, d.Id(), *resp.Ipv6CidrBlockAssociation.AssociationId),
+			Timeout: 1 * time.Minute,
+		}
+		if _, err := stateConf.WaitForState(); err != nil {
+			return fmt.Errorf(
+				"Error waiting for IPv6 CIDR (%s) to become associated: %s",
+				d.Id(), err)
+		}
+
+		d.SetPartial("ipv6_cidr_block")
 	}
 
 	d.Partial(false)
@@ -274,5 +341,40 @@ func SubnetStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc 
 
 		subnet := resp.Subnets[0]
 		return subnet, *subnet.State, nil
+	}
+}
+
+func SubnetIpv6CidrStateRefreshFunc(conn *ec2.EC2, id string, associationId string) resource.StateRefreshFunc {
+	return func() (interface{}, string, error) {
+		opts := &ec2.DescribeSubnetsInput{
+			SubnetIds: []*string{aws.String(id)},
+		}
+		resp, err := conn.DescribeSubnets(opts)
+		if err != nil {
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() == "InvalidSubnetID.NotFound" {
+				resp = nil
+			} else {
+				log.Printf("Error on SubnetIpv6CidrStateRefreshFunc: %s", err)
+				return nil, "", err
+			}
+		}
+
+		if resp == nil {
+			// Sometimes AWS just has consistency issues and doesn't see
+			// our instance yet. Return an empty state.
+			return nil, "", nil
+		}
+
+		if resp.Subnets[0].Ipv6CidrBlockAssociationSet == nil {
+			return nil, "", nil
+		}
+
+		for _, association := range resp.Subnets[0].Ipv6CidrBlockAssociationSet {
+			if *association.AssociationId == associationId {
+				return association, *association.Ipv6CidrBlockState.State, nil
+			}
+		}
+
+		return nil, "", nil
 	}
 }


### PR DESCRIPTION
Fixes: #13588

It was pointed out in #13588 that we don't need to ForceNew on a change
of IPv6 CIDR block. The logic I decided to implement here was to
disassociate then associate. We should only be able to be associated to
1 IPv6 CIDR block at once. This feels like a risky move. We can
disassociate and then error on the associate. This would leave us in a
situation where we have no IPv6 CIDR block associated

The alternative here would be that the failure of association, triggers
a reassociation with the old IPv6 CIDR block

I added a test to make sure that the subnet Ids don't change as the ipv6
block changes. Before removing the ForceNew from the ipv6_cidr_block,
the test results in the following:

```
=== RUN   TestAccAWSSubnet_ipv6
--- FAIL: TestAccAWSSubnet_ipv6 (92.09s)
	resource_aws_subnet_test.go:105: Expected SubnetIDs not to change, but both got before: subnet-0d2b6a6a and after: subnet-742c6d13
```

After the removal of ForceNew, the test result looks as follows:

```
=== RUN   TestAccAWSSubnet_ipv6
--- PASS: TestAccAWSSubnet_ipv6 (188.34s)
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSubnet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/24 21:26:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSubnet_ -timeout 120m
=== RUN   TestAccAWSSubnet_importBasic
--- PASS: TestAccAWSSubnet_importBasic (85.63s)
=== RUN   TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (80.28s)
=== RUN   TestAccAWSSubnet_ipv6
--- PASS: TestAccAWSSubnet_ipv6 (188.34s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	354.283s
```