### PR TITLE
provider/openstack: Handle disassociating FloatingIP's from a server

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_floatingip_associate_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_floatingip_associate_v2.go
@@ -110,7 +110,7 @@ func resourceComputeFloatingIPAssociateV2Delete(d *schema.ResourceData, meta int
 
 	err = floatingips.DisassociateInstance(computeClient, instanceId, disassociateOpts).ExtractErr()
 	if err != nil {
-		return fmt.Errorf("Error disassociating floating IP: %s", err)
+		return CheckDeleted(d, err, "floating ip association")
 	}
 
 	return nil


### PR DESCRIPTION
that's been deleted.

Fixes #14209