### PR TITLE
provider/google: fix project metadata tests

### DIFF
--- a/builtin/providers/google/resource_compute_project_metadata_test.go
+++ b/builtin/providers/google/resource_compute_project_metadata_test.go
@@ -2,8 +2,10 @@ package google
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 	"google.golang.org/api/compute/v1"
@@ -11,7 +13,16 @@ import (
 
 // Add two key value pairs
 func TestAccComputeProjectMetadata_basic(t *testing.T) {
+	skipIfEnvNotSet(t,
+		[]string{
+			"GOOGLE_ORG",
+			"GOOGLE_BILLING_ACCOUNT",
+		}...,
+	)
+
+	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
 	var project compute.Project
+	pid := "terrafom-test-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,13 +30,13 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeProjectMetadataDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeProject_basic0_metadata,
+				Config: testAccComputeProject_basic0_metadata(pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", &project),
-					testAccCheckComputeProjectMetadataContains(&project, "banana", "orange"),
-					testAccCheckComputeProjectMetadataContains(&project, "sofa", "darwinism"),
-					testAccCheckComputeProjectMetadataSize(&project, 2),
+						"google_compute_project_metadata.fizzbuzz", pid, &project),
+					testAccCheckComputeProjectMetadataContains(pid, "banana", "orange"),
+					testAccCheckComputeProjectMetadataContains(pid, "sofa", "darwinism"),
+					testAccCheckComputeProjectMetadataSize(pid, 2),
 				),
 			},
 		},
@@ -34,7 +45,16 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 
 // Add three key value pairs, then replace one and modify a second
 func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
+	skipIfEnvNotSet(t,
+		[]string{
+			"GOOGLE_ORG",
+			"GOOGLE_BILLING_ACCOUNT",
+		}...,
+	)
+
+	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
 	var project compute.Project
+	pid := "terrafom-test-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -42,26 +62,26 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 		CheckDestroy: testAccCheckComputeProjectMetadataDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeProject_modify0_metadata,
+				Config: testAccComputeProject_modify0_metadata(pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", &project),
-					testAccCheckComputeProjectMetadataContains(&project, "paper", "pen"),
-					testAccCheckComputeProjectMetadataContains(&project, "genghis_khan", "french bread"),
-					testAccCheckComputeProjectMetadataContains(&project, "happy", "smiling"),
-					testAccCheckComputeProjectMetadataSize(&project, 3),
+						"google_compute_project_metadata.fizzbuzz", pid, &project),
+					testAccCheckComputeProjectMetadataContains(pid, "paper", "pen"),
+					testAccCheckComputeProjectMetadataContains(pid, "genghis_khan", "french bread"),
+					testAccCheckComputeProjectMetadataContains(pid, "happy", "smiling"),
+					testAccCheckComputeProjectMetadataSize(pid, 3),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccComputeProject_modify1_metadata,
+				Config: testAccComputeProject_modify1_metadata(pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", &project),
-					testAccCheckComputeProjectMetadataContains(&project, "paper", "pen"),
-					testAccCheckComputeProjectMetadataContains(&project, "paris", "french bread"),
-					testAccCheckComputeProjectMetadataContains(&project, "happy", "laughing"),
-					testAccCheckComputeProjectMetadataSize(&project, 3),
+						"google_compute_project_metadata.fizzbuzz", pid, &project),
+					testAccCheckComputeProjectMetadataContains(pid, "paper", "pen"),
+					testAccCheckComputeProjectMetadataContains(pid, "paris", "french bread"),
+					testAccCheckComputeProjectMetadataContains(pid, "happy", "laughing"),
+					testAccCheckComputeProjectMetadataSize(pid, 3),
 				),
 			},
 		},
@@ -70,7 +90,16 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 
 // Add two key value pairs, and replace both
 func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
+	skipIfEnvNotSet(t,
+		[]string{
+			"GOOGLE_ORG",
+			"GOOGLE_BILLING_ACCOUNT",
+		}...,
+	)
+
+	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
 	var project compute.Project
+	pid := "terraform-test-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -78,24 +107,24 @@ func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
 		CheckDestroy: testAccCheckComputeProjectMetadataDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeProject_basic0_metadata,
+				Config: testAccComputeProject_basic0_metadata(pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", &project),
-					testAccCheckComputeProjectMetadataContains(&project, "banana", "orange"),
-					testAccCheckComputeProjectMetadataContains(&project, "sofa", "darwinism"),
-					testAccCheckComputeProjectMetadataSize(&project, 2),
+						"google_compute_project_metadata.fizzbuzz", pid, &project),
+					testAccCheckComputeProjectMetadataContains(pid, "banana", "orange"),
+					testAccCheckComputeProjectMetadataContains(pid, "sofa", "darwinism"),
+					testAccCheckComputeProjectMetadataSize(pid, 2),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccComputeProject_basic1_metadata,
+				Config: testAccComputeProject_basic1_metadata(pid, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", &project),
-					testAccCheckComputeProjectMetadataContains(&project, "kiwi", "papaya"),
-					testAccCheckComputeProjectMetadataContains(&project, "finches", "darwinism"),
-					testAccCheckComputeProjectMetadataSize(&project, 2),
+						"google_compute_project_metadata.fizzbuzz", pid, &project),
+					testAccCheckComputeProjectMetadataContains(pid, "kiwi", "papaya"),
+					testAccCheckComputeProjectMetadataContains(pid, "finches", "darwinism"),
+					testAccCheckComputeProjectMetadataSize(pid, 2),
 				),
 			},
 		},
@@ -105,15 +134,21 @@ func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
 func testAccCheckComputeProjectMetadataDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
-	project, err := config.clientCompute.Projects.Get(config.Project).Do()
-	if err == nil && len(project.CommonInstanceMetadata.Items) > 0 {
-		return fmt.Errorf("Error, metadata items still exist")
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_compute_project_metadata" {
+			continue
+		}
+
+		project, err := config.clientCompute.Projects.Get(rs.Primary.ID).Do()
+		if err == nil && len(project.CommonInstanceMetadata.Items) > 0 {
+			return fmt.Errorf("Error, metadata items still exist in %s", rs.Primary.ID)
+		}
 	}
 
 	return nil
 }
 
-func testAccCheckComputeProjectExists(n string, project *compute.Project) resource.TestCheckFunc {
+func testAccCheckComputeProjectExists(n, pid string, project *compute.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -127,7 +162,7 @@ func testAccCheckComputeProjectExists(n string, project *compute.Project) resour
 		config := testAccProvider.Meta().(*Config)
 
 		found, err := config.clientCompute.Projects.Get(
-			config.Project).Do()
+			pid).Do()
 		if err != nil {
 			return err
 		}
@@ -142,10 +177,10 @@ func testAccCheckComputeProjectExists(n string, project *compute.Project) resour
 	}
 }
 
-func testAccCheckComputeProjectMetadataContains(project *compute.Project, key string, value string) resource.TestCheckFunc {
+func testAccCheckComputeProjectMetadataContains(pid, key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		project, err := config.clientCompute.Projects.Get(config.Project).Do()
+		project, err := config.clientCompute.Projects.Get(pid).Do()
 		if err != nil {
 			return fmt.Errorf("Error, failed to load project service for %s: %s", config.Project, err)
 		}
@@ -161,14 +196,14 @@ func testAccCheckComputeProjectMetadataContains(project *compute.Project, key st
 			}
 		}
 
-		return fmt.Errorf("Error, key %s not present", key)
+		return fmt.Errorf("Error, key %s not present in %s", key, project.SelfLink)
 	}
 }
 
-func testAccCheckComputeProjectMetadataSize(project *compute.Project, size int) resource.TestCheckFunc {
+func testAccCheckComputeProjectMetadataSize(pid string, size int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		project, err := config.clientCompute.Projects.Get(config.Project).Do()
+		project, err := config.clientCompute.Projects.Get(pid).Do()
 		if err != nil {
 			return fmt.Errorf("Error, failed to load project service for %s: %s", config.Project, err)
 		}
@@ -182,36 +217,100 @@ func testAccCheckComputeProjectMetadataSize(project *compute.Project, size int) 
 	}
 }
 
-const testAccComputeProject_basic0_metadata = `
-resource "google_compute_project_metadata" "fizzbuzz" {
-	metadata {
-		banana = "orange"
-		sofa = "darwinism"
-	}
-}`
+func testAccComputeProject_basic0_metadata(pid, name, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "project" {
+  project_id = "%s"
+  name = "%s"
+  org_id = "%s"
+  billing_account = "%s"
+}
 
-const testAccComputeProject_basic1_metadata = `
-resource "google_compute_project_metadata" "fizzbuzz" {
-	metadata {
-		kiwi = "papaya"
-		finches = "darwinism"
-	}
-}`
+resource "google_project_services" "services" {
+  project = "${google_project.project.project_id}"
+  services = ["compute-component.googleapis.com"]
+}
 
-const testAccComputeProject_modify0_metadata = `
 resource "google_compute_project_metadata" "fizzbuzz" {
-	metadata {
-		paper = "pen"
-		genghis_khan = "french bread"
-		happy = "smiling"
-	}
-}`
+  project = "${google_project.project.project_id}"
+  metadata {
+    banana = "orange"
+    sofa = "darwinism"
+  }
+  depends_on = ["google_project_services.services"]
+}`, pid, name, org, billing)
+}
 
-const testAccComputeProject_modify1_metadata = `
+func testAccComputeProject_basic1_metadata(pid, name, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "project" {
+  project_id = "%s"
+  name = "%s"
+  org_id = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_services" "services" {
+  project = "${google_project.project.project_id}"
+  services = ["compute-component.googleapis.com"]
+}
+
 resource "google_compute_project_metadata" "fizzbuzz" {
-	metadata {
-		paper = "pen"
-		paris = "french bread"
-		happy = "laughing"
-	}
-}`
+  project = "${google_project.project.project_id}"
+  metadata {
+    kiwi = "papaya"
+    finches = "darwinism"
+  }
+  depends_on = ["google_project_services.services"]
+}`, pid, name, org, billing)
+}
+
+func testAccComputeProject_modify0_metadata(pid, name, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "project" {
+  project_id = "%s"
+  name = "%s"
+  org_id = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_services" "services" {
+  project = "${google_project.project.project_id}"
+  services = ["compute-component.googleapis.com"]
+}
+
+resource "google_compute_project_metadata" "fizzbuzz" {
+  project = "${google_project.project.project_id}"
+  metadata {
+    paper = "pen"
+    genghis_khan = "french bread"
+    happy = "smiling"
+  }
+  depends_on = ["google_project_services.services"]
+}`, pid, name, org, billing)
+}
+
+func testAccComputeProject_modify1_metadata(pid, name, org, billing string) string {
+	return fmt.Sprintf(`
+resource "google_project" "project" {
+  project_id = "%s"
+  name = "%s"
+  org_id = "%s"
+  billing_account = "%s"
+}
+
+resource "google_project_services" "services" {
+  project = "${google_project.project.project_id}"
+  services = ["compute-component.googleapis.com"]
+}
+
+resource "google_compute_project_metadata" "fizzbuzz" {
+  project = "${google_project.project.project_id}"
+  metadata {
+    paper = "pen"
+    paris = "french bread"
+    happy = "laughing"
+  }
+  depends_on = ["google_project_services.services"]
+}`, pid, name, org, billing)
+}

--- a/builtin/providers/google/resource_compute_project_metadata_test.go
+++ b/builtin/providers/google/resource_compute_project_metadata_test.go
@@ -22,7 +22,7 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 
 	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
 	var project compute.Project
-	pid := "terrafom-test-" + acctest.RandString(10)
+	projectID := "terrafom-test-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -30,13 +30,13 @@ func TestAccComputeProjectMetadata_basic(t *testing.T) {
 		CheckDestroy: testAccCheckComputeProjectMetadataDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeProject_basic0_metadata(pid, pname, org, billingId),
+				Config: testAccComputeProject_basic0_metadata(projectID, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", pid, &project),
-					testAccCheckComputeProjectMetadataContains(pid, "banana", "orange"),
-					testAccCheckComputeProjectMetadataContains(pid, "sofa", "darwinism"),
-					testAccCheckComputeProjectMetadataSize(pid, 2),
+						"google_compute_project_metadata.fizzbuzz", projectID, &project),
+					testAccCheckComputeProjectMetadataContains(projectID, "banana", "orange"),
+					testAccCheckComputeProjectMetadataContains(projectID, "sofa", "darwinism"),
+					testAccCheckComputeProjectMetadataSize(projectID, 2),
 				),
 			},
 		},
@@ -54,7 +54,7 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 
 	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
 	var project compute.Project
-	pid := "terrafom-test-" + acctest.RandString(10)
+	projectID := "terrafom-test-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -62,26 +62,26 @@ func TestAccComputeProjectMetadata_modify_1(t *testing.T) {
 		CheckDestroy: testAccCheckComputeProjectMetadataDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeProject_modify0_metadata(pid, pname, org, billingId),
+				Config: testAccComputeProject_modify0_metadata(projectID, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", pid, &project),
-					testAccCheckComputeProjectMetadataContains(pid, "paper", "pen"),
-					testAccCheckComputeProjectMetadataContains(pid, "genghis_khan", "french bread"),
-					testAccCheckComputeProjectMetadataContains(pid, "happy", "smiling"),
-					testAccCheckComputeProjectMetadataSize(pid, 3),
+						"google_compute_project_metadata.fizzbuzz", projectID, &project),
+					testAccCheckComputeProjectMetadataContains(projectID, "paper", "pen"),
+					testAccCheckComputeProjectMetadataContains(projectID, "genghis_khan", "french bread"),
+					testAccCheckComputeProjectMetadataContains(projectID, "happy", "smiling"),
+					testAccCheckComputeProjectMetadataSize(projectID, 3),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccComputeProject_modify1_metadata(pid, pname, org, billingId),
+				Config: testAccComputeProject_modify1_metadata(projectID, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", pid, &project),
-					testAccCheckComputeProjectMetadataContains(pid, "paper", "pen"),
-					testAccCheckComputeProjectMetadataContains(pid, "paris", "french bread"),
-					testAccCheckComputeProjectMetadataContains(pid, "happy", "laughing"),
-					testAccCheckComputeProjectMetadataSize(pid, 3),
+						"google_compute_project_metadata.fizzbuzz", projectID, &project),
+					testAccCheckComputeProjectMetadataContains(projectID, "paper", "pen"),
+					testAccCheckComputeProjectMetadataContains(projectID, "paris", "french bread"),
+					testAccCheckComputeProjectMetadataContains(projectID, "happy", "laughing"),
+					testAccCheckComputeProjectMetadataSize(projectID, 3),
 				),
 			},
 		},
@@ -99,7 +99,7 @@ func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
 
 	billingId := os.Getenv("GOOGLE_BILLING_ACCOUNT")
 	var project compute.Project
-	pid := "terraform-test-" + acctest.RandString(10)
+	projectID := "terraform-test-" + acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -107,24 +107,24 @@ func TestAccComputeProjectMetadata_modify_2(t *testing.T) {
 		CheckDestroy: testAccCheckComputeProjectMetadataDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeProject_basic0_metadata(pid, pname, org, billingId),
+				Config: testAccComputeProject_basic0_metadata(projectID, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", pid, &project),
-					testAccCheckComputeProjectMetadataContains(pid, "banana", "orange"),
-					testAccCheckComputeProjectMetadataContains(pid, "sofa", "darwinism"),
-					testAccCheckComputeProjectMetadataSize(pid, 2),
+						"google_compute_project_metadata.fizzbuzz", projectID, &project),
+					testAccCheckComputeProjectMetadataContains(projectID, "banana", "orange"),
+					testAccCheckComputeProjectMetadataContains(projectID, "sofa", "darwinism"),
+					testAccCheckComputeProjectMetadataSize(projectID, 2),
 				),
 			},
 
 			resource.TestStep{
-				Config: testAccComputeProject_basic1_metadata(pid, pname, org, billingId),
+				Config: testAccComputeProject_basic1_metadata(projectID, pname, org, billingId),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeProjectExists(
-						"google_compute_project_metadata.fizzbuzz", pid, &project),
-					testAccCheckComputeProjectMetadataContains(pid, "kiwi", "papaya"),
-					testAccCheckComputeProjectMetadataContains(pid, "finches", "darwinism"),
-					testAccCheckComputeProjectMetadataSize(pid, 2),
+						"google_compute_project_metadata.fizzbuzz", projectID, &project),
+					testAccCheckComputeProjectMetadataContains(projectID, "kiwi", "papaya"),
+					testAccCheckComputeProjectMetadataContains(projectID, "finches", "darwinism"),
+					testAccCheckComputeProjectMetadataSize(projectID, 2),
 				),
 			},
 		},
@@ -148,7 +148,7 @@ func testAccCheckComputeProjectMetadataDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckComputeProjectExists(n, pid string, project *compute.Project) resource.TestCheckFunc {
+func testAccCheckComputeProjectExists(n, projectID string, project *compute.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -161,8 +161,7 @@ func testAccCheckComputeProjectExists(n, pid string, project *compute.Project) r
 
 		config := testAccProvider.Meta().(*Config)
 
-		found, err := config.clientCompute.Projects.Get(
-			pid).Do()
+		found, err := config.clientCompute.Projects.Get(projectID).Do()
 		if err != nil {
 			return err
 		}
@@ -177,10 +176,10 @@ func testAccCheckComputeProjectExists(n, pid string, project *compute.Project) r
 	}
 }
 
-func testAccCheckComputeProjectMetadataContains(pid, key, value string) resource.TestCheckFunc {
+func testAccCheckComputeProjectMetadataContains(projectID, key, value string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		project, err := config.clientCompute.Projects.Get(pid).Do()
+		project, err := config.clientCompute.Projects.Get(projectID).Do()
 		if err != nil {
 			return fmt.Errorf("Error, failed to load project service for %s: %s", config.Project, err)
 		}
@@ -200,10 +199,10 @@ func testAccCheckComputeProjectMetadataContains(pid, key, value string) resource
 	}
 }
 
-func testAccCheckComputeProjectMetadataSize(pid string, size int) resource.TestCheckFunc {
+func testAccCheckComputeProjectMetadataSize(projectID string, size int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
-		project, err := config.clientCompute.Projects.Get(pid).Do()
+		project, err := config.clientCompute.Projects.Get(projectID).Do()
 		if err != nil {
 			return fmt.Errorf("Error, failed to load project service for %s: %s", config.Project, err)
 		}
@@ -217,7 +216,7 @@ func testAccCheckComputeProjectMetadataSize(pid string, size int) resource.TestC
 	}
 }
 
-func testAccComputeProject_basic0_metadata(pid, name, org, billing string) string {
+func testAccComputeProject_basic0_metadata(projectID, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "project" {
   project_id = "%s"
@@ -238,10 +237,10 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     sofa = "darwinism"
   }
   depends_on = ["google_project_services.services"]
-}`, pid, name, org, billing)
+}`, projectID, name, org, billing)
 }
 
-func testAccComputeProject_basic1_metadata(pid, name, org, billing string) string {
+func testAccComputeProject_basic1_metadata(projectID, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "project" {
   project_id = "%s"
@@ -262,10 +261,10 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     finches = "darwinism"
   }
   depends_on = ["google_project_services.services"]
-}`, pid, name, org, billing)
+}`, projectID, name, org, billing)
 }
 
-func testAccComputeProject_modify0_metadata(pid, name, org, billing string) string {
+func testAccComputeProject_modify0_metadata(projectID, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "project" {
   project_id = "%s"
@@ -287,10 +286,10 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     happy = "smiling"
   }
   depends_on = ["google_project_services.services"]
-}`, pid, name, org, billing)
+}`, projectID, name, org, billing)
 }
 
-func testAccComputeProject_modify1_metadata(pid, name, org, billing string) string {
+func testAccComputeProject_modify1_metadata(projectID, name, org, billing string) string {
 	return fmt.Sprintf(`
 resource "google_project" "project" {
   project_id = "%s"
@@ -312,5 +311,5 @@ resource "google_compute_project_metadata" "fizzbuzz" {
     happy = "laughing"
   }
   depends_on = ["google_project_services.services"]
-}`, pid, name, org, billing)
+}`, projectID, name, org, billing)
 }


### PR DESCRIPTION
Update our project metadata tests to stand up their own projects, so
they don't trample all over each other anymore.

The fixes for this were more invasive than I had hoped they would be,
but the tests all pass now (when run sequentially) and there's no reason
for them not to pass when run in parallel.