### PR TITLE
provider/azurerm: Expose any dynamically-assigned private IP address

### DIFF
--- a/builtin/providers/azurerm/resource_arm_loadbalancer.go
+++ b/builtin/providers/azurerm/resource_arm_loadbalancer.go
@@ -177,13 +177,12 @@ func resourecArmLoadBalancerRead(d *schema.ResourceData, meta interface{}) error
 	d.Set("resource_group_name", id.ResourceGroup)
 
 	if loadBalancer.LoadBalancerPropertiesFormat != nil && loadBalancer.LoadBalancerPropertiesFormat.FrontendIPConfigurations != nil {
-		ipconfig := flattenLoadBalancerFrontendIpConfiguration(loadBalancer.LoadBalancerPropertiesFormat.FrontendIPConfigurations)
-		d.Set("frontend_ip_configuration", ipconfig)
+		ipconfigs := loadBalancer.LoadBalancerPropertiesFormat.FrontendIPConfigurations
+		d.Set("frontend_ip_configuration", flattenLoadBalancerFrontendIpConfiguration(ipconfigs))
 
-		for _, config := range ipconfig {
-			cfg := config.(map[string]interface{})
-			if priv_ip, ok := cfg["private_ip_address"]; ok {
-				d.Set("private_ip_address", priv_ip)
+		for _, config := range *ipconfigs {
+			if config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress != nil {
+				d.Set("private_ip_address", config.FrontendIPConfigurationPropertiesFormat.PrivateIPAddress)
 
 				// set the private IP address at most once
 				break

--- a/website/source/docs/providers/azurerm/r/loadbalancer.html.markdown
+++ b/website/source/docs/providers/azurerm/r/loadbalancer.html.markdown
@@ -60,6 +60,7 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The LoadBalancer ID.
+* `private_ip_address` - The private IP address assigned to the load balancer, if any.
 
 ## Import
 


### PR DESCRIPTION
Currently, if you want to use a private IP address with an Azure Load Balancer, you must statically assign the address in order to reference the IP elsewhere (such as in an ``azurerm_dns_a_record``). If you have something like the following:

```hcl
resource "azurerm_lb" "demo" {
  name                = "demo-lb"
  location            = "${var.location}"
  resource_group_name = "${var.resource_group}"

  frontend_ip_configuration {
    name                          = "default"
    private_ip_address_allocation = "dynamic"
    subnet_id                     = "${var.subnet_id}"
  }
}
```

the dynamically-allocated private IP address is visible when you dig into the state using ``terraform console``, but it is inaccessible using interpolation.

This pull request exposes the dynamic private IP address (if any) as ``private_ip_address`` for use elsewhere:

```hcl
resource "azurerm_dns_a_record" "demo" {
  name                = "demo"
  zone_name           = "${var.dns_zone}"
  resource_group_name = "${var.resource_group}"
  ttl                 = "300"
  records             = ["${azurerm_lb.demo.private_ip_address}"]
}

```