### PR TITLE
provider/fastly Changes setting conditionals to optional

### DIFF
--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -318,17 +318,18 @@ func resourceServiceV1() *schema.Resource {
 							Required:    true,
 							Description: "A name to refer to this Cache Setting",
 						},
-						"cache_condition": {
-							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Name of a condition to check if this Cache Setting applies",
-						},
 						"action": {
 							Type:        schema.TypeString,
 							Optional:    true,
 							Description: "Action to take",
 						},
 						// optional
+						"cache_condition": {
+							Type:        schema.TypeString,
+							Optional:    true,
+							Default:     "",
+							Description: "Name of a condition to check if this Cache Setting applies",
+						},
 						"stale_ttl": {
 							Type:        schema.TypeInt,
 							Optional:    true,

--- a/builtin/providers/fastly/resource_fastly_service_v1.go
+++ b/builtin/providers/fastly/resource_fastly_service_v1.go
@@ -776,12 +776,13 @@ func resourceServiceV1() *schema.Resource {
 							Required:    true,
 							Description: "Unique name to refer to this Request Setting",
 						},
+						// Optional fields
 						"request_condition": {
 							Type:        schema.TypeString,
-							Required:    true,
-							Description: "Name of a request condition to apply.",
+							Optional:    true,
+							Default:     "",
+							Description: "Name of a request condition to apply. If there is no condition this setting will always be applied.",
 						},
-						// Optional fields
 						"max_stale_age": {
 							Type:        schema.TypeInt,
 							Optional:    true,

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -263,7 +263,7 @@ The `request_setting` block allow you to customize Fastly's request handling, by
 defining behavior that should change based on a predefined `condition`:
 
 * `name` - (Required) The domain for this request setting.
-* `request_condition` - (Required) Name of already defined `condition` to
+* `request_condition` - (Optional) Name of already defined `condition` to
 determine if this request setting should be applied.
 * `max_stale_age` - (Optional) How old an object is allowed to be to serve
 `stale-if-error` or `stale-while-revalidate`, in seconds. Default `60`.

--- a/website/source/docs/providers/fastly/r/service_v1.html.markdown
+++ b/website/source/docs/providers/fastly/r/service_v1.html.markdown
@@ -209,7 +209,7 @@ The `cache_setting` block supports:
 * `name` - (Required) Unique name for this Cache Setting.
 * `action` - (Required) One of `cache`, `pass`, or `restart`, as defined
 on Fastly's documentation under ["Caching action descriptions"](https://docs.fastly.com/guides/performance-tuning/controlling-caching#caching-action-descriptions).
-* `cache_condition` - (Required) Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.
+* `cache_condition` - (Optional) Name of already defined `condition` used to test whether this settings object should be used. This `condition` must be of type `CACHE`.
 * `stale_ttl` - (Optional) Max "Time To Live" for stale (unreachable) objects.
 Default `300`.
 * `ttl` - (Optional) The Time-To-Live (TTL) for the object.


### PR DESCRIPTION
Allows the user to create both `request_setting`s and `chache_setting`s with no conditional set. Conditionals were previously required, but this limits options that Fastly allows as shown [here](https://docs.fastly.com/guides/securing-communications/allowing-only-tls-connections-to-your-site)

- [x] Website documentation updated

Closes #13651 