### PR TITLE
it's possible to get a nil diff in PreApply

### DIFF
--- a/command/hook_count.go
+++ b/command/hook_count.go
@@ -42,6 +42,10 @@ func (h *CountHook) PreApply(
 	h.Lock()
 	defer h.Unlock()
 
+	if d.Empty() {
+		return terraform.HookActionContinue, nil
+	}
+
 	if h.pending == nil {
 		h.pending = make(map[string]countHookAction)
 	}

--- a/command/hook_ui.go
+++ b/command/hook_ui.go
@@ -59,6 +59,11 @@ func (h *UiHook) PreApply(
 	d *terraform.InstanceDiff) (terraform.HookAction, error) {
 	h.once.Do(h.init)
 
+	// if there's no diff, there's nothing to output
+	if d.Empty() {
+		return terraform.HookActionContinue, nil
+	}
+
 	id := n.HumanId()
 
 	op := uiResourceModify


### PR DESCRIPTION
Fixes #13438

There appears to be some combination of an orphaned and deposed resource that can lead to an apply with a nil diff. While this may not be ideal, there is always the possibility of a nil diff, so we must handle it. The possibility of a nil value and if checks are required is still haphazard throughout a lot of the core, the  EvalSequences may be a good candidate for an audit.

Looking through the operations in node_resource_apply and
node_resource_destroy, there are multiple nil checks for diffApply, so
we need to continue to assume that the diff can be nil through there
until we ensure that it is non-nill in all cases.

So regardless of how we came to get a nil diff in the UiHook PreApply
method, we need to check it.