### PR TITLE
core: context test for partially-unknown splat lists

### DIFF
--- a/terraform/test-fixtures/plan-count-splat-reference/main.tf
+++ b/terraform/test-fixtures/plan-count-splat-reference/main.tf
@@ -1,0 +1,9 @@
+resource "aws_instance" "foo" {
+    name = "foo ${count.index}"
+    count = 3
+}
+
+resource "aws_instance" "bar" {
+    foo_name = "${aws_instance.foo.*.name[count.index]}"
+    count = 3
+}


### PR DESCRIPTION
This is a context test for the behavior enabled by #14135, as some insurance to decrease the chance that we break it again.