### PR TITLE
provider/pagerduty: Randomize names in acceptance tests

### DIFF
--- a/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourcePagerDutyEscalationPolicy_Basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourcePagerDutyEscalationPolicyConfig(username, email, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyEscalationPolicy("pagerduty_escalation_policy.test", "data.pagerduty_escalation_policy.by_name"),

--- a/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_escalation_policy_test.go
@@ -10,13 +10,16 @@ import (
 )
 
 func TestAccDataSourcePagerDutyEscalationPolicy_Basic(t *testing.T) {
-	rName := acctest.RandString(5)
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourcePagerDutyEscalationPolicyConfig(rName),
+				Config: testAccDataSourcePagerDutyEscalationPolicyConfig(username, email, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyEscalationPolicy("pagerduty_escalation_policy.test", "data.pagerduty_escalation_policy.by_name"),
 				),
@@ -50,15 +53,15 @@ func testAccDataSourcePagerDutyEscalationPolicy(src, n string) resource.TestChec
 	}
 }
 
-func testAccDataSourcePagerDutyEscalationPolicyConfig(rName string) string {
+func testAccDataSourcePagerDutyEscalationPolicyConfig(username, email, escalationPolicy string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "test" {
-  name  = "TF User %[1]s"
-  email = "tf.%[1]s@example.com"
+  name  = "%s"
+  email = "%s"
 }
 
 resource "pagerduty_escalation_policy" "test" {
-  name        = "TF Escalation Policy %[1]v"
+  name        = "%s"
   num_loops   = 2
 
   rule {
@@ -74,5 +77,5 @@ resource "pagerduty_escalation_policy" "test" {
 data "pagerduty_escalation_policy" "by_name" {
   name = "${pagerduty_escalation_policy.test.name}"
 }
-`, rName)
+`, username, email, escalationPolicy)
 }

--- a/builtin/providers/pagerduty/data_source_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_schedule_test.go
@@ -10,13 +10,16 @@ import (
 )
 
 func TestAccDataSourcePagerDutySchedule_Basic(t *testing.T) {
-	rName := acctest.RandString(5)
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourcePagerDutyScheduleConfig(rName),
+				Config: testAccDataSourcePagerDutyScheduleConfig(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutySchedule("pagerduty_schedule.test", "data.pagerduty_schedule.by_name"),
 				),
@@ -50,15 +53,15 @@ func testAccDataSourcePagerDutySchedule(src, n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourcePagerDutyScheduleConfig(rName string) string {
+func testAccDataSourcePagerDutyScheduleConfig(username, email, schedule string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "test" {
-  name  = "TF User %[1]s"
-  email = "tf.%[1]s@example.com"
+  name  = "%s"
+  email = "%s"
 }
 
 resource "pagerduty_schedule" "test" {
-  name = "TF Schedule %[1]s"
+  name = "%s"
 
   time_zone = "America/New_York"
 
@@ -81,5 +84,5 @@ resource "pagerduty_schedule" "test" {
 data "pagerduty_schedule" "by_name" {
   name = "${pagerduty_schedule.test.name}"
 }
-`, rName)
+`, username, email, schedule)
 }

--- a/builtin/providers/pagerduty/data_source_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_schedule_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourcePagerDutySchedule_Basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourcePagerDutyScheduleConfig(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutySchedule("pagerduty_schedule.test", "data.pagerduty_schedule.by_name"),

--- a/builtin/providers/pagerduty/data_source_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_user_test.go
@@ -10,13 +10,15 @@ import (
 )
 
 func TestAccDataSourcePagerDutyUser_Basic(t *testing.T) {
-	rName := acctest.RandString(5)
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccDataSourcePagerDutyUserConfig(rName),
+				Config: testAccDataSourcePagerDutyUserConfig(username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyUser("pagerduty_user.test", "data.pagerduty_user.by_email"),
 				),
@@ -50,15 +52,15 @@ func testAccDataSourcePagerDutyUser(src, n string) resource.TestCheckFunc {
 	}
 }
 
-func testAccDataSourcePagerDutyUserConfig(rName string) string {
+func testAccDataSourcePagerDutyUserConfig(username, email string) string {
 	return fmt.Sprintf(`
 resource "pagerduty_user" "test" {
-  name = "TF User %[1]s"
-  email = "tf.%[1]s@example.com"
+  name = "%s"
+  email = "%s"
 }
 
 data "pagerduty_user" "by_email" {
 	email = "${pagerduty_user.test.email}"
 }
-`, rName)
+`, username, email)
 }

--- a/builtin/providers/pagerduty/data_source_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/data_source_pagerduty_user_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourcePagerDutyUser_Basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccDataSourcePagerDutyUserConfig(username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourcePagerDutyUser("pagerduty_user.test", "data.pagerduty_user.by_email"),

--- a/builtin/providers/pagerduty/import_pagerduty_escalation_policy_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_escalation_policy_test.go
@@ -18,11 +18,11 @@ func TestAccPagerDutyEscalationPolicy_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyEscalationPolicyConfig(username, email, escalationPolicy),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "pagerduty_escalation_policy.foo",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/pagerduty/import_pagerduty_escalation_policy_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_escalation_policy_test.go
@@ -1,13 +1,17 @@
 package pagerduty
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccPagerDutyEscalationPolicy_import(t *testing.T) {
-	resourceName := "pagerduty_escalation_policy.foo"
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,11 +19,11 @@ func TestAccPagerDutyEscalationPolicy_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyEscalationPolicyConfig,
+				Config: testAccCheckPagerDutyEscalationPolicyConfig(username, email, escalationPolicy),
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "pagerduty_escalation_policy.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/builtin/providers/pagerduty/import_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_schedule_test.go
@@ -18,11 +18,11 @@ func TestAccPagerDutySchedule_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "pagerduty_schedule.foo",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/pagerduty/import_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_schedule_test.go
@@ -1,13 +1,17 @@
 package pagerduty
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccPagerDutySchedule_import(t *testing.T) {
-	resourceName := "pagerduty_schedule.foo"
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,11 +19,11 @@ func TestAccPagerDutySchedule_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyScheduleConfig,
+				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule),
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "pagerduty_schedule.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/builtin/providers/pagerduty/import_pagerduty_service_integration_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_service_integration_test.go
@@ -20,11 +20,11 @@ func TestAccPagerDutyServiceIntegration_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceIntegrationConfig(username, email, escalationPolicy, service, serviceIntegration),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "pagerduty_service_integration.foo",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/pagerduty/import_pagerduty_service_integration_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_service_integration_test.go
@@ -1,13 +1,19 @@
 package pagerduty
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccPagerDutyServiceIntegration_import(t *testing.T) {
-	resourceName := "pagerduty_service_integration.foo"
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,11 +21,11 @@ func TestAccPagerDutyServiceIntegration_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceIntegrationConfig,
+				Config: testAccCheckPagerDutyServiceIntegrationConfig(username, email, escalationPolicy, service, serviceIntegration),
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "pagerduty_service_integration.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/builtin/providers/pagerduty/import_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_service_test.go
@@ -19,11 +19,11 @@ func TestAccPagerDutyService_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "pagerduty_service.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -43,11 +43,11 @@ func TestAccPagerDutyServiceWithIncidentUrgency_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "pagerduty_service.foo",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/pagerduty/import_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_service_test.go
@@ -1,13 +1,18 @@
 package pagerduty
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccPagerDutyService_import(t *testing.T) {
-	resourceName := "pagerduty_service.foo"
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,11 +20,11 @@ func TestAccPagerDutyService_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceConfig,
+				Config: testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service),
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "pagerduty_service.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -28,7 +33,10 @@ func TestAccPagerDutyService_import(t *testing.T) {
 }
 
 func TestAccPagerDutyServiceWithIncidentUrgency_import(t *testing.T) {
-	resourceName := "pagerduty_service.foo"
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -36,11 +44,11 @@ func TestAccPagerDutyServiceWithIncidentUrgency_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig,
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service),
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "pagerduty_service.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/builtin/providers/pagerduty/import_pagerduty_team_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_team_test.go
@@ -16,11 +16,11 @@ func TestAccPagerDutyTeam_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyTeamDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyTeamConfig(team),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "pagerduty_team.foo",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/pagerduty/import_pagerduty_team_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_team_test.go
@@ -1,13 +1,15 @@
 package pagerduty
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccPagerDutyTeam_import(t *testing.T) {
-	resourceName := "pagerduty_team.foo"
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,11 +17,11 @@ func TestAccPagerDutyTeam_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyTeamDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyTeamConfig,
+				Config: testAccCheckPagerDutyTeamConfig(team),
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "pagerduty_team.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/builtin/providers/pagerduty/import_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_user_test.go
@@ -1,13 +1,16 @@
 package pagerduty
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccPagerDutyUser_import(t *testing.T) {
-	resourceName := "pagerduty_user.foo"
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,11 +18,11 @@ func TestAccPagerDutyUser_import(t *testing.T) {
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyUserConfig,
+				Config: testAccCheckPagerDutyUserConfig(username, email),
 			},
 
 			resource.TestStep{
-				ResourceName:      resourceName,
+				ResourceName:      "pagerduty_user.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},

--- a/builtin/providers/pagerduty/import_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/import_pagerduty_user_test.go
@@ -17,11 +17,11 @@ func TestAccPagerDutyUser_import(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyUserConfig(username, email),
 			},
 
-			resource.TestStep{
+			{
 				ResourceName:      "pagerduty_user.foo",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/builtin/providers/pagerduty/provider_test.go
+++ b/builtin/providers/pagerduty/provider_test.go
@@ -29,6 +29,10 @@ func TestProviderImpl(t *testing.T) {
 }
 
 func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("PAGERDUTY_PARALLEL"); v != "" {
+		t.Parallel()
+	}
+
 	if v := os.Getenv("PAGERDUTY_TOKEN"); v == "" {
 		t.Fatal("PAGERDUTY_TOKEN must be set for acceptance tests")
 	}

--- a/builtin/providers/pagerduty/resource_pagerduty_addon_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_addon_test.go
@@ -5,32 +5,36 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyAddon_Basic(t *testing.T) {
+	addon := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	addonUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyAddonDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyAddonConfig,
+				Config: testAccCheckPagerDutyAddonConfig(addon),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyAddonExists("pagerduty_addon.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_addon.foo", "name", "Foo status page"),
+						"pagerduty_addon.foo", "name", addon),
 					resource.TestCheckResourceAttr(
 						"pagerduty_addon.foo", "src", "https://intranet.foo.com/status"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyAddonConfigUpdated,
+				Config: testAccCheckPagerDutyAddonConfigUpdated(addonUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyAddonExists("pagerduty_addon.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_addon.foo", "name", "Bar status page"),
+						"pagerduty_addon.foo", "name", addonUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_addon.foo", "src", "https://intranet.bar.com/status"),
 				),
@@ -80,16 +84,20 @@ func testAccCheckPagerDutyAddonExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckPagerDutyAddonConfig = `
+func testAccCheckPagerDutyAddonConfig(addon string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_addon" "foo" {
-  name = "Foo status page"
+  name = "%s"
   src  = "https://intranet.foo.com/status"
 }
-`
+`, addon)
+}
 
-const testAccCheckPagerDutyAddonConfigUpdated = `
+func testAccCheckPagerDutyAddonConfigUpdated(addon string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_addon" "foo" {
-  name = "Bar status page"
+  name = "%s"
   src  = "https://intranet.bar.com/status"
 }
-`
+`, addon)
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_addon_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_addon_test.go
@@ -19,7 +19,7 @@ func TestAccPagerDutyAddon_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyAddonDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyAddonConfig(addon),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyAddonExists("pagerduty_addon.foo"),
@@ -29,7 +29,7 @@ func TestAccPagerDutyAddon_Basic(t *testing.T) {
 						"pagerduty_addon.foo", "src", "https://intranet.foo.com/status"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyAddonConfigUpdated(addonUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyAddonExists("pagerduty_addon.foo"),

--- a/builtin/providers/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -21,7 +21,7 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyEscalationPolicyConfig(username, email, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),
@@ -38,7 +38,7 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyEscalationPolicyConfigUpdated(username, email, escalationPolicyUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),
@@ -72,7 +72,7 @@ func TestAccPagerDutyEscalationPolicyWithTeams_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyEscalationPolicyWithTeamsConfig(username, email, team, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),
@@ -90,7 +90,7 @@ func TestAccPagerDutyEscalationPolicyWithTeams_Basic(t *testing.T) {
 						"pagerduty_escalation_policy.foo", "teams.#", "1"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyEscalationPolicyWithTeamsConfigUpdated(username, email, team, escalationPolicyUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),

--- a/builtin/providers/pagerduty/resource_pagerduty_escalation_policy_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_escalation_policy_test.go
@@ -5,22 +5,28 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	escalationPolicyUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyEscalationPolicyConfig,
+				Config: testAccCheckPagerDutyEscalationPolicyConfig(username, email, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_escalation_policy.foo", "name", "foo"),
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy),
 					resource.TestCheckResourceAttr(
 						"pagerduty_escalation_policy.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -31,12 +37,13 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 						"pagerduty_escalation_policy.foo", "rule.0.escalation_delay_in_minutes", "10"),
 				),
 			},
+
 			resource.TestStep{
-				Config: testAccCheckPagerDutyEscalationPolicyConfigUpdated,
+				Config: testAccCheckPagerDutyEscalationPolicyConfigUpdated(username, email, escalationPolicyUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_escalation_policy.foo", "name", "bar"),
+						"pagerduty_escalation_policy.foo", "name", escalationPolicyUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_escalation_policy.foo", "description", "bar"),
 					resource.TestCheckResourceAttr(
@@ -54,17 +61,23 @@ func TestAccPagerDutyEscalationPolicy_Basic(t *testing.T) {
 }
 
 func TestAccPagerDutyEscalationPolicyWithTeams_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	escalationPolicyUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyEscalationPolicyDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyEscalationPolicyWithTeamsConfig,
+				Config: testAccCheckPagerDutyEscalationPolicyWithTeamsConfig(username, email, team, escalationPolicy),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_escalation_policy.foo", "name", "foo"),
+						"pagerduty_escalation_policy.foo", "name", escalationPolicy),
 					resource.TestCheckResourceAttr(
 						"pagerduty_escalation_policy.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -78,11 +91,11 @@ func TestAccPagerDutyEscalationPolicyWithTeams_Basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyEscalationPolicyWithTeamsConfigUpdated,
+				Config: testAccCheckPagerDutyEscalationPolicyWithTeamsConfigUpdated(username, email, team, escalationPolicyUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyEscalationPolicyExists("pagerduty_escalation_policy.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_escalation_policy.foo", "name", "bar"),
+						"pagerduty_escalation_policy.foo", "name", escalationPolicyUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_escalation_policy.foo", "description", "bar"),
 					resource.TestCheckResourceAttr(
@@ -143,10 +156,11 @@ func testAccCheckPagerDutyEscalationPolicyExists(n string) resource.TestCheckFun
 	}
 }
 
-const testAccCheckPagerDutyEscalationPolicyConfig = `
+func testAccCheckPagerDutyEscalationPolicyConfig(name, email, escalationPolicy string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -154,7 +168,7 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "foo"
+  name        = "%s"
   description = "foo"
   num_loops   = 1
 
@@ -167,12 +181,14 @@ resource "pagerduty_escalation_policy" "foo" {
     }
   }
 }
-`
+`, name, email, escalationPolicy)
+}
 
-const testAccCheckPagerDutyEscalationPolicyConfigUpdated = `
+func testAccCheckPagerDutyEscalationPolicyConfigUpdated(name, email, escalationPolicy string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -180,7 +196,7 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "bar"
+  name        = "%s"
   description = "bar"
   num_loops   = 2
 
@@ -202,12 +218,14 @@ resource "pagerduty_escalation_policy" "foo" {
     }
   }
 }
-`
+`, name, email, escalationPolicy)
+}
 
-const testAccCheckPagerDutyEscalationPolicyWithTeamsConfig = `
+func testAccCheckPagerDutyEscalationPolicyWithTeamsConfig(name, email, team, escalationPolicy string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -215,12 +233,12 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_team" "foo" {
-  name        = "foo"
+  name        = "%s"
   description = "foo"
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "foo"
+  name        = "%s"
   description = "foo"
   num_loops   = 1
 	teams       = ["${pagerduty_team.foo.id}"]
@@ -234,12 +252,14 @@ resource "pagerduty_escalation_policy" "foo" {
     }
   }
 }
-`
+`, name, email, team, escalationPolicy)
+}
 
-const testAccCheckPagerDutyEscalationPolicyWithTeamsConfigUpdated = `
+func testAccCheckPagerDutyEscalationPolicyWithTeamsConfigUpdated(name, email, team, escalationPolicy string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -247,12 +267,12 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_team" "foo" {
-  name        = "foo"
+  name        = "%s"
   description = "foo"
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "bar"
+  name        = "%s"
   description = "bar"
   num_loops   = 2
 
@@ -274,4 +294,5 @@ resource "pagerduty_escalation_policy" "foo" {
     }
   }
 }
-`
+`, name, email, team, escalationPolicy)
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_schedule_test.go
@@ -5,22 +5,28 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutySchedule_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyScheduleConfig,
+				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "name", "foo"),
+						"pagerduty_schedule.foo", "name", schedule),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -32,11 +38,11 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyScheduleConfigUpdated,
+				Config: testAccCheckPagerDutyScheduleConfigUpdated(username, email, scheduleUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "name", "bar"),
+						"pagerduty_schedule.foo", "name", scheduleUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
@@ -52,17 +58,22 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 }
 
 func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	scheduleUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyScheduleConfigWeek,
+				Config: testAccCheckPagerDutyScheduleConfigWeek(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "name", "foo"),
+						"pagerduty_schedule.foo", "name", schedule),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -76,11 +87,11 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyScheduleConfigWeekUpdated,
+				Config: testAccCheckPagerDutyScheduleConfigWeekUpdated(username, email, scheduleUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "name", "bar"),
+						"pagerduty_schedule.foo", "name", scheduleUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "Managed by Terraform"),
 					resource.TestCheckResourceAttr(
@@ -98,17 +109,21 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 }
 
 func TestAccPagerDutySchedule_Multi(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	schedule := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyScheduleConfigMulti,
+				Config: testAccCheckPagerDutyScheduleConfigMulti(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_schedule.foo", "name", "foo"),
+						"pagerduty_schedule.foo", "name", schedule),
 					resource.TestCheckResourceAttr(
 						"pagerduty_schedule.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -215,14 +230,15 @@ func testAccCheckPagerDutyScheduleExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckPagerDutyScheduleConfig = `
+func testAccCheckPagerDutyScheduleConfig(username, email, schedule string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name  = "foo"
-  email = "foo@bar.com"
+  name  = "%s"
+  email = "%s"
 }
 
 resource "pagerduty_schedule" "foo" {
-  name = "foo"
+  name = "%s"
 
   time_zone   = "Europe/Berlin"
   description = "foo"
@@ -241,16 +257,18 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`
+`, username, email, schedule)
+}
 
-const testAccCheckPagerDutyScheduleConfigUpdated = `
+func testAccCheckPagerDutyScheduleConfigUpdated(username, email, schedule string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
 }
 
 resource "pagerduty_schedule" "foo" {
-  name = "bar"
+  name = "%s"
 
   time_zone = "America/New_York"
 
@@ -268,16 +286,18 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`
+`, username, email, schedule)
+}
 
-const testAccCheckPagerDutyScheduleConfigWeek = `
+func testAccCheckPagerDutyScheduleConfigWeek(username, email, schedule string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name  = "foo"
-  email = "foo@bar.com"
+  name  = "%s"
+  email = "%s"
 }
 
 resource "pagerduty_schedule" "foo" {
-  name = "foo"
+  name = "%s"
 
   time_zone   = "Europe/Berlin"
   description = "foo"
@@ -297,16 +317,18 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`
+`, username, email, schedule)
+}
 
-const testAccCheckPagerDutyScheduleConfigWeekUpdated = `
+func testAccCheckPagerDutyScheduleConfigWeekUpdated(username, email, schedule string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
 }
 
 resource "pagerduty_schedule" "foo" {
-  name = "bar"
+  name = "%s"
 
   time_zone = "America/New_York"
 
@@ -325,16 +347,18 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`
+`, username, email, schedule)
+}
 
-const testAccCheckPagerDutyScheduleConfigMulti = `
+func testAccCheckPagerDutyScheduleConfigMulti(username, email, schedule string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
 }
 
 resource "pagerduty_schedule" "foo" {
-  name = "foo"
+  name = "%s"
 
   time_zone   = "America/New_York"
   description = "foo"
@@ -383,4 +407,5 @@ resource "pagerduty_schedule" "foo" {
     }
   }
 }
-`
+`, username, email, schedule)
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_schedule_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_schedule_test.go
@@ -21,7 +21,7 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyScheduleConfig(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
@@ -37,7 +37,7 @@ func TestAccPagerDutySchedule_Basic(t *testing.T) {
 						"pagerduty_schedule.foo", "layer.0.name", "foo"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyScheduleConfigUpdated(username, email, scheduleUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
@@ -68,7 +68,7 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyScheduleConfigWeek(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
@@ -86,7 +86,7 @@ func TestAccPagerDutySchedule_BasicWeek(t *testing.T) {
 						"pagerduty_schedule.foo", "layer.0.restriction.0.start_day_of_week", "1"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyScheduleConfigWeekUpdated(username, email, scheduleUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),
@@ -118,7 +118,7 @@ func TestAccPagerDutySchedule_Multi(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyScheduleDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyScheduleConfigMulti(username, email, schedule),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyScheduleExists("pagerduty_schedule.foo"),

--- a/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
@@ -5,22 +5,30 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceIntegrationUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceIntegrationConfig,
+				Config: testAccCheckPagerDutyServiceIntegrationConfig(username, email, escalationPolicy, service, serviceIntegration),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service_integration.foo", "name", "foo"),
+						"pagerduty_service_integration.foo", "name", serviceIntegration),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "type", "generic_events_api_inbound_integration"),
 					resource.TestCheckResourceAttr(
@@ -28,11 +36,11 @@ func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceIntegrationConfigUpdated,
+				Config: testAccCheckPagerDutyServiceIntegrationConfigUpdated(username, email, escalationPolicy, service, serviceIntegrationUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service_integration.foo", "name", "bar"),
+						"pagerduty_service_integration.foo", "name", serviceIntegrationUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "type", "generic_events_api_inbound_integration"),
 					resource.TestCheckResourceAttr(
@@ -44,27 +52,34 @@ func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
 }
 
 func TestAccPagerDutyServiceIntegrationGeneric_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceIntegration := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceIntegrationUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceIntegrationGenericConfig,
+				Config: testAccCheckPagerDutyServiceIntegrationGenericConfig(username, email, escalationPolicy, service, serviceIntegration),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service_integration.foo", "name", "foo"),
+						"pagerduty_service_integration.foo", "name", serviceIntegration),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "type", "generic_events_api_inbound_integration"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceIntegrationGenericConfigUpdated,
+				Config: testAccCheckPagerDutyServiceIntegrationGenericConfigUpdated(username, email, escalationPolicy, service, serviceIntegrationUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service_integration.foo", "name", "bar"),
+						"pagerduty_service_integration.foo", "name", serviceIntegrationUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service_integration.foo", "type", "generic_events_api_inbound_integration"),
 				),
@@ -120,14 +135,15 @@ func testAccCheckPagerDutyServiceIntegrationExists(n string) resource.TestCheckF
 	}
 }
 
-const testAccCheckPagerDutyServiceIntegrationConfig = `
+func testAccCheckPagerDutyServiceIntegrationConfig(username, email, escalationPolicy, service, serviceIntegration string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "foo"
+  name        = "%s"
   description = "foo"
   num_loops   = 1
 
@@ -142,7 +158,7 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-  name                    = "foo"
+  name                    = "%s"
   description             = "foo"
   auto_resolve_timeout    = 1800
   acknowledgement_timeout = 1800
@@ -159,16 +175,18 @@ data "pagerduty_vendor" "datadog" {
 }
 
 resource "pagerduty_service_integration" "foo" {
-  name    = "foo"
+  name    = "%s"
   service = "${pagerduty_service.foo.id}"
   vendor  = "${data.pagerduty_vendor.datadog.id}"
 }
-`
+`, username, email, escalationPolicy, service, serviceIntegration)
+}
 
-const testAccCheckPagerDutyServiceIntegrationConfigUpdated = `
+func testAccCheckPagerDutyServiceIntegrationConfigUpdated(username, email, escalationPolicy, service, serviceIntegration string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -176,7 +194,7 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "bar"
+  name        = "%s"
   description = "bar"
   num_loops   = 2
 
@@ -191,7 +209,7 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-  name                    = "bar"
+  name                    = "%s"
   description             = "bar"
   auto_resolve_timeout    = 3600
   acknowledgement_timeout = 3600
@@ -208,20 +226,22 @@ data "pagerduty_vendor" "datadog" {
 }
 
 resource "pagerduty_service_integration" "foo" {
-  name    = "bar"
+  name    = "%s"
   service = "${pagerduty_service.foo.id}"
   vendor  = "${data.pagerduty_vendor.datadog.id}"
 }
-`
+`, username, email, escalationPolicy, service, serviceIntegration)
+}
 
-const testAccCheckPagerDutyServiceIntegrationGenericConfig = `
+func testAccCheckPagerDutyServiceIntegrationGenericConfig(username, email, escalationPolicy, service, serviceIntegration string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "foo"
+  name        = "%s"
   description = "foo"
   num_loops   = 1
 
@@ -236,7 +256,7 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-  name                    = "foo"
+  name                    = "%s"
   description             = "foo"
   auto_resolve_timeout    = 1800
   acknowledgement_timeout = 1800
@@ -249,16 +269,18 @@ resource "pagerduty_service" "foo" {
 }
 
 resource "pagerduty_service_integration" "foo" {
-  name    = "foo"
+  name    = "%s"
   service = "${pagerduty_service.foo.id}"
   type    = "generic_events_api_inbound_integration"
 }
-`
+`, username, email, escalationPolicy, service, serviceIntegration)
+}
 
-const testAccCheckPagerDutyServiceIntegrationGenericConfigUpdated = `
+func testAccCheckPagerDutyServiceIntegrationGenericConfigUpdated(username, email, escalationPolicy, service, serviceIntegration string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
   color       = "green"
   role        = "user"
   job_title   = "foo"
@@ -266,7 +288,7 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-  name        = "bar"
+  name        = "%s"
   description = "bar"
   num_loops   = 2
 
@@ -281,7 +303,7 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-  name                    = "bar"
+  name                    = "%s"
   description             = "bar"
   auto_resolve_timeout    = 3600
   acknowledgement_timeout = 3600
@@ -294,8 +316,9 @@ resource "pagerduty_service" "foo" {
 }
 
 resource "pagerduty_service_integration" "foo" {
-  name    = "bar"
+  name    = "%s"
   service = "${pagerduty_service.foo.id}"
   type    = "generic_events_api_inbound_integration"
 }
-`
+`, username, email, escalationPolicy, service, serviceIntegration)
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_integration_test.go
@@ -23,7 +23,7 @@ func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceIntegrationConfig(username, email, escalationPolicy, service, serviceIntegration),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
@@ -35,7 +35,7 @@ func TestAccPagerDutyServiceIntegration_Basic(t *testing.T) {
 						"pagerduty_service_integration.foo", "vendor", "PAM4FGS"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceIntegrationConfigUpdated(username, email, escalationPolicy, service, serviceIntegrationUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
@@ -64,7 +64,7 @@ func TestAccPagerDutyServiceIntegrationGeneric_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceIntegrationDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceIntegrationGenericConfig(username, email, escalationPolicy, service, serviceIntegration),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),
@@ -74,7 +74,7 @@ func TestAccPagerDutyServiceIntegrationGeneric_Basic(t *testing.T) {
 						"pagerduty_service_integration.foo", "type", "generic_events_api_inbound_integration"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceIntegrationGenericConfigUpdated(username, email, escalationPolicy, service, serviceIntegrationUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceIntegrationExists("pagerduty_service_integration.foo"),

--- a/builtin/providers/pagerduty/resource_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_test.go
@@ -22,7 +22,7 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -42,7 +42,7 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceConfigUpdated(username, email, escalationPolicy, serviceUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -78,7 +78,7 @@ func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -140,7 +140,7 @@ func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 						"pagerduty_service.foo", "support_hours.0.type", "fixed_time_per_day"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated(username, email, escalationPolicy, serviceUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -218,7 +218,7 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
@@ -238,7 +238,7 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 						"pagerduty_service.foo", "incident_urgency_rule.0.type", "constant"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated(username, email, escalationPolicy, serviceUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),

--- a/builtin/providers/pagerduty/resource_pagerduty_service_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_service_test.go
@@ -5,22 +5,29 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyService_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceConfig,
+				Config: testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", "foo"),
+						"pagerduty_service.foo", "name", service),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -36,11 +43,11 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceConfigUpdated,
+				Config: testAccCheckPagerDutyServiceConfigUpdated(username, email, escalationPolicy, serviceUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", "bar"),
+						"pagerduty_service.foo", "name", serviceUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "bar"),
 					resource.TestCheckResourceAttr(
@@ -60,17 +67,23 @@ func TestAccPagerDutyService_Basic(t *testing.T) {
 }
 
 func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig,
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", "foo"),
+						"pagerduty_service.foo", "name", service),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -128,11 +141,11 @@ func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated,
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated(username, email, escalationPolicy, serviceUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", "bar"),
+						"pagerduty_service.foo", "name", serviceUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "bar bar bar"),
 					resource.TestCheckResourceAttr(
@@ -194,17 +207,23 @@ func TestAccPagerDutyService_BasicWithIncidentUrgencyRules(t *testing.T) {
 }
 
 func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	escalationPolicy := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	service := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	serviceUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyServiceDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceConfig,
+				Config: testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", "foo"),
+						"pagerduty_service.foo", "name", service),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "foo"),
 					resource.TestCheckResourceAttr(
@@ -220,11 +239,11 @@ func TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules(t *testing.T)
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated,
+				Config: testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated(username, email, escalationPolicy, serviceUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyServiceExists("pagerduty_service.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_service.foo", "name", "bar"),
+						"pagerduty_service.foo", "name", serviceUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_service.foo", "description", "bar bar bar"),
 					resource.TestCheckResourceAttr(
@@ -328,10 +347,11 @@ func testAccCheckPagerDutyServiceExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckPagerDutyServiceConfig = `
+func testAccCheckPagerDutyServiceConfig(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-	name        = "foo"
-	email       = "foo@example.com"
+	name        = "%s"
+	email       = "%s"
 	color       = "green"
 	role        = "user"
 	job_title   = "foo"
@@ -339,7 +359,7 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-	name        = "bar"
+	name        = "%s"
 	description = "bar"
 	num_loops   = 2
 	rule {
@@ -352,7 +372,7 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-	name                    = "foo"
+	name                    = "%s"
 	description             = "foo"
 	auto_resolve_timeout    = 1800
 	acknowledgement_timeout = 1800
@@ -362,12 +382,14 @@ resource "pagerduty_service" "foo" {
 		urgency = "high"
 	}
 }
-`
+`, username, email, escalationPolicy, service)
+}
 
-const testAccCheckPagerDutyServiceConfigUpdated = `
+func testAccCheckPagerDutyServiceConfigUpdated(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-	name        = "foo"
-	email       = "foo@example.com"
+	name        = "%s"
+	email       = "%s"
 	color       = "green"
 	role        = "user"
 	job_title   = "foo"
@@ -375,7 +397,7 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-	name        = "bar"
+	name        = "%s"
 	description = "bar"
 	num_loops   = 2
 
@@ -389,7 +411,7 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-	name                    = "bar"
+	name                    = "%s"
 	description             = "bar"
 	auto_resolve_timeout    = 3600
 	acknowledgement_timeout = 3600
@@ -400,12 +422,14 @@ resource "pagerduty_service" "foo" {
 		urgency = "high"
 	}
 }
-`
+`, username, email, escalationPolicy, service)
+}
 
-const testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig = `
+func testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfig(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-	name        = "foo"
-	email       = "foo@example.com"
+	name        = "%s"
+	email       = "%s"
 	color       = "green"
 	role        = "user"
 	job_title   = "foo"
@@ -413,7 +437,7 @@ resource "pagerduty_user" "foo" {
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-	name        = "bar"
+	name        = "%s"
 	description = "bar"
 	num_loops   = 2
 
@@ -427,7 +451,7 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-	name                    = "foo"
+	name                    = "%s"
 	description             = "foo"
 	auto_resolve_timeout    = 1800
 	acknowledgement_timeout = 1800
@@ -463,12 +487,14 @@ resource "pagerduty_service" "foo" {
 		}
 	}
 }
-`
+`, username, email, escalationPolicy, service)
+}
 
-const testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated = `
+func testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated(username, email, escalationPolicy, service string) string {
+	return fmt.Sprintf(`
 	resource "pagerduty_user" "foo" {
-	name        = "foo"
-	email       = "foo@example.com"
+	name        = "%s"
+	email       = "%s"
 	color       = "green"
 	role        = "user"
 	job_title   = "foo"
@@ -476,7 +502,7 @@ const testAccCheckPagerDutyServiceWithIncidentUrgencyRulesConfigUpdated = `
 }
 
 resource "pagerduty_escalation_policy" "foo" {
-	name        = "bar"
+	name        = "%s"
 	description = "bar"
 	num_loops   = 2
 
@@ -490,12 +516,12 @@ resource "pagerduty_escalation_policy" "foo" {
 }
 
 resource "pagerduty_service" "foo" {
-	name                    = "bar"
+	name                    = "%s"
 	description             = "bar bar bar"
 	auto_resolve_timeout    = 3600
 	acknowledgement_timeout = 3600
 	escalation_policy       = "${pagerduty_escalation_policy.foo.id}"
-	
+
 	incident_urgency_rule {
 		type = "use_support_hours"
 		during_support_hours {
@@ -525,4 +551,5 @@ resource "pagerduty_service" "foo" {
 		}
 	}
 }
-`
+`, username, email, escalationPolicy, service)
+}

--- a/builtin/providers/pagerduty/resource_pagerduty_team_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_team_test.go
@@ -5,32 +5,36 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyTeam_Basic(t *testing.T) {
+	team := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	teamUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyTeamDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyTeamConfig,
+				Config: testAccCheckPagerDutyTeamConfig(team),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyTeamExists("pagerduty_team.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_team.foo", "name", "foo"),
+						"pagerduty_team.foo", "name", team),
 					resource.TestCheckResourceAttr(
 						"pagerduty_team.foo", "description", "foo"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyTeamConfigUpdated,
+				Config: testAccCheckPagerDutyTeamConfigUpdated(teamUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyTeamExists("pagerduty_team.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_team.foo", "name", "bar"),
+						"pagerduty_team.foo", "name", teamUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_team.foo", "description", "bar"),
 				),
@@ -68,16 +72,18 @@ func testAccCheckPagerDutyTeamExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckPagerDutyTeamConfig = `
+func testAccCheckPagerDutyTeamConfig(team string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_team" "foo" {
-  name        = "foo"
+  name        = "%s"
   description = "foo"
+}`, team)
 }
-`
 
-const testAccCheckPagerDutyTeamConfigUpdated = `
+func testAccCheckPagerDutyTeamConfigUpdated(team string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_team" "foo" {
-  name        = "bar"
+  name        = "%s"
   description = "bar"
+}`, team)
 }
-`

--- a/builtin/providers/pagerduty/resource_pagerduty_team_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_team_test.go
@@ -19,7 +19,7 @@ func TestAccPagerDutyTeam_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyTeamDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyTeamConfig(team),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyTeamExists("pagerduty_team.foo"),
@@ -29,7 +29,7 @@ func TestAccPagerDutyTeam_Basic(t *testing.T) {
 						"pagerduty_team.foo", "description", "foo"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyTeamConfigUpdated(teamUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyTeamExists("pagerduty_team.foo"),

--- a/builtin/providers/pagerduty/resource_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_user_test.go
@@ -21,7 +21,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyUserConfig(username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
@@ -39,7 +39,7 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 						"pagerduty_user.foo", "description", "foo"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyUserConfigUpdated(usernameUpdated, emailUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
@@ -72,7 +72,7 @@ func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyUserWithTeamsConfig(team1, username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
@@ -84,7 +84,7 @@ func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
 						"pagerduty_user.foo", "teams.#", "1"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyUserWithTeamsConfigUpdated(team1, team2, username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
@@ -96,7 +96,7 @@ func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
 						"pagerduty_user.foo", "teams.#", "2"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccCheckPagerDutyUserWithNoTeamsConfig(team1, team2, username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),

--- a/builtin/providers/pagerduty/resource_pagerduty_user_test.go
+++ b/builtin/providers/pagerduty/resource_pagerduty_user_test.go
@@ -5,24 +5,30 @@ import (
 	"testing"
 
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccPagerDutyUser_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	usernameUpdated := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	emailUpdated := fmt.Sprintf("%s@foo.com", usernameUpdated)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyUserConfig,
+				Config: testAccCheckPagerDutyUserConfig(username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "name", "foo"),
+						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "email", "foo@bar.com"),
+						"pagerduty_user.foo", "email", email),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "color", "green"),
 					resource.TestCheckResourceAttr(
@@ -34,13 +40,13 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyUserConfigUpdated,
+				Config: testAccCheckPagerDutyUserConfigUpdated(usernameUpdated, emailUpdated),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "name", "bar"),
+						"pagerduty_user.foo", "name", usernameUpdated),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "email", "bar@foo.com"),
+						"pagerduty_user.foo", "email", emailUpdated),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "color", "red"),
 					resource.TestCheckResourceAttr(
@@ -56,43 +62,48 @@ func TestAccPagerDutyUser_Basic(t *testing.T) {
 }
 
 func TestAccPagerDutyUserWithTeams_Basic(t *testing.T) {
+	username := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	email := fmt.Sprintf("%s@foo.com", username)
+	team1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+	team2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckPagerDutyUserDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccCheckPagerDutyUserWithTeamsConfig,
+				Config: testAccCheckPagerDutyUserWithTeamsConfig(team1, username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "name", "foo"),
+						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "email", "foo@bar.com"),
+						"pagerduty_user.foo", "email", email),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "teams.#", "1"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyUserWithTeamsConfigUpdated,
+				Config: testAccCheckPagerDutyUserWithTeamsConfigUpdated(team1, team2, username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "name", "foo"),
+						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "email", "foo@bar.com"),
+						"pagerduty_user.foo", "email", email),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "teams.#", "2"),
 				),
 			},
 			resource.TestStep{
-				Config: testAccCheckPagerDutyUserWithNoTeamsConfig,
+				Config: testAccCheckPagerDutyUserWithNoTeamsConfig(team1, team2, username, email),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckPagerDutyUserExists("pagerduty_user.foo"),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "name", "foo"),
+						"pagerduty_user.foo", "name", username),
 					resource.TestCheckResourceAttr(
-						"pagerduty_user.foo", "email", "foo@bar.com"),
+						"pagerduty_user.foo", "email", email),
 					resource.TestCheckResourceAttr(
 						"pagerduty_user.foo", "teams.#", "0"),
 				),
@@ -145,66 +156,75 @@ func testAccCheckPagerDutyUserExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccCheckPagerDutyUserConfig = `
+func testAccCheckPagerDutyUserConfig(username, email string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "foo"
-  email       = "foo@bar.com"
+  name        = "%s"
+  email       = "%s"
   color       = "green"
   role        = "user"
   job_title   = "foo"
   description = "foo"
+}`, username, email)
 }
-`
 
-const testAccCheckPagerDutyUserConfigUpdated = `
+func testAccCheckPagerDutyUserConfigUpdated(username, email string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_user" "foo" {
-  name        = "bar"
-  email       = "bar@foo.com"
+  name        = "%s"
+  email       = "%s"
   color       = "red"
   role        = "team_responder"
   job_title   = "bar"
   description = "bar"
+}`, username, email)
 }
-`
 
-const testAccCheckPagerDutyUserWithTeamsConfig = `
+func testAccCheckPagerDutyUserWithTeamsConfig(team, username, email string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_team" "foo" {
-  name = "Foo team"
+  name = "%s"
 }
 
 resource "pagerduty_user" "foo" {
-  name  = "foo"
-  email = "foo@bar.com"
+  name  = "%s"
+  email = "%s"
   teams = ["${pagerduty_team.foo.id}"]
 }
-`
-const testAccCheckPagerDutyUserWithTeamsConfigUpdated = `
+`, team, username, email)
+}
+
+func testAccCheckPagerDutyUserWithTeamsConfigUpdated(team1, team2, username, email string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_team" "foo" {
-  name = "Foo team"
+  name = "%s"
 }
 
 resource "pagerduty_team" "bar" {
-  name = "Bar team"
+  name = "%s"
 }
 
 resource "pagerduty_user" "foo" {
-  name  = "foo"
-  email = "foo@bar.com"
+  name  = "%s"
+  email = "%s"
   teams = ["${pagerduty_team.foo.id}", "${pagerduty_team.bar.id}"]
 }
-`
+`, team1, team2, username, email)
+}
 
-const testAccCheckPagerDutyUserWithNoTeamsConfig = `
+func testAccCheckPagerDutyUserWithNoTeamsConfig(team1, team2, username, email string) string {
+	return fmt.Sprintf(`
 resource "pagerduty_team" "foo" {
-  name = "Foo team"
+  name = "%s"
 }
 
 resource "pagerduty_team" "bar" {
-  name = "Bar team"
+  name = "%s"
 }
 
 resource "pagerduty_user" "foo" {
-  name  = "foo"
-  email = "foo@bar.com"
+  name  = "%s"
+  email = "%s"
 }
-`
+`, team1, team2, username, email)
+}


### PR DESCRIPTION
This PR will allow us to run PagerDuty tests in parallel and prevent us from running into collisions.

Parallel test result:
```bash
$ make testacc TEST=./builtin/providers/pagerduty
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/10 22:16:32 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/pagerduty -v  -timeout 120m
=== RUN   TestConfigEmptyToken
--- PASS: TestConfigEmptyToken (0.00s)
=== RUN   TestConfigSkipCredsValidation
2017/05/10 22:16:36 [INFO] PagerDuty client configured
--- PASS: TestConfigSkipCredsValidation (0.00s)
=== RUN   TestAccDataSourcePagerDutyEscalationPolicy_Basic
=== RUN   TestAccDataSourcePagerDutySchedule_Basic
=== RUN   TestAccDataSourcePagerDutyUser_Basic
=== RUN   TestAccDataSourcePagerDutyVendor_Basic
=== RUN   TestAccPagerDutyEscalationPolicy_import
=== RUN   TestAccPagerDutySchedule_import
=== RUN   TestAccPagerDutyServiceIntegration_import
=== RUN   TestAccPagerDutyService_import
=== RUN   TestAccPagerDutyServiceWithIncidentUrgency_import
=== RUN   TestAccPagerDutyTeam_import
=== RUN   TestAccPagerDutyUser_import
=== RUN   TestProvider
--- PASS: TestProvider (0.00s)
=== RUN   TestProviderImpl
--- PASS: TestProviderImpl (0.00s)
=== RUN   TestAccPagerDutyAddon_Basic
=== RUN   TestAccPagerDutyEscalationPolicy_Basic
=== RUN   TestAccPagerDutyEscalationPolicyWithTeams_Basic
=== RUN   TestAccPagerDutySchedule_Basic
=== RUN   TestAccPagerDutySchedule_BasicWeek
=== RUN   TestAccPagerDutySchedule_Multi
=== RUN   TestAccPagerDutyServiceIntegration_Basic
=== RUN   TestAccPagerDutyServiceIntegrationGeneric_Basic
=== RUN   TestAccPagerDutyService_Basic
=== RUN   TestAccPagerDutyService_BasicWithIncidentUrgencyRules
=== RUN   TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules
=== RUN   TestAccPagerDutyTeam_Basic
=== RUN   TestAccPagerDutyUser_Basic
=== RUN   TestAccPagerDutyUserWithTeams_Basic
--- PASS: TestAccPagerDutyTeam_Basic (12.09s)
--- PASS: TestAccPagerDutySchedule_Multi (16.66s)
--- PASS: TestAccDataSourcePagerDutyEscalationPolicy_Basic (17.10s)
--- PASS: TestAccPagerDutySchedule_BasicWeek (18.52s)
--- PASS: TestAccPagerDutyEscalationPolicyWithTeams_Basic (22.20s)
--- PASS: TestAccPagerDutyService_Basic (22.67s)
--- PASS: TestAccPagerDutyServiceIntegrationGeneric_Basic (28.02s)
--- PASS: TestAccPagerDutyServiceIntegration_Basic (28.83s)
--- PASS: TestAccPagerDutySchedule_Basic (19.96s)
--- PASS: TestAccPagerDutySchedule_import (13.74s)
--- PASS: TestAccDataSourcePagerDutyVendor_Basic (4.49s)
--- PASS: TestAccPagerDutyAddon_Basic (11.48s)
--- PASS: TestAccPagerDutyEscalationPolicy_import (11.80s)
--- PASS: TestAccPagerDutyEscalationPolicy_Basic (17.96s)
--- PASS: TestAccPagerDutyServiceIntegration_import (19.48s)
--- PASS: TestAccPagerDutyTeam_import (7.15s)
--- PASS: TestAccPagerDutyUser_import (11.79s)
--- PASS: TestAccDataSourcePagerDutyUser_Basic (10.80s)
--- PASS: TestAccDataSourcePagerDutySchedule_Basic (12.64s)
--- PASS: TestAccPagerDutyServiceWithIncidentUrgency_import (14.13s)
--- PASS: TestAccPagerDutyService_import (14.76s)
--- PASS: TestAccPagerDutyUser_Basic (13.11s)
--- PASS: TestAccPagerDutyService_BasicWithIncidentUrgencyRules (15.98s)
--- PASS: TestAccPagerDutyUserWithTeams_Basic (22.37s)
--- PASS: TestAccPagerDutyService_FromBasicToCustomIncidentUrgencyRules (19.10s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/pagerduty	58.328s
```