### PR TITLE
provider/heroku: Add resources for Heroku Pipelines

### DIFF
--- a/builtin/providers/heroku/provider.go
+++ b/builtin/providers/heroku/provider.go
@@ -33,6 +33,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_cert":        resourceHerokuCert(),
 			"heroku_domain":      resourceHerokuDomain(),
 			"heroku_drain":       resourceHerokuDrain(),
+			"heroku_pipeline":    resourceHerokuPipeline(),
 			"heroku_space":       resourceHerokuSpace(),
 		},
 

--- a/builtin/providers/heroku/provider.go
+++ b/builtin/providers/heroku/provider.go
@@ -27,14 +27,15 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"heroku_addon":       resourceHerokuAddon(),
-			"heroku_app":         resourceHerokuApp(),
-			"heroku_app_feature": resourceHerokuAppFeature(),
-			"heroku_cert":        resourceHerokuCert(),
-			"heroku_domain":      resourceHerokuDomain(),
-			"heroku_drain":       resourceHerokuDrain(),
-			"heroku_pipeline":    resourceHerokuPipeline(),
-			"heroku_space":       resourceHerokuSpace(),
+			"heroku_addon":             resourceHerokuAddon(),
+			"heroku_app":               resourceHerokuApp(),
+			"heroku_app_feature":       resourceHerokuAppFeature(),
+			"heroku_cert":              resourceHerokuCert(),
+			"heroku_domain":            resourceHerokuDomain(),
+			"heroku_drain":             resourceHerokuDrain(),
+			"heroku_pipeline":          resourceHerokuPipeline(),
+			"heroku_pipeline_coupling": resourceHerokuPipelineCoupling(),
+			"heroku_space":             resourceHerokuSpace(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/builtin/providers/heroku/resource_heroku_pipeline.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline.go
@@ -12,6 +12,7 @@ import (
 func resourceHerokuPipeline() *schema.Resource {
 	return &schema.Resource{
 		Create: resourceHerokuPipelineCreate,
+		Update: resourceHerokuPipelineUpdate,
 		Read:   resourceHerokuPipelineRead,
 		Delete: resourceHerokuPipelineDelete,
 
@@ -19,7 +20,6 @@ func resourceHerokuPipeline() *schema.Resource {
 			"name": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true, // TODO does it?
 			},
 		},
 	}
@@ -42,6 +42,24 @@ func resourceHerokuPipelineCreate(d *schema.ResourceData, meta interface{}) erro
 	d.Set("name", p.Name)
 
 	log.Printf("[INFO] Pipeline ID: %s", d.Id())
+
+	return resourceHerokuPipelineUpdate(d, meta)
+}
+
+func resourceHerokuPipelineUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	if d.HasChange("name") {
+		name := d.Get("name").(string)
+		opts := heroku.PipelineUpdateOpts{
+			Name: &name,
+		}
+
+		_, err := client.PipelineUpdate(context.TODO(), d.Id(), opts)
+		if err != nil {
+			return err
+		}
+	}
 
 	return resourceHerokuPipelineRead(d, meta)
 }

--- a/builtin/providers/heroku/resource_heroku_pipeline.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline.go
@@ -28,8 +28,9 @@ func resourceHerokuPipeline() *schema.Resource {
 func resourceHerokuPipelineCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
-	opts := heroku.PipelineCreateOpts{}
-	opts.Name = d.Get("name").(string)
+	opts := heroku.PipelineCreateOpts{
+		Name: d.Get("name").(string),
+	}
 
 	log.Printf("[DEBUG] Pipeline create configuration: %#v", opts)
 

--- a/builtin/providers/heroku/resource_heroku_pipeline_coupling.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_coupling.go
@@ -1,0 +1,88 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceHerokuPipelineCoupling() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuPipelineCouplingCreate,
+		Read:   resourceHerokuPipelineCouplingRead,
+		Delete: resourceHerokuPipelineCouplingDelete,
+
+		Schema: map[string]*schema.Schema{
+			"app": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"pipeline": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateUUID,
+			},
+			"stage": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validatePipelineStageName,
+			},
+		},
+	}
+}
+
+func resourceHerokuPipelineCouplingCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	opts := heroku.PipelineCouplingCreateOpts{}
+	opts.App = d.Get("app").(string)
+	opts.Pipeline = d.Get("pipeline").(string)
+	opts.Stage = d.Get("stage").(string)
+
+	log.Printf("[DEBUG] PipelineCoupling create configuration: %#v", opts)
+
+	p, err := client.PipelineCouplingCreate(context.TODO(), opts)
+	if err != nil {
+		return fmt.Errorf("Error creating pipeline: %s", err)
+	}
+
+	d.SetId(p.ID)
+
+	log.Printf("[INFO] PipelineCoupling ID: %s", d.Id())
+
+	return resourceHerokuPipelineCouplingRead(d, meta)
+}
+
+func resourceHerokuPipelineCouplingDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	log.Printf("[INFO] Deleting pipeline: %s", d.Id())
+
+	_, err := client.PipelineCouplingDelete(context.TODO(), d.Id())
+	if err != nil {
+		return fmt.Errorf("Error deleting pipeline: %s", err)
+	}
+
+	return nil
+}
+
+func resourceHerokuPipelineCouplingRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	p, err := client.PipelineCouplingInfo(context.TODO(), d.Id())
+	if err != nil {
+		return fmt.Errorf("Error retrieving pipeline: %s", err)
+	}
+
+	d.Set("app", p.App)
+	d.Set("pipeline", p.Pipeline)
+	d.Set("stage", p.Stage)
+
+	return nil
+}

--- a/builtin/providers/heroku/resource_heroku_pipeline_coupling.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_coupling.go
@@ -40,10 +40,11 @@ func resourceHerokuPipelineCoupling() *schema.Resource {
 func resourceHerokuPipelineCouplingCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*heroku.Service)
 
-	opts := heroku.PipelineCouplingCreateOpts{}
-	opts.App = d.Get("app").(string)
-	opts.Pipeline = d.Get("pipeline").(string)
-	opts.Stage = d.Get("stage").(string)
+	opts := heroku.PipelineCouplingCreateOpts{
+		App:      d.Get("app").(string),
+		Pipeline: d.Get("pipeline").(string),
+		Stage:    d.Get("stage").(string),
+	}
 
 	log.Printf("[DEBUG] PipelineCoupling create configuration: %#v", opts)
 

--- a/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
@@ -29,7 +29,6 @@ func TestAccHerokuPipelineCoupling_Basic(t *testing.T) {
 					testAccCheckHerokuPipelineCouplingExists("heroku_pipeline_coupling.default", &coupling),
 					testAccCheckHerokuPipelineCouplingAttributes(
 						&coupling,
-						"heroku_app.default",
 						"heroku_pipeline.default",
 						stageName,
 					),
@@ -87,7 +86,7 @@ func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.Pipelin
 	}
 }
 
-func testAccCheckHerokuPipelineCouplingAttributes(coupling *heroku.PipelineCouplingInfoResult, _, pipelineResource, stageName string) resource.TestCheckFunc {
+func testAccCheckHerokuPipelineCouplingAttributes(coupling *heroku.PipelineCouplingInfoResult, pipelineResource, stageName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		pipeline, ok := s.RootModule().Resources[pipelineResource]
 		if !ok {

--- a/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
@@ -77,7 +77,7 @@ func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.Pipelin
 		}
 
 		if foundPipelineCoupling.ID != rs.Primary.ID {
-			return fmt.Errorf("PipelineCoupling not found")
+			return fmt.Errorf("PipelineCoupling not found: %s != %s", foundPipelineCoupling.ID, rs.Primary.ID)
 		}
 
 		*pipeline = *foundPipelineCoupling

--- a/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
@@ -1,0 +1,124 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccHerokuPipelineCoupling_Basic(t *testing.T) {
+	var coupling heroku.PipelineCouplingInfoResult
+
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	stageName := "development"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuPipelineCouplingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuPipelineCouplingExists("heroku_pipeline_coupling.default", &coupling),
+					testAccCheckHerokuPipelineCouplingAttributes(
+						&coupling,
+						"heroku_app.default",
+						"heroku_pipeline.default",
+						stageName,
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuPipelineCouplingConfig_basic(appName, pipelineName, stageName string) string {
+	return fmt.Sprintf(`
+resource "heroku_app" "default" {
+  name   = "%s"
+  region = "us"
+}
+
+resource "heroku_pipeline" "default" {
+  name = "%s"
+}
+
+resource "heroku_pipeline_coupling" "default" {
+  app      = "${heroku_app.default.id}"
+  pipeline = "${heroku_pipeline.default.id}"
+  stage    = "%s"
+}
+`, appName, pipelineName, stageName)
+}
+
+func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.PipelineCouplingInfoResult) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No coupling ID set")
+		}
+
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		foundPipelineCoupling, err := client.PipelineCouplingInfo(context.TODO(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundPipelineCoupling.ID != rs.Primary.ID {
+			return fmt.Errorf("PipelineCoupling not found")
+		}
+
+		*pipeline = *foundPipelineCoupling
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuPipelineCouplingAttributes(coupling *heroku.PipelineCouplingInfoResult, _, pipelineResource, stageName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		pipeline, ok := s.RootModule().Resources[pipelineResource]
+		if !ok {
+			return fmt.Errorf("Pipeline not found: %s", pipelineResource)
+		}
+
+		if coupling.Pipeline.ID != pipeline.Primary.ID {
+			return fmt.Errorf("Bad pipeline ID: %v != %v", coupling.Pipeline.ID, pipeline.Primary.ID)
+		}
+		if coupling.Stage != stageName {
+			return fmt.Errorf("Bad stage: %s", coupling.Stage)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuPipelineCouplingDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*heroku.Service)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "heroku_pipeline_coupling" {
+			continue
+		}
+
+		_, err := client.PipelineCouplingInfo(context.TODO(), rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("PipelineCoupling still exists")
+		}
+	}
+
+	return nil
+}

--- a/builtin/providers/heroku/resource_heroku_pipeline_test.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_test.go
@@ -1,0 +1,97 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccHerokuPipeline_Basic(t *testing.T) {
+	var pipeline heroku.PipelineInfoResult
+	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuPipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuPipelineConfig_basic(pipelineName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuPipelineExists("heroku_pipeline.foobar", &pipeline),
+					testAccCheckHerokuPipelineAttributes(&pipeline, pipelineName),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuPipelineConfig_basic(pipelineName string) string {
+	return fmt.Sprintf(`
+resource "heroku_pipeline" "foobar" {
+  name = "%s"
+}
+`, pipelineName)
+}
+
+func testAccCheckHerokuPipelineExists(n string, pipeline *heroku.PipelineInfoResult) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No pipeline name set")
+		}
+
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		foundPipeline, err := client.PipelineInfo(context.TODO(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundPipeline.ID != rs.Primary.ID {
+			return fmt.Errorf("Pipeline not found")
+		}
+
+		*pipeline = *foundPipeline
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuPipelineAttributes(pipeline *heroku.PipelineInfoResult, pipelineName string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if pipeline.Name != pipelineName {
+			return fmt.Errorf("Bad name: %s", pipeline.Name)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuPipelineDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*heroku.Service)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "heroku_pipeline" {
+			continue
+		}
+
+		_, err := client.PipelineInfo(context.TODO(), rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Pipeline still exists")
+		}
+	}
+
+	return nil
+}

--- a/builtin/providers/heroku/resource_heroku_pipeline_test.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_test.go
@@ -14,6 +14,7 @@ import (
 func TestAccHerokuPipeline_Basic(t *testing.T) {
 	var pipeline heroku.PipelineInfoResult
 	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	pipelineName2 := fmt.Sprintf("%s-2", pipelineName)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -24,7 +25,15 @@ func TestAccHerokuPipeline_Basic(t *testing.T) {
 				Config: testAccCheckHerokuPipelineConfig_basic(pipelineName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckHerokuPipelineExists("heroku_pipeline.foobar", &pipeline),
-					testAccCheckHerokuPipelineAttributes(&pipeline, pipelineName),
+					resource.TestCheckResourceAttr(
+						"heroku_pipeline.foobar", "name", pipelineName),
+				),
+			},
+			{
+				Config: testAccCheckHerokuPipelineConfig_basic(pipelineName2),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"heroku_pipeline.foobar", "name", pipelineName2),
 				),
 			},
 		},
@@ -63,16 +72,6 @@ func testAccCheckHerokuPipelineExists(n string, pipeline *heroku.PipelineInfoRes
 		}
 
 		*pipeline = *foundPipeline
-
-		return nil
-	}
-}
-
-func testAccCheckHerokuPipelineAttributes(pipeline *heroku.PipelineInfoResult, pipelineName string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if pipeline.Name != pipelineName {
-			return fmt.Errorf("Bad name: %s", pipeline.Name)
-		}
 
 		return nil
 	}

--- a/builtin/providers/heroku/validators.go
+++ b/builtin/providers/heroku/validators.go
@@ -7,14 +7,14 @@ import (
 	"github.com/satori/uuid"
 )
 
-var validPipelineStageNames = []string{
-	"review",
-	"development",
-	"staging",
-	"production",
-}
-
 func validatePipelineStageName(v interface{}, k string) (ws []string, errors []error) {
+	validPipelineStageNames := []string{
+		"review",
+		"development",
+		"staging",
+		"production",
+	}
+
 	for _, s := range validPipelineStageNames {
 		if v == s {
 			return

--- a/builtin/providers/heroku/validators.go
+++ b/builtin/providers/heroku/validators.go
@@ -1,0 +1,38 @@
+package heroku
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/satori/uuid"
+)
+
+var validPipelineStageNames = []string{
+	"review",
+	"development",
+	"staging",
+	"production",
+}
+
+func validatePipelineStageName(v interface{}, k string) (ws []string, errors []error) {
+	for _, s := range validPipelineStageNames {
+		if v == s {
+			return
+		}
+	}
+
+	err := fmt.Errorf(
+		"%s is an invalid pipeline stage, must be one of [%s]",
+		v,
+		strings.Join(validPipelineStageNames, ", "),
+	)
+	errors = append(errors, err)
+	return
+}
+
+func validateUUID(v interface{}, k string) (ws []string, errors []error) {
+	if _, err := uuid.FromString(v.(string)); err != nil {
+		errors = append(errors, fmt.Errorf("%q is an invalid UUID: %s", k, err))
+	}
+	return
+}

--- a/builtin/providers/heroku/validators_test.go
+++ b/builtin/providers/heroku/validators_test.go
@@ -1,0 +1,53 @@
+package heroku
+
+import "testing"
+
+func TestPipelineStage(t *testing.T) {
+	valid := []string{
+		"review",
+		"development",
+		"staging",
+		"production",
+	}
+	for _, v := range valid {
+		_, errors := validatePipelineStageName(v, "stage")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid stage: %q", v, errors)
+		}
+	}
+
+	invalid := []string{
+		"foobarbaz",
+		"another-stage",
+		"",
+	}
+	for _, v := range invalid {
+		_, errors := validatePipelineStageName(v, "stage")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid stage", v)
+		}
+	}
+}
+
+func TestValidateUUID(t *testing.T) {
+	valid := []string{
+		"4812ccbc-2a2e-4c6c-bae4-a3d04ed51c0e",
+	}
+	for _, v := range valid {
+		_, errors := validateUUID(v, "id")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid UUID: %q", v, errors)
+		}
+	}
+
+	invalid := []string{
+		"foobarbaz",
+		"my-app-name",
+	}
+	for _, v := range invalid {
+		_, errors := validateUUID(v, "id")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid UUID", v)
+		}
+	}
+}

--- a/website/source/docs/providers/heroku/r/pipeline.html.markdown
+++ b/website/source/docs/providers/heroku/r/pipeline.html.markdown
@@ -1,0 +1,62 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_pipeline_"
+sidebar_current: "docs-heroku-resource-pipeline-x"
+description: |-
+  Provides a Heroku Pipeline resource.
+---
+
+# heroku\_pipeline
+
+
+Provides a [Heroku Pipeline](https://devcenter.heroku.com/articles/pipelines)
+resource.
+
+A pipeline is a group of Heroku apps that share the same codebase. Once a
+pipeline is created, and apps are added to different stages using
+[`heroku_pipeline_coupling`](./pipeline_coupling.html), you can promote app
+slugs to the next stage.
+
+## Example Usage
+
+```hcl
+# Create Heroku apps for staging and production
+resource "heroku_app" "staging" {
+  name = "test-app-staging"
+}
+
+resource "heroku_app" "production" {
+  name = "test-app-production"
+}
+
+# Create a Heroku pipeline
+resource "heroku_pipeline" "test-app" {
+  name = "test-app"
+}
+
+# Couple apps to different pipeline stages
+resource "heroku_pipeline_coupling" "staging" {
+  app      = "${heroku_app.staging.name}"
+  pipeline = "${heroku_pipeline.test-app.id}"
+  stage    = "staging"
+}
+
+resource "heroku_pipeline_coupling" "production" {
+  app      = "${heroku_app.production.name}"
+  pipeline = "${heroku_pipeline.test-app.id}"
+  stage    = "production"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the pipeline.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The UUID of the pipeline.
+* `name` - The name of the pipeline.

--- a/website/source/docs/providers/heroku/r/pipeline_coupling.html.markdown
+++ b/website/source/docs/providers/heroku/r/pipeline_coupling.html.markdown
@@ -1,0 +1,67 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_pipeline_coupling"
+sidebar_current: "docs-heroku-resource-pipeline-coupling"
+description: |-
+  Provides a Heroku Pipeline Coupling resource.
+---
+
+# heroku\_pipeline\_coupling
+
+
+Provides a [Heroku Pipeline Coupling](https://devcenter.heroku.com/articles/pipelines)
+resource.
+
+A pipeline is a group of Heroku apps that share the same codebase. Once a
+pipeline is created using [`heroku_pipeline`](./pipeline), and apps are added
+to different stages using `heroku_pipeline_coupling`, you can promote app slugs
+to the downstream stages.
+
+## Example Usage
+
+```hcl
+# Create Heroku apps for staging and production
+resource "heroku_app" "staging" {
+  name = "test-app-staging"
+}
+
+resource "heroku_app" "production" {
+  name = "test-app-production"
+}
+
+# Create a Heroku pipeline
+resource "heroku_pipeline" "test-app" {
+  name = "test-app"
+}
+
+# Couple apps to different pipeline stages
+resource "heroku_pipeline_coupling" "staging" {
+  app      = "${heroku_app.staging.name}"
+  pipeline = "${heroku_pipeline.test-app.id}"
+  stage    = "staging"
+}
+
+resource "heroku_pipeline_coupling" "production" {
+  app      = "${heroku_app.production.name}"
+  pipeline = "${heroku_pipeline.test-app.id}"
+  stage    = "production"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `app` - (Required) The name of the app for this coupling.
+* `pipeline` - (Required) The ID of the pipeline to add this app to.
+* `stage` - (Required) The stage to couple this app to. Must be one of
+`review`, `development`, `staging`, or `production`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The UUID of this pipeline coupling.
+* `app` - The name of the application.
+* `pipeline` - The UUID of the pipeline.
+* `stage` - The stage for this coupling.

--- a/website/source/layouts/heroku.erb
+++ b/website/source/layouts/heroku.erb
@@ -37,6 +37,14 @@
                     <a href="/docs/providers/heroku/r/drain.html">heroku_drain</a>
                     </li>
 
+                    <li<%= sidebar_current("docs-heroku-resource-pipeline-x") %>>
+                    <a href="/docs/providers/heroku/r/pipeline.html">heroku_pipeline</a>
+                    </li>
+
+                    <li<%= sidebar_current("docs-heroku-resource-pipeline-coupling") %>>
+                    <a href="/docs/providers/heroku/r/pipeline_coupling.html">heroku_pipeline_coupling</a>
+                    </li>
+
                     <li<%= sidebar_current("docs-heroku-resource-space") %>>
                     <a href="/docs/providers/heroku/r/space.html">heroku_space</a>
                     </li>


### PR DESCRIPTION
Adds 2 resources: `heroku_pipeline` and `heroku_pipeline_coupling` to allow managing [Heroku Pipelines](https://devcenter.heroku.com/articles/pipelines) with Terraform.

### Example Terraform config:

```tf
resource "heroku_pipeline" "default" {
  name = "my-pipeline"
}

resource "heroku_app" "alpha" {
  name   = "justincampbell-test-alpha"
  region = "us"
}

resource "heroku_pipeline_coupling" "alpha" {
  app      = "${heroku_app.alpha.id}"
  pipeline = "${heroku_pipeline.default.id}"
  stage    = "development"
}

resource "heroku_app" "beta" {
  name   = "justincampbell-test-beta"
  region = "us"
}

resource "heroku_pipeline_coupling" "beta" {
  app      = "${heroku_app.beta.id}"
  pipeline = "${heroku_pipeline.default.id}"
  stage    = "staging"
}

resource "heroku_app" "release" {
  name   = "justincampbell-test-release"
  region = "us"
}

resource "heroku_pipeline_coupling" "release" {
  app      = "${heroku_app.release.id}"
  pipeline = "${heroku_pipeline.default.id}"
  stage    = "production"
}
```

### Acceptance test output:

```
$ clear; make testacc TEST=./builtin/providers/heroku TESTARGS="-run Pipeline"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/28 16:16:16 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/heroku -v -run Pipeline -timeout 120m
=== RUN   TestAccHerokuPipelineCoupling_Basic
--- PASS: TestAccHerokuPipelineCoupling_Basic (4.58s)
=== RUN   TestAccHerokuPipeline_Basic
--- PASS: TestAccHerokuPipeline_Basic (2.92s)
=== RUN   TestPipelineStage
--- PASS: TestPipelineStage (0.00s)
```