### PR TITLE
documentation: Add OPC to CONTRIBUTING

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -37,6 +37,7 @@ The current list of HashiCorp Providers is as follows:
  * `aws`
  * `azurerm`
  * `google`
+ * `opc`
 
 Our testing standards are the same for both HashiCorp and Community providers,
 and HashiCorp runs full acceptance test suites for every provider nightly to


### PR DESCRIPTION
Adds the Oracle OPC provider to the list of Hashicorp Providers in the
CONTRIBUTING.md document.