### PR TITLE
Add a `url` attribute to `google_storage_bucket`

### DIFF
--- a/builtin/providers/google/resource_storage_bucket.go
+++ b/builtin/providers/google/resource_storage_bucket.go
@@ -58,6 +58,11 @@ func resourceStorageBucket() *schema.Resource {
 				Computed: true,
 			},
 
+			"url": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"storage_class": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
@@ -151,6 +156,7 @@ func resourceStorageBucketCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Assign the bucket ID as the resource ID
 	d.Set("self_link", res.SelfLink)
+	d.Set("url", fmt.Sprintf("gs://%s", bucket))
 	d.SetId(res.Id)
 
 	return nil

--- a/website/source/docs/providers/google/r/storage_bucket.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket.html.markdown
@@ -66,3 +66,5 @@ In addition to the arguments listed above, the following computed attributes are
 exported:
 
 * `self_link` - The URI of the created resource.
+
+* `url` - The base URL of the bucket, in the format `gs://<bucket-name>`.


### PR DESCRIPTION
This makes it easier to hook up bucket resources with resource definitions that expect URLs on the format `gs://<bucket-name>`.