### PR TITLE
Adding runscope provider

### DIFF
--- a/builtin/providers/runscope/config.go
+++ b/builtin/providers/runscope/config.go
@@ -1,0 +1,20 @@
+package runscope
+
+import (
+	"github.com/ewilde/go-runscope"
+	"log"
+)
+
+// Config contains runscope provider settings
+type Config struct {
+	AccessToken string
+	ApiUrl      string
+}
+
+func (c *Config) Client() (*runscope.Client, error) {
+	client := runscope.NewClient(c.ApiUrl, c.AccessToken)
+
+	log.Printf("[INFO] runscope client configured for server %s", c.ApiUrl)
+
+	return client, nil
+}

--- a/builtin/providers/runscope/data_source_runscope_integration.go
+++ b/builtin/providers/runscope/data_source_runscope_integration.go
@@ -1,0 +1,56 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+)
+
+func dataSourceRunscopeIntegration() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRunscopeIntegrationRead,
+
+		Schema: map[string]*schema.Schema{
+			"team_uuid": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"type": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func dataSourceRunscopeIntegrationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	log.Printf("[INFO] Reading Runscope integration")
+
+	searchType := d.Get("type").(string)
+
+	resp, err := client.ListIntegrations(d.Get("team_uuid").(string))
+	if err != nil {
+		return err
+	}
+
+	found := &runscope.Integration{}
+	for _, integration := range resp {
+		if integration.IntegrationType == searchType {
+			found = integration
+			break
+		}
+	}
+
+	if found == nil {
+		return fmt.Errorf("Unable to locate any user with the email: %s", searchType)
+	}
+
+	d.SetId(found.ID)
+	d.Set("id", found.ID)
+	d.Set("type", found.IntegrationType)
+
+	return nil
+}

--- a/builtin/providers/runscope/data_source_runscope_integration_test.go
+++ b/builtin/providers/runscope/data_source_runscope_integration_test.go
@@ -1,0 +1,52 @@
+package runscope
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+)
+
+func TestAccDataSourceRunscopeIntegration_Basic(t *testing.T) {
+
+	teamId := os.Getenv("RUNSCOPE_TEAM_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccDataSourceRunscopeIntegrationConfig, teamId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceRunscopeIntegration("data.runscope_integration.by_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRunscopeIntegration(dataSource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[dataSource]
+		a := r.Primary.Attributes
+
+		if a["id"] == "" {
+			return fmt.Errorf("Expected to get an integration ID from runscope data resource")
+		}
+
+		if a["type"] != "pagerduty" {
+			return fmt.Errorf("Expected to get an integration type pagerduty from runscope data resource")
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceRunscopeIntegrationConfig = `
+data "runscope_integration" "by_type" {
+	team_uuid = "%s"
+	type      = "pagerduty"
+}
+`

--- a/builtin/providers/runscope/provider.go
+++ b/builtin/providers/runscope/provider.go
@@ -1,0 +1,64 @@
+package runscope
+
+import (
+	"os"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			"access_token": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: envDefaultFunc("RUNSCOPE_ACCESS_TOKEN"),
+				Description: "A runscope access token.",
+			},
+			"api_url": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: envDefaultFunc("RUNSCOPE_API_URL"),
+				Description: "A runscope api url i.e. https://api.runscope.com.",
+				Default:     "https://api.runscope.com",
+			},
+		},
+
+		DataSourcesMap: map[string]*schema.Resource{
+			"runscope_integration": dataSourceRunscopeIntegration(),
+		},
+
+		ResourcesMap: map[string]*schema.Resource{
+			"runscope_bucket":      resourceRunscopeBucket(),
+			"runscope_test":        resourceRunscopeTest(),
+			"runscope_environment": resourceRunscopeEnvironment(),
+			"runscope_schedule":    resourceRunscopeSchedule(),
+			"runscope_step":        resourceRunscopeStep(),
+		},
+
+		ConfigureFunc: providerConfigure,
+	}
+}
+
+func envDefaultFunc(k string) schema.SchemaDefaultFunc {
+	return func() (interface{}, error) {
+		if v := os.Getenv(k); v != "" {
+			if v == "true" {
+				return true, nil
+			} else if v == "false" {
+				return false, nil
+			}
+			return v, nil
+		}
+		return nil, nil
+	}
+}
+
+func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	config := Config{
+		AccessToken: d.Get("access_token").(string),
+		ApiUrl:      d.Get("api_url").(string),
+	}
+	return config.Client()
+}

--- a/builtin/providers/runscope/provider_test.go
+++ b/builtin/providers/runscope/provider_test.go
@@ -1,0 +1,41 @@
+package runscope
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		// provider is called terraform-provider-runscope ie runscope
+		"runscope": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+}
+
+func TestProviderImpl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("RUNSCOPE_ACCESS_TOKEN"); v == "" {
+		t.Fatal("RUNSCOPE_ACCESS_TOKEN must be set for acceptance tests")
+	}
+
+	if v := os.Getenv("RUNSCOPE_TEAM_ID"); v == "" {
+		t.Fatal("RUNSCOPE_TEAM_ID must be set for acceptance tests")
+	}
+}

--- a/builtin/providers/runscope/resource_runscope_bucket.go
+++ b/builtin/providers/runscope/resource_runscope_bucket.go
@@ -1,0 +1,102 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceRunscopeBucket() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceBucketCreate,
+		Read:   resourceBucketRead,
+		Delete: resourceBucketDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"team_uuid": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceBucketCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating bucket for name: %s", name)
+
+	bucket, err := createBucketFromResourceData(d)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] bucket create: %#v", bucket)
+
+	createdBucket, err := client.CreateBucket(bucket)
+	if err != nil {
+		return fmt.Errorf("Failed to create bucket: %s", err)
+	}
+
+	d.SetId(createdBucket.Key)
+	log.Printf("[INFO] bucket key: %s", d.Id())
+
+	return resourceBucketRead(d, meta)
+}
+
+func resourceBucketRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	key := d.Id()
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Reading bucket for id: %s name: %s", key, name)
+
+	bucket, err := client.ReadBucket(key)
+	if err != nil {
+		if strings.Contains(err.Error(), "403") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Couldn't find bucket: %s", err)
+	}
+
+	d.Set("name", bucket.Name)
+	d.Set("team_uuid", bucket.Team.ID)
+	return nil
+}
+
+func resourceBucketDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	key := d.Id()
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Deleting bucket with key: %s name: %s", key, name)
+
+	if err := client.DeleteBucket(key); err != nil {
+		return fmt.Errorf("Error deleting bucket: %s", err)
+	}
+
+	return nil
+}
+
+func createBucketFromResourceData(d *schema.ResourceData) (*runscope.Bucket, error) {
+
+	bucket := runscope.Bucket{}
+	if attr, ok := d.GetOk("name"); ok {
+		bucket.Name = attr.(string)
+	}
+	if attr, ok := d.GetOk("team_uuid"); ok {
+		bucket.Team = &runscope.Team{ID: attr.(string)}
+	}
+
+	return &bucket, nil
+}

--- a/builtin/providers/runscope/resource_runscope_bucket_test.go
+++ b/builtin/providers/runscope/resource_runscope_bucket_test.go
@@ -1,0 +1,85 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccBucket_basic(t *testing.T) {
+	var bucketResponse runscope.Bucket
+	teamId := os.Getenv("RUNSCOPE_TEAM_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckBucketDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testRunscopeBucketConfigA, teamId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckBucketExists("runscope_bucket.bucket", &bucketResponse),
+					resource.TestCheckResourceAttr(
+						"runscope_bucket.bucket", "name", "runscope-bucket"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckBucketDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*runscope.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "runscope_bucket" {
+			continue
+		}
+
+		_, err := client.ReadBucket(rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Record %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckBucketExists(n string, bucket *runscope.Bucket) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*runscope.Client)
+
+		foundRecord, err := client.ReadBucket(rs.Primary.ID)
+
+		if err != nil {
+			return err
+		}
+
+		if foundRecord.Key != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		bucket = foundRecord
+
+		return nil
+	}
+}
+
+const testRunscopeBucketConfigA = `
+resource "runscope_bucket" "bucket" {
+  name = "runscope-bucket"
+  team_uuid = "%s"
+}`

--- a/builtin/providers/runscope/resource_runscope_environment.go
+++ b/builtin/providers/runscope/resource_runscope_environment.go
@@ -1,0 +1,260 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceRunscopeEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceEnvironmentCreate,
+		Read:   resourceEnvironmentRead,
+		Update: resourceEnvironmentUpdate,
+		Delete: resourceEnvironmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"bucket_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"test_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"script": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			"preserve_cookies": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: false,
+			},
+			"initial_variables": &schema.Schema{
+				Type:     schema.TypeMap,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
+				ForceNew: false,
+			},
+			"integrations": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"integration_type": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"description": &schema.Schema{
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating environment with name: %s", name)
+
+	environment, err := createEnvironmentFromResourceData(d)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] environment create: %#v", environment)
+
+	var createdEnvironment *runscope.Environment
+	bucketId := d.Get("bucket_id").(string)
+	if testId, ok := d.GetOk("test_id"); ok {
+		createdEnvironment, err = client.CreateTestEnvironment(environment,
+			&runscope.Test{ID: testId.(string), Bucket: &runscope.Bucket{Key: bucketId}})
+	} else {
+		createdEnvironment, err = client.CreateSharedEnvironment(environment,
+			&runscope.Bucket{Key: bucketId})
+	}
+	if err != nil {
+		return fmt.Errorf("Failed to create environment: %s", err)
+	}
+
+	d.SetId(createdEnvironment.ID)
+	log.Printf("[INFO] environment ID: %s", d.Id())
+
+	return resourceEnvironmentRead(d, meta)
+}
+
+func resourceEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	environmentFromResource, err := createEnvironmentFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Failed to read environment from resource data: %s", err)
+	}
+
+	var environment *runscope.Environment
+	bucketId := d.Get("bucket_id").(string)
+	if testId, ok := d.GetOk("test_id"); ok {
+		environment, err = client.ReadTestEnvironment(
+			environmentFromResource, &runscope.Test{ID: testId.(string), Bucket: &runscope.Bucket{Key: bucketId}})
+	} else {
+		environment, err = client.ReadSharedEnvironment(
+			environmentFromResource, &runscope.Bucket{Key: bucketId})
+	}
+
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Couldn't find environment: %s", err)
+	}
+
+	d.Set("bucket_id", bucketId)
+	d.Set("test_id", d.Get("test_id").(string))
+	d.Set("name", environment.Name)
+	d.Set("script", environment.Script)
+	d.Set("preserve_cookies", environment.PreserveCookies)
+	d.Set("initial_variables", environment.InitialVariables)
+	d.Set("integrations", readIntegrations(environment.Integrations))
+	return nil
+}
+
+func resourceEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	d.Partial(false)
+	environment, err := createEnvironmentFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Error updating environment: %s", err)
+	}
+
+	change := d.HasChange("name")
+	if change {
+		client := meta.(*runscope.Client)
+		bucketId := d.Get("bucket_id").(string)
+		if testId, ok := d.GetOk("test_id"); ok {
+			_, err = client.UpdateTestEnvironment(
+				environment, &runscope.Test{ID: testId.(string), Bucket: &runscope.Bucket{Key: bucketId}})
+		} else {
+			_, err = client.UpdateSharedEnvironment(
+				environment, &runscope.Bucket{Key: bucketId})
+		}
+		if err != nil {
+			return fmt.Errorf("Error updating test: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	environmentFromResource, err := createEnvironmentFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Failed to read environment from resource data: %s", err)
+	}
+
+	bucketId := d.Get("bucket_id").(string)
+	if testId, ok := d.GetOk("test_id"); ok {
+		log.Printf("[INFO] Deleting test environment with id: %s name: %s, from test %s",
+			environmentFromResource.ID, environmentFromResource.Name, testId.(string))
+		err = client.DeleteTestEnvironment(
+			environmentFromResource, &runscope.Test{ID: testId.(string), Bucket: &runscope.Bucket{Key: bucketId}})
+	} else {
+		log.Printf("[INFO] Deleting shared environment with id: %s name: %s",
+			environmentFromResource.ID, environmentFromResource.Name)
+		err = client.DeleteSharedEnvironment(
+			environmentFromResource, &runscope.Bucket{Key: bucketId})
+	}
+
+	if err != nil {
+		return fmt.Errorf("Error deleting environment: %s", err)
+	}
+
+	return nil
+}
+
+func createEnvironmentFromResourceData(d *schema.ResourceData) (*runscope.Environment, error) {
+
+	environment := runscope.NewEnvironment()
+	environment.ID = d.Id()
+
+	if attr, ok := d.GetOk("name"); ok {
+		environment.Name = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("test_id"); ok {
+		environment.TestID = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("script"); ok {
+		environment.Script = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("preserve_cookies"); ok {
+		environment.PreserveCookies = attr.(bool)
+	}
+
+	if attr, ok := d.GetOk("initial_variables"); ok {
+		variablesRaw := attr.(map[string]interface{})
+		variables := map[string]string{}
+		for k, v := range variablesRaw {
+			variables[k] = v.(string)
+		}
+
+		environment.InitialVariables = variables
+	}
+
+	if attr, ok := d.GetOk("integrations"); ok {
+		integrations := []*runscope.EnvironmentIntegration{}
+		items := attr.([]interface{})
+		for _, x := range items {
+			item := x.(map[string]interface{})
+			integration := runscope.EnvironmentIntegration{
+				ID:              item["id"].(string),
+				IntegrationType: item["integration_type"].(string),
+			}
+
+			integrations = append(integrations, &integration)
+		}
+
+		environment.Integrations = integrations
+	}
+
+	return environment, nil
+}
+
+func readIntegrations(integrations []*runscope.EnvironmentIntegration) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(integrations))
+	for _, integration := range integrations {
+
+		item := map[string]interface{}{
+			"id":               integration.ID,
+			"integration_type": integration.IntegrationType,
+			"description":      integration.Description,
+		}
+
+		result = append(result, item)
+	}
+
+	return result
+}

--- a/builtin/providers/runscope/resource_runscope_environment_test.go
+++ b/builtin/providers/runscope/resource_runscope_environment_test.go
@@ -1,0 +1,139 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccEnvironment_basic(t *testing.T) {
+	teamId := os.Getenv("RUNSCOPE_TEAM_ID")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testRunscopeEnvrionmentConfigA, teamId, teamId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckEnvironmentExists("runscope_environment.environment"),
+					resource.TestCheckResourceAttr(
+						"runscope_environment.environment", "name", "test-environment")),
+			},
+		},
+	})
+}
+
+func testAccCheckEnvironmentDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*runscope.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "runscope_environment" {
+			continue
+		}
+
+		var err error
+		bucketId := rs.Primary.Attributes["bucket_id"]
+		testId := rs.Primary.Attributes["test_id"]
+		if testId != "" {
+			err = client.DeleteTestEnvironment(&runscope.Environment{ID: rs.Primary.ID},
+				&runscope.Test{
+					ID:     testId,
+					Bucket: &runscope.Bucket{Key: bucketId}})
+		} else {
+			err = client.DeleteSharedEnvironment(&runscope.Environment{ID: rs.Primary.ID},
+				&runscope.Bucket{Key: bucketId})
+		}
+
+		if err == nil {
+			return fmt.Errorf("Record %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckEnvironmentExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*runscope.Client)
+
+		var foundRecord *runscope.Environment
+		var err error
+
+		environment := new(runscope.Environment)
+		environment.ID = rs.Primary.ID
+		bucketId := rs.Primary.Attributes["bucket_id"]
+		testId := rs.Primary.Attributes["test_id"]
+		if testId != "" {
+			foundRecord, err = client.ReadTestEnvironment(environment,
+				&runscope.Test{
+					ID:     testId,
+					Bucket: &runscope.Bucket{Key: bucketId}})
+		} else {
+			foundRecord, err = client.ReadSharedEnvironment(environment,
+				&runscope.Bucket{Key: bucketId})
+		}
+
+		if err != nil {
+			return err
+		}
+
+		if foundRecord.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		if len(foundRecord.Integrations) != 1 {
+			return fmt.Errorf("Expected %d integrations, actual %d", 1, len(environment.Integrations))
+		}
+
+		return nil
+	}
+}
+
+const testRunscopeEnvrionmentConfigA = `
+resource "runscope_environment" "environment" {
+  bucket_id    = "${runscope_bucket.bucket.id}"
+  name         = "test-environment"
+
+  integrations = [
+    {
+      id               = "${data.runscope_integration.pagerduty.id}"
+      integration_type = "pagerduty"
+    }
+  ]
+
+  initial_variables {
+    var1 = "true",
+    var2 = "value2"
+  }
+}
+
+resource "runscope_test" "test" {
+  bucket_id = "${runscope_bucket.bucket.id}"
+  name = "runscope test"
+  description = "This is a test test..."
+}
+
+resource "runscope_bucket" "bucket" {
+  name = "terraform-provider-test"
+  team_uuid = "%s"
+}
+
+data "runscope_integration" "pagerduty" {
+  team_uuid = "%s"
+  type = "pagerduty"
+}
+`

--- a/builtin/providers/runscope/resource_runscope_schedule.go
+++ b/builtin/providers/runscope/resource_runscope_schedule.go
@@ -1,0 +1,129 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceRunscopeSchedule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceScheduleCreate,
+		Read:   resourceScheduleRead,
+		Delete: resourceScheduleDelete,
+
+		Schema: map[string]*schema.Schema{
+			"bucket_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"test_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"environment_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"interval": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"note": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: false,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceScheduleCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	schedule, bucketId, testId, err := createScheduleFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] schedule create: %#v", schedule)
+
+	createdSchedule, err := client.CreateSchedule(schedule, bucketId, testId)
+	if err != nil {
+		return fmt.Errorf("Failed to create schedule: %s", err)
+	}
+
+	d.SetId(createdSchedule.ID)
+	log.Printf("[INFO] schedule ID: %s", d.Id())
+
+	return resourceScheduleRead(d, meta)
+}
+
+func resourceScheduleRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	scheduleFromResource, bucketId, testId, err := createScheduleFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Failed to read schedule from resource data: %s", err)
+	}
+
+	schedule, err := client.ReadSchedule(scheduleFromResource, bucketId, testId)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Couldn't find schedule: %s", err)
+	}
+
+	d.Set("bucket_id", bucketId)
+	d.Set("test_id", testId)
+	d.Set("environment_id", schedule.EnvironmentID)
+	d.Set("interval", schedule.Interval)
+	d.Set("note", schedule.Note)
+	return nil
+}
+
+func resourceScheduleDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	scheduleFromResource, bucketId, testId, err := createScheduleFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Failed to read schedule from resource data: %s", err)
+	}
+
+	err = client.DeleteSchedule(scheduleFromResource, bucketId, testId)
+	if err != nil {
+		return fmt.Errorf("Error deleting schedule: %s", err)
+	}
+
+	return nil
+}
+
+func createScheduleFromResourceData(d *schema.ResourceData) (*runscope.Schedule, string, string, error) {
+
+	schedule := runscope.NewSchedule()
+	bucketId := d.Get("bucket_id").(string)
+	testId := d.Get("test_id").(string)
+	environmentId := d.Get("environment_id").(string)
+	interval := d.Get("interval").(string)
+	note := ""
+
+	if v, ok := d.GetOk("note"); ok {
+		note = v.(string)
+	}
+
+	schedule.ID = d.Id()
+	schedule.Interval = interval
+	schedule.Note = note
+	schedule.EnvironmentID = environmentId
+	return schedule, bucketId, testId, nil
+}

--- a/builtin/providers/runscope/resource_runscope_schedule_test.go
+++ b/builtin/providers/runscope/resource_runscope_schedule_test.go
@@ -1,0 +1,118 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccSchedule_basic(t *testing.T) {
+	teamId := os.Getenv("RUNSCOPE_TEAM_ID")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckScheduleDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testRunscopeScheduleConfigA, teamId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckScheduleExists("runscope_schedule.daily"),
+					resource.TestCheckResourceAttr(
+						"runscope_schedule.daily", "note", "This is a daily schedule"),
+					resource.TestCheckResourceAttr(
+						"runscope_schedule.daily", "interval", "1d")),
+			},
+		},
+	})
+}
+
+func testAccCheckScheduleDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*runscope.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "runscope_schedule" {
+			continue
+		}
+
+		var err error
+		bucketId := rs.Primary.Attributes["bucket_id"]
+		testId := rs.Primary.Attributes["test_id"]
+		err = client.DeleteSchedule(&runscope.Schedule{ID: rs.Primary.ID}, bucketId, testId)
+
+		if err == nil {
+			return fmt.Errorf("Record %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckScheduleExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*runscope.Client)
+
+		var foundRecord *runscope.Schedule
+		var err error
+
+		schedule := new(runscope.Schedule)
+		schedule.ID = rs.Primary.ID
+		bucketId := rs.Primary.Attributes["bucket_id"]
+		testId := rs.Primary.Attributes["test_id"]
+
+		foundRecord, err = client.ReadSchedule(schedule, bucketId, testId)
+
+		if err != nil {
+			return err
+		}
+
+		if foundRecord.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		return nil
+	}
+}
+
+const testRunscopeScheduleConfigA = `
+resource "runscope_schedule" "daily" {
+  bucket_id      = "${runscope_bucket.bucket.id}"
+  test_id        = "${runscope_test.test.id}"
+  interval       = "1d"
+  note           = "This is a daily schedule"
+  environment_id = "${runscope_environment.environment.id}"
+}
+
+resource "runscope_test" "test" {
+  bucket_id   = "${runscope_bucket.bucket.id}"
+  name        = "runscope test"
+  description = "This is a test test..."
+}
+
+resource "runscope_bucket" "bucket" {
+  name      = "terraform-provider-test"
+  team_uuid = "%s"
+}
+
+resource "runscope_environment" "environment" {
+  bucket_id = "${runscope_bucket.bucket.id}"
+  name      = "test-environment"
+
+  initial_variables {
+    var1 = "true",
+    var2 = "value2"
+  }
+}
+`

--- a/builtin/providers/runscope/resource_runscope_step.go
+++ b/builtin/providers/runscope/resource_runscope_step.go
@@ -1,0 +1,308 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceRunscopeStep() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceStepCreate,
+		Read:   resourceStepRead,
+		Update: resourceStepUpdate,
+		Delete: resourceStepDelete,
+		Schema: map[string]*schema.Schema{
+			"bucket_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"test_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"step_type": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"method": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: false,
+			},
+			"variables": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"property": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"source": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"assertions": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"source": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"property": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+						"comparison": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+				Optional: true,
+			},
+			"headers": &schema.Schema{
+				Type:     schema.TypeList,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"header": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"value": &schema.Schema{
+							Type:     schema.TypeString,
+							Required: true,
+						},
+					},
+				},
+			},
+			"body": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceStepCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	step, bucketId, testId, err := createStepFromResourceData(d)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] step create: %#v", step)
+
+	createdStep, err := client.CreateTestStep(step, bucketId, testId)
+	if err != nil {
+		return fmt.Errorf("Failed to create step: %s", err)
+	}
+
+	d.SetId(createdStep.ID)
+	log.Printf("[INFO] step ID: %s", d.Id())
+
+	return resourceStepRead(d, meta)
+}
+
+func resourceStepRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	stepFromResource, bucketId, testId, err := createStepFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Failed to read step from resource data: %s", err)
+	}
+
+	step, err := client.ReadTestStep(stepFromResource, bucketId, testId)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Couldn't find step: %s", err)
+	}
+
+	d.Set("bucket_id", bucketId)
+	d.Set("test_id", testId)
+	d.Set("step_type", step.StepType)
+	d.Set("method", step.Method)
+	d.Set("url", step.URL)
+	d.Set("body", step.Body)
+	d.Set("variables", readVariables(step.Variables))
+	d.Set("assertions", readAssertions(step.Assertions))
+	d.Set("headers", readHeaders(step.Headers))
+	return nil
+}
+
+func resourceStepUpdate(d *schema.ResourceData, meta interface{}) error {
+	d.Partial(false)
+	stepFromResource, bucketId, testId, err := createStepFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Error updating step: %s", err)
+	}
+
+	if d.HasChange("url") ||
+		d.HasChange("variables") ||
+		d.HasChange("assertions") ||
+		d.HasChange("headers") ||
+		d.HasChange("body") {
+		client := meta.(*runscope.Client)
+		_, err = client.UpdateTestStep(stepFromResource, bucketId, testId)
+
+		if err != nil {
+			return fmt.Errorf("Error updating step: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceStepDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	stepFromResource, bucketId, testId, err := createStepFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Failed to read step from resource data: %s", err)
+	}
+
+	err = client.DeleteTestStep(stepFromResource, bucketId, testId)
+	if err != nil {
+		return fmt.Errorf("Error deleting step: %s", err)
+	}
+
+	return nil
+}
+
+func createStepFromResourceData(d *schema.ResourceData) (*runscope.TestStep, string, string, error) {
+
+	step := runscope.NewTestStep()
+	bucketId := d.Get("bucket_id").(string)
+	testId := d.Get("test_id").(string)
+	step.ID = d.Id()
+	step.StepType = d.Get("step_type").(string)
+	step.Body = d.Get("body").(string)
+	if attr, ok := d.GetOk("method"); ok {
+		step.Method = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("url"); ok {
+		step.URL = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("variables"); ok {
+		variables := []*runscope.Variable{}
+		items := attr.([]interface{})
+		for _, x := range items {
+			item := x.(map[string]interface{})
+			variable := runscope.Variable{
+				Name:     item["name"].(string),
+				Property: item["property"].(string),
+				Source:   item["source"].(string),
+			}
+
+			variables = append(variables, &variable)
+		}
+
+		step.Variables = variables
+	}
+
+	if attr, ok := d.GetOk("assertions"); ok {
+		assertions := []*runscope.Assertion{}
+		items := attr.([]interface{})
+		for _, x := range items {
+			item := x.(map[string]interface{})
+			variable := runscope.Assertion{
+				Source:     item["source"].(string),
+				Property:   item["property"].(string),
+				Comparison: item["comparison"].(string),
+				Value:      item["value"].(string),
+			}
+
+			assertions = append(assertions, &variable)
+		}
+
+		step.Assertions = assertions
+	}
+
+	if attr, ok := d.GetOk("headers"); ok {
+		step.Headers = make(map[string][]string)
+		items := attr.([]interface{})
+		for _, x := range items {
+			item := x.(map[string]interface{})
+			header := item["header"].(string)
+			step.Headers[header] = append(step.Headers[header], item["value"].(string))
+		}
+	}
+
+	return step, bucketId, testId, nil
+}
+
+func readVariables(variables []*runscope.Variable) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(variables))
+	for _, integration := range variables {
+
+		item := map[string]interface{}{
+			"name":     integration.Name,
+			"source":   integration.Source,
+			"property": integration.Property,
+		}
+
+		result = append(result, item)
+	}
+
+	return result
+}
+
+func readAssertions(assertions []*runscope.Assertion) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(assertions))
+	for _, assertion := range assertions {
+
+		item := map[string]interface{}{
+			"source":     assertion.Source,
+			"property":   assertion.Property,
+			"comparison": assertion.Comparison,
+			"value":      assertion.Value,
+		}
+
+		result = append(result, item)
+	}
+
+	return result
+}
+
+func readHeaders(headers map[string][]string) []map[string]interface{} {
+	result := make([]map[string]interface{}, len(headers))
+	for key, header := range headers {
+		result = append(result, map[string]interface{}{
+			"header": key,
+			"value":  header,
+		})
+	}
+
+	return result
+}

--- a/builtin/providers/runscope/resource_runscope_step_test.go
+++ b/builtin/providers/runscope/resource_runscope_step_test.go
@@ -1,0 +1,182 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccStep_basic(t *testing.T) {
+	teamId := os.Getenv("RUNSCOPE_TEAM_ID")
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckStepDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testRunscopeStepConfigA, teamId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckStepExists("runscope_step.main_page"),
+					resource.TestCheckResourceAttr(
+						"runscope_step.main_page", "url", "http://example.com")),
+			},
+		},
+	})
+}
+
+func testAccCheckStepDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*runscope.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "runscope_step" {
+			continue
+		}
+
+		var err error
+		bucketId := rs.Primary.Attributes["bucket_id"]
+		testId := rs.Primary.Attributes["test_id"]
+		err = client.DeleteTestStep(&runscope.TestStep{ID: rs.Primary.ID}, bucketId, testId)
+
+		if err == nil {
+			return fmt.Errorf("Record %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckStepExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*runscope.Client)
+
+		var foundRecord *runscope.TestStep
+		var err error
+
+		step := new(runscope.TestStep)
+		step.ID = rs.Primary.ID
+		bucketId := rs.Primary.Attributes["bucket_id"]
+		testId := rs.Primary.Attributes["test_id"]
+
+		foundRecord, err = client.ReadTestStep(step, bucketId, testId)
+
+		if err != nil {
+			return err
+		}
+
+		if foundRecord.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		if len(foundRecord.Variables) != 2 {
+			return fmt.Errorf("Expected %d variables, actual %d", 2, len(foundRecord.Variables))
+		}
+
+		variable := foundRecord.Variables[1]
+		if variable.Name != "httpContentEncoding" {
+			return fmt.Errorf("Expected %s variables, actual %s", "httpContentEncoding", variable.Name)
+		}
+
+		if len(foundRecord.Assertions) != 2 {
+			return fmt.Errorf("Expected %d assertions, actual %d", 2, len(foundRecord.Assertions))
+		}
+
+		assertion := foundRecord.Assertions[1]
+		if assertion.Source != "response_json" {
+			return fmt.Errorf("Expected assertion source %s, actual %s",
+				"response_json", assertion.Source)
+		}
+
+		if len(foundRecord.Headers) != 2 {
+			return fmt.Errorf("Expected %d headers, actual %d", 1, len(foundRecord.Headers))
+		}
+
+		if header, ok := foundRecord.Headers["Accept-Encoding"]; ok {
+			if len(header) != 2 {
+				return fmt.Errorf("Expected %d values for header %s, actual %d",
+					2, "Accept-Encoding", len(header))
+
+			}
+
+			if header[1] != "application/xml" {
+				return fmt.Errorf("Expected header value %s, actual %s",
+					"application/xml", header[1])
+			}
+		} else {
+			return fmt.Errorf("Expected header %s to exist", "Accept-Encoding")
+		}
+
+		return nil
+	}
+}
+
+const testRunscopeStepConfigA = `
+resource "runscope_step" "main_page" {
+  bucket_id      = "${runscope_bucket.bucket.id}"
+  test_id        = "${runscope_test.test.id}"
+  step_type      = "request"
+  url            = "http://example.com"
+  method         = "GET"
+  variables      = [
+  	{
+  	   name     = "httpStatus"
+  	   source   = "response_status"
+  	},
+  	{
+  	   name     = "httpContentEncoding"
+  	   source   = "response_header"
+  	   property = "Content-Encoding"
+  	},
+  ]
+  assertions     = [
+  	{
+  	   source     = "response_status"
+           comparison = "equal_number"
+           value      = "200"
+  	},
+  	{
+  	   source     = "response_json"
+           comparison = "equal"
+           value      = "c5baeb4a-2379-478a-9cda-1b671de77cf9",
+           property   = "data.id"
+  	},
+  ],
+  headers        = [
+  	{
+  		header = "Accept-Encoding",
+  		value  = "application/json"
+  	},
+  	{
+  		header = "Accept-Encoding",
+  		value  = "application/xml"
+  	},
+  	{
+  		header = "Authorization",
+  		value  = "Bearer bb74fe7b-b9f2-48bd-9445-bdc60e1edc6a",
+	}
+  ]
+}
+
+resource "runscope_test" "test" {
+  bucket_id   = "${runscope_bucket.bucket.id}"
+  name        = "runscope test"
+  description = "This is a test test..."
+}
+
+resource "runscope_bucket" "bucket" {
+  name      = "terraform-provider-test"
+  team_uuid = "%s"
+}
+`

--- a/builtin/providers/runscope/resource_runscope_test_item.go
+++ b/builtin/providers/runscope/resource_runscope_test_item.go
@@ -1,0 +1,142 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/schema"
+	"log"
+	"strings"
+)
+
+func resourceRunscopeTest() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceTestCreate,
+		Read:   resourceTestRead,
+		Update: resourceTestUpdate,
+		Delete: resourceTestDelete,
+
+		Schema: map[string]*schema.Schema{
+			"bucket_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"description": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: false,
+			},
+			"default_environment_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceTestCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	name := d.Get("name").(string)
+	log.Printf("[INFO] Creating test with name: %s", name)
+
+	test, err := createTestFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Failed to create test: %s", err)
+	}
+
+	log.Printf("[DEBUG] test create: %#v", test)
+
+	createdTest, err := client.CreateTest(test)
+	if err != nil {
+		return fmt.Errorf("Failed to create test: %s", err)
+	}
+
+	d.SetId(createdTest.ID)
+	log.Printf("[INFO] test ID: %s", d.Id())
+
+	return resourceTestRead(d, meta)
+}
+
+func resourceTestRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	testFromResource, err := createTestFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Error reading test: %s", err)
+	}
+
+	test, err := client.ReadTest(testFromResource)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			d.SetId("")
+			return nil
+		}
+
+		return fmt.Errorf("Couldn't find test: %s", err)
+	}
+
+	d.Set("name", test.Name)
+	d.Set("description", test.Description)
+	d.Set("default_environment_id", test.DefaultEnvironmentID)
+	return nil
+}
+
+func resourceTestUpdate(d *schema.ResourceData, meta interface{}) error {
+	d.Partial(false)
+	testFromResource, err := createTestFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Error updating test: %s", err)
+	}
+
+	if d.HasChange("description") {
+		client := meta.(*runscope.Client)
+		_, err = client.UpdateTest(testFromResource)
+
+		if err != nil {
+			return fmt.Errorf("Error updating test: %s", err)
+		}
+	}
+
+	return nil
+}
+
+func resourceTestDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*runscope.Client)
+
+	test, err := createTestFromResourceData(d)
+	if err != nil {
+		return fmt.Errorf("Error deleting test: %s", err)
+	}
+	log.Printf("[INFO] Deleting test with id: %s name: %s", test.ID, test.Name)
+
+	if err := client.DeleteTest(test); err != nil {
+		return fmt.Errorf("Error deleting test: %s", err)
+	}
+
+	return nil
+}
+
+func createTestFromResourceData(d *schema.ResourceData) (*runscope.Test, error) {
+
+	test := runscope.NewTest()
+	test.ID = d.Id()
+	if attr, ok := d.GetOk("bucket_id"); ok {
+		test.Bucket.Key = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("name"); ok {
+		test.Name = attr.(string)
+	}
+
+	if attr, ok := d.GetOk("description"); ok {
+		test.Description = attr.(string)
+	}
+
+	return test, nil
+}

--- a/builtin/providers/runscope/resource_runscope_test_item_test.go
+++ b/builtin/providers/runscope/resource_runscope_test_item_test.go
@@ -1,0 +1,94 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/ewilde/go-runscope"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"os"
+	"testing"
+)
+
+func TestAccTest_basic(t *testing.T) {
+	var test runscope.Test
+	teamId := os.Getenv("RUNSCOPE_TEAM_ID")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckTestDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testRunscopeTestConfigA, teamId),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckTestExists("runscope_test.test", &test),
+					resource.TestCheckResourceAttr(
+						"runscope_test.test", "name", "runscope test"),
+					resource.TestCheckResourceAttr(
+						"runscope_test.test", "description", "This is a test test..."),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckTestDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*runscope.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "runscope_test" {
+			continue
+		}
+
+		_, err := client.ReadTest(&runscope.Test{ID: rs.Primary.ID, Bucket: &runscope.Bucket{Key: rs.Primary.Attributes["bucket_id"]}})
+
+		if err == nil {
+			return fmt.Errorf("Record %s still exists", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}
+
+func testAccCheckTestExists(n string, test *runscope.Test) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No Record ID is set")
+		}
+
+		client := testAccProvider.Meta().(*runscope.Client)
+
+		foundRecord, err := client.ReadTest(&runscope.Test{ID: rs.Primary.ID, Bucket: &runscope.Bucket{Key: rs.Primary.Attributes["bucket_id"]}})
+
+		if err != nil {
+			return err
+		}
+
+		if foundRecord.ID != rs.Primary.ID {
+			return fmt.Errorf("Record not found")
+		}
+
+		test = foundRecord
+
+		return nil
+	}
+}
+
+const testRunscopeTestConfigA = `
+resource "runscope_test" "test" {
+  bucket_id = "${runscope_bucket.bucket.id}"
+  name = "runscope test"
+  description = "This is a test test..."
+}
+
+resource "runscope_bucket" "bucket" {
+  name = "terraform-provider-test"
+  team_uuid = "%s"
+}
+`

--- a/builtin/providers/runscope/schema.go
+++ b/builtin/providers/runscope/schema.go
@@ -1,0 +1,24 @@
+package runscope
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func validateValueFunc(values []string) schema.SchemaValidateFunc {
+	return func(v interface{}, k string) (we []string, errors []error) {
+		value := v.(string)
+		valid := false
+		for _, val := range values {
+			if value == val {
+				valid = true
+				break
+			}
+		}
+
+		if !valid {
+			errors = append(errors, fmt.Errorf("%#v is an invalid value for argument %s. Must be one of %#v", value, k, values))
+		}
+		return
+	}
+}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -62,6 +62,7 @@ import (
 	rancherprovider "github.com/hashicorp/terraform/builtin/providers/rancher"
 	randomprovider "github.com/hashicorp/terraform/builtin/providers/random"
 	rundeckprovider "github.com/hashicorp/terraform/builtin/providers/rundeck"
+	runscopeprovider "github.com/hashicorp/terraform/builtin/providers/runscope"
 	scalewayprovider "github.com/hashicorp/terraform/builtin/providers/scaleway"
 	softlayerprovider "github.com/hashicorp/terraform/builtin/providers/softlayer"
 	spotinstprovider "github.com/hashicorp/terraform/builtin/providers/spotinst"
@@ -146,6 +147,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"rancher":      rancherprovider.Provider,
 	"random":       randomprovider.Provider,
 	"rundeck":      rundeckprovider.Provider,
+	"runscope":     runscopeprovider.Provider,
 	"scaleway":     scalewayprovider.Provider,
 	"softlayer":    softlayerprovider.Provider,
 	"spotinst":     spotinstprovider.Provider,

--- a/vendor/github.com/ewilde/go-runscope/LICENSE
+++ b/vendor/github.com/ewilde/go-runscope/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/vendor/github.com/ewilde/go-runscope/Makefile
+++ b/vendor/github.com/ewilde/go-runscope/Makefile
@@ -1,0 +1,20 @@
+SOURCEDIR=.
+SOURCES = $(shell find $(SOURCEDIR) -name '*.go')
+VERSION=$(git describe --always --tags)
+BINARY=bin/runscope
+
+bin: $(BINARY)
+
+$(BINARY): $(SOURCES)
+	go build -o $(BINARY) command/*
+
+.PHONY: build
+build:
+	go get github.com/golang/lint/golint
+	go test $(go list ./... | grep -v /vendor/)
+	go vet $(go list ./... | grep -v /vendor/)
+	golint $(go list ./... | grep -v /vendor/)
+
+.PHONY: test
+test:
+	go test ./...

--- a/vendor/github.com/ewilde/go-runscope/README.md
+++ b/vendor/github.com/ewilde/go-runscope/README.md
@@ -1,0 +1,203 @@
+[![Build Status](https://travis-ci.org/ewilde/go-runscope.svg?branch=master)](https://travis-ci.org/ewilde/go-runscope)
+
+# go-runscope
+go-runscope is a [go](https://golang.org/) client library for the
+[runscope api](https://www.runscope.com/docs/api)
+
+## Installation
+
+```
+go get github.com/ewilde/go-runscope
+```
+
+## Usage
+```go
+package main
+
+import (
+    "fmt"
+    "github.com/ewilde/go-runscope"
+)
+
+func createBucket() {
+    var accessToken = "{your token}"  // See https://www.runscope.com/applications
+    var teamUUID = "{your team uuid}" // See https://www.runscope.com/teams
+    var client = runscope.NewClient(runscope.APIURL, accessToken)
+    var bucket = &runscope.Bucket{
+        Name: "My first bucket",
+        Team: &runscope.Team{
+            ID: teamUUID,
+        },
+    }
+
+    bucket, err := client.CreateBucket(bucket)
+    if err != nil {
+        log.Printf("[ERROR] error creating bucket: %s", err)
+    }
+}
+```
+
+### All Resources and Actions
+Complete examples can be found in the [examples folder](examples) or
+in the unit tests
+
+#### Bucket
+```go
+Client.CreateBucket(bucket *Bucket) (*Bucket, error)
+...
+    var bucket = &runscope.Bucket{
+        Name: "My first bucket",
+        Team: &runscope.Team{
+            ID: teamUUID,
+        },
+    }
+	bucket, err := client.CreateBucket(&{Bucket{Name: "test", Team}})
+```
+
+
+```go
+Client.ReadBucket(key string) (*Bucket, error)
+...
+    bucket, err := client.ReadBucket("htqee6p4dhvc")
+    if err != nil {
+        log.Printf("[ERROR] error creating bucket: %s", err)
+    }
+
+    fmt.Printf("Bucket read successfully: %s", bucket.String())
+```
+
+
+```go
+Client.DeleteBucket(key string)
+...
+    err := client.DeleteBucket("htqee6p4dhvc")
+    if err != nil {
+        log.Printf("[ERROR] error creating bucket: %s", err)
+    }
+```
+
+#### Environment
+```go
+Client.CreateSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error)
+...
+environment := &runscope.Environment{
+		Name: "tf_environment",
+		InitialVariables: map[string]string{
+			"VarA" : "ValB",
+			"VarB" : "ValB",
+		},
+		Integrations: []*runscope.Integration {
+			{
+				ID:              "27e48b0d-ba8e-4fe0-bcaa-dd9de08dc47d",
+				IntegrationType: "pagerduty",
+			},
+			{
+				ID:              "574f4560-0f50-41da-a2f7-bdce419ad378",
+				IntegrationType: "slack",
+			},
+		},
+	}
+
+environment, err := client.CreateSharedEnvironment(environment, createBucket())
+if err != nil {
+    log.Printf("[ERROR] error creating environment: %s", err)
+}
+```
+
+```go
+Client.ReadSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error)
+
+Client.ReadTestEnvironment(environment *Environment, test *Test) (*Environment, error)
+
+Client.UpdateSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error)
+
+Client.UpdateTestEnvironment(environment *Environment, test *Test) (*Environment, error)
+```
+#### Test
+```go
+Client.CreateTest(test *Test) (*Test, error) (*Environment, error)
+...
+    test := &Test{ Name: "tf_test", Description: "This is a tf new test", Bucket: bucket }
+	test, err = client.CreateTest(newTest)
+	defer client.DeleteTest(newTest)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+Client.ReadTest(test *Test) (*Test, error)
+
+Client.UpdateTest(test *Test) (*Test, error)
+
+Client.DeleteTest(test *Test) error
+```
+#### Test step
+```go
+Client.CreateTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error)
+...
+    step := NewTestStep()
+    step.StepType = "request"
+    step.URL = "http://example.com"
+    step.Method = "GET"
+    step.Assertions = [] Assertion {{
+        Source: "response_status",
+        Comparison : "equal_number",
+        Value: 200,
+    }}
+
+    step, err = client.CreateTestStep(step, bucket.Key, test.ID)
+    if err != nil {
+        t.Error(err)
+    }
+
+Client.ReadTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error)
+
+Client.UpdateTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error)
+
+Client.DeleteTestStep(testStep *TestStep, bucketKey string, testID string) error
+```
+#### Schedule
+```go
+Client.CreateSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error)
+...
+    schedule := NewSchedule()
+    schedule.Note = "Daily schedule"
+    schedule.Interval = "1d"
+    schedule.EnvironmentID = environment.ID
+
+    schedule, err = client.CreateSchedule(schedule, bucket.Key, test.ID)
+    if err != nil {
+        t.Error(err)
+    }
+
+Client.ReadSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error)
+
+Client.UpdateSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error)
+
+Client.DeleteSchedule(schedule *Schedule, bucketKey string, testID string) error
+```
+## Developing
+### Running the tests
+By default the tests requiring access to the runscope api (most of them)
+will be skipped. To run the integration tests please set the following
+environment variables
+
+```bash
+RUNSCOPE_ACC=true
+RUNSCOPE_ACCESS_TOKEN={your access token}
+RUNSCOPE_TEAM_UUID={your team uuid}
+```
+Access tokens can be created using the [applications](https://www.runscope.com/applications)
+section of your runscope account.
+
+Your team url can be found by taking the uuid from https://www.runscope.com/teams
+
+## Contributing
+
+1. Fork it ( https://github.com/ewilde/go-runscope/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Make sure that `make build` passes with test running
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request
+

--- a/vendor/github.com/ewilde/go-runscope/bucket.go
+++ b/vendor/github.com/ewilde/go-runscope/bucket.go
@@ -1,0 +1,99 @@
+/*
+Package runscope implements a client library for the runscope api (https://www.runscope.com/docs/api)
+
+ */
+package runscope
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/url"
+)
+
+// Bucket resources are a simple way to organize your requests and tests. See https://www.runscope.com/docs/api/buckets and https://www.runscope.com/docs/buckets
+type Bucket struct {
+	Name           string  `json:"name,omitempty"`
+	Key            string  `json:"key,omitempty"`
+	Default        bool    `json:"default,omitempty"`
+	AuthToken      string  `json:"auth_token,omitempty"`
+	TestsURL       string  `json:"tests_url,omitempty" mapstructure:"tests_url"`
+	CollectionsURL string  `json:"collections_url,omitempty"`
+	MessagesURL    string  `json:"messages_url,omitempty"`
+	TriggerURL     string  `json:"trigger_url,omitempty"`
+	VerifySsl      bool    `json:"verify_ssl,omitempty"`
+	Team           *Team   `json:"team,omitempty"`
+}
+
+// CreateBucket creates a new bucket resource. See https://www.runscope.com/docs/api/buckets#bucket-create
+func (client *Client) CreateBucket(bucket *Bucket) (*Bucket, error) {
+	log.Printf("[DEBUG] creating bucket %s", bucket.Name)
+	data := url.Values{}
+	data.Add("name", bucket.Name)
+	data.Add("team_uuid", bucket.Team.ID)
+
+	log.Printf("[DEBUG] 	request: POST %s %#v", "/buckets", data)
+
+	req, err := client.newFormURLEncodedRequest("POST", "/buckets", data)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] %#v", req)
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+	log.Printf("[DEBUG] 	response: %d %s", resp.StatusCode, bodyString)
+
+	if resp.StatusCode >= 300 {
+		errorResp := new(errorResponse)
+		if err = json.Unmarshal(bodyBytes, &errorResp); err != nil {
+			return nil, fmt.Errorf("Error creating bucket: %s", bucket.Name)
+		}
+
+		return nil, fmt.Errorf("Error creating bucket: %s, status: %d reason: %q", bucket.Name,
+			errorResp.Status, errorResp.ErrorMessage)
+
+	}
+
+	response := new(response)
+	json.Unmarshal(bodyBytes, &response)
+	return getBucketFromResponse(response.Data)
+}
+
+// ReadBucket list details about an existing bucket resource. See https://www.runscope.com/docs/api/buckets#bucket-list
+func (client *Client) ReadBucket(key string) (*Bucket, error) {
+	resource, error := client.readResource("bucket", key, fmt.Sprintf("/buckets/%s", key))
+	if error != nil {
+		return nil, error
+	}
+
+	bucket, error := getBucketFromResponse(resource.Data)
+	return bucket, error
+}
+
+// DeleteBucket deletes a bucket by key. See https://www.runscope.com/docs/api/buckets#bucket-delete
+func (client *Client) DeleteBucket(key string) error {
+	return client.deleteResource("bucket", key, fmt.Sprintf("/buckets/%s", key))
+}
+
+func (bucket *Bucket) String() string {
+	value, err := json.Marshal(bucket)
+	if err != nil {
+		return ""
+	}
+
+	return string(value)
+}
+
+func getBucketFromResponse(response interface{}) (*Bucket, error) {
+	bucket := new(Bucket)
+	err := decode(bucket, response)
+	return bucket, err
+}

--- a/vendor/github.com/ewilde/go-runscope/client.go
+++ b/vendor/github.com/ewilde/go-runscope/client.go
@@ -1,0 +1,256 @@
+package runscope
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"io/ioutil"
+	"log"
+	"strings"
+)
+
+// APIURL is the default runscope api uri
+const APIURL = "https://api.runscope.com"
+
+// Client provides access to create, read, update and delete runscope resources
+type Client struct {
+	APIURL      string
+	AccessToken string
+	HTTP        *http.Client
+}
+
+// Team to which buckets belong to
+type Team struct {
+	Name string
+	ID   string
+}
+
+type response struct {
+	Meta  metaResponse           `json:"meta"`
+	Data  interface{}            `json:"data"`
+	Error errorResponse          `json:"error"`
+}
+
+type errorResponse struct {
+	Status       int    `json:"status"`
+	ErrorMessage string `json:"error"`
+}
+
+type metaResponse struct {
+	Status string `json:"status"`
+}
+
+// NewClient creates a new client instance
+func NewClient(apiURL string, accessToken string) *Client {
+	client := Client{
+		APIURL:      apiURL,
+		AccessToken: accessToken,
+		HTTP:        cleanhttp.DefaultClient(),
+	}
+
+	return &client
+}
+
+func (client *Client) createResource(
+	resource interface{}, resourceType string, resourceName string, endpoint string) (*response, error) {
+	log.Printf("[DEBUG] creating %s %s", resourceType, resourceName)
+
+	bytes, err := json.Marshal(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] 	request: POST %s %s", endpoint, string(bytes))
+
+	req, err := client.newRequest("POST", endpoint, bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+	log.Printf("[DEBUG] 	response: %d %s", resp.StatusCode, bodyString)
+
+	if resp.StatusCode >= 300 {
+		errorResp := new(errorResponse)
+		if err = json.Unmarshal(bodyBytes, &errorResp); err != nil {
+			return nil, fmt.Errorf("Error creating %s: %s", resourceType, resourceName)
+		}
+
+		return nil, fmt.Errorf("Error creating %s: %s, status: %d reason: %q", resourceType,
+			resourceName, errorResp.Status, errorResp.ErrorMessage)
+	}
+
+	response := new(response)
+	json.Unmarshal(bodyBytes, &response)
+	return response, nil
+
+}
+
+func (client *Client) readResource(resourceType string, resourceName string, endpoint string) (*response, error) {
+	log.Printf("[DEBUG] reading %s %s", resourceType, resourceName)
+	response := new(response)
+
+	req, err := client.newRequest("GET", endpoint, nil)
+	if err != nil {
+		return response, err
+	}
+
+	log.Printf("[DEBUG] 	request: GET %s", endpoint)
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return response, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+	log.Printf("[DEBUG] 	response: %d %s", resp.StatusCode, bodyString)
+
+	if resp.StatusCode >= 300 {
+		errorResp := new(errorResponse)
+		if err = json.Unmarshal(bodyBytes, &errorResp); err != nil {
+			return response, fmt.Errorf("Status: %s Error reading %s: %s",
+				resp.Status, resourceType, resourceName)
+		}
+
+		return response, fmt.Errorf("Status: %s Error reading %s: %s, reason: %q",
+			resp.Status, resourceType, resourceName, errorResp.ErrorMessage)
+	}
+
+	json.Unmarshal(bodyBytes, &response)
+	return response, nil
+}
+
+func (client *Client) updateResource(resource interface{}, resourceType string, resourceName string, endpoint string) (*response, error) {
+	log.Printf("[DEBUG] updating %s %s", resourceType, resourceName)
+	response := response{}
+	bytes, err := json.Marshal(resource)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("[DEBUG] 	request: PUT %s %s", endpoint, string(bytes))
+	req, err := client.newRequest("PUT", endpoint, bytes)
+	if err != nil {
+		return &response, err
+	}
+
+	resp, err := client.HTTP.Do(req)
+	if err != nil {
+		return &response, err
+	}
+	defer resp.Body.Close()
+
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	bodyString := string(bodyBytes)
+	log.Printf("[DEBUG] 	response: %d %s", resp.StatusCode, bodyString)
+
+	if resp.StatusCode >= 300 {
+		errorResp := new(errorResponse)
+		if err = json.Unmarshal(bodyBytes, &errorResp); err != nil {
+			return &response, fmt.Errorf("Status: %s Error reading %s: %s",
+				resp.Status, resourceType, resourceName)
+		}
+
+		return &response, fmt.Errorf("Status: %s Error reading %s: %s, reason: %q",
+			resp.Status, resourceType, resourceName, errorResp.ErrorMessage)
+	}
+
+	json.Unmarshal(bodyBytes, &response)
+	return &response, nil
+}
+
+func (client *Client) deleteResource(resourceType string, resourceName string, endpoint string) (error) {
+	log.Printf("[DEBUG] deleting %s %s", resourceType, resourceName)
+	req, err := client.newRequest("DELETE", endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] 	request: DELETE %s", endpoint)
+	resp, err := client.HTTP.Do(req)
+	log.Printf("[DEBUG] 	response: %d", resp.StatusCode)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		bodyBytes, _ := ioutil.ReadAll(resp.Body)
+		bodyString := string(bodyBytes)
+		log.Printf("[DEBUG] %s", bodyString)
+
+		errorResp := new(errorResponse)
+		if err = json.Unmarshal(bodyBytes, &errorResp); err != nil {
+			return fmt.Errorf("Status: %s Error deleting %s: %s",
+				resp.Status, resourceType, resourceName)
+		}
+
+		return fmt.Errorf("Status: %s Error deleting %s: %s, reason: %q",
+			resp.Status, resourceType, resourceName, errorResp.ErrorMessage)
+	}
+
+	return nil
+}
+
+func (client *Client) newFormURLEncodedRequest(method string, endpoint string, data url.Values) (*http.Request, error) {
+
+	var urlStr string
+	urlStr = client.APIURL + endpoint
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("Error during parsing request URL: %s", err)
+	}
+
+	req, err := http.NewRequest(method, url.String(), strings.NewReader(data.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("Error during creation of request: %s", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", client.AccessToken))
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	return req, nil
+}
+
+func (client *Client) newRequest(method string, endpoint string, body []byte) (*http.Request, error) {
+
+	var urlStr string
+	urlStr = client.APIURL + endpoint
+	url, err := url.Parse(urlStr)
+	if err != nil {
+		return nil, fmt.Errorf("Error during parsing request URL: %s", err)
+	}
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, url.String(), bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("Error during creation of request: %s", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", client.AccessToken))
+	req.Header.Add("Accept", "application/json")
+
+	if method != "GET" {
+		req.Header.Add("Content-Type", "application/json")
+	}
+
+	return req, nil
+}

--- a/vendor/github.com/ewilde/go-runscope/decode.go
+++ b/vendor/github.com/ewilde/go-runscope/decode.go
@@ -1,0 +1,45 @@
+package runscope
+
+import (
+	"reflect"
+	"time"
+	"github.com/mitchellh/mapstructure"
+)
+
+func floatToTimeDurationHookFunc() mapstructure.DecodeHookFunc {
+	return func(
+		f reflect.Type,
+		t reflect.Type,
+		data interface{}) (interface{}, error) {
+		if f.Kind() != reflect.Float64 {
+			return data, nil
+		}
+
+		if t != reflect.TypeOf(time.Now()) {
+			return data, nil
+		}
+
+		// Convert it by parsing
+		rawValue := data.(float64)
+		seconds := int64(rawValue)
+		nanoSeconds := int64((rawValue - float64(int64(rawValue)))*1e9)
+		return time.Unix(seconds, nanoSeconds), nil
+	}
+}
+
+func decode(result interface{}, response interface{}) error {
+
+	config := &mapstructure.DecoderConfig{
+		Metadata: nil,
+		Result:   result,
+		TagName:  "json",
+		DecodeHook: floatToTimeDurationHookFunc(),
+	}
+	decoder, err := mapstructure.NewDecoder(config)
+	if err != nil {
+		panic(err)
+	}
+
+	err = decoder.Decode(response)
+	return err
+}

--- a/vendor/github.com/ewilde/go-runscope/environment.go
+++ b/vendor/github.com/ewilde/go-runscope/environment.go
@@ -1,0 +1,157 @@
+package runscope
+
+import (
+	"time"
+	"fmt"
+	"encoding/json"
+)
+
+// Environment stores details for shared and test-specific environments. See https://www.runscope.com/docs/api/environments
+type Environment struct {
+	ID                  string                    `json:"id,omitempty"`
+	Name                string                    `json:"name,omitempty"`
+	Script              string                    `json:"script,omitempty"`
+	PreserveCookies     bool                      `json:"preserve_cookies,omitempty"`
+	TestID              string                    `json:"test_id,omitempty"`
+	InitialVariables    map[string]string         `json:"initial_variables,omitempty"`
+	Integrations        []*EnvironmentIntegration `json:"integrations,omitempty"`
+	Regions             []string                  `json:"regions,omitempty"`
+	VerifySsl           bool                      `json:"verify_ssl,omitempty"`
+	ExportedAt          *time.Time                `json:"exported_at,omitempty"`
+	RetryOnFailure      bool                      `json:"retry_on_failure,omitempty"`
+	RemoteAgents        []*LocalMachine           `json:"remote_agents,omitempty"`
+	WebHooks            []string                  `json:"webhooks,omitempty"`
+	ParentEnvironmentID string                    `json:"parent_environment_id,omitempty"`
+	EmailSettings       *EmailSettings            `json:"emails,omitempty"`
+	ClientCertificate   string                    `json:"client_certificate,omitempty"`
+}
+
+// EmailSettings determining how test failures trigger notifications
+type EmailSettings struct {
+	NotifyAll       bool       `json:"notify_all,omitempty"`
+	NotifyOn        string     `json:"notify_on,omitempty"`
+	NotifyThreshold int        `json:"notify_threshold,omitempty"`
+	Recipients      []*Contact `json:"recipients,omitempty"`
+}
+
+// EnvironmentIntegration represents an integration with a third-party. See https://www.runscope.com/docs/api/integrations
+type EnvironmentIntegration struct {
+	ID              string `json:"id"`
+	IntegrationType string `json:"integration_type"`
+	Description     string `json:"description,omitempty"`
+}
+
+// LocalMachine used in an environment to represent a remote agent
+type LocalMachine struct {
+	Name string `json:"name"`
+	UUID string `json:"uuid"`
+}
+
+// NewEnvironment creates a new environment
+func NewEnvironment() *Environment {
+	return new(Environment)
+}
+
+// CreateSharedEnvironment creates a new shared environment. See https://www.runscope.com/docs/api/environments#create-shared
+func (client *Client) CreateSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error) {
+	return client.createEnvironment(environment, fmt.Sprintf("/buckets/%s/environments", bucket.Key))
+}
+
+// CreateTestEnvironment creates a new test environment. See https://www.runscope.com/docs/api/environments#create
+func (client *Client) CreateTestEnvironment(environment *Environment, test *Test) (*Environment, error) {
+	return client.createEnvironment(environment, fmt.Sprintf("/buckets/%s/tests/%s/environments",
+		test.Bucket.Key, test.ID))
+}
+
+// ReadSharedEnvironment lists details about an existing shared environment. See https://www.runscope.com/docs/api/environments#detail
+func (client *Client) ReadSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error) {
+	return client.readEnvironment(environment, fmt.Sprintf("/buckets/%s/environments/%s",
+		bucket.Key, environment.ID))
+}
+
+// ReadTestEnvironment lists details about an existing test environment. See https://www.runscope.com/docs/api/environments#detail
+func (client *Client) ReadTestEnvironment(environment *Environment, test *Test) (*Environment, error) {
+	return client.readEnvironment(environment, fmt.Sprintf("/buckets/%s/tests/%s/environments/%s",
+		test.Bucket.Key, test.ID, environment.ID))
+}
+
+// UpdateSharedEnvironment updates details about an existing shared environment. See https://www.runscope.com/docs/api/environments#modify
+func (client *Client) UpdateSharedEnvironment(environment *Environment, bucket *Bucket) (*Environment, error) {
+	return client.updateEnvironment(environment,
+		fmt.Sprintf("/buckets/%s/Environments/%s", bucket.Key, environment.ID))
+}
+
+// UpdateTestEnvironment updates details about an existing test environment. See https://www.runscope.com/docs/api/environments#modify
+func (client *Client) UpdateTestEnvironment(environment *Environment, test *Test) (*Environment, error) {
+	return client.updateEnvironment(environment,
+		fmt.Sprintf("/buckets/%s/tests/%s/environments/%s", test.Bucket.Key, test.ID, environment.ID))
+}
+
+// DeleteSharedEnvironment deletes an existing shared environment. https://www.runscope.com/docs/api/environments#delete
+func (client *Client) DeleteSharedEnvironment(environment *Environment, bucket *Bucket) error {
+	return client.deleteResource("environment", environment.ID,
+		fmt.Sprintf("/buckets/%s/environments/%s", bucket.Key, environment.ID))
+}
+
+// DeleteTestEnvironment deletes an existing test environment. https://www.runscope.com/docs/api/environments#delete
+func (client *Client) DeleteTestEnvironment(environment *Environment, test *Test) error {
+	return client.deleteResource("environment", environment.ID,
+		fmt.Sprintf("/buckets/%s/environments/%s/tests/%s", test.Bucket.Key, test.ID, environment.ID))
+}
+
+func (environment *Environment) String() string {
+	value, err := json.Marshal(environment)
+	if err != nil {
+		return ""
+	}
+
+	return string(value)
+}
+
+func (client *Client) createEnvironment(environment *Environment, endpoint string) (*Environment, error) {
+	newResource, error := client.createResource(environment, "environment", environment.Name, endpoint)
+	if error != nil {
+		return nil, error
+	}
+
+	newEnvironment, error := getEnvironmentFromResponse(newResource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return newEnvironment, nil
+}
+
+func (client *Client) readEnvironment(environment *Environment, endpoint string) (*Environment, error) {
+	resource, error := client.readResource("environment", environment.ID, endpoint)
+	if error != nil {
+		return nil, error
+	}
+
+	readEnvironment, error := getEnvironmentFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return readEnvironment, nil
+}
+
+func (client *Client) updateEnvironment(environment *Environment, endpoint string) (*Environment, error) {
+	resource, error := client.updateResource(environment,"environment", environment.ID, endpoint)
+	if error != nil {
+		return nil, error
+	}
+
+	updatedEnvironment, error := getEnvironmentFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return updatedEnvironment, nil
+}
+
+func getEnvironmentFromResponse(response interface{}) (*Environment, error) {
+	environment := new(Environment)
+	err := decode(environment, response)
+	return environment, err
+}

--- a/vendor/github.com/ewilde/go-runscope/schedule.go
+++ b/vendor/github.com/ewilde/go-runscope/schedule.go
@@ -1,0 +1,76 @@
+package runscope
+
+import "fmt"
+
+// Schedule determines how often a test is executed. See https://www.runscope.com/docs/api/schedules
+type Schedule struct {
+	ID            string `json:"id,omitempty"`
+	EnvironmentID string `json:"environment_id,omitempty"`
+	Interval      string `json:"interval,omitempty"`
+	Note          string `json:"note,omitempty"`
+}
+
+// NewSchedule creates a new schedule struct
+func NewSchedule() *Schedule {
+	return &Schedule {}
+}
+
+// CreateSchedule creates a new test schedule. See https://www.runscope.com/docs/api/schedules#create
+func (client *Client) CreateSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error) {
+	newResource, error := client.createResource(schedule, "schedule", schedule.Note,
+		fmt.Sprintf("/buckets/%s/tests/%s/schedules", bucketKey, testID))
+	if error != nil {
+		return nil, error
+	}
+
+	newSchedule, error := getScheduleFromResponse(newResource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return newSchedule, nil
+}
+
+// ReadSchedule list details about an existing test schedule. See https://www.runscope.com/docs/api/schedules#detail
+func (client *Client) ReadSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error) {
+	resource, error := client.readResource("schedule", schedule.ID,
+		fmt.Sprintf("/buckets/%s/tests/%s/schedules/%s", bucketKey, testID, schedule.ID))
+	if error != nil {
+		return nil, error
+	}
+
+	readSchedule, error := getScheduleFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return readSchedule, nil
+}
+
+// UpdateSchedule updates an existing test schedule. See https://www.runscope.com/docs/api/schedules#modify
+func (client *Client) UpdateSchedule(schedule *Schedule, bucketKey string, testID string) (*Schedule, error) {
+	resource, error := client.updateResource(schedule, "schedule", schedule.ID,
+		fmt.Sprintf("/buckets/%s/tests/%s/schedules/%s", bucketKey, testID, schedule.ID))
+	if error != nil {
+		return nil, error
+	}
+
+	readSchedule, error := getScheduleFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return readSchedule, nil
+}
+
+// DeleteSchedule delete an existing test schedule. See https://www.runscope.com/docs/api/schedules#delete
+func (client *Client) DeleteSchedule(schedule *Schedule, bucketKey string, testID string) error {
+	return client.deleteResource("schedule", schedule.ID,
+		fmt.Sprintf("/buckets/%s/tests/%s/schedules/%s", bucketKey, testID, schedule.ID))
+}
+
+func getScheduleFromResponse(response interface{}) (*Schedule, error) {
+	schedule := new(Schedule)
+	err := decode(schedule, response)
+	return schedule, err
+}

--- a/vendor/github.com/ewilde/go-runscope/team.go
+++ b/vendor/github.com/ewilde/go-runscope/team.go
@@ -1,0 +1,80 @@
+package runscope
+
+import (
+	"fmt"
+	"time"
+)
+
+
+// Integration represents an integration with a third-party. See https://www.runscope.com/docs/api/integrations
+type Integration struct {
+	ID              string `json:"id"`
+	UUID            string `json:"uuid"`
+	IntegrationType string `json:"type"`
+	Description     string `json:"description,omitempty"`
+}
+
+// People represents a person belonging to a team. See https://www.runscope.com/docs/api/teams
+type People struct {
+	ID		    string    `json:"id"`
+	UUID		string    `json:"uuid"`
+	Name		string    `json:"name"`
+	Email		string	  `json:"email"`
+	CreatedAt	time.Time `json:"created_at"`
+	LastLoginAt	time.Time `json:"last_login_at"`
+	GroupName	string    `json:"group_name"`
+}
+
+// ListIntegrations list all configured integrations for your team. See https://www.runscope.com/docs/api/integrations
+func (client *Client) ListIntegrations(teamID string) ([]*Integration, error) {
+	resource, error := client.readResource("integration", teamID,
+		fmt.Sprintf("/teams/%s/integrations", teamID))
+	if error != nil {
+		return nil, error
+	}
+
+	integration, error := getIntegrationFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return integration, nil
+}
+
+// ListPeople list all the people on your team. See https://www.runscope.com/docs/api/teams
+func (client *Client) ListPeople(teamID string) ([]*People, error) {
+	resource, error := client.readResource("people", teamID,
+		fmt.Sprintf("/teams/%s/people", teamID))
+	if error != nil {
+		return nil, error
+	}
+
+	people, error := getPeopleFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return people, nil
+}
+
+func choose(items []*Integration,test func(*Integration) bool) (result []*Integration) {
+	for _, item := range items {
+		if test(item) {
+			result = append(result, item)
+		}
+	}
+
+	return
+}
+
+func getIntegrationFromResponse(response interface{}) ([]*Integration, error) {
+	var integrations []*Integration
+	err := decode(&integrations, response)
+	return integrations, err
+}
+
+func getPeopleFromResponse(response interface{}) ([]*People, error) {
+	var people []*People
+	err := decode(&people, response)
+	return people, err
+}

--- a/vendor/github.com/ewilde/go-runscope/test.go
+++ b/vendor/github.com/ewilde/go-runscope/test.go
@@ -1,0 +1,186 @@
+package runscope
+
+import (
+	"fmt"
+	"time"
+	"encoding/json"
+)
+
+// Test represents the details for a runscope test. See https://www.runscope.com/docs/api/tests
+type Test struct {
+	ID                   string         `json:"id,omitempty"`
+	Bucket               *Bucket        `json:"-"`
+	Name                 string         `json:"name,omitempty"`
+	Description          string         `json:"description,omitempty"`
+	CreatedAt            *time.Time     `json:"created_at,omitempty"`
+	CreatedBy            *Contact       `json:"created_by,omitempty"`
+	DefaultEnvironmentID string         `json:"default_environment_id,omitempty"`
+	ExportedAt           *time.Time     `json:"exported_at,omitempty"`
+	Environments         []*Environment `json:"environments"`
+	LastRun              *TestRun       `json:"last_run"`
+	Steps                []*TestStep    `json:"steps"`
+}
+
+// TestRun represents the details of the last time the test ran
+type TestRun struct {
+	RemoteAgentUUID     string     `json:"remote_agent_uuid,omitempty"`
+	FinishedAt          *time.Time `json:"finished_at,omitempty"`
+	ErrorCount          int        `json:"error_count,omitempty"`
+	MessageSuccess      int        `json:"message_success,omitempty"`
+	TestUUID            string     `json:"test_uuid,omitempty"`
+	ID                  string     `json:"id,omitempty"`
+	ExtractorSuccess    int        `json:"extractor_success,omitempty"`
+	UUID                string     `json:"uuid,omitempty"`
+	EnvironmentUUID     string     `json:"environment_uuid,omitempty"`
+	EnvironmentName     string     `json:"environment_name,omitempty"`
+	Source              string     `json:"source,omitempty"`
+	RemoteAgentName     string     `json:"remote_agent_name,omitempty"`
+	RemoteAgent         string     `json:"remote_agent,omitempty"`
+	Status              string     `json:"status,omitempty"`
+	BucketKey           string     `json:"bucket_key,omitempty"`
+	RemoteAgentVersion  string     `json:"remote_agent_version,omitempty"`
+	SubstitutionSuccess int        `json:"substitution_success,omitempty"`
+	MessageCount        int        `json:"message_count,omitempty"`
+	ScriptCount         int        `json:"script_count,omitempty"`
+	SubstitutionCount   int        `json:"substitution_count,omitempty"`
+	ScriptSuccess       int        `json:"script_success,omitempty"`
+	AssertionCount      int        `json:"assertion_count,omitempty"`
+	AssertionSuccess    int        `json:"assertion_success,omitempty"`
+	CreatedAt           *time.Time `json:"created_at,omitempty"`
+	Messages            []string   `json:"messages,omitempty"`
+	ExtractorCount      int        `json:"extractor_count,omitempty"`
+	TemplateUUIDs       []string   `json:"template_uuids,omitempty"`
+	Region              string     `json:"region,omitempty"`
+}
+
+// TestStep represents each step that makes up part of the test. See https://www.runscope.com/docs/api/steps
+type TestStep struct {
+	URL        string                 `json:"url,omitempty"`
+	Variables  []*Variable            `json:"variables,omitempty"`
+	Args       map[string]interface{} `json:"args,omitempty"`
+	StepType   string                 `json:"step_type,omitempty"`
+	Auth       map[string]string      `json:"auth,omitempty"`
+	ID         string                 `json:"id,omitempty"`
+	Body       string                 `json:"body,omitempty"`
+	Note       string                 `json:"note,omitempty"`
+	Headers    map[string][]string    `json:"headers,omitempty"`
+	RequestID  string                 `json:"request_id,omitempty"`
+	Assertions []*Assertion           `json:"assertions,omitempty"`
+	Scripts    []*Script               `json:"scripts,omitempty"`
+	Method     string                 `json:"method,omitempty"`
+}
+
+// Variable allow you to extract data from request, subtest, and Ghost Inspector steps for use in subsequent steps in the test. Similar to Assertions, each variable is defined by a name, source, and property. See https://www.runscope.com/docs/api/steps#variables
+type Variable struct {
+	Name     string `json:"name,omitempty"`
+	Property string `json:"property,omitempty"`
+	Source   string `json:"source,omitempty"`
+}
+
+// Assertion allow you to specify success criteria for a given request, Ghost Inspector, subtest, or condition step. Each assertion is defined by a source, property, comparison, and value. See https://www.runscope.com/docs/api/steps#assertions
+type Assertion struct {
+	Comparison string      `json:"comparison,omitempty"`
+	Value      interface{} `json:"value,omitempty"`
+	Source     string      `json:"source,omitempty"`
+	Property   string      `json:"property,omitempty"`
+}
+
+// Script not sure how this is used, currently not documented, but looks like a javascript string that gets evaluated? See See https://www.runscope.com/docs/api/steps
+type Script struct {
+	Value string `json:"value"`
+}
+/*
+"request_id": "2dbfb5d2-3b5a-499c-9550-b06f9a475feb",
+"assertions": [
+{
+"comparison": "equal_number",
+"value": 200,
+"source": "response_status"
+}
+],
+"scripts": [],
+"before_scripts": [],
+"data": "",
+"method": "GET"
+*/
+
+// Contact details
+type Contact struct {
+	Email string     `json:"email,omitempty"`
+        ID    string     `json:"id"`
+        Name  string     `json:"name,omitempty"`
+}
+
+// NewTest creates a new test struct
+func NewTest() *Test {
+	return &Test { Bucket: &Bucket{}}
+}
+
+// CreateTest creates a new runscope test. See https://www.runscope.com/docs/api/tests#create
+func (client *Client) CreateTest(test *Test) (*Test, error) {
+	newResource, error := client.createResource(test, "test", test.Name,
+		fmt.Sprintf("/buckets/%s/tests", test.Bucket.Key))
+	if error != nil {
+		return nil, error
+	}
+
+	newTest, error := getTestFromResponse(newResource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	newTest.Bucket = test.Bucket
+	return newTest, nil
+}
+
+// ReadTest list details about an existing test. See https://www.runscope.com/docs/api/tests#detail
+func (client *Client) ReadTest(test *Test) (*Test, error) {
+	resource, error := client.readResource("test", test.ID, fmt.Sprintf("/buckets/%s/tests/%s", test.Bucket.Key, test.ID))
+	if error != nil {
+		return nil, error
+	}
+
+	readTest, error := getTestFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	readTest.Bucket = test.Bucket
+	return readTest, nil
+}
+
+// UpdateTest update an existing test. See https://www.runscope.com/docs/api/tests#modifying
+func (client *Client) UpdateTest(test *Test) (*Test, error) {
+	resource, error := client.updateResource(test, "test", test.ID, fmt.Sprintf("/buckets/%s/tests/%s", test.Bucket.Key, test.ID))
+	if error != nil {
+		return nil, error
+	}
+
+	readTest, error := getTestFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	readTest.Bucket = test.Bucket
+	return readTest, nil
+}
+
+// DeleteTest delete an existing test. See https://www.runscope.com/docs/api/tests#delete
+func (client *Client) DeleteTest(test *Test) error {
+	return client.deleteResource("test", test.ID, fmt.Sprintf("/buckets/%s/tests/%s", test.Bucket.Key, test.ID))
+}
+
+func (test *Test) String() string {
+	value, err := json.Marshal(test)
+	if err != nil {
+		return ""
+	}
+
+	return string(value)
+}
+
+func getTestFromResponse(response interface{}) (*Test, error) {
+	test := new(Test)
+	err := decode(test, response)
+	return test, err
+}

--- a/vendor/github.com/ewilde/go-runscope/test_step.go
+++ b/vendor/github.com/ewilde/go-runscope/test_step.go
@@ -1,0 +1,100 @@
+package runscope
+
+import (
+	"fmt"
+	"errors"
+)
+
+// NewTestStep creates a new test step struct
+func NewTestStep() *TestStep {
+	return &TestStep {}
+}
+
+// CreateTestStep creates a new runscope test step. See https://www.runscope.com/docs/api/steps#add
+func (client *Client) CreateTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error) {
+	if error := testStep.validate(); error != nil {
+		return nil, error
+	}
+
+	newResource, error := client.createResource(testStep, "test step", testStep.ID,
+		fmt.Sprintf("/buckets/%s/tests/%s/steps", bucketKey, testID))
+	if error != nil {
+		return nil, error
+	}
+
+	steps := newResource.Data.([]interface{})
+	step := steps[len(steps) - 1].(map[string]interface{})
+	newTestStep, error := getTestStepFromResponse(step)
+	if error != nil {
+		return nil, error
+	}
+
+	return newTestStep, nil
+}
+
+// ReadTestStep list details about an existing test step. https://www.runscope.com/docs/api/steps#detail
+func (client *Client) ReadTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error) {
+	resource, error := client.readResource("test step", testStep.ID,
+		fmt.Sprintf("/buckets/%s/tests/%s/steps/%s", bucketKey, testID, testStep.ID))
+	if error != nil {
+		return nil, error
+	}
+
+	readTestStep, error := getTestStepFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return readTestStep, nil
+}
+
+// UpdateTestStep updates an existing test step. https://www.runscope.com/docs/api/steps#modify
+func (client *Client) UpdateTestStep(testStep *TestStep, bucketKey string, testID string) (*TestStep, error) {
+	resource, error := client.updateResource(testStep, "test step", testStep.ID,
+		fmt.Sprintf("/buckets/%s/tests/%s/steps/%s", bucketKey, testID, testStep.ID))
+	if error != nil {
+		return nil, error
+	}
+
+	readTestStep, error := getTestStepFromResponse(resource.Data)
+	if error != nil {
+		return nil, error
+	}
+
+	return readTestStep, nil
+}
+
+// DeleteTestStep delete an existing test step. https://www.runscope.com/docs/api/steps#delete
+func (client *Client) DeleteTestStep(testStep *TestStep, bucketKey string, testID string) error {
+	return client.deleteResource("test step", testStep.ID,
+		fmt.Sprintf("/buckets/%s/tests/%s/steps/%s", bucketKey, testID, testStep.ID))
+}
+
+func getTestStepFromResponse(response interface{}) (*TestStep, error) {
+	testStep := new(TestStep)
+	err := decode(testStep, response)
+	return testStep, err
+}
+
+
+func (step *TestStep) validate() error {
+	if step.StepType == "request" {
+		if err := step.validateRequestType(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (step *TestStep) validateRequestType() error {
+	if step.Method == "" {
+		return errors.New("A request test step must specify 'Method' property")
+	}
+
+	if step.Method == "GET" && step.Body != "" {
+		return errors.New("A request test step that specifies a 'GET' method can not include a body property")
+	}
+
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1485,6 +1485,12 @@
 			"versionExact": "1.0.0"
 		},
 		{
+			"checksumSHA1": "qQ+YriXypz5mEiLL3wEKpzpC/IU=",
+			"path": "github.com/ewilde/go-runscope",
+			"revision": "1c4acc6628957c6402f929cdff2f2894ba207ef7",
+			"revisionTime": "2017-05-30T12:16:57Z"
+		},
+		{
 			"checksumSHA1": "xPPXsop1MasrinvYYmMBeuwDu9c=",
 			"path": "github.com/exponent-io/jsonpath",
 			"revision": "d6023ce2651d8eafb5c75bb0c7167536102ec9f5",

--- a/website/source/docs/providers/runscope/d/integration.html.markdown
+++ b/website/source/docs/providers/runscope/d/integration.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "runscope"
+page_title: "Runscope: runscope_integration"
+sidebar_current: "docs-runscope-datasource-integration"
+description: |-
+  Get information about runscope integrations enabled on for your team.
+---
+
+# runscope\_integration
+
+Use this data source to get information about a specific [integration](https://www.runscope.com/docs/api/integrations)
+that you can with other runscope resources.
+
+## Example Usage
+
+```hcl
+data "runscope_integration" "pagerduty" {
+  team_uuid = "d26553c0-3537-40a8-9d3c-64b0453262a9"
+  type = "pagerduty"
+}
+
+resource "runscope_environment" "environment" {
+  bucket_id    = "${runscope_bucket.bucket.id}"
+  name         = "test-environment"
+
+  integrations = [
+    {
+      id               = "${data.runscope_integration.pagerduty.id}"
+      integration_type = "pagerduty"
+    }
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `team_uuid` - (Required) Your team unique identifier.
+* `type` - (Required) Type of integration to lookup i.e. pagerduty
+
+## Attributes Reference
+* `id` - The unique identifier of the found integration.

--- a/website/source/docs/providers/runscope/index.html.markdown
+++ b/website/source/docs/providers/runscope/index.html.markdown
@@ -1,0 +1,48 @@
+---
+layout: "runscope"
+page_title: "Provider: Runscope"
+sidebar_current: "docs-runscope-index"
+description: |-
+  The Runscope provider is used to interact with the resources supported by Runscope. The provider needs to be configured with the proper access token before it can be used.
+---
+
+# Runscope Provider
+
+The Runscope provider is used to interact with the
+resources supported by Runscope. The provider needs to be configured
+with an access token before it can be used.
+
+Use the navigation to the left to read about the available resources.
+
+## Example Usage
+
+```hcl
+# Configure the Runscope provider
+provider "runscope" {
+  access_token = "${var.access_token}"
+}
+
+# Create a bucket
+resource "runscope_bucket" "main" {
+  name         = "terraform-ftw"
+  team_uuid    = "870ed937-bc6e-4d8b-a9a5-d7f9f2412fa3"
+}
+
+# Create a test in the bucket
+resource "runscope_test" "api" {
+  name         = "api-test"
+  description  = "checks the api is up and running"
+  bucket_id    = "${runscope_bucket.main}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `access_token` - (Required) The Runscope access token.
+  This can also be specified with the `RUNSCOPE_ACCESS_TOKEN` shell
+  environment variable.
+* `api_url` - (Optional) If set, specifies the Runscope api url, this
+   defaults to `"https://api.runscope.com`. This can also be specified
+   with the `RUNSCOPE_API_URL` shell environment variable.

--- a/website/source/docs/providers/runscope/r/bucket.html.markdown
+++ b/website/source/docs/providers/runscope/r/bucket.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "runscope"
+page_title: "Runscope: runscope_bucket"
+sidebar_current: "docs-runscope-resource-bucket"
+description: |-
+  Provides a Runscope bucket resource.
+---
+
+# runscope\_bucket
+
+A [bucket](https://www.runscope.com/docs/api/buckets) resource.
+[Buckets](https://www.runscope.com/docs/buckets) are a simple way to
+organize your requests and tests.
+
+## Example Usage
+
+```hcl
+# Add a bucket to your runscope account
+resource "runscope_bucket" "main" {
+  name      = "a-bucket"
+  team_uuid = "870ed937-bc6e-4d8b-a9a5-d7f9f2412fa3"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (String, Required) The name of this bucket.
+* `team_uuid` - (String, Required) Unique identifier for the team this bucket
+  is being created for.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `name` - The name of this bucket.
+* `team_uuid` - Unique identifier for the team this bucket belongs to.

--- a/website/source/docs/providers/runscope/r/environment.html.markdown
+++ b/website/source/docs/providers/runscope/r/environment.html.markdown
@@ -1,0 +1,108 @@
+---
+layout: "runscope"
+page_title: "Runscope: runscope_environment"
+sidebar_current: "docs-runscope-resource-environment"
+description: |-
+  Provides a Runscope environment resource.
+---
+
+# runscope\_environment
+
+An [environment](https://www.runscope.com/docs/api/environments) resource.
+An [environment](https://www.runscope.com/docs/api-testing/environments)
+is is a group of configuration settings (initial variables, locations,
+notifications, integrations, etc.) used when running a test.
+Every test has at least one environment, but you can create additional
+environments as needed. For common settings (base URLs, API keys)
+that you'd like to use across all tests within a bucket,
+use a [Shared Environment](https://www.runscope.com/docs/api-testing/environments#shared).
+
+### Creating a shared environment
+```hcl
+resource "runscope_environment" "environment" {
+  bucket_id    = "${runscope_bucket.bucket.id}"
+  name         = "shared-environment"
+
+  integrations = [
+    {
+      id               = "${data.runscope_integration.pagerduty.id}"
+      integration_type = "pagerduty"
+    }
+  ]
+
+  initial_variables {
+    var1 = "true",
+    var2 = "value2"
+  }
+}
+
+data "runscope_integration" "pagerduty" {
+  team_uuid = "%s"
+  type = "pagerduty"
+}
+```
+### Creating a test environment
+```hcl
+resource "runscope_environment" "environment" {
+  bucket_id    = "${runscope_bucket.bucket.id}"
+  test_id      = "${runscope_test.api.id}
+  name         = "test-environment"
+
+  integrations = [
+    {
+      id               = "${data.runscope_integration.pagerduty.id}"
+      integration_type = "pagerduty"
+    }
+  ]
+
+  initial_variables {
+    var1 = "true",
+    var2 = "value2"
+  }
+}
+
+data "runscope_integration" "pagerduty" {
+  team_uuid = "194204f3-19a3-4ef7-a492-b14a277025da"
+  type = "pagerduty"
+}
+
+# Add a test to a bucket
+resource "runscope_test" "api" {
+  name         = "api-test"
+  description  = "checks the api is up and running"
+  bucket_id    = "${runscope_bucket.main}"
+}
+
+# Create a bucket
+resource "runscope_bucket" "main" {
+  name         = "terraform-ftw"
+  team_uuid    = "870ed937-bc6e-4d8b-a9a5-d7f9f2412fa3"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket_id` - (Required) The id of the bucket to associate this environment with.
+* `test_id` - (Optional) The id of the test to associate this environment with.
+If given, creates a test specific environment, otherwise creates a shared environment.
+* `name` - (Required) The name of environment.
+* `script` - (Optional) The [script](https://www.runscope.com/docs/api-testing/scripts#initial-script)
+to to run to setup the environment
+* `preserve_cookies` - (Optional) If this is set to true, tests using this enviornment will manage cookies between steps.
+* `initial_variables` - (Optional) Map of keys and values being used for variables when the test begins.
+* `integrations` - (Optional) A list of integrations to enable for test runs using this environment.
+Integrations documented below.
+
+Integrations (`integrations`) supports the following:
+
+* `id` - (Required) The id of the integration to enable.
+Look the values up using the [runscope_integration](../d/integration.html) data resource.
+* `integration_type` - (Required) The type of integration to enable
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the environment.

--- a/website/source/docs/providers/runscope/r/schedule.html.markdown
+++ b/website/source/docs/providers/runscope/r/schedule.html.markdown
@@ -1,0 +1,69 @@
+---
+layout: "runscope"
+page_title: "Runscope: runscope_schedule"
+sidebar_current: "docs-runscope-resource-schedule"
+description: |-
+  Provides a Runscope schedule resource.
+---
+
+# runscope\_schedule
+
+A [schedule](https://www.runscope.com/docs/api/schedules) resource.
+Tests can be scheduled to run on frequencies up to every minute.
+One ore more schedules can be configured per test with each schedule
+using a unique Test-specific or Shared [Environment](environment.html).
+### Creating a schedule
+```hcl
+resource "runscope_schedule" "daily" {
+  bucket_id      = "${runscope_bucket.bucket.id}"
+  test_id        = "${runscope_test.test.id}"
+  interval       = "1d"
+  note           = "This is a daily schedule"
+  environment_id = "${runscope_environment.environment.id}"
+}
+
+resource "runscope_test" "test" {
+  bucket_id   = "${runscope_bucket.bucket.id}"
+  name        = "runscope test"
+  description = "This is a test test..."
+}
+
+resource "runscope_bucket" "bucket" {
+  name      = "terraform-provider-test"
+  team_uuid = "d038db69-b5a9-45af-80d8-3be47c37e309"
+}
+
+resource "runscope_environment" "environment" {
+  bucket_id = "${runscope_bucket.bucket.id}"
+  name      = "test-environment"
+
+  initial_variables {
+    var1 = "true",
+    var2 = "value2"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket_id` - (Required) The id of the bucket to associate this schedule with.
+* `test_id` - (Required) The id of the test to associate this schedule with.
+* `environment_id` - (Required) The id of the environment to use when running the test.
+If given, creates a test specific schedule, otherwise creates a shared schedule.
+* `interval` - (Required) The schedule's interval, must be one of:
+ * 1m — every minute
+ * 5m — every 5 minutes
+ * 15m — every 15 minutes
+ * 30m — every 30 minutes
+ * 1h — every hour
+ * 6h — every 6 hours
+ * 1d — every day.
+* `note` - (Optional) A human-friendly description for the schedule.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the schedule.

--- a/website/source/docs/providers/runscope/r/step.html.markdown
+++ b/website/source/docs/providers/runscope/r/step.html.markdown
@@ -1,0 +1,161 @@
+---
+layout: "runscope"
+page_title: "Runscope: runscope_step"
+sidebar_current: "docs-runscope-resource-step"
+description: |-
+  Provides a Runscope step resource.
+---
+
+# runscope\_step
+
+A [step](https://www.runscope.com/docs/api/steps) resource.
+API tests are comprised of a series of steps, most often HTTP requests.
+In addition to requests, you can also add additional types of steps to
+your tests like pauses and conditions.
+
+### Creating a step
+```hcl
+resource "runscope_step" "main_page" {
+  bucket_id      = "${runscope_bucket.bucket.id}"
+  test_id        = "${runscope_test.test.id}"
+  step_type      = "request"
+  url            = "http://example.com"
+  method         = "GET"
+  variables      = [
+  	{
+  	   name     = "httpStatus"
+  	   source   = "response_status"
+  	},
+  	{
+  	   name     = "httpContentEncoding"
+  	   source   = "response_header"
+  	   property = "Content-Encoding"
+  	},
+  ]
+  assertions     = [
+  	{
+  	   source     = "response_status"
+       comparison = "equal_number"
+       value      = "200"
+  	},
+  	{
+  	   source     = "response_json"
+       comparison = "equal"
+       value      = "c5baeb4a-2379-478a-9cda-1b671de77cf9",
+       property   = "data.id"
+  	},
+  ],
+  headers        = [
+  	{
+  		header = "Accept-Encoding",
+  		value  = "application/json"
+  	},
+  	{
+  		header = "Accept-Encoding",
+  		value  = "application/xml"
+  	},
+  	{
+  		header = "Authorization",
+  		value  = "Bearer bb74fe7b-b9f2-48bd-9445-bdc60e1edc6a",
+	}
+  ]
+}
+
+resource "runscope_test" "test" {
+  bucket_id   = "${runscope_bucket.bucket.id}"
+  name        = "runscope test"
+  description = "This is a test test..."
+}
+
+resource "runscope_bucket" "bucket" {
+  name      = "terraform-provider-test"
+  team_uuid = "dfb75aac-eeb3-4451-8675-3a37ab421e4f"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `bucket_id` - (Required) The id of the bucket to associate this step with.
+* `test_id` - (Required) The id of the test to associate this step with.
+* `step_type` - (Required) The type of step.
+ * [request](#request-steps)
+ * pause
+ * condition
+ * ghost
+ * subtest
+
+### Request steps
+When creating a `request` type of step the additional arguments also apply:
+
+* `method` - (Required) The HTTP method for this request step.
+* `variables` - (Optional) A list of variables to extract out of the HTTP response from this request. Variables documented below.
+* `assertions` - (Optional) A list of assertions to apply to the HTTP response from this request. Assertions documented below.
+* `headers` - (Optional) A list of headers to apply to the request. Headers documented below.
+* `body` - (Optional) A string to use as the body of the request.
+
+Variables (`variables`) supports the following:
+
+* `name` - (Required) Name of the variable to define.
+* `property` - (Required) The name of the source property. i.e. header name or json path
+* `source` - (Required) The variable source, for list of allowed values see: https://www.runscope.com/docs/api/steps#assertions
+
+Assertions (`assertions`) supports the following:
+
+* `source` - (Required) The assertion source, for list of allowed values see: https://www.runscope.com/docs/api/steps#assertions
+* `property` - (Optional) The name of the source property. i.e. header name or json path
+* `comparison` - (Required) The assertion comparison to make i.e. `equals`, for list of allowed values see: https://www.runscope.com/docs/api/steps#assertions
+* `value` - (Optional) The value the `comparison` will use
+
+**Example Assertions**
+
+Status Code == 200
+
+```json
+"assertions": [
+    {
+        "source": "response_status",
+        "comparison": "equal_number",
+        "value": 200
+    }
+]
+```
+
+JSON element 'address' contains the text "avenue"
+
+
+```json
+"assertions": [
+    {
+        "source": "response_json",
+        "property": "address",
+        "comparison": "contains",
+        "value": "avenue"
+    }
+]
+```
+
+Response Time is faster than 1 second.
+
+
+```json
+"assertions": [
+    {
+        "source": "response_time",
+        "comparison": "is_less_than",
+        "value": 1000
+    }
+]
+```
+
+The `headers` list supports the following:
+
+* `header` - (Required) The name of the header
+* `value` - (Required) The name header value
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the step.

--- a/website/source/docs/providers/runscope/r/test.html.markdown
+++ b/website/source/docs/providers/runscope/r/test.html.markdown
@@ -1,0 +1,47 @@
+---
+layout: "runscope"
+page_title: "Runscope: runscope_test"
+sidebar_current: "docs-runscope-resource-test"
+description: |-
+  Provides a Runscope test resource.
+---
+
+# runscope\_test
+
+A [test](https://www.runscope.com/docs/api/tests) resource.
+[Tests](https://www.runscope.com/docs/buckets) are made up of
+a collection of [test steps](test_steps.html) and an
+[environment](environment.html).
+
+## Example Usage
+
+```hcl
+# Add a test to a bucket
+resource "runscope_test" "api" {
+  name         = "api-test"
+  description  = "checks the api is up and running"
+  bucket_id    = "${runscope_bucket.main}"
+}
+
+# Create a bucket
+resource "runscope_bucket" "main" {
+  name         = "terraform-ftw"
+  team_uuid    = "870ed937-bc6e-4d8b-a9a5-d7f9f2412fa3"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (String, Required) The name of this test.
+* `description` - (String, Optional) Human-readable description of the new test.
+  is being created for.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The unique identifier for the test.
+* `name` - The name of this test.
+* `description` - Human-readable description of the new test.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -404,6 +404,10 @@
             <a href="/docs/providers/rundeck/index.html">Rundeck</a>
           </li>
 
+          <li<%= sidebar_current("docs-providers-runscope") %>>
+            <a href="/docs/providers/runscope/index.html">Runscope</a>
+          </li>
+
           <li<%= sidebar_current("docs-providers-scaleway") %>>
             <a href="/docs/providers/scaleway/index.html">Scaleway</a>
           </li>

--- a/website/source/layouts/runscope.erb
+++ b/website/source/layouts/runscope.erb
@@ -1,0 +1,47 @@
+<% wrap_layout :inner do %>
+    <% content_for :sidebar do %>
+        <div class="docs-sidebar hidden-print affix-top" role="complementary">
+            <ul class="nav docs-sidenav">
+                <li<%= sidebar_current("docs-home") %>>
+                <a href="/docs/providers/index.html">All Providers</a>
+                </li>
+
+                <li<%= sidebar_current("docs-runscope-index") %>>
+                <a href="/docs/providers/runscope/index.html">Runscope Provider</a>
+                </li>
+
+                <li<%= sidebar_current("docs-runscope-datasource") %>>
+                    <a href="#">Data Sources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-runscope-datasource-user") %>>
+                            <a href="/docs/providers/runscope/d/integration.html">runscope_integration</a>
+                        </li>
+                    </ul>
+                </li>
+
+                <li<%= sidebar_current("docs-runscope-resource") %>>
+                <a href="#">Resources</a>
+                <ul class="nav nav-visible">
+                    <li<%= sidebar_current("docs-runscope-resource-bucket") %>>
+                    <a href="/docs/providers/runscope/r/bucket.html">runscope_bucket</a>
+                    </li>
+                    <li<%= sidebar_current("docs-runscope-resource-environment") %>>
+                    <a href="/docs/providers/runscope/r/environment.html">runscope_environment</a>
+                    </li>
+                    <li<%= sidebar_current("docs-runscope-resource-schedule") %>>
+                    <a href="/docs/providers/runscope/r/schedule.html">runscope_schedule</a>
+                    </li>
+                    <li<%= sidebar_current("docs-runscope-resource-step") %>>
+                    <a href="/docs/providers/runscope/r/step.html">runscope_step</a>
+                    </li>
+                    <li<%= sidebar_current("docs-runscope-resource-test") %>>
+                    <a href="/docs/providers/runscope/r/test.html">runscope_test</a>
+                    </li>
+                </ul>
+                </li>
+            </ul>
+        </div>
+    <% end %>
+
+    <%= yield %>
+    <% end %>


### PR DESCRIPTION
This PR adds support to create runscope resources: https://www.runscope.com/docs/api/buckets, initially just buckets

This is my first contribution and I'm new to writing go, so will likely need some help getting this correct. Anyhow here goes:

PR checklist:
- [x] Minimal LOC. I've only implemented the bucket resource, should this be successful, I'll follow up with environment, test and step resources
- [x] Documentation
- [x] Acceptance test
- [x] Go fmt on new code

It currently supports
```hcl
provider "runscope" {
  access_token = "FD738F8B-BF6B-43AF-8279-164D42A5DE7B"
}

resource "runscope_bucket" "main" {
  name      = "a-bucket"
  team_uuid = "041206D7-1663-4922-B64D-87E8619B38A3"
}
```

Output of the acceptance tests:
```bash
make testacc TEST=./builtin/providers/runscope
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/04 20:28:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/runscope -v  -timeout 120m
=== RUN   TestCreateBucket
2017/05/04 20:28:38 [INFO] runscope client configured for server https://api.runscope.com
--- PASS: TestCreateBucket (1.73s)
=== RUN   TestReadBucket
2017/05/04 20:28:40 [INFO] runscope client configured for server https://api.runscope.com
--- PASS: TestReadBucket (1.86s)
=== RUN   TestDeserializeResult
--- PASS: TestDeserializeResult (0.00s)
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProviderImpl
--- PASS: TestProviderImpl (0.00s)
=== RUN   TestAccBucket_basic
--- PASS: TestAccBucket_basic (3.38s)
PASS
ok  	github.com/ewilde/terraform/builtin/providers/runscope	6.985s
```
