### PR TITLE
provider/test: allow assigning a label to each instance

### DIFF
--- a/builtin/providers/test/data_source_label.go
+++ b/builtin/providers/test/data_source_label.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func providerLabelDataSource() *schema.Resource {
+	return &schema.Resource{
+		Read: providerLabelDataSourceRead,
+
+		Schema: map[string]*schema.Schema{
+			"label": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func providerLabelDataSourceRead(d *schema.ResourceData, meta interface{}) error {
+	label := meta.(string)
+	d.SetId(label)
+	d.Set("label", label)
+	return nil
+}

--- a/builtin/providers/test/data_source_label_test.go
+++ b/builtin/providers/test/data_source_label_test.go
@@ -1,0 +1,45 @@
+package test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestProviderLabelDataSource(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		CheckDestroy: func(s *terraform.State) error {
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: strings.TrimSpace(`
+provider "test" {
+  label = "foo"
+}
+
+data "test_provider_label" "test" {
+}
+				`),
+				Check: func(s *terraform.State) error {
+					res, hasRes := s.RootModule().Resources["data.test_provider_label.test"]
+					if !hasRes {
+						return errors.New("No test_provider_label in state")
+					}
+					if got, want := res.Primary.ID, "foo"; got != want {
+						return fmt.Errorf("wrong id %q; want %q", got, want)
+					}
+					if got, want := res.Primary.Attributes["label"], "foo"; got != want {
+						return fmt.Errorf("wrong id %q; want %q", got, want)
+					}
+					return nil
+				},
+			},
+		},
+	})
+}

--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -7,17 +7,27 @@ import (
 
 func Provider() terraform.ResourceProvider {
 	return &schema.Provider{
+		Schema: map[string]*schema.Schema{
+			// Optional attribute to label a particular instance for a test
+			// that has multiple instances of this provider, so that they
+			// can be distinguished using the test_provider_label data source.
+			"label": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"test_resource":         testResource(),
 			"test_resource_gh12183": testResourceGH12183(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
-			"test_data_source": testDataSource(),
+			"test_data_source":    testDataSource(),
+			"test_provider_label": providerLabelDataSource(),
 		},
 		ConfigureFunc: providerConfigure,
 	}
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
-	return nil, nil
+	return d.Get("label"), nil
 }


### PR DESCRIPTION
When testing the behavior of multiple provider instances (either aliases or child module overrides) it's convenient to be able to label the individual instances to determine which one is actually being used for the purpose of making test assertions.

This can be used as follows:

```hcl
# root.tf

provider "test" {
  label = "root"
}

data "test_provider_label" "foo" {
}

module "child" {
  source = "./child"

  in = "${var.in}"
  count = 2
}

output "root_test_provider_label" {
  value = "${data.test_provider_label.foo.label}"
}

output "child_test_provider_label" {
  value = "${module.child.provider_label}"
}
```

```hcl
# child/child.tf

provider "test" {
  label = "child"
}

data "test_provider_label" "foo" {
}

output "provider_label" {
  value = "${data.test_provider_label.foo.label}"
}
```

Later I intend to use this to write some automated tests that verify that module inheritance is behaving as expected (which it currently isn't, but planning to work on that...) but for now I'm just using it for manual testing like the above in order to understand different permutations of the current behavior.
