### PR TITLE
ignition: ignition_file, interpolation support

### DIFF
--- a/website/source/docs/providers/ignition/d/file.html.md
+++ b/website/source/docs/providers/ignition/d/file.html.md
@@ -19,7 +19,10 @@ data "ignition_file" "hello" {
 	filesystem = "foo"
 	path = "/hello.txt"
 	content {
-		content = "Hello World!"
+		content = "Hello $${world}"
+		vars {
+			world = "World!"
+		}
 	}
 }
 ```
@@ -52,7 +55,7 @@ The following arguments are supported:
 
 	__Note__: `content` and `source` are mutually exclusive
 
-* `mode` - (Optional) The list of partitions and their configuration for 
+* `mode` - (Optional) The list of partitions and their configuration for
 this particular disk..
 
 * `uid` - (Optional) The user ID of the owner.
@@ -60,10 +63,14 @@ this particular disk..
 * `gid` - (Optional) The group ID of the owner.
 
 The `content` block supports:
- 
+
 * `mime` - (Required) MIME format of the content (default _text/plain_).
 
 * `content` - (Required) Content of the file.
+
+* `vars` - (Optional) Variables for interpolation within the content. Note
+  that variables must all be primitives. Direct references to lists or maps
+  will cause a validation error.
 
 The `source` block supports:
 


### PR DESCRIPTION
The PR introduce support for interpolation as does the template provider to the `ignition_file` data resource. 

```tf
data "ignition_file" "bar" {
	filesystem = "bar"
	path = "/bar"
	content {
		content = "bar $${bar} $${foo+10}"
		vars {
			bar = "foo"
			foo = 32
		}
	}
}
```

//cc @stack72 