### PR TITLE
provider/aws: Add support description to aws_iam_role

### DIFF
--- a/builtin/providers/aws/resource_aws_iam_role_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_test.go
@@ -178,6 +178,10 @@ func testAccCheckAWSRoleAttributes(role *iam.GetRoleOutput) resource.TestCheckFu
 		if *role.Role.Path != "/" {
 			return fmt.Errorf("Bad path: %s", *role.Role.Path)
 		}
+
+		if *role.Role.Description != "Test Role" {
+			return fmt.Errorf("Bad description: %s", *role.Role.Description)
+		}
 		return nil
 	}
 }
@@ -186,6 +190,7 @@ const testAccAWSRoleConfig = `
 resource "aws_iam_role" "role" {
   name   = "test-role"
   path = "/"
+  description = "Test Role"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
 }
 `

--- a/website/source/docs/providers/aws/r/iam_role.html.markdown
+++ b/website/source/docs/providers/aws/r/iam_role.html.markdown
@@ -46,6 +46,7 @@ The following arguments are supported:
 
 * `path` - (Optional) The path to the role.
   See [IAM Identifiers](https://docs.aws.amazon.com/IAM/latest/UserGuide/Using_Identifiers.html) for more information.
+* `description` - (Optional) The description of the role.
 
 ## Attributes Reference
 
@@ -55,6 +56,7 @@ The following attributes are exported:
 * `create_date` - The creation date of the IAM role.
 * `unique_id` - The stable and unique string identifying the role.
 * `name` - The name of the role.
+* `description` - The description of the role.
 
 ## Example of Using Data Source for Assume Role Policy
 


### PR DESCRIPTION
Fixes #14198

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRole_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/04 23:02:49 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRole_ -timeout 120m
=== RUN   TestAccAWSRole_basic
--- PASS: TestAccAWSRole_basic (20.59s)
=== RUN   TestAccAWSRole_namePrefix
--- PASS: TestAccAWSRole_namePrefix (92.25s)
=== RUN   TestAccAWSRole_testNameChange
--- PASS: TestAccAWSRole_testNameChange (51.13s)
=== RUN   TestAccAWSRole_badJSON
--- PASS: TestAccAWSRole_badJSON (0.01s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    164.009s
```