### PR TITLE
provider/aws: Fixes the bug where SNS delivery policy get always recreated

### DIFF
--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -55,9 +55,15 @@ func resourceAwsSnsTopic() *schema.Resource {
 				},
 			},
 			"delivery_policy": &schema.Schema{
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: false,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ForceNew:         false,
+				ValidateFunc:     validateJsonString,
+				DiffSuppressFunc: suppressEquivalentJsonDiffs,
+				StateFunc: func(v interface{}) string {
+					json, _ := normalizeJsonString(v)
+					return json
+				},
 			},
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,


### PR DESCRIPTION
This PR should address the problem from https://github.com/hashicorp/terraform/issues/14024.

I tested it locally and it works, however I couldn't find any good example for how to test this behaviour. Some tips would be great.