### PR TITLE
provider/aws: Fix Content-Encoding for S3 object acc test

### DIFF
--- a/builtin/providers/aws/data_source_aws_s3_bucket_object_test.go
+++ b/builtin/providers/aws/data_source_aws_s3_bucket_object_test.go
@@ -149,7 +149,7 @@ func TestAccDataSourceAWSS3BucketObject_allParams(t *testing.T) {
 					resource.TestCheckNoResourceAttr("data.aws_s3_bucket_object.obj", "body"),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "cache_control", "no-cache"),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_disposition", "attachment"),
-					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_encoding", "gzip"),
+					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_encoding", "identity"),
 					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "content_language", "en-GB"),
 					// Encryption is off
 					resource.TestCheckResourceAttr("data.aws_s3_bucket_object.obj", "server_side_encryption", ""),
@@ -284,7 +284,7 @@ CONTENT
 	content_type = "application/unknown"
 	cache_control = "no-cache"
 	content_disposition = "attachment"
-	content_encoding = "gzip"
+	content_encoding = "identity"
 	content_language = "en-GB"
 	tags {
 		Key1 = "Value 1"

--- a/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
+++ b/website/source/docs/providers/aws/r/s3_bucket_object.html.markdown
@@ -62,6 +62,8 @@ resource "aws_s3_bucket_object" "examplebucket_object" {
 
 ## Argument Reference
 
+-> **Note:** If you specify `content_encoding` you are responsible for encoding the body appropriately (i.e. `source` and `content` both expect already encoded/compressed bytes)
+
 The following arguments are supported:
 
 * `bucket` - (Required) The name of the bucket to put the file in.


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccDataSourceAWSS3BucketObject_allParams
--- FAIL: TestAccDataSourceAWSS3BucketObject_allParams (6.00s)
    testing.go:280: Step 0 error: Check failed: Check 1/1 error: S3Bucket Object error: ReadError: an error occurred during response body reading
        caused by: gzip: invalid header
FAIL
```

I also added a note to help users avoid the same problem.

### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccDataSourceAWSS3BucketObject_allParams'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/11 17:48:22 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccDataSourceAWSS3BucketObject_allParams -timeout 120m
=== RUN   TestAccDataSourceAWSS3BucketObject_allParams
--- PASS: TestAccDataSourceAWSS3BucketObject_allParams (109.23s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	109.263s
```