### PR TITLE
provider/aws: Fix source_dest_check with network_interface

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -90,6 +90,11 @@ func resourceAwsInstance() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Suppress diff if network_interface is set
+					_, ok := d.GetOk("network_interface")
+					return ok
+				},
 			},
 
 			"user_data": {
@@ -642,6 +647,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("primary_network_interface_id", primaryNetworkInterface.NetworkInterfaceId)
 		d.Set("associate_public_ip_address", primaryNetworkInterface.Association != nil)
 		d.Set("ipv6_address_count", len(primaryNetworkInterface.Ipv6Addresses))
+		d.Set("source_dest_check", *primaryNetworkInterface.SourceDestCheck)
 
 		for _, address := range primaryNetworkInterface.Ipv6Addresses {
 			ipv6Addresses = append(ipv6Addresses, *address.Ipv6Address)


### PR DESCRIPTION
The default value for `source_dest_check` needs to remain the same, so as not to break any backwards compatibility, however, adding a new `network_interface` parameter with a pre-configured network_interface that has `source_dest_check` set to false throws a diff after initial apply. Since we don't want to change `source_dest_check` to computed in order to not break sane defaults, ignore the diff thrown if `network_interface` attributes are configured on an instance.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run=TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/28 16:26:02 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck -timeout 120m
=== RUN   TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck
--- PASS: TestAccAWSInstance_primaryNetworkInterfaceSourceDestCheck (134.20s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    134.211s
```

```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run=TestAccAWSInstance_sourceDestCheck"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/28 16:15:14 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_sourceDestCheck -timeout 120m
=== RUN   TestAccAWSInstance_sourceDestCheck
--- PASS: TestAccAWSInstance_sourceDestCheck (179.81s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws   179.815s
```

Fixes: #14068