### PR TITLE
update error response when env does not exist

### DIFF
--- a/command/env_command.go
+++ b/command/env_command.go
@@ -57,7 +57,7 @@ const (
 	envDoesNotExist = `
 Environment %q doesn't exist!
 
-You can create this environment with the "-new" option.`
+You can create this environment with the "new" option.`
 
 	envChanged = `[reset][green]Switched to environment %q!`
 


### PR DESCRIPTION
minor update to error response to advise user to use "new" instead of "-new"