### PR TITLE
provider/google: Add support for privateIpGoogleAccess on subnetworks

### DIFF
--- a/builtin/providers/google/data_source_google_compute_subnetwork.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork.go
@@ -29,6 +29,10 @@ func dataSourceGoogleComputeSubnetwork() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+			"private_ip_google_access": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
 			"network": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -75,6 +79,7 @@ func dataSourceGoogleComputeSubnetworkRead(d *schema.ResourceData, meta interfac
 	}
 
 	d.Set("ip_cidr_range", subnetwork.IpCidrRange)
+	d.Set("private_ip_google_access", subnetwork.PrivateIpGoogleAccess)
 	d.Set("self_link", subnetwork.SelfLink)
 	d.Set("description", subnetwork.Description)
 	d.Set("gateway_address", subnetwork.GatewayAddress)

--- a/builtin/providers/google/data_source_google_compute_subnetwork_test.go
+++ b/builtin/providers/google/data_source_google_compute_subnetwork_test.go
@@ -45,6 +45,7 @@ func testAccDataSourceGoogleSubnetworkCheck(data_source_name string, resource_na
 			"description",
 			"ip_cidr_range",
 			"network",
+			"private_ip_google_access",
 		}
 
 		for _, attr_to_check := range subnetwork_attrs_to_test {
@@ -73,6 +74,7 @@ resource "google_compute_subnetwork" "foobar" {
 	description = "my-description"
 	ip_cidr_range = "10.0.0.0/24"
 	network  = "${google_compute_network.foobar.self_link}"
+	private_ip_google_access = true
 }
 
 data "google_compute_subnetwork" "my_subnetwork" {

--- a/builtin/providers/google/resource_compute_subnetwork.go
+++ b/builtin/providers/google/resource_compute_subnetwork.go
@@ -59,6 +59,12 @@ func resourceComputeSubnetwork() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"private_ip_google_access": &schema.Schema{
+				Type:     schema.TypeBool,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"self_link": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -98,10 +104,11 @@ func resourceComputeSubnetworkCreate(d *schema.ResourceData, meta interface{}) e
 
 	// Build the subnetwork parameters
 	subnetwork := &compute.Subnetwork{
-		Name:        d.Get("name").(string),
-		Description: d.Get("description").(string),
-		IpCidrRange: d.Get("ip_cidr_range").(string),
-		Network:     network,
+		Name:                  d.Get("name").(string),
+		Description:           d.Get("description").(string),
+		IpCidrRange:           d.Get("ip_cidr_range").(string),
+		PrivateIpGoogleAccess: d.Get("private_ip_google_access").(bool),
+		Network:               network,
 	}
 
 	log.Printf("[DEBUG] Subnetwork insert request: %#v", subnetwork)

--- a/builtin/providers/google/resource_compute_subnetwork_test.go
+++ b/builtin/providers/google/resource_compute_subnetwork_test.go
@@ -102,4 +102,12 @@ resource "google_compute_subnetwork" "network-ref-by-name" {
 	network = "${google_compute_network.custom-test.name}"
 }
 
-`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))
+resource "google_compute_subnetwork" "network-with-private-google-access" {
+	name = "subnetwork-test-%s"
+	ip_cidr_range = "10.2.0.0/16"
+	region = "us-central1"
+	network = "${google_compute_network.custom-test.self_link}"
+	private_ip_google_access = true
+}
+
+`, acctest.RandString(10), acctest.RandString(10), acctest.RandString(10), acctest.RandString(10))

--- a/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/d/datasource_compute_subnetwork.html.markdown
@@ -38,7 +38,7 @@ The following arguments are supported:
 In addition to the arguments listed above, the following attributes are exported:
 
 * `network` - The network name or resource link to the parent
-    network of this subnetwork. 
+    network of this subnetwork.
 
 * `description` - Description of this subnetwork.
 
@@ -46,5 +46,9 @@ In addition to the arguments listed above, the following attributes are exported
     network are assigned to, represented as a CIDR block.
 
 * `gateway_address` - The IP address of the gateway.
+
+* `private_ip_google_access` - Whether the VMs in this subnet
+    can access Google services without assigned external IP
+    addresses.
 
 * `self_link` - The URI of the created resource.

--- a/website/source/docs/providers/google/r/compute_subnetwork.html.markdown
+++ b/website/source/docs/providers/google/r/compute_subnetwork.html.markdown
@@ -45,6 +45,10 @@ The following arguments are supported:
 * `region` - (Optional) The region this subnetwork will be created in. If
     unspecified, this defaults to the region configured in the provider.
 
+* `private_ip_google_access` - Whether the VMs in this subnet
+    can access Google services without assigned external IP
+    addresses.
+
 ## Attributes Reference
 
 In addition to the arguments listed above, the following computed attributes are


### PR DESCRIPTION
```tf
provider "google" {
  region = "us-central1"
}

resource "google_compute_network" "foo_network" {
  name = "foo"
}

resource "google_compute_subnetwork" "foo_subnetwork" {
  name          = "foo"
  network       = "${google_compute_network.foo_network.self_link}"
  ip_cidr_range = "10.0.0.0/24"
  region        = "us-central1"
  private_ip_google_access = true
}

data "google_compute_subnetwork" "foo_data" {
    name = "${google_compute_subnetwork.foo_subnetwork.name}"
}
```

```
<= data.google_compute_subnetwork.foo_data
    description:              "<computed>"
    gateway_address:          "<computed>"
    ip_cidr_range:            "<computed>"
    name:                     "foo"
    network:                  "<computed>"
    private_ip_google_access: "<computed>"
    self_link:                "<computed>"

+ google_compute_network.foo_network
    gateway_ipv4: "<computed>"
    name:         "foo"
    self_link:    "<computed>"

+ google_compute_subnetwork.foo_subnetwork
    gateway_address:          "<computed>"
    ip_cidr_range:            "10.0.0.0/24"
    name:                     "foo"
    network:                  "${google_compute_network.foo_network.self_link}"
    private_ip_google_access: "true"
    region:                   "us-central1"
    self_link:                "<computed>"


Plan: 2 to add, 0 to change, 0 to destroy.
```