### PR TITLE
Propagate AWS CodePipeline action roles

### DIFF
--- a/builtin/providers/aws/resource_aws_codepipeline.go
+++ b/builtin/providers/aws/resource_aws_codepipeline.go
@@ -335,6 +335,10 @@ func expandAwsCodePipelineActions(s []interface{}) []*codepipeline.ActionDeclara
 			action.InputArtifacts = inputArtifacts
 
 		}
+		ra := data["role_arn"].(string)
+		if ra != "" {
+			action.RoleArn = aws.String(ra)
+		}
 		ro := data["run_order"].(int)
 		if ro > 0 {
 			action.RunOrder = aws.Int64(int64(ro))
@@ -370,6 +374,10 @@ func flattenAwsCodePipelineStageActions(actions []*codepipeline.ActionDeclaratio
 
 		if len(action.InputArtifacts) > 0 {
 			values["input_artifacts"] = flattenAwsCodePipelineActionsInputArtifacts(action.InputArtifacts)
+		}
+
+		if action.RoleArn != nil {
+			values["role_arn"] = *action.RoleArn
 		}
 
 		if action.RunOrder != nil {

--- a/builtin/providers/aws/resource_aws_codepipeline_test.go
+++ b/builtin/providers/aws/resource_aws_codepipeline_test.go
@@ -43,6 +43,22 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.type", "KMS"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccAWSCodePipeline_deployWithServiceRole(t *testing.T) {
+	if os.Getenv("GITHUB_TOKEN") == "" {
+		t.Skip("Environment variable GITHUB_TOKEN is not set")
+	}
+
+	name := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSCodePipelineDestroy,
+		Steps: []resource.TestStep{
 			{
 				Config: testAccAWSCodePipelineConfig_deployWithServiceRole(name),
 				Check: resource.ComposeTestCheckFunc(

--- a/builtin/providers/aws/resource_aws_codepipeline_test.go
+++ b/builtin/providers/aws/resource_aws_codepipeline_test.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -40,6 +41,17 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.type", "S3"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.id", "4567"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.type", "KMS"),
+				),
+			},
+			{
+				Config: testAccAWSCodePipelineConfig_deployWithServiceRole(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSCodePipelineExists("aws_codepipeline.bar"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.2.name", "Deploy"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.2.action.0.category", "Deploy"),
+					resource.TestMatchResourceAttr(
+						"aws_codepipeline.bar", "stage.2.action.0.role_arn",
+						regexp.MustCompile("^arn:aws:iam::[0-9]{12}:role/codepipeline-action-role.*")),
 				),
 			},
 		},
@@ -313,4 +325,190 @@ resource "aws_codepipeline" "bar" {
   }
 }
 `, rName, rName, rName)
+}
+
+func testAccAWSCodePipelineConfig_deployWithServiceRole(rName string) string {
+	return fmt.Sprintf(`
+resource "aws_s3_bucket" "foo" {
+  bucket = "tf-test-pipeline-%s"
+  acl    = "private"
+}
+
+resource "aws_iam_role" "codepipeline_role" {
+  name = "codepipeline-role-%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codepipeline.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_policy" {
+  name = "codepipeline_policy"
+  role = "${aws_iam_role.codepipeline_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.foo.arn}",
+        "${aws_s3_bucket.foo.arn}/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "codebuild:BatchGetBuilds",
+        "codebuild:StartBuild"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "sts:AssumeRole"
+      ],
+      "Resource": "${aws_iam_role.codepipeline_action_role.arn}"
+    }
+  ]
+}
+EOF
+}
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "codepipeline_action_role" {
+  name = "codepipeline-action-role-%s"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "codepipeline_action_policy" {
+  name = "codepipeline_action_policy"
+  role = "${aws_iam_role.codepipeline_action_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect":"Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:GetBucketVersioning"
+      ],
+      "Resource": [
+        "${aws_s3_bucket.foo.arn}",
+        "${aws_s3_bucket.foo.arn}/*"
+      ]
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_codepipeline" "bar" {
+  name     = "test-pipeline-%s"
+  role_arn = "${aws_iam_role.codepipeline_role.arn}"
+
+  artifact_store {
+    location = "${aws_s3_bucket.foo.bucket}"
+    type     = "S3"
+
+    encryption_key {
+      id   = "4567"
+      type = "KMS"
+    }
+  }
+
+  stage {
+    name = "Source"
+
+    action {
+      name             = "Source"
+      category         = "Source"
+      owner            = "ThirdParty"
+      provider         = "GitHub"
+      version          = "1"
+      output_artifacts = ["bar"]
+
+      configuration {
+        Owner  = "foo-terraform"
+        Repo   = "bar"
+        Branch = "stable"
+      }
+    }
+  }
+
+  stage {
+    name = "Build"
+
+    action {
+      name             = "Build"
+      category         = "Build"
+      owner            = "AWS"
+      provider         = "CodeBuild"
+      input_artifacts  = ["bar"]
+      output_artifacts = ["baz"]
+      version          = "1"
+
+      configuration {
+        ProjectName = "foo"
+      }
+    }
+  }
+
+  stage {
+    name = "Deploy"
+
+    action {
+      name            = "CreateChangeSet"
+      category        = "Deploy"
+      owner           = "AWS"
+      provider        = "CloudFormation"
+      input_artifacts = ["baz"]
+      role_arn        = "${aws_iam_role.codepipeline_action_role.arn}"
+      version         = "1"
+
+      configuration {
+        ActionMode    = "CHANGE_SET_REPLACE"
+        ChangeSetName = "changeset"
+        StackName     = "stack"
+        TemplatePath  = "baz::template.yaml"
+      }
+    }
+  }}
+`, rName, rName, rName, rName)
 }


### PR DESCRIPTION
CodePipeline stage actions can optionally specify an IAM execution role. The provider nominally supports them, but they don't seem to be getting passed to/from AWS.

(Please forgive any non-idiomatic Go syntax. It is not in my wheelhouse.)