### PR TITLE
provider/aws: Improved IAM Role description tests & validation

### DIFF
--- a/builtin/providers/aws/import_aws_iam_role_test.go
+++ b/builtin/providers/aws/import_aws_iam_role_test.go
@@ -3,22 +3,24 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSIAMRole_importBasic(t *testing.T) {
 	resourceName := "aws_iam_role.role"
+	rName := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRoleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testAccAWSRoleConfig,
+			{
+				Config: testAccAWSRoleConfig(rName),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/aws/resource_aws_iam_role_test.go
+++ b/builtin/providers/aws/resource_aws_iam_role_test.go
@@ -10,12 +10,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSRole_basic(t *testing.T) {
 	var conf iam.GetRoleOutput
+	rName := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -23,13 +25,48 @@ func TestAccAWSRole_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRoleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRoleConfig,
+				Config: testAccAWSRoleConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
-					testAccCheckAWSRoleAttributes(&conf),
-					resource.TestCheckResourceAttrSet(
-						"aws_iam_role.role", "create_date",
-					),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/"),
+					resource.TestCheckResourceAttrSet("aws_iam_role.role", "create_date"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSRole_basicWithDescription(t *testing.T) {
+	var conf iam.GetRoleOutput
+	rName := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSRoleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSRoleConfigWithDescription(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/"),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "description", "This 1s a D3scr!pti0n with weird content: &@90ë“‘{«¡Çø}"),
+				),
+			},
+			{
+				Config: testAccAWSRoleConfigWithUpdatedDescription(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "path", "/"),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "description", "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë“‘{«¡Çø}"),
+				),
+			},
+			{
+				Config: testAccAWSRoleConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
+					resource.TestCheckResourceAttrSet("aws_iam_role.role", "create_date"),
+					resource.TestCheckResourceAttr("aws_iam_role.role", "description", ""),
 				),
 			},
 		},
@@ -38,6 +75,7 @@ func TestAccAWSRole_basic(t *testing.T) {
 
 func TestAccAWSRole_namePrefix(t *testing.T) {
 	var conf iam.GetRoleOutput
+	rName := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
@@ -47,7 +85,7 @@ func TestAccAWSRole_namePrefix(t *testing.T) {
 		CheckDestroy:    testAccCheckAWSRoleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRolePrefixNameConfig,
+				Config: testAccAWSRolePrefixNameConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists("aws_iam_role.role", &conf),
 					testAccCheckAWSRoleGeneratedNamePrefix(
@@ -60,6 +98,7 @@ func TestAccAWSRole_namePrefix(t *testing.T) {
 
 func TestAccAWSRole_testNameChange(t *testing.T) {
 	var conf iam.GetRoleOutput
+	rName := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -67,14 +106,14 @@ func TestAccAWSRole_testNameChange(t *testing.T) {
 		CheckDestroy: testAccCheckAWSRoleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSRolePre,
+				Config: testAccAWSRolePre(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists("aws_iam_role.role_update_test", &conf),
 				),
 			},
 
 			{
-				Config: testAccAWSRolePost,
+				Config: testAccAWSRolePost(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSRoleExists("aws_iam_role.role_update_test", &conf),
 				),
@@ -84,13 +123,15 @@ func TestAccAWSRole_testNameChange(t *testing.T) {
 }
 
 func TestAccAWSRole_badJSON(t *testing.T) {
+	rName := acctest.RandString(10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSRoleDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config:      testAccAWSRoleConfig_badJson,
+				Config:      testAccAWSRoleConfig_badJson(rName),
 				ExpectError: regexp.MustCompile(`.*contains an invalid JSON:.*`),
 			},
 		},
@@ -169,43 +210,52 @@ func testAccCheckAWSRoleGeneratedNamePrefix(resource, prefix string) resource.Te
 	}
 }
 
-func testAccCheckAWSRoleAttributes(role *iam.GetRoleOutput) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if *role.Role.RoleName != "test-role" {
-			return fmt.Errorf("Bad name: %s", *role.Role.RoleName)
-		}
-
-		if *role.Role.Path != "/" {
-			return fmt.Errorf("Bad path: %s", *role.Role.Path)
-		}
-
-		if *role.Role.Description != "Test Role" {
-			return fmt.Errorf("Bad description: %s", *role.Role.Description)
-		}
-		return nil
-	}
-}
-
-const testAccAWSRoleConfig = `
+func testAccAWSRoleConfig(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "role" {
-  name   = "test-role"
-  path = "/"
-  description = "Test Role"
-  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
-}
-`
-
-const testAccAWSRolePrefixNameConfig = `
-resource "aws_iam_role" "role" {
-  name_prefix = "test-role-"
+  name   = "test-role-%s"
   path = "/"
   assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
 }
-`
+`, rName)
+}
 
-const testAccAWSRolePre = `
+func testAccAWSRoleConfigWithDescription(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name   = "test-role-%s"
+  description = "This 1s a D3scr!pti0n with weird content: &@90ë“‘{«¡Çø}"
+  path = "/"
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+`, rName)
+}
+
+func testAccAWSRoleConfigWithUpdatedDescription(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name   = "test-role-%s"
+  description = "This 1s an Upd@ted D3scr!pti0n with weird content: &90ë“‘{«¡Çø}"
+  path = "/"
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+`, rName)
+}
+
+func testAccAWSRolePrefixNameConfig(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "role" {
+  name_prefix = "test-role-%s"
+  path = "/"
+  assume_role_policy = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"Service\":[\"ec2.amazonaws.com\"]},\"Action\":[\"sts:AssumeRole\"]}]}"
+}
+`, rName)
+}
+
+func testAccAWSRolePre(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "role_update_test" {
-  name = "tf_old_name"
+  name = "tf_old_name_%s"
   path = "/test/"
   assume_role_policy = <<EOF
 {
@@ -225,7 +275,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "role_update_test" {
-  name = "role_update_test"
+  name = "role_update_test_%s"
   role = "${aws_iam_role.role_update_test.id}"
   policy = <<EOF
 {
@@ -245,16 +295,17 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "role_update_test" {
-  name = "role_update_test"
+  name = "role_update_test_%s"
   path = "/test/"
   roles = ["${aws_iam_role.role_update_test.name}"]
 }
+`, rName, rName, rName)
+}
 
-`
-
-const testAccAWSRolePost = `
+func testAccAWSRolePost(rName string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "role_update_test" {
-  name = "tf_new_name"
+  name = "tf_new_name_%s"
   path = "/test/"
   assume_role_policy = <<EOF
 {
@@ -274,7 +325,7 @@ EOF
 }
 
 resource "aws_iam_role_policy" "role_update_test" {
-  name = "role_update_test"
+  name = "role_update_test_%s"
   role = "${aws_iam_role.role_update_test.id}"
   policy = <<EOF
 {
@@ -294,30 +345,33 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "role_update_test" {
-  name = "role_update_test"
+  name = "role_update_test_%s"
   path = "/test/"
   roles = ["${aws_iam_role.role_update_test.name}"]
 }
+`, rName, rName, rName)
+}
 
-`
-
-const testAccAWSRoleConfig_badJson = `
-	resource "aws_iam_role" "my_instance_role" {
-  name = "test-role"
+func testAccAWSRoleConfig_badJson(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_iam_role" "my_instance_role" {
+  name = "test-role-%s"
 
   assume_role_policy = <<POLICY
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-                "Service": "ec2.amazonaws.com",
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+  {
+    "Action": "sts:AssumeRole",
+    "Principal": {
+    "Service": "ec2.amazonaws.com",
+    },
+    "Effect": "Allow",
+    "Sid": ""
+  }
+  ]
 }
 POLICY
-}`
+}
+`, rName)
+}

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -1301,3 +1301,18 @@ func validateWafMetricName(v interface{}, k string) (ws []string, errors []error
 	}
 	return
 }
+
+func validateIamRoleDescription(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+
+	if len(value) > 1000 {
+		errors = append(errors, fmt.Errorf("%q cannot be longer than 1000 caracters", k))
+	}
+
+	if !regexp.MustCompile(`[\p{L}\p{M}\p{Z}\p{S}\p{N}\p{P}]*`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"Only alphanumeric & accented characters allowed in %q: %q (Must satisfy regular expression pattern: [\\p{L}\\p{M}\\p{Z}\\p{S}\\p{N}\\p{P}]*)",
+			k, value))
+	}
+	return
+}

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -2209,3 +2209,26 @@ func TestValidateWafMetricName(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateIamRoleDescription(t *testing.T) {
+	validNames := []string{
+		"This 1s a D3scr!pti0n with weird content: @ #^ù£ê®æ ø]ŒîÏî~ÈÙ£÷=,ë",
+		strings.Repeat("W", 1000),
+	}
+	for _, v := range validNames {
+		_, errors := validateIamRoleDescription(v, "description")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid IAM Role Description: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		strings.Repeat("W", 1001), // > 1000
+	}
+	for _, v := range invalidNames {
+		_, errors := validateIamRoleDescription(v, "description")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid IAM Role Description", v)
+		}
+	}
+}


### PR DESCRIPTION
## Description
This augments https://github.com/hashicorp/terraform/pull/14208 to add acceptance tests, adding validation. (I also started the work for the description, but @minamijoyo did it fast 😄 )

Acceptance tests create the role with the description, then update it.
This work also adds more randomization to iam role tests.

## Tests
```bash
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSIAMRole_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/04 21:10:03 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSIAMRole_importBasic -timeout 120m
=== RUN   TestAccAWSIAMRole_importBasic
--- PASS: TestAccAWSIAMRole_importBasic (17.14s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	17.170s

make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRole_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/04 22:23:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRole_ -timeout 120m
=== RUN   TestAccAWSRole_basic
--- PASS: TestAccAWSRole_basic (15.90s)
=== RUN   TestAccAWSRole_basicWithDescription
--- PASS: TestAccAWSRole_basicWithDescription (38.47s)
=== RUN   TestAccAWSRole_namePrefix
--- PASS: TestAccAWSRole_namePrefix (15.29s)
=== RUN   TestAccAWSRole_testNameChange
--- PASS: TestAccAWSRole_testNameChange (35.00s)
=== RUN   TestAccAWSRole_badJSON
--- PASS: TestAccAWSRole_badJSON (0.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	104.691s
```