### PR TITLE
provider/aws: aws_db_option_group normalizes name to lowercase

### DIFF
--- a/builtin/providers/aws/resource_aws_db_option_group.go
+++ b/builtin/providers/aws/resource_aws_db_option_group.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -36,6 +37,10 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateDbOptionGroupName,
+				StateFunc: func(v interface{}) string {
+					value := v.(string)
+					return strings.ToLower(value)
+				},
 			},
 			"name_prefix": &schema.Schema{
 				Type:         schema.TypeString,
@@ -43,6 +48,10 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validateDbOptionGroupNamePrefix,
+				StateFunc: func(v interface{}) string {
+					value := v.(string)
+					return strings.ToLower(value)
+				},
 			},
 			"engine_name": &schema.Schema{
 				Type:     schema.TypeString,

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -49,7 +49,7 @@ func TestAccAWSDBOptionGroup_namePrefix(t *testing.T) {
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.test", &v),
 					testAccCheckAWSDBOptionGroupAttributes(&v),
 					resource.TestMatchResourceAttr(
-						"aws_db_option_group.test", "name", regexp.MustCompile("^tf-test-")),
+						"aws_db_option_group.test", "name", regexp.MustCompile("^tf-TEST-")),
 				),
 			},
 		},
@@ -112,7 +112,7 @@ func TestAccAWSDBOptionGroup_basicDestroyWithInstance(t *testing.T) {
 
 func TestAccAWSDBOptionGroup_OptionSettings(t *testing.T) {
 	var v rds.OptionGroup
-	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
+	rName := fmt.Sprintf("option-group-TEST-terraform-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -149,7 +149,7 @@ func TestAccAWSDBOptionGroup_OptionSettings(t *testing.T) {
 
 func TestAccAWSDBOptionGroup_sqlServerOptionsUpdate(t *testing.T) {
 	var v rds.OptionGroup
-	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
+	rName := fmt.Sprintf("option-group-TEST-terraform-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -181,7 +181,7 @@ func TestAccAWSDBOptionGroup_sqlServerOptionsUpdate(t *testing.T) {
 
 func TestAccAWSDBOptionGroup_multipleOptions(t *testing.T) {
 	var v rds.OptionGroup
-	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
+	rName := fmt.Sprintf("option-group-TEST-terraform-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -434,7 +434,7 @@ resource "aws_db_option_group" "test" {
 func testAccAWSDBOptionGroup_defaultDescription(n int) string {
 	return fmt.Sprintf(`
 resource "aws_db_option_group" "test" {
-  name = "tf-test-%d"
+  name = "tf-TEST-%d"
   engine_name = "mysql"
   major_engine_version = "5.6"
 }

--- a/website/source/docs/providers/aws/r/db_option_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_option_group.html.markdown
@@ -38,10 +38,10 @@ resource "aws_db_option_group" "bar" {
 
 The following arguments are supported:
 
-* `name` - (Optional, Forces new resource) The name of the option group. If omitted, Terraform will assign a random, unique name.
-* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`.
+* `name` - (Optional, Forces new resource) The name of the option group. If omitted, Terraform will assign a random, unique name. This is converted to lowercase, as is stored in AWS.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. This is converted to lowercase, as is stored in AWS.
 * `option_group_description` - (Optional) The description of the option group. Defaults to "Managed by Terraform".
-* `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with..
+* `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with.
 * `major_engine_version` - (Required) Specifies the major version of the engine that this option group should be associated with.
 * `option` - (Optional) A list of Options to apply.
 * `tags` - (Optional) A mapping of tags to assign to the resource.


### PR DESCRIPTION
This fixes #11040. The code here lowercases the name and/or prefix before sending it to the AWS API and the terraform state. This means the state will match the actual resource name and be able to converge the diff.

Other providers might validate and throw an error or warning instead of just letting it work, but this is consistent with `aws_db_instance`. If this is the wrong approach, I can use a validator instead.

I've also updated *all* the tests to include uppercase letters, which might be overkill.