### PR TITLE
provider/google: Log HTTP requests and responses in DEBUG mode

### DIFF
--- a/builtin/providers/google/config.go
+++ b/builtin/providers/google/config.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/hashicorp/terraform/helper/logging"
 	"github.com/hashicorp/terraform/helper/pathorcontents"
 	"github.com/hashicorp/terraform/terraform"
 	"golang.org/x/oauth2"
@@ -94,6 +95,8 @@ func (c *Config) loadAndValidate() error {
 			return err
 		}
 	}
+
+	client.Transport = logging.NewTransport("Google", client.Transport)
 
 	versionString := terraform.VersionString()
 	userAgent := fmt.Sprintf(

--- a/helper/logging/transport.go
+++ b/helper/logging/transport.go
@@ -1,0 +1,53 @@
+package logging
+
+import (
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+type transport struct {
+	name      string
+	transport http.RoundTripper
+}
+
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if IsDebugOrHigher() {
+		reqData, err := httputil.DumpRequestOut(req, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logReqMsg, t.name, string(reqData))
+		} else {
+			log.Printf("[ERROR] %s API Request error: %#v", t.name, err)
+		}
+	}
+
+	resp, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return resp, err
+	}
+
+	if IsDebugOrHigher() {
+		respData, err := httputil.DumpResponse(resp, true)
+		if err == nil {
+			log.Printf("[DEBUG] "+logRespMsg, t.name, string(respData))
+		} else {
+			log.Printf("[ERROR] %s API Response error: %#v", t.name, err)
+		}
+	}
+
+	return resp, nil
+}
+
+func NewTransport(name string, t http.RoundTripper) *transport {
+	return &transport{name, t}
+}
+
+const logReqMsg = `%s API Request Details:
+---[ REQUEST ]---------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespMsg = `%s API Response Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`


### PR DESCRIPTION
This is to allow easier debugging of the Google provider and create a transparently logging `RoundTripper` which we can use in other providers that use SDKs which allow passing a custom transport or `http.Client` (which should be most of them) to get a similar behaviour.

### Snippet from debug log

```
2017/05/08 09:55:24 [DEBUG] Google API Request Details:
---[ REQUEST ]---------------------------------------
POST https://www.googleapis.com/compute/v1/projects/terraform-testing/regions/us-central1/addresses?alt=json HTTP/1.1
Host: www.googleapis.com
Content-Type: application/json
User-Agent: google-api-go-client/0.5 (darwin amd64) Terraform/0.9.5-dev

{"name":"address-test-j7idu01jis"}

-----------------------------------------------------
2017/05/08 09:55:30 [DEBUG] Google API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/2.0 200 OK
Alt-Svc: quic=":443"; ma=2592000; v="37,36,35"
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Content-Type: application/json; charset=UTF-8
Date: Mon, 08 May 2017 07:55:28 GMT
Etag: "v4wxzBlixxu7uZ08oFMb8_FmBGc/1gCxrHTRN8pmcWYp-XollYtqIfs"
Expires: Mon, 01 Jan 1990 00:00:00 GMT
Pragma: no-cache
Server: GSE
Vary: Origin
Vary: X-Origin
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 1; mode=block

{
 "kind": "compute#operation",
 "id": "7108038085358492319",
 "name": "operation-1494230127968-54efe8ffd7f00-b2784eec-3529555d",
 "operationType": "insert",
 "targetLink": "https://www.googleapis.com/compute/v1/projects/terraform-testing/regions/us-central1/addresses/address-test-j7idu01jis",
 "targetId": "5174079380724226719",
 "status": "PENDING",
 "user": "radeksimko@terraform-testing.iam.gserviceaccount.com",
 "progress": 0,
 "insertTime": "2017-05-08T00:55:28.363-07:00",
 "selfLink": "https://www.googleapis.com/compute/v1/projects/terraform-testing/regions/us-central1/operations/operation-1494230127968-54efe8ffd7f00-b2784eec-3529555d",
 "region": "https://www.googleapis.com/compute/v1/projects/terraform-testing/regions/us-central1"
}

-----------------------------------------------------
```