### PR TITLE
provider/aws: Increase timeout for (dis)associating IPv6 addr to subnet

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -234,7 +234,7 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 			Pending: []string{"disassociating", "associated"},
 			Target:  []string{"disassociated"},
 			Refresh: SubnetIpv6CidrStateRefreshFunc(conn, d.Id(), d.Get("ipv6_cidr_block_association_id").(string)),
-			Timeout: 1 * time.Minute,
+			Timeout: 3 * time.Minute,
 		}
 		if _, err := stateConf.WaitForState(); err != nil {
 			return fmt.Errorf(
@@ -263,7 +263,7 @@ func resourceAwsSubnetUpdate(d *schema.ResourceData, meta interface{}) error {
 			Pending: []string{"associating", "disassociated"},
 			Target:  []string{"associated"},
 			Refresh: SubnetIpv6CidrStateRefreshFunc(conn, d.Id(), *resp.Ipv6CidrBlockAssociation.AssociationId),
-			Timeout: 1 * time.Minute,
+			Timeout: 3 * time.Minute,
 		}
 		if _, err := stateConf.WaitForState(); err != nil {
 			return fmt.Errorf(


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSSubnet_ipv6
--- FAIL: TestAccAWSSubnet_ipv6 (199.70s)
    testing.go:280: Step 2 error: Error applying: 1 error(s) occurred:
        
        * aws_subnet.foo: 1 error(s) occurred:
        
        * aws_subnet.foo: Error waiting for IPv6 CIDR (subnet-4c43b817) to become disassociated: timeout while waiting for state to become 'disassociated' (timeout: 1m0s)
FAIL
```
