### PR TITLE
config: Add getenv interpolation function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	"math"
 	"net"
+	"os"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -70,6 +71,7 @@ func Funcs() map[string]ast.Function {
 		"distinct":     interpolationFuncDistinct(),
 		"element":      interpolationFuncElement(),
 		"file":         interpolationFuncFile(),
+		"getenv":       interpolationFuncGetenv(),
 		"matchkeys":    interpolationFuncMatchKeys(),
 		"floor":        interpolationFuncFloor(),
 		"format":       interpolationFuncFormat(),
@@ -1341,6 +1343,20 @@ func interpolationFuncSubstr() ast.Function {
 			}
 
 			return str[offset:length], nil
+		},
+	}
+}
+
+// interpolationFuncGetenv implements the "getenv" function, which literally
+// passes off to os.Getenv in the Go standard library. This function returns
+// the value of the requested environment variable, or an empty string if it
+// does not exist.
+func interpolationFuncGetenv() ast.Function {
+	return ast.Function{
+		ArgTypes:   []ast.Type{ast.TypeString},
+		ReturnType: ast.TypeString,
+		Callback: func(args []interface{}) (interface{}, error) {
+			return os.Getenv(args[0].(string)), nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2317,3 +2317,35 @@ func TestInterpolateFuncSubstr(t *testing.T) {
 		},
 	})
 }
+
+func TestInterpolateFuncGetenv(t *testing.T) {
+	os.Setenv("TF_INTERP_FUNC_GETENV_TEST", "foobar")
+	testFunction(t, testFunctionConfig{
+		Vars: map[string]ast.Variable{
+			"var.getenv_test":         interfaceToVariableSwallowError("TF_INTERP_FUNC_GETENV_TEST"),
+			"var.getenv_test_missing": interfaceToVariableSwallowError("TF_INTERP_FUNC_GETENV_TEST_MISSING"),
+		},
+		Cases: []testFunctionCase{
+			{
+				`${getenv("TF_INTERP_FUNC_GETENV_TEST")}`,
+				"foobar",
+				false,
+			},
+			{
+				`${getenv("TF_INTERP_FUNC_GETENV_TEST_MISSING")}`,
+				"",
+				false,
+			},
+			{
+				`${getenv(var.getenv_test)}`,
+				"foobar",
+				false,
+			},
+			{
+				`${getenv(var.getenv_test_missing)}`,
+				"",
+				false,
+			},
+		},
+	})
+}

--- a/website/source/docs/configuration/environment-variables.html.md
+++ b/website/source/docs/configuration/environment-variables.html.md
@@ -99,3 +99,11 @@ tests, but by setting this variable you can force these tests to be skipped.
 export TF_SKIP_REMOTE_TESTS=1
 make test
 ```
+
+## The `getenv` Interpolation Function
+
+The [`getenv`](/docs/configuration/interpolation.html#getenv-key-) interpolation
+function can be used to get the value of any environment variable available to
+the Terraform process. Note that this function is subject to the same rules as
+any other interpolation function and as such will not work within `variable`
+blocks - use `TF_VAR_` variables to assign values instead.

--- a/website/source/docs/configuration/interpolation.html.md
+++ b/website/source/docs/configuration/interpolation.html.md
@@ -246,6 +246,14 @@ The supported built-in functions are:
       `formatlist("instance %v has private ip %v", aws_instance.foo.*.id, aws_instance.foo.*.private_ip)`.
       Passing lists with different lengths to formatlist results in an error.
 
+  * `getenv(key)` - Gets the value for the environment variable defined by
+     `key`. Returns an empty string if the environment variable does not exist.
+     Note that this functionality differs from the
+     [`TF_VAR_`](/docs/configuration/environment-variables.html#tf_var_name) pattern
+     in that it does not assign values to
+     [variables](/docs/configuration/variables.html), and allows you to access any
+     environment variable available to the Terraform process.
+
   * `index(list, elem)` - Finds the index of a given element in a list.
       This function only works on flat lists.
       Example: `index(aws_instance.foo.*.tags.Name, "foo-test")`


### PR DESCRIPTION
I think that there was possibly some discussion on supporting more general fetching of environment variables in #1621 by supplying an `env.` variable namespace. Barring that though, I think the interpolation function API is a very good fit for supporting this use case, and seems like an easy win!

Commit message below. I've also supplied docs not just in the function reference but also in the general environment variables configuration section as well.

-----

This is a very simple function that just passes off to `os.Getenv` in the Go standard library. However, it adds some first-class support for fetching environment variables without having to supply them as variables being passed in to Terraform, supporting some use cases where doing so would unnecessarily complicate tooling or would be prohibitive altogether.

