### PR TITLE
Allow use of default timeout for rancher resources

### DIFF
--- a/builtin/providers/rancher/resource_rancher_certificate.go
+++ b/builtin/providers/rancher/resource_rancher_certificate.go
@@ -96,7 +96,7 @@ func resourceRancherCertificate() *schema.Resource {
 
 func resourceRancherCertificateCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO][rancher] Creating Certificate: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -141,7 +141,7 @@ func resourceRancherCertificateCreate(d *schema.ResourceData, meta interface{}) 
 
 func resourceRancherCertificateRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing Certificate: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -173,7 +173,7 @@ func resourceRancherCertificateRead(d *schema.ResourceData, meta interface{}) er
 
 func resourceRancherCertificateUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Updating Certificate: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func resourceRancherCertificateUpdate(d *schema.ResourceData, meta interface{}) 
 func resourceRancherCertificateDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Certificate: %s", d.Id())
 	id := d.Id()
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func resourceRancherCertificateImport(d *schema.ResourceData, meta interface{}) 
 	if envID != "" {
 		d.Set("environment_id", envID)
 	} else {
-		client, err := meta.(*Config).GlobalClient()
+		client, err := getConfig(d, meta).GlobalClient()
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -42,12 +42,15 @@ func resourceRancherEnvironment() *schema.Resource {
 				Optional: true,
 			},
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Default: schema.DefaultTimeout(30 * time.Second),
+		},
 	}
 }
 
 func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating Environment: %s", d.Id())
-	client, err := meta.(*Config).GlobalClient()
+	client, err := getConfig(d, meta).GlobalClient()
 	if err != nil {
 		return err
 	}
@@ -90,7 +93,7 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 
 func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing Environment: %s", d.Id())
-	client, err := meta.(*Config).GlobalClient()
+	client, err := getConfig(d, meta).GlobalClient()
 	if err != nil {
 		return err
 	}
@@ -122,7 +125,7 @@ func resourceRancherEnvironmentRead(d *schema.ResourceData, meta interface{}) er
 }
 
 func resourceRancherEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).GlobalClient()
+	client, err := getConfig(d, meta).GlobalClient()
 	if err != nil {
 		return err
 	}
@@ -154,7 +157,7 @@ func resourceRancherEnvironmentUpdate(d *schema.ResourceData, meta interface{}) 
 func resourceRancherEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Environment: %s", d.Id())
 	id := d.Id()
-	client, err := meta.(*Config).GlobalClient()
+	client, err := getConfig(d, meta).GlobalClient()
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/rancher/resource_rancher_host.go
+++ b/builtin/providers/rancher/resource_rancher_host.go
@@ -60,7 +60,7 @@ func resourceRancherHost() *schema.Resource {
 
 func resourceRancherHostCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO][rancher] Creating Host: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -87,7 +87,7 @@ func resourceRancherHostCreate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceRancherHostRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing Host: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func resourceRancherHostRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceRancherHostUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Updating Host: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func resourceRancherHostUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceRancherHostDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Host: %s", d.Id())
 	id := d.Id()
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}

--- a/builtin/providers/rancher/resource_rancher_registration_token.go
+++ b/builtin/providers/rancher/resource_rancher_registration_token.go
@@ -61,7 +61,7 @@ func resourceRancherRegistrationToken() *schema.Resource {
 
 func resourceRancherRegistrationTokenCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating RegistrationToken: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -101,11 +101,11 @@ func resourceRancherRegistrationTokenCreate(d *schema.ResourceData, meta interfa
 
 func resourceRancherRegistrationTokenRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing RegistrationToken: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
-	// client := meta.(*Config)
+	// client := getConfig(d, meta)
 
 	regT, err := client.RegistrationToken.ById(d.Id())
 	if err != nil {
@@ -140,7 +140,7 @@ func resourceRancherRegistrationTokenRead(d *schema.ResourceData, meta interface
 func resourceRancherRegistrationTokenDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting RegistrationToken: %s", d.Id())
 	id := d.Id()
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -210,7 +210,7 @@ func resourceRancherRegistrationTokenImport(d *schema.ResourceData, meta interfa
 	if envID != "" {
 		d.Set("environment_id", envID)
 	} else {
-		client, err := meta.(*Config).GlobalClient()
+		client, err := getConfig(d, meta).GlobalClient()
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}

--- a/builtin/providers/rancher/resource_rancher_registry.go
+++ b/builtin/providers/rancher/resource_rancher_registry.go
@@ -49,7 +49,7 @@ func resourceRancherRegistry() *schema.Resource {
 
 func resourceRancherRegistryCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating Registry: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func resourceRancherRegistryCreate(d *schema.ResourceData, meta interface{}) err
 
 func resourceRancherRegistryRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing Registry: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -123,7 +123,7 @@ func resourceRancherRegistryRead(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceRancherRegistryUpdate(d *schema.ResourceData, meta interface{}) error {
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -146,7 +146,7 @@ func resourceRancherRegistryUpdate(d *schema.ResourceData, meta interface{}) err
 func resourceRancherRegistryDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Registry: %s", d.Id())
 	id := d.Id()
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func resourceRancherRegistryImport(d *schema.ResourceData, meta interface{}) ([]
 	if envID != "" {
 		d.Set("environment_id", envID)
 	} else {
-		client, err := meta.(*Config).GlobalClient()
+		client, err := getConfig(d, meta).GlobalClient()
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}

--- a/builtin/providers/rancher/resource_rancher_registry_credential.go
+++ b/builtin/providers/rancher/resource_rancher_registry_credential.go
@@ -57,7 +57,7 @@ func resourceRancherRegistryCredential() *schema.Resource {
 
 func resourceRancherRegistryCredentialCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating RegistryCredential: %s", d.Id())
-	client, err := meta.(*Config).RegistryClient(d.Get("registry_id").(string))
+	client, err := getConfig(d, meta).RegistryClient(d.Get("registry_id").(string))
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func resourceRancherRegistryCredentialCreate(d *schema.ResourceData, meta interf
 
 func resourceRancherRegistryCredentialRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing RegistryCredential: %s", d.Id())
-	client, err := meta.(*Config).RegistryClient(d.Get("registry_id").(string))
+	client, err := getConfig(d, meta).RegistryClient(d.Get("registry_id").(string))
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func resourceRancherRegistryCredentialRead(d *schema.ResourceData, meta interfac
 
 func resourceRancherRegistryCredentialUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Updating RegistryCredential: %s", d.Id())
-	client, err := meta.(*Config).RegistryClient(d.Get("registry_id").(string))
+	client, err := getConfig(d, meta).RegistryClient(d.Get("registry_id").(string))
 	if err != nil {
 		return err
 	}
@@ -168,7 +168,7 @@ func resourceRancherRegistryCredentialUpdate(d *schema.ResourceData, meta interf
 func resourceRancherRegistryCredentialDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting RegistryCredential: %s", d.Id())
 	id := d.Id()
-	client, err := meta.(*Config).RegistryClient(d.Get("registry_id").(string))
+	client, err := getConfig(d, meta).RegistryClient(d.Get("registry_id").(string))
 	if err != nil {
 		return err
 	}
@@ -238,7 +238,7 @@ func resourceRancherRegistryCredentialImport(d *schema.ResourceData, meta interf
 	if regID != "" {
 		d.Set("registry_id", regID)
 	} else {
-		client, err := meta.(*Config).GlobalClient()
+		client, err := getConfig(d, meta).GlobalClient()
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}

--- a/builtin/providers/rancher/resource_rancher_stack.go
+++ b/builtin/providers/rancher/resource_rancher_stack.go
@@ -91,7 +91,7 @@ func resourceRancherStack() *schema.Resource {
 
 func resourceRancherStackCreate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Creating Stack: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -128,7 +128,7 @@ func resourceRancherStackCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceRancherStackRead(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Refreshing Stack: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func resourceRancherStackRead(d *schema.ResourceData, meta interface{}) error {
 
 func resourceRancherStackUpdate(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Updating Stack: %s", d.Id())
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -308,7 +308,7 @@ func resourceRancherStackUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceRancherStackDelete(d *schema.ResourceData, meta interface{}) error {
 	log.Printf("[INFO] Deleting Stack: %s", d.Id())
 	id := d.Id()
-	client, err := meta.(*Config).EnvironmentClient(d.Get("environment_id").(string))
+	client, err := getConfig(d, meta).EnvironmentClient(d.Get("environment_id").(string))
 	if err != nil {
 		return err
 	}
@@ -349,7 +349,7 @@ func resourceRancherStackImport(d *schema.ResourceData, meta interface{}) ([]*sc
 	if envID != "" {
 		d.Set("environment_id", envID)
 	} else {
-		client, err := meta.(*Config).GlobalClient()
+		client, err := getConfig(d, meta).GlobalClient()
 		if err != nil {
 			return []*schema.ResourceData{}, err
 		}
@@ -399,7 +399,7 @@ func makeStackData(d *schema.ResourceData, meta interface{}) (data map[string]in
 		catalogID := c.(string)
 		externalID += "catalog://" + catalogID
 
-		catalogClient, err := meta.(*Config).CatalogClient()
+		catalogClient, err := getConfig(d, meta).CatalogClient()
 		if err != nil {
 			return data, err
 		}


### PR DESCRIPTION
Redoing the work from GH-12070.  Even with the ability to set timeouts on resources, it still depends on the actual provider.  This change allows the setting of the default timeout (wasn't sure how to best document that though) of the rancher client.