### PR TITLE
Fix docs for openstack lbaas v2 resource type names.

### DIFF
--- a/website/source/docs/providers/openstack/r/lb_listener_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_listener_v2.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_lb_listener_v2"
-sidebar_current: "docs-openstack-resource-lbaas-listener-v2"
+sidebar_current: "docs-openstack-resource-lb-listener-v2"
 description: |-
   Manages a V2 listener resource within OpenStack.
 ---
 
-# openstack\_lbaas\_listener\_v2
+# openstack\_lb\_listener\_v2
 
 Manages a V2 listener resource within OpenStack.
 

--- a/website/source/docs/providers/openstack/r/lb_member_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_member_v2.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_lb_member_v2"
-sidebar_current: "docs-openstack-resource-lbaas-member-v2"
+sidebar_current: "docs-openstack-resource-lb-member-v2"
 description: |-
   Manages a V2 member resource within OpenStack.
 ---
 
-# openstack\_lbaas\_member\_v2
+# openstack\_lb\_member\_v2
 
 Manages a V2 member resource within OpenStack.
 

--- a/website/source/docs/providers/openstack/r/lb_monitor_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_monitor_v2.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_lb_monitor_v2"
-sidebar_current: "docs-openstack-resource-lbaas-monitor-v2"
+sidebar_current: "docs-openstack-resource-lb-monitor-v2"
 description: |-
   Manages a V2 monitor resource within OpenStack.
 ---
 
-# openstack\_lbaas\_monitor\_v2
+# openstack\_lb\_monitor\_v2
 
 Manages a V2 monitor resource within OpenStack.
 

--- a/website/source/docs/providers/openstack/r/lb_pool_v2.html.markdown
+++ b/website/source/docs/providers/openstack/r/lb_pool_v2.html.markdown
@@ -1,12 +1,12 @@
 ---
 layout: "openstack"
 page_title: "OpenStack: openstack_lb_pool_v2"
-sidebar_current: "docs-openstack-resource-lbaas-pool-v2"
+sidebar_current: "docs-openstack-resource-lb-pool-v2"
 description: |-
   Manages a V2 pool resource within OpenStack.
 ---
 
-# openstack\_lbaas\_pool\_v2
+# openstack\_lb\_pool\_v2
 
 Manages a V2 pool resource within OpenStack.
 


### PR DESCRIPTION
The documentation title/sidbar incorrectly referred to resource types `openstack_lbass_*` when the actual type names are `openstack_lb_*`.

The current version of the docs are incorrect.  This doc update does not need to wait for the next release.