### PR TITLE
provider/github: Log HTTP requests and responses in DEBUG mode

### DIFF
--- a/builtin/providers/github/config.go
+++ b/builtin/providers/github/config.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 
 	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/logging"
 	"golang.org/x/oauth2"
 )
 
@@ -27,6 +28,8 @@ func (c *Config) Client() (interface{}, error) {
 	)
 	tc := oauth2.NewClient(oauth2.NoContext, ts)
 
+	tc.Transport = logging.NewTransport("Github", tc.Transport)
+
 	org.client = github.NewClient(tc)
 	if c.BaseURL != "" {
 		u, err := url.Parse(c.BaseURL)
@@ -35,5 +38,6 @@ func (c *Config) Client() (interface{}, error) {
 		}
 		org.client.BaseURL = u
 	}
+
 	return &org, nil
 }


### PR DESCRIPTION
This should shed some light on the intermittent failures of Github acceptance tests that we keep seeing.

### Example
```
2017/05/10 21:54:51 [DEBUG] Github API Request Details:
---[ REQUEST ]---------------------------------------
POST /repos/*REDACTED*/test-repo/labels HTTP/1.1
Host: api.github.com
User-Agent: go-github/4
Content-Length: 32
Accept: application/vnd.github.v3+json
Content-Type: application/json
Accept-Encoding: gzip

{"name":"foo","color":"000000"}

-----------------------------------------------------
2017/05/10 21:54:52 [DEBUG] Github API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 201 Created
Content-Length: 137
Access-Control-Allow-Origin: *
Access-Control-Expose-Headers: ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval
Cache-Control: private, max-age=60, s-maxage=60
Content-Security-Policy: default-src 'none'
Content-Type: application/json; charset=utf-8
Date: Wed, 10 May 2017 19:54:52 GMT
Etag: "33ce873352f0894f03139ca05792060c"
Location: https://api.github.com/repos/*REDACTED*/test-repo/labels/foo
Server: GitHub.com
Status: 201 Created
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
Vary: Accept, Authorization, Cookie, X-GitHub-OTP
Vary: Accept-Encoding
X-Accepted-Oauth-Scopes: 
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-Github-Media-Type: github.v3; format=json
X-Github-Request-Id: DFCB:3F97:7787E93:9426BC2:5913700C
X-Oauth-Scopes: public_repo
X-Ratelimit-Limit: 5000
X-Ratelimit-Remaining: 4998
X-Ratelimit-Reset: 1494449692
X-Served-By: 2d7a5e35115884240089368322196839
X-Xss-Protection: 1; mode=block

{"id":602417973,"url":"https://api.github.com/repos/*REDACTED*/test-repo/labels/foo","name":"foo","color":"000000","default":false}
-----------------------------------------------------
```