### PR TITLE
"terraform providers" command

### DIFF
--- a/command/providers.go
+++ b/command/providers.go
@@ -1,0 +1,125 @@
+package command
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform/moduledeps"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xlab/treeprint"
+)
+
+// ProvidersCommand is a Command implementation that prints out information
+// about the providers used in the current configuration/state.
+type ProvidersCommand struct {
+	Meta
+}
+
+func (c *ProvidersCommand) Help() string {
+	return providersCommandHelp
+}
+
+func (c *ProvidersCommand) Synopsis() string {
+	return "Prints a tree of the providers used in the configuration"
+}
+
+func (c *ProvidersCommand) Run(args []string) int {
+
+	cmdFlags := c.Meta.flagSet("providers")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	configPath, err := ModulePath(cmdFlags.Args())
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	// Load the config
+	root, err := c.Module(configPath)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+		return 1
+	}
+
+	// Validate the config (to ensure the version constraints are valid)
+	err = root.Validate()
+	if err != nil {
+		c.Ui.Error(err.Error())
+		return 1
+	}
+
+	// Load the backend
+	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
+		return 1
+	}
+
+	// Get the state
+	env := c.Env()
+	state, err := b.State(env)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
+	if err := state.RefreshState(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load state: %s", err))
+		return 1
+	}
+
+	s := state.State()
+
+	depTree := terraform.ModuleTreeDependencies(root, s)
+	depTree.SortDescendents()
+
+	printRoot := treeprint.New()
+	providersCommandPopulateTreeNode(printRoot, depTree)
+
+	c.Ui.Output(printRoot.String())
+
+	return 0
+}
+
+func providersCommandPopulateTreeNode(node treeprint.Tree, deps *moduledeps.Module) {
+	names := make([]string, 0, len(deps.Providers))
+	for name := range deps.Providers {
+		names = append(names, string(name))
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		dep := deps.Providers[moduledeps.ProviderInstance(name)]
+		versionsStr := dep.Versions.String()
+		if versionsStr != "" {
+			versionsStr = " " + versionsStr
+		}
+		var reasonStr string
+		switch dep.Reason {
+		case moduledeps.ProviderDependencyInherited:
+			reasonStr = " (inherited)"
+		case moduledeps.ProviderDependencyFromState:
+			reasonStr = " (from state)"
+		}
+		node.AddNode(fmt.Sprintf("provider.%s%s%s", name, versionsStr, reasonStr))
+	}
+
+	for _, child := range deps.Children {
+		childNode := node.AddBranch(fmt.Sprintf("module.%s", child.Name))
+		providersCommandPopulateTreeNode(childNode, child)
+	}
+}
+
+const providersCommandHelp = `
+Usage: terraform providers [dir]
+
+  Prints out a tree of modules in the referenced configuration annotated with
+  their provider requirements.
+
+  This provides an overview of all of the provider requirements across all
+  referenced modules, as an aid to understanding why particular provider
+  plugins are needed and why particular versions are selected.
+
+`

--- a/command/providers_test.go
+++ b/command/providers_test.go
@@ -1,0 +1,43 @@
+package command
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/mitchellh/cli"
+)
+
+func TestProviders(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.Chdir(testFixturePath("providers")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Chdir(cwd)
+
+	ui := new(cli.MockUi)
+	c := &ProvidersCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
+	}
+
+	output := ui.OutputWriter.String()
+	if !strings.Contains(output, "provider.foo") {
+		t.Errorf("output missing provider.foo\n\n%s", output)
+	}
+	if !strings.Contains(output, "provider.bar") {
+		t.Errorf("output missing provider.bar\n\n%s", output)
+	}
+	if !strings.Contains(output, "provider.baz") {
+		t.Errorf("output missing provider.baz\n\n%s", output)
+	}
+}

--- a/command/test-fixtures/providers/main.tf
+++ b/command/test-fixtures/providers/main.tf
@@ -1,0 +1,11 @@
+provider "foo" {
+
+}
+
+resource "bar_instance" "test" {
+
+}
+
+provider "baz" {
+  version = "1.2.0"
+}

--- a/commands.go
+++ b/commands.go
@@ -149,6 +149,12 @@ func init() {
 			}, nil
 		},
 
+		"providers": func() (cli.Command, error) {
+			return &command.ProvidersCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"push": func() (cli.Command, error) {
 			return &command.PushCommand{
 				Meta: meta,

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -178,7 +178,7 @@ func NewContext(opts *ContextOpts) (*Context, error) {
 	var providers map[string]ResourceProviderFactory
 	if opts.ProviderResolver != nil {
 		var err error
-		deps := moduleTreeDependencies(opts.Module, state)
+		deps := ModuleTreeDependencies(opts.Module, state)
 		reqd := deps.AllPluginRequirements()
 		providers, err = resourceProviderFactories(opts.ProviderResolver, reqd)
 		if err != nil {

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -7,7 +7,7 @@ import (
 	"github.com/hashicorp/terraform/plugin/discovery"
 )
 
-// moduleTreeDependencies returns the dependencies of the tree of modules
+// ModuleTreeDependencies returns the dependencies of the tree of modules
 // described by the given configuration tree and state.
 //
 // Both configuration and state are required because there can be resources
@@ -16,7 +16,7 @@ import (
 // This function will panic if any invalid version constraint strings are
 // present in the configuration. This is guaranteed not to happen for any
 // configuration that has passed a call to Config.Validate().
-func moduleTreeDependencies(root *module.Tree, state *State) *moduledeps.Module {
+func ModuleTreeDependencies(root *module.Tree, state *State) *moduledeps.Module {
 
 	// First we walk the configuration tree to build the overall structure
 	// and capture the explicit/implicit/inherited provider dependencies.

--- a/terraform/module_dependencies_test.go
+++ b/terraform/module_dependencies_test.go
@@ -248,7 +248,7 @@ func TestModuleTreeDependencies(t *testing.T) {
 				root = testModule(t, test.ConfigDir)
 			}
 
-			got := moduleTreeDependencies(root, test.State)
+			got := ModuleTreeDependencies(root, test.State)
 			if !got.Equal(test.Want) {
 				t.Errorf(
 					"wrong dependency tree\ngot:  %s\nwant: %s",

--- a/vendor/github.com/xlab/treeprint/LICENSE
+++ b/vendor/github.com/xlab/treeprint/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+Copyright © 2016 Maxim Kupriianov <max@kc.vc>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the “Software”), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/vendor/github.com/xlab/treeprint/README.md
+++ b/vendor/github.com/xlab/treeprint/README.md
@@ -1,0 +1,126 @@
+treeprint [![GoDoc](https://godoc.org/github.com/xlab/treeprint?status.svg)](https://godoc.org/github.com/xlab/treeprint) ![test coverage](https://img.shields.io/badge/coverage-68.6%25-green.svg)
+=========
+
+Package `treeprint` provides a simple ASCII tree composing tool.
+
+<a href="https://upload.wikimedia.org/wikipedia/commons/5/58/ENC_SYSTEME_FIGURE.jpeg"><img alt="SYSTEME FIGURE" src="https://upload.wikimedia.org/wikipedia/commons/thumb/5/58/ENC_SYSTEME_FIGURE.jpeg/896px-ENC_SYSTEME_FIGURE.jpeg" align="left" width="300"></a>
+
+If you are familiar with the [tree](http://mama.indstate.edu/users/ice/tree/) utility that is a recursive directory listing command that produces a depth indented listing of files, then you have the idea of what it would look like.
+
+On my system the command yields the following
+
+```
+ $ tree
+.
+├── LICENSE
+├── README.md
+├── treeprint.go
+└── treeprint_test.go
+
+0 directories, 4 files
+```
+
+and I'd like to have the same format for my Go data structures when I print them.
+
+## Installation
+
+```
+$ go get github.com/xlab/treeprint
+```
+
+## Concept of work
+
+The general idea is that you initialise a new tree with `treeprint.New()` and then add nodes and
+branches into it. Use `AddNode()` when you want add a node on the same level as the target or
+use `AddBranch()` when you want to go a level deeper. So `tree.AddBranch().AddNode().AddNode()` would
+create a new level with two distinct nodes on it. So `tree.AddNode().AddNode()` is a flat thing and
+`tree.AddBranch().AddBranch().AddBranch()` is a high thing. Use `String()` or `Bytes()` on a branch
+to render a subtree, or use it on the root to print the whole tree.
+
+## Use cases
+
+When you want to render a complex data structure:
+
+```go
+func main() {
+    tree := treeprint.New()
+
+    // create a new branch in the root
+    one := tree.AddBranch("one")
+
+    // add some nodes
+    one.AddNode("subnode1").AddNode("subnode2")
+
+    // create a new sub-branch
+    one.AddBranch("two").
+        AddNode("subnode1").AddNode("subnode2"). // add some nodes
+        AddBranch("three"). // add a new sub-branch
+        AddNode("subnode1").AddNode("subnode2") // add some nodes too
+
+    // add one more node that should surround the inner branch
+    one.AddNode("subnode3")
+
+    // add a new node to the root
+    tree.AddNode("outernode")
+
+    fmt.Println(tree.String())
+}
+```
+
+Will give you:
+
+```
+.
+├── one
+│   ├── subnode1
+│   ├── subnode2
+│   ├── two
+│   │   ├── subnode1
+│   │   ├── subnode2
+│   │   └── three
+│   │       ├── subnode1
+│   │       └── subnode2
+│   └── subnode3
+└── outernode
+```
+
+Another case, when you have to make a tree where any leaf may have some meta-data (as `tree` is capable of it):
+
+```go
+func main {
+    tree := treeprint.New()
+
+    tree.AddNode("Dockerfile")
+    tree.AddNode("Makefile")
+    tree.AddNode("aws.sh")
+    tree.AddMetaBranch(" 204", "bin").
+        AddNode("dbmaker").AddNode("someserver").AddNode("testtool")
+    tree.AddMetaBranch(" 374", "deploy").
+        AddNode("Makefile").AddNode("bootstrap.sh")
+    tree.AddMetaNode("122K", "testtool.a")
+
+    fmt.Println(tree.String())
+}
+```
+
+Output:
+
+```
+.
+├── Dockerfile
+├── Makefile
+├── aws.sh
+├── [ 204]  bin
+│   ├── dbmaker
+│   ├── someserver
+│   └── testtool
+├── [ 374]  deploy
+│   ├── Makefile
+│   └── bootstrap.sh
+└── [122K]  testtool.a
+```
+
+Yay! So it works.
+
+## License
+MIT

--- a/vendor/github.com/xlab/treeprint/helpers.go
+++ b/vendor/github.com/xlab/treeprint/helpers.go
@@ -1,0 +1,47 @@
+package treeprint
+
+import (
+	"reflect"
+	"strings"
+)
+
+func isEmpty(v *reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func tagSpec(tag string) (name string, omit bool) {
+	parts := strings.Split(tag, ",")
+	if len(parts) < 2 {
+		return tag, false
+	}
+	if parts[1] == "omitempty" {
+		return parts[0], true
+	}
+	return parts[0], false
+}
+
+func filterTags(tag reflect.StructTag) string {
+	tags := strings.Split(string(tag), " ")
+	filtered := make([]string, 0, len(tags))
+	for i := range tags {
+		if strings.HasPrefix(tags[i], "tree:") {
+			continue
+		}
+		filtered = append(filtered, tags[i])
+	}
+	return strings.Join(filtered, " ")
+}

--- a/vendor/github.com/xlab/treeprint/struct.go
+++ b/vendor/github.com/xlab/treeprint/struct.go
@@ -1,0 +1,340 @@
+package treeprint
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type StructTreeOption int
+
+const (
+	StructNameTree StructTreeOption = iota
+	StructValueTree
+	StructTagTree
+	StructTypeTree
+	StructTypeSizeTree
+)
+
+func FromStruct(v interface{}, opt ...StructTreeOption) (Tree, error) {
+	var treeOpt StructTreeOption
+	if len(opt) > 0 {
+		treeOpt = opt[0]
+	}
+	switch treeOpt {
+	case StructNameTree:
+		tree := New()
+		err := nameTree(tree, v)
+		return tree, err
+	case StructValueTree:
+		tree := New()
+		err := valueTree(tree, v)
+		return tree, err
+	case StructTagTree:
+		tree := New()
+		err := tagTree(tree, v)
+		return tree, err
+	case StructTypeTree:
+		tree := New()
+		err := typeTree(tree, v)
+		return tree, err
+	case StructTypeSizeTree:
+		tree := New()
+		err := typeSizeTree(tree, v)
+		return tree, err
+	default:
+		err := fmt.Errorf("treeprint: invalid StructTreeOption %v", treeOpt)
+		return nil, err
+	}
+}
+
+type FmtFunc func(name string, v interface{}) (string, bool)
+
+func FromStructWithMeta(v interface{}, fmtFunc FmtFunc) (Tree, error) {
+	if fmtFunc == nil {
+		tree := New()
+		err := nameTree(tree, v)
+		return tree, err
+	}
+	tree := New()
+	err := metaTree(tree, v, fmtFunc)
+	return tree, err
+}
+
+func Repr(v interface{}) string {
+	tree := New()
+	vType := reflect.TypeOf(v)
+	vValue := reflect.ValueOf(v)
+	_, val, isStruct := getValue(vType, &vValue)
+	if !isStruct {
+		return fmt.Sprintf("%+v", val.Interface())
+	}
+	err := valueTree(tree, val.Interface())
+	if err != nil {
+		return err.Error()
+	}
+	return tree.String()
+}
+
+func nameTree(tree Tree, v interface{}) error {
+	typ, val, err := checkType(v)
+	if err != nil {
+		return err
+	}
+	fields := typ.NumField()
+	for i := 0; i < fields; i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+		name, skip, omit := getMeta(field.Name, field.Tag)
+		if skip || omit && isEmpty(&fieldValue) {
+			continue
+		}
+		typ, val, isStruct := getValue(field.Type, &fieldValue)
+		if !val.CanSet() {
+			continue
+		}
+		if !isStruct {
+			tree.AddNode(name)
+			continue
+		} else if subNum := typ.NumField(); subNum == 0 {
+			tree.AddNode(name)
+			continue
+		}
+		branch := tree.AddBranch(name)
+		if err := nameTree(branch, val.Interface()); err != nil {
+			err := fmt.Errorf("%v on struct branch %s", name)
+			return err
+		}
+	}
+	return nil
+}
+
+func getMeta(fieldName string, tag reflect.StructTag) (name string, skip, omit bool) {
+	if tagStr := tag.Get("tree"); len(tagStr) > 0 {
+		name, omit = tagSpec(tagStr)
+	}
+	if name == "-" {
+		return fieldName, true, omit
+	}
+	if len(name) == 0 {
+		name = fieldName
+	} else if trimmed := strings.TrimSpace(name); len(trimmed) == 0 {
+		name = fieldName
+	}
+	return
+}
+
+func valueTree(tree Tree, v interface{}) error {
+	typ, val, err := checkType(v)
+	if err != nil {
+		return err
+	}
+	fields := typ.NumField()
+	for i := 0; i < fields; i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+		name, skip, omit := getMeta(field.Name, field.Tag)
+		if skip || omit && isEmpty(&fieldValue) {
+			continue
+		}
+		typ, val, isStruct := getValue(field.Type, &fieldValue)
+		if !val.CanSet() {
+			continue
+		}
+		if !isStruct {
+			tree.AddMetaNode(val.Interface(), name)
+			continue
+		} else if subNum := typ.NumField(); subNum == 0 {
+			tree.AddMetaNode(val.Interface(), name)
+			continue
+		}
+		branch := tree.AddBranch(name)
+		if err := valueTree(branch, val.Interface()); err != nil {
+			err := fmt.Errorf("%v on struct branch %s", name)
+			return err
+		}
+	}
+	return nil
+}
+
+func tagTree(tree Tree, v interface{}) error {
+	typ, val, err := checkType(v)
+	if err != nil {
+		return err
+	}
+	fields := typ.NumField()
+	for i := 0; i < fields; i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+		name, skip, omit := getMeta(field.Name, field.Tag)
+		if skip || omit && isEmpty(&fieldValue) {
+			continue
+		}
+		filteredTag := filterTags(field.Tag)
+		typ, val, isStruct := getValue(field.Type, &fieldValue)
+		if !val.CanSet() {
+			continue
+		}
+		if !isStruct {
+			tree.AddMetaNode(filteredTag, name)
+			continue
+		} else if subNum := typ.NumField(); subNum == 0 {
+			tree.AddMetaNode(filteredTag, name)
+			continue
+		}
+		branch := tree.AddMetaBranch(filteredTag, name)
+		if err := tagTree(branch, val.Interface()); err != nil {
+			err := fmt.Errorf("%v on struct branch %s", name)
+			return err
+		}
+	}
+	return nil
+}
+
+func typeTree(tree Tree, v interface{}) error {
+	typ, val, err := checkType(v)
+	if err != nil {
+		return err
+	}
+	fields := typ.NumField()
+	for i := 0; i < fields; i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+		name, skip, omit := getMeta(field.Name, field.Tag)
+		if skip || omit && isEmpty(&fieldValue) {
+			continue
+		}
+		typ, val, isStruct := getValue(field.Type, &fieldValue)
+		if !val.CanSet() {
+			continue
+		}
+		typename := fmt.Sprintf("%T", val.Interface())
+		if !isStruct {
+			tree.AddMetaNode(typename, name)
+			continue
+		} else if subNum := typ.NumField(); subNum == 0 {
+			tree.AddMetaNode(typename, name)
+			continue
+		}
+		branch := tree.AddMetaBranch(typename, name)
+		if err := typeTree(branch, val.Interface()); err != nil {
+			err := fmt.Errorf("%v on struct branch %s", name)
+			return err
+		}
+	}
+	return nil
+}
+
+func typeSizeTree(tree Tree, v interface{}) error {
+	typ, val, err := checkType(v)
+	if err != nil {
+		return err
+	}
+	fields := typ.NumField()
+	for i := 0; i < fields; i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+		name, skip, omit := getMeta(field.Name, field.Tag)
+		if skip || omit && isEmpty(&fieldValue) {
+			continue
+		}
+		typ, val, isStruct := getValue(field.Type, &fieldValue)
+		if !val.CanSet() {
+			continue
+		}
+		typesize := typ.Size()
+		if !isStruct {
+			tree.AddMetaNode(typesize, name)
+			continue
+		} else if subNum := typ.NumField(); subNum == 0 {
+			tree.AddMetaNode(typesize, name)
+			continue
+		}
+		branch := tree.AddMetaBranch(typesize, name)
+		if err := typeSizeTree(branch, val.Interface()); err != nil {
+			err := fmt.Errorf("%v on struct branch %s", name)
+			return err
+		}
+	}
+	return nil
+}
+
+func metaTree(tree Tree, v interface{}, fmtFunc FmtFunc) error {
+	typ, val, err := checkType(v)
+	if err != nil {
+		return err
+	}
+	fields := typ.NumField()
+	for i := 0; i < fields; i++ {
+		field := typ.Field(i)
+		fieldValue := val.Field(i)
+		name, skip, omit := getMeta(field.Name, field.Tag)
+		if skip || omit && isEmpty(&fieldValue) {
+			continue
+		}
+		typ, val, isStruct := getValue(field.Type, &fieldValue)
+		if !val.CanSet() {
+			continue
+		}
+		formatted, show := fmtFunc(name, val.Interface())
+		if !isStruct {
+			if show {
+				tree.AddMetaNode(formatted, name)
+				continue
+			}
+			tree.AddNode(name)
+			continue
+		} else if subNum := typ.NumField(); subNum == 0 {
+			if show {
+				tree.AddMetaNode(formatted, name)
+				continue
+			}
+			tree.AddNode(name)
+			continue
+		}
+		var branch Tree
+		if show {
+			branch = tree.AddMetaBranch(formatted, name)
+		} else {
+			branch = tree.AddBranch(name)
+		}
+		if err := metaTree(branch, val.Interface(), fmtFunc); err != nil {
+			err := fmt.Errorf("%v on struct branch %s", name)
+			return err
+		}
+	}
+	return nil
+}
+
+func getValue(typ reflect.Type, val *reflect.Value) (reflect.Type, *reflect.Value, bool) {
+	switch typ.Kind() {
+	case reflect.Ptr:
+		typ = typ.Elem()
+		if typ.Kind() == reflect.Struct {
+			elem := val.Elem()
+			return typ, &elem, true
+		}
+	case reflect.Struct:
+		return typ, val, true
+	}
+	return typ, val, false
+}
+
+func checkType(v interface{}) (reflect.Type, *reflect.Value, error) {
+	typ := reflect.TypeOf(v)
+	val := reflect.ValueOf(v)
+	switch typ.Kind() {
+	case reflect.Ptr:
+		typ = typ.Elem()
+		if typ.Kind() != reflect.Struct {
+			err := fmt.Errorf("treeprint: %T is not a struct we could work with", v)
+			return nil, nil, err
+		}
+		val = val.Elem()
+	case reflect.Struct:
+	default:
+		err := fmt.Errorf("treeprint: %T is not a struct we could work with", v)
+		return nil, nil, err
+	}
+	return typ, &val, nil
+}

--- a/vendor/github.com/xlab/treeprint/treeprint.go
+++ b/vendor/github.com/xlab/treeprint/treeprint.go
@@ -1,0 +1,184 @@
+// Package treeprint provides a simple ASCII tree composing tool.
+package treeprint
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+)
+
+type Value interface{}
+type MetaValue interface{}
+
+// Tree represents a tree structure with leaf-nodes and branch-nodes.
+type Tree interface {
+	// AddNode adds a new node to a branch.
+	AddNode(v Value) Tree
+	// AddMetaNode adds a new node with meta value provided to a branch.
+	AddMetaNode(meta MetaValue, v Value) Tree
+	// AddBranch adds a new branch node (a level deeper).
+	AddBranch(v Value) Tree
+	// AddMetaBranch adds a new branch node (a level deeper) with meta value provided.
+	AddMetaBranch(meta MetaValue, v Value) Tree
+	// Branch converts a leaf-node to a branch-node,
+	// applying this on a branch-node does no effect.
+	Branch() Tree
+	// FindByMeta finds a node whose meta value matches the provided one by reflect.DeepEqual,
+	// returns nil if not found.
+	FindByMeta(meta MetaValue) Tree
+	// FindByValue finds a node whose value matches the provided one by reflect.DeepEqual,
+	// returns nil if not found.
+	FindByValue(value Value) Tree
+	// String renders the tree or subtree as a string.
+	String() string
+	// Bytes renders the tree or subtree as byteslice.
+	Bytes() []byte
+}
+
+type node struct {
+	Root  *node
+	Meta  MetaValue
+	Value Value
+	Nodes []*node
+}
+
+func (n *node) AddNode(v Value) Tree {
+	n.Nodes = append(n.Nodes, &node{
+		Root:  n,
+		Value: v,
+	})
+	if n.Root != nil {
+		return n.Root
+	}
+	return n
+}
+
+func (n *node) AddMetaNode(meta MetaValue, v Value) Tree {
+	n.Nodes = append(n.Nodes, &node{
+		Root:  n,
+		Meta:  meta,
+		Value: v,
+	})
+	if n.Root != nil {
+		return n.Root
+	}
+	return n
+}
+
+func (n *node) AddBranch(v Value) Tree {
+	branch := &node{
+		Value: v,
+	}
+	n.Nodes = append(n.Nodes, branch)
+	return branch
+}
+
+func (n *node) AddMetaBranch(meta MetaValue, v Value) Tree {
+	branch := &node{
+		Meta:  meta,
+		Value: v,
+	}
+	n.Nodes = append(n.Nodes, branch)
+	return branch
+}
+
+func (n *node) Branch() Tree {
+	n.Root = nil
+	return n
+}
+
+func (n *node) FindByMeta(meta MetaValue) Tree {
+	for _, node := range n.Nodes {
+		if reflect.DeepEqual(node.Meta, meta) {
+			return node
+		}
+		if v := node.FindByMeta(meta); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+func (n *node) FindByValue(value Value) Tree {
+	for _, node := range n.Nodes {
+		if reflect.DeepEqual(node.Value, value) {
+			return node
+		}
+		if v := node.FindByMeta(value); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+func (n *node) Bytes() []byte {
+	buf := new(bytes.Buffer)
+	level := 0
+	levelEnded := make(map[int]bool)
+	if n.Root == nil {
+		buf.WriteString(string(EdgeTypeStart))
+		buf.WriteByte('\n')
+	} else {
+		edge := EdgeTypeMid
+		if len(n.Nodes) == 0 {
+			edge = EdgeTypeEnd
+			levelEnded[level] = true
+		}
+		printValues(buf, 0, levelEnded, edge, n.Meta, n.Value)
+	}
+	if len(n.Nodes) > 0 {
+		printNodes(buf, level, levelEnded, n.Nodes)
+	}
+	return buf.Bytes()
+}
+
+func (n *node) String() string {
+	return string(n.Bytes())
+}
+
+func printNodes(wr io.Writer,
+	level int, levelEnded map[int]bool, nodes []*node) {
+
+	for i, node := range nodes {
+		edge := EdgeTypeMid
+		if i == len(nodes)-1 {
+			levelEnded[level] = true
+			edge = EdgeTypeEnd
+		}
+		printValues(wr, level, levelEnded, edge, node.Meta, node.Value)
+		if len(node.Nodes) > 0 {
+			printNodes(wr, level+1, levelEnded, node.Nodes)
+		}
+	}
+}
+
+func printValues(wr io.Writer,
+	level int, levelEnded map[int]bool, edge EdgeType, meta MetaValue, val Value) {
+
+	for i := 0; i < level; i++ {
+		if levelEnded[i] {
+			fmt.Fprint(wr, "    ")
+			continue
+		}
+		fmt.Fprintf(wr, "%s   ", EdgeTypeLink)
+	}
+	if meta != nil {
+		fmt.Fprintf(wr, "%s [%v]  %v\n", edge, meta, val)
+		return
+	}
+	fmt.Fprintf(wr, "%s %v\n", edge, val)
+}
+
+type EdgeType string
+
+const (
+	EdgeTypeStart EdgeType = "."
+	EdgeTypeLink  EdgeType = "│"
+	EdgeTypeMid   EdgeType = "├──"
+	EdgeTypeEnd   EdgeType = "└──"
+)
+
+func New() Tree {
+	return &node{}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3106,6 +3106,12 @@
 			"revisionTime": "2017-02-25T17:21:24Z"
 		},
 		{
+			"checksumSHA1": "xtw+Llokq30p1Gn+Q8JBZ7NtE+I=",
+			"path": "github.com/xlab/treeprint",
+			"revision": "1d6e342255576c977e946a2384fc487a22d3fceb",
+			"revisionTime": "2016-10-29T10:40:18Z"
+		},
+		{
 			"checksumSHA1": "eXEiPlpDRaamJQ4vPX/9t333kQc=",
 			"comment": "v1.5.4-13-g75ce5fb",
 			"path": "github.com/ziutek/mymysql/mysql",

--- a/website/source/docs/commands/index.html.markdown
+++ b/website/source/docs/commands/index.html.markdown
@@ -41,6 +41,7 @@ Common commands:
     init               Initialize a new or existing Terraform configuration
     output             Read an output from a state file
     plan               Generate and show an execution plan
+    providers          Prints a tree of the providers used in the configuration
     push               Upload this Terraform module to Terraform Enterprise to run
     refresh            Update local state file against real resources
     show               Inspect Terraform state or plan

--- a/website/source/docs/commands/providers.html.markdown
+++ b/website/source/docs/commands/providers.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "docs"
+page_title: "Command: providers"
+sidebar_current: "docs-commands-providers"
+description: |-
+  The "providers" sub-command prints information about the providers used
+  in the current configuration.
+---
+
+# Command: show
+
+The `terraform providers` command prints information about the providers
+used in the current configuration.
+
+Provider dependencies are created in several different ways:
+
+* Explicit use of a `provider` block in configuration, optionally including
+  a version constraint.
+
+* Use of any resource belonging to a particular provider in a `resource` or
+  `data` block in configuration.
+
+* Existance of any resource instance belonging to a particular provider in
+  the current _state_. For example, if a particular resource is removed
+  from configuration, it continues to create a dependency on its provider
+  until its instances have been destroyed.
+
+This command gives an overview of all of the current dependencies, as an aid
+to understanding why a particular provider is needed.
+
+## Usage
+
+Usage: `terraform show [config-path]`
+
+Pass an explicit configuration path to override the default of using the
+current working directory.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -109,6 +109,10 @@
             <a href="/docs/commands/plan.html">plan</a>
           </li>
 
+          <li<%= sidebar_current("docs-commands-providers") %>>
+            <a href="/docs/commands/providers.html">providers</a>
+          </li>
+
           <li<%= sidebar_current("docs-commands-push") %>>
             <a href="/docs/commands/push.html">push</a>
           </li>


### PR DESCRIPTION
This new command prints out the tree of modules annotated with their associated required providers.

```
$ terraform providers
.
├── provider.aws >=2.0.0
└── module.server
    └── provider.aws (inherited)
```

The purpose of this command is to help users answer questions such as "why is this provider required?", "why is Terraform using an older version of this provider?", and "what combination of modules is creating an impossible provider version situation?"
    
For configurations using many modules this sort of question is likely to come up a lot once we support versioned providers.
    
As a bonus use-case, this command also shows explicitly when a provider configuration is being inherited from a parent module, to help users to understand where the configuration is coming from for each module when some child modules provide their own provider configurations.

