### PR TITLE
Docs: `dir` flag in `get` cmd -> root module def. in `modules/index.html`

### DIFF
--- a/website/source/docs/commands/get.html.markdown
+++ b/website/source/docs/commands/get.html.markdown
@@ -9,7 +9,7 @@ description: |-
 # Command: get
 
 The `terraform get` command is used to download and update
-[modules](/docs/modules/index.html).
+[modules](/docs/modules/index.html) mentioned in the root module.
 
 ## Usage
 
@@ -28,3 +28,4 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-update` - If specified, modules that are already downloaded will be
    checked for updates and the updates will be downloaded if present.
+* `dir` - Sets the path of the [root module](/docs/modules/index.html#definitions).

--- a/website/source/docs/modules/index.html.markdown
+++ b/website/source/docs/modules/index.html.markdown
@@ -15,3 +15,8 @@ in Terraform as well as for basic code organization.
 Modules are very easy to both use and create. Depending on what you're
 looking to do first, use the navigation on the left to dive into how
 modules work.
+
+## Definitions
+**Root module**
+That is the current working directory when you run [`terraform apply`](/docs/commands/apply.html) or [`get`](/docs/commands/get.html), holding the Terraform [configuration files](/docs/configuration/index.html).
+It is itself a valid module.


### PR DESCRIPTION
The meaning of the `dir` flag was not obvious. See [Gitter conversation](https://gitter.im/hashicorp-terraform/Lobby?at=58ff4707d32c6f2f093bcd2f).