### PR TITLE
website: copy vagrant cloud docs

### DIFF
--- a/website/source/docs/enterprise/faq/index.html.md
+++ b/website/source/docs/enterprise/faq/index.html.md
@@ -11,3 +11,5 @@ description: |-
 [Monolithic Artifacts](/docs/enterprise/faq/monolithic-artifacts.html) - *How do I build multiple applications into one artifact?*
 
 [Rolling Deployments](/docs/enterprise/faq/rolling-deployments.html) - *How do I configure rolling deployments?*
+
+[Vagrant Cloud Migration](/docs/enterprise/faq/vagrant-cloud-migration.html) - *How can I prepare for the Vagrant Cloud Mirgration?*

--- a/website/source/docs/enterprise/faq/vagrant-cloud-migration.html.md
+++ b/website/source/docs/enterprise/faq/vagrant-cloud-migration.html.md
@@ -1,0 +1,23 @@
+---
+layout: "enterprise"
+page_title: "Vagrant Cloud Migration - FAQ - Terraform Enterprise"
+sidebar_current: "docs-enterprise-faq-vagrant-cloud-migration"
+description: |-
+  Vagrant-related functionality will be moved from Terraform Enterprise into its own product, Vagrant Cloud. This migration is currently planned for June 27th, 2017.
+---
+
+# Vagrant Cloud Migration
+
+Vagrant-related functionality will be moved from Terraform Enterprise into its own product, Vagrant Cloud. This migration is currently planned for **June 27th, 2017**.
+
+All existing Vagrant boxes will be moved to the new system on that date. All users, organizations, and teams will be copied as well.
+
+## Authentication Tokens
+
+No existing Terraform Enterprise authentication tokens will be transferred. To prevent a disruption of service for Vagrant-related operations, users must create a new authentication token and check "Migrate to Vagrant Cloud" and begin using these tokens for creating and modifying Vagrant boxes. These tokens will be moved on the migration date.
+
+Creating a token via `vagrant login` will also mark a token as "Migrate to Vagrant Cloud".
+
+## More Information
+
+At least 1 month prior to the migration, we will be releasing more information on the specifics and impact of the migration.

--- a/website/source/layouts/enterprise.erb
+++ b/website/source/layouts/enterprise.erb
@@ -176,6 +176,10 @@
           <li<%= sidebar_current("docs-enterprise-faq-deployments") %>>
             <a href="/docs/enterprise/faq/rolling-deployments.html">Rolling Deployments</a>
           </li>
+
+          <li<%= sidebar_current("docs-enterprise-faq-vagrant-cloud-migration") %>>
+            <a href="/docs/enterprise/faq/vagrant-cloud-migration.html">Vagrant Cloud Migration</a>
+          </li>
         </ul>
       </li>
 


### PR DESCRIPTION
**Description**

As part of the docs cleanup, this page needed to be copied over. 

@KFishner any thoughts on the left nav hierarchy for this? I was going to put it under support but it didn't have an index. My next best guess was under FAQ?