### PR TITLE
provider/aws: Add support for importing Kinesis Streams

### DIFF
--- a/builtin/providers/aws/resource_aws_kinesis_stream.go
+++ b/builtin/providers/aws/resource_aws_kinesis_stream.go
@@ -18,21 +18,24 @@ func resourceAwsKinesisStream() *schema.Resource {
 		Read:   resourceAwsKinesisStreamRead,
 		Update: resourceAwsKinesisStreamUpdate,
 		Delete: resourceAwsKinesisStreamDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsKinesisStreamImport,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"shard_count": &schema.Schema{
+			"shard_count": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"retention_period": &schema.Schema{
+			"retention_period": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  24,
@@ -46,14 +49,14 @@ func resourceAwsKinesisStream() *schema.Resource {
 				},
 			},
 
-			"shard_level_metrics": &schema.Schema{
+			"shard_level_metrics": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
 
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Optional: true,
 				Computed: true,
@@ -61,6 +64,12 @@ func resourceAwsKinesisStream() *schema.Resource {
 			"tags": tagsSchema(),
 		},
 	}
+}
+
+func resourceAwsKinesisStreamImport(
+	d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("name", d.Id())
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceAwsKinesisStreamCreate(d *schema.ResourceData, meta interface{}) error {
@@ -140,6 +149,7 @@ func resourceAwsKinesisStreamRead(d *schema.ResourceData, meta interface{}) erro
 		return err
 
 	}
+	d.SetId(state.arn)
 	d.Set("arn", state.arn)
 	d.Set("shard_count", len(state.openShards))
 	d.Set("retention_period", state.retentionPeriod)

--- a/website/source/docs/providers/aws/r/kinesis_stream.html.markdown
+++ b/website/source/docs/providers/aws/r/kinesis_stream.html.markdown
@@ -53,6 +53,15 @@ when creating a Kinesis stream. See [Amazon Kinesis Streams][2] for more.
 * `arn` - The Amazon Resource Name (ARN) specifying the Stream
 
 
+## Import
+
+Kinesis Streams can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_kinesis_stream.test_stream terraform-kinesis-test
+```
+
 [1]: https://aws.amazon.com/documentation/kinesis/
 [2]: https://docs.aws.amazon.com/kinesis/latest/dev/amazon-kinesis-streams.html
 [3]: https://docs.aws.amazon.com/streams/latest/dev/monitoring-with-cloudwatch.html
+


### PR DESCRIPTION
Fixes: #14260

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSKinesisStream_import'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/08 10:32:47 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSKinesisStream_import -timeout 120m
=== RUN   TestAccAWSKinesisStream_importBasic
--- PASS: TestAccAWSKinesisStream_importBasic (101.93s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	101.978s
```