### PR TITLE
provider/aws Remove and add subnets sequentially if az is the same

### DIFF
--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -725,44 +725,61 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		removed := expandStringList(os.Difference(ns).List())
 		added := expandStringList(ns.Difference(os).List())
+		subnetconn := meta.(*AWSClient).ec2conn
 
-		if len(removed) > 0 {
-			detachOpts := &elb.DetachLoadBalancerFromSubnetsInput{
-				LoadBalancerName: aws.String(d.Id()),
-				Subnets:          removed,
+		// This section sorts the removed/added subnets based on availability zones
+		dup_az_count := 0
+		for i, r_subnet_id := range removed {
+			r_subnet, err := subnetconn.DescribeSubnets(&ec2.DescribeSubnetsInput{
+				SubnetIds: []*string{r_subnet_id},
+			})
+			if err != nil {
+				return err
+			}
+			for j, a_subnet_id := range added {
+				a_subnet, err := subnetconn.DescribeSubnets(&ec2.DescribeSubnetsInput{
+					SubnetIds: []*string{a_subnet_id},
+				})
+				if err != nil {
+					return err
+				}
+				if *r_subnet.Subnets[0].AvailabilityZone == *a_subnet.Subnets[0].AvailabilityZone {
+					removed[dup_az_count], removed[i] = removed[i], removed[dup_az_count]
+					added[j], added[dup_az_count] = added[dup_az_count], added[j]
+					dup_az_count += 1
+				}
+			}
+		}
+
+		// Subnets with the same availability zones need to be removed
+		// and then added one at a time to avoid api errors
+		for i := 0; i < dup_az_count; i++ {
+			curr_removed_subnet := make([]*string, 0, 1)
+			curr_removed_subnet = append(curr_removed_subnet, removed[i])
+			err := removeSubnets(d.Id(), curr_removed_subnet, meta)
+			if err != nil {
+				return err
 			}
 
-			log.Printf("[DEBUG] ELB detach subnets opts: %s", detachOpts)
-			_, err := elbconn.DetachLoadBalancerFromSubnets(detachOpts)
+			curr_added_subnet := make([]*string, 0, 1)
+			curr_added_subnet = append(curr_added_subnet, added[i])
+			err = addSubnets(d.Id(), curr_added_subnet, meta)
 			if err != nil {
-				return fmt.Errorf("Failure removing ELB subnets: %s", err)
+				return err
+			}
+		}
+
+		if len(removed) > 0 {
+			err := removeSubnets(d.Id(), removed, meta)
+			if err != nil {
+				return err
 			}
 		}
 
 		if len(added) > 0 {
-			attachOpts := &elb.AttachLoadBalancerToSubnetsInput{
-				LoadBalancerName: aws.String(d.Id()),
-				Subnets:          added,
-			}
-
-			log.Printf("[DEBUG] ELB attach subnets opts: %s", attachOpts)
-			err := resource.Retry(5*time.Minute, func() *resource.RetryError {
-				_, err := elbconn.AttachLoadBalancerToSubnets(attachOpts)
-				if err != nil {
-					if awsErr, ok := err.(awserr.Error); ok {
-						// eventually consistent issue with removing a subnet in AZ1 and
-						// immediately adding a new one in the same AZ
-						if awsErr.Code() == "InvalidConfigurationRequest" && strings.Contains(awsErr.Message(), "cannot be attached to multiple subnets in the same AZ") {
-							log.Printf("[DEBUG] retrying az association")
-							return resource.RetryableError(awsErr)
-						}
-					}
-					return resource.NonRetryableError(err)
-				}
-				return nil
-			})
+			err := addSubnets(d.Id(), added, meta)
 			if err != nil {
-				return fmt.Errorf("Failure adding ELB subnets: %s", err)
+				return err
 			}
 		}
 
@@ -973,4 +990,50 @@ func isValidProtocol(s string) bool {
 	}
 
 	return true
+}
+
+func removeSubnets(id string, removed []*string, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	detachOpts := &elb.DetachLoadBalancerFromSubnetsInput{
+		LoadBalancerName: aws.String(id),
+		Subnets:          removed,
+	}
+
+	log.Printf("[DEBUG] ELB detach subnets opts: %s", detachOpts)
+	_, err := elbconn.DetachLoadBalancerFromSubnets(detachOpts)
+	if err != nil {
+		return fmt.Errorf("Failure removing ELB subnets: %s", err)
+	}
+	return nil
+}
+
+func addSubnets(id string, added []*string, meta interface{}) error {
+	elbconn := meta.(*AWSClient).elbconn
+
+	attachOpts := &elb.AttachLoadBalancerToSubnetsInput{
+		LoadBalancerName: aws.String(id),
+		Subnets:          added,
+	}
+
+	log.Printf("[DEBUG] ELB attach subnets opts: %s", attachOpts)
+	err := resource.Retry(5*time.Minute, func() *resource.RetryError {
+		_, err := elbconn.AttachLoadBalancerToSubnets(attachOpts)
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				// eventually consistent issue with removing a subnet in AZ1 and
+				// immediately adding a new one in the same AZ
+				if awsErr.Code() == "InvalidConfigurationRequest" && strings.Contains(awsErr.Message(), "cannot be attached to multiple subnets in the same AZ") {
+					log.Printf("[DEBUG] retrying az association")
+					return resource.RetryableError(awsErr)
+				}
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Failure adding ELB subnets: %s", err)
+	}
+	return nil
 }

--- a/builtin/providers/aws/resource_aws_elb.go
+++ b/builtin/providers/aws/resource_aws_elb.go
@@ -725,46 +725,11 @@ func resourceAwsElbUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		removed := expandStringList(os.Difference(ns).List())
 		added := expandStringList(ns.Difference(os).List())
-		subnetconn := meta.(*AWSClient).ec2conn
 
-		azs := map[string]string{}
-		subnets, err := subnetconn.DescribeSubnets(&ec2.DescribeSubnetsInput{
-			SubnetIds: append(removed, added...),
-		})
-		if err != nil {
+		// If we are adding and removing subnets in the same AZ then we need to swap those sequentially.
+		if err := swapMatchingAZSubnets(removed, added, d, meta); err != nil {
 			return err
 		}
-		for _, subnet := range subnets.Subnets {
-			azs[*subnet.SubnetId] = *subnet.AvailabilityZone
-		}
-		// This section sorts the removed/added subnets based on availability zones
-		dup_az_count := 0
-		for i, r_subnet_id := range removed {
-			for j, a_subnet_id := range added {
-				if azs[*r_subnet_id] == azs[*a_subnet_id] {
-					removed[dup_az_count], removed[i] = removed[i], removed[dup_az_count]
-					added[j], added[dup_az_count] = added[dup_az_count], added[j]
-					dup_az_count += 1
-				}
-			}
-		}
-
-		// Subnets with the same availability zones need to be removed
-		// and then added one at a time to avoid api errors
-		for i := 0; i < dup_az_count; i++ {
-			curr_removed_subnet := []*string{removed[i]}
-			err := removeSubnets(d.Id(), curr_removed_subnet, meta)
-			if err != nil {
-				return err
-			}
-
-			curr_added_subnet := []*string{added[i]}
-			err = addSubnets(d.Id(), curr_added_subnet, meta)
-			if err != nil {
-				return err
-			}
-		}
-
 		if len(removed) > 0 {
 			err := removeSubnets(d.Id(), removed, meta)
 			if err != nil {
@@ -986,6 +951,49 @@ func isValidProtocol(s string) bool {
 	}
 
 	return true
+}
+
+func swapMatchingAZSubnets(removed []*string, added []*string, d *schema.ResourceData, meta interface{}) error {
+	subnetconn := meta.(*AWSClient).ec2conn
+
+	azs := map[string]string{}
+	subnets, err := subnetconn.DescribeSubnets(&ec2.DescribeSubnetsInput{
+		SubnetIds: append(removed, added...),
+	})
+	if err != nil {
+		return err
+	}
+	for _, subnet := range subnets.Subnets {
+		azs[*subnet.SubnetId] = *subnet.AvailabilityZone
+	}
+	// This section sorts the removed/added subnets based on availability zones
+	dup_az_count := 0
+	for i, r_subnet_id := range removed {
+		for j, a_subnet_id := range added {
+			if azs[*r_subnet_id] == azs[*a_subnet_id] {
+				removed[dup_az_count], removed[i] = removed[i], removed[dup_az_count]
+				added[j], added[dup_az_count] = added[dup_az_count], added[j]
+				dup_az_count += 1
+			}
+		}
+	}
+
+	// Subnets with the same availability zones need to be removed
+	// and then added one at a time to avoid api errors
+	for i := 0; i < dup_az_count; i++ {
+		curr_removed_subnet := []*string{removed[i]}
+		err := removeSubnets(d.Id(), curr_removed_subnet, meta)
+		if err != nil {
+			return err
+		}
+
+		curr_added_subnet := []*string{added[i]}
+		err = addSubnets(d.Id(), curr_added_subnet, meta)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func removeSubnets(id string, removed []*string, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_elb_test.go
+++ b/builtin/providers/aws/resource_aws_elb_test.go
@@ -1530,6 +1530,13 @@ resource "aws_subnet" "public_a_two" {
   availability_zone = "us-west-2a"
 }
 
+resource "aws_subnet" "public_b_two" {
+  vpc_id = "${aws_vpc.azelb.id}"
+
+  cidr_block        = "10.1.8.0/24"
+  availability_zone = "us-west-2b"
+}
+
 resource "aws_elb" "ourapp" {
   name = "terraform-asg-deployment-example"
 
@@ -1592,12 +1599,19 @@ resource "aws_subnet" "public_a_two" {
   availability_zone = "us-west-2a"
 }
 
+resource "aws_subnet" "public_b_two" {
+  vpc_id = "${aws_vpc.azelb.id}"
+
+  cidr_block        = "10.1.8.0/24"
+  availability_zone = "us-west-2b"
+}
+
 resource "aws_elb" "ourapp" {
   name = "terraform-asg-deployment-example"
 
   subnets = [
     "${aws_subnet.public_a_two.id}",
-    "${aws_subnet.public_b_one.id}",
+    "${aws_subnet.public_b_two.id}",
   ]
 
   listener {


### PR DESCRIPTION
This PR sequentially removes and then adds subnets if their availability zones are the same. This prevents #14072 from happening. 

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSELB_swap_subnets'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/01 09:26:04 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSELB_swap_subnets -timeout 120m
=== RUN   TestAccAWSELB_swap_subnets
--- PASS: TestAccAWSELB_swap_subnets (67.88s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	67.925s
```