### PR TITLE
Chase API in upstream joyent/triton-go

### DIFF
--- a/builtin/providers/triton/resource_fabric.go
+++ b/builtin/providers/triton/resource_fabric.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -109,7 +110,7 @@ func resourceFabricCreate(d *schema.ResourceData, meta interface{}) error {
 		routes[cidr] = ip
 	}
 
-	fabric, err := client.Fabrics().CreateFabricNetwork(&triton.CreateFabricNetworkInput{
+	fabric, err := client.Fabrics().CreateFabricNetwork(context.Background(), &triton.CreateFabricNetworkInput{
 		FabricVLANID:     d.Get("vlan_id").(int),
 		Name:             d.Get("name").(string),
 		Description:      d.Get("description").(string),
@@ -134,7 +135,7 @@ func resourceFabricCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceFabricExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*triton.Client)
 
-	return resourceExists(client.Fabrics().GetFabricNetwork(&triton.GetFabricNetworkInput{
+	return resourceExists(client.Fabrics().GetFabricNetwork(context.Background(), &triton.GetFabricNetworkInput{
 		FabricVLANID: d.Get("vlan_id").(int),
 		NetworkID:    d.Id(),
 	}))
@@ -143,7 +144,7 @@ func resourceFabricExists(d *schema.ResourceData, meta interface{}) (bool, error
 func resourceFabricRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	fabric, err := client.Fabrics().GetFabricNetwork(&triton.GetFabricNetworkInput{
+	fabric, err := client.Fabrics().GetFabricNetwork(context.Background(), &triton.GetFabricNetworkInput{
 		FabricVLANID: d.Get("vlan_id").(int),
 		NetworkID:    d.Id(),
 	})
@@ -171,7 +172,7 @@ func resourceFabricRead(d *schema.ResourceData, meta interface{}) error {
 func resourceFabricDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	return client.Fabrics().DeleteFabricNetwork(&triton.DeleteFabricNetworkInput{
+	return client.Fabrics().DeleteFabricNetwork(context.Background(), &triton.DeleteFabricNetworkInput{
 		FabricVLANID: d.Get("vlan_id").(int),
 		NetworkID:    d.Id(),
 	})

--- a/builtin/providers/triton/resource_fabric_test.go
+++ b/builtin/providers/triton/resource_fabric_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -48,7 +49,7 @@ func testCheckTritonFabricExists(name string) resource.TestCheckFunc {
 			return err
 		}
 
-		exists, err := resourceExists(conn.Fabrics().GetFabricNetwork(&triton.GetFabricNetworkInput{
+		exists, err := resourceExists(conn.Fabrics().GetFabricNetwork(context.Background(), &triton.GetFabricNetworkInput{
 			FabricVLANID: vlanID,
 			NetworkID:    rs.Primary.ID,
 		}))
@@ -77,7 +78,7 @@ func testCheckTritonFabricDestroy(s *terraform.State) error {
 			return err
 		}
 
-		exists, err := resourceExists(conn.Fabrics().GetFabricNetwork(&triton.GetFabricNetworkInput{
+		exists, err := resourceExists(conn.Fabrics().GetFabricNetwork(context.Background(), &triton.GetFabricNetworkInput{
 			FabricVLANID: vlanID,
 			NetworkID:    rs.Primary.ID,
 		}))

--- a/builtin/providers/triton/resource_firewall_rule.go
+++ b/builtin/providers/triton/resource_firewall_rule.go
@@ -1,6 +1,8 @@
 package triton
 
 import (
+	"context"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/joyent/triton-go"
 )
@@ -45,7 +47,7 @@ func resourceFirewallRule() *schema.Resource {
 func resourceFirewallRuleCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	rule, err := client.Firewall().CreateFirewallRule(&triton.CreateFirewallRuleInput{
+	rule, err := client.Firewall().CreateFirewallRule(context.Background(), &triton.CreateFirewallRuleInput{
 		Rule:        d.Get("rule").(string),
 		Enabled:     d.Get("enabled").(bool),
 		Description: d.Get("description").(string),
@@ -62,7 +64,7 @@ func resourceFirewallRuleCreate(d *schema.ResourceData, meta interface{}) error 
 func resourceFirewallRuleExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*triton.Client)
 
-	return resourceExists(client.Firewall().GetFirewallRule(&triton.GetFirewallRuleInput{
+	return resourceExists(client.Firewall().GetFirewallRule(context.Background(), &triton.GetFirewallRuleInput{
 		ID: d.Id(),
 	}))
 }
@@ -70,7 +72,7 @@ func resourceFirewallRuleExists(d *schema.ResourceData, meta interface{}) (bool,
 func resourceFirewallRuleRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	rule, err := client.Firewall().GetFirewallRule(&triton.GetFirewallRuleInput{
+	rule, err := client.Firewall().GetFirewallRule(context.Background(), &triton.GetFirewallRuleInput{
 		ID: d.Id(),
 	})
 	if err != nil {
@@ -89,7 +91,7 @@ func resourceFirewallRuleRead(d *schema.ResourceData, meta interface{}) error {
 func resourceFirewallRuleUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	_, err := client.Firewall().UpdateFirewallRule(&triton.UpdateFirewallRuleInput{
+	_, err := client.Firewall().UpdateFirewallRule(context.Background(), &triton.UpdateFirewallRuleInput{
 		ID:          d.Id(),
 		Rule:        d.Get("rule").(string),
 		Enabled:     d.Get("enabled").(bool),
@@ -105,7 +107,7 @@ func resourceFirewallRuleUpdate(d *schema.ResourceData, meta interface{}) error 
 func resourceFirewallRuleDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	return client.Firewall().DeleteFirewallRule(&triton.DeleteFirewallRuleInput{
+	return client.Firewall().DeleteFirewallRule(context.Background(), &triton.DeleteFirewallRuleInput{
 		ID: d.Id(),
 	})
 }

--- a/builtin/providers/triton/resource_firewall_rule_test.go
+++ b/builtin/providers/triton/resource_firewall_rule_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -96,7 +97,7 @@ func testCheckTritonFirewallRuleExists(name string) resource.TestCheckFunc {
 		}
 		conn := testAccProvider.Meta().(*triton.Client)
 
-		resp, err := conn.Firewall().GetFirewallRule(&triton.GetFirewallRuleInput{
+		resp, err := conn.Firewall().GetFirewallRule(context.Background(), &triton.GetFirewallRuleInput{
 			ID: rs.Primary.ID,
 		})
 		if err != nil && triton.IsResourceNotFound(err) {
@@ -121,7 +122,7 @@ func testCheckTritonFirewallRuleDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, err := conn.Firewall().GetFirewallRule(&triton.GetFirewallRuleInput{
+		resp, err := conn.Firewall().GetFirewallRule(context.Background(), &triton.GetFirewallRuleInput{
 			ID: rs.Primary.ID,
 		})
 		if triton.IsResourceNotFound(err) {

--- a/builtin/providers/triton/resource_key.go
+++ b/builtin/providers/triton/resource_key.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -49,7 +50,7 @@ func resourceKeyCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	_, err := client.Keys().CreateKey(&triton.CreateKeyInput{
+	_, err := client.Keys().CreateKey(context.Background(), &triton.CreateKeyInput{
 		Name: d.Get("name").(string),
 		Key:  d.Get("key").(string),
 	})
@@ -65,7 +66,7 @@ func resourceKeyCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*triton.Client)
 
-	_, err := client.Keys().GetKey(&triton.GetKeyInput{
+	_, err := client.Keys().GetKey(context.Background(), &triton.GetKeyInput{
 		KeyName: d.Id(),
 	})
 	if err != nil {
@@ -78,7 +79,7 @@ func resourceKeyExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 func resourceKeyRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	key, err := client.Keys().GetKey(&triton.GetKeyInput{
+	key, err := client.Keys().GetKey(context.Background(), &triton.GetKeyInput{
 		KeyName: d.Id(),
 	})
 	if err != nil {
@@ -94,7 +95,7 @@ func resourceKeyRead(d *schema.ResourceData, meta interface{}) error {
 func resourceKeyDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	return client.Keys().DeleteKey(&triton.DeleteKeyInput{
+	return client.Keys().DeleteKey(context.Background(), &triton.DeleteKeyInput{
 		KeyName: d.Id(),
 	})
 }

--- a/builtin/providers/triton/resource_key_test.go
+++ b/builtin/providers/triton/resource_key_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -78,7 +79,7 @@ func testCheckTritonKeyExists(name string) resource.TestCheckFunc {
 		}
 		conn := testAccProvider.Meta().(*triton.Client)
 
-		key, err := conn.Keys().GetKey(&triton.GetKeyInput{
+		key, err := conn.Keys().GetKey(context.Background(), &triton.GetKeyInput{
 			KeyName: rs.Primary.ID,
 		})
 		if err != nil {
@@ -102,7 +103,7 @@ func testCheckTritonKeyDestroy(s *terraform.State) error {
 				continue
 			}
 
-			key, err := conn.Keys().GetKey(&triton.GetKeyInput{
+			key, err := conn.Keys().GetKey(context.Background(), &triton.GetKeyInput{
 				KeyName: rs.Primary.ID,
 			})
 			if err != nil {

--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"time"
@@ -242,7 +243,7 @@ func resourceMachineCreate(d *schema.ResourceData, meta interface{}) error {
 		tags[k] = v.(string)
 	}
 
-	machine, err := client.Machines().CreateMachine(&triton.CreateMachineInput{
+	machine, err := client.Machines().CreateMachine(context.Background(), &triton.CreateMachineInput{
 		Name:            d.Get("name").(string),
 		Package:         d.Get("package").(string),
 		Image:           d.Get("image").(string),
@@ -259,7 +260,7 @@ func resourceMachineCreate(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Target: []string{fmt.Sprintf(machineStateRunning)},
 		Refresh: func() (interface{}, string, error) {
-			getResp, err := client.Machines().GetMachine(&triton.GetMachineInput{
+			getResp, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 				ID: d.Id(),
 			})
 			if err != nil {
@@ -286,7 +287,7 @@ func resourceMachineCreate(d *schema.ResourceData, meta interface{}) error {
 func resourceMachineExists(d *schema.ResourceData, meta interface{}) (bool, error) {
 	client := meta.(*triton.Client)
 
-	return resourceExists(client.Machines().GetMachine(&triton.GetMachineInput{
+	return resourceExists(client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 		ID: d.Id(),
 	}))
 }
@@ -294,14 +295,14 @@ func resourceMachineExists(d *schema.ResourceData, meta interface{}) (bool, erro
 func resourceMachineRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	machine, err := client.Machines().GetMachine(&triton.GetMachineInput{
+	machine, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 		ID: d.Id(),
 	})
 	if err != nil {
 		return err
 	}
 
-	nics, err := client.Machines().ListNICs(&triton.ListNICsInput{
+	nics, err := client.Machines().ListNICs(context.Background(), &triton.ListNICsInput{
 		MachineID: d.Id(),
 	})
 	if err != nil {
@@ -366,7 +367,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 		oldName := oldNameInterface.(string)
 		newName := newNameInterface.(string)
 
-		err := client.Machines().RenameMachine(&triton.RenameMachineInput{
+		err := client.Machines().RenameMachine(context.Background(), &triton.RenameMachineInput{
 			ID:   d.Id(),
 			Name: newName,
 		})
@@ -378,7 +379,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 			Pending: []string{oldName},
 			Target:  []string{newName},
 			Refresh: func() (interface{}, string, error) {
-				getResp, err := client.Machines().GetMachine(&triton.GetMachineInput{
+				getResp, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 					ID: d.Id(),
 				})
 				if err != nil {
@@ -406,11 +407,11 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		var err error
 		if len(tags) == 0 {
-			err = client.Machines().DeleteMachineTags(&triton.DeleteMachineTagsInput{
+			err = client.Machines().DeleteMachineTags(context.Background(), &triton.DeleteMachineTagsInput{
 				ID: d.Id(),
 			})
 		} else {
-			err = client.Machines().ReplaceMachineTags(&triton.ReplaceMachineTagsInput{
+			err = client.Machines().ReplaceMachineTags(context.Background(), &triton.ReplaceMachineTagsInput{
 				ID:   d.Id(),
 				Tags: tags,
 			})
@@ -423,7 +424,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 		stateConf := &resource.StateChangeConf{
 			Target: []string{expectedTagsMD5},
 			Refresh: func() (interface{}, string, error) {
-				getResp, err := client.Machines().GetMachine(&triton.GetMachineInput{
+				getResp, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 					ID: d.Id(),
 				})
 				if err != nil {
@@ -446,7 +447,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 	if d.HasChange("package") {
 		newPackage := d.Get("package").(string)
 
-		err := client.Machines().ResizeMachine(&triton.ResizeMachineInput{
+		err := client.Machines().ResizeMachine(context.Background(), &triton.ResizeMachineInput{
 			ID:      d.Id(),
 			Package: newPackage,
 		})
@@ -457,7 +458,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 		stateConf := &resource.StateChangeConf{
 			Target: []string{fmt.Sprintf("%s@%s", newPackage, "running")},
 			Refresh: func() (interface{}, string, error) {
-				getResp, err := client.Machines().GetMachine(&triton.GetMachineInput{
+				getResp, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 					ID: d.Id(),
 				})
 				if err != nil {
@@ -482,11 +483,11 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		var err error
 		if enable {
-			err = client.Machines().EnableMachineFirewall(&triton.EnableMachineFirewallInput{
+			err = client.Machines().EnableMachineFirewall(context.Background(), &triton.EnableMachineFirewallInput{
 				ID: d.Id(),
 			})
 		} else {
-			err = client.Machines().DisableMachineFirewall(&triton.DisableMachineFirewallInput{
+			err = client.Machines().DisableMachineFirewall(context.Background(), &triton.DisableMachineFirewallInput{
 				ID: d.Id(),
 			})
 		}
@@ -497,7 +498,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 		stateConf := &resource.StateChangeConf{
 			Target: []string{fmt.Sprintf("%t", enable)},
 			Refresh: func() (interface{}, string, error) {
-				getResp, err := client.Machines().GetMachine(&triton.GetMachineInput{
+				getResp, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 					ID: d.Id(),
 				})
 				if err != nil {
@@ -531,7 +532,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		for _, nicI := range newNICs.Difference(oldNICs).List() {
 			nic := nicI.(map[string]interface{})
-			if _, err := client.Machines().AddNIC(&triton.AddNICInput{
+			if _, err := client.Machines().AddNIC(context.Background(), &triton.AddNICInput{
 				MachineID: d.Id(),
 				Network:   nic["network"].(string),
 			}); err != nil {
@@ -541,7 +542,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 
 		for _, nicI := range oldNICs.Difference(newNICs).List() {
 			nic := nicI.(map[string]interface{})
-			if err := client.Machines().RemoveNIC(&triton.RemoveNICInput{
+			if err := client.Machines().RemoveNIC(context.Background(), &triton.RemoveNICInput{
 				MachineID: d.Id(),
 				MAC:       nic["mac"].(string),
 			}); err != nil {
@@ -559,7 +560,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 	if len(metadata) > 0 {
-		if _, err := client.Machines().UpdateMachineMetadata(&triton.UpdateMachineMetadataInput{
+		if _, err := client.Machines().UpdateMachineMetadata(context.Background(), &triton.UpdateMachineMetadataInput{
 			ID:       d.Id(),
 			Metadata: metadata,
 		}); err != nil {
@@ -569,7 +570,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 		stateConf := &resource.StateChangeConf{
 			Target: []string{"converged"},
 			Refresh: func() (interface{}, string, error) {
-				getResp, err := client.Machines().GetMachine(&triton.GetMachineInput{
+				getResp, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 					ID: d.Id(),
 				})
 				if err != nil {
@@ -607,7 +608,7 @@ func resourceMachineUpdate(d *schema.ResourceData, meta interface{}) error {
 func resourceMachineDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	err := client.Machines().DeleteMachine(&triton.DeleteMachineInput{
+	err := client.Machines().DeleteMachine(context.Background(), &triton.DeleteMachineInput{
 		ID: d.Id(),
 	})
 	if err != nil {
@@ -617,7 +618,7 @@ func resourceMachineDelete(d *schema.ResourceData, meta interface{}) error {
 	stateConf := &resource.StateChangeConf{
 		Target: []string{machineStateDeleted},
 		Refresh: func() (interface{}, string, error) {
-			getResp, err := client.Machines().GetMachine(&triton.GetMachineInput{
+			getResp, err := client.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 				ID: d.Id(),
 			})
 			if err != nil {

--- a/builtin/providers/triton/resource_machine_test.go
+++ b/builtin/providers/triton/resource_machine_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -129,7 +130,7 @@ func testCheckTritonMachineExists(name string) resource.TestCheckFunc {
 		}
 		conn := testAccProvider.Meta().(*triton.Client)
 
-		machine, err := conn.Machines().GetMachine(&triton.GetMachineInput{
+		machine, err := conn.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 			ID: rs.Primary.ID,
 		})
 		if err != nil {
@@ -158,7 +159,7 @@ func testCheckTritonMachineHasFabric(name, fabricName string) resource.TestCheck
 		}
 		conn := testAccProvider.Meta().(*triton.Client)
 
-		nics, err := conn.Machines().ListNICs(&triton.ListNICsInput{
+		nics, err := conn.Machines().ListNICs(context.Background(), &triton.ListNICsInput{
 			MachineID: machine.Primary.ID,
 		})
 		if err != nil {
@@ -183,7 +184,7 @@ func testCheckTritonMachineDestroy(s *terraform.State) error {
 			continue
 		}
 
-		resp, err := conn.Machines().GetMachine(&triton.GetMachineInput{
+		resp, err := conn.Machines().GetMachine(context.Background(), &triton.GetMachineInput{
 			ID: rs.Primary.ID,
 		})
 		if err != nil {

--- a/builtin/providers/triton/resource_vlan.go
+++ b/builtin/providers/triton/resource_vlan.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"errors"
 	"strconv"
 
@@ -51,7 +52,7 @@ func resourceVLAN() *schema.Resource {
 func resourceVLANCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	vlan, err := client.Fabrics().CreateFabricVLAN(&triton.CreateFabricVLANInput{
+	vlan, err := client.Fabrics().CreateFabricVLAN(context.Background(), &triton.CreateFabricVLANInput{
 		ID:          d.Get("vlan_id").(int),
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
@@ -72,7 +73,7 @@ func resourceVLANExists(d *schema.ResourceData, meta interface{}) (bool, error) 
 		return false, err
 	}
 
-	return resourceExists(client.Fabrics().GetFabricVLAN(&triton.GetFabricVLANInput{
+	return resourceExists(client.Fabrics().GetFabricVLAN(context.Background(), &triton.GetFabricVLANInput{
 		ID: id,
 	}))
 }
@@ -85,7 +86,7 @@ func resourceVLANRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	vlan, err := client.Fabrics().GetFabricVLAN(&triton.GetFabricVLANInput{
+	vlan, err := client.Fabrics().GetFabricVLAN(context.Background(), &triton.GetFabricVLANInput{
 		ID: id,
 	})
 	if err != nil {
@@ -102,7 +103,7 @@ func resourceVLANRead(d *schema.ResourceData, meta interface{}) error {
 func resourceVLANUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*triton.Client)
 
-	vlan, err := client.Fabrics().UpdateFabricVLAN(&triton.UpdateFabricVLANInput{
+	vlan, err := client.Fabrics().UpdateFabricVLAN(context.Background(), &triton.UpdateFabricVLANInput{
 		ID:          d.Get("vlan_id").(int),
 		Name:        d.Get("name").(string),
 		Description: d.Get("description").(string),
@@ -123,7 +124,7 @@ func resourceVLANDelete(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	return client.Fabrics().DeleteFabricVLAN(&triton.DeleteFabricVLANInput{
+	return client.Fabrics().DeleteFabricVLAN(context.Background(), &triton.DeleteFabricVLANInput{
 		ID: id,
 	})
 }

--- a/builtin/providers/triton/resource_vlan_test.go
+++ b/builtin/providers/triton/resource_vlan_test.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -76,7 +77,7 @@ func testCheckTritonVLANExists(name string) resource.TestCheckFunc {
 			return err
 		}
 
-		resp, err := conn.Fabrics().GetFabricVLAN(&triton.GetFabricVLANInput{
+		resp, err := conn.Fabrics().GetFabricVLAN(context.Background(), &triton.GetFabricVLANInput{
 			ID: id,
 		})
 		if err != nil && triton.IsResourceNotFound(err) {
@@ -106,7 +107,7 @@ func testCheckTritonVLANDestroy(s *terraform.State) error {
 			return err
 		}
 
-		resp, err := conn.Fabrics().GetFabricVLAN(&triton.GetFabricVLANInput{
+		resp, err := conn.Fabrics().GetFabricVLAN(context.Background(), &triton.GetFabricVLANInput{
 			ID: id,
 		})
 		if triton.IsResourceNotFound(err) {

--- a/vendor/github.com/joyent/triton-go/accounts.go
+++ b/vendor/github.com/joyent/triton-go/accounts.go
@@ -1,11 +1,11 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"time"
-
-	"fmt"
 
 	"github.com/hashicorp/errwrap"
 )
@@ -40,9 +40,9 @@ type Account struct {
 
 type GetAccountInput struct{}
 
-func (client *AccountsClient) GetAccount(input *GetAccountInput) (*Account, error) {
+func (client *AccountsClient) GetAccount(ctx context.Context, input *GetAccountInput) (*Account, error) {
 	path := fmt.Sprintf("/%s", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -75,8 +75,9 @@ type UpdateAccountInput struct {
 
 // UpdateAccount updates your account details with the given parameters.
 // TODO(jen20) Work out a safe way to test this
-func (client *AccountsClient) UpdateAccount(input *UpdateAccountInput) (*Account, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s", client.accountName), input)
+func (client *AccountsClient) UpdateAccount(ctx context.Context, input *UpdateAccountInput) (*Account, error) {
+	path := fmt.Sprintf("/%s", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/config.go
+++ b/vendor/github.com/joyent/triton-go/config.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,8 +28,9 @@ type Config struct {
 type GetConfigInput struct{}
 
 // GetConfig outputs configuration for your account.
-func (client *ConfigClient) GetConfig(input *GetConfigInput) (*Config, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/config", client.accountName), nil)
+func (client *ConfigClient) GetConfig(ctx context.Context, input *GetConfigInput) (*Config, error) {
+	path := fmt.Sprintf("/%s/config", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -51,9 +53,9 @@ type UpdateConfigInput struct {
 }
 
 // UpdateConfig updates configuration values for your account.
-// TODO(jen20) Work out a safe way to test this (after networks c implemented)
-func (client *ConfigClient) UpdateConfig(input *UpdateConfigInput) (*Config, error) {
-	respReader, err := client.executeRequest(http.MethodPut, fmt.Sprintf("/%s/config", client.accountName), input)
+func (client *ConfigClient) UpdateConfig(ctx context.Context, input *UpdateConfigInput) (*Config, error) {
+	path := fmt.Sprintf("/%s/config", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/datacenters.go
+++ b/vendor/github.com/joyent/triton-go/datacenters.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"sort"
 
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -27,9 +28,9 @@ type DataCenter struct {
 
 type ListDataCentersInput struct{}
 
-func (client *DataCentersClient) ListDataCenters(*ListDataCentersInput) ([]*DataCenter, error) {
+func (client *DataCentersClient) ListDataCenters(ctx context.Context, _ *ListDataCentersInput) ([]*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -68,9 +69,9 @@ type GetDataCenterInput struct {
 	Name string
 }
 
-func (client *DataCentersClient) GetDataCenter(input *GetDataCenterInput) (*DataCenter, error) {
+func (client *DataCentersClient) GetDataCenter(ctx context.Context, input *GetDataCenterInput) (*DataCenter, error) {
 	path := fmt.Sprintf("/%s/datacenters/%s", client.accountName, input.Name)
-	resp, err := client.executeRequestRaw(http.MethodGet, path, nil)
+	resp, err := client.executeRequestRaw(ctx, http.MethodGet, path, nil)
 	if err != nil {
 		return nil, errwrap.Wrapf("Error executing GetDatacenter request: {{err}}", err)
 	}

--- a/vendor/github.com/joyent/triton-go/fabrics.go
+++ b/vendor/github.com/joyent/triton-go/fabrics.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -26,9 +27,9 @@ type FabricVLAN struct {
 
 type ListFabricVLANsInput struct{}
 
-func (client *FabricsClient) ListFabricVLANs(*ListFabricVLANsInput) ([]*FabricVLAN, error) {
+func (client *FabricsClient) ListFabricVLANs(ctx context.Context, _ *ListFabricVLANsInput) ([]*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -51,9 +52,9 @@ type CreateFabricVLANInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FabricsClient) CreateFabricVLAN(input *CreateFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) CreateFabricVLAN(ctx context.Context, input *CreateFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -76,9 +77,9 @@ type UpdateFabricVLANInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FabricsClient) UpdateFabricVLAN(input *UpdateFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) UpdateFabricVLAN(ctx context.Context, input *UpdateFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodPut, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPut, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -99,9 +100,9 @@ type GetFabricVLANInput struct {
 	ID int `json:"-"`
 }
 
-func (client *FabricsClient) GetFabricVLAN(input *GetFabricVLANInput) (*FabricVLAN, error) {
+func (client *FabricsClient) GetFabricVLAN(ctx context.Context, input *GetFabricVLANInput) (*FabricVLAN, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -122,9 +123,9 @@ type DeleteFabricVLANInput struct {
 	ID int `json:"-"`
 }
 
-func (client *FabricsClient) DeleteFabricVLAN(input *DeleteFabricVLANInput) error {
+func (client *FabricsClient) DeleteFabricVLAN(ctx context.Context, input *DeleteFabricVLANInput) error {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -139,9 +140,9 @@ type ListFabricNetworksInput struct {
 	FabricVLANID int `json:"-"`
 }
 
-func (client *FabricsClient) ListFabricNetworks(input *ListFabricNetworksInput) ([]*Network, error) {
+func (client *FabricsClient) ListFabricNetworks(ctx context.Context, input *ListFabricNetworksInput) ([]*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks", client.accountName, input.FabricVLANID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -171,9 +172,9 @@ type CreateFabricNetworkInput struct {
 	InternetNAT      bool              `json:"internet_nat"`
 }
 
-func (client *FabricsClient) CreateFabricNetwork(input *CreateFabricNetworkInput) (*Network, error) {
+func (client *FabricsClient) CreateFabricNetwork(ctx context.Context, input *CreateFabricNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks", client.accountName, input.FabricVLANID)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -195,9 +196,9 @@ type GetFabricNetworkInput struct {
 	NetworkID    string `json:"-"`
 }
 
-func (client *FabricsClient) GetFabricNetwork(input *GetFabricNetworkInput) (*Network, error) {
+func (client *FabricsClient) GetFabricNetwork(ctx context.Context, input *GetFabricNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks/%s", client.accountName, input.FabricVLANID, input.NetworkID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -219,9 +220,9 @@ type DeleteFabricNetworkInput struct {
 	NetworkID    string `json:"-"`
 }
 
-func (client *FabricsClient) DeleteFabricNetwork(input *DeleteFabricNetworkInput) error {
+func (client *FabricsClient) DeleteFabricNetwork(ctx context.Context, input *DeleteFabricNetworkInput) error {
 	path := fmt.Sprintf("/%s/fabrics/default/vlans/%d/networks/%s", client.accountName, input.FabricVLANID, input.NetworkID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/firewall.go
+++ b/vendor/github.com/joyent/triton-go/firewall.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -38,9 +39,9 @@ type FirewallRule struct {
 
 type ListFirewallRulesInput struct{}
 
-func (client *FirewallClient) ListFirewallRules(*ListFirewallRulesInput) ([]*FirewallRule, error) {
+func (client *FirewallClient) ListFirewallRules(ctx context.Context, _ *ListFirewallRulesInput) ([]*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/fwrules", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -61,9 +62,9 @@ type GetFirewallRuleInput struct {
 	ID string
 }
 
-func (client *FirewallClient) GetFirewallRule(input *GetFirewallRuleInput) (*FirewallRule, error) {
+func (client *FirewallClient) GetFirewallRule(ctx context.Context, input *GetFirewallRuleInput) (*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -86,8 +87,9 @@ type CreateFirewallRuleInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FirewallClient) CreateFirewallRule(input *CreateFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules", client.accountName), input)
+func (client *FirewallClient) CreateFirewallRule(ctx context.Context, input *CreateFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -111,8 +113,9 @@ type UpdateFirewallRuleInput struct {
 	Description string `json:"description"`
 }
 
-func (client *FirewallClient) UpdateFirewallRule(input *UpdateFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID), input)
+func (client *FirewallClient) UpdateFirewallRule(ctx context.Context, input *UpdateFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -133,8 +136,9 @@ type EnableFirewallRuleInput struct {
 	ID string `json:"-"`
 }
 
-func (client *FirewallClient) EnableFirewallRule(input *EnableFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s/enable", client.accountName, input.ID), input)
+func (client *FirewallClient) EnableFirewallRule(ctx context.Context, input *EnableFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s/enable", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -155,8 +159,9 @@ type DisableFirewallRuleInput struct {
 	ID string `json:"-"`
 }
 
-func (client *FirewallClient) DisableFirewallRule(input *DisableFirewallRuleInput) (*FirewallRule, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/fwrules/%s/disable", client.accountName, input.ID), input)
+func (client *FirewallClient) DisableFirewallRule(ctx context.Context, input *DisableFirewallRuleInput) (*FirewallRule, error) {
+	path := fmt.Sprintf("/%s/fwrules/%s/disable", client.accountName, input.ID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -177,9 +182,9 @@ type DeleteFirewallRuleInput struct {
 	ID string
 }
 
-func (client *FirewallClient) DeleteFirewallRule(input *DeleteFirewallRuleInput) error {
+func (client *FirewallClient) DeleteFirewallRule(ctx context.Context, input *DeleteFirewallRuleInput) error {
 	path := fmt.Sprintf("/%s/fwrules/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -194,9 +199,9 @@ type ListMachineFirewallRulesInput struct {
 	MachineID string
 }
 
-func (client *FirewallClient) ListMachineFirewallRules(input *ListMachineFirewallRulesInput) ([]*FirewallRule, error) {
+func (client *FirewallClient) ListMachineFirewallRules(ctx context.Context, input *ListMachineFirewallRulesInput) ([]*FirewallRule, error) {
 	path := fmt.Sprintf("/%s/machines/%s/firewallrules", client.accountName, input.MachineID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/images.go
+++ b/vendor/github.com/joyent/triton-go/images.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -48,9 +49,9 @@ type Image struct {
 
 type ListImagesInput struct{}
 
-func (client *ImagesClient) ListImages(*ListImagesInput) ([]*Image, error) {
+func (client *ImagesClient) ListImages(ctx context.Context, _ *ListImagesInput) ([]*Image, error) {
 	path := fmt.Sprintf("/%s/images", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -71,9 +72,9 @@ type GetImageInput struct {
 	ImageID string
 }
 
-func (client *ImagesClient) GetImage(input *GetImageInput) (*Image, error) {
+func (client *ImagesClient) GetImage(ctx context.Context, input *GetImageInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -94,9 +95,9 @@ type DeleteImageInput struct {
 	ImageID string
 }
 
-func (client *ImagesClient) DeleteImage(input *DeleteImageInput) error {
+func (client *ImagesClient) DeleteImage(ctx context.Context, input *DeleteImageInput) error {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -118,13 +119,13 @@ type MantaLocation struct {
 	ManifestPath string `json:"manifest_path"`
 }
 
-func (client *ImagesClient) ExportImage(input *ExportImageInput) (*MantaLocation, error) {
+func (client *ImagesClient) ExportImage(ctx context.Context, input *ExportImageInput) (*MantaLocation, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
 	query := &url.Values{}
 	query.Set("action", "export")
 	query.Set("manta_path", input.MantaPath)
 
-	respReader, err := client.executeRequestURIParams(http.MethodGet, path, nil, query)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodGet, path, nil, query)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -152,9 +153,9 @@ type CreateImageFromMachineInput struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 }
 
-func (client *ImagesClient) CreateImageFromMachine(input *CreateImageFromMachineInput) (*Image, error) {
+func (client *ImagesClient) CreateImageFromMachine(ctx context.Context, input *CreateImageFromMachineInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images", client.accountName)
-	respReader, err := client.executeRequest(http.MethodPost, path, input)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -182,12 +183,12 @@ type UpdateImageInput struct {
 	Tags        map[string]string `json:"tags,omitempty"`
 }
 
-func (client *ImagesClient) UpdateImage(input *UpdateImageInput) (*Image, error) {
+func (client *ImagesClient) UpdateImage(ctx context.Context, input *UpdateImageInput) (*Image, error) {
 	path := fmt.Sprintf("/%s/images/%s", client.accountName, input.ImageID)
 	query := &url.Values{}
 	query.Set("action", "update")
 
-	respReader, err := client.executeRequestURIParams(http.MethodPost, path, input, query)
+	respReader, err := client.executeRequestURIParams(ctx, http.MethodPost, path, input, query)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/keys.go
+++ b/vendor/github.com/joyent/triton-go/keys.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -34,9 +35,9 @@ type ListKeysInput struct{}
 
 // ListKeys lists all public keys we have on record for the specified
 // account.
-func (client *KeysClient) ListKeys(*ListKeysInput) ([]*Key, error) {
-	path := fmt.Sprintf("/%s/keys")
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+func (client *KeysClient) ListKeys(ctx context.Context, _ *ListKeysInput) ([]*Key, error) {
+	path := fmt.Sprintf("/%s/keys", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -57,9 +58,9 @@ type GetKeyInput struct {
 	KeyName string
 }
 
-func (client *KeysClient) GetKey(input *GetKeyInput) (*Key, error) {
+func (client *KeysClient) GetKey(ctx context.Context, input *GetKeyInput) (*Key, error) {
 	path := fmt.Sprintf("/%s/keys/%s", client.accountName, input.KeyName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -80,9 +81,9 @@ type DeleteKeyInput struct {
 	KeyName string
 }
 
-func (client *KeysClient) DeleteKey(input *DeleteKeyInput) error {
+func (client *KeysClient) DeleteKey(ctx context.Context, input *DeleteKeyInput) error {
 	path := fmt.Sprintf("/%s/keys/%s", client.accountName, input.KeyName)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -104,8 +105,9 @@ type CreateKeyInput struct {
 }
 
 // CreateKey uploads a new OpenSSH key to Triton for use in HTTP signing and SSH.
-func (client *KeysClient) CreateKey(input *CreateKeyInput) (*Key, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/keys", client.accountName), input)
+func (client *KeysClient) CreateKey(ctx context.Context, input *CreateKeyInput) (*Key, error) {
+	path := fmt.Sprintf("/%s/keys", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/networks.go
+++ b/vendor/github.com/joyent/triton-go/networks.go
@@ -2,9 +2,10 @@ package triton
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
-	"fmt"
+	"context"
 	"github.com/hashicorp/errwrap"
 )
 
@@ -35,9 +36,9 @@ type Network struct {
 
 type ListNetworksInput struct{}
 
-func (client *NetworksClient) ListNetworks(*ListNetworksInput) ([]*Network, error) {
+func (client *NetworksClient) ListNetworks(ctx context.Context, _ *ListNetworksInput) ([]*Network, error) {
 	path := fmt.Sprintf("/%s/networks", client.accountName)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -58,9 +59,9 @@ type GetNetworkInput struct {
 	ID string
 }
 
-func (client *NetworksClient) GetNetwork(input *GetNetworkInput) (*Network, error) {
+func (client *NetworksClient) GetNetwork(ctx context.Context, input *GetNetworkInput) (*Network, error) {
 	path := fmt.Sprintf("/%s/networks/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/packages.go
+++ b/vendor/github.com/joyent/triton-go/packages.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -43,8 +44,9 @@ type ListPackagesInput struct {
 	Group   string `json:"group"`
 }
 
-func (client *PackagesClient) ListPackages(input *ListPackagesInput) ([]*Package, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/packages", client.accountName), input)
+func (client *PackagesClient) ListPackages(ctx context.Context, input *ListPackagesInput) ([]*Package, error) {
+	path := fmt.Sprintf("/%s/packages", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -65,9 +67,9 @@ type GetPackageInput struct {
 	ID string
 }
 
-func (client *PackagesClient) GetPackage(input *GetPackageInput) (*Package, error) {
+func (client *PackagesClient) GetPackage(ctx context.Context, input *GetPackageInput) (*Package, error) {
 	path := fmt.Sprintf("/%s/packages/%s", client.accountName, input.ID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/roles.go
+++ b/vendor/github.com/joyent/triton-go/roles.go
@@ -1,10 +1,12 @@
 package triton
 
 import (
-	"fmt"
-	"github.com/hashicorp/errwrap"
-	"net/http"
+	"context"
 	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/errwrap"
 )
 
 type RolesClient struct {
@@ -27,8 +29,9 @@ type Role struct {
 
 type ListRolesInput struct{}
 
-func (client *RolesClient) ListRoles(*ListRolesInput) ([]*Role, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/roles", client.accountName), nil)
+func (client *RolesClient) ListRoles(ctx context.Context, _ *ListRolesInput) ([]*Role, error) {
+	path := fmt.Sprintf("/%s/roles", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -45,13 +48,13 @@ func (client *RolesClient) ListRoles(*ListRolesInput) ([]*Role, error) {
 	return result, nil
 }
 
-type GetRoleInput struct{
+type GetRoleInput struct {
 	RoleID string
 }
 
-func (client *RolesClient) GetRole(input *GetRoleInput) (*Role, error) {
+func (client *RolesClient) GetRole(ctx context.Context, input *GetRoleInput) (*Role, error) {
 	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
-	respReader, err := client.executeRequest(http.MethodGet, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -85,8 +88,9 @@ type CreateRoleInput struct {
 	DefaultMembers []string `json:"default_members,omitempty"`
 }
 
-func (client *RolesClient) CreateRole(input *CreateRoleInput) (*Role, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/roles", client.accountName), input)
+func (client *RolesClient) CreateRole(ctx context.Context, input *CreateRoleInput) (*Role, error) {
+	path := fmt.Sprintf("/%s/roles", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -123,8 +127,9 @@ type UpdateRoleInput struct {
 	DefaultMembers []string `json:"default_members,omitempty"`
 }
 
-func (client *RolesClient) UpdateRole(input *UpdateRoleInput) (*Role, error) {
-	respReader, err := client.executeRequest(http.MethodPost, fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID), input)
+func (client *RolesClient) UpdateRole(ctx context.Context, input *UpdateRoleInput) (*Role, error) {
+	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
+	respReader, err := client.executeRequest(ctx, http.MethodPost, path, input)
 	if respReader != nil {
 		defer respReader.Close()
 	}
@@ -145,9 +150,9 @@ type DeleteRoleInput struct {
 	RoleID string
 }
 
-func (client *RolesClient) DeleteRoles(input *DeleteRoleInput) error {
+func (client *RolesClient) DeleteRoles(ctx context.Context, input *DeleteRoleInput) error {
 	path := fmt.Sprintf("/%s/roles/%s", client.accountName, input.RoleID)
-	respReader, err := client.executeRequest(http.MethodDelete, path, nil)
+	respReader, err := client.executeRequest(ctx, http.MethodDelete, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/github.com/joyent/triton-go/services.go
+++ b/vendor/github.com/joyent/triton-go/services.go
@@ -1,6 +1,7 @@
 package triton
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,8 +27,9 @@ type Service struct {
 
 type ListServicesInput struct{}
 
-func (client *ServicesClient) ListServices(*ListServicesInput) ([]*Service, error) {
-	respReader, err := client.executeRequest(http.MethodGet, fmt.Sprintf("/%s/services", client.accountName), nil)
+func (client *ServicesClient) ListServices(ctx context.Context, _ *ListServicesInput) ([]*Service, error) {
+	path := fmt.Sprintf("/%s/services", client.accountName)
+	respReader, err := client.executeRequest(ctx, http.MethodGet, path, nil)
 	if respReader != nil {
 		defer respReader.Close()
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2349,10 +2349,10 @@
 			"revisionTime": "2016-06-16T18:50:15Z"
 		},
 		{
-			"checksumSHA1": "XsjyaC6eTHUy/n0iuR46TZcgAK8=",
+			"checksumSHA1": "o8jaSD36Zq42PMnmUaiB+vq+QNA=",
 			"path": "github.com/joyent/triton-go",
-			"revision": "c73729fd38522591909a371c8180ca7090a59ab9",
-			"revisionTime": "2017-04-28T18:47:44Z"
+			"revision": "97ccd9f6c0c0652cf87997bcb01955e0329cd37e",
+			"revisionTime": "2017-05-09T20:29:43Z"
 		},
 		{
 			"checksumSHA1": "QzUqkCSn/ZHyIK346xb9V6EBw9U=",


### PR DESCRIPTION
This PR adds `context` to all of the `triton-go` API calls.  This is a new PR but identical content with #14360 but with clean history (I hosed my local git history and didn't want to clean it up).

CC @jen20