### PR TITLE
provider/aws: Prevent Crash when importing aws_route53_record

### DIFF
--- a/builtin/providers/aws/resource_aws_route53_record.go
+++ b/builtin/providers/aws/resource_aws_route53_record.go
@@ -460,7 +460,9 @@ func resourceAwsRoute53RecordRead(d *schema.ResourceData, meta interface{}) erro
 	if _, ok := d.GetOk("zone_id"); !ok {
 		parts := strings.Split(d.Id(), "_")
 
-		if len(parts) == 1 {
+		//we check that we have parsed the id into the correct number of segments
+		//we need at least 3 segments!
+		if len(parts) == 1 || len(parts) < 3 {
 			return fmt.Errorf("Error Importing aws_route_53 record. Please make sure the record ID is in the form ZONEID_RECORDNAME_TYPE (i.e. Z4KAPRWWNC7JR_dev_A")
 		}
 

--- a/website/source/docs/providers/aws/r/route53_record.html.markdown
+++ b/website/source/docs/providers/aws/r/route53_record.html.markdown
@@ -141,7 +141,18 @@ Weighted routing policies support the following:
 
 ## Import
 
-Route53 Records can be imported using ID of the record, e.g.
+Route53 Records can be imported using ID of the record. The ID is made up as ZONEID_RECORDNAME_TYPE_SET-IDENTIFIER
+
+e.g.
+
+```
+Z4KAPRWWNC7JR_dev.example.com_NS_dev
+```
+
+In this example, `Z4KAPRWWNC7JR` is the ZoneID, `dev.example.com` is the Record Name, `NS` is the Type and `dev` is the Set Identifier.
+Only the Set Identifier is actually optional in the ID
+
+To import the ID above, it would look as follows:
 
 ```
 $ terraform import aws_route53_record.myrecord Z4KAPRWWNC7JR_dev.example.com_NS_dev


### PR DESCRIPTION
Fixes: #14217

We now check to make sure that we have the correct number of parts when
we have split the resource ID. It isn't an elegant fix but it works as
expected. Also added some more documentation about what is required to
actually construct the Id needed for import