### PR TITLE
automatic plugin downloads

### DIFF
--- a/command/apply.go
+++ b/command/apply.go
@@ -132,10 +132,15 @@ func (c *ApplyCommand) Run(args []string) int {
 		}
 	*/
 
+	var conf *config.Config
+	if mod != nil {
+		conf = mod.Config()
+	}
+
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{
-		ConfigPath: configPath,
-		Plan:       plan,
+		Config: conf,
+		Plan:   plan,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))

--- a/command/console.go
+++ b/command/console.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/helper/wrappedstreams"
 	"github.com/hashicorp/terraform/repl"
 
@@ -43,8 +44,16 @@ func (c *ConsoleCommand) Run(args []string) int {
 		return 1
 	}
 
+	var conf *config.Config
+	if mod != nil {
+		conf = mod.Config()
+	}
+
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: conf,
+	})
+
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/env_delete.go
+++ b/command/env_delete.go
@@ -43,8 +43,17 @@ func (c *EnvDeleteCommand) Run(args []string) int {
 		return 1
 	}
 
+	cfg, err := c.Config(configPath)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+		return 1
+	}
+
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: cfg,
+	})
+
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/env_list.go
+++ b/command/env_list.go
@@ -26,8 +26,17 @@ func (c *EnvListCommand) Run(args []string) int {
 		return 1
 	}
 
+	cfg, err := c.Config(configPath)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+		return 1
+	}
+
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: cfg,
+	})
+
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/env_new.go
+++ b/command/env_new.go
@@ -46,8 +46,16 @@ func (c *EnvNewCommand) Run(args []string) int {
 		return 1
 	}
 
+	conf, err := c.Config(configPath)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+	}
+
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: conf,
+	})
+
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/env_select.go
+++ b/command/env_select.go
@@ -31,8 +31,17 @@ func (c *EnvSelectCommand) Run(args []string) int {
 		return 1
 	}
 
+	conf, err := c.Config(configPath)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+		return 1
+	}
+
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: conf,
+	})
+
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/graph.go
+++ b/command/graph.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/dag"
 	"github.com/hashicorp/terraform/terraform"
@@ -62,10 +63,15 @@ func (c *GraphCommand) Run(args []string) int {
 		}
 	}
 
+	var conf *config.Config
+	if mod != nil {
+		conf = mod.Config()
+	}
+
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{
-		ConfigPath: configPath,
-		Plan:       plan,
+		Config: conf,
+		Plan:   plan,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))

--- a/command/import.go
+++ b/command/import.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -60,8 +61,15 @@ func (c *ImportCommand) Run(args []string) int {
 		}
 	}
 
+	var conf *config.Config
+	if mod != nil {
+		conf = mod.Config()
+	}
+
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: conf,
+	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/init.go
+++ b/command/init.go
@@ -6,10 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/go-getter"
+	getter "github.com/hashicorp/go-getter"
+	"github.com/hashicorp/terraform/backend"
 	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 	"github.com/hashicorp/terraform/helper/variables"
+	"github.com/hashicorp/terraform/plugin/discovery"
+	"github.com/hashicorp/terraform/terraform"
 )
 
 // InitCommand is a Command implementation that takes a Terraform
@@ -19,7 +22,7 @@ type InitCommand struct {
 }
 
 func (c *InitCommand) Run(args []string) int {
-	var flagBackend, flagGet bool
+	var flagBackend, flagGet, flagGetPlugins bool
 	var flagConfigExtra map[string]interface{}
 
 	args = c.Meta.process(args, false)
@@ -27,6 +30,7 @@ func (c *InitCommand) Run(args []string) int {
 	cmdFlags.BoolVar(&flagBackend, "backend", true, "")
 	cmdFlags.Var((*variables.FlagAny)(&flagConfigExtra), "backend-config", "")
 	cmdFlags.BoolVar(&flagGet, "get", true, "")
+	cmdFlags.BoolVar(&flagGetPlugins, "get-plugins", true, "")
 	cmdFlags.BoolVar(&c.forceInitCopy, "force-copy", false, "suppress prompts about copying state data")
 	cmdFlags.BoolVar(&c.Meta.stateLock, "lock", true, "lock state")
 	cmdFlags.DurationVar(&c.Meta.stateLockTimeout, "lock-timeout", 0, "lock timeout")
@@ -103,6 +107,8 @@ func (c *InitCommand) Run(args []string) int {
 		return 0
 	}
 
+	var back backend.Backend
+
 	// If we're performing a get or loading the backend, then we perform
 	// some extra tasks.
 	if flagGet || flagBackend {
@@ -125,10 +131,12 @@ func (c *InitCommand) Run(args []string) int {
 					"Error downloading modules: %s", err))
 				return 1
 			}
+
 		}
 
-		// If we're requesting backend configuration and configure it
-		if flagBackend {
+		// If we're requesting backend configuration or looking for required
+		// plugins, load the backend
+		if flagBackend || flagGetPlugins {
 			header = true
 
 			// Only output that we're initializing a backend if we have
@@ -145,10 +153,33 @@ func (c *InitCommand) Run(args []string) int {
 				ConfigExtra: flagConfigExtra,
 				Init:        true,
 			}
-			if _, err := c.Backend(opts); err != nil {
+			if back, err = c.Backend(opts); err != nil {
 				c.Ui.Error(err.Error())
 				return 1
 			}
+		}
+	}
+
+	// Now that we have loaded all modules, check the module tree for missing providers
+	if flagGetPlugins {
+		sMgr, err := back.State(c.Env())
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error loading state: %s", err))
+			return 1
+		}
+
+		if err := sMgr.RefreshState(); err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error refreshing state: %s", err))
+			return 1
+		}
+
+		err = c.getProviders(path, sMgr.State())
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf(
+				"Error getting plugins: %s", err))
+			return 1
 		}
 	}
 
@@ -161,6 +192,31 @@ func (c *InitCommand) Run(args []string) int {
 	c.Ui.Output(c.Colorize().Color(strings.TrimSpace(outputInitSuccess)))
 
 	return 0
+}
+
+// load the complete module tree, and fetch any missing providers
+func (c *InitCommand) getProviders(path string, state *terraform.State) error {
+	mod, err := c.Module(path)
+	if err != nil {
+		return err
+	}
+
+	if err := mod.Validate(); err != nil {
+		return err
+	}
+
+	requirements := terraform.ModuleTreeDependencies(mod, state).AllPluginRequirements()
+	missing := c.missingProviders(requirements)
+
+	dst := c.pluginDir()
+	for provider, reqd := range missing {
+		err := discovery.GetProvider(dst, provider, reqd)
+		// TODO: return all errors
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (c *InitCommand) copySource(dst, src, pwd string) error {
@@ -225,6 +281,8 @@ Options:
                        prompts.
 
   -get=true            Download any modules for this configuration.
+
+  -get-plugins=true    Download any missing plugins for this configuration.
 
   -input=true          Ask for input if necessary. If false, will error if
                        input was required.

--- a/command/init.go
+++ b/command/init.go
@@ -106,11 +106,7 @@ func (c *InitCommand) Run(args []string) int {
 	// If we're performing a get or loading the backend, then we perform
 	// some extra tasks.
 	if flagGet || flagBackend {
-		// Load the configuration in this directory so that we can know
-		// if we have anything to get or any backend to configure. We do
-		// this to improve the UX. Practically, we could call the functions
-		// below without checking this to the same effect.
-		conf, err := config.LoadDir(path)
+		conf, err := c.Config(path)
 		if err != nil {
 			c.Ui.Error(fmt.Sprintf(
 				"Error loading configuration: %s", err))
@@ -145,7 +141,7 @@ func (c *InitCommand) Run(args []string) int {
 			}
 
 			opts := &BackendOpts{
-				ConfigPath:  path,
+				Config:      conf,
 				ConfigExtra: flagConfigExtra,
 				Init:        true,
 			}

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -9,11 +9,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hcl"
 	"github.com/hashicorp/terraform/backend"
@@ -29,9 +27,9 @@ import (
 
 // BackendOpts are the options used to initialize a backend.Backend.
 type BackendOpts struct {
-	// ConfigPath is a path to a file or directory containing the backend
-	// configuration (declaration).
-	ConfigPath string
+	// Module is the root module from which we will extract the terraform and
+	// backend configuration.
+	Config *config.Config
 
 	// ConfigFile is a path to a file that contains configuration that
 	// is merged directly into the backend configuration when loaded
@@ -178,71 +176,34 @@ func (m *Meta) Operation() *backend.Operation {
 
 // backendConfig returns the local configuration for the backend
 func (m *Meta) backendConfig(opts *BackendOpts) (*config.Backend, error) {
-	// If no explicit path was given then it is okay for there to be
-	// no backend configuration found.
-	emptyOk := opts.ConfigPath == ""
-
-	// Determine the path to the configuration.
-	path := opts.ConfigPath
-
-	// If we had no path set, it is an error. We can't initialize unset
-	if path == "" {
-		path = "."
-	}
-
-	// Expand the path
-	if !filepath.IsAbs(path) {
-		var err error
-		path, err = filepath.Abs(path)
+	if opts.Config == nil {
+		// check if the config was missing, or just not required
+		conf, err := m.Config(".")
 		if err != nil {
-			return nil, fmt.Errorf(
-				"Error expanding path to backend config %q: %s", path, err)
+			return nil, err
 		}
-	}
 
-	log.Printf("[DEBUG] command: loading backend config file: %s", path)
-
-	// We first need to determine if we're loading a file or a directory.
-	fi, err := os.Stat(path)
-	if err != nil {
-		if os.IsNotExist(err) && emptyOk {
-			log.Printf(
-				"[INFO] command: backend config not found, returning nil: %s",
-				path)
+		if conf == nil {
+			log.Println("[INFO] command: no config, returning nil")
 			return nil, nil
 		}
 
-		return nil, err
+		log.Println("[WARNING] BackendOpts.Config not set, but config found")
+		opts.Config = conf
 	}
 
-	var f func(string) (*config.Config, error) = config.LoadFile
-	if fi.IsDir() {
-		f = config.LoadDir
-	}
-
-	// Load the configuration
-	c, err := f(path)
-	if err != nil {
-		// Check for the error where we have no config files and return nil
-		// as the configuration type.
-		if errwrap.ContainsType(err, new(config.ErrNoConfigsFound)) {
-			log.Printf(
-				"[INFO] command: backend config not found, returning nil: %s",
-				path)
-			return nil, nil
-		}
-
-		return nil, err
-	}
+	c := opts.Config
 
 	// If there is no Terraform configuration block, no backend config
 	if c.Terraform == nil {
+		log.Println("[INFO] command: empty terraform config, returning nil")
 		return nil, nil
 	}
 
 	// Get the configuration for the backend itself.
 	backend := c.Terraform.Backend
 	if backend == nil {
+		log.Println("[INFO] command: empty backend config, returning nil")
 		return nil, nil
 	}
 

--- a/command/plan.go
+++ b/command/plan.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/config/module"
 )
 
@@ -68,10 +69,14 @@ func (c *PlanCommand) Run(args []string) int {
 		}
 	}
 
+	var conf *config.Config
+	if mod != nil {
+		conf = mod.Config()
+	}
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{
-		ConfigPath: configPath,
-		Plan:       plan,
+		Config: conf,
+		Plan:   plan,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -39,7 +39,7 @@ func (m mockGetProvider) GetProvider(dst, provider string, req discovery.Constra
 			panic(err)
 		}
 
-		if req.Has(version) {
+		if req.Allows(version) {
 			// provider filename
 			name := m.FileName(provider, v)
 			path := filepath.Join(dst, name)

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -1,0 +1,56 @@
+package command
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/terraform/plugin/discovery"
+)
+
+// mockGetProvider providers a GetProvider method for testing automatic
+// provider downloads
+type mockGetProvider struct {
+	// A map of provider names to available versions.
+	// The tests expect the versions to be in order from newest to oldest.
+	Providers map[string][]string
+}
+
+func (m mockGetProvider) FileName(provider, version string) string {
+	return fmt.Sprintf("terraform-provider-%s-V%s-X4", provider, version)
+}
+
+// GetProvider will check the Providers map to see if it can find a suitable
+// version, and put an empty file in the dst directory.
+func (m mockGetProvider) GetProvider(dst, provider string, req discovery.Constraints) error {
+	versions := m.Providers[provider]
+	if len(versions) == 0 {
+		return fmt.Errorf("provider %q not found", provider)
+	}
+
+	err := os.MkdirAll(dst, 0755)
+	if err != nil {
+		return fmt.Errorf("error creating plugins directory: %s", err)
+	}
+
+	for _, v := range versions {
+		version, err := discovery.VersionStr(v).Parse()
+		if err != nil {
+			panic(err)
+		}
+
+		if req.Has(version) {
+			// provider filename
+			name := m.FileName(provider, v)
+			path := filepath.Join(dst, name)
+			f, err := os.Create(path)
+			if err != nil {
+				return fmt.Errorf("error fetching provider: %s", err)
+			}
+			f.Close()
+			return nil
+		}
+	}
+
+	return fmt.Errorf("no suitable version for provider %q found with constraints %s", provider, req)
+}

--- a/command/providers.go
+++ b/command/providers.go
@@ -94,7 +94,7 @@ func providersCommandPopulateTreeNode(node treeprint.Tree, deps *moduledeps.Modu
 
 	for _, name := range names {
 		dep := deps.Providers[moduledeps.ProviderInstance(name)]
-		versionsStr := dep.Versions.String()
+		versionsStr := dep.Constraints.String()
 		if versionsStr != "" {
 			versionsStr = " " + versionsStr
 		}

--- a/command/providers.go
+++ b/command/providers.go
@@ -52,7 +52,9 @@ func (c *ProvidersCommand) Run(args []string) int {
 	}
 
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: root.Config(),
+	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/push.go
+++ b/command/push.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/atlas-go/archive"
 	"github.com/hashicorp/atlas-go/v1"
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -98,9 +99,14 @@ func (c *PushCommand) Run(args []string) int {
 		return 1
 	}
 
+	var conf *config.Config
+	if mod != nil {
+		conf = mod.Config()
+	}
+
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{
-		ConfigPath: configPath,
+		Config: conf,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))

--- a/command/refresh.go
+++ b/command/refresh.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/backend"
+	"github.com/hashicorp/terraform/config"
 	"github.com/hashicorp/terraform/terraform"
 )
 
@@ -43,8 +44,15 @@ func (c *RefreshCommand) Run(args []string) int {
 		return 1
 	}
 
+	var conf *config.Config
+	if mod != nil {
+		conf = mod.Config()
+	}
+
 	// Load the backend
-	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
+	b, err := c.Backend(&BackendOpts{
+		Config: conf,
+	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))
 		return 1

--- a/command/test-fixtures/init-get-providers/main.tf
+++ b/command/test-fixtures/init-get-providers/main.tf
@@ -1,0 +1,11 @@
+provider "exact" {
+	version = "1.2.3"
+}
+
+provider "greater_than" {
+	version = ">= 2.3.3"
+}
+
+provider "between" {
+	version = "> 1.0.0 , < 3.0.0"
+}

--- a/command/unlock.go
+++ b/command/unlock.go
@@ -43,9 +43,15 @@ func (c *UnlockCommand) Run(args []string) int {
 		return 1
 	}
 
+	conf, err := c.Config(configPath)
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
+		return 1
+	}
+
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{
-		ConfigPath: configPath,
+		Config: conf,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))

--- a/moduledeps/dependencies.go
+++ b/moduledeps/dependencies.go
@@ -13,8 +13,8 @@ type Providers map[ProviderInstance]ProviderDependency
 // instance, including both the set of allowed versions and the reason for
 // the dependency.
 type ProviderDependency struct {
-	Versions discovery.VersionSet
-	Reason   ProviderDependencyReason
+	Constraints discovery.Constraints
+	Reason      ProviderDependencyReason
 }
 
 // ProviderDependencyReason is an enumeration of reasons why a dependency might be

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -114,9 +114,9 @@ func (m *Module) PluginRequirements() discovery.PluginRequirements {
 		// by using Intersection to merge the version sets.
 		pty := inst.Type()
 		if existing, exists := ret[pty]; exists {
-			ret[pty] = existing.Intersection(dep.Versions)
+			ret[pty] = existing.Intersection(dep.Constraints)
 		} else {
-			ret[pty] = dep.Versions
+			ret[pty] = dep.Constraints
 		}
 	}
 	return ret
@@ -163,7 +163,7 @@ func (m *Module) Equal(other *Module) bool {
 	}
 
 	// Can't use reflect.DeepEqual on this provider structure because
-	// the nested VersionSet objects contain function pointers that
+	// the nested Constraints objects contain function pointers that
 	// never compare as equal. So we'll need to walk it the long way.
 	for inst, dep := range m.Providers {
 		if _, exists := other.Providers[inst]; !exists {
@@ -174,10 +174,10 @@ func (m *Module) Equal(other *Module) bool {
 			return false
 		}
 
-		// VersionSets are not too easy to compare robustly, so
+		// Constraints are not too easy to compare robustly, so
 		// we'll just use their string representations as a proxy
 		// for now.
-		if dep.Versions.String() != other.Providers[inst].Versions.String() {
+		if dep.Constraints.String() != other.Providers[inst].Constraints.String() {
 			return false
 		}
 	}

--- a/moduledeps/module.go
+++ b/moduledeps/module.go
@@ -114,7 +114,7 @@ func (m *Module) PluginRequirements() discovery.PluginRequirements {
 		// by using Intersection to merge the version sets.
 		pty := inst.Type()
 		if existing, exists := ret[pty]; exists {
-			ret[pty] = existing.Intersection(dep.Constraints)
+			ret[pty] = existing.Append(dep.Constraints)
 		} else {
 			ret[pty] = dep.Constraints
 		}

--- a/moduledeps/module_test.go
+++ b/moduledeps/module_test.go
@@ -192,13 +192,13 @@ func TestModulePluginRequirements(t *testing.T) {
 		Name: "root",
 		Providers: Providers{
 			"foo": ProviderDependency{
-				Versions: discovery.ConstraintStr(">=1.0.0").MustParse(),
+				Constraints: discovery.ConstraintStr(">=1.0.0").MustParse(),
 			},
 			"foo.bar": ProviderDependency{
-				Versions: discovery.ConstraintStr(">=2.0.0").MustParse(),
+				Constraints: discovery.ConstraintStr(">=2.0.0").MustParse(),
 			},
 			"baz": ProviderDependency{
-				Versions: discovery.ConstraintStr(">=3.0.0").MustParse(),
+				Constraints: discovery.ConstraintStr(">=3.0.0").MustParse(),
 			},
 		},
 	}

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -90,7 +90,7 @@ func newestVersion(available []Version, required Constraints) (Version, error) {
 	found := false
 
 	for _, v := range available {
-		if required.Has(v) {
+		if required.Allows(v) {
 			if !found {
 				latest = v
 				found = true

--- a/plugin/discovery/get.go
+++ b/plugin/discovery/get.go
@@ -1,0 +1,170 @@
+package discovery
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"runtime"
+	"strings"
+
+	"golang.org/x/net/html"
+
+	getter "github.com/hashicorp/go-getter"
+)
+
+const releasesURL = "https://releases.hashicorp.com/"
+
+// pluginURL generates URLs to lookup the versions of a plugin, or the file path.
+//
+// The URL for releases follows the pattern:
+//    https://releases.hashicorp.com/terraform-providers/terraform-provider-name/ +
+//        terraform-provider-name_<x.y.z>/terraform-provider-name_<x.y.z>_<os>_<arch>.<ext>
+//
+// The name prefix common to all plugins of this type.
+// This is either `terraform-provider` or `terraform-provisioner`.
+type pluginBaseName string
+
+// base returns the top level directory for all plugins of this type
+func (p pluginBaseName) base() string {
+	// the top level directory is the plural form of the plugin type
+	return releasesURL + string(p) + "s"
+}
+
+// versions returns the url to the directory to list available versions for this plugin
+func (p pluginBaseName) versions(name string) string {
+	return fmt.Sprintf("%s/%s-%s", p.base(), p, name)
+}
+
+// file returns the full path to a plugin based on the plugin name,
+// version, GOOS and GOARCH.
+func (p pluginBaseName) file(name, version string) string {
+	releasesDir := fmt.Sprintf("%s-%s_%s/", p, name, version)
+	fileName := fmt.Sprintf("%s-%s_%s_%s_%s.zip", p, name, version, runtime.GOOS, runtime.GOARCH)
+	return fmt.Sprintf("%s/%s/%s", p.versions(name), releasesDir, fileName)
+}
+
+var providersURL = pluginBaseName("terraform-provider")
+var provisionersURL = pluginBaseName("terraform-provisioners")
+
+// GetProvider fetches a provider plugin based on the version constraints, and
+// copies it to the dst directory.
+//
+// TODO: verify checksum and signature
+func GetProvider(dst, provider string, req Constraints) error {
+	versions, err := listProviderVersions(provider)
+	// TODO: return multiple errors
+	if err != nil {
+		return err
+	}
+
+	version := newestVersion(versions, req)
+	if version == nil {
+		return fmt.Errorf("no version of %q available that fulfills constraints %s", provider, req)
+	}
+
+	url := providersURL.file(provider, version.String())
+
+	log.Printf("[DEBUG] getting provider %q version %q at %s", provider, version, url)
+	return getter.Get(dst, url)
+}
+
+// take the list of available versions for a plugin, and the required
+// Constraints, and return the latest available version that satisfies the
+// constraints.
+func newestVersion(available []*Version, required Constraints) *Version {
+	var latest *Version
+	for _, v := range available {
+		if required.Has(*v) {
+			if latest == nil {
+				latest = v
+				continue
+			}
+
+			if v.NewerThan(*latest) {
+				latest = v
+			}
+		}
+	}
+
+	return latest
+}
+
+// list the version available for the named plugin
+func listProviderVersions(name string) ([]*Version, error) {
+	versions, err := listPluginVersions(providersURL.versions(name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch versions for provider %q: %s", name, err)
+	}
+	return versions, nil
+}
+
+func listProvisionerVersions(name string) ([]*Version, error) {
+	versions, err := listPluginVersions(provisionersURL.versions(name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch versions for provisioner %q: %s", name, err)
+	}
+
+	return versions, nil
+}
+
+// return a list of the plugin versions at the given URL
+// TODO: This doesn't yet take into account plugin protocol version.
+//       That may have to be checked via an http header via a separate request
+//       to each plugin file.
+func listPluginVersions(url string) ([]*Version, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := ioutil.ReadAll(resp.Body)
+		log.Printf("[ERROR] failed to fetch plugin versions from %s\n%s\n%s", url, resp.Status, body)
+		return nil, errors.New(resp.Status)
+	}
+
+	body, err := html.Parse(resp.Body)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	names := []string{}
+
+	// all we need to do is list links on the directory listing page that look like plugins
+	var f func(*html.Node)
+	f = func(n *html.Node) {
+		if n.Type == html.ElementNode && n.Data == "a" {
+			c := n.FirstChild
+			if c != nil && c.Type == html.TextNode && strings.HasPrefix(c.Data, "terraform-") {
+				names = append(names, c.Data)
+				fmt.Println(c.Data)
+				return
+			}
+		}
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			f(c)
+		}
+	}
+	f(body)
+
+	var versions []*Version
+
+	for _, name := range names {
+		parts := strings.SplitN(name, "_", 2)
+		if len(parts) == 2 && parts[1] != "" {
+			v, err := VersionStr(parts[1]).Parse()
+			if err != nil {
+				// filter invalid versions scraped from the page
+				log.Printf("[WARN] invalid version found for %q: %s", name, err)
+				continue
+			}
+
+			versions = append(versions, &v)
+		}
+	}
+
+	return versions, nil
+}

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -1,0 +1,61 @@
+package discovery
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVersionListing(t *testing.T) {
+	handler := http.NewServeMux()
+	handler.HandleFunc("/terraform-providers/terraform-provider-test/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(versionList))
+	})
+
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	providersURL.releases = server.URL + "/"
+
+	versions, err := listProviderVersions("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedSet := map[string]bool{
+		"1.2.4": true,
+		"1.2.3": true,
+		"1.2.1": true,
+	}
+
+	for _, v := range versions {
+		if !expectedSet[v.String()] {
+			t.Fatalf("didn't get version %s in listing", v)
+		}
+		delete(expectedSet, v.String())
+	}
+}
+
+const versionList = `<!DOCTYPE html>
+<html>
+<body>
+  <ul>
+  <li>
+    <a href="../">../</a>
+  </li>
+  <li>
+    <a href="/terraform-provider-test/1.2.3/">terraform-provider-test_1.2.3</a>
+  </li>
+  <li>
+    <a href="/terraform-provider-test/1.2.1/">terraform-provider-test_1.2.1</a>
+  </li>
+  <li>
+    <a href="/terraform-provider-test/1.2.4/">terraform-provider-test_1.2.4</a>
+  </li>
+  </ul>
+  <footer>
+    Proudly fronted by <a href="https://fastly.com/?utm_source=hashicorp" target="_TOP">Fastly</a>
+  </footer>
+</body>
+</html>
+`

--- a/plugin/discovery/get_test.go
+++ b/plugin/discovery/get_test.go
@@ -36,6 +36,41 @@ func TestVersionListing(t *testing.T) {
 	}
 }
 
+func TestNewestVersion(t *testing.T) {
+	var available []Version
+	for _, v := range []string{"1.2.3", "1.2.1", "1.2.4"} {
+		version, err := VersionStr(v).Parse()
+		if err != nil {
+			t.Fatal(err)
+		}
+		available = append(available, version)
+	}
+
+	reqd, err := ConstraintStr(">1.2.1").Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found, err := newestVersion(available, reqd)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if found.String() != "1.2.4" {
+		t.Fatalf("expected newest version 1.2.4, got: %s", found)
+	}
+
+	reqd, err = ConstraintStr("> 1.2.4").Parse()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found, err = newestVersion(available, reqd)
+	if err == nil {
+		t.Fatalf("expceted error, got version %s", found)
+	}
+}
+
 const versionList = `<!DOCTYPE html>
 <html>
 <body>

--- a/plugin/discovery/meta_set.go
+++ b/plugin/discovery/meta_set.go
@@ -100,7 +100,7 @@ func (s PluginMetaSet) Newest() PluginMeta {
 			panic(err)
 		}
 
-		if first == true || version.newerThan(winnerVersion) {
+		if first == true || version.NewerThan(winnerVersion) {
 			winner = p
 			winnerVersion = version
 			first = false

--- a/plugin/discovery/meta_set.go
+++ b/plugin/discovery/meta_set.go
@@ -139,7 +139,7 @@ func (s PluginMetaSet) ConstrainVersions(reqd PluginRequirements) map[string]Plu
 		if err != nil {
 			panic(err)
 		}
-		if allowedVersions.Has(version) {
+		if allowedVersions.Allows(version) {
 			ret[p.Name].Add(p)
 		}
 	}

--- a/plugin/discovery/requirements.go
+++ b/plugin/discovery/requirements.go
@@ -17,7 +17,7 @@ func (r PluginRequirements) Merge(other PluginRequirements) PluginRequirements {
 	}
 	for n, vs := range other {
 		if existing, exists := ret[n]; exists {
-			ret[n] = existing.Intersection(vs)
+			ret[n] = existing.Append(vs)
 		} else {
 			ret[n] = vs
 		}

--- a/plugin/discovery/requirements.go
+++ b/plugin/discovery/requirements.go
@@ -4,8 +4,8 @@ package discovery
 // kind) that are required to exist and have versions within the given
 // corresponding sets.
 //
-// PluginRequirements is a map from plugin name to VersionSet.
-type PluginRequirements map[string]VersionSet
+// PluginRequirements is a map from plugin name to Constraints.
+type PluginRequirements map[string]Constraints
 
 // Merge takes the contents of the receiver and the other given requirements
 // object and merges them together into a single requirements structure

--- a/plugin/discovery/version.go
+++ b/plugin/discovery/version.go
@@ -32,6 +32,6 @@ func (v Version) String() string {
 	return v.raw.String()
 }
 
-func (v Version) newerThan(other Version) bool {
+func (v Version) NewerThan(other Version) bool {
 	return v.raw.GreaterThan(other.raw)
 }

--- a/plugin/discovery/version_set.go
+++ b/plugin/discovery/version_set.go
@@ -9,18 +9,18 @@ import (
 // obtain a real Constraint object, or discover that it is invalid.
 type ConstraintStr string
 
-// Parse transforms a ConstraintStr into a VersionSet if it is
+// Parse transforms a ConstraintStr into a Constraints if it is
 // syntactically valid. If it isn't then an error is returned instead.
-func (s ConstraintStr) Parse() (VersionSet, error) {
+func (s ConstraintStr) Parse() (Constraints, error) {
 	raw, err := version.NewConstraint(string(s))
 	if err != nil {
-		return VersionSet{}, err
+		return Constraints{}, err
 	}
-	return VersionSet{raw}, nil
+	return Constraints{raw}, nil
 }
 
 // MustParse is like Parse but it panics if the constraint string is invalid.
-func (s ConstraintStr) MustParse() VersionSet {
+func (s ConstraintStr) MustParse() Constraints {
 	ret, err := s.Parse()
 	if err != nil {
 		panic(err)
@@ -28,33 +28,30 @@ func (s ConstraintStr) MustParse() VersionSet {
 	return ret
 }
 
-// VersionSet represents a set of versions which any given Version is either
+// Constraints represents a set of versions which any given Version is either
 // a member of or not.
-type VersionSet struct {
-	// Internally a version set is actually a list of constraints that
-	// *remove* versions from the set. Thus a VersionSet with an empty
-	// Constraints list would be one that contains *all* versions.
+type Constraints struct {
 	raw version.Constraints
 }
 
-// AllVersions is a VersionSet containing all versions
-var AllVersions VersionSet
+// AllVersions is a Constraints containing all versions
+var AllVersions Constraints
 
 func init() {
-	AllVersions = VersionSet{
+	AllVersions = Constraints{
 		raw: make(version.Constraints, 0),
 	}
 }
 
 // Has returns true if the given version is in the receiving set.
-func (s VersionSet) Has(v Version) bool {
+func (s Constraints) Has(v Version) bool {
 	return s.raw.Check(v.raw)
 }
 
-// Intersection combines the receving set with the given other set to produce a
-// set that is the intersection of both sets, which is to say that it contains
-// only the versions that are members of both sets.
-func (s VersionSet) Intersection(other VersionSet) VersionSet {
+// Intersection combines the receiving set with the given other set to produce
+// a set that is the intersection of both sets, which is to say that resulting
+// constraints contain only the versions that are members of both.
+func (s Constraints) Intersection(other Constraints) Constraints {
 	raw := make(version.Constraints, 0, len(s.raw)+len(other.raw))
 
 	// Since "raw" is a list of constraints that remove versions from the set,
@@ -63,11 +60,11 @@ func (s VersionSet) Intersection(other VersionSet) VersionSet {
 	raw = append(raw, s.raw...)
 	raw = append(raw, other.raw...)
 
-	return VersionSet{raw}
+	return Constraints{raw}
 }
 
 // String returns a string representation of the set members as a set
 // of range constraints.
-func (s VersionSet) String() string {
+func (s Constraints) String() string {
 	return s.raw.String()
 }

--- a/plugin/discovery/version_set.go
+++ b/plugin/discovery/version_set.go
@@ -43,15 +43,15 @@ func init() {
 	}
 }
 
-// Has returns true if the given version is in the receiving set.
-func (s Constraints) Has(v Version) bool {
+// Allows returns true if the given version is in the receiving set.
+func (s Constraints) Allows(v Version) bool {
 	return s.raw.Check(v.raw)
 }
 
-// Intersection combines the receiving set with the given other set to produce
+// Append combines the receiving set with the given other set to produce
 // a set that is the intersection of both sets, which is to say that resulting
 // constraints contain only the versions that are members of both.
-func (s Constraints) Intersection(other Constraints) Constraints {
+func (s Constraints) Append(other Constraints) Constraints {
 	raw := make(version.Constraints, 0, len(s.raw)+len(other.raw))
 
 	// Since "raw" is a list of constraints that remove versions from the set,

--- a/plugin/discovery/version_set_test.go
+++ b/plugin/discovery/version_set_test.go
@@ -56,7 +56,7 @@ func TestVersionSet(t *testing.T) {
 				t.Fatalf("unwanted error parsing version string %q: %s", test.VersionStr, err)
 			}
 
-			if got, want := accepted.Has(version), test.ShouldHave; got != want {
+			if got, want := accepted.Allows(version), test.ShouldHave; got != want {
 				t.Errorf("Has returned %#v; want %#v", got, want)
 			}
 		})

--- a/plugins.go
+++ b/plugins.go
@@ -3,8 +3,6 @@ package main
 import (
 	"log"
 	"path/filepath"
-
-	"github.com/kardianos/osext"
 )
 
 // globalPluginDirs returns directories that should be searched for
@@ -15,16 +13,6 @@ import (
 // older versions where both satisfy the provider version constraints.
 func globalPluginDirs() []string {
 	var ret []string
-
-	// Look in the same directory as the Terraform executable.
-	// If found, this replaces what we found in the config path.
-	exePath, err := osext.Executable()
-	if err != nil {
-		log.Printf("[ERROR] Error discovering exe directory: %s", err)
-	} else {
-		ret = append(ret, filepath.Dir(exePath))
-	}
-
 	// Look in ~/.terraform.d/plugins/ , or its equivalent on non-UNIX
 	dir, err := ConfigDir()
 	if err != nil {

--- a/terraform/module_dependencies.go
+++ b/terraform/module_dependencies.go
@@ -62,8 +62,8 @@ func moduleTreeConfigDependencies(root *module.Tree, inheritProviders map[string
 				versionSet = discovery.ConstraintStr(pCfg.Version).MustParse()
 			}
 			providers[inst] = moduledeps.ProviderDependency{
-				Versions: versionSet,
-				Reason:   moduledeps.ProviderDependencyExplicit,
+				Constraints: versionSet,
+				Reason:      moduledeps.ProviderDependencyExplicit,
 			}
 		}
 
@@ -84,8 +84,8 @@ func moduleTreeConfigDependencies(root *module.Tree, inheritProviders map[string
 			}
 
 			providers[inst] = moduledeps.ProviderDependency{
-				Versions: discovery.AllVersions,
-				Reason:   reason,
+				Constraints: discovery.AllVersions,
+				Reason:      reason,
 			}
 		}
 
@@ -146,8 +146,8 @@ func moduleTreeMergeStateDependencies(root *moduledeps.Module, state *State) {
 					module.Providers = make(moduledeps.Providers)
 				}
 				module.Providers[inst] = moduledeps.ProviderDependency{
-					Versions: discovery.AllVersions,
-					Reason:   moduledeps.ProviderDependencyFromState,
+					Constraints: discovery.AllVersions,
+					Reason:      moduledeps.ProviderDependencyFromState,
 				}
 			}
 		}

--- a/terraform/module_dependencies_test.go
+++ b/terraform/module_dependencies_test.go
@@ -40,12 +40,12 @@ func TestModuleTreeDependencies(t *testing.T) {
 				Name: "root",
 				Providers: moduledeps.Providers{
 					"foo": moduledeps.ProviderDependency{
-						Versions: discovery.ConstraintStr(">=1.0.0").MustParse(),
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.ConstraintStr(">=1.0.0").MustParse(),
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 					"foo.bar": moduledeps.ProviderDependency{
-						Versions: discovery.ConstraintStr(">=2.0.0").MustParse(),
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.ConstraintStr(">=2.0.0").MustParse(),
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 				},
 				Children: nil,
@@ -58,8 +58,8 @@ func TestModuleTreeDependencies(t *testing.T) {
 				Name: "root",
 				Providers: moduledeps.Providers{
 					"foo": moduledeps.ProviderDependency{
-						Versions: discovery.AllVersions,
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.AllVersions,
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 				},
 				Children: nil,
@@ -72,12 +72,12 @@ func TestModuleTreeDependencies(t *testing.T) {
 				Name: "root",
 				Providers: moduledeps.Providers{
 					"foo": moduledeps.ProviderDependency{
-						Versions: discovery.AllVersions,
-						Reason:   moduledeps.ProviderDependencyImplicit,
+						Constraints: discovery.AllVersions,
+						Reason:      moduledeps.ProviderDependencyImplicit,
 					},
 					"foo.baz": moduledeps.ProviderDependency{
-						Versions: discovery.AllVersions,
-						Reason:   moduledeps.ProviderDependencyImplicit,
+						Constraints: discovery.AllVersions,
+						Reason:      moduledeps.ProviderDependencyImplicit,
 					},
 				},
 				Children: nil,
@@ -90,8 +90,8 @@ func TestModuleTreeDependencies(t *testing.T) {
 				Name: "root",
 				Providers: moduledeps.Providers{
 					"foo": moduledeps.ProviderDependency{
-						Versions: discovery.ConstraintStr(">=1.0.0").MustParse(),
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.ConstraintStr(">=1.0.0").MustParse(),
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 				},
 				Children: nil,
@@ -104,12 +104,12 @@ func TestModuleTreeDependencies(t *testing.T) {
 				Name: "root",
 				Providers: moduledeps.Providers{
 					"foo": moduledeps.ProviderDependency{
-						Versions: discovery.AllVersions,
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.AllVersions,
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 					"bar": moduledeps.ProviderDependency{
-						Versions: discovery.AllVersions,
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.AllVersions,
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 				},
 				Children: []*moduledeps.Module{
@@ -117,12 +117,12 @@ func TestModuleTreeDependencies(t *testing.T) {
 						Name: "child",
 						Providers: moduledeps.Providers{
 							"foo": moduledeps.ProviderDependency{
-								Versions: discovery.AllVersions,
-								Reason:   moduledeps.ProviderDependencyInherited,
+								Constraints: discovery.AllVersions,
+								Reason:      moduledeps.ProviderDependencyInherited,
 							},
 							"baz": moduledeps.ProviderDependency{
-								Versions: discovery.AllVersions,
-								Reason:   moduledeps.ProviderDependencyImplicit,
+								Constraints: discovery.AllVersions,
+								Reason:      moduledeps.ProviderDependencyImplicit,
 							},
 						},
 						Children: []*moduledeps.Module{
@@ -130,12 +130,12 @@ func TestModuleTreeDependencies(t *testing.T) {
 								Name: "grandchild",
 								Providers: moduledeps.Providers{
 									"foo": moduledeps.ProviderDependency{
-										Versions: discovery.AllVersions,
-										Reason:   moduledeps.ProviderDependencyExplicit,
+										Constraints: discovery.AllVersions,
+										Reason:      moduledeps.ProviderDependencyExplicit,
 									},
 									"bar": moduledeps.ProviderDependency{
-										Versions: discovery.AllVersions,
-										Reason:   moduledeps.ProviderDependencyInherited,
+										Constraints: discovery.AllVersions,
+										Reason:      moduledeps.ProviderDependencyInherited,
 									},
 								},
 							},
@@ -163,8 +163,8 @@ func TestModuleTreeDependencies(t *testing.T) {
 				Name: "root",
 				Providers: moduledeps.Providers{
 					"foo": moduledeps.ProviderDependency{
-						Versions: discovery.AllVersions,
-						Reason:   moduledeps.ProviderDependencyFromState,
+						Constraints: discovery.AllVersions,
+						Reason:      moduledeps.ProviderDependencyFromState,
 					},
 				},
 				Children: nil,
@@ -209,16 +209,16 @@ func TestModuleTreeDependencies(t *testing.T) {
 				Name: "root",
 				Providers: moduledeps.Providers{
 					"foo": moduledeps.ProviderDependency{
-						Versions: discovery.ConstraintStr(">=1.0.0").MustParse(),
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.ConstraintStr(">=1.0.0").MustParse(),
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 					"foo.bar": moduledeps.ProviderDependency{
-						Versions: discovery.ConstraintStr(">=2.0.0").MustParse(),
-						Reason:   moduledeps.ProviderDependencyExplicit,
+						Constraints: discovery.ConstraintStr(">=2.0.0").MustParse(),
+						Reason:      moduledeps.ProviderDependencyExplicit,
 					},
 					"baz": moduledeps.ProviderDependency{
-						Versions: discovery.AllVersions,
-						Reason:   moduledeps.ProviderDependencyFromState,
+						Constraints: discovery.AllVersions,
+						Reason:      moduledeps.ProviderDependencyFromState,
 					},
 				},
 				Children: []*moduledeps.Module{
@@ -229,8 +229,8 @@ func TestModuleTreeDependencies(t *testing.T) {
 								Name: "grandchild",
 								Providers: moduledeps.Providers{
 									"banana": moduledeps.ProviderDependency{
-										Versions: discovery.AllVersions,
-										Reason:   moduledeps.ProviderDependencyFromState,
+										Constraints: discovery.AllVersions,
+										Reason:      moduledeps.ProviderDependencyFromState,
 									},
 								},
 							},

--- a/terraform/test_failure
+++ b/terraform/test_failure
@@ -1,0 +1,9 @@
+--- FAIL: TestContext2Plan_moduleProviderInherit (0.01s)
+	context_plan_test.go:552: bad: []string{"child"}
+map[string]dag.Vertex{}
+"module.middle.null"
+map[string]dag.Vertex{}
+"module.middle.module.inner.null"
+map[string]dag.Vertex{}
+"aws"
+FAIL


### PR DESCRIPTION
This starts a basic implementation of fetching plugins during `terraform init`

This is an early version, with few tests, that only fetches plugins from the default location. The URLs are still subject to change, and since there are no plugin releases, it doesn't work at all yet.

#### Some housekeeping first:

- Have Meta.Backend use a `*config.Config` in `BackendOpts`, rather than a config path. This unifies where the config is loaded, and allows us to load the config in the same way as the backend would, before calling Backend.

- Rename `discovery.VersionSet` to `discovery.Constraints`. `VersionSet` was a simple wrapper around `version.Constraints`, so keep the name more consistent.

- Expose `Version.NewerThan` from the discovery package, so we don't need to drop down to the underlying `version.Version` to make comparisons.


#### Initial Implementation:

Create `discovery.GetProvider` to fetch a provider matching the given constraints. This is limited to providers that will be found on the releases site, and has hardcoded path templates for the files. This isn't directly implemented using a `getter.Detector` and `Getter`, because we already have the constraints parsed, and we know if we're looking for a provider (or provisioner when they are supported). This does use `getter.Get` internally once the url has been resolved, and could be extended to fetch exact url sources rather than searching the releases index pages.

This does not yet take into account the plugin protocol version. How we will obtain that has yet to be determined, so we can leave it out for now.