### PR TITLE
improve SIGINT output

### DIFF
--- a/backend/local/backend_apply.go
+++ b/backend/local/backend_apply.go
@@ -121,7 +121,7 @@ func (b *Local) opApply(
 	select {
 	case <-ctx.Done():
 		if b.CLI != nil {
-			b.CLI.Output("Interrupt received. Gracefully shutting down...")
+			b.CLI.Output("stopping apply operation...")
 		}
 
 		// Stop execution

--- a/command/apply.go
+++ b/command/apply.go
@@ -201,7 +201,7 @@ func (c *ApplyCommand) Run(args []string) int {
 		ctxCancel()
 
 		// Notify the user
-		c.Ui.Output("Interrupt received. Gracefully shutting down...")
+		c.Ui.Output(outputInterrupt)
 
 		// Still get the result, since there is still one
 		select {
@@ -418,3 +418,7 @@ func outputsAsString(state *terraform.State, modPath []string, schema []*config.
 
 	return strings.TrimSpace(outputBuf.String())
 }
+
+const outputInterrupt = `Interrupt received.
+Please wait for Terraform to exit or data loss may occur.
+Gracefully shutting down...`


### PR DESCRIPTION
- add data-loss warning to SIGINT handler in apply
- remove redundant output when interrupting apply