### PR TITLE
providers/heroku: import heroku_app resource

### DIFF
--- a/builtin/providers/heroku/import_heroku_app_test.go
+++ b/builtin/providers/heroku/import_heroku_app_test.go
@@ -1,0 +1,58 @@
+package heroku
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccHerokuApp_importBasic(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppConfig_basic(appName),
+			},
+			{
+				ResourceName:            "heroku_app.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_vars"},
+			},
+		},
+	})
+}
+
+func TestAccHerokuApp_importOrganization(t *testing.T) {
+	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+	org := os.Getenv("HEROKU_ORGANIZATION")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+			if org == "" {
+				t.Skip("HEROKU_ORGANIZATION is not set; skipping test.")
+			}
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAppDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAppConfig_organization(appName, org),
+			},
+			{
+				ResourceName:            "heroku_app.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_vars"},
+			},
+		},
+	})
+}


### PR DESCRIPTION
Adds support for importing normal and organization apps with the heroku_app resource.

The resource itself depends on an `organization` value in the configuration to switch behavior for the different kinds of apps, so `schema.ImportStatePassthrough` is not sufficient.

Resolves https://github.com/hashicorp/terraform/issues/12087.