### PR TITLE
provider/google: Move 404 checking into a function in provider.go, call it from instance and IGM

### DIFF
--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -252,7 +252,7 @@ func getNetworkNameFromSelfLink(network string) (string, error) {
 	return network, nil
 }
 
-func readError(err error, d *schema.ResourceData, resource string) error {
+func handleNotFoundError(err error, d *schema.ResourceData, resource string) error {
 	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 		log.Printf("[WARN] Removing %s because it's gone", resource)
 		// The resource doesn't exist anymore

--- a/builtin/providers/google/provider.go
+++ b/builtin/providers/google/provider.go
@@ -3,6 +3,7 @@ package google
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -249,4 +250,16 @@ func getNetworkNameFromSelfLink(network string) (string, error) {
 	}
 
 	return network, nil
+}
+
+func readError(err error, d *schema.ResourceData, resource string) error {
+	if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+		log.Printf("[WARN] Removing %s because it's gone", resource)
+		// The resource doesn't exist anymore
+		d.SetId("")
+
+		return nil
+	}
+
+	return fmt.Errorf("Error reading %s: %s", resource, err)
 }

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
-	"google.golang.org/api/googleapi"
 )
 
 func stringScopeHashcode(v interface{}) int {
@@ -361,16 +360,7 @@ func getInstance(config *Config, d *schema.ResourceData) (*compute.Instance, err
 	instance, err := config.clientCompute.Instances.Get(
 		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
-		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
-			log.Printf("[WARN] Removing Instance %q because it's gone", d.Get("name").(string))
-			// The resource doesn't exist anymore
-			id := d.Id()
-			d.SetId("")
-
-			return nil, fmt.Errorf("Resource %s no longer exists", id)
-		}
-
-		return nil, fmt.Errorf("Error reading instance: %s", err)
+		return nil, readError(err, d, fmt.Sprintf("Instance %s", d.Get("name").(string)))
 	}
 
 	return instance, nil
@@ -705,13 +695,8 @@ func resourceComputeInstanceCreate(d *schema.ResourceData, meta interface{}) err
 func resourceComputeInstanceRead(d *schema.ResourceData, meta interface{}) error {
 	config := meta.(*Config)
 
-	id := d.Id()
 	instance, err := getInstance(config, d)
-	if err != nil {
-		if strings.Contains(err.Error(), "no longer exists") {
-			log.Printf("[WARN] Google Compute Instance (%s) not found", id)
-			return nil
-		}
+	if err != nil || instance == nil {
 		return err
 	}
 

--- a/builtin/providers/google/resource_compute_instance.go
+++ b/builtin/providers/google/resource_compute_instance.go
@@ -360,7 +360,7 @@ func getInstance(config *Config, d *schema.ResourceData) (*compute.Instance, err
 	instance, err := config.clientCompute.Instances.Get(
 		project, d.Get("zone").(string), d.Id()).Do()
 	if err != nil {
-		return nil, readError(err, d, fmt.Sprintf("Instance %s", d.Get("name").(string)))
+		return nil, handleNotFoundError(err, d, fmt.Sprintf("Instance %s", d.Get("name").(string)))
 	}
 
 	return instance, nil

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -222,7 +222,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		manager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone.(string), d.Id()).Do()
 
 		if e != nil {
-			return readError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
+			return handleNotFoundError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 		}
 	} else {
 		// If the resource was imported, the only info we have is the ID. Try to find the resource

--- a/builtin/providers/google/resource_compute_instance_group_manager.go
+++ b/builtin/providers/google/resource_compute_instance_group_manager.go
@@ -222,7 +222,7 @@ func resourceComputeInstanceGroupManagerRead(d *schema.ResourceData, meta interf
 		manager, e = config.clientCompute.InstanceGroupManagers.Get(project, zone.(string), d.Id()).Do()
 
 		if e != nil {
-			return e
+			return readError(e, d, fmt.Sprintf("Instance Group Manager %q", d.Get("name").(string)))
 		}
 	} else {
 		// If the resource was imported, the only info we have is the ID. Try to find the resource


### PR DESCRIPTION
Initial PR for #13943. It fixes the specific concern by adding in 404 checking for `resource_compute_instance_group_manager`, and also shows the new function being reused in `resource_compute_instance` (note that it also exposed a bug- if there is a 404, we should return `nil` instead of an error). If this looks good, I'll check it in and then open up a separate PR for the rest of the resources.