### PR TITLE
Allow a codepipeline action to specify a role_arn

### DIFF
--- a/builtin/providers/aws/resource_aws_codepipeline.go
+++ b/builtin/providers/aws/resource_aws_codepipeline.go
@@ -323,6 +323,11 @@ func expandAwsCodePipelineActions(s []interface{}) []*codepipeline.ActionDeclara
 			Configuration: conf,
 		}
 
+		ra := data["role_arn"].(string)
+		if len(ra) > 0 {
+			action.RoleArn = aws.String(ra)
+		}
+
 		oa := data["output_artifacts"].([]interface{})
 		if len(oa) > 0 {
 			outputArtifacts := expandAwsCodePipelineActionsOutputArtifacts(oa)
@@ -353,6 +358,9 @@ func flattenAwsCodePipelineStageActions(actions []*codepipeline.ActionDeclaratio
 			"provider": *action.ActionTypeId.Provider,
 			"version":  *action.ActionTypeId.Version,
 			"name":     *action.Name,
+		}
+		if action.RoleArn != nil {
+			values["role_arn"] = *action.RoleArn
 		}
 		if action.Configuration != nil {
 			config := flattenAwsCodePipelineStageActionConfiguration(action.Configuration)

--- a/builtin/providers/aws/resource_aws_codepipeline_test.go
+++ b/builtin/providers/aws/resource_aws_codepipeline_test.go
@@ -31,6 +31,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.type", "S3"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.id", "1234"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.type", "KMS"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.role_arn", "arn:aws:iam::1234567890123:role/tst-role"),
 				),
 			},
 			{
@@ -40,6 +41,7 @@ func TestAccAWSCodePipeline_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.type", "S3"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.id", "4567"),
 					resource.TestCheckResourceAttr("aws_codepipeline.bar", "artifact_store.0.encryption_key.0.type", "KMS"),
+					resource.TestCheckResourceAttr("aws_codepipeline.bar", "stage.1.action.0.role_arn", "arn:aws:iam::1234567890123:role/tst-role"),
 				),
 			},
 		},
@@ -193,6 +195,7 @@ resource "aws_codepipeline" "bar" {
       provider        = "CodeBuild"
       input_artifacts = ["test"]
       version         = "1"
+      role_arn        = "arn:aws:iam::1234567890123:role/tst-role"
 
       configuration {
         ProjectName = "test"
@@ -305,6 +308,7 @@ resource "aws_codepipeline" "bar" {
       provider        = "CodeBuild"
       input_artifacts = ["bar"]
       version         = "1"
+      role_arn        = "arn:aws:iam::1234567890123:role/tst-role"
 
       configuration {
         ProjectName = "foo"


### PR DESCRIPTION
The codepipeline resource allows an action to specify a role_arn. However that role is never passed to AWS. This PR fixes that behavior.