### PR TITLE
Make `wait_for_ready_timeout` default match code

### DIFF
--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -50,7 +50,7 @@ The following arguments are supported:
 off of. Example stacks can be found in the [Amazon API documentation][1]
 * `template_name` – (Optional) The name of the Elastic Beanstalk Configuration
   template to use in deployment
-* `wait_for_ready_timeout` - (Default: `10m`) The maximum
+* `wait_for_ready_timeout` - (Default: `20m`) The maximum
   [duration](https://golang.org/pkg/time/#ParseDuration) that Terraform should
   wait for an Elastic Beanstalk Environment to be in a ready state before timing
   out.


### PR DESCRIPTION
The `wait_for_ready_timeout` timeout was listed as 10m, but
cd79471ecbad41b8bb9e70cc5e8e47b210cc3f32 altered reality to be 20m. The
documentation should match the code.

This is one possible solution to https://github.com/hashicorp/terraform/issues/14148