### PR TITLE
provider/google: fix panic in GKE provisioning with addons

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -408,14 +408,14 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 		addonsConfig := v.([]interface{})[0].(map[string]interface{})
 		cluster.AddonsConfig = &container.AddonsConfig{}
 
-		if v, ok := addonsConfig["http_load_balancing"]; ok {
+		if v, ok := addonsConfig["http_load_balancing"]; ok && len(v.([]interface{})) > 0 {
 			addon := v.([]interface{})[0].(map[string]interface{})
 			cluster.AddonsConfig.HttpLoadBalancing = &container.HttpLoadBalancing{
 				Disabled: addon["disabled"].(bool),
 			}
 		}
 
-		if v, ok := addonsConfig["horizontal_pod_autoscaling"]; ok {
+		if v, ok := addonsConfig["horizontal_pod_autoscaling"]; ok && len(v.([]interface{})) > 0 {
 			addon := v.([]interface{})[0].(map[string]interface{})
 			cluster.AddonsConfig.HorizontalPodAutoscaling = &container.HorizontalPodAutoscaling{
 				Disabled: addon["disabled"].(bool),


### PR DESCRIPTION
If any element in `addons_config` is set, the data structure will be returned fully expanded. Check that subelements aren't empty before attempting to access their contents.