### PR TITLE
adds `description` to `command` schema in `rundeck_job` resource

### DIFF
--- a/builtin/providers/rundeck/resource_job.go
+++ b/builtin/providers/rundeck/resource_job.go
@@ -183,6 +183,10 @@ func resourceRundeckJob() *schema.Resource {
 				Required: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
+						"description": &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
 						"shell_command": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
@@ -364,6 +368,7 @@ func jobFromResourceData(d *schema.ResourceData) (*rundeck.JobDetail, error) {
 	for _, commandI := range commandConfigs {
 		commandMap := commandI.(map[string]interface{})
 		command := rundeck.JobCommand{
+			Description:    commandMap["description"].(string),
 			ShellCommand:   commandMap["shell_command"].(string),
 			Script:         commandMap["inline_script"].(string),
 			ScriptFile:     commandMap["script_file"].(string),
@@ -552,6 +557,7 @@ func jobToResourceData(job *rundeck.JobDetail, d *schema.ResourceData) error {
 		d.Set("command_ordering_strategy", job.CommandSequence.OrderingStrategy)
 		for _, command := range job.CommandSequence.Commands {
 			commandConfigI := map[string]interface{}{
+				"description":      command.Description,
 				"shell_command":    command.ShellCommand,
 				"inline_script":    command.Script,
 				"script_file":      command.ScriptFile,

--- a/builtin/providers/rundeck/resource_job_test.go
+++ b/builtin/providers/rundeck/resource_job_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/apparentlymart/go-rundeck-api/rundeck"
-
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -25,6 +24,9 @@ func TestAccJob_basic(t *testing.T) {
 					func(s *terraform.State) error {
 						if expected := "basic-job"; job.Name != expected {
 							return fmt.Errorf("wrong name; expected %v, got %v", expected, job.Name)
+						}
+						if expected := "Prints Hello World"; job.CommandSequence.Commands[0].Description != expected {
+							return fmt.Errorf("failed to set command description; expected %v, got %v", expected, job.CommandSequence.Commands[0].Description)
 						}
 						return nil
 					},
@@ -98,6 +100,7 @@ resource "rundeck_job" "test" {
     default_value = "bar"
   }
   command {
+    description = "Prints Hello World"
     shell_command = "echo Hello World"
   }
 }

--- a/website/source/docs/providers/rundeck/r/job.html.md
+++ b/website/source/docs/providers/rundeck/r/job.html.md
@@ -125,6 +125,8 @@ The following arguments are supported:
 
 `command` blocks must have any one of the following combinations of arguments as contents:
 
+* `description`: (Optional) gives a description to the command block.
+
 * `shell_command` gives a single shell command to execute on the nodes.
 
 * `inline_script` gives a whole shell script, inline in the configuration, to execute on the nodes.


### PR DESCRIPTION
This change allows you to add descriptions to command/step blocks in Rundeck. This is especially nice when viewing a definition that contains multiple script steps.