### PR TITLE
Fix parsing of digitalocean dns records

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_record.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record.go
@@ -132,16 +132,11 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 		return err
 	}
 
-	// Update response data for records with domain value
 	if t := rec.Type; t == "CNAME" || t == "MX" || t == "NS" || t == "SRV" {
-		// Append dot to response if resource value is absolute
-		if value := d.Get("value").(string); strings.HasSuffix(value, ".") {
-			rec.Data += "."
-			// If resource value ends with current domain, make response data absolute
-			if strings.HasSuffix(value, domain+".") {
-				rec.Data += domain + "."
-			}
+		if rec.Data == "@" {
+			rec.Data = domain
 		}
+		rec.Data += "."
 	}
 
 	d.Set("name", rec.Name)


### PR DESCRIPTION
Currently if one uses a file like:
```

# Configure the DigitalOcean Provider
provider "digitalocean" {
  token = "${var.do_token}"
}

resource "digitalocean_record" "mx" {
  name = "foobaz"
  domain = "thistesting1.com"
  type = "MX"
  value = "thistesting1.com."
  priority = "10"
}
```
Then terraform will constantly suggest that the changes are necessary, as the parsing of these records is currently incorrect.

This changeset fixes how some digitalocean dns records were getting parsed. In particular, it allows for understanding "@" as shorthand for the domain itself, preventing terraform from suggesting changes that wouldn't have any actual effect. This changeset also adds a trailing "." to certain record types which are required to be submitted with a trailing dot, but which digitalocean does not return with a trailing dot, again preventing changes that wouldn't have an effect.

Tests have been added for the above, and with just adding the tests, the current code is failing, as it is handling some records(e.g. MX) incorrectly.

Let me know if you have any questions!