### PR TITLE
Improve the wording of an error message

### DIFF
--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -154,7 +154,7 @@ func validateStreamViewType(v interface{}, k string) (ws []string, errors []erro
 	}
 
 	if !viewTypes[value] {
-		errors = append(errors, fmt.Errorf("%q be a valid DynamoDB StreamViewType", k))
+		errors = append(errors, fmt.Errorf("%q must be a valid DynamoDB StreamViewType", k))
 	}
 	return
 }


### PR DESCRIPTION
Previously the following code:

```hcl
resource "aws_dynamodb_table" "example" {
  name             = "example"
  read_capacity    = 5
  write_capacity   = 5
  hash_key         = "my_id"
  stream_enabled   = true
  stream_view_type = "NOT_A_VALID_STREAM_VIEW_TYPE"

  attribute {
    name = "my_id"
    type = "S"
  }
}
```

would yield an error message when you ran `terraform plan`:

```
* aws_dynamodb_table.bookmarks: "stream_view_type" be a valid DynamoDB StreamViewType
```

This sentence doesn't make sense – this patch adds the missing "must".