### PR TITLE
provider/aws: Add ARN to security group data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_security_group.go
+++ b/builtin/providers/aws/data_source_aws_security_group.go
@@ -14,23 +14,29 @@ func dataSourceAwsSecurityGroup() *schema.Resource {
 		Read: dataSourceAwsSecurityGroupRead,
 
 		Schema: map[string]*schema.Schema{
-			"vpc_id": &schema.Schema{
+			"vpc_id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
 			"filter": ec2CustomFiltersSchema(),
 
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
 			},
+
+			"arn": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchemaComputed(),
 		},
 	}
@@ -81,6 +87,8 @@ func dataSourceAwsSecurityGroupRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("description", sg.Description)
 	d.Set("vpc_id", sg.VpcId)
 	d.Set("tags", tagsToMap(sg.Tags))
+	d.Set("arn", fmt.Sprintf("arn:%s:ec2:%s:%s/security-group/%s",
+		meta.(*AWSClient).partition, meta.(*AWSClient).region, *sg.OwnerId, *sg.GroupId))
 
 	return nil
 }

--- a/builtin/providers/aws/data_source_aws_security_group_test.go
+++ b/builtin/providers/aws/data_source_aws_security_group_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"strings"
+
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -64,6 +66,10 @@ func testAccDataSourceAwsSecurityGroupCheck(name string) resource.TestCheckFunc 
 
 		if attr["tags.Name"] != "tf-acctest" {
 			return fmt.Errorf("bad Name tag %s", attr["tags.Name"])
+		}
+
+		if !strings.Contains(attr["arn"], attr["id"]) {
+			return fmt.Errorf("bad ARN %s", attr["arn"])
 		}
 
 		return nil

--- a/website/source/docs/providers/aws/d/security_group.html.markdown
+++ b/website/source/docs/providers/aws/d/security_group.html.markdown
@@ -65,6 +65,10 @@ All of the argument attributes except `filter` blocks are also exported as
 result attributes. This data source will complete the data by populating
 any fields that are not included in the configuration with the data for
 the selected Security Group.
-Additionally, the `description` attribute is exported.
+
+The following fields are also exported:
+
+* `description` - The description of the security group.
+* `arn` - The computed ARN of the security group.
 
 ~> **Note:** The [default security group for a VPC](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_SecurityGroups.html#DefaultSecurityGroup) has the name `default`.


### PR DESCRIPTION
Adds computed `arn` to security group data source

```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run=TestAccDataSourceAwsSecurityGroup"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/05 10:17:35 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccDataSourceAwsSecurityGroup -timeout 120m
=== RUN   TestAccDataSourceAwsSecurityGroup
--- PASS: TestAccDataSourceAwsSecurityGroup (56.72s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    56.725s
```

Fixes: #14237 