### PR TITLE
provider/azurerm: ignoring the case during Diff to the `create_option` field of`azurerm_virtual_machine`

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine.go
@@ -177,8 +177,9 @@ func resourceArmVirtualMachine() *schema.Resource {
 						},
 
 						"create_option": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 
 						"disk_size_gb": {
@@ -232,8 +233,9 @@ func resourceArmVirtualMachine() *schema.Resource {
 						},
 
 						"create_option": {
-							Type:     schema.TypeString,
-							Required: true,
+							Type:             schema.TypeString,
+							Required:         true,
+							DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 						},
 
 						"caching": {


### PR DESCRIPTION
Issue #13927 identified that the casing on the `create_option` field isn't being ignored when comparing the diff - meaning there's perpetual changes:

```
$ envchain azurerm terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_resource_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...7b56ba/resourceGroups/tharvey-bug13927)
azurerm_virtual_network.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...work/virtualNetworks/tharveybug13927vn)
azurerm_storage_account.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...rage/storageAccounts/tharveybug13927sa)
azurerm_subnet.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...orks/tharveybug13927vn/subnets/acctsub)
azurerm_network_interface.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-.../networkInterfaces/tharvey-bug13927nic)
azurerm_storage_container.test: Refreshing state... (ID: vhds)
azurerm_virtual_machine.x0: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...ute/virtualMachines/tharvey-bug13927vm)
The Terraform execution plan has been generated and is shown below.
Resources are shown in alphabetical order for quick scanning. Green resources
will be created (or destroyed and then created if an existing resource
exists), yellow resources are being changed in-place, and red resources
will be destroyed. Cyan entries are data sources to be read.

Note: You didn't specify an "-out" parameter to save this plan, so when
"apply" is called, Terraform can't guarantee this is what will execute.

~ azurerm_virtual_machine.x0
    storage_data_disk.0.create_option: "Empty" => "empty"


Plan: 0 to add, 1 to change, 0 to destroy.
```

This PR fixes that so that it works as expected:
```
$ envchain azurerm terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

azurerm_resource_group.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...7b56ba/resourceGroups/tharvey-bug13927)
azurerm_storage_account.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...rage/storageAccounts/tharveybug13927sa)
azurerm_virtual_network.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...work/virtualNetworks/tharveybug13927vn)
azurerm_storage_container.test: Refreshing state... (ID: vhds)
azurerm_subnet.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...orks/tharveybug13927vn/subnets/acctsub)
azurerm_network_interface.test: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-.../networkInterfaces/tharvey-bug13927nic)
azurerm_virtual_machine.x0: Refreshing state... (ID: /subscriptions/00000000-0000-0000-0000-...ute/virtualMachines/tharvey-bug13927vm)
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```

Fixes #13927