### PR TITLE
Make the ASG delete timeout configurable

### DIFF
--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -27,6 +27,10 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(5 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": &schema.Schema{
 				Type:          schema.TypeString,
@@ -705,7 +709,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		if g, _ = getAwsAutoscalingGroup(d.Id(), conn); g != nil {
 			return resource.RetryableError(
 				fmt.Errorf("Auto Scaling Group still exists"))

--- a/builtin/providers/aws/resource_aws_autoscaling_group.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group.go
@@ -28,7 +28,7 @@ func resourceAwsAutoscalingGroup() *schema.Resource {
 		},
 
 		Timeouts: &schema.ResourceTimeout{
-			Delete: schema.DefaultTimeout(5 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -687,7 +687,7 @@ func resourceAwsAutoscalingGroupDelete(d *schema.ResourceData, meta interface{})
 	// We retry the delete operation to handle InUse/InProgress errors coming
 	// from scaling operations. We should be able to sneak in a delete in between
 	// scaling operations within 5m.
-	err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+	err = resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		if _, err := conn.DeleteAutoScalingGroup(&deleteopts); err != nil {
 			if awserr, ok := err.(awserr.Error); ok {
 				switch awserr.Code() {
@@ -769,7 +769,7 @@ func resourceAwsAutoscalingGroupDrain(d *schema.ResourceData, meta interface{}) 
 
 	// Next, wait for the autoscale group to drain
 	log.Printf("[DEBUG] Waiting for group to have zero instances")
-	return resource.Retry(10*time.Minute, func() *resource.RetryError {
+	return resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		g, err := getAwsAutoscalingGroup(d.Id(), conn)
 		if err != nil {
 			return resource.NonRetryableError(err)

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -135,11 +135,15 @@ func (r *Resource) Apply(
 		return s, err
 	}
 
-	// Instance Diff shoould have the timeout info, need to copy it over to the
+	// Instance Diff should have the timeout info, need to copy it over to the
 	// ResourceData meta
 	rt := ResourceTimeout{}
 	if _, ok := d.Meta[TimeoutKey]; ok {
 		if err := rt.DiffDecode(d); err != nil {
+			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+		}
+	} else if _, ok := s.Meta[TimeoutKey]; ok {
+		if err := rt.StateDecode(s); err != nil {
 			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
 		}
 	} else {

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -142,9 +142,11 @@ func (r *Resource) Apply(
 		if err := rt.DiffDecode(d); err != nil {
 			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
 		}
-	} else if _, ok := s.Meta[TimeoutKey]; ok {
-		if err := rt.StateDecode(s); err != nil {
-			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+	} else if s != nil {
+		if _, ok := s.Meta[TimeoutKey]; ok {
+			if err := rt.StateDecode(s); err != nil {
+				log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+			}
 		}
 	} else {
 		log.Printf("[DEBUG] No meta timeoutkey found in Apply()")

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -172,7 +172,7 @@ care to not duplicate these hooks in `aws_autoscaling_lifecycle_hook`.
 `autoscaling_group` provides the following
 [Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
 
-- `delete` - (Default `5 minutes`) Used for destroying ASG.
+- `delete` - (Default `10 minutes`) Used for destroying ASG.  The same timeout setting also applies to the wait time to drain connection.
 
 ## Waiting for Capacity
 

--- a/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
+++ b/website/source/docs/providers/aws/r/autoscaling_group.html.markdown
@@ -57,6 +57,10 @@ EOF
     value               = "ipsum"
     propagate_at_launch = false
   }
+
+  timeouts {
+      delete = "5m"
+  }
 }
 ```
 
@@ -161,6 +165,14 @@ autoscaling group has been created, and depending on your
 been launched, creating unintended behavior. If you need hooks to run on all
 instances, add them with `initial_lifecycle_hook` here, but take
 care to not duplicate these hooks in `aws_autoscaling_lifecycle_hook`.
+
+<a id="timeouts"></a>
+## Timeouts
+
+`autoscaling_group` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `delete` - (Default `5 minutes`) Used for destroying ASG.
 
 ## Waiting for Capacity
 


### PR DESCRIPTION
Fix issue #14394 

I've added a configurable delete timeout for the ASG.

I've modified helper/schema/resource.go to read the meta from the state when it is not present in the diff. I'm not sure why this is happening, but on every tries I made, the diff never had the meta info into. It might not be the proper way to fix that problem tough, if someone more familiar with the code base could have a look. But it does not seem to cause any regression nor problem.

Documentation is also updated to reflect the new supported timeout.