### PR TITLE
Documented aws_api_gateway_usage_plan.api_stages attributes as required

### DIFF
--- a/website/source/docs/providers/aws/r/api_gateway_usage_plan.html.markdown
+++ b/website/source/docs/providers/aws/r/api_gateway_usage_plan.html.markdown
@@ -72,8 +72,8 @@ The API Gateway Usage Plan argument layout is a structure composed of several su
 
 #### Api Stages arguments
 
-  * `api_id` (Optional) - API Id of the associated API stage in a usage plan.
-  * `stage` (Optional) - API stage name of the associated API stage in a usage plan.
+  * `api_id` (Required) - API Id of the associated API stage in a usage plan.
+  * `stage` (Required) - API stage name of the associated API stage in a usage plan.
 
 #### Quota Settings Arguments
 


### PR DESCRIPTION
```bash
$ terraform -v
Terraform v0.9.3
```

#### Configuration with no `api_stages.stage`

```bash
$ cat main.tf
resource "aws_api_gateway_usage_plan" "api_usage" {
  name        = "Sample name"
  description = "Sample description"

  api_stages {
    api_id = "Sample API id"
  }
}

$ terraform plan
1 error(s) occurred:

* aws_api_gateway_usage_plan.api_usage: "api_stages.0.stage": required field is not set
```

#### Configuration with no `api_stages.api_id`

```bash
$ cat main.tf
resource "aws_api_gateway_usage_plan" "api_usage" {
  name        = "Sample name"
  description = "Sample description"

  api_stages {
    stage = "Sample stage"
  }
}

$ terraform plan
1 error(s) occurred:

* aws_api_gateway_usage_plan.api_usage: "api_stages.0.api_id": required field is not set
```