### PR TITLE
providers/heroku: use a helper for common app post-create tasks

### DIFF
--- a/builtin/providers/heroku/resource_heroku_app.go
+++ b/builtin/providers/heroku/resource_heroku_app.go
@@ -232,15 +232,8 @@ func resourceHerokuAppCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(a.Name)
 	log.Printf("[INFO] App ID: %s", d.Id())
 
-	if v, ok := d.GetOk("config_vars"); ok {
-		err = updateConfigVars(d.Id(), client, nil, v.([]interface{}))
-		if err != nil {
-			return err
-		}
-	}
-
-	if v, ok := d.GetOk("buildpacks"); ok {
-		err = updateBuildpacks(d.Id(), client, v.([]interface{}))
+	if err := performAppPostCreateTasks(d, client); err != nil {
+		return err
 	}
 
 	return resourceHerokuAppRead(d, meta)
@@ -305,11 +298,8 @@ func resourceHerokuOrgAppCreate(d *schema.ResourceData, meta interface{}) error 
 	d.SetId(a.Name)
 	log.Printf("[INFO] App ID: %s", d.Id())
 
-	if v, ok := d.GetOk("config_vars"); ok {
-		err = updateConfigVars(d.Id(), client, nil, v.([]interface{}))
-		if err != nil {
-			return err
-		}
+	if err := performAppPostCreateTasks(d, client); err != nil {
+		return err
 	}
 
 	return resourceHerokuAppRead(d, meta)
@@ -530,6 +520,23 @@ func updateBuildpacks(id string, client *heroku.Service, v []interface{}) error 
 
 	if _, err := client.BuildpackInstallationUpdate(context.TODO(), id, opts); err != nil {
 		return fmt.Errorf("Error updating buildpacks: %s", err)
+	}
+
+	return nil
+}
+
+// performAppPostCreateTasks performs post-create tasks common to both org and non-org apps.
+func performAppPostCreateTasks(d *schema.ResourceData, client *heroku.Service) error {
+	if v, ok := d.GetOk("config_vars"); ok {
+		if err := updateConfigVars(d.Id(), client, nil, v.([]interface{})); err != nil {
+			return err
+		}
+	}
+
+	if v, ok := d.GetOk("buildpacks"); ok {
+		if err := updateBuildpacks(d.Id(), client, v.([]interface{})); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Buildpacks were being configured post-create for non-org apps but not
for org apps. Consolidate post-create tasks into a helper used by both
paths.