### PR TITLE
WIP: Migrate include_admins to enforce_admins in Github API

### DIFF
--- a/builtin/providers/github/resource_github_branch_protection.go
+++ b/builtin/providers/github/resource_github_branch_protection.go
@@ -57,6 +57,29 @@ func resourceGithubBranchProtection() *schema.Resource {
 				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"dismissal_restrictions": {
+							Type:     schema.TypeList,
+							Optional: true,
+							DefaultFunc: func() (interface{}, error) {
+								return []string{}, nil
+							},
+							MaxItems: 1,
+							Elem: &schema.Resource{
+								Schema: map[string]*schema.Schema{
+									"users": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+									"teams": {
+										Type:     schema.TypeList,
+										Optional: true,
+										Elem:     &schema.Schema{Type: schema.TypeString},
+									},
+								},
+							},
+						},
+						"dismiss_stale_reviews": {
 							Type:     schema.TypeBool,
 							Optional: true,
 							Default:  false,
@@ -142,8 +165,31 @@ func resourceGithubBranchProtectionRead(d *schema.ResourceData, meta interface{}
 
 	rprr := githubProtection.RequiredPullRequestReviews
 	if rprr != nil {
+		var userLogins []string
+		var teamSlugs []string
+		dr := rprr.DismissalRestrictions
+		if dr != nil {
+			for _, u := range dr.Users {
+				if u.Login != nil {
+					userLogins = append(userLogins, *u.Login)
+				}
+			}
+			for _, t := range dr.Teams {
+				if t.Slug != nil {
+					teamSlugs = append(teamSlugs, *t.Slug)
+				}
+			}
+		}
+
 		d.Set("required_pull_request_reviews", []interface{}{
 			map[string]interface{}{
+				"dismiss_stale_reviews": rprr.DismissStaleReviews,
+				"dismissal_restrictions": []interface{}{
+					map[string]interface{}{
+						"users": userLogins,
+						"teams": teamSlugs,
+					},
+				},
 			},
 		})
 	} else {
@@ -244,6 +290,37 @@ func buildProtectionRequest(d *schema.ResourceData) (*github.ProtectionRequest, 
 		for _, v := range vL {
 			m := v.(map[string]interface{})
 
+			rprr := new(github.RequiredPullRequestReviewsRequest)
+			rprr.DismissStaleReviews = m["dismiss_stale_reviews"].(bool)
+
+			if v, ok := m["dismissal_restrictions"]; ok {
+				vL := v.([]interface{})
+				if len(vL) > 1 {
+					return nil, errors.New("cannot specify restrictions more than one time")
+				}
+
+				for _, v := range vL {
+					m := v.(map[string]interface{})
+
+					restrictions := new(github.RestrictionsRequest)
+
+					restrictions.Users = []string{}
+					if users, ok := m["users"].([]interface{}); ok {
+						for _, u := range users {
+							restrictions.Users = append(restrictions.Users, u.(string))
+						}
+					}
+
+					restrictions.Teams = []string{}
+					if teams, ok := m["teams"].([]interface{}); ok {
+						for _, t := range teams {
+							restrictions.Teams = append(restrictions.Teams, t.(string))
+						}
+					}
+
+					rprr.DismissalRestrictionsRequest = restrictions
+				}
+			}
 
 			protectionRequest.RequiredPullRequestReviews = rprr
 		}
@@ -258,7 +335,7 @@ func buildProtectionRequest(d *schema.ResourceData) (*github.ProtectionRequest, 
 		for _, v := range vL {
 			m := v.(map[string]interface{})
 
-			restrictions := new(github.BranchRestrictionsRequest)
+			restrictions := new(github.RestrictionsRequest)
 
 			restrictions.Users = []string{}
 			if users, ok := m["users"].([]interface{}); ok {

--- a/vendor/github.com/google/go-github/github/repos.go
+++ b/vendor/github.com/google/go-github/github/repos.go
@@ -511,7 +511,7 @@ type Branch struct {
 type Protection struct {
 	RequiredStatusChecks       *RequiredStatusChecks       `json:"required_status_checks"`
 	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
-	Restrictions               *BranchRestrictions         `json:"restrictions"`
+	Restrictions               *Restrictions               `json:"restrictions"`
 	// Enforce required status checks for repository administrators. (Required.)
 	EnforceAdmins *EnforceAdmin `json:"enforce_admins"`
 }
@@ -523,9 +523,9 @@ type EnforceAdmin struct {
 
 // ProtectionRequest represents a request to create/edit a branch's protection.
 type ProtectionRequest struct {
-	RequiredStatusChecks       *RequiredStatusChecks       `json:"required_status_checks"`
-	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
-	Restrictions               *BranchRestrictionsRequest  `json:"restrictions"`
+	RequiredStatusChecks       *RequiredStatusChecks              `json:"required_status_checks"`
+	RequiredPullRequestReviews *RequiredPullRequestReviewsRequest `json:"required_pull_request_reviews"`
+	Restrictions               *RestrictionsRequest               `json:"restrictions"`
 	// Enforce required status checks for repository administrators. (Required.)
 	EnforceAdmins bool `json:"enforce_admins"`
 }
@@ -541,22 +541,32 @@ type RequiredStatusChecks struct {
 
 // RequiredPullRequestReviews represents the protection configuration for pull requests.
 type RequiredPullRequestReviews struct {
+	DismissalRestrictions *Restrictions `json:"dismissal_restrictions,omitempty"`
+	DismissStaleReviews   bool          `json:"dismiss_stale_reviews,omitempty"`
 }
 
-// BranchRestrictions represents the restriction that only certain users or
+// RequiredPullRequestReviewsRequest represents the protection configuration for pull requests.
+// It is separate from RequiredPullRequestReviews above because the request structure is
+// different from the response structure.
+type RequiredPullRequestReviewsRequest struct {
+	DismissalRestrictionsRequest *RestrictionsRequest `json:"dismissal_restrictions,omitempty"`
+	DismissStaleReviews          bool                 `json:"dismiss_stale_reviews,omitempty"`
+}
+
+// Restrictions represents the restriction that only certain users or
 // teams may push to a branch.
-type BranchRestrictions struct {
+type Restrictions struct {
 	// The list of user logins with push access.
 	Users []*User `json:"users"`
 	// The list of team slugs with push access.
 	Teams []*Team `json:"teams"`
 }
 
-// BranchRestrictionsRequest represents the request to create/edit the
+// RestrictionsRequest represents the request to create/edit the
 // restriction that only certain users or teams may push to a branch. It is
-// separate from BranchRestrictions above because the request structure is
+// separate from Restrictions above because the request structure is
 // different from the response structure.
-type BranchRestrictionsRequest struct {
+type RestrictionsRequest struct {
 	// The list of user logins with push access. (Required; use []string{} instead of nil for empty list.)
 	Users []string `json:"users"`
 	// The list of team slugs with push access. (Required; use []string{} instead of nil for empty list.)

--- a/vendor/github.com/google/go-github/github/repos.go
+++ b/vendor/github.com/google/go-github/github/repos.go
@@ -512,6 +512,13 @@ type Protection struct {
 	RequiredStatusChecks       *RequiredStatusChecks       `json:"required_status_checks"`
 	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
 	Restrictions               *BranchRestrictions         `json:"restrictions"`
+	// Enforce required status checks for repository administrators. (Required.)
+	EnforceAdmins *EnforceAdmin `json:"enforce_admins"`
+}
+
+// EnforceAdmins represents the statues of the enforcement of the protections for admin users.
+type EnforceAdmin struct {
+	Enabled bool `json:"enabled"`
 }
 
 // ProtectionRequest represents a request to create/edit a branch's protection.
@@ -519,12 +526,12 @@ type ProtectionRequest struct {
 	RequiredStatusChecks       *RequiredStatusChecks       `json:"required_status_checks"`
 	RequiredPullRequestReviews *RequiredPullRequestReviews `json:"required_pull_request_reviews"`
 	Restrictions               *BranchRestrictionsRequest  `json:"restrictions"`
+	// Enforce required status checks for repository administrators. (Required.)
+	EnforceAdmins bool `json:"enforce_admins"`
 }
 
 // RequiredStatusChecks represents the protection status of a individual branch.
 type RequiredStatusChecks struct {
-	// Enforce required status checks for repository administrators. (Required.)
-	IncludeAdmins bool `json:"include_admins"`
 	// Require branches to be up to date before merging. (Required.)
 	Strict bool `json:"strict"`
 	// The list of status checks to require in order to merge into this
@@ -534,8 +541,6 @@ type RequiredStatusChecks struct {
 
 // RequiredPullRequestReviews represents the protection configuration for pull requests.
 type RequiredPullRequestReviews struct {
-	// Enforce pull request reviews for repository administrators. (Required.)
-	IncludeAdmins bool `json:"include_admins"`
 }
 
 // BranchRestrictions represents the restriction that only certain users or

--- a/website/source/docs/providers/github/r/branch_protection.html.markdown
+++ b/website/source/docs/providers/github/r/branch_protection.html.markdown
@@ -21,15 +21,14 @@ This resource allows you to configure branch protection for repositories in your
 resource "github_branch_protection" "foo_master" {
   repository = "foo"
   branch = "master"
+  enforce_admins = true
 
   required_status_checks {
-    include_admins = true
     strict = false
     contexts = ["ci/travis"]
   }
 
   required_pull_request_reviews {
-    include_admins = true
   }
 
   restrictions {
@@ -44,6 +43,7 @@ The following arguments are supported:
 
 * `repository` - (Required) The GitHub repository name.
 * `branch` - (Required) The Git branch to protect.
+* `enforce_admins`: (Required) Enforce protection for repository administrators too. Defaults to `false`.
 * `required_status_checks` - (Optional) Enforce restrictions for required status checks. See [Required Status Checks](#required-status-checks) below for details.
 * `required_pull_request_reviews` - (Optional) Enforce restrictions for pull request reviews. See [Required Pull Request Reviews](#required-pull-request-reviews) below for details.
 * `restrictions` - (Optional) Enforce restrictions for the users and teams that may push to the branch. See [Restrictions](#restrictions) below for details.
@@ -52,7 +52,6 @@ The following arguments are supported:
 
 `required_status_checks` supports the following arguments:
 
-* `include_admins`: (Optional) Enforce required status checks for repository administrators. Defaults to `false`.
 * `strict`: (Optional) Require branches to be up to date before merging. Defaults to `false`.
 * `contexts`: (Optional) The list of status checks to require in order to merge into this branch. No status checks are required by default.
 
@@ -60,7 +59,6 @@ The following arguments are supported:
 
 `required_pull_request_reviews` supports the following arguments:
 
-* `include_admins`: (Optional) Enforce required status checks for repository administrators. Defaults to `false`.
 
 ### Restrictions
 

--- a/website/source/docs/providers/github/r/branch_protection.html.markdown
+++ b/website/source/docs/providers/github/r/branch_protection.html.markdown
@@ -29,6 +29,7 @@ resource "github_branch_protection" "foo_master" {
   }
 
   required_pull_request_reviews {
+    dismiss_stale_reviews = true
   }
 
   restrictions {
@@ -59,6 +60,17 @@ The following arguments are supported:
 
 `required_pull_request_reviews` supports the following arguments:
 
+* `dismissal_restrictions`: (Optional) Specify which users and teams can dismiss pull request reviews. See [Dismissal Restrictions](#dismissal-restrictions) below for details.
+* `dismiss_stale_reviews`: (Optional) Dismiss approved reviews automatically when a new commit is pushed. Defaults to `false`.
+
+#### Dismissal Restrictions
+
+`dismissal_restrictions` supports the following arguments:
+
+* `users`: (Optional) The list of user logins which can dismiss pull request reviews.
+* `teams`: (Optional) The list of team slugs which can dismiss pull request reviews.
+
+`restrictions` is only available for organization-owned repositories.
 
 ### Restrictions
 


### PR DESCRIPTION
There's been a **breaking change** in the GitHub API in the last day or so which changes the format of the request/response for the Branches Protection API call. The options for `include_admins` on each of the settings has been removed, and an all-encompassing `enforce_admins` has been provided for setting at the branch level.

Also, the API supports control over who can dismiss pull request reviews and management of stale reviews.

I've updated the code, tests, and documentation with the new details, and run some Acceptance Tests for Github. I've had some issues with this whereby users are getting removed from the organisation on the test, and it's not repeatable, so I'm not 100% confident in the results. For example:

```
--- FAIL: TestAccGithubBranchProtection_basic (1.50s)
        testing.go:280: Step 0 error: Check failed: Check 3/12 error: Expected Restrictions.Users to be [some_user], got []
=== RUN   TestAccGithubBranchProtection_importBasic
--- FAIL: TestAccGithubBranchProtection_importBasic (1.05s)
        testing.go:280: Step 0 error: After applying this step, the plan was not empty:

                DIFF:

                UPDATE: github_branch_protection.master
                  required_pull_request_reviews.0.dismissal_restrictions.#: "1" => "0"
                  restrictions.0.users.#:                                   "0" => "1"
                  restrictions.0.users.0:                                   "" => "some_user"

                STATE:

                github_branch_protection.master:
                  ID = test-repo:master
                  branch = master
                  enforce_admins = true
                  repository = test-repo
                  required_pull_request_reviews.# = 1
                  required_pull_request_reviews.0.dismiss_stale_reviews = false
                  required_pull_request_reviews.0.dismissal_restrictions.# = 1
                  required_pull_request_reviews.0.dismissal_restrictions.0.teams.# = 0
                  required_pull_request_reviews.0.dismissal_restrictions.0.users.# = 0
                  required_status_checks.# = 1
                  required_status_checks.0.contexts.# = 1
                  required_status_checks.0.contexts.0 = github/foo
                  required_status_checks.0.strict = true
                  restrictions.# = 1
                  restrictions.0.teams.# = 0
                  restrictions.0.users.# = 0
```

But `some_user` cannot be added back in as they are no longer part of the Organisation. The requests and response processing do at least seem to work as expected.

TODO:

- [ ] Improve handling of the default case for `dismissal_restrictions` so that the default generated by `resourceGithubBranchProtection` matches the "empty" value returned by the API response.
- [ ] See what additional tests can be added around `enforce_admins` and the new `dismiss*` options.
- [ ] Sync `vendor/` updates with upstream repositories.
- [ ] Add a possible note in the documentation this is linked with a preview API call and there is a risk of further breaking changes until release?

I will aim to add some of these in the coming days, but I welcome reviews on my code so far (bit rusty in Golang) and make sure I'm on the right track for Terraform.