### PR TITLE
Document GOOGLE_APPLICATION_CREDENTIALS support.

### DIFF
--- a/website/source/docs/providers/google/index.html.markdown
+++ b/website/source/docs/providers/google/index.html.markdown
@@ -46,6 +46,10 @@ The following keys can be used to configure the provider.
     * `GOOGLE_CLOUD_KEYFILE_JSON`
     * `GCLOUD_KEYFILE_JSON`
 
+    The [`GOOGLE_APPLICATION_CREDENTIALS`](https://developers.google.com/identity/protocols/application-default-credentials#howtheywork)
+    environment variable can also contain the path of a file to obtain credentials
+    from.
+
 * `project` - (Required) The ID of the project to apply any resources to.  This
   can be specified using any of the following environment variables (listed in
   order of precedence):


### PR DESCRIPTION
We've supported GOOGLE_APPLICATION_CREDENTIALS as an environment
variable (it comes free with our OAuth2 client) but it has never been
documented. Documenting it now to resolve #12626.