### PR TITLE
Randomizes glacier vault name

### DIFF
--- a/builtin/providers/aws/import_aws_glacier_vault_test.go
+++ b/builtin/providers/aws/import_aws_glacier_vault_test.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSGlacierVault_importBasic(t *testing.T) {
 	resourceName := "aws_glacier_vault.full"
+	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +17,7 @@ func TestAccAWSGlacierVault_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckGlacierVaultDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGlacierVault_full,
+				Config: testAccGlacierVault_full(rInt),
 			},
 
 			resource.TestStep{

--- a/builtin/providers/aws/resource_aws_glacier_vault_test.go
+++ b/builtin/providers/aws/resource_aws_glacier_vault_test.go
@@ -15,13 +15,14 @@ import (
 )
 
 func TestAccAWSGlacierVault_basic(t *testing.T) {
+	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGlacierVaultDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccGlacierVault_basic,
+				Config: testAccGlacierVault_basic(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGlacierVaultExists("aws_glacier_vault.test"),
 				),
@@ -208,11 +209,13 @@ func testAccCheckGlacierVaultDestroy(s *terraform.State) error {
 	return nil
 }
 
-const testAccGlacierVault_basic = `
+func testAccGlacierVault_basic(rInt int) string {
+	return fmt.Sprintf(`
 resource "aws_glacier_vault" "test" {
-  name = "my_test_vault"
+  name = "my_test_vault_%d"
 }
-`
+`, rInt)
+}
 
 func testAccGlacierVault_full(rInt int) string {
 	return fmt.Sprintf(`


### PR DESCRIPTION
This PR fixes `TestAccAWSGlacierVault_RemoveNotifications` by randomizing the glacier vault name 

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSGlacierVault_RemoveNotifications'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/25 10:27:02 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSGlacierVault_RemoveNotifications -timeout 120m
=== RUN   TestAccAWSGlacierVault_RemoveNotifications
--- PASS: TestAccAWSGlacierVault_RemoveNotifications (32.41s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	**32.442s**
```

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSGlacierVault_full'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/25 10:27:02 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSGlacierVault_full -timeout 120m
=== RUN   TestAccAWSGlacierVault_full
--- PASS: TestAccAWSGlacierVault_full (15.81s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	15.846s
```

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSGlacierVault_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/25 10:29:11 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSGlacierVault_importBasic -timeout 120m
=== RUN   TestAccAWSGlacierVault_importBasic
--- PASS: TestAccAWSGlacierVault_importBasic (19.03s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	19.070s
```