### PR TITLE
provider/fastly: Make request_condition optional

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -778,7 +778,8 @@ func resourceServiceV1() *schema.Resource {
 						},
 						"request_condition": {
 							Type:        schema.TypeString,
-							Required:    true,
+							Optional:    true,
+							Default:     "",
 							Description: "Name of a request condition to apply.",
 						},
 						// Optional fields

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -263,7 +263,7 @@ The `request_setting` block allow you to customize Fastly's request handling, by
 defining behavior that should change based on a predefined `condition`:
 
 * `name` - (Required) The domain for this request setting.
-* `request_condition` - (Required) Name of already defined `condition` to
+* `request_condition` - (Optional) Name of already defined `condition` to
 determine if this request setting should be applied.
 * `max_stale_age` - (Optional) How old an object is allowed to be to serve
 `stale-if-error` or `stale-while-revalidate`, in seconds. Default `60`.


### PR DESCRIPTION
Makes the `request_condition` setting optional for Fastly `request_settings` as seen here:

![Fastly request setting example](https://docs.fastly.com/img/guides/only-tls-create-new-request.png)

This also updates the relevant documentation.
