### PR TITLE
provider/nomad: Update acceptance tests to correctly reflect nomad API

### DIFF
--- a/builtin/providers/nomad/resource_job_test.go
+++ b/builtin/providers/nomad/resource_job_test.go
@@ -207,15 +207,17 @@ func testResourceJob_checkExists(s *terraform.State) error {
 func testResourceJob_checkDestroy(jobID string) r.TestCheckFunc {
 	return func(*terraform.State) error {
 		client := testProvider.Meta().(*api.Client)
-		_, _, err := client.Jobs().Info(jobID, nil)
-		if err != nil && strings.Contains(err.Error(), "404") {
+		job, _, err := client.Jobs().Info(jobID, nil)
+		// This should likely never happen, due to how nomad caches jobs
+		if err != nil && strings.Contains(err.Error(), "404") || job == nil {
 			return nil
 		}
-		if err == nil {
-			err = errors.New("not destroyed")
+
+		if job.Status != "dead" {
+			return fmt.Errorf("Job %q has not been stopped. Status: %s", jobID, job.Status)
 		}
 
-		return err
+		return nil
 	}
 }
 
@@ -284,9 +286,12 @@ func testResourceJob_updateCheck(s *terraform.State) error {
 
 	{
 		// Verify foo doesn't exist
-		_, _, err := client.Jobs().Info("foo", nil)
-		if err == nil {
-			return errors.New("reading foo success")
+		job, _, err := client.Jobs().Info("foo", nil)
+		if err != nil {
+			return fmt.Errorf("error reading %q job: %s", "foo", err)
+		}
+		if job.Status != "dead" {
+			return fmt.Errorf("%q job is not dead. Status: %q", "foo", job.Status)
 		}
 	}
 


### PR DESCRIPTION
Previously Nomad acceptance tests would look for a `404` response from the Nomad API when querying a nomad job after it had been stopped. Nomad has, for a while now, cached jobs such that they are still returnable from the API but have `"dead"` as their status.

```
$ make testacc TEST=./builtin/providers/nomad
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/03 16:27:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/nomad -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestResourceJob_basic
--- PASS: TestResourceJob_basic (0.03s)
=== RUN   TestResourceJob_refresh
--- PASS: TestResourceJob_refresh (0.04s)
=== RUN   TestResourceJob_disableDestroyDeregister
--- PASS: TestResourceJob_disableDestroyDeregister (0.05s)
=== RUN   TestResourceJob_idChange
--- PASS: TestResourceJob_idChange (0.06s)
=== RUN   TestResourceJob_parameterizedJob
--- PASS: TestResourceJob_parameterizedJob (0.02s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/nomad  0.222s
```