### PR TITLE
provider/aws: Allow filtering of aws_subnet_ids by tags

### DIFF
--- a/builtin/providers/aws/data_source_aws_subnet_ids.go
+++ b/builtin/providers/aws/data_source_aws_subnet_ids.go
@@ -12,10 +12,14 @@ func dataSourceAwsSubnetIDs() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceAwsSubnetIDsRead,
 		Schema: map[string]*schema.Schema{
+
+			"tags": tagsSchemaComputed(),
+
 			"vpc_id": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 			},
+
 			"ids": &schema.Schema{
 				Type:     schema.TypeSet,
 				Computed: true,
@@ -36,6 +40,10 @@ func dataSourceAwsSubnetIDsRead(d *schema.ResourceData, meta interface{}) error 
 			"vpc-id": d.Get("vpc_id").(string),
 		},
 	)
+
+	req.Filters = append(req.Filters, buildEC2TagFilterList(
+		tagsFromMap(d.Get("tags").(map[string]interface{})),
+	)...)
 
 	log.Printf("[DEBUG] DescribeSubnets %s\n", req)
 	resp, err := conn.DescribeSubnets(req)

--- a/builtin/providers/aws/data_source_aws_subnet_ids_test.go
+++ b/builtin/providers/aws/data_source_aws_subnet_ids_test.go
@@ -21,7 +21,8 @@ func TestAccDataSourceAwsSubnetIDs(t *testing.T) {
 			{
 				Config: testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("data.aws_subnet_ids.selected", "ids.#", "1"),
+					resource.TestCheckResourceAttr("data.aws_subnet_ids.selected", "ids.#", "3"),
+					resource.TestCheckResourceAttr("data.aws_subnet_ids.private", "ids.#", "2"),
 				),
 			},
 		},
@@ -39,20 +40,50 @@ func testAccDataSourceAwsSubnetIDsConfigWithDataSource(rInt int) string {
 	  }
 	}
 
-	resource "aws_subnet" "test" {
+	resource "aws_subnet" "test_public_a" {
 	  vpc_id            = "${aws_vpc.test.id}"
 	  cidr_block        = "172.%d.123.0/24"
 	  availability_zone = "us-west-2a"
 
 	  tags {
-	    Name = "terraform-testacc-subnet-ids-data-source"
+	    Name = "terraform-testacc-subnet-ids-data-source-public-a"
+			Tier = "Public"
+	  }
+	}
+
+	resource "aws_subnet" "test_private_a" {
+	  vpc_id            = "${aws_vpc.test.id}"
+	  cidr_block        = "172.%d.125.0/24"
+	  availability_zone = "us-west-2a"
+
+	  tags {
+	    Name = "terraform-testacc-subnet-ids-data-source-private-a"
+			Tier = "Private"
+	  }
+	}
+
+	resource "aws_subnet" "test_private_b" {
+	  vpc_id            = "${aws_vpc.test.id}"
+	  cidr_block        = "172.%d.126.0/24"
+	  availability_zone = "us-west-2b"
+
+	  tags {
+	    Name = "terraform-testacc-subnet-ids-data-source-private-b"
+			Tier = "Private"
 	  }
 	}
 
 	data "aws_subnet_ids" "selected" {
 	  vpc_id = "${aws_vpc.test.id}"
 	}
-	`, rInt, rInt)
+
+	data "aws_subnet_ids" "private" {
+		vpc_id = "${aws_vpc.test.id}"
+		tags {
+			Tier = "Private"
+		}
+	}
+	`, rInt, rInt, rInt, rInt)
 }
 
 func testAccDataSourceAwsSubnetIDsConfig(rInt int) string {
@@ -65,14 +96,37 @@ func testAccDataSourceAwsSubnetIDsConfig(rInt int) string {
 		  }
 		}
 
-		resource "aws_subnet" "test" {
+		resource "aws_subnet" "test_public_a" {
 		  vpc_id            = "${aws_vpc.test.id}"
 		  cidr_block        = "172.%d.123.0/24"
 		  availability_zone = "us-west-2a"
 
 		  tags {
-		    Name = "terraform-testacc-subnet-ids-data-source"
+		    Name = "terraform-testacc-subnet-ids-data-source-public-a"
+				Tier = "Public"
 		  }
 		}
-		`, rInt, rInt)
+
+		resource "aws_subnet" "test_private_a" {
+		  vpc_id            = "${aws_vpc.test.id}"
+		  cidr_block        = "172.%d.125.0/24"
+		  availability_zone = "us-west-2a"
+
+		  tags {
+		    Name = "terraform-testacc-subnet-ids-data-source-private-a"
+				Tier = "Private"
+		  }
+		}
+
+		resource "aws_subnet" "test_private_b" {
+		  vpc_id            = "${aws_vpc.test.id}"
+		  cidr_block        = "172.%d.126.0/24"
+		  availability_zone = "us-west-2b"
+
+		  tags {
+		    Name = "terraform-testacc-subnet-ids-data-source-private-b"
+				Tier = "Private"
+		  }
+		}
+		`, rInt, rInt, rInt, rInt)
 }

--- a/website/source/docs/providers/aws/d/subnet_ids.html.markdown
+++ b/website/source/docs/providers/aws/d/subnet_ids.html.markdown
@@ -31,9 +31,32 @@ output "subnet_cidr_blocks" {
 }
 ```
 
+The following example retrieves a list of all subnets in a VPC with a custom
+tag of `Tier` set to a value of "Private" so that the `aws_instance` resource
+can loop through the subnets, putting instances across availability zones.
+
+```hcl
+data "aws_subnet_ids" "private" {
+  vpc_id = "${var.vpc_id}"
+  tags {
+    Tier = "Private"
+  }
+}
+
+resource "aws_instance" "app" {
+  count         = "3"
+  ami           = "${var.ami}"
+  instance_type = "t2.micro"
+  subnet_id     = "${element(data.aws_subnet_ids.private.ids, count.index)}"
+}
+```
+
 ## Argument Reference
 
 * `vpc_id` - (Required) The VPC ID that you want to filter from.
+
+* `tags` - (Optional) A mapping of tags, each pair of which must exactly match
+  a pair on the desired subnets.
 
 ## Attributes Reference
 


### PR DESCRIPTION
This is the minimal amount of work needed to be able to create a list of a subset of subnet IDs in a VPC, allowing people to loop through them easily when creating EC2 instances or provide a list straight to an ELB.

As mentioned in the docs updated this allows for configuration like this:
```hcl
data "aws_subnet_ids" "private" {
  vpc_id = "${var.vpc_id}"
  tags {
    Tier = "Private"
  }
}

resource "aws_instance" "app" {
  count         = "3"
  ami           = "${var.ami}"
  instance_type = "t2.micro"
  subnet_id     = "${element(data.aws_subnet_ids.private.ids, count.index)}"
}
```
Which in my brief testing led to plans of the following:
```
+ aws_instance.app.0
    ami:                         "ami-971238f1"
    associate_public_ip_address: "<computed>"
    availability_zone:           "<computed>"
    ebs_block_device.#:          "<computed>"
    ephemeral_block_device.#:    "<computed>"
    instance_state:              "<computed>"
    instance_type:               "t2.micro"
    ipv6_addresses.#:            "<computed>"
    key_name:                    "<computed>"
    network_interface_id:        "<computed>"
    placement_group:             "<computed>"
    private_dns:                 "<computed>"
    private_ip:                  "<computed>"
    public_dns:                  "<computed>"
    public_ip:                   "<computed>"
    root_block_device.#:         "<computed>"
    security_groups.#:           "<computed>"
    source_dest_check:           "true"
    subnet_id:                   "subnet-669ac310"
    tenancy:                     "<computed>"
    vpc_security_group_ids.#:    "<computed>"

+ aws_instance.app.1
    ami:                         "ami-971238f1"
    associate_public_ip_address: "<computed>"
    availability_zone:           "<computed>"
    ebs_block_device.#:          "<computed>"
    ephemeral_block_device.#:    "<computed>"
    instance_state:              "<computed>"
    instance_type:               "t2.micro"
    ipv6_addresses.#:            "<computed>"
    key_name:                    "<computed>"
    network_interface_id:        "<computed>"
    placement_group:             "<computed>"
    private_dns:                 "<computed>"
    private_ip:                  "<computed>"
    public_dns:                  "<computed>"
    public_ip:                   "<computed>"
    root_block_device.#:         "<computed>"
    security_groups.#:           "<computed>"
    source_dest_check:           "true"
    subnet_id:                   "subnet-a4aa8dc0"
    tenancy:                     "<computed>"
    vpc_security_group_ids.#:    "<computed>"

+ aws_instance.app.2
    ami:                         "ami-971238f1"
    associate_public_ip_address: "<computed>"
    availability_zone:           "<computed>"
    ebs_block_device.#:          "<computed>"
    ephemeral_block_device.#:    "<computed>"
    instance_state:              "<computed>"
    instance_type:               "t2.micro"
    ipv6_addresses.#:            "<computed>"
    key_name:                    "<computed>"
    network_interface_id:        "<computed>"
    placement_group:             "<computed>"
    private_dns:                 "<computed>"
    private_ip:                  "<computed>"
    public_dns:                  "<computed>"
    public_ip:                   "<computed>"
    root_block_device.#:         "<computed>"
    security_groups.#:           "<computed>"
    source_dest_check:           "true"
    subnet_id:                   "subnet-9b5c3cc3"
    tenancy:                     "<computed>"
    vpc_security_group_ids.#:    "<computed>"


Plan: 3 to add, 0 to change, 0 to destroy.
```
The order appears to be stable every time I plan but to be honest I'm not sure exactly what the ordering is that's coming back from AWS' API. As long as it's stable I don't actually care what order my instances are placed in the subnets although I imagine that some people may have a requirement that different filters lead to a stable order of AZs but I've deliberately left that out of scope for now.

I've also just added filtering by tags but any of the filters on the [singular subnet data source](https://www.terraform.io/docs/providers/aws/d/subnet.html) should be usable. I can add these if people want them or we can do that in a future PR if people want that functionality at a later date.

Testing looping through multiple times and also that sort order is stable:
```
$ for i in 1 2 3; do terraform plan | grep subnet_id; done
data.aws_subnet_ids.private: Refreshing state...
    subnet_id:                   "subnet-679ac311"
    subnet_id:                   "subnet-9a5c3cc2"
    subnet_id:                   "subnet-adaa8dc9"
    subnet_id:                   "subnet-679ac311"
    subnet_id:                   "subnet-9a5c3cc2"
    subnet_id:                   "subnet-adaa8dc9"
data.aws_subnet_ids.private: Refreshing state...
    subnet_id:                   "subnet-679ac311"
    subnet_id:                   "subnet-9a5c3cc2"
    subnet_id:                   "subnet-adaa8dc9"
    subnet_id:                   "subnet-679ac311"
    subnet_id:                   "subnet-9a5c3cc2"
    subnet_id:                   "subnet-adaa8dc9"
data.aws_subnet_ids.private: Refreshing state...
    subnet_id:                   "subnet-679ac311"
    subnet_id:                   "subnet-9a5c3cc2"
    subnet_id:                   "subnet-adaa8dc9"
    subnet_id:                   "subnet-679ac311"
    subnet_id:                   "subnet-9a5c3cc2"
    subnet_id:                   "subnet-adaa8dc9"
```

Acceptance tests:
```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run=TestAccDataSourceAwsSubnetIDs"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/25 13:40:09 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccDataSourceAwsSubnetIDs -timeout 120m
=== RUN   TestAccDataSourceAwsSubnetIDs
--- PASS: TestAccDataSourceAwsSubnetIDs (108.30s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	108.322s
```