### PR TITLE
Replace "All Providers" link text w/ "All Commands"

### DIFF
--- a/website/source/layouts/commands-state.erb
+++ b/website/source/layouts/commands-state.erb
@@ -3,7 +3,7 @@
     <div class="docs-sidebar hidden-print affix-top" role="complementary">
       <ul class="nav docs-sidenav">
         <li<%= sidebar_current("docs-home") %>>
-          <a href="/docs/commands/index.html">All Providers</a>
+          <a href="/docs/commands/index.html">All Commands</a>
         </li>
 
         <li<%= sidebar_current("docs-state-index") %>>


### PR DESCRIPTION
This was probably a c/p mistake when this page was first created. The
src is rightly pointed back to the commands index, not resources.