### PR TITLE
provider/dme: Save records in lowercase to avoid diffs

### DIFF
--- a/builtin/providers/dme/resource_dme_record.go
+++ b/builtin/providers/dme/resource_dme_record.go
@@ -33,6 +33,9 @@ func resourceDMERecord() *schema.Resource {
 			"value": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				StateFunc: func(value interface{}) string {
+					return strings.ToLower(value.(string))
+				},
 			},
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,


### PR DESCRIPTION
This is to address the following test failure:
```
=== RUN   TestAccDMERecordAAAA
--- FAIL: TestAccDMERecordAAAA (2.93s)
    testing.go:280: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        UPDATE: dme_record.test
          value: "fe80::0202:b3ff:fe1e:8329" => "FE80::0202:B3FF:FE1E:8329"
        
        STATE:
        
        dme_record.test:
          ID = 50336391
          domainid = 4242281
          gtdLocation = DEFAULT
          name = testaaaa
          ttl = 2000
          type = AAAA
          value = fe80::0202:b3ff:fe1e:8329
FAIL
```

There's more DME tests failing at the moment for different reasons, but I think it's wise to only fix one at a time in a single PR.

### Test plan

```
make testacc TEST=./builtin/providers/dme TESTARGS='-run=TestAccDMERecordAAAA'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/01 21:13:42 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/dme -v -run=TestAccDMERecordAAAA -timeout 120m
=== RUN   TestAccDMERecordAAAA
--- PASS: TestAccDMERecordAAAA (3.59s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/dme	3.613s
```