### PR TITLE
provider/google: stop trying to set mysqlReplicaConfiguration on read

### DIFF
--- a/builtin/providers/google/resource_sql_database_instance.go
+++ b/builtin/providers/google/resource_sql_database_instance.go
@@ -243,6 +243,7 @@ func resourceSqlDatabaseInstance() *schema.Resource {
 			"replica_configuration": &schema.Schema{
 				Type:     schema.TypeList,
 				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"ca_certificate": &schema.Schema{
@@ -522,9 +523,6 @@ func resourceSqlDatabaseInstanceCreate(d *schema.ResourceData, meta interface{})
 
 	if v, ok := d.GetOk("replica_configuration"); ok {
 		_replicaConfigurationList := v.([]interface{})
-		if len(_replicaConfigurationList) > 1 {
-			return fmt.Errorf("Only one replica_configuration block may be defined")
-		}
 
 		if len(_replicaConfigurationList) == 1 && _replicaConfigurationList[0] != nil {
 			replicaConfiguration := &sqladmin.ReplicaConfiguration{}
@@ -836,57 +834,16 @@ func resourceSqlDatabaseInstanceRead(d *schema.ResourceData, meta interface{}) e
 
 	if v, ok := d.GetOk("replica_configuration"); ok && v != nil {
 		_replicaConfigurationList := v.([]interface{})
-		if len(_replicaConfigurationList) > 1 {
-			return fmt.Errorf("Only one replica_configuration block may be defined")
-		}
-
 		if len(_replicaConfigurationList) == 1 && _replicaConfigurationList[0] != nil {
-			mySqlReplicaConfiguration := instance.ReplicaConfiguration.MysqlReplicaConfiguration
 			_replicaConfiguration := _replicaConfigurationList[0].(map[string]interface{})
 
 			if vp, okp := _replicaConfiguration["failover_target"]; okp && vp != nil {
 				_replicaConfiguration["failover_target"] = instance.ReplicaConfiguration.FailoverTarget
 			}
 
-			if vp, okp := _replicaConfiguration["ca_certificate"]; okp && vp != nil {
-				_replicaConfiguration["ca_certificate"] = mySqlReplicaConfiguration.CaCertificate
-			}
-
-			if vp, okp := _replicaConfiguration["client_certificate"]; okp && vp != nil {
-				_replicaConfiguration["client_certificate"] = mySqlReplicaConfiguration.ClientCertificate
-			}
-
-			if vp, okp := _replicaConfiguration["client_key"]; okp && vp != nil {
-				_replicaConfiguration["client_key"] = mySqlReplicaConfiguration.ClientKey
-			}
-
-			if vp, okp := _replicaConfiguration["connect_retry_interval"]; okp && vp != nil {
-				_replicaConfiguration["connect_retry_interval"] = mySqlReplicaConfiguration.ConnectRetryInterval
-			}
-
-			if vp, okp := _replicaConfiguration["dump_file_path"]; okp && vp != nil {
-				_replicaConfiguration["dump_file_path"] = mySqlReplicaConfiguration.DumpFilePath
-			}
-
-			if vp, okp := _replicaConfiguration["master_heartbeat_period"]; okp && vp != nil {
-				_replicaConfiguration["master_heartbeat_period"] = mySqlReplicaConfiguration.MasterHeartbeatPeriod
-			}
-
-			if vp, okp := _replicaConfiguration["password"]; okp && vp != nil {
-				_replicaConfiguration["password"] = mySqlReplicaConfiguration.Password
-			}
-
-			if vp, okp := _replicaConfiguration["ssl_cipher"]; okp && vp != nil {
-				_replicaConfiguration["ssl_cipher"] = mySqlReplicaConfiguration.SslCipher
-			}
-
-			if vp, okp := _replicaConfiguration["username"]; okp && vp != nil {
-				_replicaConfiguration["username"] = mySqlReplicaConfiguration.Username
-			}
-
-			if vp, okp := _replicaConfiguration["verify_server_certificate"]; okp && vp != nil {
-				_replicaConfiguration["verify_server_certificate"] = mySqlReplicaConfiguration.VerifyServerCertificate
-			}
+			// Don't attempt to assign anything from instance.ReplicaConfiguration.MysqlReplicaConfiguration,
+			// since those fields are set on create and then not stored. See description at
+			// https://cloud.google.com/sql/docs/mysql/admin-api/v1beta4/instances
 
 			_replicaConfigurationList[0] = _replicaConfiguration
 			d.Set("replica_configuration", _replicaConfigurationList)

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -414,68 +414,6 @@ func testAccCheckGoogleSqlDatabaseInstanceEquals(n string,
 			if server != local && len(server) > 0 && len(local) > 0 {
 				return fmt.Errorf("Error replica_configuration.failover_target mismatch, (%s, %s)", server, local)
 			}
-
-			if instance.ReplicaConfiguration.MysqlReplicaConfiguration != nil {
-				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.CaCertificate
-				local = attributes["replica_configuration.0.ca_certificate"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.ca_certificate mismatch, (%s, %s)", server, local)
-				}
-
-				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.ClientCertificate
-				local = attributes["replica_configuration.0.client_certificate"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.client_certificate mismatch, (%s, %s)", server, local)
-				}
-
-				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.ClientKey
-				local = attributes["replica_configuration.0.client_key"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.client_key mismatch, (%s, %s)", server, local)
-				}
-
-				server = strconv.FormatInt(instance.ReplicaConfiguration.MysqlReplicaConfiguration.ConnectRetryInterval, 10)
-				local = attributes["replica_configuration.0.connect_retry_interval"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.connect_retry_interval mismatch, (%s, %s)", server, local)
-				}
-
-				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.DumpFilePath
-				local = attributes["replica_configuration.0.dump_file_path"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.dump_file_path mismatch, (%s, %s)", server, local)
-				}
-
-				server = strconv.FormatInt(instance.ReplicaConfiguration.MysqlReplicaConfiguration.MasterHeartbeatPeriod, 10)
-				local = attributes["replica_configuration.0.master_heartbeat_period"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.master_heartbeat_period mismatch, (%s, %s)", server, local)
-				}
-
-				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.Password
-				local = attributes["replica_configuration.0.password"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.password mismatch, (%s, %s)", server, local)
-				}
-
-				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.SslCipher
-				local = attributes["replica_configuration.0.ssl_cipher"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.ssl_cipher mismatch, (%s, %s)", server, local)
-				}
-
-				server = instance.ReplicaConfiguration.MysqlReplicaConfiguration.Username
-				local = attributes["replica_configuration.0.username"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.username mismatch, (%s, %s)", server, local)
-				}
-
-				server = strconv.FormatBool(instance.ReplicaConfiguration.MysqlReplicaConfiguration.VerifyServerCertificate)
-				local = attributes["replica_configuration.0.verify_server_certificate"]
-				if server != local && len(server) > 0 && len(local) > 0 {
-					return fmt.Errorf("Error replica_configuration.verify_server_certificate mismatch, (%s, %s)", server, local)
-				}
-			}
 		}
 
 		return nil


### PR DESCRIPTION
This is branched off of #14336, so that should be reviewed first.

Fixes #11651.

Even though it's part of the API, `mysqlReplicaConfiguration` is never returned on read. The documentation notes:
> MySQL specific configuration when replicating from a MySQL on-premises master. Replication configuration information such as the username, password, certificates, and keys are not stored in the instance metadata. The configuration information is used only to set up the replication connection and is stored by MySQL in a file named master.info in the data directory.

Because it isn't returned on read, trying to read after setting it on create would crash every time. This fixes that crash.

This change also sets `MaxItems: 1` on `replica_configuration` and removes read-time checks that it only has 1 item.