### PR TITLE
provider/aws: Exclude aws_instance volume tagging for China and Gov C…

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -171,6 +171,20 @@ func (c *AWSClient) DynamoDB() *dynamodb.DynamoDB {
 	return c.dynamodbconn
 }
 
+func (c *AWSClient) IsGovCloud() bool {
+	if c.region == "us-gov-west-1" {
+		return true
+	}
+	return false
+}
+
+func (c *AWSClient) IsChinaCloud() bool {
+	if c.region == "cn-north-1" {
+		return true
+	}
+	return false
+}
+
 // Client configures and returns a fully initialized AWSClient
 func (c *Config) Client() (interface{}, error) {
 	// Get the auth and region. This can fail if keys/regions were not


### PR DESCRIPTION
…louds

Fixes: #14049

The China and Gov regions do not support the new way of tagging
instances and volumes on creation. Therefore, we need to hack this to
make sure we don't try and set these on instance creation