### PR TITLE
provider/aws Return an error if PrincipalIsNotFound because of invalid parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ BUG FIXES:
 * provider/aws: Exclude aws_instance volume tagging for China and Gov Clouds [GH-14055]
 * provider/aws: Fix source_dest_check with network_interface [GH-14079]
 * provider/aws: Fixes the bug where SNS delivery policy get always recreated [GH-14064]
+* provider/aws: Prevent Crash when importing aws_route53_record [GH-14218]
 * provider/digitalocean: Prevent diffs when using IDs of images instead of slugs [GH-13879]
 * provider/fastly: Changes setting conditionals to optional [GH-14103]
 * provider/google: Ignore certain project services that can't be enabled directly via the api [GH-13730]

--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -127,10 +127,6 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 					}
 					_, err := stateConf.WaitForState()
 					if err != nil {
-						// If the Principal still cannot be found then it may have been an acutal invalid Principal that was passed in.
-						if strings.Contains(fmt.Sprintf("%s", err), "retrying") {
-							return fmt.Errorf("InvalidParameter: Invalid parameter: Policy Error: PrincipalNotFound")
-						}
 						return err
 					}
 				}
@@ -151,7 +147,7 @@ func resourceAwsSNSUpdateRefreshFunc(
 				// if the error contains the PrincipalNotFound message, we can retry
 				if strings.Contains(awsErr.Message(), "PrincipalNotFound") {
 					log.Printf("[DEBUG] Retrying AWS SNS Topic Update: %s", params)
-					return nil, "retrying", nil
+					return nil, "retrying", err
 				}
 			}
 			return nil, "failed", err

--- a/builtin/providers/aws/resource_aws_sns_topic.go
+++ b/builtin/providers/aws/resource_aws_sns_topic.go
@@ -127,6 +127,10 @@ func resourceAwsSnsTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 					}
 					_, err := stateConf.WaitForState()
 					if err != nil {
+						// If the Principal still cannot be found then it may have been an acutal invalid Principal that was passed in.
+						if strings.Contains(fmt.Sprintf("%s", err), "retrying") {
+							return fmt.Errorf("InvalidParameter: Invalid parameter: Policy Error: PrincipalNotFound")
+						}
 						return err
 					}
 				}

--- a/builtin/providers/aws/resource_aws_sns_topic_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -62,6 +63,21 @@ func TestAccAWSSNSTopic_withIAMRole(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccAWSSNSTopic_withFakeIAMRole(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_sns_topic.test_topic",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config:      testAccAWSSNSTopicConfig_withFakeIAMRole,
+				ExpectError: regexp.MustCompile(`PrincipalNotFound`),
 			},
 		},
 	})
@@ -292,6 +308,30 @@ resource "aws_sns_topic" "test_topic" {
       "Effect": "Allow",
       "Principal": {
         "AWS": "${aws_iam_role.example.arn}"
+			},
+      "Action": "sns:Publish",
+      "Resource": "arn:aws:sns:us-west-2::example"
+    }
+  ],
+  "Version": "2012-10-17",
+  "Id": "Policy1445931846145"
+}
+EOF
+}
+`
+
+// Test for https://github.com/hashicorp/terraform/issues/3660
+const testAccAWSSNSTopicConfig_withFakeIAMRole = `
+resource "aws_sns_topic" "test_topic" {
+  name = "example"
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Sid": "Stmt1445931846145",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::012345678901:role/wooo"
 			},
       "Action": "sns:Publish",
       "Resource": "arn:aws:sns:us-west-2::example"

--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -107,11 +107,6 @@ func (conf *StateChangeConf) WaitForState() (interface{}, error) {
 				Error:  err,
 			}
 
-			if err != nil {
-				resCh <- result
-				return
-			}
-
 			// If we're waiting for the absence of a thing, then return
 			if res == nil && len(conf.Target) == 0 {
 				targetOccurence++


### PR DESCRIPTION
This PR fixes #14179 where a invalid principal name was passed into an `sns_topic`. 

```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSSNSTopic_withFakeIAMRole'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/04 15:07:54 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSSNSTopic_withFakeIAMRole -timeout 120m
=== RUN   TestAccAWSSNSTopic_withFakeIAMRole
--- PASS: TestAccAWSSNSTopic_withFakeIAMRole (72.10s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	72.135s
```