### PR TITLE
provider/aws: Allow updating predicates in WAF Rule + no predicates

### DIFF
--- a/builtin/providers/aws/resource_aws_waf_rule.go
+++ b/builtin/providers/aws/resource_aws_waf_rule.go
@@ -129,13 +129,16 @@ func resourceAwsWafRuleRead(d *schema.ResourceData, meta interface{}) error {
 func resourceAwsWafRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).wafconn
 
-	o, n := d.GetChange("predicates")
-	oldP, newP := o.(*schema.Set).List(), n.(*schema.Set).List()
+	if d.HasChange("predicates") {
+		o, n := d.GetChange("predicates")
+		oldP, newP := o.(*schema.Set).List(), n.(*schema.Set).List()
 
-	err := updateWafRuleResource(d.Id(), oldP, newP, conn)
-	if err != nil {
-		return fmt.Errorf("Error Updating WAF Rule: %s", err)
+		err := updateWafRuleResource(d.Id(), oldP, newP, conn)
+		if err != nil {
+			return fmt.Errorf("Error Updating WAF Rule: %s", err)
+		}
 	}
+
 	return resourceAwsWafRuleRead(d, meta)
 }
 

--- a/builtin/providers/aws/resource_aws_waf_rule_test.go
+++ b/builtin/providers/aws/resource_aws_waf_rule_test.go
@@ -181,6 +181,29 @@ func testCheckResourceAttrWithIndexesAddr(name, format string, idx *int, value s
 	}
 }
 
+func TestAccAWSWafRule_noPredicates(t *testing.T) {
+	var rule waf.Rule
+	ruleName := fmt.Sprintf("wafrule%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafRuleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafRuleConfig_noPredicates(ruleName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafRuleExists("aws_waf_rule.wafrule", &rule),
+					resource.TestCheckResourceAttr(
+						"aws_waf_rule.wafrule", "name", ruleName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_rule.wafrule", "predicates.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSWafRuleDisappears(v *waf.Rule) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
@@ -361,4 +384,12 @@ resource "aws_waf_rule" "wafrule" {
     type = "ByteMatch"
   }
 }`, name, name, name, name)
+}
+
+func testAccAWSWafRuleConfig_noPredicates(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_rule" "wafrule" {
+  name = "%s"
+  metric_name = "%s"
+}`, name, name)
 }


### PR DESCRIPTION
This is to fix a bug very similar to #10403 and #11959

TL;DR We were not deleting any predicates except when deleting the whole Rule.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSWafRule_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/04/29 07:22:01 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSWafRule_ -timeout 120m
=== RUN   TestAccAWSWafRule_basic
--- PASS: TestAccAWSWafRule_basic (31.54s)
=== RUN   TestAccAWSWafRule_changeNameForceNew
--- PASS: TestAccAWSWafRule_changeNameForceNew (62.36s)
=== RUN   TestAccAWSWafRule_disappears
--- PASS: TestAccAWSWafRule_disappears (30.40s)
=== RUN   TestAccAWSWafRule_changePredicates
--- PASS: TestAccAWSWafRule_changePredicates (54.65s)
=== RUN   TestAccAWSWafRule_noPredicates
--- PASS: TestAccAWSWafRule_noPredicates (21.86s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	200.836s
```

cc @yusukegoto