### PR TITLE
Add support for joining domain for resource db_instance

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -341,7 +341,18 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"resource_id": {
+				Type: schema.TypeString,
+			},
+
+			"domain": {
 				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
+			"domain-iam-role-name": {
+				Type:     schema.TypeString,
+				Optional: true,
 				Computed: true,
 			},
 
@@ -648,6 +659,14 @@ func resourceAwsDbInstanceCreate(d *schema.ResourceData, meta interface{}) error
 			opts.EnableIAMDatabaseAuthentication = aws.Bool(attr.(bool))
 		}
 
+		if attr, ok := d.GetOk("domain"); ok {
+			opts.Domain = aws.String(attr.(string))
+		}
+
+		if attr, ok := d.GetOk("domain-iam-role-name"); ok {
+			opts.DomainIAMRoleName = aws.String(attr.(string))
+		}
+
 		log.Printf("[DEBUG] DB Instance create configuration: %#v", opts)
 		var err error
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
@@ -762,6 +781,11 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	if v.MonitoringRoleArn != nil {
 		d.Set("monitoring_role_arn", v.MonitoringRoleArn)
+	}
+
+	if v.DomainMemberships != nil {
+		d.Set("domain", v.DomainMemberships[0].Domain)
+		d.Set("domain-iam-role-name", v.DomainMemberships[0].IAMRoleName)
 	}
 
 	// list tags for resource
@@ -1012,6 +1036,18 @@ func resourceAwsDbInstanceUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("iam_database_authentication_enabled") {
 		req.EnableIAMDatabaseAuthentication = aws.Bool(d.Get("iam_database_authentication_enabled").(bool))
+		requestUpdate = true
+	}
+
+	if d.HasChange("domain") && !d.IsNewResource() {
+		d.SetPartial("domain")
+		req.Domain = aws.String(d.Get("domain").(string))
+		requestUpdate = true
+	}
+
+	if d.HasChange("domain-iam-role-name") && !d.IsNewResource() {
+		d.SetPartial("domain-iam-role-name")
+		req.DomainIAMRoleName = aws.String(d.Get("domain-iam-role-name").(string))
 		requestUpdate = true
 	}
 

--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -341,7 +341,8 @@ func resourceAwsDbInstance() *schema.Resource {
 			},
 
 			"resource_id": {
-				Type: schema.TypeString,
+				Type:     schema.TypeString,
+				Computed: true,
 			},
 
 			"domain": {


### PR DESCRIPTION
This will resolve #13329.

Adds domain and domain-iam-role-name parameters to resource aws_db_instance.