### PR TITLE
build: Fix Travis vet issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 sudo: false
 language: go
 go:
-- 1.8
+- 1.8.x
 
 # add TF_CONSUL_TEST=1 to run consul tests
 # they were causing timouts in travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
 - bash scripts/gogetcookie.sh
 - go get github.com/kardianos/govendor
 script:
-- make vet vendor-status test
+- make vendor-status test vet
 - GOOS=windows go build
 branches:
   only:

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ cover:
 # vet runs the Go source code static analysis tool `vet` to find
 # any common errors.
 vet:
-	@echo "go vet ."
-	@go vet $$(go list ./... | grep -v vendor/) ; if [ $$? -eq 1 ]; then \
+	@echo 'go vet $$(go list ./... | grep -v /terraform/vendor/)'
+	@go vet $$(go list ./... | grep -v /terraform/vendor/) ; if [ $$? -eq 1 ]; then \
 		echo ""; \
 		echo "Vet found suspicious constructs. Please check the reported constructs"; \
 		echo "and fix them if necessary before submitting the code for review."; \


### PR DESCRIPTION
Fixes #13122.

This runs the vet step *after* the test step, so that all dependencies are installed by the `go test -i` as mentioned here: https://github.com/hashicorp/terraform/pull/14001#issuecomment-297525938.

I'm going to submit a second PR with these changes *and* a purposeful vet error introduced to see if Travis picks it up.