### PR TITLE
Add `arn` attribute to `aws_ses_domain_identity` resource

### DIFF
--- a/builtin/providers/aws/resource_aws_ses_domain_identity.go
+++ b/builtin/providers/aws/resource_aws_ses_domain_identity.go
@@ -19,12 +19,16 @@ func resourceAwsSesDomainIdentity() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
+			"arn": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
 			"domain": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-
 			"verification_token": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
@@ -77,6 +81,7 @@ func resourceAwsSesDomainIdentityRead(d *schema.ResourceData, meta interface{}) 
 		return nil
 	}
 
+	d.Set("arn", fmt.Sprintf("arn:%s:ses:%s:%s:identity/%s", meta.(*AWSClient).partition, meta.(*AWSClient).region, meta.(*AWSClient).accountid, d.Id()))
 	d.Set("verification_token", verificationAttrs.VerificationToken)
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_ses_domain_identity_test.go
+++ b/builtin/providers/aws/resource_aws_ses_domain_identity_test.go
@@ -12,6 +12,10 @@ import (
 )
 
 func TestAccAwsSESDomainIdentity_basic(t *testing.T) {
+	domain := fmt.Sprintf(
+		"%s.terraformtesting.com",
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
@@ -20,12 +24,10 @@ func TestAccAwsSESDomainIdentity_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAwsSESDomainIdentityDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: fmt.Sprintf(
-					testAccAwsSESDomainIdentityConfig,
-					acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum),
-				),
+				Config: fmt.Sprintf(testAccAwsSESDomainIdentityConfig, domain),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsSESDomainIdentityExists("aws_ses_domain_identity.test"),
+					testAccCheckAwsSESDomainIdentityArn("aws_ses_domain_identity.test", domain),
 				),
 			},
 		},
@@ -93,8 +95,27 @@ func testAccCheckAwsSESDomainIdentityExists(n string) resource.TestCheckFunc {
 	}
 }
 
+func testAccCheckAwsSESDomainIdentityArn(n string, domain string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, _ := s.RootModule().Resources[n]
+
+		expected := fmt.Sprintf(
+			"arn:%s:ses:%s:%s:identity/%s",
+			testAccProvider.Meta().(*AWSClient).partition,
+			testAccProvider.Meta().(*AWSClient).region,
+			testAccProvider.Meta().(*AWSClient).accountid,
+			domain)
+
+		if rs.Primary.Attributes["arn"] != expected {
+			return fmt.Errorf("Incorrect ARN: expected %q, got %q", expected, rs.Primary.Attributes["arn"])
+		}
+
+		return nil
+	}
+}
+
 const testAccAwsSESDomainIdentityConfig = `
 resource "aws_ses_domain_identity" "test" {
-	domain = "%s.terraformtesting.com"
+	domain = "%s"
 }
 `

--- a/website/source/docs/providers/aws/r/ses_domain_identity.html.markdown
+++ b/website/source/docs/providers/aws/r/ses_domain_identity.html.markdown
@@ -15,10 +15,12 @@ Provides an SES domain identity resource
 The following arguments are supported:
 
 * `domain` - (Required) The domain name to assign to SES
- 
+
 ## Attributes Reference
- 
+
 The following attributes are exported:
+
+* `arn` - The ARN of the domain identity.
 
 * `verification_token` - A code which when added to the domain as a TXT record
   will signal to SES that the owner of the domain has authorised SES to act on
@@ -41,6 +43,6 @@ resource "aws_route53_record" "example_amazonses_verification_record" {
   type    = "TXT"
   ttl     = "600"
   records = ["${aws_ses_domain_identity.example.verification_token}"]
-} 
+}
 ```
 


### PR DESCRIPTION
Adds an `arn` attribute to the `aws_ses_domain_identity` resource.