### PR TITLE
core: allow partially-unknown lists from splat syntax

### DIFF
--- a/terraform/interpolate.go
+++ b/terraform/interpolate.go
@@ -594,10 +594,6 @@ func (i *Interpolater) computeResourceMultiVariable(
 		}
 
 		if singleAttr, ok := r.Primary.Attributes[v.Field]; ok {
-			if singleAttr == config.UnknownVariableValue {
-				return &unknownVariable, nil
-			}
-
 			values = append(values, singleAttr)
 			continue
 		}
@@ -611,10 +607,6 @@ func (i *Interpolater) computeResourceMultiVariable(
 		multiAttr, err := i.interpolateComplexTypeAttribute(v.Field, r.Primary.Attributes)
 		if err != nil {
 			return nil, err
-		}
-
-		if multiAttr == unknownVariable {
-			return &unknownVariable, nil
 		}
 
 		values = append(values, multiAttr)

--- a/terraform/interpolate_test.go
+++ b/terraform/interpolate_test.go
@@ -359,8 +359,81 @@ func TestInterpolater_resourceVariableMulti(t *testing.T) {
 	}
 
 	testInterpolate(t, i, scope, "aws_instance.web.*.foo", ast.Variable{
-		Value: config.UnknownVariableValue,
-		Type:  ast.TypeUnknown,
+		Type: ast.TypeList,
+		Value: []ast.Variable{
+			{
+				Type:  ast.TypeUnknown,
+				Value: config.UnknownVariableValue,
+			},
+		},
+	})
+}
+
+func TestInterpolater_resourceVariableMultiPartialUnknown(t *testing.T) {
+	lock := new(sync.RWMutex)
+	state := &State{
+		Modules: []*ModuleState{
+			&ModuleState{
+				Path: rootModulePath,
+				Resources: map[string]*ResourceState{
+					"aws_instance.web.0": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo": "1",
+							},
+						},
+					},
+					"aws_instance.web.1": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo": config.UnknownVariableValue,
+							},
+						},
+					},
+					"aws_instance.web.2": &ResourceState{
+						Type: "aws_instance",
+						Primary: &InstanceState{
+							ID: "bar",
+							Attributes: map[string]string{
+								"foo": "2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	i := &Interpolater{
+		Module:    testModule(t, "interpolate-resource-variable-multi"),
+		State:     state,
+		StateLock: lock,
+	}
+
+	scope := &InterpolationScope{
+		Path: rootModulePath,
+	}
+
+	testInterpolate(t, i, scope, "aws_instance.web.*.foo", ast.Variable{
+		Type: ast.TypeList,
+		Value: []ast.Variable{
+			{
+				Type:  ast.TypeString,
+				Value: "1",
+			},
+			{
+				Type:  ast.TypeUnknown,
+				Value: config.UnknownVariableValue,
+			},
+			{
+				Type:  ast.TypeString,
+				Value: "2",
+			},
+		},
 	})
 }
 
@@ -408,8 +481,13 @@ func TestInterpolater_resourceVariableMultiList(t *testing.T) {
 	}
 
 	testInterpolate(t, i, scope, "aws_instance.web.*.ip", ast.Variable{
-		Value: config.UnknownVariableValue,
-		Type:  ast.TypeUnknown,
+		Type: ast.TypeList,
+		Value: []ast.Variable{
+			{
+				Type:  ast.TypeUnknown,
+				Value: config.UnknownVariableValue,
+			},
+		},
 	})
 }
 

--- a/terraform/test-fixtures/interpolate-resource-variable-multi/main.tf
+++ b/terraform/test-fixtures/interpolate-resource-variable-multi/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "web" {
+    count = 3
+}

--- a/vendor/github.com/hashicorp/hil/ast/literal.go
+++ b/vendor/github.com/hashicorp/hil/ast/literal.go
@@ -77,3 +77,12 @@ func (n *LiteralNode) String() string {
 func (n *LiteralNode) Type(Scope) (Type, error) {
 	return n.Typex, nil
 }
+
+// IsUnknown returns true either if the node's value is itself unknown
+// of if it is a collection containing any unknown elements, deeply.
+func (n *LiteralNode) IsUnknown() bool {
+	return IsUnknown(Variable{
+		Type:  n.Typex,
+		Value: n.Value,
+	})
+}

--- a/vendor/github.com/hashicorp/hil/ast/variables_helper.go
+++ b/vendor/github.com/hashicorp/hil/ast/variables_helper.go
@@ -3,54 +3,61 @@ package ast
 import "fmt"
 
 func VariableListElementTypesAreHomogenous(variableName string, list []Variable) (Type, error) {
-	listTypes := make(map[Type]struct{})
+	if len(list) == 0 {
+		return TypeInvalid, fmt.Errorf("list %q does not have any elements so cannot determine type.", variableName)
+	}
+
+	elemType := TypeUnknown
 	for _, v := range list {
-		// Allow unknown
 		if v.Type == TypeUnknown {
 			continue
 		}
 
-		if _, ok := listTypes[v.Type]; ok {
+		if elemType == TypeUnknown {
+			elemType = v.Type
 			continue
 		}
-		listTypes[v.Type] = struct{}{}
+
+		if v.Type != elemType {
+			return TypeInvalid, fmt.Errorf(
+				"list %q does not have homogenous types. found %s and then %s",
+				variableName,
+				elemType, v.Type,
+			)
+		}
+
+		elemType = v.Type
 	}
 
-	if len(listTypes) != 1 && len(list) != 0 {
-		return TypeInvalid, fmt.Errorf("list %q does not have homogenous types. found %s", variableName, reportTypes(listTypes))
-	}
-
-	if len(list) > 0 {
-		return list[0].Type, nil
-	}
-
-	return TypeInvalid, fmt.Errorf("list %q does not have any elements so cannot determine type.", variableName)
+	return elemType, nil
 }
 
 func VariableMapValueTypesAreHomogenous(variableName string, vmap map[string]Variable) (Type, error) {
-	valueTypes := make(map[Type]struct{})
+	if len(vmap) == 0 {
+		return TypeInvalid, fmt.Errorf("map %q does not have any elements so cannot determine type.", variableName)
+	}
+
+	elemType := TypeUnknown
 	for _, v := range vmap {
-		// Allow unknown
 		if v.Type == TypeUnknown {
 			continue
 		}
 
-		if _, ok := valueTypes[v.Type]; ok {
+		if elemType == TypeUnknown {
+			elemType = v.Type
 			continue
 		}
 
-		valueTypes[v.Type] = struct{}{}
+		if v.Type != elemType {
+			return TypeInvalid, fmt.Errorf(
+				"map %q does not have homogenous types. found %s and then %s",
+				variableName,
+				elemType, v.Type,
+			)
+		}
+
+		elemType = v.Type
 	}
 
-	if len(valueTypes) != 1 && len(vmap) != 0 {
-		return TypeInvalid, fmt.Errorf("map %q does not have homogenous value types. found %s", variableName, reportTypes(valueTypes))
-	}
-
-	// For loop here is an easy way to get a single key, we return immediately.
-	for _, v := range vmap {
-		return v.Type, nil
-	}
-
-	// This means the map is empty
-	return TypeInvalid, fmt.Errorf("map %q does not have any elements so cannot determine type.", variableName)
+	return elemType, nil
 }

--- a/vendor/github.com/hashicorp/hil/check_types.go
+++ b/vendor/github.com/hashicorp/hil/check_types.go
@@ -98,10 +98,6 @@ func (v *TypeCheck) visit(raw ast.Node) ast.Node {
 			pos.Column, pos.Line, err)
 	}
 
-	if v.StackPeek() == ast.TypeUnknown {
-		v.err = errExitUnknown
-	}
-
 	return result
 }
 
@@ -114,6 +110,14 @@ func (tc *typeCheckArithmetic) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	exprs := make([]ast.Type, len(tc.n.Exprs))
 	for i, _ := range tc.n.Exprs {
 		exprs[len(tc.n.Exprs)-1-i] = v.StackPop()
+	}
+
+	// If any operand is unknown then our result is automatically unknown
+	for _, ty := range exprs {
+		if ty == ast.TypeUnknown {
+			v.StackPush(ast.TypeUnknown)
+			return tc.n, nil
+		}
 	}
 
 	switch tc.n.Op {
@@ -333,6 +337,11 @@ func (tc *typeCheckCall) TypeCheck(v *TypeCheck) (ast.Node, error) {
 			continue
 		}
 
+		if args[i] == ast.TypeUnknown {
+			v.StackPush(ast.TypeUnknown)
+			return tc.n, nil
+		}
+
 		if args[i] != expected {
 			cn := v.ImplicitConversion(args[i], expected, tc.n.Args[i])
 			if cn != nil {
@@ -350,6 +359,11 @@ func (tc *typeCheckCall) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	if function.Variadic && function.VariadicType != ast.TypeAny {
 		args = args[len(function.ArgTypes):]
 		for i, t := range args {
+			if t == ast.TypeUnknown {
+				v.StackPush(ast.TypeUnknown)
+				return tc.n, nil
+			}
+
 			if t != function.VariadicType {
 				realI := i + len(function.ArgTypes)
 				cn := v.ImplicitConversion(
@@ -383,6 +397,11 @@ func (tc *typeCheckConditional) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	falseType := v.StackPop()
 	trueType := v.StackPop()
 	condType := v.StackPop()
+
+	if condType == ast.TypeUnknown {
+		v.StackPush(ast.TypeUnknown)
+		return tc.n, nil
+	}
 
 	if condType != ast.TypeBool {
 		cn := v.ImplicitConversion(condType, ast.TypeBool, tc.n.CondExpr)
@@ -457,6 +476,13 @@ func (tc *typeCheckOutput) TypeCheck(v *TypeCheck) (ast.Node, error) {
 		types[len(n.Exprs)-1-i] = v.StackPop()
 	}
 
+	for _, ty := range types {
+		if ty == ast.TypeUnknown {
+			v.StackPush(ast.TypeUnknown)
+			return tc.n, nil
+		}
+	}
+
 	// If there is only one argument and it is a list, we evaluate to a list
 	if len(types) == 1 {
 		switch t := types[0]; t {
@@ -469,7 +495,14 @@ func (tc *typeCheckOutput) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	}
 
 	// Otherwise, all concat args must be strings, so validate that
+	resultType := ast.TypeString
 	for i, t := range types {
+
+		if t == ast.TypeUnknown {
+			resultType = ast.TypeUnknown
+			continue
+		}
+
 		if t != ast.TypeString {
 			cn := v.ImplicitConversion(t, ast.TypeString, n.Exprs[i])
 			if cn != nil {
@@ -482,8 +515,8 @@ func (tc *typeCheckOutput) TypeCheck(v *TypeCheck) (ast.Node, error) {
 		}
 	}
 
-	// This always results in type string
-	v.StackPush(ast.TypeString)
+	// This always results in type string, unless there are unknowns
+	v.StackPush(resultType)
 
 	return n, nil
 }
@@ -509,13 +542,6 @@ func (tc *typeCheckVariableAccess) TypeCheck(v *TypeCheck) (ast.Node, error) {
 			"unknown variable accessed: %s", tc.n.Name)
 	}
 
-	// Check if the variable contains any unknown types. If so, then
-	// mark it as unknown.
-	if ast.IsUnknown(variable) {
-		v.StackPush(ast.TypeUnknown)
-		return tc.n, nil
-	}
-
 	// Add the type to the stack
 	v.StackPush(variable.Type)
 
@@ -529,6 +555,11 @@ type typeCheckIndex struct {
 func (tc *typeCheckIndex) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	keyType := v.StackPop()
 	targetType := v.StackPop()
+
+	if keyType == ast.TypeUnknown || targetType == ast.TypeUnknown {
+		v.StackPush(ast.TypeUnknown)
+		return tc.n, nil
+	}
 
 	// Ensure we have a VariableAccess as the target
 	varAccessNode, ok := tc.n.Target.(*ast.VariableAccess)

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2130,28 +2130,28 @@
 			"revisionTime": "2017-02-17T16:47:38Z"
 		},
 		{
-			"checksumSHA1": "2Nrl/YKrmowkRgCDLhA6UTFgYEY=",
+			"checksumSHA1": "zz3/f3YpHHBN78uLhnhLBW2aF8o=",
 			"path": "github.com/hashicorp/hil",
-			"revision": "5b8d13c8c5c2753e109fab25392a1dbfa2db93d2",
-			"revisionTime": "2016-12-21T19:20:42Z"
+			"revision": "747a6e1523d6808f91144df070435b16865cd333",
+			"revisionTime": "2017-05-01T20:07:50Z"
 		},
 		{
-			"checksumSHA1": "oZ2a2x9qyHqvqJdv/Du3LGeaFdA=",
+			"checksumSHA1": "0S0KeBcfqVFYBPeZkuJ4fhQ5mCA=",
 			"path": "github.com/hashicorp/hil/ast",
-			"revision": "5b8d13c8c5c2753e109fab25392a1dbfa2db93d2",
-			"revisionTime": "2016-12-21T19:20:42Z"
+			"revision": "747a6e1523d6808f91144df070435b16865cd333",
+			"revisionTime": "2017-05-01T20:07:50Z"
 		},
 		{
 			"checksumSHA1": "P5PZ3k7SmqWmxgJ8Q0gLzeNpGhE=",
 			"path": "github.com/hashicorp/hil/parser",
-			"revision": "5b8d13c8c5c2753e109fab25392a1dbfa2db93d2",
-			"revisionTime": "2016-12-21T19:20:42Z"
+			"revision": "747a6e1523d6808f91144df070435b16865cd333",
+			"revisionTime": "2017-05-01T20:07:50Z"
 		},
 		{
 			"checksumSHA1": "DC1k5kOua4oFqmo+JRt0YzfP44o=",
 			"path": "github.com/hashicorp/hil/scanner",
-			"revision": "5b8d13c8c5c2753e109fab25392a1dbfa2db93d2",
-			"revisionTime": "2016-12-21T19:20:42Z"
+			"revision": "747a6e1523d6808f91144df070435b16865cd333",
+			"revisionTime": "2017-05-01T20:07:50Z"
 		},
 		{
 			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",


### PR DESCRIPTION
This was actually redundant anyway since HIL itself applied a similar rule where any partially-unknown list would be automatically flattened to a single unknown value.
    
However, now we're changing HIL to explicitly permit partially-unknown lists so that we can allow the index operator `[...]` to succeed when applied to one of the elements that _is_ known.
    
This, in conjunction with hashicorp/hil#51 and hashicorp/hil#52, fixes #3449.
