### PR TITLE
provider/google: fix Service Account provider .Read

### DIFF
--- a/builtin/providers/google/resource_google_service_account.go
+++ b/builtin/providers/google/resource_google_service_account.go
@@ -118,11 +118,10 @@ func resourceGoogleServiceAccountRead(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		if gerr, ok := err.(*googleapi.Error); ok && gerr.Code == 404 {
 			log.Printf("[WARN] Removing reference to service account %q because it no longer exists", d.Id())
-			saName := d.Id()
 			// The resource doesn't exist anymore
 			d.SetId("")
 
-			return fmt.Errorf("Error getting service account with name %q: %s", saName, err)
+			return nil
 		}
 		return fmt.Errorf("Error reading service account %q: %q", d.Id(), err)
 	}


### PR DESCRIPTION
The implementation would return an error if the resource was detected as
removed - this would break Terraform during plan/apply instead of making it re-create the
missing service account.