### PR TITLE
provider/aws: Fix test config for SES Receipt Rule

### DIFF
--- a/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
+++ b/builtin/providers/aws/resource_aws_ses_receipt_rule_test.go
@@ -277,18 +277,18 @@ resource "aws_ses_receipt_rule" "actions" {
     add_header_action {
 			header_name = "Added-By"
 			header_value = "Terraform"
-			position = 1
+			position = 2
     }
 
     add_header_action {
 			header_name = "Another-Header"
 			header_value = "First"
-			position = 0
+			position = 1
     }
 
     stop_action {
 			scope = "RuleSet"
-			position = 2
+			position = 3
     }
 }
 `, srrsRandomInt)


### PR DESCRIPTION
It seems Amazon has decided to change their indexing and get away from zero-based indexing. Not sure why, but this seems to be fixing the test.

I think this resource specifically could use some decent refactoring as `Read()` is significantly relying on config which is not conventional and may cause some other issues, like prevent this resource from being imported easily.

I thought it's better to make it pass first and then eventually fix it.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSESReceiptRule_actions'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/11 10:15:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSESReceiptRule_actions -timeout 120m
=== RUN   TestAccAWSSESReceiptRule_actions
--- PASS: TestAccAWSSESReceiptRule_actions (59.96s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	59.994s
```