### PR TITLE
Make triton machine deletes synchronous.

### DIFF
--- a/builtin/providers/triton/resource_machine.go
+++ b/builtin/providers/triton/resource_machine.go
@@ -623,7 +623,7 @@ func resourceMachineDelete(d *schema.ResourceData, meta interface{}) error {
 			})
 			if err != nil {
 				if triton.IsResourceNotFound(err) {
-					return nil, "deleted", nil
+					return getResp, "deleted", nil
 				}
 				return nil, "", err
 			}


### PR DESCRIPTION
It is required for `DELETE` operations to return a non-`nil` response:

https://github.com/hashicorp/terraform/blob/4c3a053f0cf59ac9d7ab15cbcfbee50f788fde55/helper/resource/state.go#L126

I desired, I can include a follow on commit to this PR that updates `helper/resource/state.go`'s comment re: `StateRefreshFunc`/`WaitForState()` to note that `DELETE`-like operations should include a non-`nil` response.  Something akin to:

```
diff --git a/helper/resource/state.go b/helper/resource/state.go
index 37c586a11..d1c99a963 100644
--- a/helper/resource/state.go
+++ b/helper/resource/state.go
@@ -13,7 +13,8 @@ var refreshGracePeriod = 30 * time.Second
 // It returns three results. `result` is any object that will be returned
 // as the final object after waiting for state change. This allows you to
 // return the final updated object, for example an EC2 instance after refreshing
-// it.
+// it.  The result object must be non-nil even if the case where the target
+// state has been achieved (e.g. DELETE operations).
 //
 // `state` is the latest state of that object. And `err` is any error that
 // may have happened while refreshing the state.
```