### PR TITLE
providers/heroku: add heroku_space resource

### DIFF
--- a/builtin/providers/heroku/provider.go
+++ b/builtin/providers/heroku/provider.go
@@ -25,11 +25,12 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"heroku_app":    resourceHerokuApp(),
 			"heroku_addon":  resourceHerokuAddon(),
+			"heroku_app":    resourceHerokuApp(),
+			"heroku_cert":   resourceHerokuCert(),
 			"heroku_domain": resourceHerokuDomain(),
 			"heroku_drain":  resourceHerokuDrain(),
-			"heroku_cert":   resourceHerokuCert(),
+			"heroku_space":  resourceHerokuSpace(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/heroku/resource_heroku_space.go
+++ b/builtin/providers/heroku/resource_heroku_space.go
@@ -1,0 +1,31 @@
+package heroku
+
+import "github.com/hashicorp/terraform/helper/schema"
+
+func resourceHerokuSpace() *schema.Resource {
+	return &schema.Resource{
+		Create: func(_ *schema.ResourceData, _ interface{}) error { return nil },
+		Read:   func(_ *schema.ResourceData, _ interface{}) error { return nil },
+		Update: func(_ *schema.ResourceData, _ interface{}) error { return nil },
+		Delete: func(_ *schema.ResourceData, _ interface{}) error { return nil },
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+
+			"organization": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"region": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}

--- a/builtin/providers/heroku/resource_heroku_space.go
+++ b/builtin/providers/heroku/resource_heroku_space.go
@@ -1,13 +1,19 @@
 package heroku
 
-import "github.com/hashicorp/terraform/helper/schema"
+import (
+	"context"
+	"log"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
 
 func resourceHerokuSpace() *schema.Resource {
 	return &schema.Resource{
-		Create: func(_ *schema.ResourceData, _ interface{}) error { return nil },
-		Read:   func(_ *schema.ResourceData, _ interface{}) error { return nil },
-		Update: func(_ *schema.ResourceData, _ interface{}) error { return nil },
-		Delete: func(_ *schema.ResourceData, _ interface{}) error { return nil },
+		Create: resourceHerokuSpaceCreate,
+		Read:   resourceHerokuSpaceRead,
+		Update: resourceHerokuSpaceUpdate,
+		Delete: resourceHerokuSpaceDelete,
 
 		Schema: map[string]*schema.Schema{
 			"name": {
@@ -28,4 +34,78 @@ func resourceHerokuSpace() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceHerokuSpaceCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	opts := heroku.SpaceCreateOpts{}
+	opts.Name = d.Get("name").(string)
+	opts.Organization = d.Get("organization").(string)
+
+	if v, ok := d.GetOk("region"); ok {
+		vs := v.(string)
+		opts.Region = &vs
+	}
+
+	space, err := client.SpaceCreate(context.TODO(), opts)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(space.ID)
+	log.Printf("[INFO] Space ID: %s", d.Id())
+
+	setSpaceAttributes(d, (*heroku.Space)(space))
+	return nil
+}
+
+func resourceHerokuSpaceRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	space, err := client.SpaceInfo(context.TODO(), d.Id())
+	if err != nil {
+		return err
+	}
+
+	setSpaceAttributes(d, (*heroku.Space)(space))
+	return nil
+}
+
+func resourceHerokuSpaceUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	if !d.HasChange("name") {
+		return nil
+	}
+
+	name := d.Get("name").(string)
+	opts := heroku.SpaceUpdateOpts{Name: &name}
+
+	space, err := client.SpaceUpdate(context.TODO(), d.Id(), opts)
+	if err != nil {
+		return err
+	}
+
+	setSpaceAttributes(d, (*heroku.Space)(space))
+	return nil
+}
+
+func setSpaceAttributes(d *schema.ResourceData, space *heroku.Space) {
+	d.Set("name", space.Name)
+	d.Set("organization", space.Organization.Name)
+	d.Set("region", space.Region.Name)
+}
+
+func resourceHerokuSpaceDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	log.Printf("[INFO] Deleting space: %s", d.Id())
+	_, err := client.SpaceDelete(context.TODO(), d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
 }

--- a/builtin/providers/heroku/resource_heroku_space.go
+++ b/builtin/providers/heroku/resource_heroku_space.go
@@ -56,6 +56,8 @@ func resourceHerokuSpaceCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(space.ID)
 	log.Printf("[INFO] Space ID: %s", d.Id())
 
+	// The type conversion here can be dropped when the vendored version of
+	// heroku-go is updated.
 	setSpaceAttributes(d, (*heroku.Space)(space))
 	return nil
 }
@@ -68,6 +70,8 @@ func resourceHerokuSpaceRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// The type conversion here can be dropped when the vendored version of
+	// heroku-go is updated.
 	setSpaceAttributes(d, (*heroku.Space)(space))
 	return nil
 }
@@ -87,6 +91,8 @@ func resourceHerokuSpaceUpdate(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	// The type conversion here can be dropped when the vendored version of
+	// heroku-go is updated.
 	setSpaceAttributes(d, (*heroku.Space)(space))
 	return nil
 }

--- a/builtin/providers/heroku/resource_heroku_space_test.go
+++ b/builtin/providers/heroku/resource_heroku_space_test.go
@@ -15,6 +15,7 @@ import (
 func TestAccHerokuSpace_Basic(t *testing.T) {
 	var space heroku.SpaceInfoResult
 	spaceName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	spaceName2 := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	org := os.Getenv("HEROKU_ORGANIZATION")
 
 	resource.Test(t, resource.TestCase{
@@ -31,6 +32,14 @@ func TestAccHerokuSpace_Basic(t *testing.T) {
 				Config: testAccCheckHerokuSpaceConfig_basic(spaceName, org),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
+					testAccCheckHerokuSpaceAttributes(&space, spaceName),
+				),
+			},
+			{
+				Config: testAccCheckHerokuSpaceConfig_basic(spaceName2, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
+					testAccCheckHerokuSpaceAttributes(&space, spaceName2),
 				),
 			},
 		},
@@ -66,11 +75,21 @@ func testAccCheckHerokuSpaceExists(n string, space *heroku.SpaceInfoResult) reso
 			return err
 		}
 
-		if foundSpace.Name != rs.Primary.ID {
+		if foundSpace.ID != rs.Primary.ID {
 			return fmt.Errorf("Space not found")
 		}
 
 		*space = *foundSpace
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuSpaceAttributes(space *heroku.SpaceInfoResult, spaceName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if space.Name != spaceName {
+			return fmt.Errorf("Bad name: %s", space.Name)
+		}
 
 		return nil
 	}

--- a/builtin/providers/heroku/resource_heroku_space_test.go
+++ b/builtin/providers/heroku/resource_heroku_space_test.go
@@ -1,0 +1,95 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccHerokuSpace_Basic(t *testing.T) {
+	var space heroku.SpaceInfoResult
+	spaceName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := os.Getenv("HEROKU_ORGANIZATION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if org == "" {
+				t.Skip("HEROKU_ORGANIZATION is not set; skipping test.")
+			}
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuSpaceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuSpaceConfig_basic(spaceName, org),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuSpaceExists("heroku_space.foobar", &space),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuSpaceConfig_basic(spaceName, orgName string) string {
+	return fmt.Sprintf(`
+resource "heroku_space" "foobar" {
+  name = "%s"
+	organization = "%s"
+	region = "virginia"
+}
+`, spaceName, orgName)
+}
+
+func testAccCheckHerokuSpaceExists(n string, space *heroku.SpaceInfoResult) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No space name set")
+		}
+
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		foundSpace, err := client.SpaceInfo(context.TODO(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundSpace.Name != rs.Primary.ID {
+			return fmt.Errorf("Space not found")
+		}
+
+		*space = *foundSpace
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuSpaceDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*heroku.Service)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "heroku_space" {
+			continue
+		}
+
+		_, err := client.SpaceInfo(context.TODO(), rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Space still exists")
+		}
+	}
+
+	return nil
+}

--- a/website/source/docs/providers/heroku/r/space.html.markdown
+++ b/website/source/docs/providers/heroku/r/space.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_space"
+sidebar_current: "docs-heroku-resource-space"
+description: |-
+  Provides a Heroku Space resource for running apps in isolated, highly available, secure app execution environments.
+---
+
+# heroku\_space
+
+Provides a Heroku Space resource for running apps in isolated, highly available, secure app execution environments.
+
+## Example Usage
+
+```hcl
+# Create a new Heroku space
+resource "heroku_space" "default" {
+  name = "test-space"
+  organization = "my-company"
+  region = "virginia"
+}
+
+# Create a new Heroku app in test-space
+resource "heroku_app" "default" {
+  name = "test-app"
+  space = "${heroku_space.default.name}"
+  organization = {
+    name = "my-company"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the space.
+* `organization` - (Required) The name of the organization which will own the space.
+* `region` - (Optional) The region that the space should be created in.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the space.
+* `name` - The space's name.
+* `plan` - The space's organization.
+* `region` - The space's region.

--- a/website/source/docs/providers/heroku/r/space.html.markdown
+++ b/website/source/docs/providers/heroku/r/space.html.markdown
@@ -44,5 +44,5 @@ The following attributes are exported:
 
 * `id` - The ID of the space.
 * `name` - The space's name.
-* `plan` - The space's organization.
+* `organization` - The space's organization.
 * `region` - The space's region.

--- a/website/source/docs/providers/heroku/r/space.html.markdown
+++ b/website/source/docs/providers/heroku/r/space.html.markdown
@@ -13,14 +13,14 @@ Provides a Heroku Space resource for running apps in isolated, highly available,
 ## Example Usage
 
 ```hcl
-# Create a new Heroku space
+// Create a new Heroku space
 resource "heroku_space" "default" {
   name = "test-space"
   organization = "my-company"
   region = "virginia"
 }
 
-# Create a new Heroku app in test-space
+// Create a new Heroku app in test-space
 resource "heroku_app" "default" {
   name = "test-app"
   space = "${heroku_space.default.name}"

--- a/website/source/layouts/heroku.erb
+++ b/website/source/layouts/heroku.erb
@@ -32,6 +32,10 @@
                     <li<%= sidebar_current("docs-heroku-resource-drain") %>>
                     <a href="/docs/providers/heroku/r/drain.html">heroku_drain</a>
                     </li>
+
+                    <li<%= sidebar_current("docs-heroku-resource-space") %>>
+                    <a href="/docs/providers/heroku/r/space.html">heroku_space</a>
+                    </li>
         </ul>
         </li>
       </ul>


### PR DESCRIPTION
This introduces a new `heroku_space` resource for managing [Heroku Private Spaces](https://www.heroku.com/private-spaces).

It creates, renames, and destroys private spaces in the configured region.

Combined with #13862, this should resolve #7059.

<details>
<summary>Acceptance test results</summary>

```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/24 17:43:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/heroku -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProvider_impl
--- PASS: TestProvider_impl (0.00s)
=== RUN   TestAccHerokuAddon_Basic
--- PASS: TestAccHerokuAddon_Basic (4.19s)
=== RUN   TestAccHerokuAddon_noPlan
--- PASS: TestAccHerokuAddon_noPlan (5.59s)
=== RUN   TestAccHerokuApp_Basic
--- PASS: TestAccHerokuApp_Basic (2.81s)
=== RUN   TestAccHerokuApp_NameChange
--- PASS: TestAccHerokuApp_NameChange (5.03s)
=== RUN   TestAccHerokuApp_NukeVars
--- PASS: TestAccHerokuApp_NukeVars (5.05s)
=== RUN   TestAccHerokuApp_Organization
--- PASS: TestAccHerokuApp_Organization (3.16s)
=== RUN   TestAccHerokuCert_Basic
--- PASS: TestAccHerokuCert_Basic (19.18s)
=== RUN   TestAccHerokuDomain_Basic
--- PASS: TestAccHerokuDomain_Basic (3.28s)
=== RUN   TestAccHerokuDrain_Basic
--- PASS: TestAccHerokuDrain_Basic (3.30s)
=== RUN   TestAccHerokuSpace_Basic
--- PASS: TestAccHerokuSpace_Basic (7.24s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/heroku	58.851s
```
</details>