### PR TITLE
Correct argument description for targets

### DIFF
--- a/website/source/docs/providers/aws/r/ssm_maintenance_window_task.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_maintenance_window_task.html.markdown
@@ -20,7 +20,7 @@ resource "aws_ssm_maintenance_window" "window" {
   cutoff = 1
 }
 
-resource "aws_ssm_maintenance_window_task" "target" {
+resource "aws_ssm_maintenance_window_task" "task" {
   window_id = "${aws_ssm_maintenance_window.window.id}"
   task_type = "RUN_COMMAND"
   task_arn = "AWS-RunShellScript"
@@ -51,7 +51,7 @@ The following arguments are supported:
 * `task_type` - (Required) The type of task being registered. The only allowed value is `RUN_COMMAND`.
 * `task_arn` - (Required) The ARN of the task to execute.
 * `service_role_arn` - (Required) The role that should be assumed when executing the task.
-* `targets` - (Required) The targets (either instances or tags). Instances are specified using Key=instanceids,Values=instanceid1,instanceid2. Tags are specified using Key=tag name,Values=tag value.
+* `targets` - (Required) The targets (either instances or window target ids). Instances are specified using Key=InstanceIds,Values=instanceid1,instanceid2. Window target ids are specified using Key=WindowTargetIds,Values=window target id1, window target id2.
 * `priority` - (Optional) The priority of the task in the Maintenance Window, the lower the number the higher the priority. Tasks in a Maintenance Window are scheduled in priority order with tasks that have the same priority scheduled in parallel.
 * `logging_info` - (Optional) A structure containing information about an Amazon S3 bucket to write instance-level logs to. Documented below.
 


### PR DESCRIPTION
Correct `targets` argument description to show the allowed keys are `InstanceIds` or `WindowTargetIds`

Relevant for v0.9.5