### PR TITLE
Add `path` to `google_pubsub_subscription`

### DIFF
--- a/builtin/providers/google/resource_pubsub_subscription.go
+++ b/builtin/providers/google/resource_pubsub_subscription.go
@@ -38,6 +38,11 @@ func resourcePubsubSubscription() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"path": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"push_config": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
@@ -113,6 +118,7 @@ func resourcePubsubSubscriptionCreate(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.SetId(res.Name)
+	d.Set("path", name)
 
 	return nil
 }


### PR DESCRIPTION
The path is used to globally identify a subscription. Specifically, I need to pass the path to a Dataflow job.