### PR TITLE
provider/aws: Retry deletion of AWSConfig Rule on ResourceInUseException

### DIFF
--- a/builtin/providers/aws/resource_aws_config_config_rule.go
+++ b/builtin/providers/aws/resource_aws_config_config_rule.go
@@ -242,8 +242,17 @@ func resourceAwsConfigConfigRuleDelete(d *schema.ResourceData, meta interface{})
 	name := d.Get("name").(string)
 
 	log.Printf("[DEBUG] Deleting AWS Config config rule %q", name)
-	_, err := conn.DeleteConfigRule(&configservice.DeleteConfigRuleInput{
-		ConfigRuleName: aws.String(name),
+	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
+		_, err := conn.DeleteConfigRule(&configservice.DeleteConfigRuleInput{
+			ConfigRuleName: aws.String(name),
+		})
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "ResourceInUseException" {
+				return resource.RetryableError(err)
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("Deleting Config Rule failed: %s", err)


### PR DESCRIPTION
### Context

Terraform sometimes fails to delete an AWSConfig rule - this was observed and reported in #terraform channel in Hangops Slack:

> this is for aws config rules … I create them like this
> ``` count = "${length(var.all_rules)}"
>  name = "all_rules"
>  depends_on = ["module.awsconfigusw2"]
>  source {
>    owner             = "AWS"
>    source_identifier = "${element(var.all_rules, count.index)}"
>  }
> ```
> where all_rules is a list with 20 rules. This goes fine with creating but if I try to delete them I got this
> ```
> * aws_config_config_rule.all.3: Deleting Config Rule failed: ResourceInUseException: The rule all_rules is currently being deleted. Please retry after some time.
>     status code: 400, request id: 7a1a8dd2-31ed-11e7-bd6f-cf59f2d58153
> ```
> 
> I got this for 19 rules out of 20 when I try to delete them

I personally wasn't able to reproduce this. I'd probably need to have rules which already collected a lot of data and those data would take time to delete. The mentioned conversation along with documentation are IMO sufficient to prove this needs fixing.

http://docs.aws.amazon.com/config/latest/APIReference/API_DeleteConfigRule.html

> `ResourceInUseException`
> The rule is currently being deleted or the rule is deleting your evaluation results. Try your request again later.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSConfig'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/06 16:17:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSConfig -timeout 120m
=== RUN   TestAccAWSConfig
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/importBasic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled
=== RUN   TestAccAWSConfig/ConfigurationRecorder
=== RUN   TestAccAWSConfig/ConfigurationRecorder/basic
=== RUN   TestAccAWSConfig/ConfigurationRecorder/allParams
=== RUN   TestAccAWSConfig/ConfigurationRecorder/importBasic
=== RUN   TestAccAWSConfig/DeliveryChannel
=== RUN   TestAccAWSConfig/DeliveryChannel/basic
=== RUN   TestAccAWSConfig/DeliveryChannel/allParams
=== RUN   TestAccAWSConfig/DeliveryChannel/importBasic
=== RUN   TestAccAWSConfig/Config
=== RUN   TestAccAWSConfig/Config/ownerAws
=== RUN   TestAccAWSConfig/Config/customlambda
=== RUN   TestAccAWSConfig/Config/importAws
=== RUN   TestAccAWSConfig/Config/importLambda
=== RUN   TestAccAWSConfig/Config/basic
--- PASS: TestAccAWSConfig (1662.96s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus (388.78s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/importBasic (93.25s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/basic (88.16s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorderStatus/startEnabled (207.37s)
    --- PASS: TestAccAWSConfig/ConfigurationRecorder (262.04s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/basic (86.43s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/allParams (84.57s)
        --- PASS: TestAccAWSConfig/ConfigurationRecorder/importBasic (91.04s)
    --- PASS: TestAccAWSConfig/DeliveryChannel (287.65s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/basic (94.21s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/allParams (98.57s)
        --- PASS: TestAccAWSConfig/DeliveryChannel/importBasic (94.87s)
    --- PASS: TestAccAWSConfig/Config (724.48s)
        --- PASS: TestAccAWSConfig/Config/ownerAws (124.52s)
        --- PASS: TestAccAWSConfig/Config/customlambda (174.59s)
        --- PASS: TestAccAWSConfig/Config/importAws (126.87s)
        --- PASS: TestAccAWSConfig/Config/importLambda (179.30s)
        --- PASS: TestAccAWSConfig/Config/basic (119.20s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1662.988s
```