### PR TITLE
core: Added GetOkAllowZero method to the ResourceData

### DIFF
--- a/helper/schema/resource_data.go
+++ b/helper/schema/resource_data.go
@@ -104,6 +104,19 @@ func (d *ResourceData) GetOk(key string) (interface{}, bool) {
 	return r.Value, exists
 }
 
+// GetOkAllowZero returns the data for the given key and whether or
+// not the key has been set to some value at some point.
+// This method does not check if the value is non-zero, unlike GetOk.
+//
+// The first result will not necessarilly be nil if the value doesn't exist.
+// The second result should be checked to determine this information.
+func (d *ResourceData) GetOkAllowZero(key string) (interface{}, bool) {
+	r := d.getRaw(key, getSourceSet)
+	exists := r.Exists && !r.Computed
+
+	return r.Value, exists
+}
+
 func (d *ResourceData) getRaw(key string, level getSource) getResult {
 	var parts []string
 	if key != "" {

--- a/helper/schema/resource_data_test.go
+++ b/helper/schema/resource_data_test.go
@@ -1304,6 +1304,63 @@ func TestResourceDataGetOkAllowZero(t *testing.T) {
 			Value: 0,
 			Ok:    true,
 		},
+
+		{
+			Schema: map[string]*Schema{
+				"from_port": &Schema{
+					Type:     TypeInt,
+					Optional: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"from_port": "80",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"from_port": &terraform.ResourceAttrDiff{
+						Old:        "80",
+						New:        "0",
+						NewRemoved: true,
+					},
+				},
+			},
+
+			Key:   "from_port",
+			Value: 0,
+			Ok:    false,
+		},
+
+		{
+			Schema: map[string]*Schema{
+				"from_port": &Schema{
+					Type:     TypeInt,
+					Optional: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"from_port": "80",
+				},
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"from_port": &terraform.ResourceAttrDiff{
+						Old: "80",
+						New: "0",
+					},
+				},
+			},
+
+			Key:   "from_port",
+			Value: 0,
+			Ok:    true,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
### What is this?
To fix #5964 (and some involved issues), I added the `GetOkAllowZero` method to the `ResourceData`.
This method returns a non-computed value like the `GetOk` method does, but without non-zero check.

### Review points
All I know is that the long story exists behind the problem, and I do NOT understand the comprehensive detail of the problem.
This PR is enough to fix my problem (see below), but possibly might be too naïve for the whole problem. So any advices are welcome.

Also the naming of the method can be questioned; `GetNonComputed` sounds better?

### Note
This PR is the former half part of #13492 to fix #5690.
Once this get merged, I'm going to open new PR with the latter half part, as advised by @paddycarver.