### PR TITLE
provider/aws: Force lowercasing for DB Option group name or name_prefix

### DIFF
--- a/builtin/providers/aws/resource_aws_db_option_group.go
+++ b/builtin/providers/aws/resource_aws_db_option_group.go
@@ -37,10 +37,6 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 				ForceNew:      true,
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateDbOptionGroupName,
-				StateFunc: func(v interface{}) string {
-					value := v.(string)
-					return strings.ToLower(value)
-				},
 			},
 			"name_prefix": &schema.Schema{
 				Type:         schema.TypeString,
@@ -48,10 +44,6 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validateDbOptionGroupNamePrefix,
-				StateFunc: func(v interface{}) string {
-					value := v.(string)
-					return strings.ToLower(value)
-				},
 			},
 			"engine_name": &schema.Schema{
 				Type:     schema.TypeString,
@@ -148,7 +140,7 @@ func resourceAwsDbOptionGroupCreate(d *schema.ResourceData, meta interface{}) er
 		return fmt.Errorf("Error creating DB Option Group: %s", err)
 	}
 
-	d.SetId(groupName)
+	d.SetId(strings.ToLower(groupName))
 	log.Printf("[INFO] DB Option Group ID: %s", d.Id())
 
 	return resourceAwsDbOptionGroupUpdate(d, meta)

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -49,7 +49,7 @@ func TestAccAWSDBOptionGroup_namePrefix(t *testing.T) {
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.test", &v),
 					testAccCheckAWSDBOptionGroupAttributes(&v),
 					resource.TestMatchResourceAttr(
-						"aws_db_option_group.test", "name", regexp.MustCompile("^tf-TEST-")),
+						"aws_db_option_group.test", "name", regexp.MustCompile("^tf-test-")),
 				),
 			},
 		},
@@ -112,7 +112,7 @@ func TestAccAWSDBOptionGroup_basicDestroyWithInstance(t *testing.T) {
 
 func TestAccAWSDBOptionGroup_OptionSettings(t *testing.T) {
 	var v rds.OptionGroup
-	rName := fmt.Sprintf("option-group-TEST-terraform-%s", acctest.RandString(5))
+	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -149,7 +149,7 @@ func TestAccAWSDBOptionGroup_OptionSettings(t *testing.T) {
 
 func TestAccAWSDBOptionGroup_sqlServerOptionsUpdate(t *testing.T) {
 	var v rds.OptionGroup
-	rName := fmt.Sprintf("option-group-TEST-terraform-%s", acctest.RandString(5))
+	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -181,7 +181,7 @@ func TestAccAWSDBOptionGroup_sqlServerOptionsUpdate(t *testing.T) {
 
 func TestAccAWSDBOptionGroup_multipleOptions(t *testing.T) {
 	var v rds.OptionGroup
-	rName := fmt.Sprintf("option-group-TEST-terraform-%s", acctest.RandString(5))
+	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -434,7 +434,7 @@ resource "aws_db_option_group" "test" {
 func testAccAWSDBOptionGroup_defaultDescription(n int) string {
 	return fmt.Sprintf(`
 resource "aws_db_option_group" "test" {
-  name = "tf-TEST-%d"
+  name = "tf-test-%d"
   engine_name = "mysql"
   major_engine_version = "5.6"
 }

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -1141,9 +1141,9 @@ func validateDbOptionGroupName(v interface{}, k string) (ws []string, errors []e
 		errors = append(errors, fmt.Errorf(
 			"first character of %q must be a letter", k))
 	}
-	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"only alphanumeric characters and hyphens allowed in %q", k))
+			"only lowercase alphanumeric characters and hyphens allowed in %q", k))
 	}
 	if regexp.MustCompile(`--`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
@@ -1166,7 +1166,7 @@ func validateDbOptionGroupNamePrefix(v interface{}, k string) (ws []string, erro
 		errors = append(errors, fmt.Errorf(
 			"first character of %q must be a letter", k))
 	}
-	if !regexp.MustCompile(`^[0-9A-Za-z-]+$`).MatchString(value) {
+	if !regexp.MustCompile(`^[0-9a-z-]+$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"only alphanumeric characters and hyphens allowed in %q", k))
 	}

--- a/website/source/docs/providers/aws/r/db_option_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_option_group.html.markdown
@@ -38,8 +38,8 @@ resource "aws_db_option_group" "bar" {
 
 The following arguments are supported:
 
-* `name` - (Optional, Forces new resource) The name of the option group. If omitted, Terraform will assign a random, unique name. This is converted to lowercase, as is stored in AWS.
-* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. This is converted to lowercase, as is stored in AWS.
+* `name` - (Optional, Forces new resource) The name of the option group. If omitted, Terraform will assign a random, unique name. Must be lowercase, to match as it is stored in AWS.
+* `name_prefix` - (Optional, Forces new resource) Creates a unique name beginning with the specified prefix. Conflicts with `name`. Must be lowercase, to match as it is stored in AWS.
 * `option_group_description` - (Optional) The description of the option group. Defaults to "Managed by Terraform".
 * `engine_name` - (Required) Specifies the name of the engine that this option group should be associated with.
 * `major_engine_version` - (Required) Specifies the major version of the engine that this option group should be associated with.


### PR DESCRIPTION
Continue https://github.com/hashicorp/terraform/pull/14192 and require users to specify `name` and `name_prefix` as lower case strings, to match AWS style. Currently the DB Option Group tests are failing because the `name` attribute is also used as the `id`, however the `id` is not receiving the lowercasing. As a result, the `id` locally used for lookups does not match the casing used to create the resource, so lookup fails. 

Here we modify the validation to error at the `plan` stage if non-lowercase is used. As it stands, I believe any upper or mixed case `name` or `name_prefix` is hitting https://github.com/hashicorp/terraform/issues/11040

The `strings.ToLower` may be superfluous with the validation, but it felt like good measure 👍 

```
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBOptionGroup -timeout 120m
=== RUN   TestAccAWSDBOptionGroup_importBasic
--- PASS: TestAccAWSDBOptionGroup_importBasic (14.92s)
=== RUN   TestAccAWSDBOptionGroup_basic
--- PASS: TestAccAWSDBOptionGroup_basic (11.15s)
=== RUN   TestAccAWSDBOptionGroup_namePrefix
--- PASS: TestAccAWSDBOptionGroup_namePrefix (11.58s)
=== RUN   TestAccAWSDBOptionGroup_generatedName
k--- PASS: TestAccAWSDBOptionGroup_generatedName (11.31s)
=== RUN   TestAccAWSDBOptionGroup_defaultDescription
--- PASS: TestAccAWSDBOptionGroup_defaultDescription (11.75s)
=== RUN   TestAccAWSDBOptionGroup_basicDestroyWithInstance
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (556.28s)
=== RUN   TestAccAWSDBOptionGroup_OptionSettings
--- PASS: TestAccAWSDBOptionGroup_OptionSettings (20.26s)
=== RUN   TestAccAWSDBOptionGroup_sqlServerOptionsUpdate
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (20.02s)
=== RUN   TestAccAWSDBOptionGroup_multipleOptions
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (11.75s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    669.051s
```