### PR TITLE
Update HIL vendor for conditional type checking fix

### DIFF
--- a/vendor/github.com/hashicorp/hil/check_types.go
+++ b/vendor/github.com/hashicorp/hil/check_types.go
@@ -414,7 +414,7 @@ func (tc *typeCheckConditional) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	}
 
 	// The types of the true and false expression must match
-	if trueType != falseType {
+	if trueType != falseType && trueType != ast.TypeUnknown && falseType != ast.TypeUnknown {
 
 		// Since passing around stringified versions of other types is
 		// common, we pragmatically allow the false expression to dictate
@@ -460,7 +460,13 @@ func (tc *typeCheckConditional) TypeCheck(v *TypeCheck) (ast.Node, error) {
 	}
 
 	// Result type (guaranteed to also match falseType due to the above)
-	v.StackPush(trueType)
+	if trueType == ast.TypeUnknown {
+		// falseType may also be unknown, but that's okay because two
+		// unknowns means our result is unknown anyway.
+		v.StackPush(falseType)
+	} else {
+		v.StackPush(trueType)
+	}
 
 	return tc.n, nil
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2144,28 +2144,28 @@
 			"revisionTime": "2017-05-04T19:02:34Z"
 		},
 		{
-			"checksumSHA1": "zz3/f3YpHHBN78uLhnhLBW2aF8o=",
+			"checksumSHA1": "M09yxoBoCEtG7EcHR8aEWLzMMJc=",
 			"path": "github.com/hashicorp/hil",
-			"revision": "747a6e1523d6808f91144df070435b16865cd333",
-			"revisionTime": "2017-05-01T20:07:50Z"
+			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
+			"revisionTime": "2017-05-12T21:33:05Z"
 		},
 		{
 			"checksumSHA1": "0S0KeBcfqVFYBPeZkuJ4fhQ5mCA=",
 			"path": "github.com/hashicorp/hil/ast",
-			"revision": "747a6e1523d6808f91144df070435b16865cd333",
-			"revisionTime": "2017-05-01T20:07:50Z"
+			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
+			"revisionTime": "2017-05-12T21:33:05Z"
 		},
 		{
 			"checksumSHA1": "P5PZ3k7SmqWmxgJ8Q0gLzeNpGhE=",
 			"path": "github.com/hashicorp/hil/parser",
-			"revision": "747a6e1523d6808f91144df070435b16865cd333",
-			"revisionTime": "2017-05-01T20:07:50Z"
+			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
+			"revisionTime": "2017-05-12T21:33:05Z"
 		},
 		{
 			"checksumSHA1": "DC1k5kOua4oFqmo+JRt0YzfP44o=",
 			"path": "github.com/hashicorp/hil/scanner",
-			"revision": "747a6e1523d6808f91144df070435b16865cd333",
-			"revisionTime": "2017-05-01T20:07:50Z"
+			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
+			"revisionTime": "2017-05-12T21:33:05Z"
 		},
 		{
 			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",


### PR DESCRIPTION
hashicorp/hil#53 addresses a regression with type checking of unknown values in the HIL conditional operator.

This fixes #14399.