### PR TITLE
provider/aws: Refresh ssm document from state on 404

### DIFF
--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -177,8 +177,12 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	resp, err := ssmconn.DescribeDocument(docInput)
-
 	if err != nil {
+		if ssmErr, ok := err.(awserr.Error); ok && ssmErr.Code() == "InvalidDocument" {
+			log.Printf("[WARN] SSM Documnet not found so removing from state")
+			d.SetId("")
+			return nil
+		}
 		return errwrap.Wrapf("[ERROR] Error describing SSM document: {{err}}", err)
 	}
 

--- a/builtin/providers/aws/resource_aws_ssm_document.go
+++ b/builtin/providers/aws/resource_aws_ssm_document.go
@@ -179,7 +179,7 @@ func resourceAwsSsmDocumentRead(d *schema.ResourceData, meta interface{}) error 
 	resp, err := ssmconn.DescribeDocument(docInput)
 	if err != nil {
 		if ssmErr, ok := err.(awserr.Error); ok && ssmErr.Code() == "InvalidDocument" {
-			log.Printf("[WARN] SSM Documnet not found so removing from state")
+			log.Printf("[WARN] SSM Document not found so removing from state")
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
Originally reported in #13976

When an SSM Document was deleted outside of Terraform, a terraform
refresh would return the following:

```
% terraform plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_ssm_document.foo: Refreshing state... (ID: test_document-stack72)
Error refreshing state: 1 error(s) occurred:

* aws_ssm_document.foo: aws_ssm_document.foo: [ERROR] Error describing SSM document: InvalidDocument:
	status code: 400, request id: 70c9bed1-33bb-11e7-99aa-697e9b0914e9

```

On applying this patch, it now looks as follows:

```
% terraform plan
  [WARN] /Users/stacko/Code/go/bin/terraform-provider-aws overrides an internal plugin for aws-provider.
    If you did not expect to see this message you will need to remove the old plugin.
    See https://www.terraform.io/docs/internals/internal-plugins.html
  Refreshing Terraform state in-memory prior to plan...
  The refreshed state will be used to calculate this plan, but will not be
  persisted to local or remote state storage.

  aws_ssm_document.foo: Refreshing state... (ID: test_document-stack72)
  The Terraform execution plan has been generated and is shown below.
  Resources are shown in alphabetical order for quick scanning. Green resources
  will be created (or destroyed and then created if an existing resource
  exists), yellow resources are being changed in-place, and red resources
  will be destroyed. Cyan entries are data sources to be read.

  Note: You didn't specify an "-out" parameter to save this plan, so when
  "apply" is called, Terraform can't guarantee this is what will execute.

  + aws_ssm_document.foo
      arn:              "<computed>"
      content:          "    {\n      \"schemaVersion\": \"1.2\",\n      \"description\": \"Check ip configuration of a Linux instance.\",\n      \"parameters\": {\n\n      },\n      \"runtimeConfig\": {\n        \"aws:runShellScript\": {\n          \"properties\": [\n            {\n              \"id\": \"0.aws:runShellScript\",\n              \"runCommand\": [\"ifconfig\"]\n            }\n          ]\n        }\n      }\n    }\n"
      created_date:     "<computed>"
      default_version:  "<computed>"
      description:      "<computed>"
      document_type:    "Command"
      hash:             "<computed>"
      hash_type:        "<computed>"
      latest_version:   "<computed>"
      name:             "test_document-stack72"
      owner:            "<computed>"
      parameter.#:      "<computed>"
      platform_types.#: "<computed>"
      schema_version:   "<computed>"
      status:           "<computed>"

  Plan: 1 to add, 0 to change, 0 to destroy.
```