### PR TITLE
provider/google: a few quick test fixes

### DIFF
--- a/builtin/providers/google/resource_compute_instance_template_test.go
+++ b/builtin/providers/google/resource_compute_instance_template_test.go
@@ -27,7 +27,7 @@ func TestAccComputeInstanceTemplate_basic(t *testing.T) {
 						"google_compute_instance_template.foobar", &instanceTemplate),
 					testAccCheckComputeInstanceTemplateTag(&instanceTemplate, "foo"),
 					testAccCheckComputeInstanceTemplateMetadata(&instanceTemplate, "foo", "bar"),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
+					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 				),
 			},
 		},
@@ -67,7 +67,7 @@ func TestAccComputeInstanceTemplate_disks(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeInstanceTemplateExists(
 						"google_compute_instance_template.foobar", &instanceTemplate),
-					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "https://www.googleapis.com/compute/v1/projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
+					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "projects/debian-cloud/global/images/debian-8-jessie-v20160803", true, true),
 					testAccCheckComputeInstanceTemplateDisk(&instanceTemplate, "terraform-test-foobar", false, false),
 				),
 			},

--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -403,7 +403,7 @@ var testAccContainerCluster_withVersion = fmt.Sprintf(`
 resource "google_container_cluster" "with_version" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
-	node_version = "1.6.0"
+	node_version = "1.6.1"
 	initial_node_count = 1
 
 	master_auth {


### PR DESCRIPTION
This greens 3 out of the 6 currently failing tests 🎉 

```
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeInstanceTemplate_basic -timeout 120m
=== RUN   TestAccComputeInstanceTemplate_basic
--- PASS: TestAccComputeInstanceTemplate_basic (23.77s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	23.897s
```

```
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeInstanceTemplate_disks -timeout 120m
=== RUN   TestAccComputeInstanceTemplate_disks
--- PASS: TestAccComputeInstanceTemplate_disks (25.16s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	25.281s
```

```
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccContainerCluster_withVersion -timeout 120m
=== RUN   TestAccContainerCluster_withVersion
--- PASS: TestAccContainerCluster_withVersion (294.72s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	294.864s
```