### PR TITLE
Fix import path on provider-localfile

### DIFF
--- a/builtin/bins/provider-localfile/main.go
+++ b/builtin/bins/provider-localfile/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform/builtin/providers/localfile"
+	"github.com/hashicorp/terraform/builtin/providers/local"
 	"github.com/hashicorp/terraform/plugin"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProviderFunc: localfile.Provider,
+		ProviderFunc: local.Provider,
 	})
 }


### PR DESCRIPTION
This PR fixes import path for provider-localfile, added on [#12757 provider/localfile: Implement localfile provider](https://github.com/hashicorp/terraform/pull/12757)


### Before

```bash
go run builtin/bins/provider-localfile/main.go

builtin/bins/provider-localfile/main.go:4:2: cannot find package "github.com/hashicorp/terraform/builtin/providers/localfile" in any of:
	/go/src/github.com/hashicorp/terraform/vendor/github.com/hashicorp/terraform/builtin/providers/localfile (vendor tree)
	/usr/local/go1.8.1/src/github.com/hashicorp/terraform/builtin/providers/localfile (from $GOROOT)
	/go/src/github.com/hashicorp/terraform/builtin/providers/localfile (from $GOPATH)

# Missing import path also affects `go get ./...`
```

### After

```bash
go run builtin/bins/provider-atlas/main.go

This binary is a plugin. These are not meant to be executed directly.
Please execute the program that consumes these plugins, which will
load any plugins automatically
exit status 1
```

### P.S.

Only this provider is not match the naming between `builtin/bins` (localfile) and `builtin/providers` (local).
So it should be unified, but I'm not sure which one is preferable.