### PR TITLE
provider/aws: aws_spot_instance_request not forcenew on volume_tags

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -25,7 +25,7 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 
 			// Everything on a spot instance is ForceNew except tags
 			for k, v := range s {
-				if k == "tags" {
+				if k == "tags" || k == "volume_tags" {
 					continue
 				}
 				v.ForceNew = true


### PR DESCRIPTION
The introduction of volume_tags was causing a ForceNew on
spot_instance_requests

This has now been treated the same way as tags

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSpotInstanceRequest_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/28 05:17:42 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSpotInstanceRequest_ -timeout 120m
=== RUN   TestAccAWSSpotInstanceRequest_basic
--- PASS: TestAccAWSSpotInstanceRequest_basic (213.75s)
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (212.14s)
=== RUN   TestAccAWSSpotInstanceRequest_vpc
--- PASS: TestAccAWSSpotInstanceRequest_vpc (130.44s)
=== RUN   TestAccAWSSpotInstanceRequest_SubnetAndSG
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSG (234.43s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	790.791s
```