### PR TITLE
provider/aws: Add support for SSM Documents to aws_cloudwatch_event_target

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_event_target_test.go
@@ -18,7 +18,7 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudWatchEventTargetConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
@@ -28,7 +28,7 @@ func TestAccAWSCloudWatchEventTarget_basic(t *testing.T) {
 						regexp.MustCompile(":tf-acc-moon$")),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudWatchEventTargetConfigModified,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
@@ -50,7 +50,7 @@ func TestAccAWSCloudWatchEventTarget_missingTargetId(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudWatchEventTargetConfigMissingTargetId,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.moobar", &target),
@@ -71,7 +71,7 @@ func TestAccAWSCloudWatchEventTarget_full(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSCloudWatchEventTargetConfig_full,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.foobar", &target),
@@ -81,6 +81,24 @@ func TestAccAWSCloudWatchEventTarget_full(t *testing.T) {
 						regexp.MustCompile("^arn:aws:kinesis:.*:stream/terraform-kinesis-test$")),
 					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.foobar", "input", "{ \"source\": [\"aws.cloudtrail\"] }\n"),
 					resource.TestCheckResourceAttr("aws_cloudwatch_event_target.foobar", "input_path", ""),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSCloudWatchEventTarget_ssmDocument(t *testing.T) {
+	var target events.Target
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCloudWatchEventTargetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSCloudWatchEventTargetConfigSsmDocument,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckCloudWatchEventTargetExists("aws_cloudwatch_event_target.test", &target),
 				),
 			},
 		},
@@ -124,17 +142,6 @@ func testAccCheckAWSCloudWatchEventTargetDestroy(s *terraform.State) error {
 	}
 
 	return nil
-}
-
-func testAccCheckTargetIdExists(targetId string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[targetId]
-		if !ok {
-			return fmt.Errorf("Not found: %s", targetId)
-		}
-
-		return nil
-	}
 }
 
 var testAccAWSCloudWatchEventTargetConfig = `
@@ -247,5 +254,97 @@ INPUT
 resource "aws_kinesis_stream" "test_stream" {
     name = "terraform-kinesis-test"
     shard_count = 1
+}
+`
+
+var testAccAWSCloudWatchEventTargetConfigSsmDocument = `
+resource "aws_ssm_document" "foo" {
+  name = "test_document-100"
+  document_type = "Command"
+
+  content = <<DOC
+    {
+      "schemaVersion": "1.2",
+      "description": "Check ip configuration of a Linux instance.",
+      "parameters": {
+
+      },
+      "runtimeConfig": {
+        "aws:runShellScript": {
+          "properties": [
+            {
+              "id": "0.aws:runShellScript",
+              "runCommand": ["ifconfig"]
+            }
+          ]
+        }
+      }
+    }
+DOC
+}
+
+resource "aws_cloudwatch_event_rule" "console" {
+  name        = "another_test"
+  description = "another_test"
+
+  event_pattern = <<PATTERN
+{
+  "source": [
+    "aws.autoscaling"
+  ]
+}
+PATTERN
+}
+
+resource "aws_cloudwatch_event_target" "test" {
+
+  arn = "${aws_ssm_document.foo.arn}"
+  rule = "${aws_cloudwatch_event_rule.console.id}"
+  role_arn = "${aws_iam_role.test_role.arn}"
+
+  run_command_targets {
+    key = "tag:Name"
+    values = ["acceptance_test"]
+  }
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "events.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "test_policy" {
+  name = "test_policy"
+  role = "${aws_iam_role.test_role.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": "ssm:*",
+            "Effect": "Allow",
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}
+EOF
 }
 `

--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -27,6 +27,10 @@ func resourceAwsSsmDocument() *schema.Resource {
 		Delete: resourceAwsSsmDocumentDelete,
 
 		Schema: map[string]*schema.Schema{
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -195,6 +199,9 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("name", doc.Name)
 	d.Set("owner", doc.Owner)
 	d.Set("platform_types", flattenStringList(doc.PlatformTypes))
+	if err := d.Set("arn", flattenAwsSsmDocumentArn(meta, doc.Name)); err != nil {
+		return fmt.Errorf("[DEBUG] Error setting arn error: %#v", err)
+	}
 
 	d.Set("status", doc.Status)
 
@@ -236,6 +243,12 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	return nil
+}
+
+func flattenAwsSsmDocumentArn(meta interface{}, docName *string) string {
+	region := meta.(*AWSClient).region
+
+	return fmt.Sprintf("arn:aws:ssm:%s::document/%s", region, *docName)
 }
 
 func resourceAwsSsmDocumentUpdate(d *schema.ResourceData, meta interface{}) error {

--- a/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_event_target.html.markdown
@@ -62,3 +62,11 @@ The following arguments are supported:
 * `input` - (Optional) Valid JSON text passed to the target.
 * `input_path` - (Optional) The value of the [JSONPath](http://goessner.net/articles/JsonPath/)
 	that is used for extracting part of the matched event when passing it to the target.
+* `role_arn` - (Optional) The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered.
+* `run_command_targets` - (Optional) Parameters used when you are using the rule to invoke Amazon EC2 Run Command. Documented below. A maximum of 5 are allowed.
+
+`run_command_parameters` support the following:
+
+* `key` - (Required) Can be either `tag:tag-key` or `InstanceIds`.
+* `values` - (Required) If Key is `tag:tag-key`, Values is a list of tag values. If Key is `InstanceIds`, Values is a list of Amazon EC2 instance IDs.
+


### PR DESCRIPTION
```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudWatchEventTarget_' 
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/29 11:00:09 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSCloudWatchEventTarget_ -timeout 120m
=== RUN   TestAccAWSCloudWatchEventTarget_basic
--- PASS: TestAccAWSCloudWatchEventTarget_basic (58.75s)
=== RUN   TestAccAWSCloudWatchEventTarget_missingTargetId
--- PASS: TestAccAWSCloudWatchEventTarget_missingTargetId (36.11s)
=== RUN   TestAccAWSCloudWatchEventTarget_full
--- PASS: TestAccAWSCloudWatchEventTarget_full (90.30s)
=== RUN   TestAccAWSCloudWatchEventTarget_ssmDocument
--- PASS: TestAccAWSCloudWatchEventTarget_ssmDocument (38.64s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	223.833s
```