### PR TITLE
main: synchronize writes to VT100-faker on Windows

### DIFF
--- a/synchronized_writers.go
+++ b/synchronized_writers.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"io"
+	"sync"
+)
+
+type synchronizedWriter struct {
+	io.Writer
+	mutex *sync.Mutex
+}
+
+// synchronizedWriters takes a set of writers and returns wrappers that ensure
+// that only one write can be outstanding at a time across the whole set.
+func synchronizedWriters(targets ...io.Writer) []io.Writer {
+	mutex := &sync.Mutex{}
+	ret := make([]io.Writer, len(targets))
+	for i, target := range targets {
+		ret[i] = &synchronizedWriter{
+			Writer: target,
+			mutex:  mutex,
+		}
+	}
+	return ret
+}
+
+func (w *synchronizedWriter) Write(p []byte) (int, error) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+	return w.Writer.Write(p)
+}


### PR DESCRIPTION
Before:

![Terraform with stderr and stdin output interleaved, creating gibberish](https://cloud.githubusercontent.com/assets/20180/25685627/b5025c38-301d-11e7-9748-69799bad54ab.png)


After:

![Terraform with stderr and stdin output separated, as expected](https://cloud.githubusercontent.com/assets/20180/25685631/b978554c-301d-11e7-8be7-5255dc7d3cc8.png)


---

We use a third-party library "colorable" to translate VT100 color sequences into Windows console attribute-setting calls when Terraform is running on Windows.

colorable is not concurrency-safe for multiple writes to the same console, because it writes to the console one character at a time and so two concurrent writers get their characters interleaved, creating unreadable garble.

Here we wrap around it a synchronization mechanism to ensure that there can be only one Write call outstanding across both stderr and stdout, mimicking the usual behavior we expect (when stderr/stdout are a normal file handle) of each Write being completed atomically.

This fixes #11363.
