### PR TITLE
provider/google : documentation : Added a missing resource in panel

### DIFF
--- a/website/source/layouts/google.erb
+++ b/website/source/layouts/google.erb
@@ -66,6 +66,10 @@
       <a href="/docs/providers/google/r/compute_autoscaler.html">google_compute_autoscaler</a>
       </li>
 
+      <li<%= sidebar_current("docs-google-compute-backend-bucket") %>>
+      <a href="/docs/providers/google/r/compute_backend_service_bucket.html">google_compute_backend_bucket</a>
+      </li>
+
       <li<%= sidebar_current("docs-google-compute-backend-service") %>>
       <a href="/docs/providers/google/r/compute_backend_service.html">google_compute_backend_service</a>
       </li>
@@ -182,7 +186,7 @@
       <li<%= sidebar_current("docs-google-container-cluster") %>>
       <a href="/docs/providers/google/r/container_cluster.html">google_container_cluster</a>
       </li>
-      
+
       <li<%= sidebar_current("docs-google-container-node-pool") %>>
       <a href="/docs/providers/google/r/container_node_pool.html">google_container_node_pool</a>
       </li>


### PR DESCRIPTION
Hi

google_compute_backend_bucket resource was missing in right panel.

Thanks.
