### PR TITLE
Support reading Cloudformation Exports

### DIFF
--- a/builtin/providers/aws/data_source_aws_cloudformation_exports.go
+++ b/builtin/providers/aws/data_source_aws_cloudformation_exports.go
@@ -1,0 +1,48 @@
+package aws
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceAwsCloudFormationExports() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceAwsCloudFormationExportsRead,
+
+		Schema: map[string]*schema.Schema{
+			"values": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+			"stack_ids": {
+				Type:     schema.TypeMap,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsCloudFormationExportsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).cfconn
+	d.SetId(fmt.Sprintf("cloudformation-exports-%s", meta.(*AWSClient).region))
+	input := &cloudformation.ListExportsInput{}
+	values := make(map[string]string)
+	stack_ids := make(map[string]string)
+	err := conn.ListExportsPages(input,
+		func(page *cloudformation.ListExportsOutput, lastPage bool) bool {
+			flattenCloudformationExports(values, stack_ids, page.Exports)
+			if page.NextToken != nil {
+				return true
+			} else {
+				return false
+			}
+		})
+	if err != nil {
+		return fmt.Errorf("Failed listing CloudFormation exports: %s", err)
+	}
+	d.Set("values", values)
+	d.Set("stack_ids", stack_ids)
+	return nil
+}

--- a/builtin/providers/aws/data_source_aws_cloudformation_exports_test.go
+++ b/builtin/providers/aws/data_source_aws_cloudformation_exports_test.go
@@ -1,0 +1,92 @@
+package aws
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSCloudformationExports_dataSource(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccCheckAwsCloudformationExportsJson,
+			},
+			resource.TestStep{
+				Config: testAccAWSCloudformationExportsDataSource,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("data.aws_cloudformation_exports.cfn", "values.waiter", "waiter"),
+					resource.TestMatchResourceAttr("data.aws_cloudformation_exports.cfn", "values.my-vpc-id",
+						regexp.MustCompile("^vpc-[a-z0-9]{8}$")),
+					resource.TestMatchResourceAttr("data.aws_cloudformation_exports.cfn", "stack_ids.waiter",
+						regexp.MustCompile("^arn:aws:cloudformation")),
+				),
+			},
+		},
+	})
+}
+
+const testAccCheckAwsCloudformationExportsJson = `
+resource "aws_cloudformation_stack" "cfs" {
+  name = "tf-waiter-stack"
+  timeout_in_minutes = 6
+  template_body = <<STACK
+{
+  "Resources": {
+    "waiter": {
+      "Type": "AWS::CloudFormation::WaitConditionHandle",
+      "Properties": { }
+    }
+  },
+  "Outputs": {
+    "WaitHandle": {
+      "Value": "waiter" ,
+      "Description": "VPC ID",
+      "Export": {
+        "Name": "waiter" 
+      }
+    }
+  }
+}
+STACK
+}
+resource "aws_cloudformation_stack" "yaml" {
+  name = "tf-acc-ds-yaml-stack"
+  parameters {
+    CIDR = "10.10.10.0/24"
+  }
+  timeout_in_minutes = 6
+  template_body = <<STACK
+Parameters:
+  CIDR:
+    Type: String
+
+Resources:
+  myvpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref CIDR
+      Tags:
+        -
+          Key: Name
+          Value: Primary_CF_VPC
+
+Outputs:
+  VPCId:
+    Value: !Ref myvpc
+    Description: VPC ID
+    Export:
+      Name: my-vpc-id
+STACK
+  tags {
+    Name = "Form the Cloud"
+    Second = "meh"
+  }
+}
+`
+const testAccAWSCloudformationExportsDataSource = `
+data "aws_cloudformation_exports" "cfn" { }
+`

--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -171,6 +171,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_caller_identity":          dataSourceAwsCallerIdentity(),
 			"aws_canonical_user_id":        dataSourceAwsCanonicalUserId(),
 			"aws_cloudformation_stack":     dataSourceAwsCloudFormationStack(),
+			"aws_cloudformation_exports":   dataSourceAwsCloudFormationExports(),
 			"aws_db_instance":              dataSourceAwsDbInstance(),
 			"aws_db_snapshot":              dataSourceAwsDbSnapshot(),
 			"aws_ebs_snapshot":             dataSourceAwsEbsSnapshot(),

--- a/builtin/providers/aws/structure.go
+++ b/builtin/providers/aws/structure.go
@@ -1191,6 +1191,13 @@ func flattenCloudFormationOutputs(cfOutputs []*cloudformation.Output) map[string
 	return outputs
 }
 
+func flattenCloudformationExports(values, stack_ids map[string]string, cfExports []*cloudformation.Export) {
+	for _, e := range cfExports {
+		values[*e.Name] = *e.Value
+		stack_ids[*e.Name] = *e.ExportingStackId
+	}
+}
+
 func flattenAsgSuspendedProcesses(list []*autoscaling.SuspendedProcess) []string {
 	strs := make([]string, 0, len(list))
 	for _, r := range list {

--- a/website/source/docs/providers/aws/d/cloudformation_exports.html.markdown
+++ b/website/source/docs/providers/aws/d/cloudformation_exports.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "aws"
+page_title: "AWS: aws_cloudformation_exports"
+sidebar_current: "docs-aws-datasource-cloudformation-exports"
+description: |-
+    Provides metadata of a CloudFormation Exports (e.g. Cross Stack References)
+---
+
+# aws\_cloudformation\_exports
+
+The CloudFormation Exports data source allows access to stack
+exports specified in the [Output](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/outputs-section-structure.html) section of the Cloudformation Template using the optional Export Property. 
+
+ -> Note: The data resource runs before the Terraform `resource` declarations. For this reason, the exports must have been created prior to the Terraform `apply`. If you are trying to use a value from a Cloudformation Stack in the same Terraform run please use normal interpolation or Cloudformation Outputs. 
+
+## Example Usage
+
+```hcl
+data "aws_cloudformation_exports" "us_west_2" { }
+
+resource "aws_instance" "web" {
+  ami           = "ami-abb07bcb"
+  instance_type = "t1.micro"
+  subnet_id     = "${data.aws_cloudformation_exports.us_west_2.values["MyVpcSubnetId"]}"
+
+  tags {
+    Name = "HelloWorld"
+    DependsOnStack = "${data.aws_cloudformation_exports.us_west_2.stack_ids["MyVpcSubnetId"]}"
+  }
+}
+```
+
+## Argument Reference
+
+ There are no arguments
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `values` - A map of values from Cloudformation exports keyed by the name equivalent of creating a map using `Name:Value` from [list-exports](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/list-exports.html)
+* `stack_ids` - A map of stack Ids (AWS ARNs) equivalent of creating a map using
+    `Name:ExportingStackId` from [list-exports](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/list-exports.html) 

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -47,6 +47,9 @@
                         <li<%= sidebar_current("docs-aws-datasource-canonical-user-id") %>>
                             <a href="/docs/providers/aws/d/canonical_user_id.html">aws_canonical_user_id</a>
                         </li>
+                        <li<%= sidebar_current("docs-aws-datasource-cloudformation-exports") %>>
+                            <a href="/docs/providers/aws/d/cloudformation_exports.html">aws_cloudformation_exports</a>
+                        </li>
                         <li<%= sidebar_current("docs-aws-datasource-cloudformation-stack") %>>
                             <a href="/docs/providers/aws/d/cloudformation_stack.html">aws_cloudformation_stack</a>
                         </li>


### PR DESCRIPTION
This is an initial PR for supporting directly reading cloudformation exports. Teams could have used the data source aws_cloudformation_stack and read the Outputs from there. The main enhancement from adding this is not having to know which stack provided the export. This is problematic when exports are created using nested stacks because AWS adds random characters to the stack and makes automating the use of Terraform not as elegant.

There are some potential points of debate here.
1. is it worth adding this feature if there is a work around?
1. ~~the exporting stack ID doesn't really fit well~~
   * ~~I don't think there are many use cases for consuming it~~
   * ~~I used the convention ${export_name}_exporting_stack_id: <arn>~~
   * ~~If there is a method to support this better I am happy to refactor, but I questioned the value initially and felt the community could better inform me~~
1. I created separate maps for stack_ids and values from the exports 

I added acceptance tests ~~, but wanted to settle on exporting stack ID before writing the documentation. If this implementation is acceptable I'll add the documentation.~~

Updated with docs

