### PR TITLE
provider/google: documentation and validation fixes for forwarding rules

### DIFF
--- a/builtin/providers/google/resource_compute_forwarding_rule.go
+++ b/builtin/providers/google/resource_compute_forwarding_rule.go
@@ -89,6 +89,7 @@ func resourceComputeForwardingRule() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 				Set:      schema.HashString,
+				MaxItems: 5,
 			},
 
 			"project": &schema.Schema{

--- a/website/source/docs/providers/google/r/compute_forwarding_rule.html.markdown
+++ b/website/source/docs/providers/google/r/compute_forwarding_rule.html.markdown
@@ -3,7 +3,7 @@ layout: "google"
 page_title: "Google: google_compute_forwarding_rule"
 sidebar_current: "docs-google-compute-forwarding-rule"
 description: |-
-  Manages a Target Pool within GCE.
+  Manages a Forwarding Rule within GCE.
 ---
 
 # google\_compute\_forwarding\_rule
@@ -54,8 +54,9 @@ The following arguments are supported:
 * `port_range` - (Optional) A range e.g. "1024-2048" or a single port "1024"
     (defaults to all ports!). Only used for external load balancing.
 
-* `ports` - (Optional) A list of ports to use for internal load balancing
-    (defaults to all ports).
+* `ports` - (Optional) A list of ports (maximum of 5) to use for internal load
+    balancing. Packets addressed to these ports will be forwarded to the backends
+    configured with this forwarding rule. Required for internal load balancing.
 
 * `project` - (Optional) The project in which the resource belongs. If it
     is not provided, the provider project is used.


### PR DESCRIPTION
Fixes #13822 (as best as it can. There isn't a way to check that it isn't empty during the plan phase only if the load balancing scheme is internal. We _could_ fail faster during apply, but I don't think it's worth it.)

Fixes #13823.