### PR TITLE
provider/aws: Update aws_ebs_volume when attached

### DIFF
--- a/builtin/providers/aws/resource_aws_ebs_volume.go
+++ b/builtin/providers/aws/resource_aws_ebs_volume.go
@@ -179,7 +179,7 @@ func resourceAWSEbsVolumeUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"creating", "modifying"},
-			Target:     []string{"available"},
+			Target:     []string{"available", "in-use"},
 			Refresh:    volumeStateRefreshFunc(conn, *result.VolumeModification.VolumeId),
 			Timeout:    5 * time.Minute,
 			Delay:      10 * time.Second,


### PR DESCRIPTION
Fixes: #12496

When an EBS volume was attached to an instance and the user tried to
resize, they would get an error as follows:

```
* aws_ebs_volume.ebs_data_volume: Error waiting for Volume (vol-027e83f7) to become available: unexpected state 'in-use', wanted target 'available'. last error: %!s(<nil>)
```

`available` is a state *only* when creating an EBS volume that is not attached. When an instance is attached, it will go into the state `in-use`. Therefore `in-use` is a valid state when modifying an EBS volume that is attached:

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSEBSVolume_'                                   ✹ ✭
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/27 07:08:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSEBSVolume_ -timeout 120m
=== RUN   TestAccAWSEBSVolume_importBasic
--- PASS: TestAccAWSEBSVolume_importBasic (41.10s)
=== RUN   TestAccAWSEBSVolume_basic
--- PASS: TestAccAWSEBSVolume_basic (38.22s)
=== RUN   TestAccAWSEBSVolume_updateAttachedEbsVolume
--- PASS: TestAccAWSEBSVolume_updateAttachedEbsVolume (199.11s)
=== RUN   TestAccAWSEBSVolume_updateSize
--- PASS: TestAccAWSEBSVolume_updateSize (70.53s)
=== RUN   TestAccAWSEBSVolume_updateType
--- PASS: TestAccAWSEBSVolume_updateType (69.75s)
=== RUN   TestAccAWSEBSVolume_updateIops
--- PASS: TestAccAWSEBSVolume_updateIops (70.38s)
=== RUN   TestAccAWSEBSVolume_kmsKey
--- PASS: TestAccAWSEBSVolume_kmsKey (76.64s)
=== RUN   TestAccAWSEBSVolume_NoIops
--- PASS: TestAccAWSEBSVolume_NoIops (39.80s)
=== RUN   TestAccAWSEBSVolume_withTags
--- PASS: TestAccAWSEBSVolume_withTags (38.04s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	643.609s
```