### PR TITLE
provider/google: Fix health check http/https defaults

### DIFF
--- a/builtin/providers/google/resource_compute_health_check.go
+++ b/builtin/providers/google/resource_compute_health_check.go
@@ -110,11 +110,11 @@ func resourceComputeHealthCheck() *schema.Resource {
 						"host": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  80,
 						},
 						"port": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
+							Default:  80,
 						},
 						"proxy_header": &schema.Schema{
 							Type:     schema.TypeString,
@@ -140,11 +140,11 @@ func resourceComputeHealthCheck() *schema.Resource {
 						"host": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
-							Default:  443,
 						},
 						"port": &schema.Schema{
 							Type:     schema.TypeInt,
 							Optional: true,
+							Default:  443,
 						},
 						"proxy_header": &schema.Schema{
 							Type:     schema.TypeString,


### PR DESCRIPTION
Change the http_health_check and https_health_check default values in resource_compute_health_check.go to match the default values in the documentation, and the default values of the specific health check resources.