### PR TITLE
provider/aws: Add support for targets to aws_ssm_association

### DIFF
--- a/builtin/providers/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/builtin/providers/aws/resource_aws_ssm_maintenance_window_task.go
@@ -144,7 +144,7 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 		TaskType:       aws.String(d.Get("task_type").(string)),
 		ServiceRoleArn: aws.String(d.Get("service_role_arn").(string)),
 		TaskArn:        aws.String(d.Get("task_arn").(string)),
-		Targets:        expandAwsSsmMaintenanceWindowTargets(d),
+		Targets:        expandAwsSsmTargets(d),
 	}
 
 	if v, ok := d.GetOk("priority"); ok {
@@ -196,7 +196,7 @@ func resourceAwsSsmMaintenanceWindowTaskRead(d *schema.ResourceData, meta interf
 				}
 			}
 
-			if err := d.Set("targets", flattenAwsSsmMaintenanceWindowTargets(t.Targets)); err != nil {
+			if err := d.Set("targets", flattenAwsSsmTargets(t.Targets)); err != nil {
 				return fmt.Errorf("[DEBUG] Error setting targets error: %#v", err)
 			}
 		}

--- a/website/source/docs/providers/aws/r/ssm_association.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_association.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Assosciates an SSM Document to an instance.
 ---
 
-# aws\_ssm\_association
+# aws_ssm_association
 
 Assosciates an SSM Document to an instance.
 
@@ -68,8 +68,9 @@ resource "aws_ssm_association" "foo" {
 The following arguments are supported:
 
 * `name` - (Required) The name of the SSM document to apply.
-* `instance_id` - (Required) The instance id to apply an SSM document to.
+* `instance_id` - (Optional) The instance id to apply an SSM document to.
 * `parameters` - (Optional) Additional parameters to pass to the SSM document.
+* `targets` - (Optional) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/ssm_association.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_association.html.markdown
@@ -70,7 +70,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the SSM document to apply.
 * `instance_id` - (Optional) The instance id to apply an SSM document to.
 * `parameters` - (Optional) Additional parameters to pass to the SSM document.
-* `targets` - (Optional) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value.
+* `targets` - (Optional) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value. Only 1 target is currently supported by AWS.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Fixes: #13975

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSSMAssociation_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/05 20:32:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSSMAssociation_ -timeout 120m
=== RUN   TestAccAWSSSMAssociation_basic
--- PASS: TestAccAWSSSMAssociation_basic (139.13s)
=== RUN   TestAccAWSSSMAssociation_withTargets
--- PASS: TestAccAWSSSMAssociation_withTargets (33.19s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	172.343s
```