### PR TITLE
backend/remote-state: add parameters for custom s3 backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ BACKWARDS INCOMPATIBILITIES / NOTES:
 
 * provider/aws: Users of aws_cloudfront_distributions with custom_origins have been broken due to changes in the AWS API requiring   `OriginReadTimeout` being set for updates. This has been fixed and will show as a change in terraform plan / apply. [GH-13367]
 * provider/aws: Users of China and Gov clouds, cannot use the new tagging of volumes created as part of aws_instances [GH-14055]
+* backend/remote-state: Add options for custom s3 endpoints
 
 FEATURES:
 

--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -131,6 +131,48 @@ func New() backend.Backend {
 				Description: "The permissions applied when assuming a role.",
 				Default:     "",
 			},
+
+			"insecure": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Use insecure connection to S3.",
+				Default:     false,
+			},
+
+			"skip_creds_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set to skip credentials validation.",
+				Default:     false,
+			},
+
+			"skip_region_validation": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set to skip AWS region validation.",
+				Default:     false,
+			},
+
+			"skip_requesting_account_id": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set to skip requesting account ID.",
+				Default:     false,
+			},
+
+			"skip_metadata_api_check": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set to skip metadata API check.",
+				Default:     false,
+			},
+
+			"s3_force_path_style": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Description: "Set to force S3 path style.",
+				Default:     false,
+			},
 		},
 	}
 
@@ -170,17 +212,23 @@ func (b *Backend) configure(ctx context.Context) error {
 	b.lockTable = data.Get("lock_table").(string)
 
 	cfg := &terraformAWS.Config{
-		AccessKey:             data.Get("access_key").(string),
-		AssumeRoleARN:         data.Get("role_arn").(string),
-		AssumeRoleExternalID:  data.Get("external_id").(string),
-		AssumeRolePolicy:      data.Get("assume_role_policy").(string),
-		AssumeRoleSessionName: data.Get("session_name").(string),
-		CredsFilename:         data.Get("shared_credentials_file").(string),
-		Profile:               data.Get("profile").(string),
-		Region:                data.Get("region").(string),
-		S3Endpoint:            data.Get("endpoint").(string),
-		SecretKey:             data.Get("secret_key").(string),
-		Token:                 data.Get("token").(string),
+		AccessKey:               data.Get("access_key").(string),
+		AssumeRoleARN:           data.Get("role_arn").(string),
+		AssumeRoleExternalID:    data.Get("external_id").(string),
+		AssumeRolePolicy:        data.Get("assume_role_policy").(string),
+		AssumeRoleSessionName:   data.Get("session_name").(string),
+		CredsFilename:           data.Get("shared_credentials_file").(string),
+		Profile:                 data.Get("profile").(string),
+		Region:                  data.Get("region").(string),
+		S3Endpoint:              data.Get("endpoint").(string),
+		SecretKey:               data.Get("secret_key").(string),
+		Token:                   data.Get("token").(string),
+		Insecure:                data.Get("insecure").(bool),
+		SkipCredsValidation:     data.Get("skip_creds_validation").(bool),
+		SkipRegionValidation:    data.Get("skip_region_validation").(bool),
+		SkipRequestingAccountId: data.Get("skip_requesting_account_id").(bool),
+		SkipMetadataApiCheck:    data.Get("skip_metadata_api_check").(bool),
+		S3ForcePathStyle:        data.Get("s3_force_path_style").(bool),
 	}
 
 	client, err := cfg.Client()

--- a/website/source/docs/backends/types/s3.html.md
+++ b/website/source/docs/backends/types/s3.html.md
@@ -102,3 +102,9 @@ The following configuration options or environment variables are supported:
  * `token` - (Optional) Use this to set an MFA token. It can also be
    sourced from the `AWS_SESSION_TOKEN` environment variable.
  * `role_arn` - (Optional) The role to be assumed
+ * `insecure` - (Optional) Whether to use an insecure connection to S3. Defaults to false.
+ * `skip_creds_validation` - (Optional) Set to skip AWS credentials validation. Defaults to false.
+ * `skip_region_validation` - (Optional) Set to skip AWS region validation. Defaults to false.
+ * `skip_requesting_account_id` - (Optional) Set to skip requesting the AWS account ID. Defaults to false.
+ * `skip_metadata_api_check` - (Optional) Set to skip the AWS metadata api check. Defaults to false.
+ * `s3_force_path_style` - (Optional) Set to force S3 path style. Defaults to false.


### PR DESCRIPTION
Changes made in 0.9.3 broke compatibility with a custom s3 backend a customer I
support relies on. I believe it's due to changes made to make the backend
client use the AWS provider client, possibly related to https://github.com/hashicorp/terraform/commit/6e136c848aab07522b3bcd048ecf79c51bf74418

In order to work for my customer, the backend needs to be able to pass additional
parameters to the AWS client configuration. Added to the s3 backend config:

 * insecure
 * skip_creds_validation
 * skip_region_validation
 * skip_requesting_account_id
 * skip_metadata_api_check
 * s3_force_path_style