### PR TITLE
Handle `google_storage_bucket_object` not being found

### DIFF
--- a/builtin/providers/google/resource_storage_bucket_object.go
+++ b/builtin/providers/google/resource_storage_bucket_object.go
@@ -151,6 +151,14 @@ func resourceStorageBucketObjectDelete(d *schema.ResourceData, meta interface{})
 	err := DeleteCall.Do()
 
 	if err != nil {
+		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
+			log.Printf("[WARN] Removing Bucket Object %q because it's gone", name)
+			// The resource doesn't exist anymore
+			d.SetId("")
+
+			return nil
+		}
+
 		return fmt.Errorf("Error deleting contents of object %s: %s", name, err)
 	}
 


### PR DESCRIPTION
Mark the resource as no longer available.