### PR TITLE
Allowed method on aggregator is `avg` ! `average`

### DIFF
--- a/builtin/providers/datadog/resource_datadog_timeboard.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard.go
@@ -704,11 +704,11 @@ func resourceDatadogTimeboardExists(d *schema.ResourceData, meta interface{}) (b
 func validateAggregatorMethod(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	validMethods := map[string]struct{}{
-		"avg": {},
-		"max":     {},
-		"min":     {},
-		"sum":     {},
-		"last":    {},
+		"avg":  {},
+		"max":  {},
+		"min":  {},
+		"sum":  {},
+		"last": {},
 	}
 	if _, ok := validMethods[value]; !ok {
 		errors = append(errors, fmt.Errorf(

--- a/builtin/providers/datadog/resource_datadog_timeboard.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard.go
@@ -704,7 +704,7 @@ func resourceDatadogTimeboardExists(d *schema.ResourceData, meta interface{}) (b
 func validateAggregatorMethod(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
 	validMethods := map[string]struct{}{
-		"average": {},
+		"avg": {},
 		"max":     {},
 		"min":     {},
 		"sum":     {},
@@ -712,7 +712,7 @@ func validateAggregatorMethod(v interface{}, k string) (ws []string, errors []er
 	}
 	if _, ok := validMethods[value]; !ok {
 		errors = append(errors, fmt.Errorf(
-			`%q contains an invalid method %q. Valid methods are either "average", "max", "min", "sum", or "last"`, k, value))
+			`%q contains an invalid method %q. Valid methods are either "avg", "max", "min", "sum", or "last"`, k, value))
 	}
 	return
 }

--- a/builtin/providers/datadog/resource_datadog_timeboard_test.go
+++ b/builtin/providers/datadog/resource_datadog_timeboard_test.go
@@ -224,7 +224,7 @@ func checkDestroy(s *terraform.State) error {
 
 func TestValidateAggregatorMethod(t *testing.T) {
 	validMethods := []string{
-		"average",
+		"avg",
 		"max",
 		"min",
 		"sum",
@@ -237,7 +237,7 @@ func TestValidateAggregatorMethod(t *testing.T) {
 	}
 
 	invalidMethods := []string{
-		"avg",
+		"average",
 		"suM",
 		"m",
 		"foo",


### PR DESCRIPTION
While Datadog will accept the value of `average` when creating the query graph, the resultant graph will be empty. Passing the value of `avg` instead correctly renders the graph.

Graph with `average`:
![image](https://cloud.githubusercontent.com/assets/1454296/25972238/2d96b996-366d-11e7-94fc-e91c01a70fe2.png)

Graph with `avg`:
![image](https://cloud.githubusercontent.com/assets/1454296/25972267/4a4107f4-366d-11e7-9a3c-15b5f13e1e67.png)
