### PR TITLE
provider/google: add failover parameter to sql database instance

### DIFF
--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -266,6 +266,11 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 							Optional: true,
 							ForceNew: true,
 						},
+						"failover_target": &schema.Schema{
+							Type:     schema.TypeBool,
+							Optional: true,
+							ForceNew: true,
+						},
 						"master_heartbeat_period": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
@@ -508,6 +513,10 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 			replicaConfiguration := &sqladmin.ReplicaConfiguration{}
 			mySqlReplicaConfiguration := &sqladmin.MySqlReplicaConfiguration{}
 			_replicaConfiguration := _replicaConfigurationList[0].(map[string]interface{})
+
+			if vp, okp := _replicaConfiguration["failover_target"]; okp {
+				replicaConfiguration.FailoverTarget = vp.(bool)
+			}
 
 			if vp, okp := _replicaConfiguration["ca_certificate"]; okp {
 				mySqlReplicaConfiguration.CaCertificate = vp.(string)
@@ -830,6 +839,10 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 		if len(_replicaConfigurationList) == 1 && _replicaConfigurationList[0] != nil {
 			mySqlReplicaConfiguration := instance.ReplicaConfiguration.MysqlReplicaConfiguration
 			_replicaConfiguration := _replicaConfigurationList[0].(map[string]interface{})
+
+			if vp, okp := _replicaConfiguration["failover_target"]; okp && vp != nil {
+				_replicaConfiguration["failover_target"] = instance.ReplicaConfiguration.FailoverTarget
+			}
 
 			if vp, okp := _replicaConfiguration["ca_certificate"]; okp && vp != nil {
 				_replicaConfiguration["ca_certificate"] = mySqlReplicaConfiguration.CaCertificate

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -408,66 +408,73 @@ func testAccCheckGoogleSqlDatabaseInstanceEquals(n string,
 			return fmt.Errorf("Error settings.pricing_plan mismatch, (%s, %s)", server, local)
 		}
 
-		if instance.ReplicaConfiguration != nil &&
-			instance.ReplicaConfiguration.MysqlReplicaConfiguration != nil {
-			server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.CaCertificate
-			local = attributes["replica_configuration.0.ca_certificate"]
+		if instance.ReplicaConfiguration != nil {
+			server = strconv.FormatBool(instance.ReplicaConfiguration.FailoverTarget)
+			local = attributes["replica_configuration.0.failover_target"]
 			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.ca_certificate mismatch, (%s, %s)", server, local)
+				return fmt.Errorf("Error replica_configuration.failover_target mismatch, (%s, %s)", server, local)
 			}
 
-			server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.ClientCertificate
-			local = attributes["replica_configuration.0.client_certificate"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.client_certificate mismatch, (%s, %s)", server, local)
-			}
+			if instance.ReplicaConfiguration.MysqlReplicaConfiguration != nil {
+				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.CaCertificate
+				local = attributes["replica_configuration.0.ca_certificate"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.ca_certificate mismatch, (%s, %s)", server, local)
+				}
 
-			server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.ClientKey
-			local = attributes["replica_configuration.0.client_key"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.client_key mismatch, (%s, %s)", server, local)
-			}
+				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.ClientCertificate
+				local = attributes["replica_configuration.0.client_certificate"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.client_certificate mismatch, (%s, %s)", server, local)
+				}
 
-			server = strconv.FormatInt(instance.ReplicaConfiguration.MysqlReplicaConfiguration.ConnectRetryInterval, 10)
-			local = attributes["replica_configuration.0.connect_retry_interval"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.connect_retry_interval mismatch, (%s, %s)", server, local)
-			}
+				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.ClientKey
+				local = attributes["replica_configuration.0.client_key"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.client_key mismatch, (%s, %s)", server, local)
+				}
 
-			server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.DumpFilePath
-			local = attributes["replica_configuration.0.dump_file_path"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.dump_file_path mismatch, (%s, %s)", server, local)
-			}
+				server = strconv.FormatInt(instance.ReplicaConfiguration.MysqlReplicaConfiguration.ConnectRetryInterval, 10)
+				local = attributes["replica_configuration.0.connect_retry_interval"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.connect_retry_interval mismatch, (%s, %s)", server, local)
+				}
 
-			server = strconv.FormatInt(instance.ReplicaConfiguration.MysqlReplicaConfiguration.MasterHeartbeatPeriod, 10)
-			local = attributes["replica_configuration.0.master_heartbeat_period"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.master_heartbeat_period mismatch, (%s, %s)", server, local)
-			}
+				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.DumpFilePath
+				local = attributes["replica_configuration.0.dump_file_path"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.dump_file_path mismatch, (%s, %s)", server, local)
+				}
 
-			server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.Password
-			local = attributes["replica_configuration.0.password"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.password mismatch, (%s, %s)", server, local)
-			}
+				server = strconv.FormatInt(instance.ReplicaConfiguration.MysqlReplicaConfiguration.MasterHeartbeatPeriod, 10)
+				local = attributes["replica_configuration.0.master_heartbeat_period"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.master_heartbeat_period mismatch, (%s, %s)", server, local)
+				}
 
-			server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.SslCipher
-			local = attributes["replica_configuration.0.ssl_cipher"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.ssl_cipher mismatch, (%s, %s)", server, local)
-			}
+				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.Password
+				local = attributes["replica_configuration.0.password"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.password mismatch, (%s, %s)", server, local)
+				}
 
-			server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.Username
-			local = attributes["replica_configuration.0.username"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.username mismatch, (%s, %s)", server, local)
-			}
+				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.SslCipher
+				local = attributes["replica_configuration.0.ssl_cipher"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.ssl_cipher mismatch, (%s, %s)", server, local)
+				}
 
-			server = strconv.FormatBool(instance.ReplicaConfiguration.MysqlReplicaConfiguration.VerifyServerCertificate)
-			local = attributes["replica_configuration.0.verify_server_certificate"]
-			if server != local && len(server) > 0 && len(local) > 0 {
-				return fmt.Errorf("Error replica_configuration.verify_server_certificate mismatch, (%s, %s)", server, local)
+				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.Username
+				local = attributes["replica_configuration.0.username"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.username mismatch, (%s, %s)", server, local)
+				}
+
+				server = strconv.FormatBool(instance.ReplicaConfiguration.MysqlReplicaConfiguration.VerifyServerCertificate)
+				local = attributes["replica_configuration.0.verify_server_certificate"]
+				if server != local && len(server) > 0 && len(local) > 0 {
+					return fmt.Errorf("Error replica_configuration.verify_server_certificate mismatch, (%s, %s)", server, local)
+				}
 			}
 		}
 

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -163,6 +163,11 @@ to work, cannot be updated, and supports:
 * `dump_file_path` - (Optional) Path to a SQL file in GCS from which slave
     instances are created. Format is `gs://bucket/filename`.
 
+* `failover_target` - (Optional) Specifies if the replica is the failover target.
+    If the field is set to true the replica will be designated as a failover replica.
+    If the master instance fails, the replica instance will be promoted as
+    the new master instance.
+
 * `master_heartbeat_period` - (Optional) Time in ms between replication
     heartbeats.
 


### PR DESCRIPTION
Fixes #11652.

I wasn't sure the best way to test this, since it looks like the only test involving replica configs so far isn't actually run, and has this comment: `Note - this test is not feasible to run unless we generate backups first.` (https://github.com/hashicorp/terraform/blob/master/builtin/providers/google/resource_sql_database_instance_test.go#L599)