### PR TITLE
Don't error out getting s3 object tags in govcloud

### DIFF
--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -127,6 +127,8 @@ func resourceAwsS3BucketObject() *schema.Resource {
 func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) error {
 	s3conn := meta.(*AWSClient).s3conn
 
+	restricted := meta.(*AWSClient).IsGovCloud() || meta.(*AWSClient).IsChinaCloud()
+
 	var body io.ReadSeeker
 
 	if v, ok := d.GetOk("source"); ok {
@@ -192,6 +194,10 @@ func resourceAwsS3BucketObjectPut(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	if v, ok := d.GetOk("tags"); ok {
+		if restricted {
+			return fmt.Errorf("This region does not allow for tags on S3 objects")
+		}
+
 		// The tag-set must be encoded as URL Query parameters.
 		values := url.Values{}
 		for k, v := range v.(map[string]interface{}) {
@@ -271,18 +277,15 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 		d.Set("storage_class", resp.StorageClass)
 	}
 
-	tagResp, err := s3conn.GetObjectTagging(
-		&s3.GetObjectTaggingInput{
-			Bucket: aws.String(bucket),
-			Key:    aws.String(key),
-		})
-	if err != nil {
-		// Treat the inability to get object tags in a restricted regions as a
-		// soft error.
-		if !restricted {
+	if !restricted {
+		tagResp, err := s3conn.GetObjectTagging(
+			&s3.GetObjectTaggingInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(key),
+			})
+		if err != nil {
 			return fmt.Errorf("Failed to get object tags (bucket: %s, key: %s): %s", bucket, key, err)
 		}
-	} else {
 		d.Set("tags", tagsToMapS3(tagResp.TagSet))
 	}
 

--- a/builtin/providers/aws/resource_aws_s3_bucket_object.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_object.go
@@ -280,7 +280,7 @@ func resourceAwsS3BucketObjectRead(d *schema.ResourceData, meta interface{}) err
 		// Treat the inability to get object tags in a restricted regions as a
 		// soft error.
 		if !restricted {
-			return err
+			return fmt.Errorf("Failed to get object tags (bucket: %s, key: %s): %s", bucket, key, err)
 		}
 	} else {
 		d.Set("tags", tagsToMapS3(tagResp.TagSet))


### PR DESCRIPTION
Govcloud doesn't support tags on S3 objects, so if we can't get them, don't error out.