### PR TITLE
Fix azurerm_container_service examples

### DIFF
--- a/website/source/docs/providers/azurerm/r/container_service.html.markdown
+++ b/website/source/docs/providers/azurerm/r/container_service.html.markdown
@@ -44,7 +44,6 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent1"
-    fqdn       = "you.demo.com"
     vm_size    = "Standard_A0"
   }
 
@@ -89,7 +88,6 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent1"
-    fqdn       = "you.demo.com"
     vm_size    = "Standard_A0"
   }
 
@@ -139,7 +137,6 @@ resource "azurerm_container_service" "test" {
     name       = "default"
     count      = 1
     dns_prefix = "acctestagent1"
-    fqdn       = "you.demo.com"
     vm_size    = "Standard_A0"
   }
 


### PR DESCRIPTION
With the FQDN specified, it throws error:
 ```
1 error(s) occurred:
* azurerm_container_service.test: "agent_pool_profile.0.fqdn": this field cannot be set
```