### PR TITLE
ignition: internal cache moved to global, instead per provider instance

### DIFF
--- a/builtin/providers/ignition/provider.go
+++ b/builtin/providers/ignition/provider.go
@@ -15,6 +15,21 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+// globalCache keeps the instances of the internal types of ignition generated
+// by the different data resources with the goal to be reused by the
+// ignition_config data resource. The key of the maps are a hash of the types
+// calculated on the type serialized to JSON.
+var globalCache = &cache{
+	disks:         make(map[string]*types.Disk, 0),
+	arrays:        make(map[string]*types.Raid, 0),
+	filesystems:   make(map[string]*types.Filesystem, 0),
+	files:         make(map[string]*types.File, 0),
+	systemdUnits:  make(map[string]*types.SystemdUnit, 0),
+	networkdUnits: make(map[string]*types.NetworkdUnit, 0),
+	users:         make(map[string]*types.User, 0),
+	groups:        make(map[string]*types.Group, 0),
+}
+
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
 		DataSourcesMap: map[string]*schema.Resource{
@@ -65,18 +80,6 @@ func Provider() terraform.ResourceProvider {
 				"ignition_group",
 				resourceGroup(),
 			),
-		},
-		ConfigureFunc: func(*schema.ResourceData) (interface{}, error) {
-			return &cache{
-				disks:         make(map[string]*types.Disk, 0),
-				arrays:        make(map[string]*types.Raid, 0),
-				filesystems:   make(map[string]*types.Filesystem, 0),
-				files:         make(map[string]*types.File, 0),
-				systemdUnits:  make(map[string]*types.SystemdUnit, 0),
-				networkdUnits: make(map[string]*types.NetworkdUnit, 0),
-				users:         make(map[string]*types.User, 0),
-				groups:        make(map[string]*types.Group, 0),
-			}, nil
 		},
 	}
 }

--- a/builtin/providers/ignition/resource_ignition_config.go
+++ b/builtin/providers/ignition/resource_ignition_config.go
@@ -91,7 +91,7 @@ func resourceConfig() *schema.Resource {
 }
 
 func resourceIgnitionFileRead(d *schema.ResourceData, meta interface{}) error {
-	rendered, err := renderConfig(d, meta.(*cache))
+	rendered, err := renderConfig(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func resourceIgnitionFileRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceIgnitionFileExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	rendered, err := renderConfig(d, meta.(*cache))
+	rendered, err := renderConfig(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_disk.go
+++ b/builtin/providers/ignition/resource_ignition_disk.go
@@ -59,7 +59,7 @@ func resourceDisk() *schema.Resource {
 }
 
 func resourceDiskRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildDisk(d, meta.(*cache))
+	id, err := buildDisk(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func resourceDiskRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceDiskExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildDisk(d, meta.(*cache))
+	id, err := buildDisk(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_file.go
+++ b/builtin/providers/ignition/resource_ignition_file.go
@@ -90,7 +90,7 @@ func resourceFile() *schema.Resource {
 }
 
 func resourceFileRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildFile(d, meta.(*cache))
+	id, err := buildFile(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func resourceFileRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceFileExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildFile(d, meta.(*cache))
+	id, err := buildFile(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_filesystem.go
+++ b/builtin/providers/ignition/resource_ignition_filesystem.go
@@ -63,7 +63,7 @@ func resourceFilesystem() *schema.Resource {
 }
 
 func resourceFilesystemRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildFilesystem(d, meta.(*cache))
+	id, err := buildFilesystem(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -73,7 +73,7 @@ func resourceFilesystemRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceFilesystemExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildFilesystem(d, meta.(*cache))
+	id, err := buildFilesystem(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_group.go
+++ b/builtin/providers/ignition/resource_ignition_group.go
@@ -30,7 +30,7 @@ func resourceGroup() *schema.Resource {
 }
 
 func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildGroup(d, meta.(*cache))
+	id, err := buildGroup(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func resourceGroupRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGroupExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildGroup(d, meta.(*cache))
+	id, err := buildGroup(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_networkd_unit.go
+++ b/builtin/providers/ignition/resource_ignition_networkd_unit.go
@@ -25,7 +25,7 @@ func resourceNetworkdUnit() *schema.Resource {
 }
 
 func resourceNetworkdUnitRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildNetworkdUnit(d, meta.(*cache))
+	id, err := buildNetworkdUnit(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -40,7 +40,7 @@ func resourceNetworkdUnitDelete(d *schema.ResourceData, meta interface{}) error 
 }
 
 func resourceNetworkdUnitExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildNetworkdUnit(d, meta.(*cache))
+	id, err := buildNetworkdUnit(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_raid.go
+++ b/builtin/providers/ignition/resource_ignition_raid.go
@@ -36,7 +36,7 @@ func resourceRaid() *schema.Resource {
 }
 
 func resourceRaidRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildRaid(d, meta.(*cache))
+	id, err := buildRaid(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func resourceRaidRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceRaidExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildRaid(d, meta.(*cache))
+	id, err := buildRaid(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_systemd_unit.go
+++ b/builtin/providers/ignition/resource_ignition_systemd_unit.go
@@ -55,7 +55,7 @@ func resourceSystemdUnit() *schema.Resource {
 }
 
 func resourceSystemdUnitRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildSystemdUnit(d, meta.(*cache))
+	id, err := buildSystemdUnit(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -65,7 +65,7 @@ func resourceSystemdUnitRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceSystemdUnitExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildSystemdUnit(d, meta.(*cache))
+	id, err := buildSystemdUnit(d, globalCache)
 	if err != nil {
 		return false, err
 	}

--- a/builtin/providers/ignition/resource_ignition_user.go
+++ b/builtin/providers/ignition/resource_ignition_user.go
@@ -79,7 +79,7 @@ func resourceUser() *schema.Resource {
 }
 
 func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
-	id, err := buildUser(d, meta.(*cache))
+	id, err := buildUser(d, globalCache)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func resourceUserRead(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceUserExists(d *schema.ResourceData, meta interface{}) (bool, error) {
-	id, err := buildUser(d, meta.(*cache))
+	id, err := buildUser(d, globalCache)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This is fixing a related issue to  https://github.com/hashicorp/terraform/issues/11518, was tested again several complex configurations as described in the issue.

/cc @alexsomesan