### PR TITLE
provider/heroku: Correct issue with setting CName in heroku_domain

### DIFF
--- a/builtin/providers/heroku/resource_heroku_domain.go
+++ b/builtin/providers/heroku/resource_heroku_domain.go
@@ -51,7 +51,7 @@ func resourceHerokuDomainCreate(d *schema.ResourceData, meta interface{}) error 
 
 	d.SetId(do.ID)
 	d.Set("hostname", do.Hostname)
-	d.Set("cname", fmt.Sprintf("%s.herokuapp.com", app))
+	d.Set("cname", do.CName)
 
 	log.Printf("[INFO] Domain ID: %s", d.Id())
 	return nil
@@ -81,7 +81,7 @@ func resourceHerokuDomainRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("hostname", do.Hostname)
-	d.Set("cname", fmt.Sprintf("%s.herokuapp.com", app))
+	d.Set("cname", do.CName)
 
 	return nil
 }

--- a/builtin/providers/heroku/resource_heroku_domain_test.go
+++ b/builtin/providers/heroku/resource_heroku_domain_test.go
@@ -30,8 +30,7 @@ func TestAccHerokuDomain_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"heroku_domain.foobar", "app", appName),
 					resource.TestCheckResourceAttr(
-						"heroku_domain.foobar", "cname",
-						fmt.Sprintf("%s.herokuapp.com", appName)),
+						"heroku_domain.foobar", "cname", "terraform.example.com.herokudns.com"),
 				),
 			},
 		},


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/14434 by using the returned `CName` from the API instead of a forced format of `<appname>.heroku.com`

cc @arr-dev, sorry! I didn't notice you planned to PR the fix until just now 😦 