### PR TITLE
Fix vet errors in fastly provider

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -2010,7 +2010,7 @@ func resourceServiceV1Read(d *schema.ResourceData, meta interface{}) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up GCS for (%s), version (%s): %s", d.Id(), s.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up GCS for (%s), version (%v): %s", d.Id(), s.ActiveVersion.Number, err)
 		}
 
 		gcsl := flattenGCS(GCSList)

--- a/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_cache_setting_test.go
@@ -75,7 +75,7 @@ func testAccCheckFastlyServiceV1CacheSettingsAttributes(service *gofastly.Servic
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Request Setting for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Request Setting for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(rqList) != len(rqs) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_conditionals_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_conditionals_test.go
@@ -57,7 +57,7 @@ func testAccCheckFastlyServiceV1ConditionalAttributes(service *gofastly.ServiceD
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Conditions for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Conditions for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(conditionList) != len(conditions) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_gcslogging_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gcslogging_test.go
@@ -85,7 +85,7 @@ func testAccCheckFastlyServiceV1Attributes_gcs(service *gofastly.ServiceDetail, 
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up GCSs for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up GCSs for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(gcsList) != 1 {

--- a/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_gzip_test.go
@@ -169,7 +169,7 @@ func testAccCheckFastlyServiceV1GzipsAttributes(service *gofastly.ServiceDetail,
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Gzips for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Gzips for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(gzipsList) != len(gzips) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_headers_test.go
@@ -163,7 +163,7 @@ func testAccCheckFastlyServiceV1HeaderAttributes(service *gofastly.ServiceDetail
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Headers for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Headers for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(headersList) != len(headers) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_healthcheck_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_healthcheck_test.go
@@ -88,7 +88,7 @@ func testAccCheckFastlyServiceV1HealthCheckAttributes(service *gofastly.ServiceD
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Healthcheck for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Healthcheck for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(healthcheckList) != len(healthchecks) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_papertrail_test.go
@@ -75,7 +75,7 @@ func testAccCheckFastlyServiceV1PapertrailAttributes(service *gofastly.ServiceDe
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Papertrail for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Papertrail for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(papertrailList) != len(papertrails) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_request_setting_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_request_setting_test.go
@@ -56,7 +56,7 @@ func testAccCheckFastlyServiceV1RequestSettingsAttributes(service *gofastly.Serv
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Request Setting for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Request Setting for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(rqList) != len(rqs) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_response_object_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_response_object_test.go
@@ -80,7 +80,7 @@ func testAccCheckFastlyServiceV1ResponseObjectAttributes(service *gofastly.Servi
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Response Object for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Response Object for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(responseObjectList) != len(responseObjects) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_s3logging_test.go
@@ -171,7 +171,7 @@ func testAccCheckFastlyServiceV1S3LoggingAttributes(service *gofastly.ServiceDet
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up S3 Logging for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up S3 Logging for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(s3List) != len(s3s) {

--- a/builtin/providers/fastly/resource_fastly_service_v1_sumologic_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_sumologic_test.go
@@ -83,7 +83,7 @@ func testAccCheckFastlyServiceV1Attributes_sumologic(service *gofastly.ServiceDe
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Sumologics for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Sumologics for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(sumologicList) != 1 {

--- a/builtin/providers/fastly/resource_fastly_service_v1_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_test.go
@@ -305,7 +305,7 @@ func testAccCheckFastlyServiceV1Attributes(service *gofastly.ServiceDetail, name
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Domains for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Domains for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		expected := len(domains)
@@ -339,7 +339,7 @@ func testAccCheckFastlyServiceV1Attributes_backends(service *gofastly.ServiceDet
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up Backends for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up Backends for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		expected := len(backendList)

--- a/builtin/providers/fastly/resource_fastly_service_v1_vcl_test.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1_vcl_test.go
@@ -61,7 +61,7 @@ func testAccCheckFastlyServiceV1VCLAttributes(service *gofastly.ServiceDetail, n
 		})
 
 		if err != nil {
-			return fmt.Errorf("[ERR] Error looking up VCL for (%s), version (%s): %s", service.Name, service.ActiveVersion.Number, err)
+			return fmt.Errorf("[ERR] Error looking up VCL for (%s), version (%v): %s", service.Name, service.ActiveVersion.Number, err)
 		}
 
 		if len(vclList) != vclCount {


### PR DESCRIPTION
Fixes #13983.
Another instance of #13122 where vet errors weren't picked up by Travis, and as such, they exist in a tagged release.