### PR TITLE
[WIP] Add support for Task Roles when running on ECS or CodeBuild

### DIFF
--- a/builtin/providers/aws/auth_helpers.go
+++ b/builtin/providers/aws/auth_helpers.go
@@ -13,6 +13,7 @@ import (
 	awsCredentials "github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
+	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -95,7 +96,7 @@ func parseAccountInfoFromArn(arn string) (string, string, error) {
 // environment in the case that they're not explicitly specified
 // in the Terraform configuration.
 func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
-	// build a chain provider, lazy-evaulated by aws-sdk
+	// build a chain provider, lazy-evaluated by aws-sdk
 	providers := []awsCredentials.Provider{
 		&awsCredentials.StaticProvider{Value: awsCredentials.Value{
 			AccessKeyID:     c.AccessKey,
@@ -118,6 +119,12 @@ func GetCredentials(c *Config) (*awsCredentials.Credentials, error) {
 		HTTPClient: client,
 	}
 	usedEndpoint := setOptionalEndpoint(cfg)
+
+	// Add the default AWS provider for ECS Task Roles if the relevant env variable is set
+	if uri := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"); len(uri) > 0 {
+		providers = append(providers, defaults.RemoteCredProvider(*cfg, defaults.Handlers()))
+		log.Print("[INFO] ECS container credentials detected, RemoteCredProvider added to auth chain")
+	}
 
 	if !c.SkipMetadataApiCheck {
 		// Real AWS should reply to a simple metadata request.


### PR DESCRIPTION
This PR is intended to address #8746. It adds the `RemoteCredProvider` from the AWS SDK if the `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` environment variable is set. The `RemoteCredProvider` uses the value of that environment variable and appends it to the hard-coded URL `http://169.254.170.2`, and uses the resulting URL to obtain Task Role credentials.

A few questions about the PR:
1. I'm not sure what `Handlers` to provide to the `RemoteCredProvider`, so I went with the SDK defaults. Is this the right pattern to follow for adding this provider?
1. Testing - This is quite difficult to unit test, as the SDK is hard-coded to use 169.254.170.2 for container credentials, making it difficult to mock. Any suggestions?
1. (Somewhat tangential) What's the rationale behind a custom provider chain, rather than allowing the AWS SDK to find credentials using its default search path (at least when credentials aren't specified directly in TF)?