### PR TITLE
[MS] provider/azurerm: New resource - Express Route Circuit

### DIFF
--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -52,6 +52,7 @@ type ArmClient struct {
 
 	appGatewayClient             network.ApplicationGatewaysClient
 	ifaceClient                  network.InterfacesClient
+	expressRouteCircuitClient    network.ExpressRouteCircuitsClient
 	loadBalancerClient           network.LoadBalancersClient
 	localNetConnClient           network.LocalNetworkGatewaysClient
 	publicIPClient               network.PublicIPAddressesClient

--- a/builtin/providers/azurerm/config.go
+++ b/builtin/providers/azurerm/config.go
@@ -279,6 +279,12 @@ func (c *Config) getArmClient() (*ArmClient, error) {
 	ifc.Sender = autorest.CreateSender(withRequestLogging())
 	client.ifaceClient = ifc
 
+	erc := network.NewExpressRouteCircuitsClientWithBaseURI(endpoint, c.SubscriptionID)
+	setUserAgent(&erc.Client)
+	erc.Authorizer = spt
+	erc.Sender = autorest.CreateSender(withRequestLogging())
+	client.expressRouteCircuitClient = erc
+
 	lbc := network.NewLoadBalancersClientWithBaseURI(endpoint, c.SubscriptionID)
 	setUserAgent(&lbc.Client)
 	lbc.Authorizer = spt

--- a/builtin/providers/azurerm/express_route_circuit.go
+++ b/builtin/providers/azurerm/express_route_circuit.go
@@ -20,21 +20,21 @@ func extractResourceGroupAndErcName(resourceId string) (resourceGroup string, na
 	return
 }
 
-func retrieveErcByResourceId(resourceId string, meta interface{}) (*network.ExpressRouteCircuit, string, bool, error) {
+func retrieveErcByResourceId(resourceId string, meta interface{}) (erc *network.ExpressRouteCircuit, resourceGroup string, e error) {
 	ercClient := meta.(*ArmClient).expressRouteCircuitClient
 
 	resGroup, name, err := extractResourceGroupAndErcName(resourceId)
 	if err != nil {
-		return nil, "", false, errwrap.Wrapf("Error Parsing Azure Resource ID {{err}}", err)
+		return nil, "", errwrap.Wrapf("Error Parsing Azure Resource ID - {{err}}", err)
 	}
 
 	resp, err := ercClient.Get(resGroup, name)
 	if err != nil {
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, "", false, nil
+			return nil, "", nil
 		}
-		return nil, "", false, fmt.Errorf("Error making Read request on Express Route Circuit %s: %s", name, err)
+		return nil, "", errwrap.Wrapf(fmt.Sprintf("Error making Read request on Express Route Circuit %s: {{err}}", name), err)
 	}
 
-	return &resp, resGroup, true, nil
+	return &resp, resGroup, nil
 }

--- a/builtin/providers/azurerm/express_route_circuit.go
+++ b/builtin/providers/azurerm/express_route_circuit.go
@@ -1,0 +1,76 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+)
+
+func extractResourceGroupAndErcName(resourceId string) (resourceGroup string, name string, err error) {
+	id, err := parseAzureResourceID(resourceId)
+
+	if err != nil {
+		return "", "", err
+	}
+	resourceGroup = id.ResourceGroup
+	name = id.Path["expressRouteCircuits"]
+
+	return
+}
+
+func retrieveErcByResourceId(resourceId string, meta interface{}) (*network.ExpressRouteCircuit, string, bool, error) {
+	ercClient := meta.(*ArmClient).expressRouteCircuitClient
+
+	resGroup, name, err := extractResourceGroupAndErcName(resourceId)
+	if err != nil {
+		return nil, "", false, errwrap.Wrapf("Error Parsing Azure Resource ID {{err}}", err)
+	}
+
+	resp, err := ercClient.Get(resGroup, name)
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, "", false, nil
+		}
+		return nil, "", false, fmt.Errorf("Error making Read request on Express Route Circuit %s: %s", name, err)
+	}
+
+	return &resp, resGroup, true, nil
+}
+
+func validateSkuTier(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	allowedValues := []string{
+		string(network.ExpressRouteCircuitSkuTierStandard),
+		string(network.ExpressRouteCircuitSkuTierPremium),
+	}
+
+	if !isStringValueAllowed(value, allowedValues) {
+		errors = append(errors, fmt.Errorf(`Allowed sku_tier value(s) are %+v, provided value is "%s"`, allowedValues, value))
+	}
+	return
+}
+
+func validateSkuFamily(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	allowedValues := []string{
+		string(network.MeteredData),
+		string(network.UnlimitedData),
+	}
+
+	if !isStringValueAllowed(value, allowedValues) {
+		errors = append(errors, fmt.Errorf(`Allowed sku_family value(s) are %+v, provided value is "%s"`, allowedValues, value))
+	}
+	return
+}
+
+func isStringValueAllowed(v string, allowedValues []string) bool {
+	for _, allowed := range allowedValues {
+		if strings.ToLower(v) == strings.ToLower(allowed) {
+			return true
+		}
+	}
+	return false
+}

--- a/builtin/providers/azurerm/express_route_circuit.go
+++ b/builtin/providers/azurerm/express_route_circuit.go
@@ -3,7 +3,6 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/errwrap"
@@ -38,39 +37,4 @@ func retrieveErcByResourceId(resourceId string, meta interface{}) (*network.Expr
 	}
 
 	return &resp, resGroup, true, nil
-}
-
-func validateSkuTier(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	allowedValues := []string{
-		string(network.ExpressRouteCircuitSkuTierStandard),
-		string(network.ExpressRouteCircuitSkuTierPremium),
-	}
-
-	if !isStringValueAllowed(value, allowedValues) {
-		errors = append(errors, fmt.Errorf(`Allowed sku_tier value(s) are %+v, provided value is "%s"`, allowedValues, value))
-	}
-	return
-}
-
-func validateSkuFamily(v interface{}, k string) (ws []string, errors []error) {
-	value := v.(string)
-	allowedValues := []string{
-		string(network.MeteredData),
-		string(network.UnlimitedData),
-	}
-
-	if !isStringValueAllowed(value, allowedValues) {
-		errors = append(errors, fmt.Errorf(`Allowed sku_family value(s) are %+v, provided value is "%s"`, allowedValues, value))
-	}
-	return
-}
-
-func isStringValueAllowed(v string, allowedValues []string) bool {
-	for _, allowed := range allowedValues {
-		if strings.ToLower(v) == strings.ToLower(allowed) {
-			return true
-		}
-	}
-	return false
 }

--- a/builtin/providers/azurerm/express_route_circuit.go
+++ b/builtin/providers/azurerm/express_route_circuit.go
@@ -1,11 +1,15 @@
 package azurerm
 
 import (
+	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func extractResourceGroupAndErcName(resourceId string) (resourceGroup string, name string, err error) {
@@ -37,4 +41,35 @@ func retrieveErcByResourceId(resourceId string, meta interface{}) (erc *network.
 	}
 
 	return &resp, resGroup, nil
+}
+
+func expandExpressRouteCircuitSku(skuSettings *schema.Set) *network.ExpressRouteCircuitSku {
+	v := skuSettings.List()[0].(map[string]interface{}) // [0] is guarded by MinItems in schema.
+	tier := v["tier"].(string)
+	family := v["family"].(string)
+	name := fmt.Sprintf("%s_%s", tier, family)
+
+	return &network.ExpressRouteCircuitSku{
+		Name:   &name,
+		Tier:   network.ExpressRouteCircuitSkuTier(tier),
+		Family: network.ExpressRouteCircuitSkuFamily(family),
+	}
+}
+
+func flattenExpressRouteCircuitSku(sku *network.ExpressRouteCircuitSku) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"tier":   string(sku.Tier),
+			"family": string(sku.Family),
+		},
+	}
+}
+
+func resourceArmExpressRouteCircuitSkuHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["tier"].(string))))
+	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["family"].(string))))
+
+	return hashcode.String(buf.String())
 }

--- a/builtin/providers/azurerm/express_route_circuit.go
+++ b/builtin/providers/azurerm/express_route_circuit.go
@@ -1,15 +1,11 @@
 package azurerm
 
 import (
-	"bytes"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/errwrap"
-	"github.com/hashicorp/terraform/helper/hashcode"
-	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func extractResourceGroupAndErcName(resourceId string) (resourceGroup string, name string, err error) {
@@ -41,35 +37,4 @@ func retrieveErcByResourceId(resourceId string, meta interface{}) (erc *network.
 	}
 
 	return &resp, resGroup, nil
-}
-
-func expandExpressRouteCircuitSku(skuSettings *schema.Set) *network.ExpressRouteCircuitSku {
-	v := skuSettings.List()[0].(map[string]interface{}) // [0] is guarded by MinItems in schema.
-	tier := v["tier"].(string)
-	family := v["family"].(string)
-	name := fmt.Sprintf("%s_%s", tier, family)
-
-	return &network.ExpressRouteCircuitSku{
-		Name:   &name,
-		Tier:   network.ExpressRouteCircuitSkuTier(tier),
-		Family: network.ExpressRouteCircuitSkuFamily(family),
-	}
-}
-
-func flattenExpressRouteCircuitSku(sku *network.ExpressRouteCircuitSku) []interface{} {
-	return []interface{}{
-		map[string]interface{}{
-			"tier":   string(sku.Tier),
-			"family": string(sku.Family),
-		},
-	}
-}
-
-func resourceArmExpressRouteCircuitSkuHash(v interface{}) int {
-	var buf bytes.Buffer
-	m := v.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["tier"].(string))))
-	buf.WriteString(fmt.Sprintf("%s-", strings.ToLower(m["family"].(string))))
-
-	return hashcode.String(buf.String())
 }

--- a/builtin/providers/azurerm/import_arm_express_route_circuit_test.go
+++ b/builtin/providers/azurerm/import_arm_express_route_circuit_test.go
@@ -1,0 +1,29 @@
+package azurerm
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAzureRMExpressRouteCircuit_importBasic(t *testing.T) {
+	resourceName := "azurerm_express_route_circuit.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMExpressRouteCircuitDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAzureRMExpressRouteCircuit_basic(acctest.RandInt()),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/azurerm/provider.go
+++ b/builtin/providers/azurerm/provider.go
@@ -78,6 +78,8 @@ func Provider() terraform.ResourceProvider {
 			"azurerm_eventhub_consumer_group":     resourceArmEventHubConsumerGroup(),
 			"azurerm_eventhub_namespace":          resourceArmEventHubNamespace(),
 
+			"azurerm_express_route_circuit": resourceArmExpressRouteCircuit(),
+
 			"azurerm_lb":                      resourceArmLoadBalancer(),
 			"azurerm_lb_backend_address_pool": resourceArmLoadBalancerBackendAddressPool(),
 			"azurerm_lb_nat_rule":             resourceArmLoadBalancerNatRule(),

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit.go
@@ -16,9 +16,9 @@ import (
 
 func resourceArmExpressRouteCircuit() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceArmExpressRouteCircuitCreate,
+		Create: resourceArmExpressRouteCircuitCreateOrUpdate,
 		Read:   resourceArmExpressRouteCircuitRead,
-		Update: resourceArmExpressRouteCircuitCreate,
+		Update: resourceArmExpressRouteCircuitCreateOrUpdate,
 		Delete: resourceArmExpressRouteCircuitDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -110,7 +110,7 @@ func resourceArmExpressRouteCircuit() *schema.Resource {
 	}
 }
 
-func resourceArmExpressRouteCircuitCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceArmExpressRouteCircuitCreateOrUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*ArmClient)
 	ercClient := client.expressRouteCircuitClient
 
@@ -122,7 +122,7 @@ func resourceArmExpressRouteCircuitCreate(d *schema.ResourceData, meta interface
 	serviceProviderName := d.Get("service_provider_name").(string)
 	peeringLocation := d.Get("peering_location").(string)
 	bandwidthInMbps := int32(d.Get("bandwidth_in_mbps").(int))
-	sku := expandExpressRouteCircuitSku(d.Get("sku").(*schema.Set))
+	sku := expandExpressRouteCircuitSku(d)
 	allowRdfeOps := d.Get("allow_classic_operations").(bool)
 	tags := d.Get("tags").(map[string]interface{})
 	expandedTags := expandTags(tags)
@@ -207,7 +207,8 @@ func resourceArmExpressRouteCircuitDelete(d *schema.ResourceData, meta interface
 	return err
 }
 
-func expandExpressRouteCircuitSku(skuSettings *schema.Set) *network.ExpressRouteCircuitSku {
+func expandExpressRouteCircuitSku(d *schema.ResourceData) *network.ExpressRouteCircuitSku {
+	skuSettings := d.Get("sku").(*schema.Set)
 	v := skuSettings.List()[0].(map[string]interface{}) // [0] is guarded by MinItems in schema.
 	tier := v["tier"].(string)
 	family := v["family"].(string)

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit.go
@@ -155,12 +155,12 @@ func resourceArmExpressRouteCircuitCreate(d *schema.ResourceData, meta interface
 }
 
 func resourceArmExpressRouteCircuitRead(d *schema.ResourceData, meta interface{}) error {
-	erc, resGroup, exists, err := retrieveErcByResourceId(d.Id(), meta)
+	erc, resGroup, err := retrieveErcByResourceId(d.Id(), meta)
 	if err != nil {
 		return err
 	}
 
-	if !exists {
+	if erc == nil {
 		d.SetId("")
 		log.Printf("[INFO] Express Route Circuit %q not found. Removing from state", d.Get("name").(string))
 		return nil

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit.go
@@ -37,15 +37,17 @@ func resourceArmExpressRouteCircuit() *schema.Resource {
 			"location": locationSchema(),
 
 			"service_provider_name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"peering_location": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"bandwidth_in_mbps": {
@@ -61,6 +63,7 @@ func resourceArmExpressRouteCircuit() *schema.Resource {
 					string(network.ExpressRouteCircuitSkuTierStandard),
 					string(network.ExpressRouteCircuitSkuTierPremium),
 				}, true),
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"sku_family": {
@@ -71,6 +74,7 @@ func resourceArmExpressRouteCircuit() *schema.Resource {
 					string(network.MeteredData),
 					string(network.UnlimitedData),
 				}, true),
+				DiffSuppressFunc: ignoreCaseDiffSuppressFunc,
 			},
 
 			"allow_classic_operations": {

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit.go
@@ -1,0 +1,197 @@
+package azurerm
+
+import (
+	"log"
+
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/errwrap"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArmExpressRouteCircuit() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceArmExpressRouteCircuitCreate,
+		Read:   resourceArmExpressRouteCircuitRead,
+		Update: resourceArmExpressRouteCircuitCreate,
+		Delete: resourceArmExpressRouteCircuitDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"resource_group_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"location": locationSchema(),
+
+			"service_provider_name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"peering_location": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+
+			"bandwidth_in_mbps": {
+				Type:     schema.TypeInt,
+				Required: true,
+			},
+
+			"sku_tier": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      string(network.ExpressRouteCircuitSkuTierStandard),
+				ValidateFunc: validateSkuTier,
+			},
+
+			"sku_family": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      string(network.MeteredData),
+				ValidateFunc: validateSkuFamily,
+			},
+
+			"allow_classic_operations": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+
+			"service_provider_provisioning_state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"service_key": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tags": tagsSchema(),
+		},
+	}
+}
+
+func resourceArmExpressRouteCircuitCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*ArmClient)
+	ercClient := client.expressRouteCircuitClient
+
+	log.Printf("[INFO] preparing arguments for Azure ARM ExpressRouteCircuit creation.")
+
+	name := d.Get("name").(string)
+	resGroup := d.Get("resource_group_name").(string)
+	location := d.Get("location").(string)
+	serviceProviderName := d.Get("service_provider_name").(string)
+	peeringLocation := d.Get("peering_location").(string)
+	bandwidthInMbps := int32(d.Get("bandwidth_in_mbps").(int))
+	skuTier := d.Get("sku_tier").(string)
+	skuFamily := d.Get("sku_family").(string)
+	skuName := fmt.Sprintf("%s_%s", skuTier, skuFamily)
+	allowRdfeOps := d.Get("allow_classic_operations").(bool)
+	tags := d.Get("tags").(map[string]interface{})
+	expandedTags := expandTags(tags)
+
+	erc := network.ExpressRouteCircuit{
+		Name:     &name,
+		Location: &location,
+		Sku: &network.ExpressRouteCircuitSku{
+			Name:   &skuName,
+			Tier:   network.ExpressRouteCircuitSkuTier(skuTier),
+			Family: network.ExpressRouteCircuitSkuFamily(skuFamily),
+		},
+		ExpressRouteCircuitPropertiesFormat: &network.ExpressRouteCircuitPropertiesFormat{
+			AllowClassicOperations: &allowRdfeOps,
+			ServiceProviderProperties: &network.ExpressRouteCircuitServiceProviderProperties{
+				ServiceProviderName: &serviceProviderName,
+				PeeringLocation:     &peeringLocation,
+				BandwidthInMbps:     &bandwidthInMbps,
+			},
+		},
+		Tags: expandedTags,
+	}
+
+	_, err := ercClient.CreateOrUpdate(resGroup, name, erc, make(chan struct{}))
+	if err != nil {
+		return errwrap.Wrapf("Error Creating/Updating ExpressRouteCircuit {{err}}", err)
+	}
+
+	read, err := ercClient.Get(resGroup, name)
+	if err != nil {
+		return errwrap.Wrapf("Error Getting ExpressRouteCircuit {{err}}", err)
+	}
+	if read.ID == nil {
+		return fmt.Errorf("Cannot read ExpressRouteCircuit %s (resource group %s) ID", name, resGroup)
+	}
+
+	d.SetId(*read.ID)
+
+	return resourceArmExpressRouteCircuitRead(d, meta)
+}
+
+func resourceArmExpressRouteCircuitRead(d *schema.ResourceData, meta interface{}) error {
+	erc, resGroup, exists, err := retrieveErcByResourceId(d.Id(), meta)
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		d.SetId("")
+		log.Printf("[INFO] Express Route Circuit %q not found. Removing from state", d.Get("name").(string))
+		return nil
+	}
+
+	d.Set("name", erc.Name)
+	d.Set("resource_group_name", resGroup)
+	d.Set("location", erc.Location)
+
+	if erc.ServiceProviderProperties != nil {
+		d.Set("service_provider_name", erc.ServiceProviderProperties.ServiceProviderName)
+		d.Set("peering_location", erc.ServiceProviderProperties.PeeringLocation)
+		d.Set("bandwidth_in_mbps", erc.ServiceProviderProperties.BandwidthInMbps)
+	}
+
+	if erc.Sku != nil {
+		d.Set("sku_tier", string(erc.Sku.Tier))
+		d.Set("sku_family", string(erc.Sku.Family))
+	}
+
+	d.Set("service_provider_provisioning_state", string(erc.ServiceProviderProvisioningState))
+	d.Set("service_key", erc.ServiceKey)
+	d.Set("allow_classic_operations", erc.AllowClassicOperations)
+
+	flattenAndSetTags(d, erc.Tags)
+
+	return nil
+}
+
+func resourceArmExpressRouteCircuitDelete(d *schema.ResourceData, meta interface{}) error {
+	ercClient := meta.(*ArmClient).expressRouteCircuitClient
+
+	resGroup, name, err := extractResourceGroupAndErcName(d.Id())
+	if err != nil {
+		return errwrap.Wrapf("Error Parsing Azure Resource ID {{err}}", err)
+	}
+
+	_, err = ercClient.Delete(resGroup, name, make(chan struct{}))
+	if err != nil {
+		return errwrap.Wrapf("Error Deleting ExpressRouteCircuit {{err}}", err)
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
 )
 
 func resourceArmExpressRouteCircuit() *schema.Resource {
@@ -53,17 +54,23 @@ func resourceArmExpressRouteCircuit() *schema.Resource {
 			},
 
 			"sku_tier": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      string(network.ExpressRouteCircuitSkuTierStandard),
-				ValidateFunc: validateSkuTier,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(network.ExpressRouteCircuitSkuTierStandard),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.ExpressRouteCircuitSkuTierStandard),
+					string(network.ExpressRouteCircuitSkuTierPremium),
+				}, true),
 			},
 
 			"sku_family": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				Default:      string(network.MeteredData),
-				ValidateFunc: validateSkuFamily,
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  string(network.MeteredData),
+				ValidateFunc: validation.StringInSlice([]string{
+					string(network.MeteredData),
+					string(network.UnlimitedData),
+				}, true),
 			},
 
 			"allow_classic_operations": {

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
@@ -1,0 +1,111 @@
+package azurerm
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/arm/network"
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAzureRMExpressRouteCircuit_basic(t *testing.T) {
+	var erc network.ExpressRouteCircuit
+	ri := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMExpressRouteCircuitDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAzureRMExpressRouteCircuit_basic(ri),
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMExpressRouteCircuitExists("azurerm_express_route_circuit.test", &erc),
+				),
+			},
+		},
+	})
+}
+
+func testCheckAzureRMExpressRouteCircuitExists(name string, erc *network.ExpressRouteCircuit) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		expressRouteCircuitName := rs.Primary.Attributes["name"]
+		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+		if !hasResourceGroup {
+			return fmt.Errorf("Bad: no resource group found in state for Express Route Circuit: %s", expressRouteCircuitName)
+		}
+
+		conn := testAccProvider.Meta().(*ArmClient).expressRouteCircuitClient
+
+		resp, err := conn.Get(resourceGroup, expressRouteCircuitName)
+		if err != nil {
+			if resp.StatusCode == http.StatusNotFound {
+				return fmt.Errorf("Bad: Express Route Circuit %q (resource group: %q) does not exist", expressRouteCircuitName, resourceGroup)
+			}
+
+			return fmt.Errorf("Bad: Get on expressRouteCircuitClient: %s", err)
+		}
+
+		*erc = resp
+
+		return nil
+	}
+}
+
+func testCheckAzureRMExpressRouteCircuitDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*ArmClient).expressRouteCircuitClient
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "azurerm_express_route_circuit" {
+			continue
+		}
+
+		name := rs.Primary.Attributes["name"]
+		resourceGroup := rs.Primary.Attributes["resource_group_name"]
+
+		resp, err := conn.Get(resourceGroup, name)
+
+		if err != nil {
+			return nil
+		}
+
+		if resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Express Route Circuit still exists:\n%#v", resp.ExpressRouteCircuitPropertiesFormat)
+		}
+	}
+
+	return nil
+}
+
+func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
+	return fmt.Sprintf(`
+		resource "azurerm_resource_group" "test" {
+			name = "acctestrg-%d"
+			location = "West US"
+		}
+
+		resource "azurerm_express_route_circuit" "test" {
+			name = "arm-test-erc-%d"
+			location = "West US"
+			resource_group_name = "${azurerm_resource_group.test.name}"
+			service_provider_name = "Equinix"
+			peering_location = "Silicon Valley"
+			bandwidth_in_mbps = 50
+			sku_tier = "Standard"
+			sky_family = "MeteredData"
+			allow_classic_operations = false
+
+			tags {
+				Environment = "production"
+				Purpose = "AcceptanceTests"
+			}
+		}`, rInt, rInt)
+}

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
@@ -100,7 +100,7 @@ func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
 			peering_location = "Silicon Valley"
 			bandwidth_in_mbps = 50
 			sku_tier = "Standard"
-			sky_family = "MeteredData"
+			sku_family = "MeteredData"
 			allow_classic_operations = false
 
 			tags {

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
@@ -3,10 +3,7 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 	"testing"
-
-	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -89,14 +86,14 @@ func testCheckAzureRMExpressRouteCircuitDestroy(s *terraform.State) error {
 }
 
 func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
-	return strings.Replace(`
+	return fmt.Sprintf(`
 		resource "azurerm_resource_group" "test" {
 			name = "acctestrg-%d"
 			location = "West US"
 		}
 
 		resource "azurerm_express_route_circuit" "test" {
-			name = "arm-test-erc-%d"
+			name = "arm-test-erc-%[1]d"
 			location = "West US"
 			resource_group_name = "${azurerm_resource_group.test.name}"
 			service_provider_name = "Equinix"
@@ -112,5 +109,5 @@ func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
 				Environment = "production"
 				Purpose = "AcceptanceTests"
 			}
-		}`, "%d", strconv.Itoa(rInt), -1)
+		}`, rInt)
 }

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
@@ -3,7 +3,10 @@ package azurerm
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 	"testing"
+
+	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/arm/network"
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -86,7 +89,7 @@ func testCheckAzureRMExpressRouteCircuitDestroy(s *terraform.State) error {
 }
 
 func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
-	return fmt.Sprintf(`
+	return strings.Replace(`
 		resource "azurerm_resource_group" "test" {
 			name = "acctestrg-%d"
 			location = "West US"
@@ -107,5 +110,5 @@ func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
 				Environment = "production"
 				Purpose = "AcceptanceTests"
 			}
-		}`, rInt, rInt)
+		}`, "%d", strconv.Itoa(rInt), -1)
 }

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
@@ -93,7 +93,7 @@ func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
 		}
 
 		resource "azurerm_express_route_circuit" "test" {
-			name = "arm-test-erc-%[1]d"
+			name = "acctest-erc-%[1]d"
 			location = "West US"
 			resource_group_name = "${azurerm_resource_group.test.name}"
 			service_provider_name = "Equinix"

--- a/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
+++ b/builtin/providers/azurerm/resource_arm_express_route_circuit_test.go
@@ -102,8 +102,10 @@ func testAccAzureRMExpressRouteCircuit_basic(rInt int) string {
 			service_provider_name = "Equinix"
 			peering_location = "Silicon Valley"
 			bandwidth_in_mbps = 50
-			sku_tier = "Standard"
-			sku_family = "MeteredData"
+			sku {
+			    tier = "Standard"
+			    family = "MeteredData"
+		    }
 			allow_classic_operations = false
 
 			tags {

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -111,6 +111,7 @@ To make a resource importable, please see the
 ### Azure (Resource Manager)
 
 * azurerm_availability_set
+* azurerm_express_route_circuit
 * azurerm_dns_zone
 * azurerm_local_network_gateway
 * azurerm_network_security_group

--- a/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
+++ b/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
@@ -1,0 +1,78 @@
+---
+layout: "azurerm"
+page_title: "Azure Resource Manager: azurerm_express_route_circuit"
+sidebar_current: "docs-azurerm-resource-express-route-circuit"
+description: |-
+  Creates an ExpressRoute circuit.
+---
+
+# azurerm\_express\_route\_circuit
+
+Creates an ExpressRoute circuit.
+
+## Example Usage
+
+```hcl
+resource "azurerm_express_route_circuit" "test" {
+  name                     = "expressRoute1"
+  resource_group_name      = "${azurerm_resource_group.test.name}"
+  location                 = "West US"
+  service_provider_name    = "Equinix"
+  peering_location         = "Silicon Valley"
+  bandwidth_in_mbps        = 50
+  sku_tier                 = "Standard"
+  sku_family               = "MeteredData"
+  allow_classic_operations = false
+
+  tags {
+    environment = "Production"
+  }
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the ExpressRoute circuit. Changing this forces a
+    new resource to be created.
+
+* `resource_group_name` - (Required) The name of the resource group in which to
+    create the namespace. Changing this forces a new resource to be created.
+
+* `location` - (Required) Specifies the supported Azure location where the resource exists.
+    Changing this forces a new resource to be created.
+
+* `service_provider_name` - (Required) The name of the ExpressRoute Service Provider.
+
+* `peering_location` - (Required) The name of the peering location and not the ARM resource location.
+
+* `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created.
+
+* `sku_tier` - (Optional) Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers. 
+    The default value is "Standard".
+
+* `sku_family` - (Optional) Chosen SKU family of ExpressRoute circuit. 
+    Choose from MeteredData or UnlimitedData SKU families. The default value is "MeteredData".
+
+* `allow_classic_operations` - (Optional) Allow the circuit to interact with classic (RDFE) resources.
+    The default value is false.
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The Resource ID of the ExpressRoute circuit.
+* `serviceProviderProvisioningState` - The ServiceProviderProvisioningState state of the resource. 
+    Possible values are "NotProvisioned", "Provisioning", "Provisioned", and "Deprovisioning".
+* `serviceKey` - The string needed by the service provider to provision the ExpressRoute circuit.
+
+## Import
+
+ExpressRoute circuits can be imported using the `resource id`, e.g.
+
+```
+terraform import azurerm_express_route_circuit.myExpressRoute /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/mygroup1/providers/Microsoft.Network/expressRouteCircuits/myExpressRoute
+```

--- a/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
+++ b/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
@@ -49,11 +49,11 @@ The following arguments are supported:
 
 * `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created.
 
-* `sku_tier` - (Optional) Chosen SKU Tier of ExpressRoute circuit. Choose from Premium or Standard SKU tiers. 
+* `sku_tier` - (Optional) Chosen SKU Tier of ExpressRoute circuit. Value must be either "Premium" or "Standard". 
     The default value is "Standard".
 
 * `sku_family` - (Optional) Chosen SKU family of ExpressRoute circuit. 
-    Choose from MeteredData or UnlimitedData SKU families. The default value is "MeteredData".
+    Value must be either "MeteredData" or "UnlimitedData". The default value is "MeteredData".
 
 * `allow_classic_operations` - (Optional) Allow the circuit to interact with classic (RDFE) resources.
     The default value is false.
@@ -65,9 +65,9 @@ The following arguments are supported:
 The following attributes are exported:
 
 * `id` - The Resource ID of the ExpressRoute circuit.
-* `serviceProviderProvisioningState` - The ServiceProviderProvisioningState state of the resource. 
+* `service_provider_provisioning_state` - The ServiceProviderProvisioningState state of the resource. 
     Possible values are "NotProvisioned", "Provisioning", "Provisioned", and "Deprovisioning".
-* `serviceKey` - The string needed by the service provider to provision the ExpressRoute circuit.
+* `service_key` - The string needed by the service provider to provision the ExpressRoute circuit.
 
 ## Import
 

--- a/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
+++ b/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
@@ -47,13 +47,15 @@ The following arguments are supported:
 
 * `peering_location` - (Required) The name of the peering location and not the ARM resource location.
 
-* `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created.
+* `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created. Once you increase your bandwidth, 
+    you will not be able to decrease it to its previous value.
 
 * `sku_tier` - (Optional) Chosen SKU Tier of ExpressRoute circuit. Value must be either "Premium" or "Standard". 
     The default value is "Standard".
 
-* `sku_family` - (Optional) Chosen SKU family of ExpressRoute circuit. 
-    Value must be either "MeteredData" or "UnlimitedData". The default value is "MeteredData".
+* `sku_family` - (Optional) Chosen SKU family (billing model) of ExpressRoute circuit. 
+    Value must be either "MeteredData" or "UnlimitedData". The default value is "MeteredData". 
+    Once you set the billing model to "UnlimitedData", you will not be able to switch to "MeteredData".
 
 * `allow_classic_operations` - (Optional) Allow the circuit to interact with classic (RDFE) resources.
     The default value is false.

--- a/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
+++ b/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
@@ -13,6 +13,11 @@ Creates an ExpressRoute circuit.
 ## Example Usage
 
 ```hcl
+resource "azurerm_resource_group" "test" {
+  name     = "exprtTest"
+  location = "West US"
+}
+
 resource "azurerm_express_route_circuit" "test" {
   name                     = "expressRoute1"
   resource_group_name      = "${azurerm_resource_group.test.name}"

--- a/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
+++ b/website/source/docs/providers/azurerm/r/express_route_circuit.html.markdown
@@ -25,8 +25,10 @@ resource "azurerm_express_route_circuit" "test" {
   service_provider_name    = "Equinix"
   peering_location         = "Silicon Valley"
   bandwidth_in_mbps        = 50
-  sku_tier                 = "Standard"
-  sku_family               = "MeteredData"
+  sku {
+    tier   = "Standard"
+    family = "MeteredData"
+  }
   allow_classic_operations = false
 
   tags {
@@ -55,24 +57,26 @@ The following arguments are supported:
 * `bandwidth_in_mbps` - (Required) The bandwidth in Mbps of the circuit being created. Once you increase your bandwidth, 
     you will not be able to decrease it to its previous value.
 
-* `sku_tier` - (Optional) Chosen SKU Tier of ExpressRoute circuit. Value must be either "Premium" or "Standard". 
-    The default value is "Standard".
-
-* `sku_family` - (Optional) Chosen SKU family (billing model) of ExpressRoute circuit. 
-    Value must be either "MeteredData" or "UnlimitedData". The default value is "MeteredData". 
-    Once you set the billing model to "UnlimitedData", you will not be able to switch to "MeteredData".
+* `sku` - (Required) Chosen SKU of ExpressRoute circuit as documented below.
 
 * `allow_classic_operations` - (Optional) Allow the circuit to interact with classic (RDFE) resources.
     The default value is false.
 
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 
+`sku` supports the following:
+
+* `tier` - (Required) The service tier. Value must be either "Premium" or "Standard".
+
+* `family` - (Required) The billing mode. Value must be either "MeteredData" or "UnlimitedData". 
+   Once you set the billing model to "UnlimitedData", you will not be able to switch to "MeteredData".
+
 ## Attributes Reference
 
 The following attributes are exported:
 
 * `id` - The Resource ID of the ExpressRoute circuit.
-* `service_provider_provisioning_state` - The ServiceProviderProvisioningState state of the resource. 
+* `service_provider_provisioning_state` - The ExpressRoute circuit provisioning state from your chosen service provider. 
     Possible values are "NotProvisioned", "Provisioning", "Provisioned", and "Deprovisioning".
 * `service_key` - The string needed by the service provider to provision the ExpressRoute circuit.
 

--- a/website/source/layouts/azurerm.erb
+++ b/website/source/layouts/azurerm.erb
@@ -218,6 +218,9 @@
                   <a href="/docs/providers/azurerm/r/traffic_manager_endpoint.html">azurerm_traffic_manager_endpoint</a>
                 </li>
 
+                <li<%= sidebar_current("docs-azurerm-resource-express-route-circuit") %>>
+                  <a href="/docs/providers/azurerm/r/express_route_circuit.html">azurerm_express_route_circuit</a>
+                </li>
               </ul>
             </li>
 


### PR DESCRIPTION
#14122 Adding basic support for Express Route Circuit. 

Setting up an Express Route Circuit involves two major steps:
* Creating an Express Route Circuit, then provide the "service key" to the connectivity provider for provisioning on their side.
* Once the connection is provisioned by the provider, you can then continue to setup peering.

This change enables the first step, once the resource is created, the service key is returned as an attribute (see documentation).

Peering setup support is still underway, will be in another PR.

Tests:

```
$ make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMExpressRouteCircuit_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/05 23:11:33 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMExpressRouteCircuit_importBasic -timeout 120m
=== RUN   TestAccAzureRMExpressRouteCircuit_importBasic
--- PASS: TestAccAzureRMExpressRouteCircuit_importBasic (97.99s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	98.006s

$ make testacc TEST=./builtin/providers/azurerm TESTARGS='-run=TestAccAzureRMExpressRouteCircuit_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/05 23:14:40 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm -v -run=TestAccAzureRMExpressRouteCircuit_basic -timeout 120m
=== RUN   TestAccAzureRMExpressRouteCircuit_basic
--- PASS: TestAccAzureRMExpressRouteCircuit_basic (125.20s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	125.219s
```