### PR TITLE
provider/aws: Randomize key pair name for EC2 instance test

### DIFF
--- a/builtin/providers/aws/resource_aws_instance_test.go
+++ b/builtin/providers/aws/resource_aws_instance_test.go
@@ -860,6 +860,8 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 		}
 	}
 
+	keyPairName := fmt.Sprintf("tf-acc-test-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:        func() { testAccPreCheck(t) },
 		IDRefreshName:   "aws_instance.foo",
@@ -868,10 +870,10 @@ func TestAccAWSInstance_keyPairCheck(t *testing.T) {
 		CheckDestroy:    testAccCheckInstanceDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccInstanceConfigKeyPair,
+				Config: testAccInstanceConfigKeyPair(keyPairName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckInstanceExists("aws_instance.foo", &v),
-					testCheckKeyPair("tmp-key"),
+					testCheckKeyPair(keyPairName),
 				),
 			},
 		},
@@ -1852,13 +1854,14 @@ resource "aws_eip" "foo_eip" {
 }
 `
 
-const testAccInstanceConfigKeyPair = `
+func testAccInstanceConfigKeyPair(keyPairName string) string {
+	return fmt.Sprintf(`
 provider "aws" {
 	region = "us-east-1"
 }
 
 resource "aws_key_pair" "debugging" {
-	key_name = "tmp-key"
+	key_name = "%s"
 	public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 phodgson@thoughtworks.com"
 }
 
@@ -1870,7 +1873,8 @@ resource "aws_instance" "foo" {
 		Name = "testAccInstanceConfigKeyPair_TestAMI"
 	}
 }
-`
+`, keyPairName)
+}
 
 const testAccInstanceConfigRootBlockDeviceMismatch = `
 resource "aws_vpc" "foo" {


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSInstance_keyPairCheck
--- FAIL: TestAccAWSInstance_keyPairCheck (2.48s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_key_pair.debugging: 1 error(s) occurred:
        
        * aws_key_pair.debugging: Error import KeyPair: InvalidKeyPair.Duplicate: The keypair 'tmp-key' already exists.
            status code: 400, request id: 29cc7819-a588-4e89-b163-19ac78dc92aa
FAIL
```

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSInstance_keyPairCheck'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/11 13:32:38 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSInstance_keyPairCheck -timeout 120m
=== RUN   TestAccAWSInstance_keyPairCheck
--- PASS: TestAccAWSInstance_keyPairCheck (90.42s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	90.449s
```