### PR TITLE
Allows zero-value ELB and ALB names

### DIFF
--- a/builtin/providers/aws/resource_aws_alb_test.go
+++ b/builtin/providers/aws/resource_aws_alb_test.go
@@ -98,6 +98,26 @@ func TestAccAWSALB_generatedName(t *testing.T) {
 	})
 }
 
+func TestAccAWSALB_generatesNameForZeroValue(t *testing.T) {
+	var conf elbv2.LoadBalancer
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_alb.alb_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSALBDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSALBConfig_zeroValueName(),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSALBExists("aws_alb.alb_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_alb.alb_test", "name"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSALB_namePrefix(t *testing.T) {
 	var conf elbv2.LoadBalancer
 
@@ -776,6 +796,82 @@ resource "aws_security_group" "alb_test" {
 func testAccAWSALBConfig_generatedName() string {
 	return fmt.Sprintf(`
 resource "aws_alb" "alb_test" {
+  internal        = true
+  security_groups = ["${aws_security_group.alb_test.id}"]
+  subnets         = ["${aws_subnet.alb_test.*.id}"]
+
+  idle_timeout = 30
+  enable_deletion_protection = false
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+variable "subnets" {
+  default = ["10.0.1.0/24", "10.0.2.0/24"]
+  type    = "list"
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_vpc" "alb_test" {
+  cidr_block = "10.0.0.0/16"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = "${aws_vpc.alb_test.id}"
+
+  tags {
+    Name = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_subnet" "alb_test" {
+  count                   = 2
+  vpc_id                  = "${aws_vpc.alb_test.id}"
+  cidr_block              = "${element(var.subnets, count.index)}"
+  map_public_ip_on_launch = true
+  availability_zone       = "${element(data.aws_availability_zones.available.names, count.index)}"
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}
+
+resource "aws_security_group" "alb_test" {
+  name        = "allow_all_alb_test"
+  description = "Used for ALB Testing"
+  vpc_id      = "${aws_vpc.alb_test.id}"
+
+  ingress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags {
+    TestName = "TestAccAWSALB_basic"
+  }
+}`)
+}
+
+func testAccAWSALBConfig_zeroValueName() string {
+	return fmt.Sprintf(`
+resource "aws_alb" "alb_test" {
+  name            = ""
   internal        = true
   security_groups = ["${aws_security_group.alb_test.id}"]
   subnets         = ["${aws_subnet.alb_test.*.id}"]

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -161,14 +161,17 @@ func validateStreamViewType(v interface{}, k string) (ws []string, errors []erro
 
 func validateElbName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
-	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
-		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters and hyphens allowed in %q: %q",
-			k, value))
+	if len(value) == 0 {
+		return // short-circuit
 	}
 	if len(value) > 32 {
 		errors = append(errors, fmt.Errorf(
 			"%q cannot be longer than 32 characters: %q", k, value))
+	}
+	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+		errors = append(errors, fmt.Errorf(
+			"only alphanumeric characters and hyphens allowed in %q: %q",
+			k, value))
 	}
 	if regexp.MustCompile(`^-`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
The `aws_alb` and `aws_elb` resources did not allow zero-value name fields.