### PR TITLE
[WIP] Add a `tags_map` function

### DIFF
--- a/config/interpolate_funcs.go
+++ b/config/interpolate_funcs.go
@@ -98,6 +98,7 @@ func Funcs() map[string]ast.Function {
 		"sort":         interpolationFuncSort(),
 		"split":        interpolationFuncSplit(),
 		"substr":       interpolationFuncSubstr(),
+		"tags_map":     interpolationFuncTagsMap(),
 		"timestamp":    interpolationFuncTimestamp(),
 		"title":        interpolationFuncTitle(),
 		"trimspace":    interpolationFuncTrimSpace(),
@@ -1373,6 +1374,35 @@ func interpolationFuncSubstr() ast.Function {
 			}
 
 			return str[offset:length], nil
+		},
+	}
+}
+
+func interpolationFuncTagsMap() ast.Function {
+	return ast.Function{
+		ArgTypes: []ast.Type{
+			ast.TypeList,
+		},
+		ReturnType: ast.TypeMap,
+		Callback: func(args []interface{}) (interface{}, error) {
+			//tags := args[0].([]map[string]string)
+			tags := args[0].([]ast.Variable)
+
+			result := make(map[string]ast.Variable)
+
+			for i := 0; i < len(tags); i++ {
+				tag := tags[i].Value.(map[string]ast.Variable)
+
+				key := tag["key"]
+				value := tag["value"]
+
+				result[key.Value.(string)] = ast.Variable{
+					Type:  ast.TypeString,
+					Value: value.Value.(string),
+				}
+			}
+
+			return result, nil
 		},
 	}
 }

--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2346,3 +2346,15 @@ func TestInterpolateFuncSubstr(t *testing.T) {
 		},
 	})
 }
+
+func TestInterpolateFuncTagsMap(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			{
+				`${tags_map(list(map("key", "foo", "value", "bar")))}`,
+				map[string]interface{}{"foo": "bar"},
+				false,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Ref #12478. Adds a `tags_map` interpolation function. This is just a WIP, but I wanted to get some initial feedback. My first thought was the change the `tags` parameter on all of the relevant AWS resources from `list<map<string, string>>` to `map<string, string>`, but I decided against this (even though I believe that it is the more correct solution) because it would be a backwards incompatibility. Instead, I added a new interpolation function that can be used to convert AWS tags to from a list to a map.