### PR TITLE
provider/digitalocean: Remove unneeded droplet test

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_droplet_test.go
@@ -41,11 +41,6 @@ func TestAccDigitalOceanDroplet_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"digitalocean_droplet.foobar", "user_data", "foobar"),
 				),
-				Destroy: false,
-			},
-			{
-				Config:   testAccCheckDigitalOceanDropletConfig_basic(rInt),
-				PlanOnly: true,
 			},
 		},
 	})


### PR DESCRIPTION
Reverts #13883.

Quoting @radeksimko: "We actually refresh the state
as part of every test step, so this is not necessary"

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>