### PR TITLE
add to "VPN connection route" error message

### DIFF
--- a/builtin/providers/aws/resource_vpn_connection_route.go
+++ b/builtin/providers/aws/resource_vpn_connection_route.go
@@ -85,7 +85,9 @@ func resourceAwsVpnConnectionRouteRead(d *schema.ResourceData, meta interface{})
 			d.SetId("")
 			return nil
 		} else {
-			log.Printf("[ERROR] Error finding VPN connection route: %s", err)
+			// if the route has changed, we won't know, and we won't be able to find it
+			// check the AWS console for any out-of-band edits made by your colleagues
+			log.Printf("[ERROR] Error finding VPN connection route: %s (did it change? check the AWS console)", err)
 			return err
 		}
 	}


### PR DESCRIPTION
Most resources and objects on AWS have IDs, but these connection routes don't.
If the routes have been edited, Terraform won't be able to find the route, and it'll
error out when trying to find them. Ideally, Terraform would be able to "fix" the edit,
this update is a short-term fix to help users solve their own problem in the meantime.