### PR TITLE
provider/triton: Read TRITON_* as well as SDC_*

### DIFF
--- a/builtin/providers/triton/provider.go
+++ b/builtin/providers/triton/provider.go
@@ -22,25 +22,25 @@ func Provider() terraform.ResourceProvider {
 			"account": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SDC_ACCOUNT", ""),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"TRITON_ACCOUNT", "SDC_ACCOUNT"}, ""),
 			},
 
 			"url": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SDC_URL", "https://us-west-1.api.joyentcloud.com"),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"TRITON_URL", "SDC_URL"}, "https://us-west-1.api.joyentcloud.com"),
 			},
 
 			"key_material": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SDC_KEY_MATERIAL", ""),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"TRITON_KEY_MATERIAL", "SDC_KEY_MATERIAL"}, ""),
 			},
 
 			"key_id": {
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("SDC_KEY_ID", ""),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"TRITON_KEY_ID", "SDC_KEY_ID"}, ""),
 			},
 		},
 


### PR DESCRIPTION
The Triton CLI tools have been using TRITON_* as their configuration environment variables for some time now. This commit makes Terraform use them in preference to any SDC_* variables set, and allows Terraform to work with the credentials set by the `triton env` in the CLI.