### PR TITLE
core: Avoid crash on empty TypeSet blocks

### DIFF
--- a/helper/schema/serialize.go
+++ b/helper/schema/serialize.go
@@ -85,6 +85,9 @@ func SerializeValueForHash(buf *bytes.Buffer, val interface{}, schema *Schema) {
 // to hash complex substructures when used in sets, and so the serialization
 // is not reversible.
 func SerializeResourceForHash(buf *bytes.Buffer, val interface{}, resource *Resource) {
+	if val == nil {
+		return
+	}
 	sm := resource.Schema
 	m := val.(map[string]interface{})
 	var keys []string

--- a/helper/schema/set_test.go
+++ b/helper/schema/set_test.go
@@ -111,3 +111,20 @@ func TestSetUnion(t *testing.T) {
 func testSetInt(v interface{}) int {
 	return v.(int)
 }
+
+func TestHashResource_nil(t *testing.T) {
+	resource := &Resource{
+		Schema: map[string]*Schema{
+			"name": {
+				Type:     TypeString,
+				Optional: true,
+			},
+		},
+	}
+	f := HashResource(resource)
+
+	idx := f(nil)
+	if idx != 0 {
+		t.Fatalf("Expected 0 when hashing nil, given: %d", idx)
+	}
+}


### PR DESCRIPTION
I discovered this when working on K8S Service. It's possible to make Terraform crash when there's a `TypeSet` with `Elem: &Resource` which in turn has all fields `Optional`.

Without arguing too much about whether this is sensible config I think Terraform just shouldn't crash.

Attached is also a test covering the bug.

### Test plan

```
make test TEST=./helper/schema
==> Checking that code complies with gofmt requirements...
==> Checking AWS provider for unchecked errors...
==> NOTE: at this time we only look for uncheck errors in the AWS package
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/09 08:51:30 Generated command/internal_plugin_list.go
go test -i ./helper/schema || exit 1
echo ./helper/schema | \
		xargs -t -n4 go test  -timeout=60s -parallel=4
go test -timeout=60s -parallel=4 ./helper/schema
ok  	github.com/hashicorp/terraform/helper/schema	0.090s
```