### PR TITLE
provider/nomad: Update Nomad provider tests

### DIFF
--- a/builtin/providers/nomad/resource_job_test.go
+++ b/builtin/providers/nomad/resource_job_test.go
@@ -288,7 +288,11 @@ func testResourceJob_updateCheck(s *terraform.State) error {
 		// Verify foo doesn't exist
 		job, _, err := client.Jobs().Info("foo", nil)
 		if err != nil {
-			return fmt.Errorf("error reading %q job: %s", "foo", err)
+			// Job could have already been purged from nomad server
+			if !strings.Contains(err.Error(), "(job not found)") {
+				return fmt.Errorf("error reading %q job: %s", "foo", err)
+			}
+			return nil
 		}
 		if job.Status != "dead" {
 			return fmt.Errorf("%q job is not dead. Status: %q", "foo", job.Status)


### PR DESCRIPTION
Nomad server could have already purged the test job `foo` by the time the test checks to make sure the `foo` job has been deleted, resulting in a `404` response from the Nomad server.

```
$ make testacc TEST=./builtin/providers/nomad
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/04 15:51:01 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/nomad -v  -timeout 120m
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestResourceJob_basic
--- PASS: TestResourceJob_basic (1.78s)
=== RUN   TestResourceJob_refresh
--- PASS: TestResourceJob_refresh (3.30s)
=== RUN   TestResourceJob_disableDestroyDeregister
--- PASS: TestResourceJob_disableDestroyDeregister (3.63s)
=== RUN   TestResourceJob_idChange
--- PASS: TestResourceJob_idChange (3.44s)
=== RUN   TestResourceJob_parameterizedJob
--- PASS: TestResourceJob_parameterizedJob (1.76s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/nomad  13.924s
```