### PR TITLE
Add sha512 hash functions

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"crypto/sha256"
+	"crypto/sha512"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
@@ -57,6 +58,7 @@ func Funcs() map[string]ast.Function {
 		"base64decode": interpolationFuncBase64Decode(),
 		"base64encode": interpolationFuncBase64Encode(),
 		"base64sha256": interpolationFuncBase64Sha256(),
+		"base64sha512": interpolationFuncBase64Sha512(),
 		"ceil":         interpolationFuncCeil(),
 		"chomp":        interpolationFuncChomp(),
 		"cidrhost":     interpolationFuncCidrHost(),
@@ -90,6 +92,7 @@ func Funcs() map[string]ast.Function {
 		"replace":      interpolationFuncReplace(),
 		"sha1":         interpolationFuncSha1(),
 		"sha256":       interpolationFuncSha256(),
+		"sha512":       interpolationFuncSha512(),
 		"signum":       interpolationFuncSignum(),
 		"slice":        interpolationFuncSlice(),
 		"sort":         interpolationFuncSort(),
@@ -1240,6 +1243,20 @@ func interpolationFuncSha256() ast.Function {
 	}
 }
 
+func interpolationFuncSha512() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			h := sha512.New()
+			h.Write([]byte(s))
+			hash := hex.EncodeToString(h.Sum(nil))
+			return hash, nil
+		},
+	}
+}
+
 func interpolationFuncTrimSpace() ast.Function {
 	return ast.Function{
 		ArgTypes:   []ast.Type{ast.TypeString},
@@ -1258,6 +1275,21 @@ func interpolationFuncBase64Sha256() ast.Function {
 		Callback: func(args []interface{}) (interface{}, error) {
 			s := args[0].(string)
 			h := sha256.New()
+			h.Write([]byte(s))
+			shaSum := h.Sum(nil)
+			encoded := base64.StdEncoding.EncodeToString(shaSum[:])
+			return encoded, nil
+		},
+	}
+}
+
+func interpolationFuncBase64Sha512() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			s := args[0].(string)
+			h := sha512.New()
 			h.Write([]byte(s))
 			shaSum := h.Sum(nil)
 			encoded := base64.StdEncoding.EncodeToString(shaSum[:])

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2070,6 +2070,18 @@ func TestInterpolateFuncSha256(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncSha512(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${sha512("test")}`,
+				"ee26b0dd4af7e749aa1a8ee3c10ae9923f618980772e473f8819a5d4940e0db27ac185f8a0e1d5f84f88bc887fd67b143732c304cc5fa9ad8e6f57f50028a8ff",
+				false,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncTitle(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{
@@ -2123,6 +2135,23 @@ func TestInterpolateFuncBase64Sha256(t *testing.T) {
 			{ // This will differ because we're base64-encoding hex represantiation, not raw bytes
 				`${base64encode(sha256("test"))}`,
 				"OWY4NmQwODE4ODRjN2Q2NTlhMmZlYWEwYzU1YWQwMTVhM2JmNGYxYjJiMGI4MjJjZDE1ZDZjMTViMGYwMGEwOA==",
+				false,
+			},
+		},
+	})
+}
+
+func TestInterpolateFuncBase64Sha512(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${base64sha512("test")}`,
+				"7iaw3Ur350mqGo7jwQrpkj9hiYB3Lkc/iBml1JQODbJ6wYX4oOHV+E+IvIh/1nsUNzLDBMxfqa2Ob1f1ACio/w==",
+				false,
+			},
+			{ // This will differ because we're base64-encoding hex represantiation, not raw bytes
+				`${base64encode(sha512("test"))}`,
+				"ZWUyNmIwZGQ0YWY3ZTc0OWFhMWE4ZWUzYzEwYWU5OTIzZjYxODk4MDc3MmU0NzNmODgxOWE1ZDQ5NDBlMGRiMjdhYzE4NWY4YTBlMWQ1Zjg0Zjg4YmM4ODdmZDY3YjE0MzczMmMzMDRjYzVmYTlhZDhlNmY1N2Y1MDAyOGE4ZmY=",
 				false,
 			},
 		},

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -151,6 +151,11 @@ The supported built-in functions are:
     **This is not equivalent** of `base64encode(sha256(string))`
     since `sha256()` returns hexadecimal representation.
 
+  * `base64sha512(string)` - Returns a base64-encoded representation of raw
+    SHA-512 sum of the given string.
+    **This is not equivalent** of `base64encode(sha512(string))`
+    since `sha512()` returns hexadecimal representation.
+
   * `ceil(float)` - Returns the least integer value greater than or equal
       to the argument.
 
@@ -313,6 +318,10 @@ The supported built-in functions are:
   * `sha256(string)` - Returns a (conventional) hexadecimal representation of the
     SHA-256 hash of the given string.
     Example: `"${sha256("${aws_vpc.default.tags.customer}-s3-bucket")}"`
+
+  * `sha512(string)` - Returns a (conventional) hexadecimal representation of the
+    SHA-512 hash of the given string.
+    Example: `"${sha512("${aws_vpc.default.tags.customer}-s3-bucket")}"`
 
   * `signum(int)` - Returns `-1` for negative numbers, `0` for `0` and `1` for positive numbers.
       This function is useful when you need to set a value for the first resource and


### PR DESCRIPTION
This commit adds `sha512` hash functions, this pretty much is a copy of `sha256`.