### PR TITLE
provider/aws: Fix SG update on instance with multiple network interfaces

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -836,11 +836,37 @@ func resourceAwsInstanceUpdate(d *schema.ResourceData, meta interface{}) error {
 				groups = append(groups, aws.String(v.(string)))
 			}
 		}
-		_, err := conn.ModifyInstanceAttribute(&ec2.ModifyInstanceAttributeInput{
-			InstanceId: aws.String(d.Id()),
-			Groups:     groups,
+		// If a user has multiple network interface attachments on the target EC2 instance, simply modifying the
+		// instance attributes via a `ModifyInstanceAttributes()` request would fail with the following error message:
+		// "There are multiple interfaces attached to instance 'i-XX'. Please specify an interface ID for the operation instead."
+		// Thus, we need to actually modify the primary network interface for the new security groups, as the primary
+		// network interface is where we modify/create security group assignments during Create.
+		log.Printf("[INFO] Modifying `vpc_security_group_ids` on Instance %q", d.Id())
+		instances, err := conn.DescribeInstances(&ec2.DescribeInstancesInput{
+			InstanceIds: []*string{aws.String(d.Id())},
 		})
 		if err != nil {
+			return err
+		}
+		instance := instances.Reservations[0].Instances[0]
+		var primaryInterface ec2.InstanceNetworkInterface
+		for _, ni := range instance.NetworkInterfaces {
+			if *ni.Attachment.DeviceIndex == 0 {
+				primaryInterface = *ni
+			}
+		}
+
+		if primaryInterface.NetworkInterfaceId == nil {
+			log.Print("[Error] Attempted to set vpc_security_group_ids on an instance without a primary network interface")
+			return fmt.Errorf(
+				"Failed to update vpc_security_group_ids on %q, which does not contain a primary network interface",
+				d.Id())
+		}
+
+		if _, err := conn.ModifyNetworkInterfaceAttribute(&ec2.ModifyNetworkInterfaceAttributeInput{
+			NetworkInterfaceId: primaryInterface.NetworkInterfaceId,
+			Groups:             groups,
+		}); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
With an EC2 instance that only had a single network interface, the primary interface, the Update function would call `ModifyInstanceAttribute()` on the target instance. This would only work if there was a single network interface attached to the EC2 instance. If, however, a secondary network interface was attached to the instance, the `ModifyInstanceAttribute()` API call would fail with the following error message:

 > There are multiple interfaces attached to instance 'i-XXXXX'. Please specify an interface ID for the operation instead.

 After this changeset, modifying instance security groups now makes the correct call to `ModifyNetworkInterfaceAttribute()` in order to modify the list of security groups on the primary network interface, as initially configured during the instances creation.

 This change is also safe from an instance that has a non-default primary network interface, as the instance attribute `vpc_security_group_ids` conflicts with the new `network_interface` attribute.

 Test Output:

 ```
 $ make testacc TEST=./builtin/providers/aws TESTARGS="-run=TestAccAWSInstance_addSecurityGroupNetworkInterface"
 ==> Checking that code complies with gofmt requirements...
 go generate $(go list ./... | grep -v /terraform/vendor/)
 2017/05/08 17:52:42 Generated command/internal_plugin_list.go
 TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_addSecurityGroupNetworkInterface -timeout 120m
 === RUN   TestAccAWSInstance_addSecurityGroupNetworkInterface
 --- PASS: TestAccAWSInstance_addSecurityGroupNetworkInterface (327.75s)
 PASS
 ok      github.com/hashicorp/terraform/builtin/providers/aws    327.756s
```

Fixes: #3205, #7635
Related to: #7711