### PR TITLE
Add verbose Dyn provider logs

### DIFF
--- a/builtin/providers/dyn/config.go
+++ b/builtin/providers/dyn/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/nesv/go-dynect/dynect"
 )
 
@@ -16,8 +17,11 @@ type Config struct {
 // Client() returns a new client for accessing dyn.
 func (c *Config) Client() (*dynect.ConvenientClient, error) {
 	client := dynect.NewConvenientClient(c.CustomerName)
-	err := client.Login(c.Username, c.Password)
+	if logging.IsDebugOrHigher() {
+		client.Verbose(true)
+	}
 
+	err := client.Login(c.Username, c.Password)
 	if err != nil {
 		return nil, fmt.Errorf("Error setting up Dyn client: %s", err)
 	}


### PR DESCRIPTION
To help troubleshoot, configure the underlying Dyn API module
to output verbose logs when TF_LOG is debug or higher.