### PR TITLE
website: suggest Stack Exchange sites as a place to ask questions

### DIFF
--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -13,6 +13,14 @@ description: |-
   mediums.
 </p>
 <p>
+  <strong>Stack Exchange:</strong> Terraform questions often get asked and
+  answered on
+  <a href="https://serverfault.com/">Server Fault</a> and
+  <a href="https://stackoverflow.com/">Stack Overflow</a>. Use the tag
+  "terraform" to help your question be found by Terraform experts, and please
+  be respectful of the "How to Ask" guidelines in each community.
+</p>
+<p>
   <strong>Gitter:</strong> <a href="https://gitter.im/hashicorp-terraform/Lobby">Terraform Gitter Room</a>
 </p>
 <p>
@@ -22,7 +30,7 @@ description: |-
   <strong>Mailing list:</strong> <a href="https://groups.google.com/group/terraform-tool">Terraform Google Group</a>
 </p>
 <p>
-  <strong>Bug Tracker:</strong> <a href="https://github.com/hashicorp/terraform/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here. Use IRC or the mailing list for that.
+  <strong>Bug Tracker:</strong> <a href="https://github.com/hashicorp/terraform/issues">Issue tracker on GitHub</a>. Please only use this for reporting bugs. Do not ask for general help here; use a Stack Exchange community, Gitter chat, or the mailing list for that.
 </p>
 <p>
   <strong>Training:</strong> Paid <a href="https://www.hashicorp.com/training.html">HashiCorp training courses</a> are also available in a city near you. Private training courses are also available.


### PR DESCRIPTION
There's a pre-existing Terraform presence on both Server Fault and Stack Overflow that seem to be generating good questions and answers, so here we'll try to send users to the right sites to ask questions and
encourage them to be good participants in those communities.