### PR TITLE
Add last aggregator to datadog_timeboard resource

### DIFF
--- a/builtin/providers/datadog/resource_datadog_timeboard.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard.go
@@ -708,10 +708,11 @@ func validateAggregatorMethod(v interface{}, k string) (ws []string, errors []er
 		"max":     {},
 		"min":     {},
 		"sum":     {},
+		"last":     {},
 	}
 	if _, ok := validMethods[value]; !ok {
 		errors = append(errors, fmt.Errorf(
-			`%q contains an invalid method %q. Valid methods are either "average", "max", "min", or "sum"`, k, value))
+			`%q contains an invalid method %q. Valid methods are either "average", "max", "min", "sum", or "last"`, k, value))
 	}
 	return
 }

--- a/builtin/providers/datadog/resource_datadog_timeboard.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard.go
@@ -708,7 +708,7 @@ func validateAggregatorMethod(v interface{}, k string) (ws []string, errors []er
 		"max":     {},
 		"min":     {},
 		"sum":     {},
-		"last":     {},
+		"last":    {},
 	}
 	if _, ok := validMethods[value]; !ok {
 		errors = append(errors, fmt.Errorf(


### PR DESCRIPTION
**This solves #14390**

Given this configuration:
```
  graph = {
    title = "Consul Current Latency"
    viz = "query_value"

    request = {
        q = "avg:consul.net.node.latency.p95{$env,$consul_datacenter}"
        aggregator = "last"
        type = "line"
      }
      autoscale = true
      custom_unit = "ms"
  }

```
Terraform will fail planning/applying with the following error:
```
1 error(s) occurred:

* datadog_timeboard.consul: "graph.3.request.0.aggregator" contains an invalid method "last". Valid methods are either "average", "max", "min", or "sum"
```

### Important Factoids
Datadog does have the **last** aggregator available:
![image](https://cloud.githubusercontent.com/assets/2439858/25947419/a2ec471a-364f-11e7-8d99-ec499d52371c.png)

The datadog api returns this value:
```
      {
        "definition": {
          "viz": "query_value",
          "requests": [
            {
              "q": "avg:consul.net.node.latency.p95{$env,$consul_datacenter}",
              "aggregator": "last",
              "conditional_formats": [],
              "type": "line"
            }
          ],
          "autoscale": true,
          "custom_unit": "ms"
        },
        "title": "Consul Current Latency"
      },
``` 