### PR TITLE
Fix data dns txt record set

### DIFF
--- a/builtin/providers/dns/data_dns_a_record_set_test.go
+++ b/builtin/providers/dns/data_dns_a_record_set_test.go
@@ -12,6 +12,7 @@ func TestAccDataDnsARecordSet_Basic(t *testing.T) {
 		DataSourceBlock string
 		DataSourceName  string
 		Expected        []string
+		Host            string
 	}{
 		{
 			`
@@ -23,6 +24,7 @@ func TestAccDataDnsARecordSet_Basic(t *testing.T) {
 			[]string{
 				"127.0.0.1",
 			},
+			"127.0.0.1.nip.io",
 		},
 		{
 			`
@@ -34,23 +36,30 @@ func TestAccDataDnsARecordSet_Basic(t *testing.T) {
 			[]string{
 				"129.6.15.30",
 			},
+			"time-c.nist.gov",
 		},
 	}
 
-	var steps []resource.TestStep
-
 	for _, test := range tests {
-		ts := resource.TestStep{
-			Config: test.DataSourceBlock,
-			Check: resource.ComposeTestCheckFunc(
-				testCheckAttrStringArray(fmt.Sprintf("data.dns_a_record_set.%s", test.DataSourceName), "addrs", test.Expected),
-			),
-		}
-		steps = append(steps, ts)
+		recordName := fmt.Sprintf("data.dns_a_record_set.%s", test.DataSourceName)
+
+		resource.UnitTest(t, resource.TestCase{
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						testCheckAttrStringArray(recordName, "addrs", test.Expected),
+					),
+				},
+				resource.TestStep{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(recordName, "id", test.Host),
+					),
+				},
+			},
+		})
 	}
 
-	resource.Test(t, resource.TestCase{
-		Providers: testAccProviders,
-		Steps:     steps,
-	})
 }

--- a/builtin/providers/dns/data_dns_cname_record_set_test.go
+++ b/builtin/providers/dns/data_dns_cname_record_set_test.go
@@ -10,6 +10,7 @@ func TestAccDnsCnameRecordSet_Basic(t *testing.T) {
 	tests := []struct {
 		DataSourceBlock string
 		Expected        string
+		Host            string
 	}{
 		{
 			`
@@ -18,6 +19,7 @@ func TestAccDnsCnameRecordSet_Basic(t *testing.T) {
 			}
 			`,
 			"dualstack.s.shared.global.fastly.net.",
+			"www.hashicorp.com",
 		},
 	}
 
@@ -29,6 +31,12 @@ func TestAccDnsCnameRecordSet_Basic(t *testing.T) {
 					Config: test.DataSourceBlock,
 					Check: r.ComposeTestCheckFunc(
 						r.TestCheckResourceAttr("data.dns_cname_record_set.foo", "cname", test.Expected),
+					),
+				},
+				r.TestStep{
+					Config: test.DataSourceBlock,
+					Check: r.ComposeTestCheckFunc(
+						r.TestCheckResourceAttr("data.dns_cname_record_set.foo", "id", test.Host),
 					),
 				},
 			},

--- a/builtin/providers/dns/data_dns_txt_record_set.go
+++ b/builtin/providers/dns/data_dns_txt_record_set.go
@@ -34,6 +34,7 @@ func dataSourceDnsTxtRecordSet() *schema.Resource {
 
 func dataSourceDnsTxtRecordSetRead(d *schema.ResourceData, meta interface{}) error {
 	host := d.Get("host").(string)
+
 	records, err := net.LookupTXT(host)
 	if err != nil {
 		return fmt.Errorf("error looking up TXT records for %q: %s", host, err)
@@ -45,5 +46,7 @@ func dataSourceDnsTxtRecordSetRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("record", "")
 	}
 	d.Set("records", records)
+	d.SetId(host)
+
 	return nil
 }

--- a/builtin/providers/dns/data_dns_txt_record_set_test.go
+++ b/builtin/providers/dns/data_dns_txt_record_set_test.go
@@ -1,0 +1,59 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataDnsTxtRecordSet_Basic(t *testing.T) {
+	tests := []struct {
+		DataSourceBlock string
+		DataSourceName  string
+		Expected        []string
+		Host            string
+	}{
+		{
+			`
+			data "dns_txt_record_set" "foo" {
+			  host = "hashicorp.com"
+			}
+			`,
+			"foo",
+			[]string{
+				"google-site-verification=oqoe6Z7OB_726BNm33g4OdKK57KDtCfH266f8wAvLBo",
+				"v=spf1 include:_spf.google.com include:spf.mail.intercom.io  include:stspg-customer.com include:mail.zendesk.com ~all",
+				"status-page-domain-verification=dgtdvzlp8tfn",
+			},
+			"hashicorp.com",
+		},
+	}
+
+	for _, test := range tests {
+		recordName := fmt.Sprintf("data.dns_txt_record_set.%s", test.DataSourceName)
+		resource.UnitTest(t, resource.TestCase{
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						testCheckAttrStringArray(recordName, "records", test.Expected),
+					),
+				},
+				resource.TestStep{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						testCheckAttrStringArrayMember(recordName, "record", test.Expected),
+					),
+				},
+				resource.TestStep{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(recordName, "id", test.Host),
+					),
+				},
+			},
+		})
+	}
+}

--- a/builtin/providers/dns/test_check_attr_string_array.go
+++ b/builtin/providers/dns/test_check_attr_string_array.go
@@ -27,24 +27,27 @@ func testCheckAttrStringArray(name, key string, value []string) r.TestCheckFunc 
 			return fmt.Errorf("Attributes not found for %s", attrKey)
 		}
 
-		got, _ := strconv.Atoi(count)
-		if got != len(value) {
+		gotCount, _ := strconv.Atoi(count)
+		if gotCount != len(value) {
 			return fmt.Errorf("Mismatch array count for %s: got %s, wanted %d", key, count, len(value))
 		}
 
-		for i, want := range value {
+	Next:
+		for i := 0; i < gotCount; i++ {
 			attrKey = fmt.Sprintf("%s.%d", key, i)
 			got, ok := is.Attributes[attrKey]
 			if !ok {
 				return fmt.Errorf("Missing array item for %s", attrKey)
 			}
-			if got != want {
-				return fmt.Errorf(
-					"Mismatched array item for %s: got %s, want %s",
-					attrKey,
-					got,
-					want)
+			for _, want := range value {
+				if got == want {
+					continue Next
+				}
 			}
+			return fmt.Errorf(
+				"Unexpected array item for %s: got %s",
+				attrKey,
+				got)
 		}
 
 		return nil

--- a/builtin/providers/dns/test_check_attr_string_array_member.go
+++ b/builtin/providers/dns/test_check_attr_string_array_member.go
@@ -1,0 +1,39 @@
+package dns
+
+import (
+	"fmt"
+
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testCheckAttrStringArrayMember(name, key string, value []string) r.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		is := rs.Primary
+		if is == nil {
+			return fmt.Errorf("No primary instance: %s", name)
+		}
+
+		got, ok := is.Attributes[key]
+		if !ok {
+			return fmt.Errorf("Attributes not found for %s", key)
+		}
+
+		for _, want := range value {
+			if got == want {
+				return nil
+			}
+		}
+
+		return fmt.Errorf(
+			"Unexpected value for %s: got %s",
+			key,
+			got)
+	}
+}


### PR DESCRIPTION
### Problem

When attempting to use the DNS provider's `data "dns_txt_record_set" …` I was not able to retrieve the TXT records.

#### Input
```
data "dns_txt_record_set" "example" {
  host = "example.com"
}

resource "local_file" "record" {
  content  = "${data.dns_txt_record_set.example.record}"
  filename = "${path.module}/record.txt"
}
```

#### Result
```
Error applying plan:

1 error(s) occurred:

* local_file.record: Resource 'data.dns_txt_record_set.example' does not have attribute 'record' for variable 'data.dns_txt_record_set.example.record'
```

Attempts to access the `id` and `records` attributes failed as well.

### Solution
1. Updated the A and CNAME record set tests to verify that the `id` attribute is correctly set for those (it was).
2. Added test for the DNS record set.
3. Updated the `testCheckAttrStringArray` to not care about order (since DNS record order is not predictable).
4. Fixed DNS record set by adding missing call to `d.SetId(host)`