### PR TITLE
Add support for running Google Dataflow jobs

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
+	"google.golang.org/api/dataflow/v1b3"
 	"google.golang.org/api/dns/v1"
 	"google.golang.org/api/iam/v1"
 	"google.golang.org/api/pubsub/v1"
@@ -39,6 +40,7 @@ type Config struct {
 	clientContainer       *container.Service
 	clientDns             *dns.Service
 	clientPubsub          *pubsub.Service
+	clientDataflow        *dataflow.Service
 	clientResourceManager *cloudresourcemanager.Service
 	clientStorage         *storage.Service
 	clientSqlAdmin        *sqladmin.Service
@@ -145,6 +147,13 @@ func (c *Config) loadAndValidate() error {
 		return err
 	}
 	c.clientPubsub.UserAgent = userAgent
+
+	log.Printf("[INFO] Instantiating Google Dataflow Client...")
+	c.clientDataflow, err = dataflow.New(client)
+	if err != nil {
+		return err
+	}
+	c.clientDataflow.UserAgent = userAgent
 
 	log.Printf("[INFO] Instantiating Google Cloud ResourceManager Client...")
 	c.clientResourceManager, err = cloudresourcemanager.New(client)

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -101,6 +101,7 @@ func Provider() terraform.ResourceProvider {
 			"google_project_services":               resourceGoogleProjectServices(),
 			"google_pubsub_topic":                   resourcePubsubTopic(),
 			"google_pubsub_subscription":            resourcePubsubSubscription(),
+			"google_dataflow_job":                   resourceDataflowJob(),
 			"google_service_account":                resourceGoogleServiceAccount(),
 			"google_storage_bucket":                 resourceStorageBucket(),
 			"google_storage_bucket_acl":             resourceStorageBucketAcl(),

--- a/builtin/providers/google/resource_dataflow_job.go
+++ b/builtin/providers/google/resource_dataflow_job.go
@@ -1,0 +1,178 @@
+package google
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	"google.golang.org/api/dataflow/v1b3"
+)
+
+func resourceDataflowJob() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDataflowJobCreate,
+		Read:   resourceDataflowJobRead,
+		Delete: resourceDataflowJobDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"template_gcs_path": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"temp_gcs_location": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"zone": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"max_workers": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"parameters": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"on_delete": &schema.Schema{
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringInSlice([]string{"cancel", "drain"}, false),
+				Optional:     true,
+				Default:      "drain",
+				ForceNew:     true,
+			},
+
+			"project": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
+			"state": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceDataflowJobCreate(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	jobName := d.Get("name").(string)
+	gcsPath := d.Get("template_gcs_path").(string)
+	tempLocation := d.Get("temp_gcs_location").(string)
+	zone := d.Get("zone").(string)
+	maxWorkers := d.Get("max_workers").(int)
+	params := expandStringMap(d.Get("parameters").(map[string]interface{}))
+
+	env := dataflow.RuntimeEnvironment{
+		TempLocation: tempLocation,
+		Zone:         zone,
+		MaxWorkers:   int64(maxWorkers),
+	}
+
+	request := dataflow.CreateJobFromTemplateRequest{
+		JobName:     jobName,
+		GcsPath:     gcsPath,
+		Parameters:  params,
+		Environment: &env,
+	}
+
+	job, err := config.clientDataflow.Projects.Templates.Create(project, &request).Do()
+	if err != nil {
+		return err
+	}
+
+	d.SetId(job.Id)
+
+	return resourceDataflowJobRead(d, meta)
+}
+
+func resourceDataflowJobRead(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	id := d.Id()
+
+	job, err := config.clientDataflow.Projects.Jobs.Get(project, id).Do()
+	if err != nil {
+		return handleNotFoundError(err, d, fmt.Sprintf("Dataflow job %s", id))
+	}
+
+	d.Set("state", job.CurrentState)
+
+	return nil
+}
+
+func resourceDataflowJobDelete(d *schema.ResourceData, meta interface{}) error {
+	config := meta.(*Config)
+
+	project, err := getProject(d, config)
+	if err != nil {
+		return err
+	}
+
+	id := d.Id()
+	requestedState, err := mapOnDelete(d.Get("on_delete").(string))
+	if err != nil {
+		return err
+	}
+
+	job := &dataflow.Job{
+		RequestedState: requestedState,
+	}
+
+	_, err = config.clientDataflow.Projects.Jobs.Update(project, id, job).Do()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func expandStringMap(m map[string]interface{}) map[string]string {
+	result := make(map[string]string)
+	for k, v := range m {
+		result[k] = v.(string)
+	}
+	return result
+}
+
+func mapOnDelete(policy string) (string, error) {
+	switch policy {
+	case "cancel":
+		return "JOB_STATE_CANCELLED", nil
+	case "drain":
+		return "JOB_STATE_DRAINING", nil
+	default:
+		return "", fmt.Errorf("Invalid `on_delete` policy: %s", policy)
+	}
+}

--- a/builtin/providers/google/resource_dataflow_job_test.go
+++ b/builtin/providers/google/resource_dataflow_job_test.go
@@ -1,0 +1,85 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataflowJobCreate(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDataflowJobDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccDataflowJob,
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataflowJobExists(
+						"google_dataflow_job.big_data"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckDataflowJobDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "google_dataflow_job" {
+			continue
+		}
+
+		config := testAccProvider.Meta().(*Config)
+		job, _ := config.clientDataflow.Projects.Jobs.Get(config.Project, rs.Primary.ID).Do()
+		if job != nil {
+			return fmt.Errorf("Job still present")
+		}
+	}
+
+	return nil
+}
+
+func testAccDataflowJobExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+		config := testAccProvider.Meta().(*Config)
+		_, err := config.clientDataflow.Projects.Jobs.Get(config.Project, rs.Primary.ID).Do()
+		if err != nil {
+			return fmt.Errorf("Job does not exist")
+		}
+
+		return nil
+	}
+}
+
+var testAccDataflowJob = fmt.Sprintf(`
+resource "google_storage_bucket" "temp" {
+	name = "dfjob-test-%s-temp"
+
+	force_destroy = true
+}
+
+resource "google_dataflow_job" "big_data" {
+	name = "dfjob-test-%s"
+
+	template_gcs_path = "gs://dataflow-templates/wordcount/template_file"
+	temp_gcs_location = "${google_storage_bucket.temp.url}"
+
+	parameters {
+		inputFile = "gs://dataflow-samples/shakespeare/kinglear.txt"
+		output    = "${google_storage_bucket.temp.url}/output"
+	}
+
+	on_delete = "cancel"
+}`, acctest.RandString(10), acctest.RandString(10))

--- a/vendor/google.golang.org/api/dataflow/v1b3/dataflow-api.json
+++ b/vendor/google.golang.org/api/dataflow/v1b3/dataflow-api.json
@@ -1,0 +1,4465 @@
+{
+  "revision": "20170318",
+  "id": "dataflow:v1b3",
+  "documentationLink": "https://cloud.google.com/dataflow",
+  "title": "Google Dataflow API",
+  "discoveryVersion": "v1",
+  "ownerName": "Google",
+  "resources": {
+    "projects": {
+      "methods": {
+        "workerMessages": {
+          "httpMethod": "POST",
+          "parameterOrder": [
+            "projectId"
+          ],
+          "response": {
+            "$ref": "SendWorkerMessagesResponse"
+          },
+          "scopes": [
+            "https://www.googleapis.com/auth/cloud-platform",
+            "https://www.googleapis.com/auth/userinfo.email"
+          ],
+          "parameters": {
+            "projectId": {
+              "description": "The project to send the WorkerMessages to.",
+              "required": true,
+              "type": "string",
+              "location": "path"
+            }
+          },
+          "flatPath": "v1b3/projects/{projectId}/WorkerMessages",
+          "id": "dataflow.projects.workerMessages",
+          "path": "v1b3/projects/{projectId}/WorkerMessages",
+          "description": "Send a worker_message to the service.",
+          "request": {
+            "$ref": "SendWorkerMessagesRequest"
+          }
+        }
+      },
+      "resources": {
+        "locations": {
+          "resources": {
+            "jobs": {
+              "resources": {
+                "workItems": {
+                  "methods": {
+                    "lease": {
+                      "httpMethod": "POST",
+                      "parameterOrder": [
+                        "projectId",
+                        "location",
+                        "jobId"
+                      ],
+                      "response": {
+                        "$ref": "LeaseWorkItemResponse"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/userinfo.email"
+                      ],
+                      "parameters": {
+                        "projectId": {
+                          "description": "Identifies the project this worker belongs to.",
+                          "required": true,
+                          "type": "string",
+                          "location": "path"
+                        },
+                        "jobId": {
+                          "description": "Identifies the workflow job this worker belongs to.",
+                          "required": true,
+                          "type": "string",
+                          "location": "path"
+                        },
+                        "location": {
+                          "location": "path",
+                          "description": "The location which contains the WorkItem's job.",
+                          "required": true,
+                          "type": "string"
+                        }
+                      },
+                      "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:lease",
+                      "id": "dataflow.projects.locations.jobs.workItems.lease",
+                      "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:lease",
+                      "description": "Leases a dataflow WorkItem to run.",
+                      "request": {
+                        "$ref": "LeaseWorkItemRequest"
+                      }
+                    },
+                    "reportStatus": {
+                      "request": {
+                        "$ref": "ReportWorkItemStatusRequest"
+                      },
+                      "description": "Reports the status of dataflow WorkItems leased by a worker.",
+                      "response": {
+                        "$ref": "ReportWorkItemStatusResponse"
+                      },
+                      "parameterOrder": [
+                        "projectId",
+                        "location",
+                        "jobId"
+                      ],
+                      "httpMethod": "POST",
+                      "parameters": {
+                        "projectId": {
+                          "description": "The project which owns the WorkItem's job.",
+                          "required": true,
+                          "type": "string",
+                          "location": "path"
+                        },
+                        "jobId": {
+                          "location": "path",
+                          "description": "The job which the WorkItem is part of.",
+                          "required": true,
+                          "type": "string"
+                        },
+                        "location": {
+                          "description": "The location which contains the WorkItem's job.",
+                          "required": true,
+                          "type": "string",
+                          "location": "path"
+                        }
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/userinfo.email"
+                      ],
+                      "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:reportStatus",
+                      "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:reportStatus",
+                      "id": "dataflow.projects.locations.jobs.workItems.reportStatus"
+                    }
+                  }
+                },
+                "messages": {
+                  "methods": {
+                    "list": {
+                      "parameterOrder": [
+                        "projectId",
+                        "location",
+                        "jobId"
+                      ],
+                      "httpMethod": "GET",
+                      "response": {
+                        "$ref": "ListJobMessagesResponse"
+                      },
+                      "scopes": [
+                        "https://www.googleapis.com/auth/cloud-platform",
+                        "https://www.googleapis.com/auth/userinfo.email"
+                      ],
+                      "parameters": {
+                        "jobId": {
+                          "description": "The job to get messages about.",
+                          "required": true,
+                          "type": "string",
+                          "location": "path"
+                        },
+                        "projectId": {
+                          "location": "path",
+                          "description": "A project id.",
+                          "required": true,
+                          "type": "string"
+                        },
+                        "endTime": {
+                          "location": "query",
+                          "description": "Return only messages with timestamps \u003c end_time. The default is now\n(i.e. return up to the latest messages available).",
+                          "format": "google-datetime",
+                          "type": "string"
+                        },
+                        "location": {
+                          "location": "path",
+                          "description": "The location which contains the job specified by job_id.",
+                          "required": true,
+                          "type": "string"
+                        },
+                        "startTime": {
+                          "location": "query",
+                          "description": "If specified, return only messages with timestamps \u003e= start_time.\nThe default is the job creation time (i.e. beginning of messages).",
+                          "format": "google-datetime",
+                          "type": "string"
+                        },
+                        "pageToken": {
+                          "location": "query",
+                          "description": "If supplied, this should be the value of next_page_token returned\nby an earlier call. This will cause the next page of results to\nbe returned.",
+                          "type": "string"
+                        },
+                        "pageSize": {
+                          "description": "If specified, determines the maximum number of messages to\nreturn.  If unspecified, the service may choose an appropriate\ndefault, or may return an arbitrarily large number of results.",
+                          "format": "int32",
+                          "type": "integer",
+                          "location": "query"
+                        },
+                        "minimumImportance": {
+                          "enum": [
+                            "JOB_MESSAGE_IMPORTANCE_UNKNOWN",
+                            "JOB_MESSAGE_DEBUG",
+                            "JOB_MESSAGE_DETAILED",
+                            "JOB_MESSAGE_BASIC",
+                            "JOB_MESSAGE_WARNING",
+                            "JOB_MESSAGE_ERROR"
+                          ],
+                          "description": "Filter to only get messages with importance \u003e= level",
+                          "type": "string",
+                          "location": "query"
+                        }
+                      },
+                      "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/messages",
+                      "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/messages",
+                      "id": "dataflow.projects.locations.jobs.messages.list",
+                      "description": "Request the job status."
+                    }
+                  }
+                }
+              },
+              "methods": {
+                "update": {
+                  "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}",
+                  "id": "dataflow.projects.locations.jobs.update",
+                  "request": {
+                    "$ref": "Job"
+                  },
+                  "description": "Updates the state of an existing Cloud Dataflow job.",
+                  "response": {
+                    "$ref": "Job"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "location",
+                    "jobId"
+                  ],
+                  "httpMethod": "PUT",
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "The ID of the Cloud Platform project that the job belongs to.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "description": "The job ID.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    },
+                    "location": {
+                      "location": "path",
+                      "description": "The location that contains this job.",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}"
+                },
+                "create": {
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "location"
+                  ],
+                  "response": {
+                    "$ref": "Job"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "parameters": {
+                    "replaceJobId": {
+                      "description": "Deprecated. This field is now in the Job message.",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "projectId": {
+                      "location": "path",
+                      "description": "The ID of the Cloud Platform project that the job belongs to.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "view": {
+                      "enum": [
+                        "JOB_VIEW_UNKNOWN",
+                        "JOB_VIEW_SUMMARY",
+                        "JOB_VIEW_ALL",
+                        "JOB_VIEW_DESCRIPTION"
+                      ],
+                      "description": "The level of information requested in response.",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "location": {
+                      "description": "The location that contains this job.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs",
+                  "id": "dataflow.projects.locations.jobs.create",
+                  "path": "v1b3/projects/{projectId}/locations/{location}/jobs",
+                  "description": "Creates a Cloud Dataflow job.",
+                  "request": {
+                    "$ref": "Job"
+                  }
+                },
+                "getMetrics": {
+                  "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/metrics",
+                  "id": "dataflow.projects.locations.jobs.getMetrics",
+                  "description": "Request the job status.",
+                  "parameterOrder": [
+                    "projectId",
+                    "location",
+                    "jobId"
+                  ],
+                  "httpMethod": "GET",
+                  "response": {
+                    "$ref": "JobMetrics"
+                  },
+                  "parameters": {
+                    "location": {
+                      "description": "The location which contains the job specified by job_id.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    },
+                    "startTime": {
+                      "location": "query",
+                      "description": "Return only metric data that has changed since this time.\nDefault is to return all information about all metrics for the job.",
+                      "format": "google-datetime",
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "description": "A project id.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    },
+                    "jobId": {
+                      "description": "The job to get messages for.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/metrics"
+                },
+                "get": {
+                  "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}",
+                  "id": "dataflow.projects.locations.jobs.get",
+                  "description": "Gets the state of the specified Cloud Dataflow job.",
+                  "response": {
+                    "$ref": "Job"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "location",
+                    "jobId"
+                  ],
+                  "httpMethod": "GET",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "description": "The ID of the Cloud Platform project that the job belongs to.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    },
+                    "jobId": {
+                      "description": "The job ID.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    },
+                    "view": {
+                      "location": "query",
+                      "enum": [
+                        "JOB_VIEW_UNKNOWN",
+                        "JOB_VIEW_SUMMARY",
+                        "JOB_VIEW_ALL",
+                        "JOB_VIEW_DESCRIPTION"
+                      ],
+                      "description": "The level of information requested in response.",
+                      "type": "string"
+                    },
+                    "location": {
+                      "description": "The location that contains this job.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}"
+                },
+                "list": {
+                  "id": "dataflow.projects.locations.jobs.list",
+                  "path": "v1b3/projects/{projectId}/locations/{location}/jobs",
+                  "description": "List the jobs of a project.",
+                  "httpMethod": "GET",
+                  "response": {
+                    "$ref": "ListJobsResponse"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "location"
+                  ],
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "parameters": {
+                    "filter": {
+                      "location": "query",
+                      "enum": [
+                        "UNKNOWN",
+                        "ALL",
+                        "TERMINATED",
+                        "ACTIVE"
+                      ],
+                      "description": "The kind of filter to use.",
+                      "type": "string"
+                    },
+                    "location": {
+                      "location": "path",
+                      "description": "The location that contains this job.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "pageToken": {
+                      "location": "query",
+                      "description": "Set this to the 'next_page_token' field of a previous response\nto request additional results in a long list.",
+                      "type": "string"
+                    },
+                    "pageSize": {
+                      "location": "query",
+                      "description": "If there are many jobs, limit response to at most this many.\nThe actual number of jobs returned will be the lesser of max_responses\nand an unspecified server-defined limit.",
+                      "format": "int32",
+                      "type": "integer"
+                    },
+                    "view": {
+                      "location": "query",
+                      "enum": [
+                        "JOB_VIEW_UNKNOWN",
+                        "JOB_VIEW_SUMMARY",
+                        "JOB_VIEW_ALL",
+                        "JOB_VIEW_DESCRIPTION"
+                      ],
+                      "description": "Level of information requested in response. Default is `JOB_VIEW_SUMMARY`.",
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "location": "path",
+                      "description": "The project which owns the jobs.",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs"
+                }
+              }
+            }
+          }
+        },
+        "templates": {
+          "methods": {
+            "create": {
+              "path": "v1b3/projects/{projectId}/templates",
+              "id": "dataflow.projects.templates.create",
+              "description": "Creates a Cloud Dataflow job from a template.",
+              "request": {
+                "$ref": "CreateJobFromTemplateRequest"
+              },
+              "response": {
+                "$ref": "Job"
+              },
+              "parameterOrder": [
+                "projectId"
+              ],
+              "httpMethod": "POST",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "parameters": {
+                "projectId": {
+                  "description": "Required. The ID of the Cloud Platform project that the job belongs to.",
+                  "required": true,
+                  "type": "string",
+                  "location": "path"
+                }
+              },
+              "flatPath": "v1b3/projects/{projectId}/templates"
+            },
+            "launch": {
+              "path": "v1b3/projects/{projectId}/templates:launch",
+              "id": "dataflow.projects.templates.launch",
+              "description": "Launch a template.",
+              "request": {
+                "$ref": "LaunchTemplateParameters"
+              },
+              "response": {
+                "$ref": "LaunchTemplateResponse"
+              },
+              "parameterOrder": [
+                "projectId"
+              ],
+              "httpMethod": "POST",
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "parameters": {
+                "gcsPath": {
+                  "location": "query",
+                  "description": "Required. A Cloud Storage path to the template from which to create\nthe job.\nMust be valid Cloud Storage URL, beginning with 'gs://'.",
+                  "type": "string"
+                },
+                "dryRun": {
+                  "description": "Whether or not the job should actually be executed after\nvalidating parameters. Defaults to false. Validation errors do\nnot cause the HTTP request to fail if true.",
+                  "type": "boolean",
+                  "location": "query"
+                },
+                "projectId": {
+                  "description": "Required. The ID of the Cloud Platform project that the job belongs to.",
+                  "required": true,
+                  "type": "string",
+                  "location": "path"
+                }
+              },
+              "flatPath": "v1b3/projects/{projectId}/templates:launch"
+            },
+            "get": {
+              "parameterOrder": [
+                "projectId"
+              ],
+              "httpMethod": "GET",
+              "response": {
+                "$ref": "GetTemplateResponse"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "parameters": {
+                "projectId": {
+                  "location": "path",
+                  "description": "Required. The ID of the Cloud Platform project that the job belongs to.",
+                  "required": true,
+                  "type": "string"
+                },
+                "view": {
+                  "location": "query",
+                  "enum": [
+                    "METADATA_ONLY"
+                  ],
+                  "description": "The view to retrieve. Defaults to METADATA_ONLY.",
+                  "type": "string"
+                },
+                "gcsPath": {
+                  "description": "Required. A Cloud Storage path to the template from which to\ncreate the job.\nMust be a valid Cloud Storage URL, beginning with `gs://`.",
+                  "type": "string",
+                  "location": "query"
+                }
+              },
+              "flatPath": "v1b3/projects/{projectId}/templates:get",
+              "path": "v1b3/projects/{projectId}/templates:get",
+              "id": "dataflow.projects.templates.get",
+              "description": "Get the template associated with a template."
+            }
+          }
+        },
+        "jobs": {
+          "methods": {
+            "getMetrics": {
+              "description": "Request the job status.",
+              "httpMethod": "GET",
+              "response": {
+                "$ref": "JobMetrics"
+              },
+              "parameterOrder": [
+                "projectId",
+                "jobId"
+              ],
+              "parameters": {
+                "location": {
+                  "description": "The location which contains the job specified by job_id.",
+                  "type": "string",
+                  "location": "query"
+                },
+                "startTime": {
+                  "location": "query",
+                  "description": "Return only metric data that has changed since this time.\nDefault is to return all information about all metrics for the job.",
+                  "format": "google-datetime",
+                  "type": "string"
+                },
+                "projectId": {
+                  "location": "path",
+                  "description": "A project id.",
+                  "required": true,
+                  "type": "string"
+                },
+                "jobId": {
+                  "description": "The job to get messages for.",
+                  "required": true,
+                  "type": "string",
+                  "location": "path"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/metrics",
+              "id": "dataflow.projects.jobs.getMetrics",
+              "path": "v1b3/projects/{projectId}/jobs/{jobId}/metrics"
+            },
+            "get": {
+              "description": "Gets the state of the specified Cloud Dataflow job.",
+              "httpMethod": "GET",
+              "response": {
+                "$ref": "Job"
+              },
+              "parameterOrder": [
+                "projectId",
+                "jobId"
+              ],
+              "parameters": {
+                "projectId": {
+                  "location": "path",
+                  "description": "The ID of the Cloud Platform project that the job belongs to.",
+                  "required": true,
+                  "type": "string"
+                },
+                "jobId": {
+                  "description": "The job ID.",
+                  "required": true,
+                  "type": "string",
+                  "location": "path"
+                },
+                "view": {
+                  "location": "query",
+                  "enum": [
+                    "JOB_VIEW_UNKNOWN",
+                    "JOB_VIEW_SUMMARY",
+                    "JOB_VIEW_ALL",
+                    "JOB_VIEW_DESCRIPTION"
+                  ],
+                  "description": "The level of information requested in response.",
+                  "type": "string"
+                },
+                "location": {
+                  "location": "query",
+                  "description": "The location that contains this job.",
+                  "type": "string"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}",
+              "id": "dataflow.projects.jobs.get",
+              "path": "v1b3/projects/{projectId}/jobs/{jobId}"
+            },
+            "list": {
+              "path": "v1b3/projects/{projectId}/jobs",
+              "id": "dataflow.projects.jobs.list",
+              "description": "List the jobs of a project.",
+              "response": {
+                "$ref": "ListJobsResponse"
+              },
+              "httpMethod": "GET",
+              "parameterOrder": [
+                "projectId"
+              ],
+              "parameters": {
+                "pageToken": {
+                  "description": "Set this to the 'next_page_token' field of a previous response\nto request additional results in a long list.",
+                  "type": "string",
+                  "location": "query"
+                },
+                "pageSize": {
+                  "location": "query",
+                  "description": "If there are many jobs, limit response to at most this many.\nThe actual number of jobs returned will be the lesser of max_responses\nand an unspecified server-defined limit.",
+                  "format": "int32",
+                  "type": "integer"
+                },
+                "view": {
+                  "enum": [
+                    "JOB_VIEW_UNKNOWN",
+                    "JOB_VIEW_SUMMARY",
+                    "JOB_VIEW_ALL",
+                    "JOB_VIEW_DESCRIPTION"
+                  ],
+                  "description": "Level of information requested in response. Default is `JOB_VIEW_SUMMARY`.",
+                  "type": "string",
+                  "location": "query"
+                },
+                "projectId": {
+                  "description": "The project which owns the jobs.",
+                  "required": true,
+                  "type": "string",
+                  "location": "path"
+                },
+                "filter": {
+                  "location": "query",
+                  "enum": [
+                    "UNKNOWN",
+                    "ALL",
+                    "TERMINATED",
+                    "ACTIVE"
+                  ],
+                  "description": "The kind of filter to use.",
+                  "type": "string"
+                },
+                "location": {
+                  "location": "query",
+                  "description": "The location that contains this job.",
+                  "type": "string"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "flatPath": "v1b3/projects/{projectId}/jobs"
+            },
+            "update": {
+              "id": "dataflow.projects.jobs.update",
+              "path": "v1b3/projects/{projectId}/jobs/{jobId}",
+              "description": "Updates the state of an existing Cloud Dataflow job.",
+              "request": {
+                "$ref": "Job"
+              },
+              "httpMethod": "PUT",
+              "parameterOrder": [
+                "projectId",
+                "jobId"
+              ],
+              "response": {
+                "$ref": "Job"
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "parameters": {
+                "location": {
+                  "location": "query",
+                  "description": "The location that contains this job.",
+                  "type": "string"
+                },
+                "projectId": {
+                  "location": "path",
+                  "description": "The ID of the Cloud Platform project that the job belongs to.",
+                  "required": true,
+                  "type": "string"
+                },
+                "jobId": {
+                  "description": "The job ID.",
+                  "required": true,
+                  "type": "string",
+                  "location": "path"
+                }
+              },
+              "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}"
+            },
+            "create": {
+              "request": {
+                "$ref": "Job"
+              },
+              "description": "Creates a Cloud Dataflow job.",
+              "httpMethod": "POST",
+              "parameterOrder": [
+                "projectId"
+              ],
+              "response": {
+                "$ref": "Job"
+              },
+              "parameters": {
+                "location": {
+                  "location": "query",
+                  "description": "The location that contains this job.",
+                  "type": "string"
+                },
+                "replaceJobId": {
+                  "location": "query",
+                  "description": "Deprecated. This field is now in the Job message.",
+                  "type": "string"
+                },
+                "projectId": {
+                  "location": "path",
+                  "description": "The ID of the Cloud Platform project that the job belongs to.",
+                  "required": true,
+                  "type": "string"
+                },
+                "view": {
+                  "location": "query",
+                  "enum": [
+                    "JOB_VIEW_UNKNOWN",
+                    "JOB_VIEW_SUMMARY",
+                    "JOB_VIEW_ALL",
+                    "JOB_VIEW_DESCRIPTION"
+                  ],
+                  "description": "The level of information requested in response.",
+                  "type": "string"
+                }
+              },
+              "scopes": [
+                "https://www.googleapis.com/auth/cloud-platform",
+                "https://www.googleapis.com/auth/userinfo.email"
+              ],
+              "flatPath": "v1b3/projects/{projectId}/jobs",
+              "id": "dataflow.projects.jobs.create",
+              "path": "v1b3/projects/{projectId}/jobs"
+            }
+          },
+          "resources": {
+            "debug": {
+              "methods": {
+                "getConfig": {
+                  "request": {
+                    "$ref": "GetDebugConfigRequest"
+                  },
+                  "description": "Get encoded debug configuration for component. Not cacheable.",
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "jobId"
+                  ],
+                  "response": {
+                    "$ref": "GetDebugConfigResponse"
+                  },
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "The project id.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "location": "path",
+                      "description": "The job id.",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/debug/getConfig",
+                  "id": "dataflow.projects.jobs.debug.getConfig",
+                  "path": "v1b3/projects/{projectId}/jobs/{jobId}/debug/getConfig"
+                },
+                "sendCapture": {
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "jobId"
+                  ],
+                  "response": {
+                    "$ref": "SendDebugCaptureResponse"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "description": "The project id.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    },
+                    "jobId": {
+                      "description": "The job id.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/debug/sendCapture",
+                  "id": "dataflow.projects.jobs.debug.sendCapture",
+                  "path": "v1b3/projects/{projectId}/jobs/{jobId}/debug/sendCapture",
+                  "description": "Send encoded debug capture data for component.",
+                  "request": {
+                    "$ref": "SendDebugCaptureRequest"
+                  }
+                }
+              }
+            },
+            "workItems": {
+              "methods": {
+                "reportStatus": {
+                  "request": {
+                    "$ref": "ReportWorkItemStatusRequest"
+                  },
+                  "description": "Reports the status of dataflow WorkItems leased by a worker.",
+                  "httpMethod": "POST",
+                  "parameterOrder": [
+                    "projectId",
+                    "jobId"
+                  ],
+                  "response": {
+                    "$ref": "ReportWorkItemStatusResponse"
+                  },
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "The project which owns the WorkItem's job.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "location": "path",
+                      "description": "The job which the WorkItem is part of.",
+                      "required": true,
+                      "type": "string"
+                    }
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:reportStatus",
+                  "id": "dataflow.projects.jobs.workItems.reportStatus",
+                  "path": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:reportStatus"
+                },
+                "lease": {
+                  "response": {
+                    "$ref": "LeaseWorkItemResponse"
+                  },
+                  "parameterOrder": [
+                    "projectId",
+                    "jobId"
+                  ],
+                  "httpMethod": "POST",
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "parameters": {
+                    "projectId": {
+                      "location": "path",
+                      "description": "Identifies the project this worker belongs to.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "jobId": {
+                      "description": "Identifies the workflow job this worker belongs to.",
+                      "required": true,
+                      "type": "string",
+                      "location": "path"
+                    }
+                  },
+                  "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:lease",
+                  "path": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:lease",
+                  "id": "dataflow.projects.jobs.workItems.lease",
+                  "description": "Leases a dataflow WorkItem to run.",
+                  "request": {
+                    "$ref": "LeaseWorkItemRequest"
+                  }
+                }
+              }
+            },
+            "messages": {
+              "methods": {
+                "list": {
+                  "httpMethod": "GET",
+                  "parameterOrder": [
+                    "projectId",
+                    "jobId"
+                  ],
+                  "response": {
+                    "$ref": "ListJobMessagesResponse"
+                  },
+                  "scopes": [
+                    "https://www.googleapis.com/auth/cloud-platform",
+                    "https://www.googleapis.com/auth/userinfo.email"
+                  ],
+                  "parameters": {
+                    "startTime": {
+                      "description": "If specified, return only messages with timestamps \u003e= start_time.\nThe default is the job creation time (i.e. beginning of messages).",
+                      "format": "google-datetime",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "pageToken": {
+                      "description": "If supplied, this should be the value of next_page_token returned\nby an earlier call. This will cause the next page of results to\nbe returned.",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "pageSize": {
+                      "description": "If specified, determines the maximum number of messages to\nreturn.  If unspecified, the service may choose an appropriate\ndefault, or may return an arbitrarily large number of results.",
+                      "format": "int32",
+                      "type": "integer",
+                      "location": "query"
+                    },
+                    "minimumImportance": {
+                      "enum": [
+                        "JOB_MESSAGE_IMPORTANCE_UNKNOWN",
+                        "JOB_MESSAGE_DEBUG",
+                        "JOB_MESSAGE_DETAILED",
+                        "JOB_MESSAGE_BASIC",
+                        "JOB_MESSAGE_WARNING",
+                        "JOB_MESSAGE_ERROR"
+                      ],
+                      "description": "Filter to only get messages with importance \u003e= level",
+                      "type": "string",
+                      "location": "query"
+                    },
+                    "jobId": {
+                      "location": "path",
+                      "description": "The job to get messages about.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "location": "path",
+                      "description": "A project id.",
+                      "required": true,
+                      "type": "string"
+                    },
+                    "endTime": {
+                      "location": "query",
+                      "description": "Return only messages with timestamps \u003c end_time. The default is now\n(i.e. return up to the latest messages available).",
+                      "format": "google-datetime",
+                      "type": "string"
+                    },
+                    "location": {
+                      "location": "query",
+                      "description": "The location which contains the job specified by job_id.",
+                      "type": "string"
+                    }
+                  },
+                  "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/messages",
+                  "id": "dataflow.projects.jobs.messages.list",
+                  "path": "v1b3/projects/{projectId}/jobs/{jobId}/messages",
+                  "description": "Request the job status."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "alt": {
+      "enum": [
+        "json",
+        "media",
+        "proto"
+      ],
+      "type": "string",
+      "enumDescriptions": [
+        "Responses with Content-Type of application/json",
+        "Media download with context-dependent Content-Type",
+        "Responses with Content-Type of application/x-protobuf"
+      ],
+      "location": "query",
+      "description": "Data format for response.",
+      "default": "json"
+    },
+    "key": {
+      "location": "query",
+      "description": "API key. Your API key identifies your project and provides you with API access, quota, and reports. Required unless you provide an OAuth 2.0 token.",
+      "type": "string"
+    },
+    "access_token": {
+      "location": "query",
+      "description": "OAuth access token.",
+      "type": "string"
+    },
+    "quotaUser": {
+      "location": "query",
+      "description": "Available to use for quota purposes for server-side applications. Can be any arbitrary string assigned to a user, but should not exceed 40 characters.",
+      "type": "string"
+    },
+    "pp": {
+      "description": "Pretty-print response.",
+      "type": "boolean",
+      "default": "true",
+      "location": "query"
+    },
+    "bearer_token": {
+      "description": "OAuth bearer token.",
+      "type": "string",
+      "location": "query"
+    },
+    "oauth_token": {
+      "description": "OAuth 2.0 token for the current user.",
+      "type": "string",
+      "location": "query"
+    },
+    "upload_protocol": {
+      "location": "query",
+      "description": "Upload protocol for media (e.g. \"raw\", \"multipart\").",
+      "type": "string"
+    },
+    "prettyPrint": {
+      "location": "query",
+      "description": "Returns response with indentations and line breaks.",
+      "type": "boolean",
+      "default": "true"
+    },
+    "uploadType": {
+      "description": "Legacy upload protocol for media (e.g. \"media\", \"multipart\").",
+      "type": "string",
+      "location": "query"
+    },
+    "fields": {
+      "location": "query",
+      "description": "Selector specifying which fields to include in a partial response.",
+      "type": "string"
+    },
+    "callback": {
+      "location": "query",
+      "description": "JSONP",
+      "type": "string"
+    },
+    "$.xgafv": {
+      "enum": [
+        "1",
+        "2"
+      ],
+      "description": "V1 error format.",
+      "type": "string",
+      "enumDescriptions": [
+        "v1 error format",
+        "v2 error format"
+      ],
+      "location": "query"
+    }
+  },
+  "schemas": {
+    "SourceOperationResponse": {
+      "properties": {
+        "getMetadata": {
+          "description": "A response to a request to get metadata about a source.",
+          "$ref": "SourceGetMetadataResponse"
+        },
+        "split": {
+          "$ref": "SourceSplitResponse",
+          "description": "A response to a request to split a source."
+        }
+      },
+      "id": "SourceOperationResponse",
+      "description": "The result of a SourceOperationRequest, specified in\nReportWorkItemStatusRequest.source_operation when the work item\nis completed.",
+      "type": "object"
+    },
+    "SendDebugCaptureResponse": {
+      "description": "Response to a send capture request.\nnothing",
+      "type": "object",
+      "properties": {},
+      "id": "SendDebugCaptureResponse"
+    },
+    "SideInputInfo": {
+      "description": "Information about a side input of a DoFn or an input of a SeqDoFn.",
+      "type": "object",
+      "properties": {
+        "sources": {
+          "description": "The source(s) to read element(s) from to get the value of this side input.\nIf more than one source, then the elements are taken from the\nsources, in the specified order if order matters.\nAt least one source is required.",
+          "type": "array",
+          "items": {
+            "$ref": "Source"
+          }
+        },
+        "kind": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "How to interpret the source element(s) as a side input value.",
+          "type": "object"
+        },
+        "tag": {
+          "description": "The id of the tag the user code will access this side input by;\nthis should correspond to the tag of some MultiOutputInfo.",
+          "type": "string"
+        }
+      },
+      "id": "SideInputInfo"
+    },
+    "CounterStructuredNameAndMetadata": {
+      "description": "A single message which encapsulates structured name and metadata for a given\ncounter.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Structured name of the counter.",
+          "$ref": "CounterStructuredName"
+        },
+        "metadata": {
+          "description": "Metadata associated with a counter",
+          "$ref": "CounterMetadata"
+        }
+      },
+      "id": "CounterStructuredNameAndMetadata"
+    },
+    "ConcatPosition": {
+      "properties": {
+        "position": {
+          "$ref": "Position",
+          "description": "Position within the inner source."
+        },
+        "index": {
+          "description": "Index of the inner source.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "ConcatPosition",
+      "description": "A position that encapsulates an inner position and an index for the inner\nposition. A ConcatPosition can be used by a reader of a source that\nencapsulates a set of other sources.",
+      "type": "object"
+    },
+    "WriteInstruction": {
+      "properties": {
+        "input": {
+          "$ref": "InstructionInput",
+          "description": "The input."
+        },
+        "sink": {
+          "$ref": "Sink",
+          "description": "The sink to write to."
+        }
+      },
+      "id": "WriteInstruction",
+      "description": "An instruction that writes records.\nTakes one input, produces no outputs.",
+      "type": "object"
+    },
+    "StreamingComputationRanges": {
+      "properties": {
+        "computationId": {
+          "description": "The ID of the computation.",
+          "type": "string"
+        },
+        "rangeAssignments": {
+          "description": "Data disk assignments for ranges from this computation.",
+          "type": "array",
+          "items": {
+            "$ref": "KeyRangeDataDiskAssignment"
+          }
+        }
+      },
+      "id": "StreamingComputationRanges",
+      "description": "Describes full or partial data disk assignment information of the computation\nranges.",
+      "type": "object"
+    },
+    "AutoscalingSettings": {
+      "properties": {
+        "algorithm": {
+          "enum": [
+            "AUTOSCALING_ALGORITHM_UNKNOWN",
+            "AUTOSCALING_ALGORITHM_NONE",
+            "AUTOSCALING_ALGORITHM_BASIC"
+          ],
+          "description": "The algorithm to use for autoscaling.",
+          "type": "string",
+          "enumDescriptions": [
+            "The algorithm is unknown, or unspecified.",
+            "Disable autoscaling.",
+            "Increase worker count over time to reduce job execution time."
+          ]
+        },
+        "maxNumWorkers": {
+          "description": "The maximum number of workers to cap scaling at.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "AutoscalingSettings",
+      "description": "Settings for WorkerPool autoscaling.",
+      "type": "object"
+    },
+    "ExecutionStageSummary": {
+      "description": "Description of the composing transforms, names/ids, and input/outputs of a\nstage of execution.  Some composing transforms and sources may have been\ngenerated by the Dataflow service during execution planning.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "Dataflow service generated name for this stage.",
+          "type": "string"
+        },
+        "inputSource": {
+          "description": "Input sources for this stage.",
+          "type": "array",
+          "items": {
+            "$ref": "StageSource"
+          }
+        },
+        "id": {
+          "description": "Dataflow service generated id for this stage.",
+          "type": "string"
+        },
+        "componentTransform": {
+          "description": "Transforms that comprise this execution stage.",
+          "type": "array",
+          "items": {
+            "$ref": "ComponentTransform"
+          }
+        },
+        "componentSource": {
+          "description": "Collections produced and consumed by component transforms of this stage.",
+          "type": "array",
+          "items": {
+            "$ref": "ComponentSource"
+          }
+        },
+        "kind": {
+          "enumDescriptions": [
+            "Unrecognized transform type.",
+            "ParDo transform.",
+            "Group By Key transform.",
+            "Flatten transform.",
+            "Read transform.",
+            "Write transform.",
+            "Constructs from a constant value, such as with Create.of.",
+            "Creates a Singleton view of a collection.",
+            "Opening or closing a shuffle session, often as part of a GroupByKey."
+          ],
+          "enum": [
+            "UNKNOWN_KIND",
+            "PAR_DO_KIND",
+            "GROUP_BY_KEY_KIND",
+            "FLATTEN_KIND",
+            "READ_KIND",
+            "WRITE_KIND",
+            "CONSTANT_KIND",
+            "SINGLETON_KIND",
+            "SHUFFLE_KIND"
+          ],
+          "description": "Type of tranform this stage is executing.",
+          "type": "string"
+        },
+        "outputSource": {
+          "description": "Output sources for this stage.",
+          "type": "array",
+          "items": {
+            "$ref": "StageSource"
+          }
+        }
+      },
+      "id": "ExecutionStageSummary"
+    },
+    "SendWorkerMessagesRequest": {
+      "properties": {
+        "workerMessages": {
+          "description": "The WorkerMessages to send.",
+          "type": "array",
+          "items": {
+            "$ref": "WorkerMessage"
+          }
+        }
+      },
+      "id": "SendWorkerMessagesRequest",
+      "description": "A request for sending worker messages to the service.",
+      "type": "object"
+    },
+    "SourceSplitShard": {
+      "properties": {
+        "derivationMode": {
+          "enumDescriptions": [
+            "The source derivation is unknown, or unspecified.",
+            "Produce a completely independent Source with no base.",
+            "Produce a Source based on the Source being split.",
+            "Produce a Source based on the base of the Source being split."
+          ],
+          "enum": [
+            "SOURCE_DERIVATION_MODE_UNKNOWN",
+            "SOURCE_DERIVATION_MODE_INDEPENDENT",
+            "SOURCE_DERIVATION_MODE_CHILD_OF_CURRENT",
+            "SOURCE_DERIVATION_MODE_SIBLING_OF_CURRENT"
+          ],
+          "description": "DEPRECATED",
+          "type": "string"
+        },
+        "source": {
+          "description": "DEPRECATED",
+          "$ref": "Source"
+        }
+      },
+      "id": "SourceSplitShard",
+      "description": "DEPRECATED in favor of DerivedSource.",
+      "type": "object"
+    },
+    "CPUTime": {
+      "properties": {
+        "totalMs": {
+          "description": "Total active CPU time across all cores (ie., non-idle) in milliseconds\nsince start-up.",
+          "format": "uint64",
+          "type": "string"
+        },
+        "rate": {
+          "description": "Average CPU utilization rate (% non-idle cpu / second) since previous\nsample.",
+          "format": "double",
+          "type": "number"
+        },
+        "timestamp": {
+          "description": "Timestamp of the measurement.",
+          "format": "google-datetime",
+          "type": "string"
+        }
+      },
+      "id": "CPUTime",
+      "description": "Modeled after information exposed by /proc/stat.",
+      "type": "object"
+    },
+    "Environment": {
+      "description": "Describes the environment in which a Dataflow Job runs.",
+      "type": "object",
+      "properties": {
+        "sdkPipelineOptions": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The Cloud Dataflow SDK pipeline options specified by the user. These\noptions are passed through the service and are used to recreate the\nSDK pipeline options on the worker in a language agnostic and platform\nindependent way.",
+          "type": "object"
+        },
+        "userAgent": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "A description of the process that generated the request.",
+          "type": "object"
+        },
+        "clusterManagerApiService": {
+          "description": "The type of cluster manager API to use.  If unknown or\nunspecified, the service will attempt to choose a reasonable\ndefault.  This should be in the form of the API service name,\ne.g. \"compute.googleapis.com\".",
+          "type": "string"
+        },
+        "tempStoragePrefix": {
+          "description": "The prefix of the resources the system should use for temporary\nstorage.  The system will append the suffix \"/temp-{JOBNAME} to\nthis resource prefix, where {JOBNAME} is the value of the\njob_name field.  The resulting bucket and object prefix is used\nas the prefix of the resources used to store temporary data\nneeded during the job execution.  NOTE: This will override the\nvalue in taskrunner_settings.\nThe supported resource type is:\n\nGoogle Cloud Storage:\n\n  storage.googleapis.com/{bucket}/{object}\n  bucket.storage.googleapis.com/{object}",
+          "type": "string"
+        },
+        "workerPools": {
+          "description": "The worker pools. At least one \"harness\" worker pool must be\nspecified in order for the job to have workers.",
+          "type": "array",
+          "items": {
+            "$ref": "WorkerPool"
+          }
+        },
+        "dataset": {
+          "description": "The dataset for the current project where various workflow\nrelated tables are stored.\n\nThe supported resource type is:\n\nGoogle BigQuery:\n  bigquery.googleapis.com/{dataset}",
+          "type": "string"
+        },
+        "experiments": {
+          "description": "The list of experiments to enable.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "version": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "A structure describing which components and their versions of the service\nare required in order to run the job.",
+          "type": "object"
+        },
+        "internalExperiments": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "Experimental settings.",
+          "type": "object"
+        },
+        "serviceAccountEmail": {
+          "description": "Identity to run virtual machines as. Defaults to the default account.",
+          "type": "string"
+        }
+      },
+      "id": "Environment"
+    },
+    "StreamingComputationTask": {
+      "description": "A task which describes what action should be performed for the specified\nstreaming computation ranges.",
+      "type": "object",
+      "properties": {
+        "computationRanges": {
+          "description": "Contains ranges of a streaming computation this task should apply to.",
+          "type": "array",
+          "items": {
+            "$ref": "StreamingComputationRanges"
+          }
+        },
+        "dataDisks": {
+          "description": "Describes the set of data disks this task should apply to.",
+          "type": "array",
+          "items": {
+            "$ref": "MountedDataDisk"
+          }
+        },
+        "taskType": {
+          "enumDescriptions": [
+            "The streaming computation task is unknown, or unspecified.",
+            "Stop processing specified streaming computation range(s).",
+            "Start processing specified streaming computation range(s)."
+          ],
+          "enum": [
+            "STREAMING_COMPUTATION_TASK_UNKNOWN",
+            "STREAMING_COMPUTATION_TASK_STOP",
+            "STREAMING_COMPUTATION_TASK_START"
+          ],
+          "description": "A type of streaming computation task.",
+          "type": "string"
+        }
+      },
+      "id": "StreamingComputationTask"
+    },
+    "SendDebugCaptureRequest": {
+      "description": "Request to send encoded debug information.",
+      "type": "object",
+      "properties": {
+        "componentId": {
+          "description": "The internal component id for which debug information is sent.",
+          "type": "string"
+        },
+        "workerId": {
+          "description": "The worker id, i.e., VM hostname.",
+          "type": "string"
+        },
+        "data": {
+          "description": "The encoded debug information.",
+          "type": "string"
+        }
+      },
+      "id": "SendDebugCaptureRequest"
+    },
+    "GetDebugConfigResponse": {
+      "description": "Response to a get debug configuration request.",
+      "type": "object",
+      "properties": {
+        "config": {
+          "description": "The encoded debug configuration for the requested component.",
+          "type": "string"
+        }
+      },
+      "id": "GetDebugConfigResponse"
+    },
+    "ComponentTransform": {
+      "description": "Description of a transform executed as part of an execution stage.",
+      "type": "object",
+      "properties": {
+        "originalTransform": {
+          "description": "User name for the original user transform with which this transform is\nmost closely associated.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Dataflow service generated name for this source.",
+          "type": "string"
+        },
+        "userName": {
+          "description": "Human-readable name for this transform; may be user or system generated.",
+          "type": "string"
+        }
+      },
+      "id": "ComponentTransform"
+    },
+    "StreamingSetupTask": {
+      "description": "A task which initializes part of a streaming Dataflow job.",
+      "type": "object",
+      "properties": {
+        "receiveWorkPort": {
+          "description": "The TCP port on which the worker should listen for messages from\nother streaming computation workers.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "streamingComputationTopology": {
+          "description": "The global topology of the streaming Dataflow job.",
+          "$ref": "TopologyConfig"
+        },
+        "workerHarnessPort": {
+          "description": "The TCP port used by the worker to communicate with the Dataflow\nworker harness.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "drain": {
+          "description": "The user has requested drain.",
+          "type": "boolean"
+        }
+      },
+      "id": "StreamingSetupTask"
+    },
+    "PubsubLocation": {
+      "properties": {
+        "withAttributes": {
+          "description": "If true, then the client has requested to get pubsub attributes.",
+          "type": "boolean"
+        },
+        "idLabel": {
+          "description": "If set, contains a pubsub label from which to extract record ids.\nIf left empty, record deduplication will be strictly best effort.",
+          "type": "string"
+        },
+        "timestampLabel": {
+          "description": "If set, contains a pubsub label from which to extract record timestamps.\nIf left empty, record timestamps will be generated upon arrival.",
+          "type": "string"
+        },
+        "topic": {
+          "description": "A pubsub topic, in the form of\n\"pubsub.googleapis.com/topics/\u003cproject-id\u003e/\u003ctopic-name\u003e\"",
+          "type": "string"
+        },
+        "subscription": {
+          "description": "A pubsub subscription, in the form of\n\"pubsub.googleapis.com/subscriptions/\u003cproject-id\u003e/\u003csubscription-name\u003e\"",
+          "type": "string"
+        },
+        "dropLateData": {
+          "description": "Indicates whether the pipeline allows late-arriving data.",
+          "type": "boolean"
+        },
+        "trackingSubscription": {
+          "description": "If set, specifies the pubsub subscription that will be used for tracking\ncustom time timestamps for watermark estimation.",
+          "type": "string"
+        }
+      },
+      "id": "PubsubLocation",
+      "description": "Identifies a pubsub location to use for transferring data into or\nout of a streaming Dataflow job.",
+      "type": "object"
+    },
+    "WorkerHealthReport": {
+      "description": "WorkerHealthReport contains information about the health of a worker.\n\nThe VM should be identified by the labels attached to the WorkerMessage that\nthis health ping belongs to.",
+      "type": "object",
+      "properties": {
+        "vmStartupTime": {
+          "description": "The time the VM was booted.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "vmIsHealthy": {
+          "description": "Whether the VM is healthy.",
+          "type": "boolean"
+        },
+        "reportInterval": {
+          "description": "The interval at which the worker is sending health reports.\nThe default value of 0 should be interpreted as the field is not being\nexplicitly set by the worker.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "pods": {
+          "description": "The pods running on the worker. See:\nhttp://kubernetes.io/v1.1/docs/api-reference/v1/definitions.html#_v1_pod\n\nThis field is used by the worker to send the status of the indvidual\ncontainers running on each worker.",
+          "type": "array",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object.",
+              "type": "any"
+            },
+            "type": "object"
+          }
+        }
+      },
+      "id": "WorkerHealthReport"
+    },
+    "JobMessage": {
+      "properties": {
+        "messageText": {
+          "description": "The text of the message.",
+          "type": "string"
+        },
+        "messageImportance": {
+          "enum": [
+            "JOB_MESSAGE_IMPORTANCE_UNKNOWN",
+            "JOB_MESSAGE_DEBUG",
+            "JOB_MESSAGE_DETAILED",
+            "JOB_MESSAGE_BASIC",
+            "JOB_MESSAGE_WARNING",
+            "JOB_MESSAGE_ERROR"
+          ],
+          "description": "Importance level of the message.",
+          "type": "string",
+          "enumDescriptions": [
+            "The message importance isn't specified, or is unknown.",
+            "The message is at the 'debug' level: typically only useful for\nsoftware engineers working on the code the job is running.\nTypically, Dataflow pipeline runners do not display log messages\nat this level by default.",
+            "The message is at the 'detailed' level: somewhat verbose, but\npotentially useful to users.  Typically, Dataflow pipeline\nrunners do not display log messages at this level by default.\nThese messages are displayed by default in the Dataflow\nmonitoring UI.",
+            "The message is at the 'basic' level: useful for keeping\ntrack of the execution of a Dataflow pipeline.  Typically,\nDataflow pipeline runners display log messages at this level by\ndefault, and these messages are displayed by default in the\nDataflow monitoring UI.",
+            "The message is at the 'warning' level: indicating a condition\npertaining to a job which may require human intervention.\nTypically, Dataflow pipeline runners display log messages at this\nlevel by default, and these messages are displayed by default in\nthe Dataflow monitoring UI.",
+            "The message is at the 'error' level: indicating a condition\npreventing a job from succeeding.  Typically, Dataflow pipeline\nrunners display log messages at this level by default, and these\nmessages are displayed by default in the Dataflow monitoring UI."
+          ]
+        },
+        "time": {
+          "description": "The timestamp of the message.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "id": {
+          "description": "Identifies the message.  This is automatically generated by the\nservice; the caller should treat it as an opaque string.",
+          "type": "string"
+        }
+      },
+      "id": "JobMessage",
+      "description": "A particular message pertaining to a Dataflow job.",
+      "type": "object"
+    },
+    "ParameterMetadata": {
+      "description": "Metadata for a specific parameter.",
+      "type": "object",
+      "properties": {
+        "label": {
+          "description": "Required. The label to display for the parameter.",
+          "type": "string"
+        },
+        "helpText": {
+          "description": "Required. The help text to display for the parameter.",
+          "type": "string"
+        },
+        "isOptional": {
+          "description": "Optional. Whether the parameter is optional. Defaults to false.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Required. The name of the parameter.",
+          "type": "string"
+        },
+        "regexes": {
+          "description": "Optional. Regexes that the parameter must match.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "ParameterMetadata"
+    },
+    "MultiOutputInfo": {
+      "description": "Information about an output of a multi-output DoFn.",
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "The id of the tag the user code will emit to this output by; this\nshould correspond to the tag of some SideInputInfo.",
+          "type": "string"
+        }
+      },
+      "id": "MultiOutputInfo"
+    },
+    "SourceSplitRequest": {
+      "properties": {
+        "source": {
+          "description": "Specification of the source to be split.",
+          "$ref": "Source"
+        },
+        "options": {
+          "description": "Hints for tuning the splitting process.",
+          "$ref": "SourceSplitOptions"
+        }
+      },
+      "id": "SourceSplitRequest",
+      "description": "Represents the operation to split a high-level Source specification\ninto bundles (parts for parallel processing).\n\nAt a high level, splitting of a source into bundles happens as follows:\nSourceSplitRequest is applied to the source. If it returns\nSOURCE_SPLIT_OUTCOME_USE_CURRENT, no further splitting happens and the source\nis used \"as is\". Otherwise, splitting is applied recursively to each\nproduced DerivedSource.\n\nAs an optimization, for any Source, if its does_not_need_splitting is\ntrue, the framework assumes that splitting this source would return\nSOURCE_SPLIT_OUTCOME_USE_CURRENT, and doesn't initiate a SourceSplitRequest.\nThis applies both to the initial source being split and to bundles\nproduced from it.",
+      "type": "object"
+    },
+    "SourceGetMetadataResponse": {
+      "description": "The result of a SourceGetMetadataOperation.",
+      "type": "object",
+      "properties": {
+        "metadata": {
+          "$ref": "SourceMetadata",
+          "description": "The computed metadata."
+        }
+      },
+      "id": "SourceGetMetadataResponse"
+    },
+    "MetricShortId": {
+      "description": "The metric short id is returned to the user alongside an offset into\nReportWorkItemStatusRequest",
+      "type": "object",
+      "properties": {
+        "metricIndex": {
+          "description": "The index of the corresponding metric in\nthe ReportWorkItemStatusRequest. Required.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "shortId": {
+          "description": "The service-generated short identifier for the metric.",
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "id": "MetricShortId"
+    },
+    "ShellTask": {
+      "description": "A task which consists of a shell command for the worker to execute.",
+      "type": "object",
+      "properties": {
+        "command": {
+          "description": "The shell command to run.",
+          "type": "string"
+        },
+        "exitCode": {
+          "description": "Exit code for the task.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "ShellTask"
+    },
+    "TaskRunnerSettings": {
+      "properties": {
+        "alsologtostderr": {
+          "description": "Whether to also send taskrunner log info to stderr.",
+          "type": "boolean"
+        },
+        "taskGroup": {
+          "description": "The UNIX group ID on the worker VM to use for tasks launched by\ntaskrunner; e.g. \"wheel\".",
+          "type": "string"
+        },
+        "harnessCommand": {
+          "description": "The command to launch the worker harness.",
+          "type": "string"
+        },
+        "logDir": {
+          "description": "The directory on the VM to store logs.",
+          "type": "string"
+        },
+        "oauthScopes": {
+          "description": "The OAuth2 scopes to be requested by the taskrunner in order to\naccess the Cloud Dataflow API.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "dataflowApiVersion": {
+          "description": "The API version of endpoint, e.g. \"v1b3\"",
+          "type": "string"
+        },
+        "streamingWorkerMainClass": {
+          "description": "The streaming worker main class name.",
+          "type": "string"
+        },
+        "logUploadLocation": {
+          "description": "Indicates where to put logs.  If this is not specified, the logs\nwill not be uploaded.\n\nThe supported resource type is:\n\nGoogle Cloud Storage:\n  storage.googleapis.com/{bucket}/{object}\n  bucket.storage.googleapis.com/{object}",
+          "type": "string"
+        },
+        "workflowFileName": {
+          "description": "The file to store the workflow in.",
+          "type": "string"
+        },
+        "baseTaskDir": {
+          "description": "The location on the worker for task-specific subdirectories.",
+          "type": "string"
+        },
+        "tempStoragePrefix": {
+          "description": "The prefix of the resources the taskrunner should use for\ntemporary storage.\n\nThe supported resource type is:\n\nGoogle Cloud Storage:\n  storage.googleapis.com/{bucket}/{object}\n  bucket.storage.googleapis.com/{object}",
+          "type": "string"
+        },
+        "languageHint": {
+          "description": "The suggested backend language.",
+          "type": "string"
+        },
+        "commandlinesFileName": {
+          "description": "The file to store preprocessing commands in.",
+          "type": "string"
+        },
+        "baseUrl": {
+          "description": "The base URL for the taskrunner to use when accessing Google Cloud APIs.\n\nWhen workers access Google Cloud APIs, they logically do so via\nrelative URLs.  If this field is specified, it supplies the base\nURL to use for resolving these relative URLs.  The normative\nalgorithm used is defined by RFC 1808, \"Relative Uniform Resource\nLocators\".\n\nIf not specified, the default value is \"http://www.googleapis.com/\"",
+          "type": "string"
+        },
+        "logToSerialconsole": {
+          "description": "Whether to send taskrunner log info to Google Compute Engine VM serial\nconsole.",
+          "type": "boolean"
+        },
+        "continueOnException": {
+          "description": "Whether to continue taskrunner if an exception is hit.",
+          "type": "boolean"
+        },
+        "parallelWorkerSettings": {
+          "description": "The settings to pass to the parallel worker harness.",
+          "$ref": "WorkerSettings"
+        },
+        "vmId": {
+          "description": "The ID string of the VM.",
+          "type": "string"
+        },
+        "taskUser": {
+          "description": "The UNIX user ID on the worker VM to use for tasks launched by\ntaskrunner; e.g. \"root\".",
+          "type": "string"
+        }
+      },
+      "id": "TaskRunnerSettings",
+      "description": "Taskrunner configuration settings.",
+      "type": "object"
+    },
+    "Position": {
+      "properties": {
+        "recordIndex": {
+          "description": "Position is a record index.",
+          "format": "int64",
+          "type": "string"
+        },
+        "shufflePosition": {
+          "description": "CloudPosition is a base64 encoded BatchShufflePosition (with FIXED\nsharding).",
+          "type": "string"
+        },
+        "concatPosition": {
+          "$ref": "ConcatPosition",
+          "description": "CloudPosition is a concat position."
+        },
+        "byteOffset": {
+          "description": "Position is a byte offset.",
+          "format": "int64",
+          "type": "string"
+        },
+        "end": {
+          "description": "Position is past all other positions. Also useful for the end\nposition of an unbounded range.",
+          "type": "boolean"
+        },
+        "key": {
+          "description": "Position is a string key, ordered lexicographically.",
+          "type": "string"
+        }
+      },
+      "id": "Position",
+      "description": "Position defines a position within a collection of data.  The value\ncan be either the end position, a key (used with ordered\ncollections), a byte offset, or a record index.",
+      "type": "object"
+    },
+    "SplitInt64": {
+      "properties": {
+        "lowBits": {
+          "description": "The low order bits: n & 0xffffffff.",
+          "format": "uint32",
+          "type": "integer"
+        },
+        "highBits": {
+          "description": "The high order bits, including the sign: n \u003e\u003e 32.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "SplitInt64",
+      "description": "A representation of an int64, n, that is immune to precision loss when\nencoded in JSON.",
+      "type": "object"
+    },
+    "Source": {
+      "description": "A source that records can be read and decoded from.",
+      "type": "object",
+      "properties": {
+        "spec": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The source to read from, plus its parameters.",
+          "type": "object"
+        },
+        "metadata": {
+          "description": "Optionally, metadata for this source can be supplied right away,\navoiding a SourceGetMetadataOperation roundtrip\n(see SourceOperationRequest).\n\nThis field is meaningful only in the Source objects populated\nby the user (e.g. when filling in a DerivedSource).\nSource objects supplied by the framework to the user don't have\nthis field populated.",
+          "$ref": "SourceMetadata"
+        },
+        "baseSpecs": {
+          "description": "While splitting, sources may specify the produced bundles\nas differences against another source, in order to save backend-side\nmemory and allow bigger jobs. For details, see SourceSplitRequest.\nTo support this use case, the full set of parameters of the source\nis logically obtained by taking the latest explicitly specified value\nof each parameter in the order:\nbase_specs (later items win), spec (overrides anything in base_specs).",
+          "type": "array",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object.",
+              "type": "any"
+            },
+            "type": "object"
+          }
+        },
+        "codec": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The codec to use to decode data read from the source.",
+          "type": "object"
+        },
+        "doesNotNeedSplitting": {
+          "description": "Setting this value to true hints to the framework that the source\ndoesn't need splitting, and using SourceSplitRequest on it would\nyield SOURCE_SPLIT_OUTCOME_USE_CURRENT.\n\nE.g. a file splitter may set this to true when splitting a single file\ninto a set of byte ranges of appropriate size, and set this\nto false when splitting a filepattern into individual files.\nHowever, for efficiency, a file splitter may decide to produce\nfile subranges directly from the filepattern to avoid a splitting\nround-trip.\n\nSee SourceSplitRequest for an overview of the splitting process.\n\nThis field is meaningful only in the Source objects populated\nby the user (e.g. when filling in a DerivedSource).\nSource objects supplied by the framework to the user don't have\nthis field populated.",
+          "type": "boolean"
+        }
+      },
+      "id": "Source"
+    },
+    "WorkerPool": {
+      "description": "Describes one particular pool of Cloud Dataflow workers to be\ninstantiated by the Cloud Dataflow service in order to perform the\ncomputations required by a job.  Note that a workflow job may use\nmultiple pools, in order to match the various computational\nrequirements of the various stages of the job.",
+      "type": "object",
+      "properties": {
+        "subnetwork": {
+          "description": "Subnetwork to which VMs will be assigned, if desired.  Expected to be of\nthe form \"regions/REGION/subnetworks/SUBNETWORK\".",
+          "type": "string"
+        },
+        "ipConfiguration": {
+          "enum": [
+            "WORKER_IP_UNSPECIFIED",
+            "WORKER_IP_PUBLIC",
+            "WORKER_IP_PRIVATE"
+          ],
+          "description": "Configuration for VM IPs.",
+          "type": "string",
+          "enumDescriptions": [
+            "The configuration is unknown, or unspecified.",
+            "Workers should have public IP addresses.",
+            "Workers should have private IP addresses."
+          ]
+        },
+        "taskrunnerSettings": {
+          "description": "Settings passed through to Google Compute Engine workers when\nusing the standard Dataflow task runner.  Users should ignore\nthis field.",
+          "$ref": "TaskRunnerSettings"
+        },
+        "autoscalingSettings": {
+          "description": "Settings for autoscaling of this WorkerPool.",
+          "$ref": "AutoscalingSettings"
+        },
+        "metadata": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Metadata to set on the Google Compute Engine VMs.",
+          "type": "object"
+        },
+        "network": {
+          "description": "Network to which VMs will be assigned.  If empty or unspecified,\nthe service will use the network \"default\".",
+          "type": "string"
+        },
+        "defaultPackageSet": {
+          "enum": [
+            "DEFAULT_PACKAGE_SET_UNKNOWN",
+            "DEFAULT_PACKAGE_SET_NONE",
+            "DEFAULT_PACKAGE_SET_JAVA",
+            "DEFAULT_PACKAGE_SET_PYTHON"
+          ],
+          "description": "The default package set to install.  This allows the service to\nselect a default set of packages which are useful to worker\nharnesses written in a particular language.",
+          "type": "string",
+          "enumDescriptions": [
+            "The default set of packages to stage is unknown, or unspecified.",
+            "Indicates that no packages should be staged at the worker unless\nexplicitly specified by the job.",
+            "Stage packages typically useful to workers written in Java.",
+            "Stage pacakges typically useful to workers written in Python."
+          ]
+        },
+        "numThreadsPerWorker": {
+          "description": "The number of threads per worker harness. If empty or unspecified, the\nservice will choose a number of threads (according to the number of cores\non the selected machine type for batch, or 1 by convention for streaming).",
+          "format": "int32",
+          "type": "integer"
+        },
+        "numWorkers": {
+          "description": "Number of Google Compute Engine workers in this pool needed to\nexecute the job.  If zero or unspecified, the service will\nattempt to choose a reasonable default.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "zone": {
+          "description": "Zone to run the worker pools in.  If empty or unspecified, the service\nwill attempt to choose a reasonable default.",
+          "type": "string"
+        },
+        "diskSourceImage": {
+          "description": "Fully qualified source image for disks.",
+          "type": "string"
+        },
+        "packages": {
+          "description": "Packages to be installed on workers.",
+          "type": "array",
+          "items": {
+            "$ref": "Package"
+          }
+        },
+        "teardownPolicy": {
+          "enum": [
+            "TEARDOWN_POLICY_UNKNOWN",
+            "TEARDOWN_ALWAYS",
+            "TEARDOWN_ON_SUCCESS",
+            "TEARDOWN_NEVER"
+          ],
+          "description": "Sets the policy for determining when to turndown worker pool.\nAllowed values are: `TEARDOWN_ALWAYS`, `TEARDOWN_ON_SUCCESS`, and\n`TEARDOWN_NEVER`.\n`TEARDOWN_ALWAYS` means workers are always torn down regardless of whether\nthe job succeeds. `TEARDOWN_ON_SUCCESS` means workers are torn down\nif the job succeeds. `TEARDOWN_NEVER` means the workers are never torn\ndown.\n\nIf the workers are not torn down by the service, they will\ncontinue to run and use Google Compute Engine VM resources in the\nuser's project until they are explicitly terminated by the user.\nBecause of this, Google recommends using the `TEARDOWN_ALWAYS`\npolicy except for small, manually supervised test jobs.\n\nIf unknown or unspecified, the service will attempt to choose a reasonable\ndefault.",
+          "type": "string",
+          "enumDescriptions": [
+            "The teardown policy isn't specified, or is unknown.",
+            "Always teardown the resource.",
+            "Teardown the resource on success. This is useful for debugging\nfailures.",
+            "Never teardown the resource. This is useful for debugging and\ndevelopment."
+          ]
+        },
+        "onHostMaintenance": {
+          "description": "The action to take on host maintenance, as defined by the Google\nCompute Engine API.",
+          "type": "string"
+        },
+        "poolArgs": {
+          "additionalProperties": {
+            "description": "Properties of the object. Contains field @type with type URL.",
+            "type": "any"
+          },
+          "description": "Extra arguments for this worker pool.",
+          "type": "object"
+        },
+        "diskSizeGb": {
+          "description": "Size of root disk for VMs, in GB.  If zero or unspecified, the service will\nattempt to choose a reasonable default.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "workerHarnessContainerImage": {
+          "description": "Required. Docker container image that executes the Cloud Dataflow worker\nharness, residing in Google Container Registry.",
+          "type": "string"
+        },
+        "machineType": {
+          "description": "Machine type (e.g. \"n1-standard-1\").  If empty or unspecified, the\nservice will attempt to choose a reasonable default.",
+          "type": "string"
+        },
+        "diskType": {
+          "description": "Type of root disk for VMs.  If empty or unspecified, the service will\nattempt to choose a reasonable default.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of the worker pool; currently only `harness` and `shuffle`\nare supported.",
+          "type": "string"
+        },
+        "dataDisks": {
+          "description": "Data disks that are used by a VM in this workflow.",
+          "type": "array",
+          "items": {
+            "$ref": "Disk"
+          }
+        }
+      },
+      "id": "WorkerPool"
+    },
+    "SourceOperationRequest": {
+      "description": "A work item that represents the different operations that can be\nperformed on a user-defined Source specification.",
+      "type": "object",
+      "properties": {
+        "getMetadata": {
+          "description": "Information about a request to get metadata about a source.",
+          "$ref": "SourceGetMetadataRequest"
+        },
+        "split": {
+          "$ref": "SourceSplitRequest",
+          "description": "Information about a request to split a source."
+        }
+      },
+      "id": "SourceOperationRequest"
+    },
+    "WorkItem": {
+      "properties": {
+        "configuration": {
+          "description": "Work item-specific configuration as an opaque blob.",
+          "type": "string"
+        },
+        "mapTask": {
+          "description": "Additional information for MapTask WorkItems.",
+          "$ref": "MapTask"
+        },
+        "seqMapTask": {
+          "description": "Additional information for SeqMapTask WorkItems.",
+          "$ref": "SeqMapTask"
+        },
+        "packages": {
+          "description": "Any required packages that need to be fetched in order to execute\nthis WorkItem.",
+          "type": "array",
+          "items": {
+            "$ref": "Package"
+          }
+        },
+        "projectId": {
+          "description": "Identifies the cloud project this WorkItem belongs to.",
+          "type": "string"
+        },
+        "streamingSetupTask": {
+          "$ref": "StreamingSetupTask",
+          "description": "Additional information for StreamingSetupTask WorkItems."
+        },
+        "reportStatusInterval": {
+          "description": "Recommended reporting interval.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "sourceOperationTask": {
+          "description": "Additional information for source operation WorkItems.",
+          "$ref": "SourceOperationRequest"
+        },
+        "streamingConfigTask": {
+          "$ref": "StreamingConfigTask",
+          "description": "Additional information for StreamingConfigTask WorkItems."
+        },
+        "leaseExpireTime": {
+          "description": "Time when the lease on this Work will expire.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "initialReportIndex": {
+          "description": "The initial index to use when reporting the status of the WorkItem.",
+          "format": "int64",
+          "type": "string"
+        },
+        "shellTask": {
+          "$ref": "ShellTask",
+          "description": "Additional information for ShellTask WorkItems."
+        },
+        "streamingComputationTask": {
+          "$ref": "StreamingComputationTask",
+          "description": "Additional information for StreamingComputationTask WorkItems."
+        },
+        "jobId": {
+          "description": "Identifies the workflow job this WorkItem belongs to.",
+          "type": "string"
+        },
+        "id": {
+          "description": "Identifies this WorkItem.",
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "id": "WorkItem",
+      "description": "WorkItem represents basic information about a WorkItem to be executed\nin the cloud.",
+      "type": "object"
+    },
+    "ReportedParallelism": {
+      "description": "Represents the level of parallelism in a WorkItem's input,\nreported by the worker.",
+      "type": "object",
+      "properties": {
+        "isInfinite": {
+          "description": "Specifies whether the parallelism is infinite. If true, \"value\" is\nignored.\nInfinite parallelism means the service will assume that the work item\ncan always be split into more non-empty work items by dynamic splitting.\nThis is a work-around for lack of support for infinity by the current\nJSON-based Java RPC stack.",
+          "type": "boolean"
+        },
+        "value": {
+          "description": "Specifies the level of parallelism in case it is finite.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "id": "ReportedParallelism"
+    },
+    "ResourceUtilizationReport": {
+      "description": "Worker metrics exported from workers. This contains resource utilization\nmetrics accumulated from a variety of sources. For more information, see\ngo/df-resource-signals.",
+      "type": "object",
+      "properties": {
+        "cpuTime": {
+          "description": "CPU utilization samples.",
+          "type": "array",
+          "items": {
+            "$ref": "CPUTime"
+          }
+        }
+      },
+      "id": "ResourceUtilizationReport"
+    },
+    "TopologyConfig": {
+      "properties": {
+        "userStageToComputationNameMap": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Maps user stage names to stable computation names.",
+          "type": "object"
+        },
+        "computations": {
+          "description": "The computations associated with a streaming Dataflow job.",
+          "type": "array",
+          "items": {
+            "$ref": "ComputationTopology"
+          }
+        },
+        "dataDiskAssignments": {
+          "description": "The disks assigned to a streaming Dataflow job.",
+          "type": "array",
+          "items": {
+            "$ref": "DataDiskAssignment"
+          }
+        },
+        "persistentStateVersion": {
+          "description": "Version number for persistent state.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "forwardingKeyBits": {
+          "description": "The size (in bits) of keys that will be assigned to source messages.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "TopologyConfig",
+      "description": "Global topology of the streaming Dataflow job, including all\ncomputations and their sharded locations.",
+      "type": "object"
+    },
+    "SourceSplitOptions": {
+      "description": "Hints for splitting a Source into bundles (parts for parallel\nprocessing) using SourceSplitRequest.",
+      "type": "object",
+      "properties": {
+        "desiredBundleSizeBytes": {
+          "description": "The source should be split into a set of bundles where the estimated size\nof each is approximately this many bytes.",
+          "format": "int64",
+          "type": "string"
+        },
+        "desiredShardSizeBytes": {
+          "description": "DEPRECATED in favor of desired_bundle_size_bytes.",
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "id": "SourceSplitOptions"
+    },
+    "ReadInstruction": {
+      "properties": {
+        "source": {
+          "$ref": "Source",
+          "description": "The source to read from."
+        }
+      },
+      "id": "ReadInstruction",
+      "description": "An instruction that reads records.\nTakes no inputs, produces one output.",
+      "type": "object"
+    },
+    "WorkerSettings": {
+      "properties": {
+        "servicePath": {
+          "description": "The Cloud Dataflow service path relative to the root URL, for example,\n\"dataflow/v1b3/projects\".",
+          "type": "string"
+        },
+        "shuffleServicePath": {
+          "description": "The Shuffle service path relative to the root URL, for example,\n\"shuffle/v1beta1\".",
+          "type": "string"
+        },
+        "workerId": {
+          "description": "The ID of the worker running this pipeline.",
+          "type": "string"
+        },
+        "tempStoragePrefix": {
+          "description": "The prefix of the resources the system should use for temporary\nstorage.\n\nThe supported resource type is:\n\nGoogle Cloud Storage:\n\n  storage.googleapis.com/{bucket}/{object}\n  bucket.storage.googleapis.com/{object}",
+          "type": "string"
+        },
+        "reportingEnabled": {
+          "description": "Whether to send work progress updates to the service.",
+          "type": "boolean"
+        },
+        "baseUrl": {
+          "description": "The base URL for accessing Google Cloud APIs.\n\nWhen workers access Google Cloud APIs, they logically do so via\nrelative URLs.  If this field is specified, it supplies the base\nURL to use for resolving these relative URLs.  The normative\nalgorithm used is defined by RFC 1808, \"Relative Uniform Resource\nLocators\".\n\nIf not specified, the default value is \"http://www.googleapis.com/\"",
+          "type": "string"
+        }
+      },
+      "id": "WorkerSettings",
+      "description": "Provides data to pass through to the worker harness.",
+      "type": "object"
+    },
+    "DataDiskAssignment": {
+      "properties": {
+        "vmInstance": {
+          "description": "VM instance name the data disks mounted to, for example\n\"myproject-1014-104817-4c2-harness-0\".",
+          "type": "string"
+        },
+        "dataDisks": {
+          "description": "Mounted data disks. The order is important a data disk's 0-based index in\nthis list defines which persistent directory the disk is mounted to, for\nexample the list of { \"myproject-1014-104817-4c2-harness-0-disk-0\" },\n{ \"myproject-1014-104817-4c2-harness-0-disk-1\" }.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "DataDiskAssignment",
+      "description": "Data disk assignment for a given VM instance.",
+      "type": "object"
+    },
+    "StreamingStageLocation": {
+      "properties": {
+        "streamId": {
+          "description": "Identifies the particular stream within the streaming Dataflow\njob.",
+          "type": "string"
+        }
+      },
+      "id": "StreamingStageLocation",
+      "description": "Identifies the location of a streaming computation stage, for\nstage-to-stage communication.",
+      "type": "object"
+    },
+    "ApproximateSplitRequest": {
+      "properties": {
+        "fractionConsumed": {
+          "description": "A fraction at which to split the work item, from 0.0 (beginning of the\ninput) to 1.0 (end of the input).",
+          "format": "double",
+          "type": "number"
+        },
+        "position": {
+          "description": "A Position at which to split the work item.",
+          "$ref": "Position"
+        }
+      },
+      "id": "ApproximateSplitRequest",
+      "description": "A suggestion by the service to the worker to dynamically split the WorkItem.",
+      "type": "object"
+    },
+    "Status": {
+      "properties": {
+        "details": {
+          "description": "A list of messages that carry the error details.  There will be a\ncommon set of message types for APIs to use.",
+          "type": "array",
+          "items": {
+            "additionalProperties": {
+              "description": "Properties of the object. Contains field @type with type URL.",
+              "type": "any"
+            },
+            "type": "object"
+          }
+        },
+        "code": {
+          "description": "The status code, which should be an enum value of google.rpc.Code.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "message": {
+          "description": "A developer-facing error message, which should be in English. Any\nuser-facing error message should be localized and sent in the\ngoogle.rpc.Status.details field, or localized by the client.",
+          "type": "string"
+        }
+      },
+      "id": "Status",
+      "description": "The `Status` type defines a logical error model that is suitable for different\nprogramming environments, including REST APIs and RPC APIs. It is used by\n[gRPC](https://github.com/grpc). The error model is designed to be:\n\n- Simple to use and understand for most users\n- Flexible enough to meet unexpected needs\n\n# Overview\n\nThe `Status` message contains three pieces of data: error code, error message,\nand error details. The error code should be an enum value of\ngoogle.rpc.Code, but it may accept additional error codes if needed.  The\nerror message should be a developer-facing English message that helps\ndevelopers *understand* and *resolve* the error. If a localized user-facing\nerror message is needed, put the localized message in the error details or\nlocalize it in the client. The optional error details may contain arbitrary\ninformation about the error. There is a predefined set of error detail types\nin the package `google.rpc` which can be used for common error conditions.\n\n# Language mapping\n\nThe `Status` message is the logical representation of the error model, but it\nis not necessarily the actual wire format. When the `Status` message is\nexposed in different client libraries and different wire protocols, it can be\nmapped differently. For example, it will likely be mapped to some exceptions\nin Java, but more likely mapped to some error codes in C.\n\n# Other uses\n\nThe error model and the `Status` message can be used in a variety of\nenvironments, either with or without APIs, to provide a\nconsistent developer experience across different environments.\n\nExample uses of this error model include:\n\n- Partial errors. If a service needs to return partial errors to the client,\n    it may embed the `Status` in the normal response to indicate the partial\n    errors.\n\n- Workflow errors. A typical workflow has multiple steps. Each step may\n    have a `Status` message for error reporting purpose.\n\n- Batch operations. If a client uses batch request and batch response, the\n    `Status` message should be used directly inside batch response, one for\n    each error sub-response.\n\n- Asynchronous operations. If an API call embeds asynchronous operation\n    results in its response, the status of those operations should be\n    represented directly using the `Status` message.\n\n- Logging. If some API errors are stored in logs, the message `Status` could\n    be used directly after any stripping needed for security/privacy reasons.",
+      "type": "object"
+    },
+    "StreamLocation": {
+      "description": "Describes a stream of data, either as input to be processed or as\noutput of a streaming Dataflow job.",
+      "type": "object",
+      "properties": {
+        "customSourceLocation": {
+          "description": "The stream is a custom source.",
+          "$ref": "CustomSourceLocation"
+        },
+        "streamingStageLocation": {
+          "$ref": "StreamingStageLocation",
+          "description": "The stream is part of another computation within the current\nstreaming Dataflow job."
+        },
+        "pubsubLocation": {
+          "$ref": "PubsubLocation",
+          "description": "The stream is a pubsub stream."
+        },
+        "sideInputLocation": {
+          "description": "The stream is a streaming side input.",
+          "$ref": "StreamingSideInputLocation"
+        }
+      },
+      "id": "StreamLocation"
+    },
+    "SendWorkerMessagesResponse": {
+      "properties": {
+        "workerMessageResponses": {
+          "description": "The servers response to the worker messages.",
+          "type": "array",
+          "items": {
+            "$ref": "WorkerMessageResponse"
+          }
+        }
+      },
+      "id": "SendWorkerMessagesResponse",
+      "description": "The response to the worker messages.",
+      "type": "object"
+    },
+    "LeaseWorkItemResponse": {
+      "description": "Response to a request to lease WorkItems.",
+      "type": "object",
+      "properties": {
+        "workItems": {
+          "description": "A list of the leased WorkItems.",
+          "type": "array",
+          "items": {
+            "$ref": "WorkItem"
+          }
+        }
+      },
+      "id": "LeaseWorkItemResponse"
+    },
+    "TransformSummary": {
+      "properties": {
+        "id": {
+          "description": "SDK generated id of this transform instance.",
+          "type": "string"
+        },
+        "displayData": {
+          "description": "Transform-specific display data.",
+          "type": "array",
+          "items": {
+            "$ref": "DisplayData"
+          }
+        },
+        "outputCollectionName": {
+          "description": "User  names for all collection outputs to this transform.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "kind": {
+          "enumDescriptions": [
+            "Unrecognized transform type.",
+            "ParDo transform.",
+            "Group By Key transform.",
+            "Flatten transform.",
+            "Read transform.",
+            "Write transform.",
+            "Constructs from a constant value, such as with Create.of.",
+            "Creates a Singleton view of a collection.",
+            "Opening or closing a shuffle session, often as part of a GroupByKey."
+          ],
+          "enum": [
+            "UNKNOWN_KIND",
+            "PAR_DO_KIND",
+            "GROUP_BY_KEY_KIND",
+            "FLATTEN_KIND",
+            "READ_KIND",
+            "WRITE_KIND",
+            "CONSTANT_KIND",
+            "SINGLETON_KIND",
+            "SHUFFLE_KIND"
+          ],
+          "description": "Type of transform.",
+          "type": "string"
+        },
+        "inputCollectionName": {
+          "description": "User names for all collection inputs to this transform.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "name": {
+          "description": "User provided name for this transform instance.",
+          "type": "string"
+        }
+      },
+      "id": "TransformSummary",
+      "description": "Description of the type, names/ids, and input/outputs for a transform.",
+      "type": "object"
+    },
+    "StreamingComputationConfig": {
+      "properties": {
+        "systemName": {
+          "description": "System defined name for this computation.",
+          "type": "string"
+        },
+        "stageName": {
+          "description": "Stage name of this computation.",
+          "type": "string"
+        },
+        "instructions": {
+          "description": "Instructions that comprise the computation.",
+          "type": "array",
+          "items": {
+            "$ref": "ParallelInstruction"
+          }
+        },
+        "computationId": {
+          "description": "Unique identifier for this computation.",
+          "type": "string"
+        }
+      },
+      "id": "StreamingComputationConfig",
+      "description": "Configuration information for a single streaming computation.",
+      "type": "object"
+    },
+    "Sink": {
+      "properties": {
+        "codec": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The codec to use to encode data written to the sink.",
+          "type": "object"
+        },
+        "spec": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The sink to write to, plus its parameters.",
+          "type": "object"
+        }
+      },
+      "id": "Sink",
+      "description": "A sink that records can be encoded and written to.",
+      "type": "object"
+    },
+    "LaunchTemplateParameters": {
+      "properties": {
+        "environment": {
+          "$ref": "RuntimeEnvironment",
+          "description": "The runtime environment for the job."
+        },
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The runtime parameters to pass to the job.",
+          "type": "object"
+        },
+        "jobName": {
+          "description": "Required. The job name to use for the created job.",
+          "type": "string"
+        }
+      },
+      "id": "LaunchTemplateParameters",
+      "description": "Parameters to provide to the template being launched.",
+      "type": "object"
+    },
+    "FlattenInstruction": {
+      "description": "An instruction that copies its inputs (zero or more) to its (single) output.",
+      "type": "object",
+      "properties": {
+        "inputs": {
+          "description": "Describes the inputs to the flatten instruction.",
+          "type": "array",
+          "items": {
+            "$ref": "InstructionInput"
+          }
+        }
+      },
+      "id": "FlattenInstruction"
+    },
+    "PartialGroupByKeyInstruction": {
+      "properties": {
+        "input": {
+          "description": "Describes the input to the partial group-by-key instruction.",
+          "$ref": "InstructionInput"
+        },
+        "inputElementCodec": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The codec to use for interpreting an element in the input PTable.",
+          "type": "object"
+        },
+        "valueCombiningFn": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The value combining function to invoke.",
+          "type": "object"
+        },
+        "originalCombineValuesInputStoreName": {
+          "description": "If this instruction includes a combining function this is the name of the\nintermediate store between the GBK and the CombineValues.",
+          "type": "string"
+        },
+        "originalCombineValuesStepName": {
+          "description": "If this instruction includes a combining function, this is the name of the\nCombineValues instruction lifted into this instruction.",
+          "type": "string"
+        },
+        "sideInputs": {
+          "description": "Zero or more side inputs.",
+          "type": "array",
+          "items": {
+            "$ref": "SideInputInfo"
+          }
+        }
+      },
+      "id": "PartialGroupByKeyInstruction",
+      "description": "An instruction that does a partial group-by-key.\nOne input and one output.",
+      "type": "object"
+    },
+    "InstructionInput": {
+      "description": "An input of an instruction, as a reference to an output of a\nproducer instruction.",
+      "type": "object",
+      "properties": {
+        "producerInstructionIndex": {
+          "description": "The index (origin zero) of the parallel instruction that produces\nthe output to be consumed by this input.  This index is relative\nto the list of instructions in this input's instruction's\ncontaining MapTask.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "outputNum": {
+          "description": "The output index (origin zero) within the producer.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "InstructionInput"
+    },
+    "StageSource": {
+      "properties": {
+        "originalTransformOrCollection": {
+          "description": "User name for the original user transform or collection with which this\nsource is most closely associated.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Dataflow service generated name for this source.",
+          "type": "string"
+        },
+        "sizeBytes": {
+          "description": "Size of the source, if measurable.",
+          "format": "int64",
+          "type": "string"
+        },
+        "userName": {
+          "description": "Human-readable name for this source; may be user or system generated.",
+          "type": "string"
+        }
+      },
+      "id": "StageSource",
+      "description": "Description of an input or output of an execution stage.",
+      "type": "object"
+    },
+    "StringList": {
+      "description": "A metric value representing a list of strings.",
+      "type": "object",
+      "properties": {
+        "elements": {
+          "description": "Elements of the list.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "StringList"
+    },
+    "DisplayData": {
+      "properties": {
+        "strValue": {
+          "description": "Contains value if the data is of string type.",
+          "type": "string"
+        },
+        "int64Value": {
+          "description": "Contains value if the data is of int64 type.",
+          "format": "int64",
+          "type": "string"
+        },
+        "durationValue": {
+          "description": "Contains value if the data is of duration type.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "namespace": {
+          "description": "The namespace for the key. This is usually a class name or programming\nlanguage namespace (i.e. python module) which defines the display data.\nThis allows a dax monitoring system to specially handle the data\nand perform custom rendering.",
+          "type": "string"
+        },
+        "floatValue": {
+          "description": "Contains value if the data is of float type.",
+          "format": "float",
+          "type": "number"
+        },
+        "key": {
+          "description": "The key identifying the display data.\nThis is intended to be used as a label for the display data\nwhen viewed in a dax monitoring system.",
+          "type": "string"
+        },
+        "shortStrValue": {
+          "description": "A possible additional shorter value to display.\nFor example a java_class_name_value of com.mypackage.MyDoFn\nwill be stored with MyDoFn as the short_str_value and\ncom.mypackage.MyDoFn as the java_class_name value.\nshort_str_value can be displayed and java_class_name_value\nwill be displayed as a tooltip.",
+          "type": "string"
+        },
+        "url": {
+          "description": "An optional full URL.",
+          "type": "string"
+        },
+        "label": {
+          "description": "An optional label to display in a dax UI for the element.",
+          "type": "string"
+        },
+        "timestampValue": {
+          "description": "Contains value if the data is of timestamp type.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "javaClassValue": {
+          "description": "Contains value if the data is of java class type.",
+          "type": "string"
+        },
+        "boolValue": {
+          "description": "Contains value if the data is of a boolean type.",
+          "type": "boolean"
+        }
+      },
+      "id": "DisplayData",
+      "description": "Data provided with a pipeline or transform to provide descriptive info.",
+      "type": "object"
+    },
+    "LeaseWorkItemRequest": {
+      "properties": {
+        "currentWorkerTime": {
+          "description": "The current timestamp at the worker.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "workItemTypes": {
+          "description": "Filter for WorkItem type.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "location": {
+          "description": "The location which contains the WorkItem's job.",
+          "type": "string"
+        },
+        "workerCapabilities": {
+          "description": "Worker capabilities. WorkItems might be limited to workers with specific\ncapabilities.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "workerId": {
+          "description": "Identifies the worker leasing work -- typically the ID of the\nvirtual machine running the worker.",
+          "type": "string"
+        },
+        "requestedLeaseDuration": {
+          "description": "The initial lease period.",
+          "format": "google-duration",
+          "type": "string"
+        }
+      },
+      "id": "LeaseWorkItemRequest",
+      "description": "Request to lease WorkItems.",
+      "type": "object"
+    },
+    "GetDebugConfigRequest": {
+      "properties": {
+        "componentId": {
+          "description": "The internal component id for which debug configuration is\nrequested.",
+          "type": "string"
+        },
+        "workerId": {
+          "description": "The worker id, i.e., VM hostname.",
+          "type": "string"
+        }
+      },
+      "id": "GetDebugConfigRequest",
+      "description": "Request to get updated debug configuration for component.",
+      "type": "object"
+    },
+    "GetTemplateResponse": {
+      "properties": {
+        "metadata": {
+          "$ref": "TemplateMetadata",
+          "description": "The template metadata describing the template name, available\nparameters, etc."
+        },
+        "status": {
+          "$ref": "Status",
+          "description": "The status of the get template request. Any problems with the\nrequest will be indicated in the error_details."
+        }
+      },
+      "id": "GetTemplateResponse",
+      "description": "The response to a GetTemplate request.",
+      "type": "object"
+    },
+    "ReportWorkItemStatusRequest": {
+      "description": "Request to report the status of WorkItems.",
+      "type": "object",
+      "properties": {
+        "workItemStatuses": {
+          "description": "The order is unimportant, except that the order of the\nWorkItemServiceState messages in the ReportWorkItemStatusResponse\ncorresponds to the order of WorkItemStatus messages here.",
+          "type": "array",
+          "items": {
+            "$ref": "WorkItemStatus"
+          }
+        },
+        "workerId": {
+          "description": "The ID of the worker reporting the WorkItem status.  If this\ndoes not match the ID of the worker which the Dataflow service\nbelieves currently has the lease on the WorkItem, the report\nwill be dropped (with an error response).",
+          "type": "string"
+        },
+        "currentWorkerTime": {
+          "description": "The current timestamp at the worker.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "location": {
+          "description": "The location which contains the WorkItem's job.",
+          "type": "string"
+        }
+      },
+      "id": "ReportWorkItemStatusRequest"
+    },
+    "PipelineDescription": {
+      "properties": {
+        "originalPipelineTransform": {
+          "description": "Description of each transform in the pipeline and collections between them.",
+          "type": "array",
+          "items": {
+            "$ref": "TransformSummary"
+          }
+        },
+        "displayData": {
+          "description": "Pipeline level display data.",
+          "type": "array",
+          "items": {
+            "$ref": "DisplayData"
+          }
+        },
+        "executionPipelineStage": {
+          "description": "Description of each stage of execution of the pipeline.",
+          "type": "array",
+          "items": {
+            "$ref": "ExecutionStageSummary"
+          }
+        }
+      },
+      "id": "PipelineDescription",
+      "description": "A descriptive representation of submitted pipeline as well as the executed\nform.  This data is provided by the Dataflow service for ease of visualizing\nthe pipeline and interpretting Dataflow provided metrics.",
+      "type": "object"
+    },
+    "StreamingConfigTask": {
+      "properties": {
+        "userStepToStateFamilyNameMap": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Map from user step names to state families.",
+          "type": "object"
+        },
+        "streamingComputationConfigs": {
+          "description": "Set of computation configuration information.",
+          "type": "array",
+          "items": {
+            "$ref": "StreamingComputationConfig"
+          }
+        }
+      },
+      "id": "StreamingConfigTask",
+      "description": "A task that carries configuration information for streaming computations.",
+      "type": "object"
+    },
+    "JobExecutionInfo": {
+      "properties": {
+        "stages": {
+          "additionalProperties": {
+            "$ref": "JobExecutionStageInfo"
+          },
+          "description": "A mapping from each stage to the information about that stage.",
+          "type": "object"
+        }
+      },
+      "id": "JobExecutionInfo",
+      "description": "Additional information about how a Cloud Dataflow job will be executed that\nisn't contained in the submitted job.",
+      "type": "object"
+    },
+    "Step": {
+      "description": "Defines a particular step within a Cloud Dataflow job.\n\nA job consists of multiple steps, each of which performs some\nspecific operation as part of the overall job.  Data is typically\npassed from one step to another as part of the job.\n\nHere's an example of a sequence of steps which together implement a\nMap-Reduce job:\n\n  * Read a collection of data from some source, parsing the\n    collection's elements.\n\n  * Validate the elements.\n\n  * Apply a user-defined function to map each element to some value\n    and extract an element-specific key value.\n\n  * Group elements with the same key into a single element with\n    that key, transforming a multiply-keyed collection into a\n    uniquely-keyed collection.\n\n  * Write the elements out to some data sink.\n\nNote that the Cloud Dataflow service may be used to run many different\ntypes of jobs, not just Map-Reduce.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name that identifies the step. This must be unique for each\nstep with respect to all other steps in the Cloud Dataflow job.",
+          "type": "string"
+        },
+        "kind": {
+          "description": "The kind of step in the Cloud Dataflow job.",
+          "type": "string"
+        },
+        "properties": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "Named properties associated with the step. Each kind of\npredefined step has its own required set of properties.\nMust be provided on Create.  Only retrieved with JOB_VIEW_ALL.",
+          "type": "object"
+        }
+      },
+      "id": "Step"
+    },
+    "FailedLocation": {
+      "description": "Indicates which location failed to respond to a request for data.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the failed location.",
+          "type": "string"
+        }
+      },
+      "id": "FailedLocation"
+    },
+    "Disk": {
+      "properties": {
+        "sizeGb": {
+          "description": "Size of disk in GB.  If zero or unspecified, the service will\nattempt to choose a reasonable default.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "diskType": {
+          "description": "Disk storage type, as defined by Google Compute Engine.  This\nmust be a disk type appropriate to the project and zone in which\nthe workers will run.  If unknown or unspecified, the service\nwill attempt to choose a reasonable default.\n\nFor example, the standard persistent disk type is a resource name\ntypically ending in \"pd-standard\".  If SSD persistent disks are\navailable, the resource name typically ends with \"pd-ssd\".  The\nactual valid values are defined the Google Compute Engine API,\nnot by the Cloud Dataflow API; consult the Google Compute Engine\ndocumentation for more information about determining the set of\navailable disk types for a particular project and zone.\n\nGoogle Compute Engine Disk types are local to a particular\nproject in a particular zone, and so the resource name will\ntypically look something like this:\n\ncompute.googleapis.com/projects/project-id/zones/zone/diskTypes/pd-standard",
+          "type": "string"
+        },
+        "mountPoint": {
+          "description": "Directory in a VM where disk is mounted.",
+          "type": "string"
+        }
+      },
+      "id": "Disk",
+      "description": "Describes the data disk used by a workflow job.",
+      "type": "object"
+    },
+    "CounterMetadata": {
+      "description": "CounterMetadata includes all static non-name non-value counter attributes.",
+      "type": "object",
+      "properties": {
+        "standardUnits": {
+          "enumDescriptions": [
+            "Counter returns a value in bytes.",
+            "Counter returns a value in bytes per second.",
+            "Counter returns a value in milliseconds.",
+            "Counter returns a value in microseconds.",
+            "Counter returns a value in nanoseconds.",
+            "Counter returns a timestamp in milliseconds.",
+            "Counter returns a timestamp in microseconds.",
+            "Counter returns a timestamp in nanoseconds."
+          ],
+          "enum": [
+            "BYTES",
+            "BYTES_PER_SEC",
+            "MILLISECONDS",
+            "MICROSECONDS",
+            "NANOSECONDS",
+            "TIMESTAMP_MSEC",
+            "TIMESTAMP_USEC",
+            "TIMESTAMP_NSEC"
+          ],
+          "description": "System defined Units, see above enum.",
+          "type": "string"
+        },
+        "otherUnits": {
+          "description": "A string referring to the unit type.",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "INVALID",
+            "SUM",
+            "MAX",
+            "MIN",
+            "MEAN",
+            "OR",
+            "AND",
+            "SET",
+            "DISTRIBUTION"
+          ],
+          "description": "Counter aggregation kind.",
+          "type": "string",
+          "enumDescriptions": [
+            "Counter aggregation kind was not set.",
+            "Aggregated value is the sum of all contributed values.",
+            "Aggregated value is the max of all contributed values.",
+            "Aggregated value is the min of all contributed values.",
+            "Aggregated value is the mean of all contributed values.",
+            "Aggregated value represents the logical 'or' of all contributed values.",
+            "Aggregated value represents the logical 'and' of all contributed values.",
+            "Aggregated value is a set of unique contributed values.",
+            "Aggregated value captures statistics about a distribution."
+          ]
+        },
+        "description": {
+          "description": "Human-readable description of the counter semantics.",
+          "type": "string"
+        }
+      },
+      "id": "CounterMetadata"
+    },
+    "ListJobMessagesResponse": {
+      "properties": {
+        "jobMessages": {
+          "description": "Messages in ascending timestamp order.",
+          "type": "array",
+          "items": {
+            "$ref": "JobMessage"
+          }
+        },
+        "nextPageToken": {
+          "description": "The token to obtain the next page of results if there are more.",
+          "type": "string"
+        }
+      },
+      "id": "ListJobMessagesResponse",
+      "description": "Response to a request to list job messages.",
+      "type": "object"
+    },
+    "ApproximateReportedProgress": {
+      "properties": {
+        "fractionConsumed": {
+          "description": "Completion as fraction of the input consumed, from 0.0 (beginning, nothing\nconsumed), to 1.0 (end of the input, entire input consumed).",
+          "format": "double",
+          "type": "number"
+        },
+        "consumedParallelism": {
+          "$ref": "ReportedParallelism",
+          "description": "Total amount of parallelism in the portion of input of this task that has\nalready been consumed and is no longer active. In the first two examples\nabove (see remaining_parallelism), the value should be 29 or 2\nrespectively.  The sum of remaining_parallelism and consumed_parallelism\nshould equal the total amount of parallelism in this work item.  If\nspecified, must be finite."
+        },
+        "remainingParallelism": {
+          "description": "Total amount of parallelism in the input of this task that remains,\n(i.e. can be delegated to this task and any new tasks via dynamic\nsplitting). Always at least 1 for non-finished work items and 0 for\nfinished.\n\n\"Amount of parallelism\" refers to how many non-empty parts of the input\ncan be read in parallel. This does not necessarily equal number\nof records. An input that can be read in parallel down to the\nindividual records is called \"perfectly splittable\".\nAn example of non-perfectly parallelizable input is a block-compressed\nfile format where a block of records has to be read as a whole,\nbut different blocks can be read in parallel.\n\nExamples:\n* If we are processing record #30 (starting at 1) out of 50 in a perfectly\n  splittable 50-record input, this value should be 21 (20 remaining + 1\n  current).\n* If we are reading through block 3 in a block-compressed file consisting\n  of 5 blocks, this value should be 3 (since blocks 4 and 5 can be\n  processed in parallel by new tasks via dynamic splitting and the current\n  task remains processing block 3).\n* If we are reading through the last block in a block-compressed file,\n  or reading or processing the last record in a perfectly splittable\n  input, this value should be 1, because apart from the current task, no\n  additional remainder can be split off.",
+          "$ref": "ReportedParallelism"
+        },
+        "position": {
+          "$ref": "Position",
+          "description": "A Position within the work to represent a progress."
+        }
+      },
+      "id": "ApproximateReportedProgress",
+      "description": "A progress measurement of a WorkItem by a worker.",
+      "type": "object"
+    },
+    "StateFamilyConfig": {
+      "description": "State family configuration.",
+      "type": "object",
+      "properties": {
+        "isRead": {
+          "description": "If true, this family corresponds to a read operation.",
+          "type": "boolean"
+        },
+        "stateFamily": {
+          "description": "The state family value.",
+          "type": "string"
+        }
+      },
+      "id": "StateFamilyConfig"
+    },
+    "IntegerList": {
+      "properties": {
+        "elements": {
+          "description": "Elements of the list.",
+          "type": "array",
+          "items": {
+            "$ref": "SplitInt64"
+          }
+        }
+      },
+      "id": "IntegerList",
+      "description": "A metric value representing a list of integers.",
+      "type": "object"
+    },
+    "ResourceUtilizationReportResponse": {
+      "description": "Service-side response to WorkerMessage reporting resource utilization.",
+      "type": "object",
+      "properties": {},
+      "id": "ResourceUtilizationReportResponse"
+    },
+    "SourceSplitResponse": {
+      "properties": {
+        "outcome": {
+          "enum": [
+            "SOURCE_SPLIT_OUTCOME_UNKNOWN",
+            "SOURCE_SPLIT_OUTCOME_USE_CURRENT",
+            "SOURCE_SPLIT_OUTCOME_SPLITTING_HAPPENED"
+          ],
+          "description": "Indicates whether splitting happened and produced a list of bundles.\nIf this is USE_CURRENT_SOURCE_AS_IS, the current source should\nbe processed \"as is\" without splitting. \"bundles\" is ignored in this case.\nIf this is SPLITTING_HAPPENED, then \"bundles\" contains a list of\nbundles into which the source was split.",
+          "type": "string",
+          "enumDescriptions": [
+            "The source split outcome is unknown, or unspecified.",
+            "The current source should be processed \"as is\" without splitting.",
+            "Splitting produced a list of bundles."
+          ]
+        },
+        "bundles": {
+          "description": "If outcome is SPLITTING_HAPPENED, then this is a list of bundles\ninto which the source was split. Otherwise this field is ignored.\nThis list can be empty, which means the source represents an empty input.",
+          "type": "array",
+          "items": {
+            "$ref": "DerivedSource"
+          }
+        },
+        "shards": {
+          "description": "DEPRECATED in favor of bundles.",
+          "type": "array",
+          "items": {
+            "$ref": "SourceSplitShard"
+          }
+        }
+      },
+      "id": "SourceSplitResponse",
+      "description": "The response to a SourceSplitRequest.",
+      "type": "object"
+    },
+    "ParallelInstruction": {
+      "properties": {
+        "write": {
+          "$ref": "WriteInstruction",
+          "description": "Additional information for Write instructions."
+        },
+        "systemName": {
+          "description": "System-defined name of this operation.\nUnique across the workflow.",
+          "type": "string"
+        },
+        "partialGroupByKey": {
+          "description": "Additional information for PartialGroupByKey instructions.",
+          "$ref": "PartialGroupByKeyInstruction"
+        },
+        "outputs": {
+          "description": "Describes the outputs of the instruction.",
+          "type": "array",
+          "items": {
+            "$ref": "InstructionOutput"
+          }
+        },
+        "name": {
+          "description": "User-provided name of this operation.",
+          "type": "string"
+        },
+        "parDo": {
+          "$ref": "ParDoInstruction",
+          "description": "Additional information for ParDo instructions."
+        },
+        "read": {
+          "$ref": "ReadInstruction",
+          "description": "Additional information for Read instructions."
+        },
+        "flatten": {
+          "$ref": "FlattenInstruction",
+          "description": "Additional information for Flatten instructions."
+        },
+        "originalName": {
+          "description": "System-defined name for the operation in the original workflow graph.",
+          "type": "string"
+        }
+      },
+      "id": "ParallelInstruction",
+      "description": "Describes a particular operation comprising a MapTask.",
+      "type": "object"
+    },
+    "Package": {
+      "description": "The packages that must be installed in order for a worker to run the\nsteps of the Cloud Dataflow job that will be assigned to its worker\npool.\n\nThis is the mechanism by which the Cloud Dataflow SDK causes code to\nbe loaded onto the workers. For example, the Cloud Dataflow Java SDK\nmight use this to install jars containing the user's code and all of the\nvarious dependencies (libraries, data files, etc.) required in order\nfor that code to run.",
+      "type": "object",
+      "properties": {
+        "name": {
+          "description": "The name of the package.",
+          "type": "string"
+        },
+        "location": {
+          "description": "The resource to read the package from. The supported resource type is:\n\nGoogle Cloud Storage:\n\n  storage.googleapis.com/{bucket}\n  bucket.storage.googleapis.com/",
+          "type": "string"
+        }
+      },
+      "id": "Package"
+    },
+    "KeyRangeDataDiskAssignment": {
+      "description": "Data disk assignment information for a specific key-range of a sharded\ncomputation.\nCurrently we only support UTF-8 character splits to simplify encoding into\nJSON.",
+      "type": "object",
+      "properties": {
+        "start": {
+          "description": "The start (inclusive) of the key range.",
+          "type": "string"
+        },
+        "dataDisk": {
+          "description": "The name of the data disk where data for this range is stored.\nThis name is local to the Google Cloud Platform project and uniquely\nidentifies the disk within that project, for example\n\"myproject-1014-104817-4c2-harness-0-disk-1\".",
+          "type": "string"
+        },
+        "end": {
+          "description": "The end (exclusive) of the key range.",
+          "type": "string"
+        }
+      },
+      "id": "KeyRangeDataDiskAssignment"
+    },
+    "ParDoInstruction": {
+      "properties": {
+        "input": {
+          "description": "The input.",
+          "$ref": "InstructionInput"
+        },
+        "numOutputs": {
+          "description": "The number of outputs.",
+          "format": "int32",
+          "type": "integer"
+        },
+        "sideInputs": {
+          "description": "Zero or more side inputs.",
+          "type": "array",
+          "items": {
+            "$ref": "SideInputInfo"
+          }
+        },
+        "multiOutputInfos": {
+          "description": "Information about each of the outputs, if user_fn is a  MultiDoFn.",
+          "type": "array",
+          "items": {
+            "$ref": "MultiOutputInfo"
+          }
+        },
+        "userFn": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The user function to invoke.",
+          "type": "object"
+        }
+      },
+      "id": "ParDoInstruction",
+      "description": "An instruction that does a ParDo operation.\nTakes one main input and zero or more side inputs, and produces\nzero or more outputs.\nRuns user code.",
+      "type": "object"
+    },
+    "CounterStructuredName": {
+      "description": "Identifies a counter within a per-job namespace. Counters whose structured\nnames are the same get merged into a single value for the job.",
+      "type": "object",
+      "properties": {
+        "portion": {
+          "enumDescriptions": [
+            "Counter portion has not been set.",
+            "Counter reports a key.",
+            "Counter reports a value."
+          ],
+          "enum": [
+            "ALL",
+            "KEY",
+            "VALUE"
+          ],
+          "description": "Portion of this counter, either key or value.",
+          "type": "string"
+        },
+        "originalStepName": {
+          "description": "System generated name of the original step in the user's graph, before\noptimization.",
+          "type": "string"
+        },
+        "workerId": {
+          "description": "ID of a particular worker.",
+          "type": "string"
+        },
+        "originNamespace": {
+          "description": "A string containing a more specific namespace of the counter's origin.",
+          "type": "string"
+        },
+        "executionStepName": {
+          "description": "Name of the stage. An execution step contains multiple component steps.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Counter name. Not necessarily globally-unique, but unique within the\ncontext of the other fields.\nRequired.",
+          "type": "string"
+        },
+        "origin": {
+          "enumDescriptions": [
+            "Counter was created by the Dataflow system.",
+            "Counter was created by the user."
+          ],
+          "enum": [
+            "SYSTEM",
+            "USER"
+          ],
+          "description": "One of the standard Origins defined above.",
+          "type": "string"
+        },
+        "componentStepName": {
+          "description": "Name of the optimized step being executed by the workers.",
+          "type": "string"
+        }
+      },
+      "id": "CounterStructuredName"
+    },
+    "MetricUpdate": {
+      "description": "Describes the state of a metric.",
+      "type": "object",
+      "properties": {
+        "cumulative": {
+          "description": "True if this metric is reported as the total cumulative aggregate\nvalue accumulated since the worker started working on this WorkItem.\nBy default this is false, indicating that this metric is reported\nas a delta that is not associated with any WorkItem.",
+          "type": "boolean"
+        },
+        "internal": {
+          "description": "Worker-computed aggregate value for internal use by the Dataflow\nservice.",
+          "type": "any"
+        },
+        "kind": {
+          "description": "Metric aggregation kind.  The possible metric aggregation kinds are\n\"Sum\", \"Max\", \"Min\", \"Mean\", \"Set\", \"And\", and \"Or\".\nThe specified aggregation kind is case-insensitive.\n\nIf omitted, this is not an aggregated value but instead\na single metric sample value.",
+          "type": "string"
+        },
+        "scalar": {
+          "description": "Worker-computed aggregate value for aggregation kinds \"Sum\", \"Max\", \"Min\",\n\"And\", and \"Or\".  The possible value types are Long, Double, and Boolean.",
+          "type": "any"
+        },
+        "meanCount": {
+          "description": "Worker-computed aggregate value for the \"Mean\" aggregation kind.\nThis holds the count of the aggregated values and is used in combination\nwith mean_sum above to obtain the actual mean aggregate value.\nThe only possible value type is Long.",
+          "type": "any"
+        },
+        "meanSum": {
+          "description": "Worker-computed aggregate value for the \"Mean\" aggregation kind.\nThis holds the sum of the aggregated values and is used in combination\nwith mean_count below to obtain the actual mean aggregate value.\nThe only possible value types are Long and Double.",
+          "type": "any"
+        },
+        "updateTime": {
+          "description": "Timestamp associated with the metric value. Optional when workers are\nreporting work progress; it will be filled in responses from the\nmetrics API.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "name": {
+          "$ref": "MetricStructuredName",
+          "description": "Name of the metric."
+        },
+        "set": {
+          "description": "Worker-computed aggregate value for the \"Set\" aggregation kind.  The only\npossible value type is a list of Values whose type can be Long, Double,\nor String, according to the metric's type.  All Values in the list must\nbe of the same type.",
+          "type": "any"
+        }
+      },
+      "id": "MetricUpdate"
+    },
+    "ApproximateProgress": {
+      "description": "Obsolete in favor of ApproximateReportedProgress and ApproximateSplitRequest.",
+      "type": "object",
+      "properties": {
+        "percentComplete": {
+          "description": "Obsolete.",
+          "format": "float",
+          "type": "number"
+        },
+        "remainingTime": {
+          "description": "Obsolete.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "position": {
+          "description": "Obsolete.",
+          "$ref": "Position"
+        }
+      },
+      "id": "ApproximateProgress"
+    },
+    "WorkerMessageResponse": {
+      "properties": {
+        "workerMetricsResponse": {
+          "description": "Service's response to reporting worker metrics (currently empty).",
+          "$ref": "ResourceUtilizationReportResponse"
+        },
+        "workerHealthReportResponse": {
+          "description": "The service's response to a worker's health report.",
+          "$ref": "WorkerHealthReportResponse"
+        }
+      },
+      "id": "WorkerMessageResponse",
+      "description": "A worker_message response allows the server to pass information to the\nsender.",
+      "type": "object"
+    },
+    "TemplateMetadata": {
+      "properties": {
+        "bypassTempDirValidation": {
+          "description": "If true, will bypass the validation that the temp directory is\nwritable. This should only be used with templates for pipelines\nthat are guaranteed not to need to write to the temp directory,\nwhich is subject to change based on the optimizer.",
+          "type": "boolean"
+        },
+        "name": {
+          "description": "Required. The name of the template.",
+          "type": "string"
+        },
+        "parameters": {
+          "description": "The parameters for the template.",
+          "type": "array",
+          "items": {
+            "$ref": "ParameterMetadata"
+          }
+        },
+        "description": {
+          "description": "Optional. A description of the template.",
+          "type": "string"
+        }
+      },
+      "id": "TemplateMetadata",
+      "description": "Metadata describing a template.",
+      "type": "object"
+    },
+    "WorkerMessage": {
+      "properties": {
+        "workerMessageCode": {
+          "description": "A worker message code.",
+          "$ref": "WorkerMessageCode"
+        },
+        "workerMetrics": {
+          "description": "Resource metrics reported by workers.",
+          "$ref": "ResourceUtilizationReport"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Labels are used to group WorkerMessages.\nFor example, a worker_message about a particular container\nmight have the labels:\n{ \"JOB_ID\": \"2015-04-22\",\n  \"WORKER_ID\": \"wordcount-vm-2015…\"\n  \"CONTAINER_TYPE\": \"worker\",\n  \"CONTAINER_ID\": \"ac1234def\"}\nLabel tags typically correspond to Label enum values. However, for ease\nof development other strings can be used as tags. LABEL_UNSPECIFIED should\nnot be used here.",
+          "type": "object"
+        },
+        "time": {
+          "description": "The timestamp of the worker_message.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "workerHealthReport": {
+          "description": "The health of a worker.",
+          "$ref": "WorkerHealthReport"
+        }
+      },
+      "id": "WorkerMessage",
+      "description": "WorkerMessage provides information to the backend about a worker.",
+      "type": "object"
+    },
+    "JobMetrics": {
+      "properties": {
+        "metricTime": {
+          "description": "Timestamp as of which metric values are current.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "metrics": {
+          "description": "All metrics for this job.",
+          "type": "array",
+          "items": {
+            "$ref": "MetricUpdate"
+          }
+        }
+      },
+      "id": "JobMetrics",
+      "description": "JobMetrics contains a collection of metrics descibing the detailed progress\nof a Dataflow job. Metrics correspond to user-defined and system-defined\nmetrics in the job.\n\nThis resource captures only the most recent values of each metric;\ntime-series data can be queried for them (under the same metric names)\nfrom Cloud Monitoring.",
+      "type": "object"
+    },
+    "FloatingPointList": {
+      "description": "A metric value representing a list of floating point numbers.",
+      "type": "object",
+      "properties": {
+        "elements": {
+          "description": "Elements of the list.",
+          "type": "array",
+          "items": {
+            "format": "double",
+            "type": "number"
+          }
+        }
+      },
+      "id": "FloatingPointList"
+    },
+    "CounterUpdate": {
+      "properties": {
+        "boolean": {
+          "description": "Boolean value for And, Or.",
+          "type": "boolean"
+        },
+        "nameAndKind": {
+          "description": "Counter name and aggregation type.",
+          "$ref": "NameAndKind"
+        },
+        "distribution": {
+          "$ref": "DistributionUpdate",
+          "description": "Distribution data"
+        },
+        "stringList": {
+          "$ref": "StringList",
+          "description": "List of strings, for Set."
+        },
+        "shortId": {
+          "description": "The service-generated short identifier for this counter.\nThe short_id -\u003e (name, metadata) mapping is constant for the lifetime of\na job.",
+          "format": "int64",
+          "type": "string"
+        },
+        "floatingPointList": {
+          "description": "List of floating point numbers, for Set.",
+          "$ref": "FloatingPointList"
+        },
+        "integer": {
+          "$ref": "SplitInt64",
+          "description": "Integer value for Sum, Max, Min."
+        },
+        "integerList": {
+          "$ref": "IntegerList",
+          "description": "List of integers, for Set."
+        },
+        "structuredNameAndMetadata": {
+          "description": "Counter structured name and metadata.",
+          "$ref": "CounterStructuredNameAndMetadata"
+        },
+        "floatingPoint": {
+          "description": "Floating point value for Sum, Max, Min.",
+          "format": "double",
+          "type": "number"
+        },
+        "integerMean": {
+          "$ref": "IntegerMean",
+          "description": "Integer mean aggregation value for Mean."
+        },
+        "internal": {
+          "description": "Value for internally-defined counters used by the Dataflow service.",
+          "type": "any"
+        },
+        "cumulative": {
+          "description": "True if this counter is reported as the total cumulative aggregate\nvalue accumulated since the worker started working on this WorkItem.\nBy default this is false, indicating that this counter is reported\nas a delta.",
+          "type": "boolean"
+        },
+        "floatingPointMean": {
+          "description": "Floating point mean aggregation value for Mean.",
+          "$ref": "FloatingPointMean"
+        }
+      },
+      "id": "CounterUpdate",
+      "description": "An update to a Counter sent from a worker.",
+      "type": "object"
+    },
+    "SourceMetadata": {
+      "description": "Metadata about a Source useful for automatically optimizing\nand tuning the pipeline, etc.",
+      "type": "object",
+      "properties": {
+        "producesSortedKeys": {
+          "description": "Whether this source is known to produce key/value pairs with\nthe (encoded) keys in lexicographically sorted order.",
+          "type": "boolean"
+        },
+        "infinite": {
+          "description": "Specifies that the size of this source is known to be infinite\n(this is a streaming source).",
+          "type": "boolean"
+        },
+        "estimatedSizeBytes": {
+          "description": "An estimate of the total size (in bytes) of the data that would be\nread from this source.  This estimate is in terms of external storage\nsize, before any decompression or other processing done by the reader.",
+          "format": "int64",
+          "type": "string"
+        }
+      },
+      "id": "SourceMetadata"
+    },
+    "DistributionUpdate": {
+      "properties": {
+        "max": {
+          "$ref": "SplitInt64",
+          "description": "The maximum value present in the distribution."
+        },
+        "sum": {
+          "$ref": "SplitInt64",
+          "description": "Use an int64 since we'd prefer the added precision. If overflow is a common\nproblem we can detect it and use an additional int64 or a double."
+        },
+        "count": {
+          "$ref": "SplitInt64",
+          "description": "The count of the number of elements present in the distribution."
+        },
+        "min": {
+          "$ref": "SplitInt64",
+          "description": "The minimum value present in the distribution."
+        },
+        "sumOfSquares": {
+          "description": "Use a double since the sum of squares is likely to overflow int64.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "id": "DistributionUpdate",
+      "description": "A metric value representing a distribution.",
+      "type": "object"
+    },
+    "SourceFork": {
+      "properties": {
+        "residual": {
+          "description": "DEPRECATED",
+          "$ref": "SourceSplitShard"
+        },
+        "residualSource": {
+          "$ref": "DerivedSource",
+          "description": "DEPRECATED"
+        },
+        "primary": {
+          "$ref": "SourceSplitShard",
+          "description": "DEPRECATED"
+        },
+        "primarySource": {
+          "description": "DEPRECATED",
+          "$ref": "DerivedSource"
+        }
+      },
+      "id": "SourceFork",
+      "description": "DEPRECATED in favor of DynamicSourceSplit.",
+      "type": "object"
+    },
+    "WorkerHealthReportResponse": {
+      "description": "WorkerHealthReportResponse contains information returned to the worker\nin response to a health ping.",
+      "type": "object",
+      "properties": {
+        "reportInterval": {
+          "description": "A positive value indicates the worker should change its reporting interval\nto the specified value.\n\nThe default value of zero means no change in report rate is requested by\nthe server.",
+          "format": "google-duration",
+          "type": "string"
+        }
+      },
+      "id": "WorkerHealthReportResponse"
+    },
+    "WorkItemStatus": {
+      "description": "Conveys a worker's progress through the work described by a WorkItem.",
+      "type": "object",
+      "properties": {
+        "metricUpdates": {
+          "description": "DEPRECATED in favor of counter_updates.",
+          "type": "array",
+          "items": {
+            "$ref": "MetricUpdate"
+          }
+        },
+        "errors": {
+          "description": "Specifies errors which occurred during processing.  If errors are\nprovided, and completed = true, then the WorkItem is considered\nto have failed.",
+          "type": "array",
+          "items": {
+            "$ref": "Status"
+          }
+        },
+        "dynamicSourceSplit": {
+          "$ref": "DynamicSourceSplit",
+          "description": "See documentation of stop_position."
+        },
+        "sourceOperationResponse": {
+          "$ref": "SourceOperationResponse",
+          "description": "If the work item represented a SourceOperationRequest, and the work\nis completed, contains the result of the operation."
+        },
+        "progress": {
+          "description": "DEPRECATED in favor of reported_progress.",
+          "$ref": "ApproximateProgress"
+        },
+        "requestedLeaseDuration": {
+          "description": "Amount of time the worker requests for its lease.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "reportIndex": {
+          "description": "The report index.  When a WorkItem is leased, the lease will\ncontain an initial report index.  When a WorkItem's status is\nreported to the system, the report should be sent with\nthat report index, and the response will contain the index the\nworker should use for the next report.  Reports received with\nunexpected index values will be rejected by the service.\n\nIn order to preserve idempotency, the worker should not alter the\ncontents of a report, even if the worker must submit the same\nreport multiple times before getting back a response.  The worker\nshould not submit a subsequent report until the response for the\nprevious report had been received from the service.",
+          "format": "int64",
+          "type": "string"
+        },
+        "stopPosition": {
+          "description": "A worker may split an active map task in two parts, \"primary\" and\n\"residual\", continuing to process the primary part and returning the\nresidual part into the pool of available work.\nThis event is called a \"dynamic split\" and is critical to the dynamic\nwork rebalancing feature. The two obtained sub-tasks are called\n\"parts\" of the split.\nThe parts, if concatenated, must represent the same input as would\nbe read by the current task if the split did not happen.\nThe exact way in which the original task is decomposed into the two\nparts is specified either as a position demarcating them\n(stop_position), or explicitly as two DerivedSources, if this\ntask consumes a user-defined source type (dynamic_source_split).\n\nThe \"current\" task is adjusted as a result of the split: after a task\nwith range [A, B) sends a stop_position update at C, its range is\nconsidered to be [A, C), e.g.:\n* Progress should be interpreted relative to the new range, e.g.\n  \"75% completed\" means \"75% of [A, C) completed\"\n* The worker should interpret proposed_stop_position relative to the\n  new range, e.g. \"split at 68%\" should be interpreted as\n  \"split at 68% of [A, C)\".\n* If the worker chooses to split again using stop_position, only\n  stop_positions in [A, C) will be accepted.\n* Etc.\ndynamic_source_split has similar semantics: e.g., if a task with\nsource S splits using dynamic_source_split into {P, R}\n(where P and R must be together equivalent to S), then subsequent\nprogress and proposed_stop_position should be interpreted relative\nto P, and in a potential subsequent dynamic_source_split into {P', R'},\nP' and R' must be together equivalent to P, etc.",
+          "$ref": "Position"
+        },
+        "completed": {
+          "description": "True if the WorkItem was completed (successfully or unsuccessfully).",
+          "type": "boolean"
+        },
+        "reportedProgress": {
+          "description": "The worker's progress through this WorkItem.",
+          "$ref": "ApproximateReportedProgress"
+        },
+        "sourceFork": {
+          "$ref": "SourceFork",
+          "description": "DEPRECATED in favor of dynamic_source_split."
+        },
+        "counterUpdates": {
+          "description": "Worker output counters for this WorkItem.",
+          "type": "array",
+          "items": {
+            "$ref": "CounterUpdate"
+          }
+        },
+        "workItemId": {
+          "description": "Identifies the WorkItem.",
+          "type": "string"
+        }
+      },
+      "id": "WorkItemStatus"
+    },
+    "ComponentSource": {
+      "properties": {
+        "name": {
+          "description": "Dataflow service generated name for this source.",
+          "type": "string"
+        },
+        "userName": {
+          "description": "Human-readable name for this transform; may be user or system generated.",
+          "type": "string"
+        },
+        "originalTransformOrCollection": {
+          "description": "User name for the original user transform or collection with which this\nsource is most closely associated.",
+          "type": "string"
+        }
+      },
+      "id": "ComponentSource",
+      "description": "Description of an interstitial value between transforms in an execution\nstage.",
+      "type": "object"
+    },
+    "WorkItemServiceState": {
+      "description": "The Dataflow service's idea of the current state of a WorkItem\nbeing processed by a worker.",
+      "type": "object",
+      "properties": {
+        "leaseExpireTime": {
+          "description": "Time at which the current lease will expire.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "metricShortId": {
+          "description": "The short ids that workers should use in subsequent metric updates.\nWorkers should strive to use short ids whenever possible, but it is ok\nto request the short_id again if a worker lost track of it\n(e.g. if the worker is recovering from a crash).\nNOTE: it is possible that the response may have short ids for a subset\nof the metrics.",
+          "type": "array",
+          "items": {
+            "$ref": "MetricShortId"
+          }
+        },
+        "nextReportIndex": {
+          "description": "The index value to use for the next report sent by the worker.\nNote: If the report call fails for whatever reason, the worker should\nreuse this index for subsequent report attempts.",
+          "format": "int64",
+          "type": "string"
+        },
+        "suggestedStopPoint": {
+          "$ref": "ApproximateProgress",
+          "description": "DEPRECATED in favor of split_request."
+        },
+        "splitRequest": {
+          "$ref": "ApproximateSplitRequest",
+          "description": "The progress point in the WorkItem where the Dataflow service\nsuggests that the worker truncate the task."
+        },
+        "reportStatusInterval": {
+          "description": "New recommended reporting interval.",
+          "format": "google-duration",
+          "type": "string"
+        },
+        "suggestedStopPosition": {
+          "$ref": "Position",
+          "description": "Obsolete, always empty."
+        },
+        "harnessData": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "Other data returned by the service, specific to the particular\nworker harness.",
+          "type": "object"
+        }
+      },
+      "id": "WorkItemServiceState"
+    },
+    "MetricStructuredName": {
+      "properties": {
+        "context": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Zero or more labeled fields which identify the part of the job this\nmetric is associated with, such as the name of a step or collection.\n\nFor example, built-in counters associated with steps will have\ncontext['step'] = \u003cstep-name\u003e. Counters associated with PCollections\nin the SDK will have context['pcollection'] = \u003cpcollection-name\u003e.",
+          "type": "object"
+        },
+        "origin": {
+          "description": "Origin (namespace) of metric name. May be blank for user-define metrics;\nwill be \"dataflow\" for metrics defined by the Dataflow service or SDK.",
+          "type": "string"
+        },
+        "name": {
+          "description": "Worker-defined metric name.",
+          "type": "string"
+        }
+      },
+      "id": "MetricStructuredName",
+      "description": "Identifies a metric, by describing the source which generated the\nmetric.",
+      "type": "object"
+    },
+    "SeqMapTaskOutputInfo": {
+      "description": "Information about an output of a SeqMapTask.",
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "The id of the TupleTag the user code will tag the output value by.",
+          "type": "string"
+        },
+        "sink": {
+          "description": "The sink to write the output value to.",
+          "$ref": "Sink"
+        }
+      },
+      "id": "SeqMapTaskOutputInfo"
+    },
+    "JobExecutionStageInfo": {
+      "properties": {
+        "stepName": {
+          "description": "The steps associated with the execution stage.\nNote that stages may have several steps, and that a given step\nmight be run by more than one stage.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "id": "JobExecutionStageInfo",
+      "description": "Contains information about how a particular\ngoogle.dataflow.v1beta3.Step will be executed.",
+      "type": "object"
+    },
+    "KeyRangeLocation": {
+      "description": "Location information for a specific key-range of a sharded computation.\nCurrently we only support UTF-8 character splits to simplify encoding into\nJSON.",
+      "type": "object",
+      "properties": {
+        "start": {
+          "description": "The start (inclusive) of the key range.",
+          "type": "string"
+        },
+        "dataDisk": {
+          "description": "The name of the data disk where data for this range is stored.\nThis name is local to the Google Cloud Platform project and uniquely\nidentifies the disk within that project, for example\n\"myproject-1014-104817-4c2-harness-0-disk-1\".",
+          "type": "string"
+        },
+        "end": {
+          "description": "The end (exclusive) of the key range.",
+          "type": "string"
+        },
+        "deprecatedPersistentDirectory": {
+          "description": "DEPRECATED. The location of the persistent state for this range, as a\npersistent directory in the worker local filesystem.",
+          "type": "string"
+        },
+        "deliveryEndpoint": {
+          "description": "The physical location of this range assignment to be used for\nstreaming computation cross-worker message delivery.",
+          "type": "string"
+        }
+      },
+      "id": "KeyRangeLocation"
+    },
+    "SourceGetMetadataRequest": {
+      "description": "A request to compute the SourceMetadata of a Source.",
+      "type": "object",
+      "properties": {
+        "source": {
+          "$ref": "Source",
+          "description": "Specification of the source whose metadata should be computed."
+        }
+      },
+      "id": "SourceGetMetadataRequest"
+    },
+    "SeqMapTask": {
+      "description": "Describes a particular function to invoke.",
+      "type": "object",
+      "properties": {
+        "stageName": {
+          "description": "System-defined name of the stage containing the SeqDo operation.\nUnique across the workflow.",
+          "type": "string"
+        },
+        "systemName": {
+          "description": "System-defined name of the SeqDo operation.\nUnique across the workflow.",
+          "type": "string"
+        },
+        "userFn": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The user function to invoke.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The user-provided name of the SeqDo operation.",
+          "type": "string"
+        },
+        "outputInfos": {
+          "description": "Information about each of the outputs.",
+          "type": "array",
+          "items": {
+            "$ref": "SeqMapTaskOutputInfo"
+          }
+        },
+        "inputs": {
+          "description": "Information about each of the inputs.",
+          "type": "array",
+          "items": {
+            "$ref": "SideInputInfo"
+          }
+        }
+      },
+      "id": "SeqMapTask"
+    },
+    "NameAndKind": {
+      "properties": {
+        "name": {
+          "description": "Name of the counter.",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "INVALID",
+            "SUM",
+            "MAX",
+            "MIN",
+            "MEAN",
+            "OR",
+            "AND",
+            "SET",
+            "DISTRIBUTION"
+          ],
+          "description": "Counter aggregation kind.",
+          "type": "string",
+          "enumDescriptions": [
+            "Counter aggregation kind was not set.",
+            "Aggregated value is the sum of all contributed values.",
+            "Aggregated value is the max of all contributed values.",
+            "Aggregated value is the min of all contributed values.",
+            "Aggregated value is the mean of all contributed values.",
+            "Aggregated value represents the logical 'or' of all contributed values.",
+            "Aggregated value represents the logical 'and' of all contributed values.",
+            "Aggregated value is a set of unique contributed values.",
+            "Aggregated value captures statistics about a distribution."
+          ]
+        }
+      },
+      "id": "NameAndKind",
+      "description": "Basic metadata about a counter.",
+      "type": "object"
+    },
+    "WorkerMessageCode": {
+      "properties": {
+        "parameters": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "Parameters contains specific information about the code.\n\nThis is a struct to allow parameters of different types.\n\nExamples:\n 1. For a \"HARNESS_STARTED\" message parameters might provide the name\n    of the worker and additional data like timing information.\n 2. For a \"GCS_DOWNLOAD_ERROR\" parameters might contain fields listing\n    the GCS objects being downloaded and fields containing errors.\n\nIn general complex data structures should be avoided. If a worker\nneeds to send a specific and complicated data structure then please\nconsider defining a new proto and adding it to the data oneof in\nWorkerMessageResponse.\n\nConventions:\n Parameters should only be used for information that isn't typically passed\n as a label.\n hostname and other worker identifiers should almost always be passed\n as labels since they will be included on most messages.",
+          "type": "object"
+        },
+        "code": {
+          "description": "The code is a string intended for consumption by a machine that identifies\nthe type of message being sent.\nExamples:\n 1. \"HARNESS_STARTED\" might be used to indicate the worker harness has\n     started.\n 2. \"GCS_DOWNLOAD_ERROR\" might be used to indicate an error downloading\n    a GCS file as part of the boot process of one of the worker containers.\n\nThis is a string and not an enum to make it easy to add new codes without\nwaiting for an API change.",
+          "type": "string"
+        }
+      },
+      "id": "WorkerMessageCode",
+      "description": "A message code is used to report status and error messages to the service.\nThe message codes are intended to be machine readable. The service will\ntake care of translating these into user understandable messages if\nnecessary.\n\nExample use cases:\n  1. Worker processes reporting successful startup.\n  2. Worker processes reporting specific errors (e.g. package staging\n     failure).",
+      "type": "object"
+    },
+    "CustomSourceLocation": {
+      "properties": {
+        "stateful": {
+          "description": "Whether this source is stateful.",
+          "type": "boolean"
+        }
+      },
+      "id": "CustomSourceLocation",
+      "description": "Identifies the location of a custom souce.",
+      "type": "object"
+    },
+    "MapTask": {
+      "properties": {
+        "systemName": {
+          "description": "System-defined name of this MapTask.\nUnique across the workflow.",
+          "type": "string"
+        },
+        "stageName": {
+          "description": "System-defined name of the stage containing this MapTask.\nUnique across the workflow.",
+          "type": "string"
+        },
+        "instructions": {
+          "description": "The instructions in the MapTask.",
+          "type": "array",
+          "items": {
+            "$ref": "ParallelInstruction"
+          }
+        }
+      },
+      "id": "MapTask",
+      "description": "MapTask consists of an ordered set of instructions, each of which\ndescribes one particular low-level operation for the worker to\nperform in order to accomplish the MapTask's WorkItem.\n\nEach instruction must appear in the list before any instructions which\ndepends on its output.",
+      "type": "object"
+    },
+    "FloatingPointMean": {
+      "properties": {
+        "count": {
+          "$ref": "SplitInt64",
+          "description": "The number of values being aggregated."
+        },
+        "sum": {
+          "description": "The sum of all values being aggregated.",
+          "format": "double",
+          "type": "number"
+        }
+      },
+      "id": "FloatingPointMean",
+      "description": "A representation of a floating point mean metric contribution.",
+      "type": "object"
+    },
+    "ReportWorkItemStatusResponse": {
+      "description": "Response from a request to report the status of WorkItems.",
+      "type": "object",
+      "properties": {
+        "workItemServiceStates": {
+          "description": "A set of messages indicating the service-side state for each\nWorkItem whose status was reported, in the same order as the\nWorkItemStatus messages in the ReportWorkItemStatusRequest which\nresulting in this response.",
+          "type": "array",
+          "items": {
+            "$ref": "WorkItemServiceState"
+          }
+        }
+      },
+      "id": "ReportWorkItemStatusResponse"
+    },
+    "InstructionOutput": {
+      "description": "An output of an instruction.",
+      "type": "object",
+      "properties": {
+        "originalName": {
+          "description": "System-defined name for this output in the original workflow graph.\nOutputs that do not contribute to an original instruction do not set this.",
+          "type": "string"
+        },
+        "systemName": {
+          "description": "System-defined name of this output.\nUnique across the workflow.",
+          "type": "string"
+        },
+        "onlyCountKeyBytes": {
+          "description": "For system-generated byte and mean byte metrics, certain instructions\nshould only report the key size.",
+          "type": "boolean"
+        },
+        "onlyCountValueBytes": {
+          "description": "For system-generated byte and mean byte metrics, certain instructions\nshould only report the value size.",
+          "type": "boolean"
+        },
+        "codec": {
+          "additionalProperties": {
+            "description": "Properties of the object.",
+            "type": "any"
+          },
+          "description": "The codec to use to encode data being written via this output.",
+          "type": "object"
+        },
+        "name": {
+          "description": "The user-provided name of this output.",
+          "type": "string"
+        }
+      },
+      "id": "InstructionOutput"
+    },
+    "CreateJobFromTemplateRequest": {
+      "description": "A request to create a Cloud Dataflow job from a template.",
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The runtime parameters to pass to the job.",
+          "type": "object"
+        },
+        "jobName": {
+          "description": "Required. The job name to use for the created job.",
+          "type": "string"
+        },
+        "gcsPath": {
+          "description": "Required. A Cloud Storage path to the template from which to\ncreate the job.\nMust be a valid Cloud Storage URL, beginning with `gs://`.",
+          "type": "string"
+        },
+        "environment": {
+          "description": "The runtime environment for the job.",
+          "$ref": "RuntimeEnvironment"
+        }
+      },
+      "id": "CreateJobFromTemplateRequest"
+    },
+    "IntegerMean": {
+      "properties": {
+        "count": {
+          "$ref": "SplitInt64",
+          "description": "The number of values being aggregated."
+        },
+        "sum": {
+          "$ref": "SplitInt64",
+          "description": "The sum of all values being aggregated."
+        }
+      },
+      "id": "IntegerMean",
+      "description": "A representation of an integer mean metric contribution.",
+      "type": "object"
+    },
+    "ListJobsResponse": {
+      "description": "Response to a request to list Cloud Dataflow jobs.  This may be a partial\nresponse, depending on the page size in the ListJobsRequest.",
+      "type": "object",
+      "properties": {
+        "nextPageToken": {
+          "description": "Set if there may be more results than fit in this response.",
+          "type": "string"
+        },
+        "failedLocation": {
+          "description": "Zero or more messages describing locations that failed to respond.",
+          "type": "array",
+          "items": {
+            "$ref": "FailedLocation"
+          }
+        },
+        "jobs": {
+          "description": "A subset of the requested job information.",
+          "type": "array",
+          "items": {
+            "$ref": "Job"
+          }
+        }
+      },
+      "id": "ListJobsResponse"
+    },
+    "ComputationTopology": {
+      "description": "All configuration data for a particular Computation.",
+      "type": "object",
+      "properties": {
+        "systemStageName": {
+          "description": "The system stage name.",
+          "type": "string"
+        },
+        "inputs": {
+          "description": "The inputs to the computation.",
+          "type": "array",
+          "items": {
+            "$ref": "StreamLocation"
+          }
+        },
+        "computationId": {
+          "description": "The ID of the computation.",
+          "type": "string"
+        },
+        "keyRanges": {
+          "description": "The key ranges processed by the computation.",
+          "type": "array",
+          "items": {
+            "$ref": "KeyRangeLocation"
+          }
+        },
+        "userStageName": {
+          "description": "The user stage name.",
+          "type": "string"
+        },
+        "stateFamilies": {
+          "description": "The state family values.",
+          "type": "array",
+          "items": {
+            "$ref": "StateFamilyConfig"
+          }
+        },
+        "outputs": {
+          "description": "The outputs from the computation.",
+          "type": "array",
+          "items": {
+            "$ref": "StreamLocation"
+          }
+        }
+      },
+      "id": "ComputationTopology"
+    },
+    "RuntimeEnvironment": {
+      "properties": {
+        "zone": {
+          "description": "The Compute Engine [availability zone](https://cloud.google.com/compute/docs/regions-zones/regions-zones)\nfor launching worker instances to run your pipeline.",
+          "type": "string"
+        },
+        "serviceAccountEmail": {
+          "description": "The email address of the service account to run the job as.",
+          "type": "string"
+        },
+        "tempLocation": {
+          "description": "The Cloud Storage path to use for temporary files.\nMust be a valid Cloud Storage URL, beginning with `gs://`.",
+          "type": "string"
+        },
+        "bypassTempDirValidation": {
+          "description": "Whether to bypass the safety checks for the job's temporary directory.\nUse with caution.",
+          "type": "boolean"
+        },
+        "maxWorkers": {
+          "description": "The maximum number of Google Compute Engine instances to be made\navailable to your pipeline during execution, from 1 to 1000.",
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "id": "RuntimeEnvironment",
+      "description": "The environment values to set at runtime.",
+      "type": "object"
+    },
+    "StreamingSideInputLocation": {
+      "description": "Identifies the location of a streaming side input.",
+      "type": "object",
+      "properties": {
+        "tag": {
+          "description": "Identifies the particular side input within the streaming Dataflow job.",
+          "type": "string"
+        },
+        "stateFamily": {
+          "description": "Identifies the state family where this side input is stored.",
+          "type": "string"
+        }
+      },
+      "id": "StreamingSideInputLocation"
+    },
+    "MountedDataDisk": {
+      "description": "Describes mounted data disk.",
+      "type": "object",
+      "properties": {
+        "dataDisk": {
+          "description": "The name of the data disk.\nThis name is local to the Google Cloud Platform project and uniquely\nidentifies the disk within that project, for example\n\"myproject-1014-104817-4c2-harness-0-disk-1\".",
+          "type": "string"
+        }
+      },
+      "id": "MountedDataDisk"
+    },
+    "LaunchTemplateResponse": {
+      "description": "Response to the request to launch a template.",
+      "type": "object",
+      "properties": {
+        "job": {
+          "description": "The job that was launched, if the request was not a dry run and\nthe job was successfully launched.",
+          "$ref": "Job"
+        }
+      },
+      "id": "LaunchTemplateResponse"
+    },
+    "DerivedSource": {
+      "properties": {
+        "derivationMode": {
+          "enum": [
+            "SOURCE_DERIVATION_MODE_UNKNOWN",
+            "SOURCE_DERIVATION_MODE_INDEPENDENT",
+            "SOURCE_DERIVATION_MODE_CHILD_OF_CURRENT",
+            "SOURCE_DERIVATION_MODE_SIBLING_OF_CURRENT"
+          ],
+          "description": "What source to base the produced source on (if any).",
+          "type": "string",
+          "enumDescriptions": [
+            "The source derivation is unknown, or unspecified.",
+            "Produce a completely independent Source with no base.",
+            "Produce a Source based on the Source being split.",
+            "Produce a Source based on the base of the Source being split."
+          ]
+        },
+        "source": {
+          "description": "Specification of the source.",
+          "$ref": "Source"
+        }
+      },
+      "id": "DerivedSource",
+      "description": "Specification of one of the bundles produced as a result of splitting\na Source (e.g. when executing a SourceSplitRequest, or when\nsplitting an active task using WorkItemStatus.dynamic_source_split),\nrelative to the source being split.",
+      "type": "object"
+    },
+    "DynamicSourceSplit": {
+      "description": "When a task splits using WorkItemStatus.dynamic_source_split, this\nmessage describes the two parts of the split relative to the\ndescription of the current task's input.",
+      "type": "object",
+      "properties": {
+        "primary": {
+          "description": "Primary part (continued to be processed by worker).\nSpecified relative to the previously-current source.\nBecomes current.",
+          "$ref": "DerivedSource"
+        },
+        "residual": {
+          "$ref": "DerivedSource",
+          "description": "Residual part (returned to the pool of work).\nSpecified relative to the previously-current source."
+        }
+      },
+      "id": "DynamicSourceSplit"
+    },
+    "Job": {
+      "properties": {
+        "name": {
+          "description": "The user-specified Cloud Dataflow job name.\n\nOnly one Job with a given name may exist in a project at any\ngiven time. If a caller attempts to create a Job with the same\nname as an already-existing Job, the attempt returns the\nexisting Job.\n\nThe name must match the regular expression\n`[a-z]([-a-z0-9]{0,38}[a-z0-9])?`",
+          "type": "string"
+        },
+        "replacedByJobId": {
+          "description": "If another job is an update of this job (and thus, this job is in\n`JOB_STATE_UPDATED`), this field contains the ID of that job.",
+          "type": "string"
+        },
+        "steps": {
+          "description": "The top-level steps that constitute the entire job.",
+          "type": "array",
+          "items": {
+            "$ref": "Step"
+          }
+        },
+        "executionInfo": {
+          "$ref": "JobExecutionInfo",
+          "description": "Deprecated."
+        },
+        "id": {
+          "description": "The unique ID of this job.\n\nThis field is set by the Cloud Dataflow service when the Job is\ncreated, and is immutable for the life of the job.",
+          "type": "string"
+        },
+        "currentState": {
+          "enumDescriptions": [
+            "The job's run state isn't specified.",
+            "`JOB_STATE_STOPPED` indicates that the job has not\nyet started to run.",
+            "`JOB_STATE_RUNNING` indicates that the job is currently running.",
+            "`JOB_STATE_DONE` indicates that the job has successfully completed.\nThis is a terminal job state.  This state may be set by the Cloud Dataflow\nservice, as a transition from `JOB_STATE_RUNNING`. It may also be set via a\nCloud Dataflow `UpdateJob` call, if the job has not yet reached a terminal\nstate.",
+            "`JOB_STATE_FAILED` indicates that the job has failed.  This is a\nterminal job state.  This state may only be set by the Cloud Dataflow\nservice, and only as a transition from `JOB_STATE_RUNNING`.",
+            "`JOB_STATE_CANCELLED` indicates that the job has been explicitly\ncancelled. This is a terminal job state. This state may only be\nset via a Cloud Dataflow `UpdateJob` call, and only if the job has not\nyet reached another terminal state.",
+            "`JOB_STATE_UPDATED` indicates that the job was successfully updated,\nmeaning that this job was stopped and another job was started, inheriting\nstate from this one. This is a terminal job state. This state may only be\nset by the Cloud Dataflow service, and only as a transition from\n`JOB_STATE_RUNNING`.",
+            "`JOB_STATE_DRAINING` indicates that the job is in the process of draining.\nA draining job has stopped pulling from its input sources and is processing\nany data that remains in-flight. This state may be set via a Cloud Dataflow\n`UpdateJob` call, but only as a transition from `JOB_STATE_RUNNING`. Jobs\nthat are draining may only transition to `JOB_STATE_DRAINED`,\n`JOB_STATE_CANCELLED`, or `JOB_STATE_FAILED`.",
+            "`JOB_STATE_DRAINED` indicates that the job has been drained.\nA drained job terminated by stopping pulling from its input sources and\nprocessing any data that remained in-flight when draining was requested.\nThis state is a terminal state, may only be set by the Cloud Dataflow\nservice, and only as a transition from `JOB_STATE_DRAINING`."
+          ],
+          "enum": [
+            "JOB_STATE_UNKNOWN",
+            "JOB_STATE_STOPPED",
+            "JOB_STATE_RUNNING",
+            "JOB_STATE_DONE",
+            "JOB_STATE_FAILED",
+            "JOB_STATE_CANCELLED",
+            "JOB_STATE_UPDATED",
+            "JOB_STATE_DRAINING",
+            "JOB_STATE_DRAINED"
+          ],
+          "description": "The current state of the job.\n\nJobs are created in the `JOB_STATE_STOPPED` state unless otherwise\nspecified.\n\nA job in the `JOB_STATE_RUNNING` state may asynchronously enter a\nterminal state. After a job has reached a terminal state, no\nfurther state updates may be made.\n\nThis field may be mutated by the Cloud Dataflow service;\ncallers cannot mutate it.",
+          "type": "string"
+        },
+        "location": {
+          "description": "The location that contains this job.",
+          "type": "string"
+        },
+        "currentStateTime": {
+          "description": "The timestamp associated with the current state.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "transformNameMapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "The map of transform name prefixes of the job to be replaced to the\ncorresponding name prefixes of the new job.",
+          "type": "object"
+        },
+        "createTime": {
+          "description": "The timestamp when the job was initially created. Immutable and set by the\nCloud Dataflow service.",
+          "format": "google-datetime",
+          "type": "string"
+        },
+        "environment": {
+          "description": "The environment for the job.",
+          "$ref": "Environment"
+        },
+        "labels": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "User-defined labels for this job.\n\nThe labels map can contain no more than 64 entries.  Entries of the labels\nmap are UTF8 strings that comply with the following restrictions:\n\n* Keys must conform to regexp:  \\p{Ll}\\p{Lo}{0,62}\n* Values must conform to regexp:  [\\p{Ll}\\p{Lo}\\p{N}_-]{0,63}\n* Both keys and values are additionally constrained to be \u003c= 128 bytes in\nsize.",
+          "type": "object"
+        },
+        "projectId": {
+          "description": "The ID of the Cloud Platform project that the job belongs to.",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "JOB_TYPE_UNKNOWN",
+            "JOB_TYPE_BATCH",
+            "JOB_TYPE_STREAMING"
+          ],
+          "description": "The type of Cloud Dataflow job.",
+          "type": "string",
+          "enumDescriptions": [
+            "The type of the job is unspecified, or unknown.",
+            "A batch job with a well-defined end point: data is read, data is\nprocessed, data is written, and the job is done.",
+            "A continuously streaming job with no end: data is read,\nprocessed, and written continuously."
+          ]
+        },
+        "pipelineDescription": {
+          "$ref": "PipelineDescription",
+          "description": "Preliminary field: The format of this data may change at any time.\nA description of the user pipeline and stages through which it is executed.\nCreated by Cloud Dataflow service.  Only retrieved with\nJOB_VIEW_DESCRIPTION or JOB_VIEW_ALL."
+        },
+        "replaceJobId": {
+          "description": "If this job is an update of an existing job, this field is the job ID\nof the job it replaced.\n\nWhen sending a `CreateJobRequest`, you can update a job by specifying it\nhere. The job named here is stopped, and its intermediate state is\ntransferred to this job.",
+          "type": "string"
+        },
+        "requestedState": {
+          "enumDescriptions": [
+            "The job's run state isn't specified.",
+            "`JOB_STATE_STOPPED` indicates that the job has not\nyet started to run.",
+            "`JOB_STATE_RUNNING` indicates that the job is currently running.",
+            "`JOB_STATE_DONE` indicates that the job has successfully completed.\nThis is a terminal job state.  This state may be set by the Cloud Dataflow\nservice, as a transition from `JOB_STATE_RUNNING`. It may also be set via a\nCloud Dataflow `UpdateJob` call, if the job has not yet reached a terminal\nstate.",
+            "`JOB_STATE_FAILED` indicates that the job has failed.  This is a\nterminal job state.  This state may only be set by the Cloud Dataflow\nservice, and only as a transition from `JOB_STATE_RUNNING`.",
+            "`JOB_STATE_CANCELLED` indicates that the job has been explicitly\ncancelled. This is a terminal job state. This state may only be\nset via a Cloud Dataflow `UpdateJob` call, and only if the job has not\nyet reached another terminal state.",
+            "`JOB_STATE_UPDATED` indicates that the job was successfully updated,\nmeaning that this job was stopped and another job was started, inheriting\nstate from this one. This is a terminal job state. This state may only be\nset by the Cloud Dataflow service, and only as a transition from\n`JOB_STATE_RUNNING`.",
+            "`JOB_STATE_DRAINING` indicates that the job is in the process of draining.\nA draining job has stopped pulling from its input sources and is processing\nany data that remains in-flight. This state may be set via a Cloud Dataflow\n`UpdateJob` call, but only as a transition from `JOB_STATE_RUNNING`. Jobs\nthat are draining may only transition to `JOB_STATE_DRAINED`,\n`JOB_STATE_CANCELLED`, or `JOB_STATE_FAILED`.",
+            "`JOB_STATE_DRAINED` indicates that the job has been drained.\nA drained job terminated by stopping pulling from its input sources and\nprocessing any data that remained in-flight when draining was requested.\nThis state is a terminal state, may only be set by the Cloud Dataflow\nservice, and only as a transition from `JOB_STATE_DRAINING`."
+          ],
+          "enum": [
+            "JOB_STATE_UNKNOWN",
+            "JOB_STATE_STOPPED",
+            "JOB_STATE_RUNNING",
+            "JOB_STATE_DONE",
+            "JOB_STATE_FAILED",
+            "JOB_STATE_CANCELLED",
+            "JOB_STATE_UPDATED",
+            "JOB_STATE_DRAINING",
+            "JOB_STATE_DRAINED"
+          ],
+          "description": "The job's requested state.\n\n`UpdateJob` may be used to switch between the `JOB_STATE_STOPPED` and\n`JOB_STATE_RUNNING` states, by setting requested_state.  `UpdateJob` may\nalso be used to directly set a job's requested state to\n`JOB_STATE_CANCELLED` or `JOB_STATE_DONE`, irrevocably terminating the\njob if it has not already reached a terminal state.",
+          "type": "string"
+        },
+        "tempFiles": {
+          "description": "A set of files the system should be aware of that are used\nfor temporary storage. These temporary files will be\nremoved on job completion.\nNo duplicates are allowed.\nNo file patterns are supported.\n\nThe supported files are:\n\nGoogle Cloud Storage:\n\n   storage.googleapis.com/{bucket}/{object}\n   bucket.storage.googleapis.com/{object}",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "clientRequestId": {
+          "description": "The client's unique identifier of the job, re-used across retried attempts.\nIf this field is set, the service will ensure its uniqueness.\nThe request to create a job will fail if the service has knowledge of a\npreviously submitted job with the same client's ID and job name.\nThe caller may use this field to ensure idempotence of job\ncreation across retried attempts to create a job.\nBy default, the field is empty and, in that case, the service ignores it.",
+          "type": "string"
+        }
+      },
+      "id": "Job",
+      "description": "Defines a job to be run by the Cloud Dataflow service.",
+      "type": "object"
+    }
+  },
+  "icons": {
+    "x32": "http://www.google.com/images/icons/product/search-32.gif",
+    "x16": "http://www.google.com/images/icons/product/search-16.gif"
+  },
+  "protocol": "rest",
+  "version": "v1b3",
+  "baseUrl": "https://dataflow.googleapis.com/",
+  "auth": {
+    "oauth2": {
+      "scopes": {
+        "https://www.googleapis.com/auth/cloud-platform": {
+          "description": "View and manage your data across Google Cloud Platform services"
+        },
+        "https://www.googleapis.com/auth/userinfo.email": {
+          "description": "View your email address"
+        }
+      }
+    }
+  },
+  "servicePath": "",
+  "description": "Manages Google Cloud Dataflow projects on Google Cloud Platform.",
+  "kind": "discovery#restDescription",
+  "rootUrl": "https://dataflow.googleapis.com/",
+  "basePath": "",
+  "ownerDomain": "google.com",
+  "name": "dataflow",
+  "batchPath": "batch"
+}

--- a/vendor/google.golang.org/api/dataflow/v1b3/dataflow-gen.go
+++ b/vendor/google.golang.org/api/dataflow/v1b3/dataflow-gen.go
@@ -1,0 +1,10028 @@
+// Package dataflow provides access to the Google Dataflow API.
+//
+// See https://cloud.google.com/dataflow
+//
+// Usage example:
+//
+//   import "google.golang.org/api/dataflow/v1b3"
+//   ...
+//   dataflowService, err := dataflow.New(oauthHttpClient)
+package dataflow // import "google.golang.org/api/dataflow/v1b3"
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	context "golang.org/x/net/context"
+	ctxhttp "golang.org/x/net/context/ctxhttp"
+	gensupport "google.golang.org/api/gensupport"
+	googleapi "google.golang.org/api/googleapi"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Always reference these packages, just in case the auto-generated code
+// below doesn't.
+var _ = bytes.NewBuffer
+var _ = strconv.Itoa
+var _ = fmt.Sprintf
+var _ = json.NewDecoder
+var _ = io.Copy
+var _ = url.Parse
+var _ = gensupport.MarshalJSON
+var _ = googleapi.Version
+var _ = errors.New
+var _ = strings.Replace
+var _ = context.Canceled
+var _ = ctxhttp.Do
+
+const apiId = "dataflow:v1b3"
+const apiName = "dataflow"
+const apiVersion = "v1b3"
+const basePath = "https://dataflow.googleapis.com/"
+
+// OAuth2 scopes used by this API.
+const (
+	// View and manage your data across Google Cloud Platform services
+	CloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+	// View your email address
+	UserinfoEmailScope = "https://www.googleapis.com/auth/userinfo.email"
+)
+
+func New(client *http.Client) (*Service, error) {
+	if client == nil {
+		return nil, errors.New("client is nil")
+	}
+	s := &Service{client: client, BasePath: basePath}
+	s.Projects = NewProjectsService(s)
+	return s, nil
+}
+
+type Service struct {
+	client    *http.Client
+	BasePath  string // API endpoint base URL
+	UserAgent string // optional additional User-Agent fragment
+
+	Projects *ProjectsService
+}
+
+func (s *Service) userAgent() string {
+	if s.UserAgent == "" {
+		return googleapi.UserAgent
+	}
+	return googleapi.UserAgent + " " + s.UserAgent
+}
+
+func NewProjectsService(s *Service) *ProjectsService {
+	rs := &ProjectsService{s: s}
+	rs.Jobs = NewProjectsJobsService(s)
+	rs.Locations = NewProjectsLocationsService(s)
+	rs.Templates = NewProjectsTemplatesService(s)
+	return rs
+}
+
+type ProjectsService struct {
+	s *Service
+
+	Jobs *ProjectsJobsService
+
+	Locations *ProjectsLocationsService
+
+	Templates *ProjectsTemplatesService
+}
+
+func NewProjectsJobsService(s *Service) *ProjectsJobsService {
+	rs := &ProjectsJobsService{s: s}
+	rs.Debug = NewProjectsJobsDebugService(s)
+	rs.Messages = NewProjectsJobsMessagesService(s)
+	rs.WorkItems = NewProjectsJobsWorkItemsService(s)
+	return rs
+}
+
+type ProjectsJobsService struct {
+	s *Service
+
+	Debug *ProjectsJobsDebugService
+
+	Messages *ProjectsJobsMessagesService
+
+	WorkItems *ProjectsJobsWorkItemsService
+}
+
+func NewProjectsJobsDebugService(s *Service) *ProjectsJobsDebugService {
+	rs := &ProjectsJobsDebugService{s: s}
+	return rs
+}
+
+type ProjectsJobsDebugService struct {
+	s *Service
+}
+
+func NewProjectsJobsMessagesService(s *Service) *ProjectsJobsMessagesService {
+	rs := &ProjectsJobsMessagesService{s: s}
+	return rs
+}
+
+type ProjectsJobsMessagesService struct {
+	s *Service
+}
+
+func NewProjectsJobsWorkItemsService(s *Service) *ProjectsJobsWorkItemsService {
+	rs := &ProjectsJobsWorkItemsService{s: s}
+	return rs
+}
+
+type ProjectsJobsWorkItemsService struct {
+	s *Service
+}
+
+func NewProjectsLocationsService(s *Service) *ProjectsLocationsService {
+	rs := &ProjectsLocationsService{s: s}
+	rs.Jobs = NewProjectsLocationsJobsService(s)
+	return rs
+}
+
+type ProjectsLocationsService struct {
+	s *Service
+
+	Jobs *ProjectsLocationsJobsService
+}
+
+func NewProjectsLocationsJobsService(s *Service) *ProjectsLocationsJobsService {
+	rs := &ProjectsLocationsJobsService{s: s}
+	rs.Messages = NewProjectsLocationsJobsMessagesService(s)
+	rs.WorkItems = NewProjectsLocationsJobsWorkItemsService(s)
+	return rs
+}
+
+type ProjectsLocationsJobsService struct {
+	s *Service
+
+	Messages *ProjectsLocationsJobsMessagesService
+
+	WorkItems *ProjectsLocationsJobsWorkItemsService
+}
+
+func NewProjectsLocationsJobsMessagesService(s *Service) *ProjectsLocationsJobsMessagesService {
+	rs := &ProjectsLocationsJobsMessagesService{s: s}
+	return rs
+}
+
+type ProjectsLocationsJobsMessagesService struct {
+	s *Service
+}
+
+func NewProjectsLocationsJobsWorkItemsService(s *Service) *ProjectsLocationsJobsWorkItemsService {
+	rs := &ProjectsLocationsJobsWorkItemsService{s: s}
+	return rs
+}
+
+type ProjectsLocationsJobsWorkItemsService struct {
+	s *Service
+}
+
+func NewProjectsTemplatesService(s *Service) *ProjectsTemplatesService {
+	rs := &ProjectsTemplatesService{s: s}
+	return rs
+}
+
+type ProjectsTemplatesService struct {
+	s *Service
+}
+
+// ApproximateProgress: Obsolete in favor of ApproximateReportedProgress
+// and ApproximateSplitRequest.
+type ApproximateProgress struct {
+	// PercentComplete: Obsolete.
+	PercentComplete float64 `json:"percentComplete,omitempty"`
+
+	// Position: Obsolete.
+	Position *Position `json:"position,omitempty"`
+
+	// RemainingTime: Obsolete.
+	RemainingTime string `json:"remainingTime,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "PercentComplete") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "PercentComplete") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ApproximateProgress) MarshalJSON() ([]byte, error) {
+	type noMethod ApproximateProgress
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *ApproximateProgress) UnmarshalJSON(data []byte) error {
+	type noMethod ApproximateProgress
+	var s1 struct {
+		PercentComplete gensupport.JSONFloat64 `json:"percentComplete"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.PercentComplete = float64(s1.PercentComplete)
+	return nil
+}
+
+// ApproximateReportedProgress: A progress measurement of a WorkItem by
+// a worker.
+type ApproximateReportedProgress struct {
+	// ConsumedParallelism: Total amount of parallelism in the portion of
+	// input of this task that has
+	// already been consumed and is no longer active. In the first two
+	// examples
+	// above (see remaining_parallelism), the value should be 29 or
+	// 2
+	// respectively.  The sum of remaining_parallelism and
+	// consumed_parallelism
+	// should equal the total amount of parallelism in this work item.
+	// If
+	// specified, must be finite.
+	ConsumedParallelism *ReportedParallelism `json:"consumedParallelism,omitempty"`
+
+	// FractionConsumed: Completion as fraction of the input consumed, from
+	// 0.0 (beginning, nothing
+	// consumed), to 1.0 (end of the input, entire input consumed).
+	FractionConsumed float64 `json:"fractionConsumed,omitempty"`
+
+	// Position: A Position within the work to represent a progress.
+	Position *Position `json:"position,omitempty"`
+
+	// RemainingParallelism: Total amount of parallelism in the input of
+	// this task that remains,
+	// (i.e. can be delegated to this task and any new tasks via
+	// dynamic
+	// splitting). Always at least 1 for non-finished work items and 0
+	// for
+	// finished.
+	//
+	// "Amount of parallelism" refers to how many non-empty parts of the
+	// input
+	// can be read in parallel. This does not necessarily equal number
+	// of records. An input that can be read in parallel down to
+	// the
+	// individual records is called "perfectly splittable".
+	// An example of non-perfectly parallelizable input is a
+	// block-compressed
+	// file format where a block of records has to be read as a whole,
+	// but different blocks can be read in parallel.
+	//
+	// Examples:
+	// * If we are processing record #30 (starting at 1) out of 50 in a
+	// perfectly
+	//   splittable 50-record input, this value should be 21 (20 remaining +
+	// 1
+	//   current).
+	// * If we are reading through block 3 in a block-compressed file
+	// consisting
+	//   of 5 blocks, this value should be 3 (since blocks 4 and 5 can be
+	//   processed in parallel by new tasks via dynamic splitting and the
+	// current
+	//   task remains processing block 3).
+	// * If we are reading through the last block in a block-compressed
+	// file,
+	//   or reading or processing the last record in a perfectly splittable
+	//   input, this value should be 1, because apart from the current task,
+	// no
+	//   additional remainder can be split off.
+	RemainingParallelism *ReportedParallelism `json:"remainingParallelism,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ConsumedParallelism")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ConsumedParallelism") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ApproximateReportedProgress) MarshalJSON() ([]byte, error) {
+	type noMethod ApproximateReportedProgress
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *ApproximateReportedProgress) UnmarshalJSON(data []byte) error {
+	type noMethod ApproximateReportedProgress
+	var s1 struct {
+		FractionConsumed gensupport.JSONFloat64 `json:"fractionConsumed"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.FractionConsumed = float64(s1.FractionConsumed)
+	return nil
+}
+
+// ApproximateSplitRequest: A suggestion by the service to the worker to
+// dynamically split the WorkItem.
+type ApproximateSplitRequest struct {
+	// FractionConsumed: A fraction at which to split the work item, from
+	// 0.0 (beginning of the
+	// input) to 1.0 (end of the input).
+	FractionConsumed float64 `json:"fractionConsumed,omitempty"`
+
+	// Position: A Position at which to split the work item.
+	Position *Position `json:"position,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "FractionConsumed") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "FractionConsumed") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ApproximateSplitRequest) MarshalJSON() ([]byte, error) {
+	type noMethod ApproximateSplitRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *ApproximateSplitRequest) UnmarshalJSON(data []byte) error {
+	type noMethod ApproximateSplitRequest
+	var s1 struct {
+		FractionConsumed gensupport.JSONFloat64 `json:"fractionConsumed"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.FractionConsumed = float64(s1.FractionConsumed)
+	return nil
+}
+
+// AutoscalingSettings: Settings for WorkerPool autoscaling.
+type AutoscalingSettings struct {
+	// Algorithm: The algorithm to use for autoscaling.
+	//
+	// Possible values:
+	//   "AUTOSCALING_ALGORITHM_UNKNOWN" - The algorithm is unknown, or
+	// unspecified.
+	//   "AUTOSCALING_ALGORITHM_NONE" - Disable autoscaling.
+	//   "AUTOSCALING_ALGORITHM_BASIC" - Increase worker count over time to
+	// reduce job execution time.
+	Algorithm string `json:"algorithm,omitempty"`
+
+	// MaxNumWorkers: The maximum number of workers to cap scaling at.
+	MaxNumWorkers int64 `json:"maxNumWorkers,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Algorithm") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Algorithm") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *AutoscalingSettings) MarshalJSON() ([]byte, error) {
+	type noMethod AutoscalingSettings
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CPUTime: Modeled after information exposed by /proc/stat.
+type CPUTime struct {
+	// Rate: Average CPU utilization rate (% non-idle cpu / second) since
+	// previous
+	// sample.
+	Rate float64 `json:"rate,omitempty"`
+
+	// Timestamp: Timestamp of the measurement.
+	Timestamp string `json:"timestamp,omitempty"`
+
+	// TotalMs: Total active CPU time across all cores (ie., non-idle) in
+	// milliseconds
+	// since start-up.
+	TotalMs uint64 `json:"totalMs,omitempty,string"`
+
+	// ForceSendFields is a list of field names (e.g. "Rate") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Rate") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CPUTime) MarshalJSON() ([]byte, error) {
+	type noMethod CPUTime
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *CPUTime) UnmarshalJSON(data []byte) error {
+	type noMethod CPUTime
+	var s1 struct {
+		Rate gensupport.JSONFloat64 `json:"rate"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Rate = float64(s1.Rate)
+	return nil
+}
+
+// ComponentSource: Description of an interstitial value between
+// transforms in an execution
+// stage.
+type ComponentSource struct {
+	// Name: Dataflow service generated name for this source.
+	Name string `json:"name,omitempty"`
+
+	// OriginalTransformOrCollection: User name for the original user
+	// transform or collection with which this
+	// source is most closely associated.
+	OriginalTransformOrCollection string `json:"originalTransformOrCollection,omitempty"`
+
+	// UserName: Human-readable name for this transform; may be user or
+	// system generated.
+	UserName string `json:"userName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ComponentSource) MarshalJSON() ([]byte, error) {
+	type noMethod ComponentSource
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ComponentTransform: Description of a transform executed as part of an
+// execution stage.
+type ComponentTransform struct {
+	// Name: Dataflow service generated name for this source.
+	Name string `json:"name,omitempty"`
+
+	// OriginalTransform: User name for the original user transform with
+	// which this transform is
+	// most closely associated.
+	OriginalTransform string `json:"originalTransform,omitempty"`
+
+	// UserName: Human-readable name for this transform; may be user or
+	// system generated.
+	UserName string `json:"userName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ComponentTransform) MarshalJSON() ([]byte, error) {
+	type noMethod ComponentTransform
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ComputationTopology: All configuration data for a particular
+// Computation.
+type ComputationTopology struct {
+	// ComputationId: The ID of the computation.
+	ComputationId string `json:"computationId,omitempty"`
+
+	// Inputs: The inputs to the computation.
+	Inputs []*StreamLocation `json:"inputs,omitempty"`
+
+	// KeyRanges: The key ranges processed by the computation.
+	KeyRanges []*KeyRangeLocation `json:"keyRanges,omitempty"`
+
+	// Outputs: The outputs from the computation.
+	Outputs []*StreamLocation `json:"outputs,omitempty"`
+
+	// StateFamilies: The state family values.
+	StateFamilies []*StateFamilyConfig `json:"stateFamilies,omitempty"`
+
+	// SystemStageName: The system stage name.
+	SystemStageName string `json:"systemStageName,omitempty"`
+
+	// UserStageName: The user stage name.
+	UserStageName string `json:"userStageName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComputationId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComputationId") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ComputationTopology) MarshalJSON() ([]byte, error) {
+	type noMethod ComputationTopology
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ConcatPosition: A position that encapsulates an inner position and an
+// index for the inner
+// position. A ConcatPosition can be used by a reader of a source
+// that
+// encapsulates a set of other sources.
+type ConcatPosition struct {
+	// Index: Index of the inner source.
+	Index int64 `json:"index,omitempty"`
+
+	// Position: Position within the inner source.
+	Position *Position `json:"position,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Index") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Index") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ConcatPosition) MarshalJSON() ([]byte, error) {
+	type noMethod ConcatPosition
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CounterMetadata: CounterMetadata includes all static non-name
+// non-value counter attributes.
+type CounterMetadata struct {
+	// Description: Human-readable description of the counter semantics.
+	Description string `json:"description,omitempty"`
+
+	// Kind: Counter aggregation kind.
+	//
+	// Possible values:
+	//   "INVALID" - Counter aggregation kind was not set.
+	//   "SUM" - Aggregated value is the sum of all contributed values.
+	//   "MAX" - Aggregated value is the max of all contributed values.
+	//   "MIN" - Aggregated value is the min of all contributed values.
+	//   "MEAN" - Aggregated value is the mean of all contributed values.
+	//   "OR" - Aggregated value represents the logical 'or' of all
+	// contributed values.
+	//   "AND" - Aggregated value represents the logical 'and' of all
+	// contributed values.
+	//   "SET" - Aggregated value is a set of unique contributed values.
+	//   "DISTRIBUTION" - Aggregated value captures statistics about a
+	// distribution.
+	Kind string `json:"kind,omitempty"`
+
+	// OtherUnits: A string referring to the unit type.
+	OtherUnits string `json:"otherUnits,omitempty"`
+
+	// StandardUnits: System defined Units, see above enum.
+	//
+	// Possible values:
+	//   "BYTES" - Counter returns a value in bytes.
+	//   "BYTES_PER_SEC" - Counter returns a value in bytes per second.
+	//   "MILLISECONDS" - Counter returns a value in milliseconds.
+	//   "MICROSECONDS" - Counter returns a value in microseconds.
+	//   "NANOSECONDS" - Counter returns a value in nanoseconds.
+	//   "TIMESTAMP_MSEC" - Counter returns a timestamp in milliseconds.
+	//   "TIMESTAMP_USEC" - Counter returns a timestamp in microseconds.
+	//   "TIMESTAMP_NSEC" - Counter returns a timestamp in nanoseconds.
+	StandardUnits string `json:"standardUnits,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Description") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Description") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CounterMetadata) MarshalJSON() ([]byte, error) {
+	type noMethod CounterMetadata
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CounterStructuredName: Identifies a counter within a per-job
+// namespace. Counters whose structured
+// names are the same get merged into a single value for the job.
+type CounterStructuredName struct {
+	// ComponentStepName: Name of the optimized step being executed by the
+	// workers.
+	ComponentStepName string `json:"componentStepName,omitempty"`
+
+	// ExecutionStepName: Name of the stage. An execution step contains
+	// multiple component steps.
+	ExecutionStepName string `json:"executionStepName,omitempty"`
+
+	// Name: Counter name. Not necessarily globally-unique, but unique
+	// within the
+	// context of the other fields.
+	// Required.
+	Name string `json:"name,omitempty"`
+
+	// Origin: One of the standard Origins defined above.
+	//
+	// Possible values:
+	//   "SYSTEM" - Counter was created by the Dataflow system.
+	//   "USER" - Counter was created by the user.
+	Origin string `json:"origin,omitempty"`
+
+	// OriginNamespace: A string containing a more specific namespace of the
+	// counter's origin.
+	OriginNamespace string `json:"originNamespace,omitempty"`
+
+	// OriginalStepName: System generated name of the original step in the
+	// user's graph, before
+	// optimization.
+	OriginalStepName string `json:"originalStepName,omitempty"`
+
+	// Portion: Portion of this counter, either key or value.
+	//
+	// Possible values:
+	//   "ALL" - Counter portion has not been set.
+	//   "KEY" - Counter reports a key.
+	//   "VALUE" - Counter reports a value.
+	Portion string `json:"portion,omitempty"`
+
+	// WorkerId: ID of a particular worker.
+	WorkerId string `json:"workerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComponentStepName")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComponentStepName") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CounterStructuredName) MarshalJSON() ([]byte, error) {
+	type noMethod CounterStructuredName
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CounterStructuredNameAndMetadata: A single message which encapsulates
+// structured name and metadata for a given
+// counter.
+type CounterStructuredNameAndMetadata struct {
+	// Metadata: Metadata associated with a counter
+	Metadata *CounterMetadata `json:"metadata,omitempty"`
+
+	// Name: Structured name of the counter.
+	Name *CounterStructuredName `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Metadata") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Metadata") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CounterStructuredNameAndMetadata) MarshalJSON() ([]byte, error) {
+	type noMethod CounterStructuredNameAndMetadata
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CounterUpdate: An update to a Counter sent from a worker.
+type CounterUpdate struct {
+	// Boolean: Boolean value for And, Or.
+	Boolean bool `json:"boolean,omitempty"`
+
+	// Cumulative: True if this counter is reported as the total cumulative
+	// aggregate
+	// value accumulated since the worker started working on this
+	// WorkItem.
+	// By default this is false, indicating that this counter is reported
+	// as a delta.
+	Cumulative bool `json:"cumulative,omitempty"`
+
+	// Distribution: Distribution data
+	Distribution *DistributionUpdate `json:"distribution,omitempty"`
+
+	// FloatingPoint: Floating point value for Sum, Max, Min.
+	FloatingPoint float64 `json:"floatingPoint,omitempty"`
+
+	// FloatingPointList: List of floating point numbers, for Set.
+	FloatingPointList *FloatingPointList `json:"floatingPointList,omitempty"`
+
+	// FloatingPointMean: Floating point mean aggregation value for Mean.
+	FloatingPointMean *FloatingPointMean `json:"floatingPointMean,omitempty"`
+
+	// Integer: Integer value for Sum, Max, Min.
+	Integer *SplitInt64 `json:"integer,omitempty"`
+
+	// IntegerList: List of integers, for Set.
+	IntegerList *IntegerList `json:"integerList,omitempty"`
+
+	// IntegerMean: Integer mean aggregation value for Mean.
+	IntegerMean *IntegerMean `json:"integerMean,omitempty"`
+
+	// Internal: Value for internally-defined counters used by the Dataflow
+	// service.
+	Internal interface{} `json:"internal,omitempty"`
+
+	// NameAndKind: Counter name and aggregation type.
+	NameAndKind *NameAndKind `json:"nameAndKind,omitempty"`
+
+	// ShortId: The service-generated short identifier for this counter.
+	// The short_id -> (name, metadata) mapping is constant for the lifetime
+	// of
+	// a job.
+	ShortId int64 `json:"shortId,omitempty,string"`
+
+	// StringList: List of strings, for Set.
+	StringList *StringList `json:"stringList,omitempty"`
+
+	// StructuredNameAndMetadata: Counter structured name and metadata.
+	StructuredNameAndMetadata *CounterStructuredNameAndMetadata `json:"structuredNameAndMetadata,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Boolean") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Boolean") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CounterUpdate) MarshalJSON() ([]byte, error) {
+	type noMethod CounterUpdate
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *CounterUpdate) UnmarshalJSON(data []byte) error {
+	type noMethod CounterUpdate
+	var s1 struct {
+		FloatingPoint gensupport.JSONFloat64 `json:"floatingPoint"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.FloatingPoint = float64(s1.FloatingPoint)
+	return nil
+}
+
+// CreateJobFromTemplateRequest: A request to create a Cloud Dataflow
+// job from a template.
+type CreateJobFromTemplateRequest struct {
+	// Environment: The runtime environment for the job.
+	Environment *RuntimeEnvironment `json:"environment,omitempty"`
+
+	// GcsPath: Required. A Cloud Storage path to the template from which
+	// to
+	// create the job.
+	// Must be a valid Cloud Storage URL, beginning with `gs://`.
+	GcsPath string `json:"gcsPath,omitempty"`
+
+	// JobName: Required. The job name to use for the created job.
+	JobName string `json:"jobName,omitempty"`
+
+	// Parameters: The runtime parameters to pass to the job.
+	Parameters map[string]string `json:"parameters,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Environment") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Environment") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CreateJobFromTemplateRequest) MarshalJSON() ([]byte, error) {
+	type noMethod CreateJobFromTemplateRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// CustomSourceLocation: Identifies the location of a custom souce.
+type CustomSourceLocation struct {
+	// Stateful: Whether this source is stateful.
+	Stateful bool `json:"stateful,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Stateful") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Stateful") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *CustomSourceLocation) MarshalJSON() ([]byte, error) {
+	type noMethod CustomSourceLocation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DataDiskAssignment: Data disk assignment for a given VM instance.
+type DataDiskAssignment struct {
+	// DataDisks: Mounted data disks. The order is important a data disk's
+	// 0-based index in
+	// this list defines which persistent directory the disk is mounted to,
+	// for
+	// example the list of { "myproject-1014-104817-4c2-harness-0-disk-0"
+	// },
+	// { "myproject-1014-104817-4c2-harness-0-disk-1" }.
+	DataDisks []string `json:"dataDisks,omitempty"`
+
+	// VmInstance: VM instance name the data disks mounted to, for
+	// example
+	// "myproject-1014-104817-4c2-harness-0".
+	VmInstance string `json:"vmInstance,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DataDisks") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DataDisks") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DataDiskAssignment) MarshalJSON() ([]byte, error) {
+	type noMethod DataDiskAssignment
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DerivedSource: Specification of one of the bundles produced as a
+// result of splitting
+// a Source (e.g. when executing a SourceSplitRequest, or when
+// splitting an active task using
+// WorkItemStatus.dynamic_source_split),
+// relative to the source being split.
+type DerivedSource struct {
+	// DerivationMode: What source to base the produced source on (if any).
+	//
+	// Possible values:
+	//   "SOURCE_DERIVATION_MODE_UNKNOWN" - The source derivation is
+	// unknown, or unspecified.
+	//   "SOURCE_DERIVATION_MODE_INDEPENDENT" - Produce a completely
+	// independent Source with no base.
+	//   "SOURCE_DERIVATION_MODE_CHILD_OF_CURRENT" - Produce a Source based
+	// on the Source being split.
+	//   "SOURCE_DERIVATION_MODE_SIBLING_OF_CURRENT" - Produce a Source
+	// based on the base of the Source being split.
+	DerivationMode string `json:"derivationMode,omitempty"`
+
+	// Source: Specification of the source.
+	Source *Source `json:"source,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DerivationMode") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DerivationMode") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DerivedSource) MarshalJSON() ([]byte, error) {
+	type noMethod DerivedSource
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Disk: Describes the data disk used by a workflow job.
+type Disk struct {
+	// DiskType: Disk storage type, as defined by Google Compute Engine.
+	// This
+	// must be a disk type appropriate to the project and zone in which
+	// the workers will run.  If unknown or unspecified, the service
+	// will attempt to choose a reasonable default.
+	//
+	// For example, the standard persistent disk type is a resource
+	// name
+	// typically ending in "pd-standard".  If SSD persistent disks
+	// are
+	// available, the resource name typically ends with "pd-ssd".
+	// The
+	// actual valid values are defined the Google Compute Engine API,
+	// not by the Cloud Dataflow API; consult the Google Compute
+	// Engine
+	// documentation for more information about determining the set
+	// of
+	// available disk types for a particular project and zone.
+	//
+	// Google Compute Engine Disk types are local to a particular
+	// project in a particular zone, and so the resource name will
+	// typically look something like
+	// this:
+	//
+	// compute.googleapis.com/projects/project-id/zones/zone/diskTypes
+	// /pd-standard
+	DiskType string `json:"diskType,omitempty"`
+
+	// MountPoint: Directory in a VM where disk is mounted.
+	MountPoint string `json:"mountPoint,omitempty"`
+
+	// SizeGb: Size of disk in GB.  If zero or unspecified, the service
+	// will
+	// attempt to choose a reasonable default.
+	SizeGb int64 `json:"sizeGb,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DiskType") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DiskType") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Disk) MarshalJSON() ([]byte, error) {
+	type noMethod Disk
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// DisplayData: Data provided with a pipeline or transform to provide
+// descriptive info.
+type DisplayData struct {
+	// BoolValue: Contains value if the data is of a boolean type.
+	BoolValue bool `json:"boolValue,omitempty"`
+
+	// DurationValue: Contains value if the data is of duration type.
+	DurationValue string `json:"durationValue,omitempty"`
+
+	// FloatValue: Contains value if the data is of float type.
+	FloatValue float64 `json:"floatValue,omitempty"`
+
+	// Int64Value: Contains value if the data is of int64 type.
+	Int64Value int64 `json:"int64Value,omitempty,string"`
+
+	// JavaClassValue: Contains value if the data is of java class type.
+	JavaClassValue string `json:"javaClassValue,omitempty"`
+
+	// Key: The key identifying the display data.
+	// This is intended to be used as a label for the display data
+	// when viewed in a dax monitoring system.
+	Key string `json:"key,omitempty"`
+
+	// Label: An optional label to display in a dax UI for the element.
+	Label string `json:"label,omitempty"`
+
+	// Namespace: The namespace for the key. This is usually a class name or
+	// programming
+	// language namespace (i.e. python module) which defines the display
+	// data.
+	// This allows a dax monitoring system to specially handle the data
+	// and perform custom rendering.
+	Namespace string `json:"namespace,omitempty"`
+
+	// ShortStrValue: A possible additional shorter value to display.
+	// For example a java_class_name_value of com.mypackage.MyDoFn
+	// will be stored with MyDoFn as the short_str_value
+	// and
+	// com.mypackage.MyDoFn as the java_class_name value.
+	// short_str_value can be displayed and java_class_name_value
+	// will be displayed as a tooltip.
+	ShortStrValue string `json:"shortStrValue,omitempty"`
+
+	// StrValue: Contains value if the data is of string type.
+	StrValue string `json:"strValue,omitempty"`
+
+	// TimestampValue: Contains value if the data is of timestamp type.
+	TimestampValue string `json:"timestampValue,omitempty"`
+
+	// Url: An optional full URL.
+	Url string `json:"url,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "BoolValue") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BoolValue") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DisplayData) MarshalJSON() ([]byte, error) {
+	type noMethod DisplayData
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *DisplayData) UnmarshalJSON(data []byte) error {
+	type noMethod DisplayData
+	var s1 struct {
+		FloatValue gensupport.JSONFloat64 `json:"floatValue"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.FloatValue = float64(s1.FloatValue)
+	return nil
+}
+
+// DistributionUpdate: A metric value representing a distribution.
+type DistributionUpdate struct {
+	// Count: The count of the number of elements present in the
+	// distribution.
+	Count *SplitInt64 `json:"count,omitempty"`
+
+	// Max: The maximum value present in the distribution.
+	Max *SplitInt64 `json:"max,omitempty"`
+
+	// Min: The minimum value present in the distribution.
+	Min *SplitInt64 `json:"min,omitempty"`
+
+	// Sum: Use an int64 since we'd prefer the added precision. If overflow
+	// is a common
+	// problem we can detect it and use an additional int64 or a double.
+	Sum *SplitInt64 `json:"sum,omitempty"`
+
+	// SumOfSquares: Use a double since the sum of squares is likely to
+	// overflow int64.
+	SumOfSquares float64 `json:"sumOfSquares,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Count") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Count") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DistributionUpdate) MarshalJSON() ([]byte, error) {
+	type noMethod DistributionUpdate
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *DistributionUpdate) UnmarshalJSON(data []byte) error {
+	type noMethod DistributionUpdate
+	var s1 struct {
+		SumOfSquares gensupport.JSONFloat64 `json:"sumOfSquares"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.SumOfSquares = float64(s1.SumOfSquares)
+	return nil
+}
+
+// DynamicSourceSplit: When a task splits using
+// WorkItemStatus.dynamic_source_split, this
+// message describes the two parts of the split relative to
+// the
+// description of the current task's input.
+type DynamicSourceSplit struct {
+	// Primary: Primary part (continued to be processed by
+	// worker).
+	// Specified relative to the previously-current source.
+	// Becomes current.
+	Primary *DerivedSource `json:"primary,omitempty"`
+
+	// Residual: Residual part (returned to the pool of work).
+	// Specified relative to the previously-current source.
+	Residual *DerivedSource `json:"residual,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Primary") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Primary") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *DynamicSourceSplit) MarshalJSON() ([]byte, error) {
+	type noMethod DynamicSourceSplit
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Environment: Describes the environment in which a Dataflow Job runs.
+type Environment struct {
+	// ClusterManagerApiService: The type of cluster manager API to use.  If
+	// unknown or
+	// unspecified, the service will attempt to choose a reasonable
+	// default.  This should be in the form of the API service name,
+	// e.g. "compute.googleapis.com".
+	ClusterManagerApiService string `json:"clusterManagerApiService,omitempty"`
+
+	// Dataset: The dataset for the current project where various
+	// workflow
+	// related tables are stored.
+	//
+	// The supported resource type is:
+	//
+	// Google BigQuery:
+	//   bigquery.googleapis.com/{dataset}
+	Dataset string `json:"dataset,omitempty"`
+
+	// Experiments: The list of experiments to enable.
+	Experiments []string `json:"experiments,omitempty"`
+
+	// InternalExperiments: Experimental settings.
+	InternalExperiments googleapi.RawMessage `json:"internalExperiments,omitempty"`
+
+	// SdkPipelineOptions: The Cloud Dataflow SDK pipeline options specified
+	// by the user. These
+	// options are passed through the service and are used to recreate
+	// the
+	// SDK pipeline options on the worker in a language agnostic and
+	// platform
+	// independent way.
+	SdkPipelineOptions googleapi.RawMessage `json:"sdkPipelineOptions,omitempty"`
+
+	// ServiceAccountEmail: Identity to run virtual machines as. Defaults to
+	// the default account.
+	ServiceAccountEmail string `json:"serviceAccountEmail,omitempty"`
+
+	// TempStoragePrefix: The prefix of the resources the system should use
+	// for temporary
+	// storage.  The system will append the suffix "/temp-{JOBNAME} to
+	// this resource prefix, where {JOBNAME} is the value of the
+	// job_name field.  The resulting bucket and object prefix is used
+	// as the prefix of the resources used to store temporary data
+	// needed during the job execution.  NOTE: This will override the
+	// value in taskrunner_settings.
+	// The supported resource type is:
+	//
+	// Google Cloud Storage:
+	//
+	//   storage.googleapis.com/{bucket}/{object}
+	//   bucket.storage.googleapis.com/{object}
+	TempStoragePrefix string `json:"tempStoragePrefix,omitempty"`
+
+	// UserAgent: A description of the process that generated the request.
+	UserAgent googleapi.RawMessage `json:"userAgent,omitempty"`
+
+	// Version: A structure describing which components and their versions
+	// of the service
+	// are required in order to run the job.
+	Version googleapi.RawMessage `json:"version,omitempty"`
+
+	// WorkerPools: The worker pools. At least one "harness" worker pool
+	// must be
+	// specified in order for the job to have workers.
+	WorkerPools []*WorkerPool `json:"workerPools,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "ClusterManagerApiService") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ClusterManagerApiService")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Environment) MarshalJSON() ([]byte, error) {
+	type noMethod Environment
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ExecutionStageSummary: Description of the composing transforms,
+// names/ids, and input/outputs of a
+// stage of execution.  Some composing transforms and sources may have
+// been
+// generated by the Dataflow service during execution planning.
+type ExecutionStageSummary struct {
+	// ComponentSource: Collections produced and consumed by component
+	// transforms of this stage.
+	ComponentSource []*ComponentSource `json:"componentSource,omitempty"`
+
+	// ComponentTransform: Transforms that comprise this execution stage.
+	ComponentTransform []*ComponentTransform `json:"componentTransform,omitempty"`
+
+	// Id: Dataflow service generated id for this stage.
+	Id string `json:"id,omitempty"`
+
+	// InputSource: Input sources for this stage.
+	InputSource []*StageSource `json:"inputSource,omitempty"`
+
+	// Kind: Type of tranform this stage is executing.
+	//
+	// Possible values:
+	//   "UNKNOWN_KIND" - Unrecognized transform type.
+	//   "PAR_DO_KIND" - ParDo transform.
+	//   "GROUP_BY_KEY_KIND" - Group By Key transform.
+	//   "FLATTEN_KIND" - Flatten transform.
+	//   "READ_KIND" - Read transform.
+	//   "WRITE_KIND" - Write transform.
+	//   "CONSTANT_KIND" - Constructs from a constant value, such as with
+	// Create.of.
+	//   "SINGLETON_KIND" - Creates a Singleton view of a collection.
+	//   "SHUFFLE_KIND" - Opening or closing a shuffle session, often as
+	// part of a GroupByKey.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: Dataflow service generated name for this stage.
+	Name string `json:"name,omitempty"`
+
+	// OutputSource: Output sources for this stage.
+	OutputSource []*StageSource `json:"outputSource,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComponentSource") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComponentSource") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ExecutionStageSummary) MarshalJSON() ([]byte, error) {
+	type noMethod ExecutionStageSummary
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// FailedLocation: Indicates which location failed to respond to a
+// request for data.
+type FailedLocation struct {
+	// Name: The name of the failed location.
+	Name string `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *FailedLocation) MarshalJSON() ([]byte, error) {
+	type noMethod FailedLocation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// FlattenInstruction: An instruction that copies its inputs (zero or
+// more) to its (single) output.
+type FlattenInstruction struct {
+	// Inputs: Describes the inputs to the flatten instruction.
+	Inputs []*InstructionInput `json:"inputs,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Inputs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Inputs") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *FlattenInstruction) MarshalJSON() ([]byte, error) {
+	type noMethod FlattenInstruction
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// FloatingPointList: A metric value representing a list of floating
+// point numbers.
+type FloatingPointList struct {
+	// Elements: Elements of the list.
+	Elements []float64 `json:"elements,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Elements") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Elements") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *FloatingPointList) MarshalJSON() ([]byte, error) {
+	type noMethod FloatingPointList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// FloatingPointMean: A representation of a floating point mean metric
+// contribution.
+type FloatingPointMean struct {
+	// Count: The number of values being aggregated.
+	Count *SplitInt64 `json:"count,omitempty"`
+
+	// Sum: The sum of all values being aggregated.
+	Sum float64 `json:"sum,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Count") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Count") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *FloatingPointMean) MarshalJSON() ([]byte, error) {
+	type noMethod FloatingPointMean
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *FloatingPointMean) UnmarshalJSON(data []byte) error {
+	type noMethod FloatingPointMean
+	var s1 struct {
+		Sum gensupport.JSONFloat64 `json:"sum"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Sum = float64(s1.Sum)
+	return nil
+}
+
+// GetDebugConfigRequest: Request to get updated debug configuration for
+// component.
+type GetDebugConfigRequest struct {
+	// ComponentId: The internal component id for which debug configuration
+	// is
+	// requested.
+	ComponentId string `json:"componentId,omitempty"`
+
+	// WorkerId: The worker id, i.e., VM hostname.
+	WorkerId string `json:"workerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComponentId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComponentId") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *GetDebugConfigRequest) MarshalJSON() ([]byte, error) {
+	type noMethod GetDebugConfigRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// GetDebugConfigResponse: Response to a get debug configuration
+// request.
+type GetDebugConfigResponse struct {
+	// Config: The encoded debug configuration for the requested component.
+	Config string `json:"config,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Config") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Config") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *GetDebugConfigResponse) MarshalJSON() ([]byte, error) {
+	type noMethod GetDebugConfigResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// GetTemplateResponse: The response to a GetTemplate request.
+type GetTemplateResponse struct {
+	// Metadata: The template metadata describing the template name,
+	// available
+	// parameters, etc.
+	Metadata *TemplateMetadata `json:"metadata,omitempty"`
+
+	// Status: The status of the get template request. Any problems with
+	// the
+	// request will be indicated in the error_details.
+	Status *Status `json:"status,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Metadata") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Metadata") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *GetTemplateResponse) MarshalJSON() ([]byte, error) {
+	type noMethod GetTemplateResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// InstructionInput: An input of an instruction, as a reference to an
+// output of a
+// producer instruction.
+type InstructionInput struct {
+	// OutputNum: The output index (origin zero) within the producer.
+	OutputNum int64 `json:"outputNum,omitempty"`
+
+	// ProducerInstructionIndex: The index (origin zero) of the parallel
+	// instruction that produces
+	// the output to be consumed by this input.  This index is relative
+	// to the list of instructions in this input's instruction's
+	// containing MapTask.
+	ProducerInstructionIndex int64 `json:"producerInstructionIndex,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "OutputNum") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "OutputNum") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstructionInput) MarshalJSON() ([]byte, error) {
+	type noMethod InstructionInput
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// InstructionOutput: An output of an instruction.
+type InstructionOutput struct {
+	// Codec: The codec to use to encode data being written via this output.
+	Codec googleapi.RawMessage `json:"codec,omitempty"`
+
+	// Name: The user-provided name of this output.
+	Name string `json:"name,omitempty"`
+
+	// OnlyCountKeyBytes: For system-generated byte and mean byte metrics,
+	// certain instructions
+	// should only report the key size.
+	OnlyCountKeyBytes bool `json:"onlyCountKeyBytes,omitempty"`
+
+	// OnlyCountValueBytes: For system-generated byte and mean byte metrics,
+	// certain instructions
+	// should only report the value size.
+	OnlyCountValueBytes bool `json:"onlyCountValueBytes,omitempty"`
+
+	// OriginalName: System-defined name for this output in the original
+	// workflow graph.
+	// Outputs that do not contribute to an original instruction do not set
+	// this.
+	OriginalName string `json:"originalName,omitempty"`
+
+	// SystemName: System-defined name of this output.
+	// Unique across the workflow.
+	SystemName string `json:"systemName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Codec") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Codec") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *InstructionOutput) MarshalJSON() ([]byte, error) {
+	type noMethod InstructionOutput
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// IntegerList: A metric value representing a list of integers.
+type IntegerList struct {
+	// Elements: Elements of the list.
+	Elements []*SplitInt64 `json:"elements,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Elements") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Elements") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *IntegerList) MarshalJSON() ([]byte, error) {
+	type noMethod IntegerList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// IntegerMean: A representation of an integer mean metric contribution.
+type IntegerMean struct {
+	// Count: The number of values being aggregated.
+	Count *SplitInt64 `json:"count,omitempty"`
+
+	// Sum: The sum of all values being aggregated.
+	Sum *SplitInt64 `json:"sum,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Count") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Count") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *IntegerMean) MarshalJSON() ([]byte, error) {
+	type noMethod IntegerMean
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Job: Defines a job to be run by the Cloud Dataflow service.
+type Job struct {
+	// ClientRequestId: The client's unique identifier of the job, re-used
+	// across retried attempts.
+	// If this field is set, the service will ensure its uniqueness.
+	// The request to create a job will fail if the service has knowledge of
+	// a
+	// previously submitted job with the same client's ID and job name.
+	// The caller may use this field to ensure idempotence of job
+	// creation across retried attempts to create a job.
+	// By default, the field is empty and, in that case, the service ignores
+	// it.
+	ClientRequestId string `json:"clientRequestId,omitempty"`
+
+	// CreateTime: The timestamp when the job was initially created.
+	// Immutable and set by the
+	// Cloud Dataflow service.
+	CreateTime string `json:"createTime,omitempty"`
+
+	// CurrentState: The current state of the job.
+	//
+	// Jobs are created in the `JOB_STATE_STOPPED` state unless
+	// otherwise
+	// specified.
+	//
+	// A job in the `JOB_STATE_RUNNING` state may asynchronously enter
+	// a
+	// terminal state. After a job has reached a terminal state, no
+	// further state updates may be made.
+	//
+	// This field may be mutated by the Cloud Dataflow service;
+	// callers cannot mutate it.
+	//
+	// Possible values:
+	//   "JOB_STATE_UNKNOWN" - The job's run state isn't specified.
+	//   "JOB_STATE_STOPPED" - `JOB_STATE_STOPPED` indicates that the job
+	// has not
+	// yet started to run.
+	//   "JOB_STATE_RUNNING" - `JOB_STATE_RUNNING` indicates that the job is
+	// currently running.
+	//   "JOB_STATE_DONE" - `JOB_STATE_DONE` indicates that the job has
+	// successfully completed.
+	// This is a terminal job state.  This state may be set by the Cloud
+	// Dataflow
+	// service, as a transition from `JOB_STATE_RUNNING`. It may also be set
+	// via a
+	// Cloud Dataflow `UpdateJob` call, if the job has not yet reached a
+	// terminal
+	// state.
+	//   "JOB_STATE_FAILED" - `JOB_STATE_FAILED` indicates that the job has
+	// failed.  This is a
+	// terminal job state.  This state may only be set by the Cloud
+	// Dataflow
+	// service, and only as a transition from `JOB_STATE_RUNNING`.
+	//   "JOB_STATE_CANCELLED" - `JOB_STATE_CANCELLED` indicates that the
+	// job has been explicitly
+	// cancelled. This is a terminal job state. This state may only be
+	// set via a Cloud Dataflow `UpdateJob` call, and only if the job has
+	// not
+	// yet reached another terminal state.
+	//   "JOB_STATE_UPDATED" - `JOB_STATE_UPDATED` indicates that the job
+	// was successfully updated,
+	// meaning that this job was stopped and another job was started,
+	// inheriting
+	// state from this one. This is a terminal job state. This state may
+	// only be
+	// set by the Cloud Dataflow service, and only as a transition
+	// from
+	// `JOB_STATE_RUNNING`.
+	//   "JOB_STATE_DRAINING" - `JOB_STATE_DRAINING` indicates that the job
+	// is in the process of draining.
+	// A draining job has stopped pulling from its input sources and is
+	// processing
+	// any data that remains in-flight. This state may be set via a Cloud
+	// Dataflow
+	// `UpdateJob` call, but only as a transition from `JOB_STATE_RUNNING`.
+	// Jobs
+	// that are draining may only transition to
+	// `JOB_STATE_DRAINED`,
+	// `JOB_STATE_CANCELLED`, or `JOB_STATE_FAILED`.
+	//   "JOB_STATE_DRAINED" - `JOB_STATE_DRAINED` indicates that the job
+	// has been drained.
+	// A drained job terminated by stopping pulling from its input sources
+	// and
+	// processing any data that remained in-flight when draining was
+	// requested.
+	// This state is a terminal state, may only be set by the Cloud
+	// Dataflow
+	// service, and only as a transition from `JOB_STATE_DRAINING`.
+	CurrentState string `json:"currentState,omitempty"`
+
+	// CurrentStateTime: The timestamp associated with the current state.
+	CurrentStateTime string `json:"currentStateTime,omitempty"`
+
+	// Environment: The environment for the job.
+	Environment *Environment `json:"environment,omitempty"`
+
+	// ExecutionInfo: Deprecated.
+	ExecutionInfo *JobExecutionInfo `json:"executionInfo,omitempty"`
+
+	// Id: The unique ID of this job.
+	//
+	// This field is set by the Cloud Dataflow service when the Job
+	// is
+	// created, and is immutable for the life of the job.
+	Id string `json:"id,omitempty"`
+
+	// Labels: User-defined labels for this job.
+	//
+	// The labels map can contain no more than 64 entries.  Entries of the
+	// labels
+	// map are UTF8 strings that comply with the following restrictions:
+	//
+	// * Keys must conform to regexp:  \p{Ll}\p{Lo}{0,62}
+	// * Values must conform to regexp:  [\p{Ll}\p{Lo}\p{N}_-]{0,63}
+	// * Both keys and values are additionally constrained to be <= 128
+	// bytes in
+	// size.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Location: The location that contains this job.
+	Location string `json:"location,omitempty"`
+
+	// Name: The user-specified Cloud Dataflow job name.
+	//
+	// Only one Job with a given name may exist in a project at any
+	// given time. If a caller attempts to create a Job with the same
+	// name as an already-existing Job, the attempt returns the
+	// existing Job.
+	//
+	// The name must match the regular
+	// expression
+	// `[a-z]([-a-z0-9]{0,38}[a-z0-9])?`
+	Name string `json:"name,omitempty"`
+
+	// PipelineDescription: Preliminary field: The format of this data may
+	// change at any time.
+	// A description of the user pipeline and stages through which it is
+	// executed.
+	// Created by Cloud Dataflow service.  Only retrieved
+	// with
+	// JOB_VIEW_DESCRIPTION or JOB_VIEW_ALL.
+	PipelineDescription *PipelineDescription `json:"pipelineDescription,omitempty"`
+
+	// ProjectId: The ID of the Cloud Platform project that the job belongs
+	// to.
+	ProjectId string `json:"projectId,omitempty"`
+
+	// ReplaceJobId: If this job is an update of an existing job, this field
+	// is the job ID
+	// of the job it replaced.
+	//
+	// When sending a `CreateJobRequest`, you can update a job by specifying
+	// it
+	// here. The job named here is stopped, and its intermediate state
+	// is
+	// transferred to this job.
+	ReplaceJobId string `json:"replaceJobId,omitempty"`
+
+	// ReplacedByJobId: If another job is an update of this job (and thus,
+	// this job is in
+	// `JOB_STATE_UPDATED`), this field contains the ID of that job.
+	ReplacedByJobId string `json:"replacedByJobId,omitempty"`
+
+	// RequestedState: The job's requested state.
+	//
+	// `UpdateJob` may be used to switch between the `JOB_STATE_STOPPED`
+	// and
+	// `JOB_STATE_RUNNING` states, by setting requested_state.  `UpdateJob`
+	// may
+	// also be used to directly set a job's requested state
+	// to
+	// `JOB_STATE_CANCELLED` or `JOB_STATE_DONE`, irrevocably terminating
+	// the
+	// job if it has not already reached a terminal state.
+	//
+	// Possible values:
+	//   "JOB_STATE_UNKNOWN" - The job's run state isn't specified.
+	//   "JOB_STATE_STOPPED" - `JOB_STATE_STOPPED` indicates that the job
+	// has not
+	// yet started to run.
+	//   "JOB_STATE_RUNNING" - `JOB_STATE_RUNNING` indicates that the job is
+	// currently running.
+	//   "JOB_STATE_DONE" - `JOB_STATE_DONE` indicates that the job has
+	// successfully completed.
+	// This is a terminal job state.  This state may be set by the Cloud
+	// Dataflow
+	// service, as a transition from `JOB_STATE_RUNNING`. It may also be set
+	// via a
+	// Cloud Dataflow `UpdateJob` call, if the job has not yet reached a
+	// terminal
+	// state.
+	//   "JOB_STATE_FAILED" - `JOB_STATE_FAILED` indicates that the job has
+	// failed.  This is a
+	// terminal job state.  This state may only be set by the Cloud
+	// Dataflow
+	// service, and only as a transition from `JOB_STATE_RUNNING`.
+	//   "JOB_STATE_CANCELLED" - `JOB_STATE_CANCELLED` indicates that the
+	// job has been explicitly
+	// cancelled. This is a terminal job state. This state may only be
+	// set via a Cloud Dataflow `UpdateJob` call, and only if the job has
+	// not
+	// yet reached another terminal state.
+	//   "JOB_STATE_UPDATED" - `JOB_STATE_UPDATED` indicates that the job
+	// was successfully updated,
+	// meaning that this job was stopped and another job was started,
+	// inheriting
+	// state from this one. This is a terminal job state. This state may
+	// only be
+	// set by the Cloud Dataflow service, and only as a transition
+	// from
+	// `JOB_STATE_RUNNING`.
+	//   "JOB_STATE_DRAINING" - `JOB_STATE_DRAINING` indicates that the job
+	// is in the process of draining.
+	// A draining job has stopped pulling from its input sources and is
+	// processing
+	// any data that remains in-flight. This state may be set via a Cloud
+	// Dataflow
+	// `UpdateJob` call, but only as a transition from `JOB_STATE_RUNNING`.
+	// Jobs
+	// that are draining may only transition to
+	// `JOB_STATE_DRAINED`,
+	// `JOB_STATE_CANCELLED`, or `JOB_STATE_FAILED`.
+	//   "JOB_STATE_DRAINED" - `JOB_STATE_DRAINED` indicates that the job
+	// has been drained.
+	// A drained job terminated by stopping pulling from its input sources
+	// and
+	// processing any data that remained in-flight when draining was
+	// requested.
+	// This state is a terminal state, may only be set by the Cloud
+	// Dataflow
+	// service, and only as a transition from `JOB_STATE_DRAINING`.
+	RequestedState string `json:"requestedState,omitempty"`
+
+	// Steps: The top-level steps that constitute the entire job.
+	Steps []*Step `json:"steps,omitempty"`
+
+	// TempFiles: A set of files the system should be aware of that are
+	// used
+	// for temporary storage. These temporary files will be
+	// removed on job completion.
+	// No duplicates are allowed.
+	// No file patterns are supported.
+	//
+	// The supported files are:
+	//
+	// Google Cloud Storage:
+	//
+	//    storage.googleapis.com/{bucket}/{object}
+	//    bucket.storage.googleapis.com/{object}
+	TempFiles []string `json:"tempFiles,omitempty"`
+
+	// TransformNameMapping: The map of transform name prefixes of the job
+	// to be replaced to the
+	// corresponding name prefixes of the new job.
+	TransformNameMapping map[string]string `json:"transformNameMapping,omitempty"`
+
+	// Type: The type of Cloud Dataflow job.
+	//
+	// Possible values:
+	//   "JOB_TYPE_UNKNOWN" - The type of the job is unspecified, or
+	// unknown.
+	//   "JOB_TYPE_BATCH" - A batch job with a well-defined end point: data
+	// is read, data is
+	// processed, data is written, and the job is done.
+	//   "JOB_TYPE_STREAMING" - A continuously streaming job with no end:
+	// data is read,
+	// processed, and written continuously.
+	Type string `json:"type,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "ClientRequestId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ClientRequestId") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Job) MarshalJSON() ([]byte, error) {
+	type noMethod Job
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// JobExecutionInfo: Additional information about how a Cloud Dataflow
+// job will be executed that
+// isn't contained in the submitted job.
+type JobExecutionInfo struct {
+	// Stages: A mapping from each stage to the information about that
+	// stage.
+	Stages map[string]JobExecutionStageInfo `json:"stages,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Stages") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Stages") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JobExecutionInfo) MarshalJSON() ([]byte, error) {
+	type noMethod JobExecutionInfo
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// JobExecutionStageInfo: Contains information about how a
+// particular
+// google.dataflow.v1beta3.Step will be executed.
+type JobExecutionStageInfo struct {
+	// StepName: The steps associated with the execution stage.
+	// Note that stages may have several steps, and that a given step
+	// might be run by more than one stage.
+	StepName []string `json:"stepName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "StepName") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "StepName") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JobExecutionStageInfo) MarshalJSON() ([]byte, error) {
+	type noMethod JobExecutionStageInfo
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// JobMessage: A particular message pertaining to a Dataflow job.
+type JobMessage struct {
+	// Id: Identifies the message.  This is automatically generated by
+	// the
+	// service; the caller should treat it as an opaque string.
+	Id string `json:"id,omitempty"`
+
+	// MessageImportance: Importance level of the message.
+	//
+	// Possible values:
+	//   "JOB_MESSAGE_IMPORTANCE_UNKNOWN" - The message importance isn't
+	// specified, or is unknown.
+	//   "JOB_MESSAGE_DEBUG" - The message is at the 'debug' level:
+	// typically only useful for
+	// software engineers working on the code the job is running.
+	// Typically, Dataflow pipeline runners do not display log messages
+	// at this level by default.
+	//   "JOB_MESSAGE_DETAILED" - The message is at the 'detailed' level:
+	// somewhat verbose, but
+	// potentially useful to users.  Typically, Dataflow pipeline
+	// runners do not display log messages at this level by default.
+	// These messages are displayed by default in the Dataflow
+	// monitoring UI.
+	//   "JOB_MESSAGE_BASIC" - The message is at the 'basic' level: useful
+	// for keeping
+	// track of the execution of a Dataflow pipeline.  Typically,
+	// Dataflow pipeline runners display log messages at this level
+	// by
+	// default, and these messages are displayed by default in the
+	// Dataflow monitoring UI.
+	//   "JOB_MESSAGE_WARNING" - The message is at the 'warning' level:
+	// indicating a condition
+	// pertaining to a job which may require human intervention.
+	// Typically, Dataflow pipeline runners display log messages at
+	// this
+	// level by default, and these messages are displayed by default in
+	// the Dataflow monitoring UI.
+	//   "JOB_MESSAGE_ERROR" - The message is at the 'error' level:
+	// indicating a condition
+	// preventing a job from succeeding.  Typically, Dataflow
+	// pipeline
+	// runners display log messages at this level by default, and
+	// these
+	// messages are displayed by default in the Dataflow monitoring UI.
+	MessageImportance string `json:"messageImportance,omitempty"`
+
+	// MessageText: The text of the message.
+	MessageText string `json:"messageText,omitempty"`
+
+	// Time: The timestamp of the message.
+	Time string `json:"time,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Id") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Id") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JobMessage) MarshalJSON() ([]byte, error) {
+	type noMethod JobMessage
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// JobMetrics: JobMetrics contains a collection of metrics descibing the
+// detailed progress
+// of a Dataflow job. Metrics correspond to user-defined and
+// system-defined
+// metrics in the job.
+//
+// This resource captures only the most recent values of each
+// metric;
+// time-series data can be queried for them (under the same metric
+// names)
+// from Cloud Monitoring.
+type JobMetrics struct {
+	// MetricTime: Timestamp as of which metric values are current.
+	MetricTime string `json:"metricTime,omitempty"`
+
+	// Metrics: All metrics for this job.
+	Metrics []*MetricUpdate `json:"metrics,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "MetricTime") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "MetricTime") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *JobMetrics) MarshalJSON() ([]byte, error) {
+	type noMethod JobMetrics
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// KeyRangeDataDiskAssignment: Data disk assignment information for a
+// specific key-range of a sharded
+// computation.
+// Currently we only support UTF-8 character splits to simplify encoding
+// into
+// JSON.
+type KeyRangeDataDiskAssignment struct {
+	// DataDisk: The name of the data disk where data for this range is
+	// stored.
+	// This name is local to the Google Cloud Platform project and
+	// uniquely
+	// identifies the disk within that project, for
+	// example
+	// "myproject-1014-104817-4c2-harness-0-disk-1".
+	DataDisk string `json:"dataDisk,omitempty"`
+
+	// End: The end (exclusive) of the key range.
+	End string `json:"end,omitempty"`
+
+	// Start: The start (inclusive) of the key range.
+	Start string `json:"start,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DataDisk") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DataDisk") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *KeyRangeDataDiskAssignment) MarshalJSON() ([]byte, error) {
+	type noMethod KeyRangeDataDiskAssignment
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// KeyRangeLocation: Location information for a specific key-range of a
+// sharded computation.
+// Currently we only support UTF-8 character splits to simplify encoding
+// into
+// JSON.
+type KeyRangeLocation struct {
+	// DataDisk: The name of the data disk where data for this range is
+	// stored.
+	// This name is local to the Google Cloud Platform project and
+	// uniquely
+	// identifies the disk within that project, for
+	// example
+	// "myproject-1014-104817-4c2-harness-0-disk-1".
+	DataDisk string `json:"dataDisk,omitempty"`
+
+	// DeliveryEndpoint: The physical location of this range assignment to
+	// be used for
+	// streaming computation cross-worker message delivery.
+	DeliveryEndpoint string `json:"deliveryEndpoint,omitempty"`
+
+	// DeprecatedPersistentDirectory: DEPRECATED. The location of the
+	// persistent state for this range, as a
+	// persistent directory in the worker local filesystem.
+	DeprecatedPersistentDirectory string `json:"deprecatedPersistentDirectory,omitempty"`
+
+	// End: The end (exclusive) of the key range.
+	End string `json:"end,omitempty"`
+
+	// Start: The start (inclusive) of the key range.
+	Start string `json:"start,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DataDisk") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DataDisk") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *KeyRangeLocation) MarshalJSON() ([]byte, error) {
+	type noMethod KeyRangeLocation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LaunchTemplateParameters: Parameters to provide to the template being
+// launched.
+type LaunchTemplateParameters struct {
+	// Environment: The runtime environment for the job.
+	Environment *RuntimeEnvironment `json:"environment,omitempty"`
+
+	// JobName: Required. The job name to use for the created job.
+	JobName string `json:"jobName,omitempty"`
+
+	// Parameters: The runtime parameters to pass to the job.
+	Parameters map[string]string `json:"parameters,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Environment") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Environment") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LaunchTemplateParameters) MarshalJSON() ([]byte, error) {
+	type noMethod LaunchTemplateParameters
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LaunchTemplateResponse: Response to the request to launch a template.
+type LaunchTemplateResponse struct {
+	// Job: The job that was launched, if the request was not a dry run
+	// and
+	// the job was successfully launched.
+	Job *Job `json:"job,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "Job") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Job") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LaunchTemplateResponse) MarshalJSON() ([]byte, error) {
+	type noMethod LaunchTemplateResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LeaseWorkItemRequest: Request to lease WorkItems.
+type LeaseWorkItemRequest struct {
+	// CurrentWorkerTime: The current timestamp at the worker.
+	CurrentWorkerTime string `json:"currentWorkerTime,omitempty"`
+
+	// Location: The location which contains the WorkItem's job.
+	Location string `json:"location,omitempty"`
+
+	// RequestedLeaseDuration: The initial lease period.
+	RequestedLeaseDuration string `json:"requestedLeaseDuration,omitempty"`
+
+	// WorkItemTypes: Filter for WorkItem type.
+	WorkItemTypes []string `json:"workItemTypes,omitempty"`
+
+	// WorkerCapabilities: Worker capabilities. WorkItems might be limited
+	// to workers with specific
+	// capabilities.
+	WorkerCapabilities []string `json:"workerCapabilities,omitempty"`
+
+	// WorkerId: Identifies the worker leasing work -- typically the ID of
+	// the
+	// virtual machine running the worker.
+	WorkerId string `json:"workerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CurrentWorkerTime")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CurrentWorkerTime") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LeaseWorkItemRequest) MarshalJSON() ([]byte, error) {
+	type noMethod LeaseWorkItemRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// LeaseWorkItemResponse: Response to a request to lease WorkItems.
+type LeaseWorkItemResponse struct {
+	// WorkItems: A list of the leased WorkItems.
+	WorkItems []*WorkItem `json:"workItems,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "WorkItems") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "WorkItems") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *LeaseWorkItemResponse) MarshalJSON() ([]byte, error) {
+	type noMethod LeaseWorkItemResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListJobMessagesResponse: Response to a request to list job messages.
+type ListJobMessagesResponse struct {
+	// JobMessages: Messages in ascending timestamp order.
+	JobMessages []*JobMessage `json:"jobMessages,omitempty"`
+
+	// NextPageToken: The token to obtain the next page of results if there
+	// are more.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "JobMessages") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "JobMessages") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListJobMessagesResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListJobMessagesResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ListJobsResponse: Response to a request to list Cloud Dataflow jobs.
+// This may be a partial
+// response, depending on the page size in the ListJobsRequest.
+type ListJobsResponse struct {
+	// FailedLocation: Zero or more messages describing locations that
+	// failed to respond.
+	FailedLocation []*FailedLocation `json:"failedLocation,omitempty"`
+
+	// Jobs: A subset of the requested job information.
+	Jobs []*Job `json:"jobs,omitempty"`
+
+	// NextPageToken: Set if there may be more results than fit in this
+	// response.
+	NextPageToken string `json:"nextPageToken,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g. "FailedLocation") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "FailedLocation") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ListJobsResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ListJobsResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MapTask: MapTask consists of an ordered set of instructions, each of
+// which
+// describes one particular low-level operation for the worker
+// to
+// perform in order to accomplish the MapTask's WorkItem.
+//
+// Each instruction must appear in the list before any instructions
+// which
+// depends on its output.
+type MapTask struct {
+	// Instructions: The instructions in the MapTask.
+	Instructions []*ParallelInstruction `json:"instructions,omitempty"`
+
+	// StageName: System-defined name of the stage containing this
+	// MapTask.
+	// Unique across the workflow.
+	StageName string `json:"stageName,omitempty"`
+
+	// SystemName: System-defined name of this MapTask.
+	// Unique across the workflow.
+	SystemName string `json:"systemName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Instructions") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Instructions") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MapTask) MarshalJSON() ([]byte, error) {
+	type noMethod MapTask
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MetricShortId: The metric short id is returned to the user alongside
+// an offset into
+// ReportWorkItemStatusRequest
+type MetricShortId struct {
+	// MetricIndex: The index of the corresponding metric in
+	// the ReportWorkItemStatusRequest. Required.
+	MetricIndex int64 `json:"metricIndex,omitempty"`
+
+	// ShortId: The service-generated short identifier for the metric.
+	ShortId int64 `json:"shortId,omitempty,string"`
+
+	// ForceSendFields is a list of field names (e.g. "MetricIndex") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "MetricIndex") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MetricShortId) MarshalJSON() ([]byte, error) {
+	type noMethod MetricShortId
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MetricStructuredName: Identifies a metric, by describing the source
+// which generated the
+// metric.
+type MetricStructuredName struct {
+	// Context: Zero or more labeled fields which identify the part of the
+	// job this
+	// metric is associated with, such as the name of a step or
+	// collection.
+	//
+	// For example, built-in counters associated with steps will
+	// have
+	// context['step'] = <step-name>. Counters associated with
+	// PCollections
+	// in the SDK will have context['pcollection'] = <pcollection-name>.
+	Context map[string]string `json:"context,omitempty"`
+
+	// Name: Worker-defined metric name.
+	Name string `json:"name,omitempty"`
+
+	// Origin: Origin (namespace) of metric name. May be blank for
+	// user-define metrics;
+	// will be "dataflow" for metrics defined by the Dataflow service or
+	// SDK.
+	Origin string `json:"origin,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Context") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Context") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MetricStructuredName) MarshalJSON() ([]byte, error) {
+	type noMethod MetricStructuredName
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MetricUpdate: Describes the state of a metric.
+type MetricUpdate struct {
+	// Cumulative: True if this metric is reported as the total cumulative
+	// aggregate
+	// value accumulated since the worker started working on this
+	// WorkItem.
+	// By default this is false, indicating that this metric is reported
+	// as a delta that is not associated with any WorkItem.
+	Cumulative bool `json:"cumulative,omitempty"`
+
+	// Internal: Worker-computed aggregate value for internal use by the
+	// Dataflow
+	// service.
+	Internal interface{} `json:"internal,omitempty"`
+
+	// Kind: Metric aggregation kind.  The possible metric aggregation kinds
+	// are
+	// "Sum", "Max", "Min", "Mean", "Set", "And", and "Or".
+	// The specified aggregation kind is case-insensitive.
+	//
+	// If omitted, this is not an aggregated value but instead
+	// a single metric sample value.
+	Kind string `json:"kind,omitempty"`
+
+	// MeanCount: Worker-computed aggregate value for the "Mean" aggregation
+	// kind.
+	// This holds the count of the aggregated values and is used in
+	// combination
+	// with mean_sum above to obtain the actual mean aggregate value.
+	// The only possible value type is Long.
+	MeanCount interface{} `json:"meanCount,omitempty"`
+
+	// MeanSum: Worker-computed aggregate value for the "Mean" aggregation
+	// kind.
+	// This holds the sum of the aggregated values and is used in
+	// combination
+	// with mean_count below to obtain the actual mean aggregate value.
+	// The only possible value types are Long and Double.
+	MeanSum interface{} `json:"meanSum,omitempty"`
+
+	// Name: Name of the metric.
+	Name *MetricStructuredName `json:"name,omitempty"`
+
+	// Scalar: Worker-computed aggregate value for aggregation kinds "Sum",
+	// "Max", "Min",
+	// "And", and "Or".  The possible value types are Long, Double, and
+	// Boolean.
+	Scalar interface{} `json:"scalar,omitempty"`
+
+	// Set: Worker-computed aggregate value for the "Set" aggregation kind.
+	// The only
+	// possible value type is a list of Values whose type can be Long,
+	// Double,
+	// or String, according to the metric's type.  All Values in the list
+	// must
+	// be of the same type.
+	Set interface{} `json:"set,omitempty"`
+
+	// UpdateTime: Timestamp associated with the metric value. Optional when
+	// workers are
+	// reporting work progress; it will be filled in responses from
+	// the
+	// metrics API.
+	UpdateTime string `json:"updateTime,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Cumulative") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Cumulative") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MetricUpdate) MarshalJSON() ([]byte, error) {
+	type noMethod MetricUpdate
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MountedDataDisk: Describes mounted data disk.
+type MountedDataDisk struct {
+	// DataDisk: The name of the data disk.
+	// This name is local to the Google Cloud Platform project and
+	// uniquely
+	// identifies the disk within that project, for
+	// example
+	// "myproject-1014-104817-4c2-harness-0-disk-1".
+	DataDisk string `json:"dataDisk,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DataDisk") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DataDisk") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MountedDataDisk) MarshalJSON() ([]byte, error) {
+	type noMethod MountedDataDisk
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// MultiOutputInfo: Information about an output of a multi-output DoFn.
+type MultiOutputInfo struct {
+	// Tag: The id of the tag the user code will emit to this output by;
+	// this
+	// should correspond to the tag of some SideInputInfo.
+	Tag string `json:"tag,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Tag") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Tag") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *MultiOutputInfo) MarshalJSON() ([]byte, error) {
+	type noMethod MultiOutputInfo
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// NameAndKind: Basic metadata about a counter.
+type NameAndKind struct {
+	// Kind: Counter aggregation kind.
+	//
+	// Possible values:
+	//   "INVALID" - Counter aggregation kind was not set.
+	//   "SUM" - Aggregated value is the sum of all contributed values.
+	//   "MAX" - Aggregated value is the max of all contributed values.
+	//   "MIN" - Aggregated value is the min of all contributed values.
+	//   "MEAN" - Aggregated value is the mean of all contributed values.
+	//   "OR" - Aggregated value represents the logical 'or' of all
+	// contributed values.
+	//   "AND" - Aggregated value represents the logical 'and' of all
+	// contributed values.
+	//   "SET" - Aggregated value is a set of unique contributed values.
+	//   "DISTRIBUTION" - Aggregated value captures statistics about a
+	// distribution.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: Name of the counter.
+	Name string `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *NameAndKind) MarshalJSON() ([]byte, error) {
+	type noMethod NameAndKind
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Package: The packages that must be installed in order for a worker to
+// run the
+// steps of the Cloud Dataflow job that will be assigned to its
+// worker
+// pool.
+//
+// This is the mechanism by which the Cloud Dataflow SDK causes code
+// to
+// be loaded onto the workers. For example, the Cloud Dataflow Java
+// SDK
+// might use this to install jars containing the user's code and all of
+// the
+// various dependencies (libraries, data files, etc.) required in
+// order
+// for that code to run.
+type Package struct {
+	// Location: The resource to read the package from. The supported
+	// resource type is:
+	//
+	// Google Cloud Storage:
+	//
+	//   storage.googleapis.com/{bucket}
+	//   bucket.storage.googleapis.com/
+	Location string `json:"location,omitempty"`
+
+	// Name: The name of the package.
+	Name string `json:"name,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Location") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Location") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Package) MarshalJSON() ([]byte, error) {
+	type noMethod Package
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ParDoInstruction: An instruction that does a ParDo operation.
+// Takes one main input and zero or more side inputs, and produces
+// zero or more outputs.
+// Runs user code.
+type ParDoInstruction struct {
+	// Input: The input.
+	Input *InstructionInput `json:"input,omitempty"`
+
+	// MultiOutputInfos: Information about each of the outputs, if user_fn
+	// is a  MultiDoFn.
+	MultiOutputInfos []*MultiOutputInfo `json:"multiOutputInfos,omitempty"`
+
+	// NumOutputs: The number of outputs.
+	NumOutputs int64 `json:"numOutputs,omitempty"`
+
+	// SideInputs: Zero or more side inputs.
+	SideInputs []*SideInputInfo `json:"sideInputs,omitempty"`
+
+	// UserFn: The user function to invoke.
+	UserFn googleapi.RawMessage `json:"userFn,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Input") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Input") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ParDoInstruction) MarshalJSON() ([]byte, error) {
+	type noMethod ParDoInstruction
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ParallelInstruction: Describes a particular operation comprising a
+// MapTask.
+type ParallelInstruction struct {
+	// Flatten: Additional information for Flatten instructions.
+	Flatten *FlattenInstruction `json:"flatten,omitempty"`
+
+	// Name: User-provided name of this operation.
+	Name string `json:"name,omitempty"`
+
+	// OriginalName: System-defined name for the operation in the original
+	// workflow graph.
+	OriginalName string `json:"originalName,omitempty"`
+
+	// Outputs: Describes the outputs of the instruction.
+	Outputs []*InstructionOutput `json:"outputs,omitempty"`
+
+	// ParDo: Additional information for ParDo instructions.
+	ParDo *ParDoInstruction `json:"parDo,omitempty"`
+
+	// PartialGroupByKey: Additional information for PartialGroupByKey
+	// instructions.
+	PartialGroupByKey *PartialGroupByKeyInstruction `json:"partialGroupByKey,omitempty"`
+
+	// Read: Additional information for Read instructions.
+	Read *ReadInstruction `json:"read,omitempty"`
+
+	// SystemName: System-defined name of this operation.
+	// Unique across the workflow.
+	SystemName string `json:"systemName,omitempty"`
+
+	// Write: Additional information for Write instructions.
+	Write *WriteInstruction `json:"write,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Flatten") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Flatten") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ParallelInstruction) MarshalJSON() ([]byte, error) {
+	type noMethod ParallelInstruction
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ParameterMetadata: Metadata for a specific parameter.
+type ParameterMetadata struct {
+	// HelpText: Required. The help text to display for the parameter.
+	HelpText string `json:"helpText,omitempty"`
+
+	// IsOptional: Optional. Whether the parameter is optional. Defaults to
+	// false.
+	IsOptional bool `json:"isOptional,omitempty"`
+
+	// Label: Required. The label to display for the parameter.
+	Label string `json:"label,omitempty"`
+
+	// Name: Required. The name of the parameter.
+	Name string `json:"name,omitempty"`
+
+	// Regexes: Optional. Regexes that the parameter must match.
+	Regexes []string `json:"regexes,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "HelpText") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "HelpText") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ParameterMetadata) MarshalJSON() ([]byte, error) {
+	type noMethod ParameterMetadata
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// PartialGroupByKeyInstruction: An instruction that does a partial
+// group-by-key.
+// One input and one output.
+type PartialGroupByKeyInstruction struct {
+	// Input: Describes the input to the partial group-by-key instruction.
+	Input *InstructionInput `json:"input,omitempty"`
+
+	// InputElementCodec: The codec to use for interpreting an element in
+	// the input PTable.
+	InputElementCodec googleapi.RawMessage `json:"inputElementCodec,omitempty"`
+
+	// OriginalCombineValuesInputStoreName: If this instruction includes a
+	// combining function this is the name of the
+	// intermediate store between the GBK and the CombineValues.
+	OriginalCombineValuesInputStoreName string `json:"originalCombineValuesInputStoreName,omitempty"`
+
+	// OriginalCombineValuesStepName: If this instruction includes a
+	// combining function, this is the name of the
+	// CombineValues instruction lifted into this instruction.
+	OriginalCombineValuesStepName string `json:"originalCombineValuesStepName,omitempty"`
+
+	// SideInputs: Zero or more side inputs.
+	SideInputs []*SideInputInfo `json:"sideInputs,omitempty"`
+
+	// ValueCombiningFn: The value combining function to invoke.
+	ValueCombiningFn googleapi.RawMessage `json:"valueCombiningFn,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Input") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Input") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *PartialGroupByKeyInstruction) MarshalJSON() ([]byte, error) {
+	type noMethod PartialGroupByKeyInstruction
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// PipelineDescription: A descriptive representation of submitted
+// pipeline as well as the executed
+// form.  This data is provided by the Dataflow service for ease of
+// visualizing
+// the pipeline and interpretting Dataflow provided metrics.
+type PipelineDescription struct {
+	// DisplayData: Pipeline level display data.
+	DisplayData []*DisplayData `json:"displayData,omitempty"`
+
+	// ExecutionPipelineStage: Description of each stage of execution of the
+	// pipeline.
+	ExecutionPipelineStage []*ExecutionStageSummary `json:"executionPipelineStage,omitempty"`
+
+	// OriginalPipelineTransform: Description of each transform in the
+	// pipeline and collections between them.
+	OriginalPipelineTransform []*TransformSummary `json:"originalPipelineTransform,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DisplayData") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DisplayData") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *PipelineDescription) MarshalJSON() ([]byte, error) {
+	type noMethod PipelineDescription
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Position: Position defines a position within a collection of data.
+// The value
+// can be either the end position, a key (used with
+// ordered
+// collections), a byte offset, or a record index.
+type Position struct {
+	// ByteOffset: Position is a byte offset.
+	ByteOffset int64 `json:"byteOffset,omitempty,string"`
+
+	// ConcatPosition: CloudPosition is a concat position.
+	ConcatPosition *ConcatPosition `json:"concatPosition,omitempty"`
+
+	// End: Position is past all other positions. Also useful for the
+	// end
+	// position of an unbounded range.
+	End bool `json:"end,omitempty"`
+
+	// Key: Position is a string key, ordered lexicographically.
+	Key string `json:"key,omitempty"`
+
+	// RecordIndex: Position is a record index.
+	RecordIndex int64 `json:"recordIndex,omitempty,string"`
+
+	// ShufflePosition: CloudPosition is a base64 encoded
+	// BatchShufflePosition (with FIXED
+	// sharding).
+	ShufflePosition string `json:"shufflePosition,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ByteOffset") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ByteOffset") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Position) MarshalJSON() ([]byte, error) {
+	type noMethod Position
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// PubsubLocation: Identifies a pubsub location to use for transferring
+// data into or
+// out of a streaming Dataflow job.
+type PubsubLocation struct {
+	// DropLateData: Indicates whether the pipeline allows late-arriving
+	// data.
+	DropLateData bool `json:"dropLateData,omitempty"`
+
+	// IdLabel: If set, contains a pubsub label from which to extract record
+	// ids.
+	// If left empty, record deduplication will be strictly best effort.
+	IdLabel string `json:"idLabel,omitempty"`
+
+	// Subscription: A pubsub subscription, in the form
+	// of
+	// "pubsub.googleapis.com/subscriptions/<project-id>/<subscription-nam
+	// e>"
+	Subscription string `json:"subscription,omitempty"`
+
+	// TimestampLabel: If set, contains a pubsub label from which to extract
+	// record timestamps.
+	// If left empty, record timestamps will be generated upon arrival.
+	TimestampLabel string `json:"timestampLabel,omitempty"`
+
+	// Topic: A pubsub topic, in the form
+	// of
+	// "pubsub.googleapis.com/topics/<project-id>/<topic-name>"
+	Topic string `json:"topic,omitempty"`
+
+	// TrackingSubscription: If set, specifies the pubsub subscription that
+	// will be used for tracking
+	// custom time timestamps for watermark estimation.
+	TrackingSubscription string `json:"trackingSubscription,omitempty"`
+
+	// WithAttributes: If true, then the client has requested to get pubsub
+	// attributes.
+	WithAttributes bool `json:"withAttributes,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DropLateData") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DropLateData") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *PubsubLocation) MarshalJSON() ([]byte, error) {
+	type noMethod PubsubLocation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ReadInstruction: An instruction that reads records.
+// Takes no inputs, produces one output.
+type ReadInstruction struct {
+	// Source: The source to read from.
+	Source *Source `json:"source,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Source") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Source") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ReadInstruction) MarshalJSON() ([]byte, error) {
+	type noMethod ReadInstruction
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ReportWorkItemStatusRequest: Request to report the status of
+// WorkItems.
+type ReportWorkItemStatusRequest struct {
+	// CurrentWorkerTime: The current timestamp at the worker.
+	CurrentWorkerTime string `json:"currentWorkerTime,omitempty"`
+
+	// Location: The location which contains the WorkItem's job.
+	Location string `json:"location,omitempty"`
+
+	// WorkItemStatuses: The order is unimportant, except that the order of
+	// the
+	// WorkItemServiceState messages in the
+	// ReportWorkItemStatusResponse
+	// corresponds to the order of WorkItemStatus messages here.
+	WorkItemStatuses []*WorkItemStatus `json:"workItemStatuses,omitempty"`
+
+	// WorkerId: The ID of the worker reporting the WorkItem status.  If
+	// this
+	// does not match the ID of the worker which the Dataflow
+	// service
+	// believes currently has the lease on the WorkItem, the report
+	// will be dropped (with an error response).
+	WorkerId string `json:"workerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CurrentWorkerTime")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CurrentWorkerTime") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ReportWorkItemStatusRequest) MarshalJSON() ([]byte, error) {
+	type noMethod ReportWorkItemStatusRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ReportWorkItemStatusResponse: Response from a request to report the
+// status of WorkItems.
+type ReportWorkItemStatusResponse struct {
+	// WorkItemServiceStates: A set of messages indicating the service-side
+	// state for each
+	// WorkItem whose status was reported, in the same order as
+	// the
+	// WorkItemStatus messages in the ReportWorkItemStatusRequest
+	// which
+	// resulting in this response.
+	WorkItemServiceStates []*WorkItemServiceState `json:"workItemServiceStates,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "WorkItemServiceStates") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "WorkItemServiceStates") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ReportWorkItemStatusResponse) MarshalJSON() ([]byte, error) {
+	type noMethod ReportWorkItemStatusResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ReportedParallelism: Represents the level of parallelism in a
+// WorkItem's input,
+// reported by the worker.
+type ReportedParallelism struct {
+	// IsInfinite: Specifies whether the parallelism is infinite. If true,
+	// "value" is
+	// ignored.
+	// Infinite parallelism means the service will assume that the work
+	// item
+	// can always be split into more non-empty work items by dynamic
+	// splitting.
+	// This is a work-around for lack of support for infinity by the
+	// current
+	// JSON-based Java RPC stack.
+	IsInfinite bool `json:"isInfinite,omitempty"`
+
+	// Value: Specifies the level of parallelism in case it is finite.
+	Value float64 `json:"value,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "IsInfinite") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "IsInfinite") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ReportedParallelism) MarshalJSON() ([]byte, error) {
+	type noMethod ReportedParallelism
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+func (s *ReportedParallelism) UnmarshalJSON(data []byte) error {
+	type noMethod ReportedParallelism
+	var s1 struct {
+		Value gensupport.JSONFloat64 `json:"value"`
+		*noMethod
+	}
+	s1.noMethod = (*noMethod)(s)
+	if err := json.Unmarshal(data, &s1); err != nil {
+		return err
+	}
+	s.Value = float64(s1.Value)
+	return nil
+}
+
+// ResourceUtilizationReport: Worker metrics exported from workers. This
+// contains resource utilization
+// metrics accumulated from a variety of sources. For more information,
+// see
+// go/df-resource-signals.
+type ResourceUtilizationReport struct {
+	// CpuTime: CPU utilization samples.
+	CpuTime []*CPUTime `json:"cpuTime,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "CpuTime") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CpuTime") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ResourceUtilizationReport) MarshalJSON() ([]byte, error) {
+	type noMethod ResourceUtilizationReport
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ResourceUtilizationReportResponse: Service-side response to
+// WorkerMessage reporting resource utilization.
+type ResourceUtilizationReportResponse struct {
+}
+
+// RuntimeEnvironment: The environment values to set at runtime.
+type RuntimeEnvironment struct {
+	// BypassTempDirValidation: Whether to bypass the safety checks for the
+	// job's temporary directory.
+	// Use with caution.
+	BypassTempDirValidation bool `json:"bypassTempDirValidation,omitempty"`
+
+	// MaxWorkers: The maximum number of Google Compute Engine instances to
+	// be made
+	// available to your pipeline during execution, from 1 to 1000.
+	MaxWorkers int64 `json:"maxWorkers,omitempty"`
+
+	// ServiceAccountEmail: The email address of the service account to run
+	// the job as.
+	ServiceAccountEmail string `json:"serviceAccountEmail,omitempty"`
+
+	// TempLocation: The Cloud Storage path to use for temporary files.
+	// Must be a valid Cloud Storage URL, beginning with `gs://`.
+	TempLocation string `json:"tempLocation,omitempty"`
+
+	// Zone: The Compute Engine [availability
+	// zone](https://cloud.google.com/compute/docs/regions-zones/regions-zone
+	// s)
+	// for launching worker instances to run your pipeline.
+	Zone string `json:"zone,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "BypassTempDirValidation") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BypassTempDirValidation")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *RuntimeEnvironment) MarshalJSON() ([]byte, error) {
+	type noMethod RuntimeEnvironment
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SendDebugCaptureRequest: Request to send encoded debug information.
+type SendDebugCaptureRequest struct {
+	// ComponentId: The internal component id for which debug information is
+	// sent.
+	ComponentId string `json:"componentId,omitempty"`
+
+	// Data: The encoded debug information.
+	Data string `json:"data,omitempty"`
+
+	// WorkerId: The worker id, i.e., VM hostname.
+	WorkerId string `json:"workerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComponentId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComponentId") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SendDebugCaptureRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SendDebugCaptureRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SendDebugCaptureResponse: Response to a send capture request.
+// nothing
+type SendDebugCaptureResponse struct {
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+}
+
+// SendWorkerMessagesRequest: A request for sending worker messages to
+// the service.
+type SendWorkerMessagesRequest struct {
+	// WorkerMessages: The WorkerMessages to send.
+	WorkerMessages []*WorkerMessage `json:"workerMessages,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "WorkerMessages") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "WorkerMessages") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SendWorkerMessagesRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SendWorkerMessagesRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SendWorkerMessagesResponse: The response to the worker messages.
+type SendWorkerMessagesResponse struct {
+	// WorkerMessageResponses: The servers response to the worker messages.
+	WorkerMessageResponses []*WorkerMessageResponse `json:"workerMessageResponses,omitempty"`
+
+	// ServerResponse contains the HTTP response code and headers from the
+	// server.
+	googleapi.ServerResponse `json:"-"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "WorkerMessageResponses") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "WorkerMessageResponses")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SendWorkerMessagesResponse) MarshalJSON() ([]byte, error) {
+	type noMethod SendWorkerMessagesResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SeqMapTask: Describes a particular function to invoke.
+type SeqMapTask struct {
+	// Inputs: Information about each of the inputs.
+	Inputs []*SideInputInfo `json:"inputs,omitempty"`
+
+	// Name: The user-provided name of the SeqDo operation.
+	Name string `json:"name,omitempty"`
+
+	// OutputInfos: Information about each of the outputs.
+	OutputInfos []*SeqMapTaskOutputInfo `json:"outputInfos,omitempty"`
+
+	// StageName: System-defined name of the stage containing the SeqDo
+	// operation.
+	// Unique across the workflow.
+	StageName string `json:"stageName,omitempty"`
+
+	// SystemName: System-defined name of the SeqDo operation.
+	// Unique across the workflow.
+	SystemName string `json:"systemName,omitempty"`
+
+	// UserFn: The user function to invoke.
+	UserFn googleapi.RawMessage `json:"userFn,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Inputs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Inputs") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SeqMapTask) MarshalJSON() ([]byte, error) {
+	type noMethod SeqMapTask
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SeqMapTaskOutputInfo: Information about an output of a SeqMapTask.
+type SeqMapTaskOutputInfo struct {
+	// Sink: The sink to write the output value to.
+	Sink *Sink `json:"sink,omitempty"`
+
+	// Tag: The id of the TupleTag the user code will tag the output value
+	// by.
+	Tag string `json:"tag,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Sink") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Sink") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SeqMapTaskOutputInfo) MarshalJSON() ([]byte, error) {
+	type noMethod SeqMapTaskOutputInfo
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// ShellTask: A task which consists of a shell command for the worker to
+// execute.
+type ShellTask struct {
+	// Command: The shell command to run.
+	Command string `json:"command,omitempty"`
+
+	// ExitCode: Exit code for the task.
+	ExitCode int64 `json:"exitCode,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Command") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Command") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *ShellTask) MarshalJSON() ([]byte, error) {
+	type noMethod ShellTask
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SideInputInfo: Information about a side input of a DoFn or an input
+// of a SeqDoFn.
+type SideInputInfo struct {
+	// Kind: How to interpret the source element(s) as a side input value.
+	Kind googleapi.RawMessage `json:"kind,omitempty"`
+
+	// Sources: The source(s) to read element(s) from to get the value of
+	// this side input.
+	// If more than one source, then the elements are taken from
+	// the
+	// sources, in the specified order if order matters.
+	// At least one source is required.
+	Sources []*Source `json:"sources,omitempty"`
+
+	// Tag: The id of the tag the user code will access this side input
+	// by;
+	// this should correspond to the tag of some MultiOutputInfo.
+	Tag string `json:"tag,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SideInputInfo) MarshalJSON() ([]byte, error) {
+	type noMethod SideInputInfo
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Sink: A sink that records can be encoded and written to.
+type Sink struct {
+	// Codec: The codec to use to encode data written to the sink.
+	Codec googleapi.RawMessage `json:"codec,omitempty"`
+
+	// Spec: The sink to write to, plus its parameters.
+	Spec googleapi.RawMessage `json:"spec,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Codec") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Codec") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Sink) MarshalJSON() ([]byte, error) {
+	type noMethod Sink
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Source: A source that records can be read and decoded from.
+type Source struct {
+	// BaseSpecs: While splitting, sources may specify the produced
+	// bundles
+	// as differences against another source, in order to save
+	// backend-side
+	// memory and allow bigger jobs. For details, see SourceSplitRequest.
+	// To support this use case, the full set of parameters of the source
+	// is logically obtained by taking the latest explicitly specified
+	// value
+	// of each parameter in the order:
+	// base_specs (later items win), spec (overrides anything in
+	// base_specs).
+	BaseSpecs []googleapi.RawMessage `json:"baseSpecs,omitempty"`
+
+	// Codec: The codec to use to decode data read from the source.
+	Codec googleapi.RawMessage `json:"codec,omitempty"`
+
+	// DoesNotNeedSplitting: Setting this value to true hints to the
+	// framework that the source
+	// doesn't need splitting, and using SourceSplitRequest on it
+	// would
+	// yield SOURCE_SPLIT_OUTCOME_USE_CURRENT.
+	//
+	// E.g. a file splitter may set this to true when splitting a single
+	// file
+	// into a set of byte ranges of appropriate size, and set this
+	// to false when splitting a filepattern into individual files.
+	// However, for efficiency, a file splitter may decide to produce
+	// file subranges directly from the filepattern to avoid a
+	// splitting
+	// round-trip.
+	//
+	// See SourceSplitRequest for an overview of the splitting
+	// process.
+	//
+	// This field is meaningful only in the Source objects populated
+	// by the user (e.g. when filling in a DerivedSource).
+	// Source objects supplied by the framework to the user don't have
+	// this field populated.
+	DoesNotNeedSplitting bool `json:"doesNotNeedSplitting,omitempty"`
+
+	// Metadata: Optionally, metadata for this source can be supplied right
+	// away,
+	// avoiding a SourceGetMetadataOperation roundtrip
+	// (see SourceOperationRequest).
+	//
+	// This field is meaningful only in the Source objects populated
+	// by the user (e.g. when filling in a DerivedSource).
+	// Source objects supplied by the framework to the user don't have
+	// this field populated.
+	Metadata *SourceMetadata `json:"metadata,omitempty"`
+
+	// Spec: The source to read from, plus its parameters.
+	Spec googleapi.RawMessage `json:"spec,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "BaseSpecs") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BaseSpecs") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Source) MarshalJSON() ([]byte, error) {
+	type noMethod Source
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceFork: DEPRECATED in favor of DynamicSourceSplit.
+type SourceFork struct {
+	// Primary: DEPRECATED
+	Primary *SourceSplitShard `json:"primary,omitempty"`
+
+	// PrimarySource: DEPRECATED
+	PrimarySource *DerivedSource `json:"primarySource,omitempty"`
+
+	// Residual: DEPRECATED
+	Residual *SourceSplitShard `json:"residual,omitempty"`
+
+	// ResidualSource: DEPRECATED
+	ResidualSource *DerivedSource `json:"residualSource,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Primary") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Primary") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceFork) MarshalJSON() ([]byte, error) {
+	type noMethod SourceFork
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceGetMetadataRequest: A request to compute the SourceMetadata of
+// a Source.
+type SourceGetMetadataRequest struct {
+	// Source: Specification of the source whose metadata should be
+	// computed.
+	Source *Source `json:"source,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Source") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Source") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceGetMetadataRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SourceGetMetadataRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceGetMetadataResponse: The result of a
+// SourceGetMetadataOperation.
+type SourceGetMetadataResponse struct {
+	// Metadata: The computed metadata.
+	Metadata *SourceMetadata `json:"metadata,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Metadata") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Metadata") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceGetMetadataResponse) MarshalJSON() ([]byte, error) {
+	type noMethod SourceGetMetadataResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceMetadata: Metadata about a Source useful for automatically
+// optimizing
+// and tuning the pipeline, etc.
+type SourceMetadata struct {
+	// EstimatedSizeBytes: An estimate of the total size (in bytes) of the
+	// data that would be
+	// read from this source.  This estimate is in terms of external
+	// storage
+	// size, before any decompression or other processing done by the
+	// reader.
+	EstimatedSizeBytes int64 `json:"estimatedSizeBytes,omitempty,string"`
+
+	// Infinite: Specifies that the size of this source is known to be
+	// infinite
+	// (this is a streaming source).
+	Infinite bool `json:"infinite,omitempty"`
+
+	// ProducesSortedKeys: Whether this source is known to produce key/value
+	// pairs with
+	// the (encoded) keys in lexicographically sorted order.
+	ProducesSortedKeys bool `json:"producesSortedKeys,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "EstimatedSizeBytes")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "EstimatedSizeBytes") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceMetadata) MarshalJSON() ([]byte, error) {
+	type noMethod SourceMetadata
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceOperationRequest: A work item that represents the different
+// operations that can be
+// performed on a user-defined Source specification.
+type SourceOperationRequest struct {
+	// GetMetadata: Information about a request to get metadata about a
+	// source.
+	GetMetadata *SourceGetMetadataRequest `json:"getMetadata,omitempty"`
+
+	// Split: Information about a request to split a source.
+	Split *SourceSplitRequest `json:"split,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "GetMetadata") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "GetMetadata") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceOperationRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SourceOperationRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceOperationResponse: The result of a SourceOperationRequest,
+// specified in
+// ReportWorkItemStatusRequest.source_operation when the work item
+// is completed.
+type SourceOperationResponse struct {
+	// GetMetadata: A response to a request to get metadata about a source.
+	GetMetadata *SourceGetMetadataResponse `json:"getMetadata,omitempty"`
+
+	// Split: A response to a request to split a source.
+	Split *SourceSplitResponse `json:"split,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "GetMetadata") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "GetMetadata") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceOperationResponse) MarshalJSON() ([]byte, error) {
+	type noMethod SourceOperationResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceSplitOptions: Hints for splitting a Source into bundles (parts
+// for parallel
+// processing) using SourceSplitRequest.
+type SourceSplitOptions struct {
+	// DesiredBundleSizeBytes: The source should be split into a set of
+	// bundles where the estimated size
+	// of each is approximately this many bytes.
+	DesiredBundleSizeBytes int64 `json:"desiredBundleSizeBytes,omitempty,string"`
+
+	// DesiredShardSizeBytes: DEPRECATED in favor of
+	// desired_bundle_size_bytes.
+	DesiredShardSizeBytes int64 `json:"desiredShardSizeBytes,omitempty,string"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "DesiredBundleSizeBytes") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DesiredBundleSizeBytes")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceSplitOptions) MarshalJSON() ([]byte, error) {
+	type noMethod SourceSplitOptions
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceSplitRequest: Represents the operation to split a high-level
+// Source specification
+// into bundles (parts for parallel processing).
+//
+// At a high level, splitting of a source into bundles happens as
+// follows:
+// SourceSplitRequest is applied to the source. If it
+// returns
+// SOURCE_SPLIT_OUTCOME_USE_CURRENT, no further splitting happens and
+// the source
+// is used "as is". Otherwise, splitting is applied recursively to
+// each
+// produced DerivedSource.
+//
+// As an optimization, for any Source, if its does_not_need_splitting
+// is
+// true, the framework assumes that splitting this source would
+// return
+// SOURCE_SPLIT_OUTCOME_USE_CURRENT, and doesn't initiate a
+// SourceSplitRequest.
+// This applies both to the initial source being split and to
+// bundles
+// produced from it.
+type SourceSplitRequest struct {
+	// Options: Hints for tuning the splitting process.
+	Options *SourceSplitOptions `json:"options,omitempty"`
+
+	// Source: Specification of the source to be split.
+	Source *Source `json:"source,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Options") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Options") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceSplitRequest) MarshalJSON() ([]byte, error) {
+	type noMethod SourceSplitRequest
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceSplitResponse: The response to a SourceSplitRequest.
+type SourceSplitResponse struct {
+	// Bundles: If outcome is SPLITTING_HAPPENED, then this is a list of
+	// bundles
+	// into which the source was split. Otherwise this field is
+	// ignored.
+	// This list can be empty, which means the source represents an empty
+	// input.
+	Bundles []*DerivedSource `json:"bundles,omitempty"`
+
+	// Outcome: Indicates whether splitting happened and produced a list of
+	// bundles.
+	// If this is USE_CURRENT_SOURCE_AS_IS, the current source should
+	// be processed "as is" without splitting. "bundles" is ignored in this
+	// case.
+	// If this is SPLITTING_HAPPENED, then "bundles" contains a list
+	// of
+	// bundles into which the source was split.
+	//
+	// Possible values:
+	//   "SOURCE_SPLIT_OUTCOME_UNKNOWN" - The source split outcome is
+	// unknown, or unspecified.
+	//   "SOURCE_SPLIT_OUTCOME_USE_CURRENT" - The current source should be
+	// processed "as is" without splitting.
+	//   "SOURCE_SPLIT_OUTCOME_SPLITTING_HAPPENED" - Splitting produced a
+	// list of bundles.
+	Outcome string `json:"outcome,omitempty"`
+
+	// Shards: DEPRECATED in favor of bundles.
+	Shards []*SourceSplitShard `json:"shards,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Bundles") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Bundles") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceSplitResponse) MarshalJSON() ([]byte, error) {
+	type noMethod SourceSplitResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SourceSplitShard: DEPRECATED in favor of DerivedSource.
+type SourceSplitShard struct {
+	// DerivationMode: DEPRECATED
+	//
+	// Possible values:
+	//   "SOURCE_DERIVATION_MODE_UNKNOWN" - The source derivation is
+	// unknown, or unspecified.
+	//   "SOURCE_DERIVATION_MODE_INDEPENDENT" - Produce a completely
+	// independent Source with no base.
+	//   "SOURCE_DERIVATION_MODE_CHILD_OF_CURRENT" - Produce a Source based
+	// on the Source being split.
+	//   "SOURCE_DERIVATION_MODE_SIBLING_OF_CURRENT" - Produce a Source
+	// based on the base of the Source being split.
+	DerivationMode string `json:"derivationMode,omitempty"`
+
+	// Source: DEPRECATED
+	Source *Source `json:"source,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DerivationMode") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DerivationMode") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SourceSplitShard) MarshalJSON() ([]byte, error) {
+	type noMethod SourceSplitShard
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// SplitInt64: A representation of an int64, n, that is immune to
+// precision loss when
+// encoded in JSON.
+type SplitInt64 struct {
+	// HighBits: The high order bits, including the sign: n >> 32.
+	HighBits int64 `json:"highBits,omitempty"`
+
+	// LowBits: The low order bits: n & 0xffffffff.
+	LowBits int64 `json:"lowBits,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "HighBits") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "HighBits") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *SplitInt64) MarshalJSON() ([]byte, error) {
+	type noMethod SplitInt64
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StageSource: Description of an input or output of an execution stage.
+type StageSource struct {
+	// Name: Dataflow service generated name for this source.
+	Name string `json:"name,omitempty"`
+
+	// OriginalTransformOrCollection: User name for the original user
+	// transform or collection with which this
+	// source is most closely associated.
+	OriginalTransformOrCollection string `json:"originalTransformOrCollection,omitempty"`
+
+	// SizeBytes: Size of the source, if measurable.
+	SizeBytes int64 `json:"sizeBytes,omitempty,string"`
+
+	// UserName: Human-readable name for this source; may be user or system
+	// generated.
+	UserName string `json:"userName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Name") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Name") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StageSource) MarshalJSON() ([]byte, error) {
+	type noMethod StageSource
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StateFamilyConfig: State family configuration.
+type StateFamilyConfig struct {
+	// IsRead: If true, this family corresponds to a read operation.
+	IsRead bool `json:"isRead,omitempty"`
+
+	// StateFamily: The state family value.
+	StateFamily string `json:"stateFamily,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "IsRead") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "IsRead") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StateFamilyConfig) MarshalJSON() ([]byte, error) {
+	type noMethod StateFamilyConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Status: The `Status` type defines a logical error model that is
+// suitable for different
+// programming environments, including REST APIs and RPC APIs. It is
+// used by
+// [gRPC](https://github.com/grpc). The error model is designed to
+// be:
+//
+// - Simple to use and understand for most users
+// - Flexible enough to meet unexpected needs
+//
+// # Overview
+//
+// The `Status` message contains three pieces of data: error code, error
+// message,
+// and error details. The error code should be an enum value
+// of
+// google.rpc.Code, but it may accept additional error codes if needed.
+// The
+// error message should be a developer-facing English message that
+// helps
+// developers *understand* and *resolve* the error. If a localized
+// user-facing
+// error message is needed, put the localized message in the error
+// details or
+// localize it in the client. The optional error details may contain
+// arbitrary
+// information about the error. There is a predefined set of error
+// detail types
+// in the package `google.rpc` which can be used for common error
+// conditions.
+//
+// # Language mapping
+//
+// The `Status` message is the logical representation of the error
+// model, but it
+// is not necessarily the actual wire format. When the `Status` message
+// is
+// exposed in different client libraries and different wire protocols,
+// it can be
+// mapped differently. For example, it will likely be mapped to some
+// exceptions
+// in Java, but more likely mapped to some error codes in C.
+//
+// # Other uses
+//
+// The error model and the `Status` message can be used in a variety
+// of
+// environments, either with or without APIs, to provide a
+// consistent developer experience across different
+// environments.
+//
+// Example uses of this error model include:
+//
+// - Partial errors. If a service needs to return partial errors to the
+// client,
+//     it may embed the `Status` in the normal response to indicate the
+// partial
+//     errors.
+//
+// - Workflow errors. A typical workflow has multiple steps. Each step
+// may
+//     have a `Status` message for error reporting purpose.
+//
+// - Batch operations. If a client uses batch request and batch
+// response, the
+//     `Status` message should be used directly inside batch response,
+// one for
+//     each error sub-response.
+//
+// - Asynchronous operations. If an API call embeds asynchronous
+// operation
+//     results in its response, the status of those operations should
+// be
+//     represented directly using the `Status` message.
+//
+// - Logging. If some API errors are stored in logs, the message
+// `Status` could
+//     be used directly after any stripping needed for security/privacy
+// reasons.
+type Status struct {
+	// Code: The status code, which should be an enum value of
+	// google.rpc.Code.
+	Code int64 `json:"code,omitempty"`
+
+	// Details: A list of messages that carry the error details.  There will
+	// be a
+	// common set of message types for APIs to use.
+	Details []googleapi.RawMessage `json:"details,omitempty"`
+
+	// Message: A developer-facing error message, which should be in
+	// English. Any
+	// user-facing error message should be localized and sent in
+	// the
+	// google.rpc.Status.details field, or localized by the client.
+	Message string `json:"message,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Code") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Code") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Status) MarshalJSON() ([]byte, error) {
+	type noMethod Status
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// Step: Defines a particular step within a Cloud Dataflow job.
+//
+// A job consists of multiple steps, each of which performs
+// some
+// specific operation as part of the overall job.  Data is
+// typically
+// passed from one step to another as part of the job.
+//
+// Here's an example of a sequence of steps which together implement
+// a
+// Map-Reduce job:
+//
+//   * Read a collection of data from some source, parsing the
+//     collection's elements.
+//
+//   * Validate the elements.
+//
+//   * Apply a user-defined function to map each element to some value
+//     and extract an element-specific key value.
+//
+//   * Group elements with the same key into a single element with
+//     that key, transforming a multiply-keyed collection into a
+//     uniquely-keyed collection.
+//
+//   * Write the elements out to some data sink.
+//
+// Note that the Cloud Dataflow service may be used to run many
+// different
+// types of jobs, not just Map-Reduce.
+type Step struct {
+	// Kind: The kind of step in the Cloud Dataflow job.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: The name that identifies the step. This must be unique for
+	// each
+	// step with respect to all other steps in the Cloud Dataflow job.
+	Name string `json:"name,omitempty"`
+
+	// Properties: Named properties associated with the step. Each kind
+	// of
+	// predefined step has its own required set of properties.
+	// Must be provided on Create.  Only retrieved with JOB_VIEW_ALL.
+	Properties googleapi.RawMessage `json:"properties,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Kind") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Kind") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *Step) MarshalJSON() ([]byte, error) {
+	type noMethod Step
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamLocation: Describes a stream of data, either as input to be
+// processed or as
+// output of a streaming Dataflow job.
+type StreamLocation struct {
+	// CustomSourceLocation: The stream is a custom source.
+	CustomSourceLocation *CustomSourceLocation `json:"customSourceLocation,omitempty"`
+
+	// PubsubLocation: The stream is a pubsub stream.
+	PubsubLocation *PubsubLocation `json:"pubsubLocation,omitempty"`
+
+	// SideInputLocation: The stream is a streaming side input.
+	SideInputLocation *StreamingSideInputLocation `json:"sideInputLocation,omitempty"`
+
+	// StreamingStageLocation: The stream is part of another computation
+	// within the current
+	// streaming Dataflow job.
+	StreamingStageLocation *StreamingStageLocation `json:"streamingStageLocation,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "CustomSourceLocation") to unconditionally include in API requests.
+	// By default, fields with empty values are omitted from API requests.
+	// However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "CustomSourceLocation") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamLocation) MarshalJSON() ([]byte, error) {
+	type noMethod StreamLocation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamingComputationConfig: Configuration information for a single
+// streaming computation.
+type StreamingComputationConfig struct {
+	// ComputationId: Unique identifier for this computation.
+	ComputationId string `json:"computationId,omitempty"`
+
+	// Instructions: Instructions that comprise the computation.
+	Instructions []*ParallelInstruction `json:"instructions,omitempty"`
+
+	// StageName: Stage name of this computation.
+	StageName string `json:"stageName,omitempty"`
+
+	// SystemName: System defined name for this computation.
+	SystemName string `json:"systemName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComputationId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComputationId") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamingComputationConfig) MarshalJSON() ([]byte, error) {
+	type noMethod StreamingComputationConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamingComputationRanges: Describes full or partial data disk
+// assignment information of the computation
+// ranges.
+type StreamingComputationRanges struct {
+	// ComputationId: The ID of the computation.
+	ComputationId string `json:"computationId,omitempty"`
+
+	// RangeAssignments: Data disk assignments for ranges from this
+	// computation.
+	RangeAssignments []*KeyRangeDataDiskAssignment `json:"rangeAssignments,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComputationId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComputationId") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamingComputationRanges) MarshalJSON() ([]byte, error) {
+	type noMethod StreamingComputationRanges
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamingComputationTask: A task which describes what action should
+// be performed for the specified
+// streaming computation ranges.
+type StreamingComputationTask struct {
+	// ComputationRanges: Contains ranges of a streaming computation this
+	// task should apply to.
+	ComputationRanges []*StreamingComputationRanges `json:"computationRanges,omitempty"`
+
+	// DataDisks: Describes the set of data disks this task should apply to.
+	DataDisks []*MountedDataDisk `json:"dataDisks,omitempty"`
+
+	// TaskType: A type of streaming computation task.
+	//
+	// Possible values:
+	//   "STREAMING_COMPUTATION_TASK_UNKNOWN" - The streaming computation
+	// task is unknown, or unspecified.
+	//   "STREAMING_COMPUTATION_TASK_STOP" - Stop processing specified
+	// streaming computation range(s).
+	//   "STREAMING_COMPUTATION_TASK_START" - Start processing specified
+	// streaming computation range(s).
+	TaskType string `json:"taskType,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ComputationRanges")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ComputationRanges") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamingComputationTask) MarshalJSON() ([]byte, error) {
+	type noMethod StreamingComputationTask
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamingConfigTask: A task that carries configuration information
+// for streaming computations.
+type StreamingConfigTask struct {
+	// StreamingComputationConfigs: Set of computation configuration
+	// information.
+	StreamingComputationConfigs []*StreamingComputationConfig `json:"streamingComputationConfigs,omitempty"`
+
+	// UserStepToStateFamilyNameMap: Map from user step names to state
+	// families.
+	UserStepToStateFamilyNameMap map[string]string `json:"userStepToStateFamilyNameMap,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "StreamingComputationConfigs") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g.
+	// "StreamingComputationConfigs") to include in API requests with the
+	// JSON null value. By default, fields with empty values are omitted
+	// from API requests. However, any field with an empty value appearing
+	// in NullFields will be sent to the server as null. It is an error if a
+	// field in this list has a non-empty value. This may be used to include
+	// null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamingConfigTask) MarshalJSON() ([]byte, error) {
+	type noMethod StreamingConfigTask
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamingSetupTask: A task which initializes part of a streaming
+// Dataflow job.
+type StreamingSetupTask struct {
+	// Drain: The user has requested drain.
+	Drain bool `json:"drain,omitempty"`
+
+	// ReceiveWorkPort: The TCP port on which the worker should listen for
+	// messages from
+	// other streaming computation workers.
+	ReceiveWorkPort int64 `json:"receiveWorkPort,omitempty"`
+
+	// StreamingComputationTopology: The global topology of the streaming
+	// Dataflow job.
+	StreamingComputationTopology *TopologyConfig `json:"streamingComputationTopology,omitempty"`
+
+	// WorkerHarnessPort: The TCP port used by the worker to communicate
+	// with the Dataflow
+	// worker harness.
+	WorkerHarnessPort int64 `json:"workerHarnessPort,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Drain") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Drain") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamingSetupTask) MarshalJSON() ([]byte, error) {
+	type noMethod StreamingSetupTask
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamingSideInputLocation: Identifies the location of a streaming
+// side input.
+type StreamingSideInputLocation struct {
+	// StateFamily: Identifies the state family where this side input is
+	// stored.
+	StateFamily string `json:"stateFamily,omitempty"`
+
+	// Tag: Identifies the particular side input within the streaming
+	// Dataflow job.
+	Tag string `json:"tag,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "StateFamily") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "StateFamily") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamingSideInputLocation) MarshalJSON() ([]byte, error) {
+	type noMethod StreamingSideInputLocation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StreamingStageLocation: Identifies the location of a streaming
+// computation stage, for
+// stage-to-stage communication.
+type StreamingStageLocation struct {
+	// StreamId: Identifies the particular stream within the streaming
+	// Dataflow
+	// job.
+	StreamId string `json:"streamId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "StreamId") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "StreamId") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StreamingStageLocation) MarshalJSON() ([]byte, error) {
+	type noMethod StreamingStageLocation
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// StringList: A metric value representing a list of strings.
+type StringList struct {
+	// Elements: Elements of the list.
+	Elements []string `json:"elements,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Elements") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Elements") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *StringList) MarshalJSON() ([]byte, error) {
+	type noMethod StringList
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TaskRunnerSettings: Taskrunner configuration settings.
+type TaskRunnerSettings struct {
+	// Alsologtostderr: Whether to also send taskrunner log info to stderr.
+	Alsologtostderr bool `json:"alsologtostderr,omitempty"`
+
+	// BaseTaskDir: The location on the worker for task-specific
+	// subdirectories.
+	BaseTaskDir string `json:"baseTaskDir,omitempty"`
+
+	// BaseUrl: The base URL for the taskrunner to use when accessing Google
+	// Cloud APIs.
+	//
+	// When workers access Google Cloud APIs, they logically do so
+	// via
+	// relative URLs.  If this field is specified, it supplies the base
+	// URL to use for resolving these relative URLs.  The
+	// normative
+	// algorithm used is defined by RFC 1808, "Relative Uniform
+	// Resource
+	// Locators".
+	//
+	// If not specified, the default value is "http://www.googleapis.com/"
+	BaseUrl string `json:"baseUrl,omitempty"`
+
+	// CommandlinesFileName: The file to store preprocessing commands in.
+	CommandlinesFileName string `json:"commandlinesFileName,omitempty"`
+
+	// ContinueOnException: Whether to continue taskrunner if an exception
+	// is hit.
+	ContinueOnException bool `json:"continueOnException,omitempty"`
+
+	// DataflowApiVersion: The API version of endpoint, e.g. "v1b3"
+	DataflowApiVersion string `json:"dataflowApiVersion,omitempty"`
+
+	// HarnessCommand: The command to launch the worker harness.
+	HarnessCommand string `json:"harnessCommand,omitempty"`
+
+	// LanguageHint: The suggested backend language.
+	LanguageHint string `json:"languageHint,omitempty"`
+
+	// LogDir: The directory on the VM to store logs.
+	LogDir string `json:"logDir,omitempty"`
+
+	// LogToSerialconsole: Whether to send taskrunner log info to Google
+	// Compute Engine VM serial
+	// console.
+	LogToSerialconsole bool `json:"logToSerialconsole,omitempty"`
+
+	// LogUploadLocation: Indicates where to put logs.  If this is not
+	// specified, the logs
+	// will not be uploaded.
+	//
+	// The supported resource type is:
+	//
+	// Google Cloud Storage:
+	//   storage.googleapis.com/{bucket}/{object}
+	//   bucket.storage.googleapis.com/{object}
+	LogUploadLocation string `json:"logUploadLocation,omitempty"`
+
+	// OauthScopes: The OAuth2 scopes to be requested by the taskrunner in
+	// order to
+	// access the Cloud Dataflow API.
+	OauthScopes []string `json:"oauthScopes,omitempty"`
+
+	// ParallelWorkerSettings: The settings to pass to the parallel worker
+	// harness.
+	ParallelWorkerSettings *WorkerSettings `json:"parallelWorkerSettings,omitempty"`
+
+	// StreamingWorkerMainClass: The streaming worker main class name.
+	StreamingWorkerMainClass string `json:"streamingWorkerMainClass,omitempty"`
+
+	// TaskGroup: The UNIX group ID on the worker VM to use for tasks
+	// launched by
+	// taskrunner; e.g. "wheel".
+	TaskGroup string `json:"taskGroup,omitempty"`
+
+	// TaskUser: The UNIX user ID on the worker VM to use for tasks launched
+	// by
+	// taskrunner; e.g. "root".
+	TaskUser string `json:"taskUser,omitempty"`
+
+	// TempStoragePrefix: The prefix of the resources the taskrunner should
+	// use for
+	// temporary storage.
+	//
+	// The supported resource type is:
+	//
+	// Google Cloud Storage:
+	//   storage.googleapis.com/{bucket}/{object}
+	//   bucket.storage.googleapis.com/{object}
+	TempStoragePrefix string `json:"tempStoragePrefix,omitempty"`
+
+	// VmId: The ID string of the VM.
+	VmId string `json:"vmId,omitempty"`
+
+	// WorkflowFileName: The file to store the workflow in.
+	WorkflowFileName string `json:"workflowFileName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Alsologtostderr") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Alsologtostderr") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TaskRunnerSettings) MarshalJSON() ([]byte, error) {
+	type noMethod TaskRunnerSettings
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TemplateMetadata: Metadata describing a template.
+type TemplateMetadata struct {
+	// BypassTempDirValidation: If true, will bypass the validation that the
+	// temp directory is
+	// writable. This should only be used with templates for pipelines
+	// that are guaranteed not to need to write to the temp directory,
+	// which is subject to change based on the optimizer.
+	BypassTempDirValidation bool `json:"bypassTempDirValidation,omitempty"`
+
+	// Description: Optional. A description of the template.
+	Description string `json:"description,omitempty"`
+
+	// Name: Required. The name of the template.
+	Name string `json:"name,omitempty"`
+
+	// Parameters: The parameters for the template.
+	Parameters []*ParameterMetadata `json:"parameters,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "BypassTempDirValidation") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BypassTempDirValidation")
+	// to include in API requests with the JSON null value. By default,
+	// fields with empty values are omitted from API requests. However, any
+	// field with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TemplateMetadata) MarshalJSON() ([]byte, error) {
+	type noMethod TemplateMetadata
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TopologyConfig: Global topology of the streaming Dataflow job,
+// including all
+// computations and their sharded locations.
+type TopologyConfig struct {
+	// Computations: The computations associated with a streaming Dataflow
+	// job.
+	Computations []*ComputationTopology `json:"computations,omitempty"`
+
+	// DataDiskAssignments: The disks assigned to a streaming Dataflow job.
+	DataDiskAssignments []*DataDiskAssignment `json:"dataDiskAssignments,omitempty"`
+
+	// ForwardingKeyBits: The size (in bits) of keys that will be assigned
+	// to source messages.
+	ForwardingKeyBits int64 `json:"forwardingKeyBits,omitempty"`
+
+	// PersistentStateVersion: Version number for persistent state.
+	PersistentStateVersion int64 `json:"persistentStateVersion,omitempty"`
+
+	// UserStageToComputationNameMap: Maps user stage names to stable
+	// computation names.
+	UserStageToComputationNameMap map[string]string `json:"userStageToComputationNameMap,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Computations") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Computations") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TopologyConfig) MarshalJSON() ([]byte, error) {
+	type noMethod TopologyConfig
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// TransformSummary: Description of the type, names/ids, and
+// input/outputs for a transform.
+type TransformSummary struct {
+	// DisplayData: Transform-specific display data.
+	DisplayData []*DisplayData `json:"displayData,omitempty"`
+
+	// Id: SDK generated id of this transform instance.
+	Id string `json:"id,omitempty"`
+
+	// InputCollectionName: User names for all collection inputs to this
+	// transform.
+	InputCollectionName []string `json:"inputCollectionName,omitempty"`
+
+	// Kind: Type of transform.
+	//
+	// Possible values:
+	//   "UNKNOWN_KIND" - Unrecognized transform type.
+	//   "PAR_DO_KIND" - ParDo transform.
+	//   "GROUP_BY_KEY_KIND" - Group By Key transform.
+	//   "FLATTEN_KIND" - Flatten transform.
+	//   "READ_KIND" - Read transform.
+	//   "WRITE_KIND" - Write transform.
+	//   "CONSTANT_KIND" - Constructs from a constant value, such as with
+	// Create.of.
+	//   "SINGLETON_KIND" - Creates a Singleton view of a collection.
+	//   "SHUFFLE_KIND" - Opening or closing a shuffle session, often as
+	// part of a GroupByKey.
+	Kind string `json:"kind,omitempty"`
+
+	// Name: User provided name for this transform instance.
+	Name string `json:"name,omitempty"`
+
+	// OutputCollectionName: User  names for all collection outputs to this
+	// transform.
+	OutputCollectionName []string `json:"outputCollectionName,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "DisplayData") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "DisplayData") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *TransformSummary) MarshalJSON() ([]byte, error) {
+	type noMethod TransformSummary
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkItem: WorkItem represents basic information about a WorkItem to
+// be executed
+// in the cloud.
+type WorkItem struct {
+	// Configuration: Work item-specific configuration as an opaque blob.
+	Configuration string `json:"configuration,omitempty"`
+
+	// Id: Identifies this WorkItem.
+	Id int64 `json:"id,omitempty,string"`
+
+	// InitialReportIndex: The initial index to use when reporting the
+	// status of the WorkItem.
+	InitialReportIndex int64 `json:"initialReportIndex,omitempty,string"`
+
+	// JobId: Identifies the workflow job this WorkItem belongs to.
+	JobId string `json:"jobId,omitempty"`
+
+	// LeaseExpireTime: Time when the lease on this Work will expire.
+	LeaseExpireTime string `json:"leaseExpireTime,omitempty"`
+
+	// MapTask: Additional information for MapTask WorkItems.
+	MapTask *MapTask `json:"mapTask,omitempty"`
+
+	// Packages: Any required packages that need to be fetched in order to
+	// execute
+	// this WorkItem.
+	Packages []*Package `json:"packages,omitempty"`
+
+	// ProjectId: Identifies the cloud project this WorkItem belongs to.
+	ProjectId string `json:"projectId,omitempty"`
+
+	// ReportStatusInterval: Recommended reporting interval.
+	ReportStatusInterval string `json:"reportStatusInterval,omitempty"`
+
+	// SeqMapTask: Additional information for SeqMapTask WorkItems.
+	SeqMapTask *SeqMapTask `json:"seqMapTask,omitempty"`
+
+	// ShellTask: Additional information for ShellTask WorkItems.
+	ShellTask *ShellTask `json:"shellTask,omitempty"`
+
+	// SourceOperationTask: Additional information for source operation
+	// WorkItems.
+	SourceOperationTask *SourceOperationRequest `json:"sourceOperationTask,omitempty"`
+
+	// StreamingComputationTask: Additional information for
+	// StreamingComputationTask WorkItems.
+	StreamingComputationTask *StreamingComputationTask `json:"streamingComputationTask,omitempty"`
+
+	// StreamingConfigTask: Additional information for StreamingConfigTask
+	// WorkItems.
+	StreamingConfigTask *StreamingConfigTask `json:"streamingConfigTask,omitempty"`
+
+	// StreamingSetupTask: Additional information for StreamingSetupTask
+	// WorkItems.
+	StreamingSetupTask *StreamingSetupTask `json:"streamingSetupTask,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Configuration") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Configuration") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkItem) MarshalJSON() ([]byte, error) {
+	type noMethod WorkItem
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkItemServiceState: The Dataflow service's idea of the current
+// state of a WorkItem
+// being processed by a worker.
+type WorkItemServiceState struct {
+	// HarnessData: Other data returned by the service, specific to the
+	// particular
+	// worker harness.
+	HarnessData googleapi.RawMessage `json:"harnessData,omitempty"`
+
+	// LeaseExpireTime: Time at which the current lease will expire.
+	LeaseExpireTime string `json:"leaseExpireTime,omitempty"`
+
+	// MetricShortId: The short ids that workers should use in subsequent
+	// metric updates.
+	// Workers should strive to use short ids whenever possible, but it is
+	// ok
+	// to request the short_id again if a worker lost track of it
+	// (e.g. if the worker is recovering from a crash).
+	// NOTE: it is possible that the response may have short ids for a
+	// subset
+	// of the metrics.
+	MetricShortId []*MetricShortId `json:"metricShortId,omitempty"`
+
+	// NextReportIndex: The index value to use for the next report sent by
+	// the worker.
+	// Note: If the report call fails for whatever reason, the worker
+	// should
+	// reuse this index for subsequent report attempts.
+	NextReportIndex int64 `json:"nextReportIndex,omitempty,string"`
+
+	// ReportStatusInterval: New recommended reporting interval.
+	ReportStatusInterval string `json:"reportStatusInterval,omitempty"`
+
+	// SplitRequest: The progress point in the WorkItem where the Dataflow
+	// service
+	// suggests that the worker truncate the task.
+	SplitRequest *ApproximateSplitRequest `json:"splitRequest,omitempty"`
+
+	// SuggestedStopPoint: DEPRECATED in favor of split_request.
+	SuggestedStopPoint *ApproximateProgress `json:"suggestedStopPoint,omitempty"`
+
+	// SuggestedStopPosition: Obsolete, always empty.
+	SuggestedStopPosition *Position `json:"suggestedStopPosition,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "HarnessData") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "HarnessData") to include
+	// in API requests with the JSON null value. By default, fields with
+	// empty values are omitted from API requests. However, any field with
+	// an empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkItemServiceState) MarshalJSON() ([]byte, error) {
+	type noMethod WorkItemServiceState
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkItemStatus: Conveys a worker's progress through the work
+// described by a WorkItem.
+type WorkItemStatus struct {
+	// Completed: True if the WorkItem was completed (successfully or
+	// unsuccessfully).
+	Completed bool `json:"completed,omitempty"`
+
+	// CounterUpdates: Worker output counters for this WorkItem.
+	CounterUpdates []*CounterUpdate `json:"counterUpdates,omitempty"`
+
+	// DynamicSourceSplit: See documentation of stop_position.
+	DynamicSourceSplit *DynamicSourceSplit `json:"dynamicSourceSplit,omitempty"`
+
+	// Errors: Specifies errors which occurred during processing.  If errors
+	// are
+	// provided, and completed = true, then the WorkItem is considered
+	// to have failed.
+	Errors []*Status `json:"errors,omitempty"`
+
+	// MetricUpdates: DEPRECATED in favor of counter_updates.
+	MetricUpdates []*MetricUpdate `json:"metricUpdates,omitempty"`
+
+	// Progress: DEPRECATED in favor of reported_progress.
+	Progress *ApproximateProgress `json:"progress,omitempty"`
+
+	// ReportIndex: The report index.  When a WorkItem is leased, the lease
+	// will
+	// contain an initial report index.  When a WorkItem's status
+	// is
+	// reported to the system, the report should be sent with
+	// that report index, and the response will contain the index the
+	// worker should use for the next report.  Reports received
+	// with
+	// unexpected index values will be rejected by the service.
+	//
+	// In order to preserve idempotency, the worker should not alter
+	// the
+	// contents of a report, even if the worker must submit the same
+	// report multiple times before getting back a response.  The
+	// worker
+	// should not submit a subsequent report until the response for
+	// the
+	// previous report had been received from the service.
+	ReportIndex int64 `json:"reportIndex,omitempty,string"`
+
+	// ReportedProgress: The worker's progress through this WorkItem.
+	ReportedProgress *ApproximateReportedProgress `json:"reportedProgress,omitempty"`
+
+	// RequestedLeaseDuration: Amount of time the worker requests for its
+	// lease.
+	RequestedLeaseDuration string `json:"requestedLeaseDuration,omitempty"`
+
+	// SourceFork: DEPRECATED in favor of dynamic_source_split.
+	SourceFork *SourceFork `json:"sourceFork,omitempty"`
+
+	// SourceOperationResponse: If the work item represented a
+	// SourceOperationRequest, and the work
+	// is completed, contains the result of the operation.
+	SourceOperationResponse *SourceOperationResponse `json:"sourceOperationResponse,omitempty"`
+
+	// StopPosition: A worker may split an active map task in two parts,
+	// "primary" and
+	// "residual", continuing to process the primary part and returning
+	// the
+	// residual part into the pool of available work.
+	// This event is called a "dynamic split" and is critical to the
+	// dynamic
+	// work rebalancing feature. The two obtained sub-tasks are
+	// called
+	// "parts" of the split.
+	// The parts, if concatenated, must represent the same input as would
+	// be read by the current task if the split did not happen.
+	// The exact way in which the original task is decomposed into the
+	// two
+	// parts is specified either as a position demarcating
+	// them
+	// (stop_position), or explicitly as two DerivedSources, if this
+	// task consumes a user-defined source type (dynamic_source_split).
+	//
+	// The "current" task is adjusted as a result of the split: after a
+	// task
+	// with range [A, B) sends a stop_position update at C, its range
+	// is
+	// considered to be [A, C), e.g.:
+	// * Progress should be interpreted relative to the new range, e.g.
+	//   "75% completed" means "75% of [A, C) completed"
+	// * The worker should interpret proposed_stop_position relative to the
+	//   new range, e.g. "split at 68%" should be interpreted as
+	//   "split at 68% of [A, C)".
+	// * If the worker chooses to split again using stop_position, only
+	//   stop_positions in [A, C) will be accepted.
+	// * Etc.
+	// dynamic_source_split has similar semantics: e.g., if a task
+	// with
+	// source S splits using dynamic_source_split into {P, R}
+	// (where P and R must be together equivalent to S), then
+	// subsequent
+	// progress and proposed_stop_position should be interpreted relative
+	// to P, and in a potential subsequent dynamic_source_split into {P',
+	// R'},
+	// P' and R' must be together equivalent to P, etc.
+	StopPosition *Position `json:"stopPosition,omitempty"`
+
+	// WorkItemId: Identifies the WorkItem.
+	WorkItemId string `json:"workItemId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Completed") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Completed") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkItemStatus) MarshalJSON() ([]byte, error) {
+	type noMethod WorkItemStatus
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkerHealthReport: WorkerHealthReport contains information about the
+// health of a worker.
+//
+// The VM should be identified by the labels attached to the
+// WorkerMessage that
+// this health ping belongs to.
+type WorkerHealthReport struct {
+	// Pods: The pods running on the worker.
+	// See:
+	// http://kubernetes.io/v1.1/docs/api-reference/v1/definitions.html#
+	// _v1_pod
+	//
+	// This field is used by the worker to send the status of the
+	// indvidual
+	// containers running on each worker.
+	Pods []googleapi.RawMessage `json:"pods,omitempty"`
+
+	// ReportInterval: The interval at which the worker is sending health
+	// reports.
+	// The default value of 0 should be interpreted as the field is not
+	// being
+	// explicitly set by the worker.
+	ReportInterval string `json:"reportInterval,omitempty"`
+
+	// VmIsHealthy: Whether the VM is healthy.
+	VmIsHealthy bool `json:"vmIsHealthy,omitempty"`
+
+	// VmStartupTime: The time the VM was booted.
+	VmStartupTime string `json:"vmStartupTime,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Pods") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Pods") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkerHealthReport) MarshalJSON() ([]byte, error) {
+	type noMethod WorkerHealthReport
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkerHealthReportResponse: WorkerHealthReportResponse contains
+// information returned to the worker
+// in response to a health ping.
+type WorkerHealthReportResponse struct {
+	// ReportInterval: A positive value indicates the worker should change
+	// its reporting interval
+	// to the specified value.
+	//
+	// The default value of zero means no change in report rate is requested
+	// by
+	// the server.
+	ReportInterval string `json:"reportInterval,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "ReportInterval") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "ReportInterval") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkerHealthReportResponse) MarshalJSON() ([]byte, error) {
+	type noMethod WorkerHealthReportResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkerMessage: WorkerMessage provides information to the backend
+// about a worker.
+type WorkerMessage struct {
+	// Labels: Labels are used to group WorkerMessages.
+	// For example, a worker_message about a particular container
+	// might have the labels:
+	// { "JOB_ID": "2015-04-22",
+	//   "WORKER_ID": "wordcount-vm-2015…"
+	//   "CONTAINER_TYPE": "worker",
+	//   "CONTAINER_ID": "ac1234def"}
+	// Label tags typically correspond to Label enum values. However, for
+	// ease
+	// of development other strings can be used as tags. LABEL_UNSPECIFIED
+	// should
+	// not be used here.
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Time: The timestamp of the worker_message.
+	Time string `json:"time,omitempty"`
+
+	// WorkerHealthReport: The health of a worker.
+	WorkerHealthReport *WorkerHealthReport `json:"workerHealthReport,omitempty"`
+
+	// WorkerMessageCode: A worker message code.
+	WorkerMessageCode *WorkerMessageCode `json:"workerMessageCode,omitempty"`
+
+	// WorkerMetrics: Resource metrics reported by workers.
+	WorkerMetrics *ResourceUtilizationReport `json:"workerMetrics,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Labels") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Labels") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkerMessage) MarshalJSON() ([]byte, error) {
+	type noMethod WorkerMessage
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkerMessageCode: A message code is used to report status and error
+// messages to the service.
+// The message codes are intended to be machine readable. The service
+// will
+// take care of translating these into user understandable messages
+// if
+// necessary.
+//
+// Example use cases:
+//   1. Worker processes reporting successful startup.
+//   2. Worker processes reporting specific errors (e.g. package
+// staging
+//      failure).
+type WorkerMessageCode struct {
+	// Code: The code is a string intended for consumption by a machine that
+	// identifies
+	// the type of message being sent.
+	// Examples:
+	//  1. "HARNESS_STARTED" might be used to indicate the worker harness
+	// has
+	//      started.
+	//  2. "GCS_DOWNLOAD_ERROR" might be used to indicate an error
+	// downloading
+	//     a GCS file as part of the boot process of one of the worker
+	// containers.
+	//
+	// This is a string and not an enum to make it easy to add new codes
+	// without
+	// waiting for an API change.
+	Code string `json:"code,omitempty"`
+
+	// Parameters: Parameters contains specific information about the
+	// code.
+	//
+	// This is a struct to allow parameters of different types.
+	//
+	// Examples:
+	//  1. For a "HARNESS_STARTED" message parameters might provide the
+	// name
+	//     of the worker and additional data like timing information.
+	//  2. For a "GCS_DOWNLOAD_ERROR" parameters might contain fields
+	// listing
+	//     the GCS objects being downloaded and fields containing
+	// errors.
+	//
+	// In general complex data structures should be avoided. If a
+	// worker
+	// needs to send a specific and complicated data structure then
+	// please
+	// consider defining a new proto and adding it to the data oneof
+	// in
+	// WorkerMessageResponse.
+	//
+	// Conventions:
+	//  Parameters should only be used for information that isn't typically
+	// passed
+	//  as a label.
+	//  hostname and other worker identifiers should almost always be
+	// passed
+	//  as labels since they will be included on most messages.
+	Parameters googleapi.RawMessage `json:"parameters,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Code") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Code") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkerMessageCode) MarshalJSON() ([]byte, error) {
+	type noMethod WorkerMessageCode
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkerMessageResponse: A worker_message response allows the server to
+// pass information to the
+// sender.
+type WorkerMessageResponse struct {
+	// WorkerHealthReportResponse: The service's response to a worker's
+	// health report.
+	WorkerHealthReportResponse *WorkerHealthReportResponse `json:"workerHealthReportResponse,omitempty"`
+
+	// WorkerMetricsResponse: Service's response to reporting worker metrics
+	// (currently empty).
+	WorkerMetricsResponse *ResourceUtilizationReportResponse `json:"workerMetricsResponse,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g.
+	// "WorkerHealthReportResponse") to unconditionally include in API
+	// requests. By default, fields with empty values are omitted from API
+	// requests. However, any non-pointer, non-interface field appearing in
+	// ForceSendFields will be sent to the server regardless of whether the
+	// field is empty or not. This may be used to include empty fields in
+	// Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g.
+	// "WorkerHealthReportResponse") to include in API requests with the
+	// JSON null value. By default, fields with empty values are omitted
+	// from API requests. However, any field with an empty value appearing
+	// in NullFields will be sent to the server as null. It is an error if a
+	// field in this list has a non-empty value. This may be used to include
+	// null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkerMessageResponse) MarshalJSON() ([]byte, error) {
+	type noMethod WorkerMessageResponse
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkerPool: Describes one particular pool of Cloud Dataflow workers
+// to be
+// instantiated by the Cloud Dataflow service in order to perform
+// the
+// computations required by a job.  Note that a workflow job may
+// use
+// multiple pools, in order to match the various
+// computational
+// requirements of the various stages of the job.
+type WorkerPool struct {
+	// AutoscalingSettings: Settings for autoscaling of this WorkerPool.
+	AutoscalingSettings *AutoscalingSettings `json:"autoscalingSettings,omitempty"`
+
+	// DataDisks: Data disks that are used by a VM in this workflow.
+	DataDisks []*Disk `json:"dataDisks,omitempty"`
+
+	// DefaultPackageSet: The default package set to install.  This allows
+	// the service to
+	// select a default set of packages which are useful to worker
+	// harnesses written in a particular language.
+	//
+	// Possible values:
+	//   "DEFAULT_PACKAGE_SET_UNKNOWN" - The default set of packages to
+	// stage is unknown, or unspecified.
+	//   "DEFAULT_PACKAGE_SET_NONE" - Indicates that no packages should be
+	// staged at the worker unless
+	// explicitly specified by the job.
+	//   "DEFAULT_PACKAGE_SET_JAVA" - Stage packages typically useful to
+	// workers written in Java.
+	//   "DEFAULT_PACKAGE_SET_PYTHON" - Stage pacakges typically useful to
+	// workers written in Python.
+	DefaultPackageSet string `json:"defaultPackageSet,omitempty"`
+
+	// DiskSizeGb: Size of root disk for VMs, in GB.  If zero or
+	// unspecified, the service will
+	// attempt to choose a reasonable default.
+	DiskSizeGb int64 `json:"diskSizeGb,omitempty"`
+
+	// DiskSourceImage: Fully qualified source image for disks.
+	DiskSourceImage string `json:"diskSourceImage,omitempty"`
+
+	// DiskType: Type of root disk for VMs.  If empty or unspecified, the
+	// service will
+	// attempt to choose a reasonable default.
+	DiskType string `json:"diskType,omitempty"`
+
+	// IpConfiguration: Configuration for VM IPs.
+	//
+	// Possible values:
+	//   "WORKER_IP_UNSPECIFIED" - The configuration is unknown, or
+	// unspecified.
+	//   "WORKER_IP_PUBLIC" - Workers should have public IP addresses.
+	//   "WORKER_IP_PRIVATE" - Workers should have private IP addresses.
+	IpConfiguration string `json:"ipConfiguration,omitempty"`
+
+	// Kind: The kind of the worker pool; currently only `harness` and
+	// `shuffle`
+	// are supported.
+	Kind string `json:"kind,omitempty"`
+
+	// MachineType: Machine type (e.g. "n1-standard-1").  If empty or
+	// unspecified, the
+	// service will attempt to choose a reasonable default.
+	MachineType string `json:"machineType,omitempty"`
+
+	// Metadata: Metadata to set on the Google Compute Engine VMs.
+	Metadata map[string]string `json:"metadata,omitempty"`
+
+	// Network: Network to which VMs will be assigned.  If empty or
+	// unspecified,
+	// the service will use the network "default".
+	Network string `json:"network,omitempty"`
+
+	// NumThreadsPerWorker: The number of threads per worker harness. If
+	// empty or unspecified, the
+	// service will choose a number of threads (according to the number of
+	// cores
+	// on the selected machine type for batch, or 1 by convention for
+	// streaming).
+	NumThreadsPerWorker int64 `json:"numThreadsPerWorker,omitempty"`
+
+	// NumWorkers: Number of Google Compute Engine workers in this pool
+	// needed to
+	// execute the job.  If zero or unspecified, the service will
+	// attempt to choose a reasonable default.
+	NumWorkers int64 `json:"numWorkers,omitempty"`
+
+	// OnHostMaintenance: The action to take on host maintenance, as defined
+	// by the Google
+	// Compute Engine API.
+	OnHostMaintenance string `json:"onHostMaintenance,omitempty"`
+
+	// Packages: Packages to be installed on workers.
+	Packages []*Package `json:"packages,omitempty"`
+
+	// PoolArgs: Extra arguments for this worker pool.
+	PoolArgs googleapi.RawMessage `json:"poolArgs,omitempty"`
+
+	// Subnetwork: Subnetwork to which VMs will be assigned, if desired.
+	// Expected to be of
+	// the form "regions/REGION/subnetworks/SUBNETWORK".
+	Subnetwork string `json:"subnetwork,omitempty"`
+
+	// TaskrunnerSettings: Settings passed through to Google Compute Engine
+	// workers when
+	// using the standard Dataflow task runner.  Users should ignore
+	// this field.
+	TaskrunnerSettings *TaskRunnerSettings `json:"taskrunnerSettings,omitempty"`
+
+	// TeardownPolicy: Sets the policy for determining when to turndown
+	// worker pool.
+	// Allowed values are: `TEARDOWN_ALWAYS`, `TEARDOWN_ON_SUCCESS`,
+	// and
+	// `TEARDOWN_NEVER`.
+	// `TEARDOWN_ALWAYS` means workers are always torn down regardless of
+	// whether
+	// the job succeeds. `TEARDOWN_ON_SUCCESS` means workers are torn
+	// down
+	// if the job succeeds. `TEARDOWN_NEVER` means the workers are never
+	// torn
+	// down.
+	//
+	// If the workers are not torn down by the service, they will
+	// continue to run and use Google Compute Engine VM resources in
+	// the
+	// user's project until they are explicitly terminated by the
+	// user.
+	// Because of this, Google recommends using the `TEARDOWN_ALWAYS`
+	// policy except for small, manually supervised test jobs.
+	//
+	// If unknown or unspecified, the service will attempt to choose a
+	// reasonable
+	// default.
+	//
+	// Possible values:
+	//   "TEARDOWN_POLICY_UNKNOWN" - The teardown policy isn't specified, or
+	// is unknown.
+	//   "TEARDOWN_ALWAYS" - Always teardown the resource.
+	//   "TEARDOWN_ON_SUCCESS" - Teardown the resource on success. This is
+	// useful for debugging
+	// failures.
+	//   "TEARDOWN_NEVER" - Never teardown the resource. This is useful for
+	// debugging and
+	// development.
+	TeardownPolicy string `json:"teardownPolicy,omitempty"`
+
+	// WorkerHarnessContainerImage: Required. Docker container image that
+	// executes the Cloud Dataflow worker
+	// harness, residing in Google Container Registry.
+	WorkerHarnessContainerImage string `json:"workerHarnessContainerImage,omitempty"`
+
+	// Zone: Zone to run the worker pools in.  If empty or unspecified, the
+	// service
+	// will attempt to choose a reasonable default.
+	Zone string `json:"zone,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "AutoscalingSettings")
+	// to unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "AutoscalingSettings") to
+	// include in API requests with the JSON null value. By default, fields
+	// with empty values are omitted from API requests. However, any field
+	// with an empty value appearing in NullFields will be sent to the
+	// server as null. It is an error if a field in this list has a
+	// non-empty value. This may be used to include null fields in Patch
+	// requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkerPool) MarshalJSON() ([]byte, error) {
+	type noMethod WorkerPool
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WorkerSettings: Provides data to pass through to the worker harness.
+type WorkerSettings struct {
+	// BaseUrl: The base URL for accessing Google Cloud APIs.
+	//
+	// When workers access Google Cloud APIs, they logically do so
+	// via
+	// relative URLs.  If this field is specified, it supplies the base
+	// URL to use for resolving these relative URLs.  The
+	// normative
+	// algorithm used is defined by RFC 1808, "Relative Uniform
+	// Resource
+	// Locators".
+	//
+	// If not specified, the default value is "http://www.googleapis.com/"
+	BaseUrl string `json:"baseUrl,omitempty"`
+
+	// ReportingEnabled: Whether to send work progress updates to the
+	// service.
+	ReportingEnabled bool `json:"reportingEnabled,omitempty"`
+
+	// ServicePath: The Cloud Dataflow service path relative to the root
+	// URL, for example,
+	// "dataflow/v1b3/projects".
+	ServicePath string `json:"servicePath,omitempty"`
+
+	// ShuffleServicePath: The Shuffle service path relative to the root
+	// URL, for example,
+	// "shuffle/v1beta1".
+	ShuffleServicePath string `json:"shuffleServicePath,omitempty"`
+
+	// TempStoragePrefix: The prefix of the resources the system should use
+	// for temporary
+	// storage.
+	//
+	// The supported resource type is:
+	//
+	// Google Cloud Storage:
+	//
+	//   storage.googleapis.com/{bucket}/{object}
+	//   bucket.storage.googleapis.com/{object}
+	TempStoragePrefix string `json:"tempStoragePrefix,omitempty"`
+
+	// WorkerId: The ID of the worker running this pipeline.
+	WorkerId string `json:"workerId,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "BaseUrl") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "BaseUrl") to include in
+	// API requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WorkerSettings) MarshalJSON() ([]byte, error) {
+	type noMethod WorkerSettings
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// WriteInstruction: An instruction that writes records.
+// Takes one input, produces no outputs.
+type WriteInstruction struct {
+	// Input: The input.
+	Input *InstructionInput `json:"input,omitempty"`
+
+	// Sink: The sink to write to.
+	Sink *Sink `json:"sink,omitempty"`
+
+	// ForceSendFields is a list of field names (e.g. "Input") to
+	// unconditionally include in API requests. By default, fields with
+	// empty values are omitted from API requests. However, any non-pointer,
+	// non-interface field appearing in ForceSendFields will be sent to the
+	// server regardless of whether the field is empty or not. This may be
+	// used to include empty fields in Patch requests.
+	ForceSendFields []string `json:"-"`
+
+	// NullFields is a list of field names (e.g. "Input") to include in API
+	// requests with the JSON null value. By default, fields with empty
+	// values are omitted from API requests. However, any field with an
+	// empty value appearing in NullFields will be sent to the server as
+	// null. It is an error if a field in this list has a non-empty value.
+	// This may be used to include null fields in Patch requests.
+	NullFields []string `json:"-"`
+}
+
+func (s *WriteInstruction) MarshalJSON() ([]byte, error) {
+	type noMethod WriteInstruction
+	raw := noMethod(*s)
+	return gensupport.MarshalJSON(raw, s.ForceSendFields, s.NullFields)
+}
+
+// method id "dataflow.projects.workerMessages":
+
+type ProjectsWorkerMessagesCall struct {
+	s                         *Service
+	projectId                 string
+	sendworkermessagesrequest *SendWorkerMessagesRequest
+	urlParams_                gensupport.URLParams
+	ctx_                      context.Context
+	header_                   http.Header
+}
+
+// WorkerMessages: Send a worker_message to the service.
+func (r *ProjectsService) WorkerMessages(projectId string, sendworkermessagesrequest *SendWorkerMessagesRequest) *ProjectsWorkerMessagesCall {
+	c := &ProjectsWorkerMessagesCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.sendworkermessagesrequest = sendworkermessagesrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsWorkerMessagesCall) Fields(s ...googleapi.Field) *ProjectsWorkerMessagesCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsWorkerMessagesCall) Context(ctx context.Context) *ProjectsWorkerMessagesCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsWorkerMessagesCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsWorkerMessagesCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.sendworkermessagesrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/WorkerMessages")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.workerMessages" call.
+// Exactly one of *SendWorkerMessagesResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *SendWorkerMessagesResponse.ServerResponse.Header or (if a response
+// was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsWorkerMessagesCall) Do(opts ...googleapi.CallOption) (*SendWorkerMessagesResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &SendWorkerMessagesResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Send a worker_message to the service.",
+	//   "flatPath": "v1b3/projects/{projectId}/WorkerMessages",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.workerMessages",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "projectId": {
+	//       "description": "The project to send the WorkerMessages to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/WorkerMessages",
+	//   "request": {
+	//     "$ref": "SendWorkerMessagesRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "SendWorkerMessagesResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.create":
+
+type ProjectsJobsCreateCall struct {
+	s          *Service
+	projectId  string
+	job        *Job
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Create: Creates a Cloud Dataflow job.
+func (r *ProjectsJobsService) Create(projectId string, job *Job) *ProjectsJobsCreateCall {
+	c := &ProjectsJobsCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.job = job
+	return c
+}
+
+// Location sets the optional parameter "location": The location that
+// contains this job.
+func (c *ProjectsJobsCreateCall) Location(location string) *ProjectsJobsCreateCall {
+	c.urlParams_.Set("location", location)
+	return c
+}
+
+// ReplaceJobId sets the optional parameter "replaceJobId": Deprecated.
+// This field is now in the Job message.
+func (c *ProjectsJobsCreateCall) ReplaceJobId(replaceJobId string) *ProjectsJobsCreateCall {
+	c.urlParams_.Set("replaceJobId", replaceJobId)
+	return c
+}
+
+// View sets the optional parameter "view": The level of information
+// requested in response.
+//
+// Possible values:
+//   "JOB_VIEW_UNKNOWN"
+//   "JOB_VIEW_SUMMARY"
+//   "JOB_VIEW_ALL"
+//   "JOB_VIEW_DESCRIPTION"
+func (c *ProjectsJobsCreateCall) View(view string) *ProjectsJobsCreateCall {
+	c.urlParams_.Set("view", view)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsCreateCall) Fields(s ...googleapi.Field) *ProjectsJobsCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsCreateCall) Context(ctx context.Context) *ProjectsJobsCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.job)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.create" call.
+// Exactly one of *Job or error will be non-nil. Any non-2xx status code
+// is an error. Response headers are in either
+// *Job.ServerResponse.Header or (if a response was returned at all) in
+// error.(*googleapi.Error).Header. Use googleapi.IsNotModified to check
+// whether the returned error was because http.StatusNotModified was
+// returned.
+func (c *ProjectsJobsCreateCall) Do(opts ...googleapi.CallOption) (*Job, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Job{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a Cloud Dataflow job.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.jobs.create",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "replaceJobId": {
+	//       "description": "Deprecated. This field is now in the Job message.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "view": {
+	//       "description": "The level of information requested in response.",
+	//       "enum": [
+	//         "JOB_VIEW_UNKNOWN",
+	//         "JOB_VIEW_SUMMARY",
+	//         "JOB_VIEW_ALL",
+	//         "JOB_VIEW_DESCRIPTION"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs",
+	//   "request": {
+	//     "$ref": "Job"
+	//   },
+	//   "response": {
+	//     "$ref": "Job"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.get":
+
+type ProjectsJobsGetCall struct {
+	s            *Service
+	projectId    string
+	jobId        string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets the state of the specified Cloud Dataflow job.
+func (r *ProjectsJobsService) Get(projectId string, jobId string) *ProjectsJobsGetCall {
+	c := &ProjectsJobsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	return c
+}
+
+// Location sets the optional parameter "location": The location that
+// contains this job.
+func (c *ProjectsJobsGetCall) Location(location string) *ProjectsJobsGetCall {
+	c.urlParams_.Set("location", location)
+	return c
+}
+
+// View sets the optional parameter "view": The level of information
+// requested in response.
+//
+// Possible values:
+//   "JOB_VIEW_UNKNOWN"
+//   "JOB_VIEW_SUMMARY"
+//   "JOB_VIEW_ALL"
+//   "JOB_VIEW_DESCRIPTION"
+func (c *ProjectsJobsGetCall) View(view string) *ProjectsJobsGetCall {
+	c.urlParams_.Set("view", view)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsGetCall) Fields(s ...googleapi.Field) *ProjectsJobsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsJobsGetCall) IfNoneMatch(entityTag string) *ProjectsJobsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsGetCall) Context(ctx context.Context) *ProjectsJobsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.get" call.
+// Exactly one of *Job or error will be non-nil. Any non-2xx status code
+// is an error. Response headers are in either
+// *Job.ServerResponse.Header or (if a response was returned at all) in
+// error.(*googleapi.Error).Header. Use googleapi.IsNotModified to check
+// whether the returned error was because http.StatusNotModified was
+// returned.
+func (c *ProjectsJobsGetCall) Do(opts ...googleapi.CallOption) (*Job, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Job{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets the state of the specified Cloud Dataflow job.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.jobs.get",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job ID.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "view": {
+	//       "description": "The level of information requested in response.",
+	//       "enum": [
+	//         "JOB_VIEW_UNKNOWN",
+	//         "JOB_VIEW_SUMMARY",
+	//         "JOB_VIEW_ALL",
+	//         "JOB_VIEW_DESCRIPTION"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}",
+	//   "response": {
+	//     "$ref": "Job"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.getMetrics":
+
+type ProjectsJobsGetMetricsCall struct {
+	s            *Service
+	projectId    string
+	jobId        string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// GetMetrics: Request the job status.
+func (r *ProjectsJobsService) GetMetrics(projectId string, jobId string) *ProjectsJobsGetMetricsCall {
+	c := &ProjectsJobsGetMetricsCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	return c
+}
+
+// Location sets the optional parameter "location": The location which
+// contains the job specified by job_id.
+func (c *ProjectsJobsGetMetricsCall) Location(location string) *ProjectsJobsGetMetricsCall {
+	c.urlParams_.Set("location", location)
+	return c
+}
+
+// StartTime sets the optional parameter "startTime": Return only metric
+// data that has changed since this time.
+// Default is to return all information about all metrics for the job.
+func (c *ProjectsJobsGetMetricsCall) StartTime(startTime string) *ProjectsJobsGetMetricsCall {
+	c.urlParams_.Set("startTime", startTime)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsGetMetricsCall) Fields(s ...googleapi.Field) *ProjectsJobsGetMetricsCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsJobsGetMetricsCall) IfNoneMatch(entityTag string) *ProjectsJobsGetMetricsCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsGetMetricsCall) Context(ctx context.Context) *ProjectsJobsGetMetricsCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsGetMetricsCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsGetMetricsCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}/metrics")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.getMetrics" call.
+// Exactly one of *JobMetrics or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *JobMetrics.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ProjectsJobsGetMetricsCall) Do(opts ...googleapi.CallOption) (*JobMetrics, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &JobMetrics{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Request the job status.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/metrics",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.jobs.getMetrics",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job to get messages for.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location which contains the job specified by job_id.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "A project id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "startTime": {
+	//       "description": "Return only metric data that has changed since this time.\nDefault is to return all information about all metrics for the job.",
+	//       "format": "google-datetime",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}/metrics",
+	//   "response": {
+	//     "$ref": "JobMetrics"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.list":
+
+type ProjectsJobsListCall struct {
+	s            *Service
+	projectId    string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: List the jobs of a project.
+func (r *ProjectsJobsService) List(projectId string) *ProjectsJobsListCall {
+	c := &ProjectsJobsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	return c
+}
+
+// Filter sets the optional parameter "filter": The kind of filter to
+// use.
+//
+// Possible values:
+//   "UNKNOWN"
+//   "ALL"
+//   "TERMINATED"
+//   "ACTIVE"
+func (c *ProjectsJobsListCall) Filter(filter string) *ProjectsJobsListCall {
+	c.urlParams_.Set("filter", filter)
+	return c
+}
+
+// Location sets the optional parameter "location": The location that
+// contains this job.
+func (c *ProjectsJobsListCall) Location(location string) *ProjectsJobsListCall {
+	c.urlParams_.Set("location", location)
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": If there are many
+// jobs, limit response to at most this many.
+// The actual number of jobs returned will be the lesser of
+// max_responses
+// and an unspecified server-defined limit.
+func (c *ProjectsJobsListCall) PageSize(pageSize int64) *ProjectsJobsListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": Set this to the
+// 'next_page_token' field of a previous response
+// to request additional results in a long list.
+func (c *ProjectsJobsListCall) PageToken(pageToken string) *ProjectsJobsListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// View sets the optional parameter "view": Level of information
+// requested in response. Default is `JOB_VIEW_SUMMARY`.
+//
+// Possible values:
+//   "JOB_VIEW_UNKNOWN"
+//   "JOB_VIEW_SUMMARY"
+//   "JOB_VIEW_ALL"
+//   "JOB_VIEW_DESCRIPTION"
+func (c *ProjectsJobsListCall) View(view string) *ProjectsJobsListCall {
+	c.urlParams_.Set("view", view)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsListCall) Fields(s ...googleapi.Field) *ProjectsJobsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsJobsListCall) IfNoneMatch(entityTag string) *ProjectsJobsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsListCall) Context(ctx context.Context) *ProjectsJobsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.list" call.
+// Exactly one of *ListJobsResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListJobsResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsJobsListCall) Do(opts ...googleapi.CallOption) (*ListJobsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListJobsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "List the jobs of a project.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.jobs.list",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "filter": {
+	//       "description": "The kind of filter to use.",
+	//       "enum": [
+	//         "UNKNOWN",
+	//         "ALL",
+	//         "TERMINATED",
+	//         "ACTIVE"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "If there are many jobs, limit response to at most this many.\nThe actual number of jobs returned will be the lesser of max_responses\nand an unspecified server-defined limit.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "Set this to the 'next_page_token' field of a previous response\nto request additional results in a long list.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The project which owns the jobs.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "view": {
+	//       "description": "Level of information requested in response. Default is `JOB_VIEW_SUMMARY`.",
+	//       "enum": [
+	//         "JOB_VIEW_UNKNOWN",
+	//         "JOB_VIEW_SUMMARY",
+	//         "JOB_VIEW_ALL",
+	//         "JOB_VIEW_DESCRIPTION"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs",
+	//   "response": {
+	//     "$ref": "ListJobsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsJobsListCall) Pages(ctx context.Context, f func(*ListJobsResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "dataflow.projects.jobs.update":
+
+type ProjectsJobsUpdateCall struct {
+	s          *Service
+	projectId  string
+	jobId      string
+	job        *Job
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Update: Updates the state of an existing Cloud Dataflow job.
+func (r *ProjectsJobsService) Update(projectId string, jobId string, job *Job) *ProjectsJobsUpdateCall {
+	c := &ProjectsJobsUpdateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	c.job = job
+	return c
+}
+
+// Location sets the optional parameter "location": The location that
+// contains this job.
+func (c *ProjectsJobsUpdateCall) Location(location string) *ProjectsJobsUpdateCall {
+	c.urlParams_.Set("location", location)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsUpdateCall) Fields(s ...googleapi.Field) *ProjectsJobsUpdateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsUpdateCall) Context(ctx context.Context) *ProjectsJobsUpdateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsUpdateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsUpdateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.job)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.update" call.
+// Exactly one of *Job or error will be non-nil. Any non-2xx status code
+// is an error. Response headers are in either
+// *Job.ServerResponse.Header or (if a response was returned at all) in
+// error.(*googleapi.Error).Header. Use googleapi.IsNotModified to check
+// whether the returned error was because http.StatusNotModified was
+// returned.
+func (c *ProjectsJobsUpdateCall) Do(opts ...googleapi.CallOption) (*Job, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Job{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates the state of an existing Cloud Dataflow job.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}",
+	//   "httpMethod": "PUT",
+	//   "id": "dataflow.projects.jobs.update",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job ID.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}",
+	//   "request": {
+	//     "$ref": "Job"
+	//   },
+	//   "response": {
+	//     "$ref": "Job"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.debug.getConfig":
+
+type ProjectsJobsDebugGetConfigCall struct {
+	s                     *Service
+	projectId             string
+	jobId                 string
+	getdebugconfigrequest *GetDebugConfigRequest
+	urlParams_            gensupport.URLParams
+	ctx_                  context.Context
+	header_               http.Header
+}
+
+// GetConfig: Get encoded debug configuration for component. Not
+// cacheable.
+func (r *ProjectsJobsDebugService) GetConfig(projectId string, jobId string, getdebugconfigrequest *GetDebugConfigRequest) *ProjectsJobsDebugGetConfigCall {
+	c := &ProjectsJobsDebugGetConfigCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	c.getdebugconfigrequest = getdebugconfigrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsDebugGetConfigCall) Fields(s ...googleapi.Field) *ProjectsJobsDebugGetConfigCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsDebugGetConfigCall) Context(ctx context.Context) *ProjectsJobsDebugGetConfigCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsDebugGetConfigCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsDebugGetConfigCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.getdebugconfigrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}/debug/getConfig")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.debug.getConfig" call.
+// Exactly one of *GetDebugConfigResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *GetDebugConfigResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsJobsDebugGetConfigCall) Do(opts ...googleapi.CallOption) (*GetDebugConfigResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &GetDebugConfigResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Get encoded debug configuration for component. Not cacheable.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/debug/getConfig",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.jobs.debug.getConfig",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The project id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}/debug/getConfig",
+	//   "request": {
+	//     "$ref": "GetDebugConfigRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "GetDebugConfigResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.debug.sendCapture":
+
+type ProjectsJobsDebugSendCaptureCall struct {
+	s                       *Service
+	projectId               string
+	jobId                   string
+	senddebugcapturerequest *SendDebugCaptureRequest
+	urlParams_              gensupport.URLParams
+	ctx_                    context.Context
+	header_                 http.Header
+}
+
+// SendCapture: Send encoded debug capture data for component.
+func (r *ProjectsJobsDebugService) SendCapture(projectId string, jobId string, senddebugcapturerequest *SendDebugCaptureRequest) *ProjectsJobsDebugSendCaptureCall {
+	c := &ProjectsJobsDebugSendCaptureCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	c.senddebugcapturerequest = senddebugcapturerequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsDebugSendCaptureCall) Fields(s ...googleapi.Field) *ProjectsJobsDebugSendCaptureCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsDebugSendCaptureCall) Context(ctx context.Context) *ProjectsJobsDebugSendCaptureCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsDebugSendCaptureCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsDebugSendCaptureCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.senddebugcapturerequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}/debug/sendCapture")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.debug.sendCapture" call.
+// Exactly one of *SendDebugCaptureResponse or error will be non-nil.
+// Any non-2xx status code is an error. Response headers are in either
+// *SendDebugCaptureResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsJobsDebugSendCaptureCall) Do(opts ...googleapi.CallOption) (*SendDebugCaptureResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &SendDebugCaptureResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Send encoded debug capture data for component.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/debug/sendCapture",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.jobs.debug.sendCapture",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The project id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}/debug/sendCapture",
+	//   "request": {
+	//     "$ref": "SendDebugCaptureRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "SendDebugCaptureResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.messages.list":
+
+type ProjectsJobsMessagesListCall struct {
+	s            *Service
+	projectId    string
+	jobId        string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Request the job status.
+func (r *ProjectsJobsMessagesService) List(projectId string, jobId string) *ProjectsJobsMessagesListCall {
+	c := &ProjectsJobsMessagesListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	return c
+}
+
+// EndTime sets the optional parameter "endTime": Return only messages
+// with timestamps < end_time. The default is now
+// (i.e. return up to the latest messages available).
+func (c *ProjectsJobsMessagesListCall) EndTime(endTime string) *ProjectsJobsMessagesListCall {
+	c.urlParams_.Set("endTime", endTime)
+	return c
+}
+
+// Location sets the optional parameter "location": The location which
+// contains the job specified by job_id.
+func (c *ProjectsJobsMessagesListCall) Location(location string) *ProjectsJobsMessagesListCall {
+	c.urlParams_.Set("location", location)
+	return c
+}
+
+// MinimumImportance sets the optional parameter "minimumImportance":
+// Filter to only get messages with importance >= level
+//
+// Possible values:
+//   "JOB_MESSAGE_IMPORTANCE_UNKNOWN"
+//   "JOB_MESSAGE_DEBUG"
+//   "JOB_MESSAGE_DETAILED"
+//   "JOB_MESSAGE_BASIC"
+//   "JOB_MESSAGE_WARNING"
+//   "JOB_MESSAGE_ERROR"
+func (c *ProjectsJobsMessagesListCall) MinimumImportance(minimumImportance string) *ProjectsJobsMessagesListCall {
+	c.urlParams_.Set("minimumImportance", minimumImportance)
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": If specified,
+// determines the maximum number of messages to
+// return.  If unspecified, the service may choose an
+// appropriate
+// default, or may return an arbitrarily large number of results.
+func (c *ProjectsJobsMessagesListCall) PageSize(pageSize int64) *ProjectsJobsMessagesListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": If supplied, this
+// should be the value of next_page_token returned
+// by an earlier call. This will cause the next page of results to
+// be returned.
+func (c *ProjectsJobsMessagesListCall) PageToken(pageToken string) *ProjectsJobsMessagesListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// StartTime sets the optional parameter "startTime": If specified,
+// return only messages with timestamps >= start_time.
+// The default is the job creation time (i.e. beginning of messages).
+func (c *ProjectsJobsMessagesListCall) StartTime(startTime string) *ProjectsJobsMessagesListCall {
+	c.urlParams_.Set("startTime", startTime)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsMessagesListCall) Fields(s ...googleapi.Field) *ProjectsJobsMessagesListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsJobsMessagesListCall) IfNoneMatch(entityTag string) *ProjectsJobsMessagesListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsMessagesListCall) Context(ctx context.Context) *ProjectsJobsMessagesListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsMessagesListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsMessagesListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}/messages")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.messages.list" call.
+// Exactly one of *ListJobMessagesResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListJobMessagesResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsJobsMessagesListCall) Do(opts ...googleapi.CallOption) (*ListJobMessagesResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListJobMessagesResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Request the job status.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/messages",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.jobs.messages.list",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "endTime": {
+	//       "description": "Return only messages with timestamps \u003c end_time. The default is now\n(i.e. return up to the latest messages available).",
+	//       "format": "google-datetime",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "jobId": {
+	//       "description": "The job to get messages about.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location which contains the job specified by job_id.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "minimumImportance": {
+	//       "description": "Filter to only get messages with importance \u003e= level",
+	//       "enum": [
+	//         "JOB_MESSAGE_IMPORTANCE_UNKNOWN",
+	//         "JOB_MESSAGE_DEBUG",
+	//         "JOB_MESSAGE_DETAILED",
+	//         "JOB_MESSAGE_BASIC",
+	//         "JOB_MESSAGE_WARNING",
+	//         "JOB_MESSAGE_ERROR"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "If specified, determines the maximum number of messages to\nreturn.  If unspecified, the service may choose an appropriate\ndefault, or may return an arbitrarily large number of results.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "If supplied, this should be the value of next_page_token returned\nby an earlier call. This will cause the next page of results to\nbe returned.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "A project id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "startTime": {
+	//       "description": "If specified, return only messages with timestamps \u003e= start_time.\nThe default is the job creation time (i.e. beginning of messages).",
+	//       "format": "google-datetime",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}/messages",
+	//   "response": {
+	//     "$ref": "ListJobMessagesResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsJobsMessagesListCall) Pages(ctx context.Context, f func(*ListJobMessagesResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "dataflow.projects.jobs.workItems.lease":
+
+type ProjectsJobsWorkItemsLeaseCall struct {
+	s                    *Service
+	projectId            string
+	jobId                string
+	leaseworkitemrequest *LeaseWorkItemRequest
+	urlParams_           gensupport.URLParams
+	ctx_                 context.Context
+	header_              http.Header
+}
+
+// Lease: Leases a dataflow WorkItem to run.
+func (r *ProjectsJobsWorkItemsService) Lease(projectId string, jobId string, leaseworkitemrequest *LeaseWorkItemRequest) *ProjectsJobsWorkItemsLeaseCall {
+	c := &ProjectsJobsWorkItemsLeaseCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	c.leaseworkitemrequest = leaseworkitemrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsWorkItemsLeaseCall) Fields(s ...googleapi.Field) *ProjectsJobsWorkItemsLeaseCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsWorkItemsLeaseCall) Context(ctx context.Context) *ProjectsJobsWorkItemsLeaseCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsWorkItemsLeaseCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsWorkItemsLeaseCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.leaseworkitemrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}/workItems:lease")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.workItems.lease" call.
+// Exactly one of *LeaseWorkItemResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *LeaseWorkItemResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsJobsWorkItemsLeaseCall) Do(opts ...googleapi.CallOption) (*LeaseWorkItemResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &LeaseWorkItemResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Leases a dataflow WorkItem to run.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:lease",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.jobs.workItems.lease",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "Identifies the workflow job this worker belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "Identifies the project this worker belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:lease",
+	//   "request": {
+	//     "$ref": "LeaseWorkItemRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "LeaseWorkItemResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.jobs.workItems.reportStatus":
+
+type ProjectsJobsWorkItemsReportStatusCall struct {
+	s                           *Service
+	projectId                   string
+	jobId                       string
+	reportworkitemstatusrequest *ReportWorkItemStatusRequest
+	urlParams_                  gensupport.URLParams
+	ctx_                        context.Context
+	header_                     http.Header
+}
+
+// ReportStatus: Reports the status of dataflow WorkItems leased by a
+// worker.
+func (r *ProjectsJobsWorkItemsService) ReportStatus(projectId string, jobId string, reportworkitemstatusrequest *ReportWorkItemStatusRequest) *ProjectsJobsWorkItemsReportStatusCall {
+	c := &ProjectsJobsWorkItemsReportStatusCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.jobId = jobId
+	c.reportworkitemstatusrequest = reportworkitemstatusrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsJobsWorkItemsReportStatusCall) Fields(s ...googleapi.Field) *ProjectsJobsWorkItemsReportStatusCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsJobsWorkItemsReportStatusCall) Context(ctx context.Context) *ProjectsJobsWorkItemsReportStatusCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsJobsWorkItemsReportStatusCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsJobsWorkItemsReportStatusCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.reportworkitemstatusrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/jobs/{jobId}/workItems:reportStatus")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.jobs.workItems.reportStatus" call.
+// Exactly one of *ReportWorkItemStatusResponse or error will be
+// non-nil. Any non-2xx status code is an error. Response headers are in
+// either *ReportWorkItemStatusResponse.ServerResponse.Header or (if a
+// response was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsJobsWorkItemsReportStatusCall) Do(opts ...googleapi.CallOption) (*ReportWorkItemStatusResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ReportWorkItemStatusResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Reports the status of dataflow WorkItems leased by a worker.",
+	//   "flatPath": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:reportStatus",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.jobs.workItems.reportStatus",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job which the WorkItem is part of.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The project which owns the WorkItem's job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/jobs/{jobId}/workItems:reportStatus",
+	//   "request": {
+	//     "$ref": "ReportWorkItemStatusRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "ReportWorkItemStatusResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.locations.jobs.create":
+
+type ProjectsLocationsJobsCreateCall struct {
+	s          *Service
+	projectId  string
+	location   string
+	job        *Job
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Create: Creates a Cloud Dataflow job.
+func (r *ProjectsLocationsJobsService) Create(projectId string, location string, job *Job) *ProjectsLocationsJobsCreateCall {
+	c := &ProjectsLocationsJobsCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	c.job = job
+	return c
+}
+
+// ReplaceJobId sets the optional parameter "replaceJobId": Deprecated.
+// This field is now in the Job message.
+func (c *ProjectsLocationsJobsCreateCall) ReplaceJobId(replaceJobId string) *ProjectsLocationsJobsCreateCall {
+	c.urlParams_.Set("replaceJobId", replaceJobId)
+	return c
+}
+
+// View sets the optional parameter "view": The level of information
+// requested in response.
+//
+// Possible values:
+//   "JOB_VIEW_UNKNOWN"
+//   "JOB_VIEW_SUMMARY"
+//   "JOB_VIEW_ALL"
+//   "JOB_VIEW_DESCRIPTION"
+func (c *ProjectsLocationsJobsCreateCall) View(view string) *ProjectsLocationsJobsCreateCall {
+	c.urlParams_.Set("view", view)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsCreateCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsCreateCall) Context(ctx context.Context) *ProjectsLocationsJobsCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.job)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.create" call.
+// Exactly one of *Job or error will be non-nil. Any non-2xx status code
+// is an error. Response headers are in either
+// *Job.ServerResponse.Header or (if a response was returned at all) in
+// error.(*googleapi.Error).Header. Use googleapi.IsNotModified to check
+// whether the returned error was because http.StatusNotModified was
+// returned.
+func (c *ProjectsLocationsJobsCreateCall) Do(opts ...googleapi.CallOption) (*Job, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Job{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a Cloud Dataflow job.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.locations.jobs.create",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location"
+	//   ],
+	//   "parameters": {
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "replaceJobId": {
+	//       "description": "Deprecated. This field is now in the Job message.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "view": {
+	//       "description": "The level of information requested in response.",
+	//       "enum": [
+	//         "JOB_VIEW_UNKNOWN",
+	//         "JOB_VIEW_SUMMARY",
+	//         "JOB_VIEW_ALL",
+	//         "JOB_VIEW_DESCRIPTION"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs",
+	//   "request": {
+	//     "$ref": "Job"
+	//   },
+	//   "response": {
+	//     "$ref": "Job"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.locations.jobs.get":
+
+type ProjectsLocationsJobsGetCall struct {
+	s            *Service
+	projectId    string
+	location     string
+	jobId        string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Gets the state of the specified Cloud Dataflow job.
+func (r *ProjectsLocationsJobsService) Get(projectId string, location string, jobId string) *ProjectsLocationsJobsGetCall {
+	c := &ProjectsLocationsJobsGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	c.jobId = jobId
+	return c
+}
+
+// View sets the optional parameter "view": The level of information
+// requested in response.
+//
+// Possible values:
+//   "JOB_VIEW_UNKNOWN"
+//   "JOB_VIEW_SUMMARY"
+//   "JOB_VIEW_ALL"
+//   "JOB_VIEW_DESCRIPTION"
+func (c *ProjectsLocationsJobsGetCall) View(view string) *ProjectsLocationsJobsGetCall {
+	c.urlParams_.Set("view", view)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsGetCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsJobsGetCall) IfNoneMatch(entityTag string) *ProjectsLocationsJobsGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsGetCall) Context(ctx context.Context) *ProjectsLocationsJobsGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.get" call.
+// Exactly one of *Job or error will be non-nil. Any non-2xx status code
+// is an error. Response headers are in either
+// *Job.ServerResponse.Header or (if a response was returned at all) in
+// error.(*googleapi.Error).Header. Use googleapi.IsNotModified to check
+// whether the returned error was because http.StatusNotModified was
+// returned.
+func (c *ProjectsLocationsJobsGetCall) Do(opts ...googleapi.CallOption) (*Job, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Job{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Gets the state of the specified Cloud Dataflow job.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.locations.jobs.get",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job ID.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "view": {
+	//       "description": "The level of information requested in response.",
+	//       "enum": [
+	//         "JOB_VIEW_UNKNOWN",
+	//         "JOB_VIEW_SUMMARY",
+	//         "JOB_VIEW_ALL",
+	//         "JOB_VIEW_DESCRIPTION"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}",
+	//   "response": {
+	//     "$ref": "Job"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.locations.jobs.getMetrics":
+
+type ProjectsLocationsJobsGetMetricsCall struct {
+	s            *Service
+	projectId    string
+	location     string
+	jobId        string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// GetMetrics: Request the job status.
+func (r *ProjectsLocationsJobsService) GetMetrics(projectId string, location string, jobId string) *ProjectsLocationsJobsGetMetricsCall {
+	c := &ProjectsLocationsJobsGetMetricsCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	c.jobId = jobId
+	return c
+}
+
+// StartTime sets the optional parameter "startTime": Return only metric
+// data that has changed since this time.
+// Default is to return all information about all metrics for the job.
+func (c *ProjectsLocationsJobsGetMetricsCall) StartTime(startTime string) *ProjectsLocationsJobsGetMetricsCall {
+	c.urlParams_.Set("startTime", startTime)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsGetMetricsCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsGetMetricsCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsJobsGetMetricsCall) IfNoneMatch(entityTag string) *ProjectsLocationsJobsGetMetricsCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsGetMetricsCall) Context(ctx context.Context) *ProjectsLocationsJobsGetMetricsCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsGetMetricsCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsGetMetricsCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/metrics")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.getMetrics" call.
+// Exactly one of *JobMetrics or error will be non-nil. Any non-2xx
+// status code is an error. Response headers are in either
+// *JobMetrics.ServerResponse.Header or (if a response was returned at
+// all) in error.(*googleapi.Error).Header. Use googleapi.IsNotModified
+// to check whether the returned error was because
+// http.StatusNotModified was returned.
+func (c *ProjectsLocationsJobsGetMetricsCall) Do(opts ...googleapi.CallOption) (*JobMetrics, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &JobMetrics{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Request the job status.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/metrics",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.locations.jobs.getMetrics",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job to get messages for.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location which contains the job specified by job_id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "A project id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "startTime": {
+	//       "description": "Return only metric data that has changed since this time.\nDefault is to return all information about all metrics for the job.",
+	//       "format": "google-datetime",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/metrics",
+	//   "response": {
+	//     "$ref": "JobMetrics"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.locations.jobs.list":
+
+type ProjectsLocationsJobsListCall struct {
+	s            *Service
+	projectId    string
+	location     string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: List the jobs of a project.
+func (r *ProjectsLocationsJobsService) List(projectId string, location string) *ProjectsLocationsJobsListCall {
+	c := &ProjectsLocationsJobsListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	return c
+}
+
+// Filter sets the optional parameter "filter": The kind of filter to
+// use.
+//
+// Possible values:
+//   "UNKNOWN"
+//   "ALL"
+//   "TERMINATED"
+//   "ACTIVE"
+func (c *ProjectsLocationsJobsListCall) Filter(filter string) *ProjectsLocationsJobsListCall {
+	c.urlParams_.Set("filter", filter)
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": If there are many
+// jobs, limit response to at most this many.
+// The actual number of jobs returned will be the lesser of
+// max_responses
+// and an unspecified server-defined limit.
+func (c *ProjectsLocationsJobsListCall) PageSize(pageSize int64) *ProjectsLocationsJobsListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": Set this to the
+// 'next_page_token' field of a previous response
+// to request additional results in a long list.
+func (c *ProjectsLocationsJobsListCall) PageToken(pageToken string) *ProjectsLocationsJobsListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// View sets the optional parameter "view": Level of information
+// requested in response. Default is `JOB_VIEW_SUMMARY`.
+//
+// Possible values:
+//   "JOB_VIEW_UNKNOWN"
+//   "JOB_VIEW_SUMMARY"
+//   "JOB_VIEW_ALL"
+//   "JOB_VIEW_DESCRIPTION"
+func (c *ProjectsLocationsJobsListCall) View(view string) *ProjectsLocationsJobsListCall {
+	c.urlParams_.Set("view", view)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsListCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsJobsListCall) IfNoneMatch(entityTag string) *ProjectsLocationsJobsListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsListCall) Context(ctx context.Context) *ProjectsLocationsJobsListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.list" call.
+// Exactly one of *ListJobsResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListJobsResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsJobsListCall) Do(opts ...googleapi.CallOption) (*ListJobsResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListJobsResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "List the jobs of a project.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.locations.jobs.list",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location"
+	//   ],
+	//   "parameters": {
+	//     "filter": {
+	//       "description": "The kind of filter to use.",
+	//       "enum": [
+	//         "UNKNOWN",
+	//         "ALL",
+	//         "TERMINATED",
+	//         "ACTIVE"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "If there are many jobs, limit response to at most this many.\nThe actual number of jobs returned will be the lesser of max_responses\nand an unspecified server-defined limit.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "Set this to the 'next_page_token' field of a previous response\nto request additional results in a long list.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The project which owns the jobs.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "view": {
+	//       "description": "Level of information requested in response. Default is `JOB_VIEW_SUMMARY`.",
+	//       "enum": [
+	//         "JOB_VIEW_UNKNOWN",
+	//         "JOB_VIEW_SUMMARY",
+	//         "JOB_VIEW_ALL",
+	//         "JOB_VIEW_DESCRIPTION"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs",
+	//   "response": {
+	//     "$ref": "ListJobsResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsLocationsJobsListCall) Pages(ctx context.Context, f func(*ListJobsResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "dataflow.projects.locations.jobs.update":
+
+type ProjectsLocationsJobsUpdateCall struct {
+	s          *Service
+	projectId  string
+	location   string
+	jobId      string
+	job        *Job
+	urlParams_ gensupport.URLParams
+	ctx_       context.Context
+	header_    http.Header
+}
+
+// Update: Updates the state of an existing Cloud Dataflow job.
+func (r *ProjectsLocationsJobsService) Update(projectId string, location string, jobId string, job *Job) *ProjectsLocationsJobsUpdateCall {
+	c := &ProjectsLocationsJobsUpdateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	c.jobId = jobId
+	c.job = job
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsUpdateCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsUpdateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsUpdateCall) Context(ctx context.Context) *ProjectsLocationsJobsUpdateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsUpdateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsUpdateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.job)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("PUT", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.update" call.
+// Exactly one of *Job or error will be non-nil. Any non-2xx status code
+// is an error. Response headers are in either
+// *Job.ServerResponse.Header or (if a response was returned at all) in
+// error.(*googleapi.Error).Header. Use googleapi.IsNotModified to check
+// whether the returned error was because http.StatusNotModified was
+// returned.
+func (c *ProjectsLocationsJobsUpdateCall) Do(opts ...googleapi.CallOption) (*Job, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Job{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Updates the state of an existing Cloud Dataflow job.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}",
+	//   "httpMethod": "PUT",
+	//   "id": "dataflow.projects.locations.jobs.update",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job ID.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location that contains this job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}",
+	//   "request": {
+	//     "$ref": "Job"
+	//   },
+	//   "response": {
+	//     "$ref": "Job"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.locations.jobs.messages.list":
+
+type ProjectsLocationsJobsMessagesListCall struct {
+	s            *Service
+	projectId    string
+	location     string
+	jobId        string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// List: Request the job status.
+func (r *ProjectsLocationsJobsMessagesService) List(projectId string, location string, jobId string) *ProjectsLocationsJobsMessagesListCall {
+	c := &ProjectsLocationsJobsMessagesListCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	c.jobId = jobId
+	return c
+}
+
+// EndTime sets the optional parameter "endTime": Return only messages
+// with timestamps < end_time. The default is now
+// (i.e. return up to the latest messages available).
+func (c *ProjectsLocationsJobsMessagesListCall) EndTime(endTime string) *ProjectsLocationsJobsMessagesListCall {
+	c.urlParams_.Set("endTime", endTime)
+	return c
+}
+
+// MinimumImportance sets the optional parameter "minimumImportance":
+// Filter to only get messages with importance >= level
+//
+// Possible values:
+//   "JOB_MESSAGE_IMPORTANCE_UNKNOWN"
+//   "JOB_MESSAGE_DEBUG"
+//   "JOB_MESSAGE_DETAILED"
+//   "JOB_MESSAGE_BASIC"
+//   "JOB_MESSAGE_WARNING"
+//   "JOB_MESSAGE_ERROR"
+func (c *ProjectsLocationsJobsMessagesListCall) MinimumImportance(minimumImportance string) *ProjectsLocationsJobsMessagesListCall {
+	c.urlParams_.Set("minimumImportance", minimumImportance)
+	return c
+}
+
+// PageSize sets the optional parameter "pageSize": If specified,
+// determines the maximum number of messages to
+// return.  If unspecified, the service may choose an
+// appropriate
+// default, or may return an arbitrarily large number of results.
+func (c *ProjectsLocationsJobsMessagesListCall) PageSize(pageSize int64) *ProjectsLocationsJobsMessagesListCall {
+	c.urlParams_.Set("pageSize", fmt.Sprint(pageSize))
+	return c
+}
+
+// PageToken sets the optional parameter "pageToken": If supplied, this
+// should be the value of next_page_token returned
+// by an earlier call. This will cause the next page of results to
+// be returned.
+func (c *ProjectsLocationsJobsMessagesListCall) PageToken(pageToken string) *ProjectsLocationsJobsMessagesListCall {
+	c.urlParams_.Set("pageToken", pageToken)
+	return c
+}
+
+// StartTime sets the optional parameter "startTime": If specified,
+// return only messages with timestamps >= start_time.
+// The default is the job creation time (i.e. beginning of messages).
+func (c *ProjectsLocationsJobsMessagesListCall) StartTime(startTime string) *ProjectsLocationsJobsMessagesListCall {
+	c.urlParams_.Set("startTime", startTime)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsMessagesListCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsMessagesListCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsLocationsJobsMessagesListCall) IfNoneMatch(entityTag string) *ProjectsLocationsJobsMessagesListCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsMessagesListCall) Context(ctx context.Context) *ProjectsLocationsJobsMessagesListCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsMessagesListCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsMessagesListCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/messages")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.messages.list" call.
+// Exactly one of *ListJobMessagesResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *ListJobMessagesResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsJobsMessagesListCall) Do(opts ...googleapi.CallOption) (*ListJobMessagesResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ListJobMessagesResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Request the job status.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/messages",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.locations.jobs.messages.list",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "endTime": {
+	//       "description": "Return only messages with timestamps \u003c end_time. The default is now\n(i.e. return up to the latest messages available).",
+	//       "format": "google-datetime",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "jobId": {
+	//       "description": "The job to get messages about.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location which contains the job specified by job_id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "minimumImportance": {
+	//       "description": "Filter to only get messages with importance \u003e= level",
+	//       "enum": [
+	//         "JOB_MESSAGE_IMPORTANCE_UNKNOWN",
+	//         "JOB_MESSAGE_DEBUG",
+	//         "JOB_MESSAGE_DETAILED",
+	//         "JOB_MESSAGE_BASIC",
+	//         "JOB_MESSAGE_WARNING",
+	//         "JOB_MESSAGE_ERROR"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "pageSize": {
+	//       "description": "If specified, determines the maximum number of messages to\nreturn.  If unspecified, the service may choose an appropriate\ndefault, or may return an arbitrarily large number of results.",
+	//       "format": "int32",
+	//       "location": "query",
+	//       "type": "integer"
+	//     },
+	//     "pageToken": {
+	//       "description": "If supplied, this should be the value of next_page_token returned\nby an earlier call. This will cause the next page of results to\nbe returned.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "A project id.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "startTime": {
+	//       "description": "If specified, return only messages with timestamps \u003e= start_time.\nThe default is the job creation time (i.e. beginning of messages).",
+	//       "format": "google-datetime",
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/messages",
+	//   "response": {
+	//     "$ref": "ListJobMessagesResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// Pages invokes f for each page of results.
+// A non-nil error returned from f will halt the iteration.
+// The provided context supersedes any context provided to the Context method.
+func (c *ProjectsLocationsJobsMessagesListCall) Pages(ctx context.Context, f func(*ListJobMessagesResponse) error) error {
+	c.ctx_ = ctx
+	defer c.PageToken(c.urlParams_.Get("pageToken")) // reset paging to original point
+	for {
+		x, err := c.Do()
+		if err != nil {
+			return err
+		}
+		if err := f(x); err != nil {
+			return err
+		}
+		if x.NextPageToken == "" {
+			return nil
+		}
+		c.PageToken(x.NextPageToken)
+	}
+}
+
+// method id "dataflow.projects.locations.jobs.workItems.lease":
+
+type ProjectsLocationsJobsWorkItemsLeaseCall struct {
+	s                    *Service
+	projectId            string
+	location             string
+	jobId                string
+	leaseworkitemrequest *LeaseWorkItemRequest
+	urlParams_           gensupport.URLParams
+	ctx_                 context.Context
+	header_              http.Header
+}
+
+// Lease: Leases a dataflow WorkItem to run.
+func (r *ProjectsLocationsJobsWorkItemsService) Lease(projectId string, location string, jobId string, leaseworkitemrequest *LeaseWorkItemRequest) *ProjectsLocationsJobsWorkItemsLeaseCall {
+	c := &ProjectsLocationsJobsWorkItemsLeaseCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	c.jobId = jobId
+	c.leaseworkitemrequest = leaseworkitemrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsWorkItemsLeaseCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsWorkItemsLeaseCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsWorkItemsLeaseCall) Context(ctx context.Context) *ProjectsLocationsJobsWorkItemsLeaseCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsWorkItemsLeaseCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsWorkItemsLeaseCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.leaseworkitemrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:lease")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.workItems.lease" call.
+// Exactly one of *LeaseWorkItemResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *LeaseWorkItemResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsJobsWorkItemsLeaseCall) Do(opts ...googleapi.CallOption) (*LeaseWorkItemResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &LeaseWorkItemResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Leases a dataflow WorkItem to run.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:lease",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.locations.jobs.workItems.lease",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "Identifies the workflow job this worker belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location which contains the WorkItem's job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "Identifies the project this worker belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:lease",
+	//   "request": {
+	//     "$ref": "LeaseWorkItemRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "LeaseWorkItemResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.locations.jobs.workItems.reportStatus":
+
+type ProjectsLocationsJobsWorkItemsReportStatusCall struct {
+	s                           *Service
+	projectId                   string
+	location                    string
+	jobId                       string
+	reportworkitemstatusrequest *ReportWorkItemStatusRequest
+	urlParams_                  gensupport.URLParams
+	ctx_                        context.Context
+	header_                     http.Header
+}
+
+// ReportStatus: Reports the status of dataflow WorkItems leased by a
+// worker.
+func (r *ProjectsLocationsJobsWorkItemsService) ReportStatus(projectId string, location string, jobId string, reportworkitemstatusrequest *ReportWorkItemStatusRequest) *ProjectsLocationsJobsWorkItemsReportStatusCall {
+	c := &ProjectsLocationsJobsWorkItemsReportStatusCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.location = location
+	c.jobId = jobId
+	c.reportworkitemstatusrequest = reportworkitemstatusrequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsLocationsJobsWorkItemsReportStatusCall) Fields(s ...googleapi.Field) *ProjectsLocationsJobsWorkItemsReportStatusCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsLocationsJobsWorkItemsReportStatusCall) Context(ctx context.Context) *ProjectsLocationsJobsWorkItemsReportStatusCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsLocationsJobsWorkItemsReportStatusCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsLocationsJobsWorkItemsReportStatusCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.reportworkitemstatusrequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:reportStatus")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+		"location":  c.location,
+		"jobId":     c.jobId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.locations.jobs.workItems.reportStatus" call.
+// Exactly one of *ReportWorkItemStatusResponse or error will be
+// non-nil. Any non-2xx status code is an error. Response headers are in
+// either *ReportWorkItemStatusResponse.ServerResponse.Header or (if a
+// response was returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsLocationsJobsWorkItemsReportStatusCall) Do(opts ...googleapi.CallOption) (*ReportWorkItemStatusResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &ReportWorkItemStatusResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Reports the status of dataflow WorkItems leased by a worker.",
+	//   "flatPath": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:reportStatus",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.locations.jobs.workItems.reportStatus",
+	//   "parameterOrder": [
+	//     "projectId",
+	//     "location",
+	//     "jobId"
+	//   ],
+	//   "parameters": {
+	//     "jobId": {
+	//       "description": "The job which the WorkItem is part of.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "location": {
+	//       "description": "The location which contains the WorkItem's job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "The project which owns the WorkItem's job.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/locations/{location}/jobs/{jobId}/workItems:reportStatus",
+	//   "request": {
+	//     "$ref": "ReportWorkItemStatusRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "ReportWorkItemStatusResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.templates.create":
+
+type ProjectsTemplatesCreateCall struct {
+	s                            *Service
+	projectId                    string
+	createjobfromtemplaterequest *CreateJobFromTemplateRequest
+	urlParams_                   gensupport.URLParams
+	ctx_                         context.Context
+	header_                      http.Header
+}
+
+// Create: Creates a Cloud Dataflow job from a template.
+func (r *ProjectsTemplatesService) Create(projectId string, createjobfromtemplaterequest *CreateJobFromTemplateRequest) *ProjectsTemplatesCreateCall {
+	c := &ProjectsTemplatesCreateCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.createjobfromtemplaterequest = createjobfromtemplaterequest
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsTemplatesCreateCall) Fields(s ...googleapi.Field) *ProjectsTemplatesCreateCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsTemplatesCreateCall) Context(ctx context.Context) *ProjectsTemplatesCreateCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsTemplatesCreateCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsTemplatesCreateCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.createjobfromtemplaterequest)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/templates")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.templates.create" call.
+// Exactly one of *Job or error will be non-nil. Any non-2xx status code
+// is an error. Response headers are in either
+// *Job.ServerResponse.Header or (if a response was returned at all) in
+// error.(*googleapi.Error).Header. Use googleapi.IsNotModified to check
+// whether the returned error was because http.StatusNotModified was
+// returned.
+func (c *ProjectsTemplatesCreateCall) Do(opts ...googleapi.CallOption) (*Job, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &Job{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Creates a Cloud Dataflow job from a template.",
+	//   "flatPath": "v1b3/projects/{projectId}/templates",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.templates.create",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "projectId": {
+	//       "description": "Required. The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/templates",
+	//   "request": {
+	//     "$ref": "CreateJobFromTemplateRequest"
+	//   },
+	//   "response": {
+	//     "$ref": "Job"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.templates.get":
+
+type ProjectsTemplatesGetCall struct {
+	s            *Service
+	projectId    string
+	urlParams_   gensupport.URLParams
+	ifNoneMatch_ string
+	ctx_         context.Context
+	header_      http.Header
+}
+
+// Get: Get the template associated with a template.
+func (r *ProjectsTemplatesService) Get(projectId string) *ProjectsTemplatesGetCall {
+	c := &ProjectsTemplatesGetCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	return c
+}
+
+// GcsPath sets the optional parameter "gcsPath": Required. A Cloud
+// Storage path to the template from which to
+// create the job.
+// Must be a valid Cloud Storage URL, beginning with `gs://`.
+func (c *ProjectsTemplatesGetCall) GcsPath(gcsPath string) *ProjectsTemplatesGetCall {
+	c.urlParams_.Set("gcsPath", gcsPath)
+	return c
+}
+
+// View sets the optional parameter "view": The view to retrieve.
+// Defaults to METADATA_ONLY.
+//
+// Possible values:
+//   "METADATA_ONLY"
+func (c *ProjectsTemplatesGetCall) View(view string) *ProjectsTemplatesGetCall {
+	c.urlParams_.Set("view", view)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsTemplatesGetCall) Fields(s ...googleapi.Field) *ProjectsTemplatesGetCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// IfNoneMatch sets the optional parameter which makes the operation
+// fail if the object's ETag matches the given value. This is useful for
+// getting updates only after the object has changed since the last
+// request. Use googleapi.IsNotModified to check whether the response
+// error from Do is the result of In-None-Match.
+func (c *ProjectsTemplatesGetCall) IfNoneMatch(entityTag string) *ProjectsTemplatesGetCall {
+	c.ifNoneMatch_ = entityTag
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsTemplatesGetCall) Context(ctx context.Context) *ProjectsTemplatesGetCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsTemplatesGetCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsTemplatesGetCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	if c.ifNoneMatch_ != "" {
+		reqHeaders.Set("If-None-Match", c.ifNoneMatch_)
+	}
+	var body io.Reader = nil
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/templates:get")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("GET", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.templates.get" call.
+// Exactly one of *GetTemplateResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *GetTemplateResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsTemplatesGetCall) Do(opts ...googleapi.CallOption) (*GetTemplateResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &GetTemplateResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Get the template associated with a template.",
+	//   "flatPath": "v1b3/projects/{projectId}/templates:get",
+	//   "httpMethod": "GET",
+	//   "id": "dataflow.projects.templates.get",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "gcsPath": {
+	//       "description": "Required. A Cloud Storage path to the template from which to\ncreate the job.\nMust be a valid Cloud Storage URL, beginning with `gs://`.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "Required. The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     },
+	//     "view": {
+	//       "description": "The view to retrieve. Defaults to METADATA_ONLY.",
+	//       "enum": [
+	//         "METADATA_ONLY"
+	//       ],
+	//       "location": "query",
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/templates:get",
+	//   "response": {
+	//     "$ref": "GetTemplateResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}
+
+// method id "dataflow.projects.templates.launch":
+
+type ProjectsTemplatesLaunchCall struct {
+	s                        *Service
+	projectId                string
+	launchtemplateparameters *LaunchTemplateParameters
+	urlParams_               gensupport.URLParams
+	ctx_                     context.Context
+	header_                  http.Header
+}
+
+// Launch: Launch a template.
+func (r *ProjectsTemplatesService) Launch(projectId string, launchtemplateparameters *LaunchTemplateParameters) *ProjectsTemplatesLaunchCall {
+	c := &ProjectsTemplatesLaunchCall{s: r.s, urlParams_: make(gensupport.URLParams)}
+	c.projectId = projectId
+	c.launchtemplateparameters = launchtemplateparameters
+	return c
+}
+
+// DryRun sets the optional parameter "dryRun": Whether or not the job
+// should actually be executed after
+// validating parameters. Defaults to false. Validation errors do
+// not cause the HTTP request to fail if true.
+func (c *ProjectsTemplatesLaunchCall) DryRun(dryRun bool) *ProjectsTemplatesLaunchCall {
+	c.urlParams_.Set("dryRun", fmt.Sprint(dryRun))
+	return c
+}
+
+// GcsPath sets the optional parameter "gcsPath": Required. A Cloud
+// Storage path to the template from which to create
+// the job.
+// Must be valid Cloud Storage URL, beginning with 'gs://'.
+func (c *ProjectsTemplatesLaunchCall) GcsPath(gcsPath string) *ProjectsTemplatesLaunchCall {
+	c.urlParams_.Set("gcsPath", gcsPath)
+	return c
+}
+
+// Fields allows partial responses to be retrieved. See
+// https://developers.google.com/gdata/docs/2.0/basics#PartialResponse
+// for more information.
+func (c *ProjectsTemplatesLaunchCall) Fields(s ...googleapi.Field) *ProjectsTemplatesLaunchCall {
+	c.urlParams_.Set("fields", googleapi.CombineFields(s))
+	return c
+}
+
+// Context sets the context to be used in this call's Do method. Any
+// pending HTTP request will be aborted if the provided context is
+// canceled.
+func (c *ProjectsTemplatesLaunchCall) Context(ctx context.Context) *ProjectsTemplatesLaunchCall {
+	c.ctx_ = ctx
+	return c
+}
+
+// Header returns an http.Header that can be modified by the caller to
+// add HTTP headers to the request.
+func (c *ProjectsTemplatesLaunchCall) Header() http.Header {
+	if c.header_ == nil {
+		c.header_ = make(http.Header)
+	}
+	return c.header_
+}
+
+func (c *ProjectsTemplatesLaunchCall) doRequest(alt string) (*http.Response, error) {
+	reqHeaders := make(http.Header)
+	for k, v := range c.header_ {
+		reqHeaders[k] = v
+	}
+	reqHeaders.Set("User-Agent", c.s.userAgent())
+	var body io.Reader = nil
+	body, err := googleapi.WithoutDataWrapper.JSONReader(c.launchtemplateparameters)
+	if err != nil {
+		return nil, err
+	}
+	reqHeaders.Set("Content-Type", "application/json")
+	c.urlParams_.Set("alt", alt)
+	urls := googleapi.ResolveRelative(c.s.BasePath, "v1b3/projects/{projectId}/templates:launch")
+	urls += "?" + c.urlParams_.Encode()
+	req, _ := http.NewRequest("POST", urls, body)
+	req.Header = reqHeaders
+	googleapi.Expand(req.URL, map[string]string{
+		"projectId": c.projectId,
+	})
+	return gensupport.SendRequest(c.ctx_, c.s.client, req)
+}
+
+// Do executes the "dataflow.projects.templates.launch" call.
+// Exactly one of *LaunchTemplateResponse or error will be non-nil. Any
+// non-2xx status code is an error. Response headers are in either
+// *LaunchTemplateResponse.ServerResponse.Header or (if a response was
+// returned at all) in error.(*googleapi.Error).Header. Use
+// googleapi.IsNotModified to check whether the returned error was
+// because http.StatusNotModified was returned.
+func (c *ProjectsTemplatesLaunchCall) Do(opts ...googleapi.CallOption) (*LaunchTemplateResponse, error) {
+	gensupport.SetOptions(c.urlParams_, opts...)
+	res, err := c.doRequest("json")
+	if res != nil && res.StatusCode == http.StatusNotModified {
+		if res.Body != nil {
+			res.Body.Close()
+		}
+		return nil, &googleapi.Error{
+			Code:   res.StatusCode,
+			Header: res.Header,
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer googleapi.CloseBody(res)
+	if err := googleapi.CheckResponse(res); err != nil {
+		return nil, err
+	}
+	ret := &LaunchTemplateResponse{
+		ServerResponse: googleapi.ServerResponse{
+			Header:         res.Header,
+			HTTPStatusCode: res.StatusCode,
+		},
+	}
+	target := &ret
+	if err := json.NewDecoder(res.Body).Decode(target); err != nil {
+		return nil, err
+	}
+	return ret, nil
+	// {
+	//   "description": "Launch a template.",
+	//   "flatPath": "v1b3/projects/{projectId}/templates:launch",
+	//   "httpMethod": "POST",
+	//   "id": "dataflow.projects.templates.launch",
+	//   "parameterOrder": [
+	//     "projectId"
+	//   ],
+	//   "parameters": {
+	//     "dryRun": {
+	//       "description": "Whether or not the job should actually be executed after\nvalidating parameters. Defaults to false. Validation errors do\nnot cause the HTTP request to fail if true.",
+	//       "location": "query",
+	//       "type": "boolean"
+	//     },
+	//     "gcsPath": {
+	//       "description": "Required. A Cloud Storage path to the template from which to create\nthe job.\nMust be valid Cloud Storage URL, beginning with 'gs://'.",
+	//       "location": "query",
+	//       "type": "string"
+	//     },
+	//     "projectId": {
+	//       "description": "Required. The ID of the Cloud Platform project that the job belongs to.",
+	//       "location": "path",
+	//       "required": true,
+	//       "type": "string"
+	//     }
+	//   },
+	//   "path": "v1b3/projects/{projectId}/templates:launch",
+	//   "request": {
+	//     "$ref": "LaunchTemplateParameters"
+	//   },
+	//   "response": {
+	//     "$ref": "LaunchTemplateResponse"
+	//   },
+	//   "scopes": [
+	//     "https://www.googleapis.com/auth/cloud-platform",
+	//     "https://www.googleapis.com/auth/userinfo.email"
+	//   ]
+	// }
+
+}

--- a/vendor/google.golang.org/api/googleapi/googleapi.go
+++ b/vendor/google.golang.org/api/googleapi/googleapi.go
@@ -50,7 +50,7 @@ const (
 	// UserAgent is the header string used to identify this package.
 	UserAgent = "google-api-go-client/" + Version
 
-	// The default chunk size to use for resumable uplods if not specified by the user.
+	// The default chunk size to use for resumable uploads if not specified by the user.
 	DefaultUploadChunkSize = 8 * 1024 * 1024
 
 	// The minimum chunk size that can be used for resumable uploads.  All
@@ -149,12 +149,12 @@ func IsNotModified(err error) bool {
 // CheckMediaResponse returns an error (of type *Error) if the response
 // status code is not 2xx. Unlike CheckResponse it does not assume the
 // body is a JSON error document.
+// It is the caller's responsibility to close res.Body.
 func CheckMediaResponse(res *http.Response) error {
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {
 		return nil
 	}
 	slurp, _ := ioutil.ReadAll(io.LimitReader(res.Body, 1<<20))
-	res.Body.Close()
 	return &Error{
 		Code: res.StatusCode,
 		Body: string(slurp),
@@ -278,41 +278,15 @@ func ResolveRelative(basestr, relstr string) string {
 	return us
 }
 
-// has4860Fix is whether this Go environment contains the fix for
-// http://golang.org/issue/4860
-var has4860Fix bool
-
-// init initializes has4860Fix by checking the behavior of the net/http package.
-func init() {
-	r := http.Request{
-		URL: &url.URL{
-			Scheme: "http",
-			Opaque: "//opaque",
-		},
-	}
-	b := &bytes.Buffer{}
-	r.Write(b)
-	has4860Fix = bytes.HasPrefix(b.Bytes(), []byte("GET http"))
-}
-
-// SetOpaque sets u.Opaque from u.Path such that HTTP requests to it
-// don't alter any hex-escaped characters in u.Path.
-func SetOpaque(u *url.URL) {
-	u.Opaque = "//" + u.Host + u.Path
-	if !has4860Fix {
-		u.Opaque = u.Scheme + ":" + u.Opaque
-	}
-}
-
 // Expand subsitutes any {encoded} strings in the URL passed in using
 // the map supplied.
 //
 // This calls SetOpaque to avoid encoding of the parameters in the URL path.
 func Expand(u *url.URL, expansions map[string]string) {
-	expanded, err := uritemplates.Expand(u.Path, expansions)
+	escaped, unescaped, err := uritemplates.Expand(u.Path, expansions)
 	if err == nil {
-		u.Path = expanded
-		SetOpaque(u)
+		u.Path = unescaped
+		u.RawPath = escaped
 	}
 }
 

--- a/vendor/google.golang.org/api/googleapi/internal/uritemplates/utils.go
+++ b/vendor/google.golang.org/api/googleapi/internal/uritemplates/utils.go
@@ -4,10 +4,14 @@
 
 package uritemplates
 
-func Expand(path string, values map[string]string) (string, error) {
+// Expand parses then expands a URI template with a set of values to produce
+// the resultant URI. Two forms of the result are returned: one with all the
+// elements escaped, and one with the elements unescaped.
+func Expand(path string, values map[string]string) (escaped, unescaped string, err error) {
 	template, err := parse(path)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
-	return template.Expand(values), nil
+	escaped, unescaped = template.Expand(values)
+	return escaped, unescaped, nil
 }

--- a/vendor/google.golang.org/api/googleapi/types.go
+++ b/vendor/google.golang.org/api/googleapi/types.go
@@ -6,6 +6,7 @@ package googleapi
 
 import (
 	"encoding/json"
+	"errors"
 	"strconv"
 )
 
@@ -147,6 +148,25 @@ func (s Float64s) MarshalJSON() ([]byte, error) {
 	return quotedList(len(s), func(dst []byte, i int) []byte {
 		return strconv.AppendFloat(dst, s[i], 'g', -1, 64)
 	})
+}
+
+// RawMessage is a raw encoded JSON value.
+// It is identical to json.RawMessage, except it does not suffer from
+// https://golang.org/issue/14493.
+type RawMessage []byte
+
+// MarshalJSON returns m.
+func (m RawMessage) MarshalJSON() ([]byte, error) {
+	return m, nil
+}
+
+// UnmarshalJSON sets *m to a copy of data.
+func (m *RawMessage) UnmarshalJSON(data []byte) error {
+	if m == nil {
+		return errors.New("googleapi.RawMessage: UnmarshalJSON on nil pointer")
+	}
+	*m = append((*m)[:0], data...)
+	return nil
 }
 
 /*

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3371,16 +3371,16 @@
 			"revisionTime": "2017-02-23T23:41:36Z"
 		},
 		{
-			"checksumSHA1": "yQREK/OWrz9PLljbr127+xFk6J0=",
+			"checksumSHA1": "BWKmb7kGYbfbvXO6E7tCpTh9zKE=",
 			"path": "google.golang.org/api/googleapi",
-			"revision": "3f131f305a2ae45080e71fdb780128cc92e8745e",
-			"revisionTime": "2016-08-05T04:28:55Z"
+			"revision": "48e49d1645e228d1c50c3d54fb476b2224477303",
+			"revisionTime": "2017-03-27T17:36:32Z"
 		},
 		{
-			"checksumSHA1": "ii4ET3JHk3vkMUEcg+9t/1RZSUU=",
+			"checksumSHA1": "1K0JxrUfDqAB3MyRiU1LKjfHyf4=",
 			"path": "google.golang.org/api/googleapi/internal/uritemplates",
-			"revision": "3f131f305a2ae45080e71fdb780128cc92e8745e",
-			"revisionTime": "2016-08-05T04:28:55Z"
+			"revision": "48e49d1645e228d1c50c3d54fb476b2224477303",
+			"revisionTime": "2017-03-27T17:36:32Z"
 		},
 		{
 			"checksumSHA1": "+u3FeHSXeRJZzw52OZsT3wUPb24=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3353,6 +3353,12 @@
 			"revisionTime": "2017-02-23T23:41:36Z"
 		},
 		{
+			"checksumSHA1": "xd5pqVs9z4SdULRcLhtN737ro54=",
+			"path": "google.golang.org/api/dataflow/v1b3",
+			"revision": "48e49d1645e228d1c50c3d54fb476b2224477303",
+			"revisionTime": "2017-03-27T17:36:32Z"
+		},
+		{
 			"checksumSHA1": "JYl35km48fLrIx7YUtzcgd4J7Rk=",
 			"path": "google.golang.org/api/dns/v1",
 			"revision": "3cc2e591b550923a2c5f0ab5a803feda924d5823",


### PR DESCRIPTION
Implements https://github.com/hashicorp/terraform/issues/13537.

I've been able to successfully create a Dataflow job using this resource.

I'm not sure how best to implement resource deletion, since there are several ways to cancel a job. Feedback would be welcome. I'm thinking that we could have a field called `on_delete` with the possible values being `"cancel"` and `"drain"`.