### PR TITLE
Make global forwarding rule docs clearer for IP addresses.

### DIFF
--- a/website/source/docs/providers/google/r/compute_global_forwarding_rule.html.markdown
+++ b/website/source/docs/providers/google/r/compute_global_forwarding_rule.html.markdown
@@ -80,7 +80,9 @@ The following arguments are supported:
 * `description` - (Optional) Textual description field.
 
 * `ip_address` - (Optional) The static IP. (if not set, an ephemeral IP is
-    used).
+    used). This should be the literal IP address to be used, not the `self_link`
+    to a `google_compute_address` resource. (If using a `google_compute_address`
+    resource, use the `address` property instead of the `self_link` property.)
 
 * `ip_protocol` - (Optional) The IP protocol to route, one of "TCP" "UDP" "AH"
     "ESP" or "SCTP". (default "TCP").


### PR DESCRIPTION
Update our docs for `google_compute_forwarding_rule` to clarify that the
`ip_address` field expects a literal IP address and will not accept the
`self_link` property of a `google_compute_address` resource.

Prompted by #13375