### PR TITLE
provider/aws: Increase timeout for creating security group

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -253,7 +253,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		Pending: []string{""},
 		Target:  []string{"exists"},
 		Refresh: SGStateRefreshFunc(conn, d.Id()),
-		Timeout: 1 * time.Minute,
+		Timeout: 3 * time.Minute,
 	}
 
 	resp, err := stateConf.WaitForState()


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSLambdaFunction_runtimeValidation_noRuntime
--- FAIL: TestAccAWSLambdaFunction_runtimeValidation_noRuntime (102.08s)
    testing.go:274: Step 0, expected error:
        
        Error applying: 1 error(s) occurred:
        
        * aws_security_group.sg_for_lambda: 1 error(s) occurred:
        
        * aws_security_group.sg_for_lambda: Error waiting for Security Group (sg-4cd8ba37) to become available: timeout while waiting for state to become 'exists' (timeout: 1m0s)
        
```