### PR TITLE
provider/google: Add import support to google_sql_user

### DIFF
--- a/builtin/providers/google/import_sql_user_test.go
+++ b/builtin/providers/google/import_sql_user_test.go
@@ -1,0 +1,32 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccGoogleSqlUser_importBasic(t *testing.T) {
+	resourceName := "google_sql_user.user"
+	user := acctest.RandString(10)
+	instance := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleSqlUserDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testGoogleSqlUser_basic(instance, user),
+			},
+
+			resource.TestStep{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"},
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_sql_user.go
+++ b/builtin/providers/google/resource_sql_user.go
@@ -136,8 +136,6 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 		return nil
 	}
 
-	d.SetId(fmt.Sprintf("%s.%s", instance, name))
-
 	d.Set("host", user.Host)
 	d.Set("instance", user.Instance)
 	d.Set("name", user.Name)

--- a/builtin/providers/google/resource_sql_user.go
+++ b/builtin/providers/google/resource_sql_user.go
@@ -84,7 +84,7 @@ func resourceSqlUserCreate(d *schema.ResourceData, meta interface{}) error {
 			"user %s into instance %s: %s", name, instance, err)
 	}
 
-	d.SetId(fmt.Sprintf("%s.%s", instance, name))
+	d.SetId(fmt.Sprintf("%s/%s", instance, name))
 
 	err = sqladminOperationWait(config, op, "Insert User")
 
@@ -104,10 +104,10 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	instanceAndName := strings.SplitN(d.Id(), ".", 2)
+	instanceAndName := strings.SplitN(d.Id(), "/", 2)
 	if len(instanceAndName) != 2 {
 		return fmt.Errorf(
-			"Wrong number of arguments when specifying imported id. Expected: 2.  Saw: %d. Expected Input: $INSTANCENAME.$SQLUSERNAME Input: %s",
+			"Wrong number of arguments when specifying imported id. Expected: 2.  Saw: %d. Expected Input: $INSTANCENAME/$SQLUSERNAME Input: %s",
 			len(instanceAndName),
 			d.Id())
 	}

--- a/builtin/providers/google/resource_sql_user.go
+++ b/builtin/providers/google/resource_sql_user.go
@@ -1,13 +1,11 @@
 package google
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"strings"
 
 	"github.com/hashicorp/terraform/helper/schema"
-
 	"google.golang.org/api/sqladmin/v1beta4"
 )
 
@@ -20,6 +18,9 @@ func resourceSqlUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+
+		SchemaVersion: 1,
+		MigrateState:  resourceSqlUserMigrateState,
 
 		Schema: map[string]*schema.Schema{
 			"host": &schema.Schema{
@@ -106,9 +107,9 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 	instanceAndName := strings.SplitN(d.Id(), ".", 2)
 	if len(instanceAndName) != 2 {
 		return fmt.Errorf(
-				"Wrong number of arguments when specifying imported id. Expected: 2.  Saw: %d. Expected Input: $INSTANCENAME.$SQLUSERNAME Input: %s",
-				len(instanceAndName),
-				d.Id())
+			"Wrong number of arguments when specifying imported id. Expected: 2.  Saw: %d. Expected Input: $INSTANCENAME.$SQLUSERNAME Input: %s",
+			len(instanceAndName),
+			d.Id())
 	}
 
 	instance := instanceAndName[0]

--- a/builtin/providers/google/resource_sql_user.go
+++ b/builtin/providers/google/resource_sql_user.go
@@ -105,11 +105,10 @@ func resourceSqlUserRead(d *schema.ResourceData, meta interface{}) error {
 
 	instanceAndName := strings.SplitN(d.Id(), ".", 2)
 	if len(instanceAndName) != 2 {
-		return errors.New(
-			fmt.Sprintf(
+		return fmt.Errorf(
 				"Wrong number of arguments when specifying imported id. Expected: 2.  Saw: %d. Expected Input: $INSTANCENAME.$SQLUSERNAME Input: %s",
 				len(instanceAndName),
-				d.Id()))
+				d.Id())
 	}
 
 	instance := instanceAndName[0]

--- a/builtin/providers/google/resource_sql_user_migrate.go
+++ b/builtin/providers/google/resource_sql_user_migrate.go
@@ -1,0 +1,40 @@
+package google
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func resourceSqlUserMigrateState(
+	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
+	if is.Empty() {
+		log.Println("[DEBUG] Empty SqlUserState; nothing to migrate.")
+		return is, nil
+	}
+
+	switch v {
+	case 0:
+		log.Println("[INFO] Found Google Sql User State v0; migrating to v1")
+		is, err := migrateSqlUserStateV0toV1(is)
+		if err != nil {
+			return is, err
+		}
+		return is, nil
+	default:
+		return is, fmt.Errorf("Unexpected schema version: %d", v)
+	}
+}
+
+func migrateSqlUserStateV0toV1(is *terraform.InstanceState) (*terraform.InstanceState, error) {
+	log.Printf("[DEBUG] Attributes before migration: %#v", is.Attributes)
+
+	name := is.Attributes["name"]
+	instance := is.Attributes["instance"]
+	is.ID = fmt.Sprintf("%s.%s", instance, name)
+	is.Attributes["id"] = is.ID
+
+	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
+	return is, nil
+}

--- a/builtin/providers/google/resource_sql_user_migrate.go
+++ b/builtin/providers/google/resource_sql_user_migrate.go
@@ -33,7 +33,6 @@ func migrateSqlUserStateV0toV1(is *terraform.InstanceState) (*terraform.Instance
 	name := is.Attributes["name"]
 	instance := is.Attributes["instance"]
 	is.ID = fmt.Sprintf("%s.%s", instance, name)
-	is.Attributes["id"] = is.ID
 
 	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
 	return is, nil

--- a/builtin/providers/google/resource_sql_user_migrate.go
+++ b/builtin/providers/google/resource_sql_user_migrate.go
@@ -10,7 +10,7 @@ import (
 func resourceSqlUserMigrateState(
 	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	if is.Empty() {
-		log.Println("[DEBUG] Empty SqlUserState; nothing to migrate.")
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
 		return is, nil
 	}
 
@@ -32,7 +32,7 @@ func migrateSqlUserStateV0toV1(is *terraform.InstanceState) (*terraform.Instance
 
 	name := is.Attributes["name"]
 	instance := is.Attributes["instance"]
-	is.ID = fmt.Sprintf("%s.%s", instance, name)
+	is.ID = fmt.Sprintf("%s/%s", instance, name)
 
 	log.Printf("[DEBUG] Attributes after migration: %#v", is.Attributes)
 	return is, nil

--- a/builtin/providers/google/resource_sql_user_migrate_test.go
+++ b/builtin/providers/google/resource_sql_user_migrate_test.go
@@ -1,0 +1,78 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestSqlUserMigrateState(t *testing.T) {
+	cases := map[string]struct {
+		StateVersion int
+		Attributes   map[string]string
+		Expected     map[string]string
+		Meta         interface{}
+		ID           string
+		ExpectedID   string
+	}{
+		"change id from $NAME to $INSTANCENAME.$NAME": {
+			StateVersion: 0,
+			Attributes: map[string]string{
+				"name":     "tf-user",
+				"instance": "tf-instance",
+			},
+			Expected:   map[string]string{},
+			Meta:       &Config{},
+			ID:         "tf-user",
+			ExpectedID: "tf-instance.tf-user",
+		},
+	}
+
+	for tn, tc := range cases {
+		is := &terraform.InstanceState{
+			ID:         tc.ID,
+			Attributes: tc.Attributes,
+		}
+		is, err := resourceSqlUserMigrateState(
+			tc.StateVersion, is, tc.Meta)
+
+		if err != nil {
+			t.Fatalf("bad: %s, err: %#v", tn, err)
+		}
+
+		if is.ID != tc.ExpectedID {
+			t.Fatalf("bad ID.\n\n expected: %s\n got: %s", tc.ExpectedID, is.ID)
+		}
+
+		for k, v := range tc.Expected {
+			if is.Attributes[k] != v {
+				t.Fatalf(
+					"bad: %s\n\n expected: %#v -> %#v\n got: %#v -> %#v\n in: %#v",
+					tn, k, v, k, is.Attributes[k], is.Attributes)
+			}
+		}
+	}
+}
+
+func TestSqlUserMigrateState_empty(t *testing.T) {
+	var is *terraform.InstanceState
+	var meta *Config
+
+	// should handle nil
+	is, err := resourceSqlUserMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+	if is != nil {
+		t.Fatalf("expected nil instancestate, got: %#v", is)
+	}
+
+	// should handle non-nil but empty
+	is = &terraform.InstanceState{}
+	is, err = resourceSqlUserMigrateState(0, is, meta)
+
+	if err != nil {
+		t.Fatalf("err: %#v", err)
+	}
+}

--- a/builtin/providers/google/resource_sql_user_migrate_test.go
+++ b/builtin/providers/google/resource_sql_user_migrate_test.go
@@ -21,10 +21,13 @@ func TestSqlUserMigrateState(t *testing.T) {
 				"name":     "tf-user",
 				"instance": "tf-instance",
 			},
-			Expected:   map[string]string{},
+			Expected: map[string]string{
+				"name":     "tf-user",
+				"instance": "tf-instance",
+			},
 			Meta:       &Config{},
 			ID:         "tf-user",
-			ExpectedID: "tf-instance.tf-user",
+			ExpectedID: "tf-instance/tf-user",
 		},
 	}
 

--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -152,6 +152,7 @@ To make a resource importable, please see the
 * google_compute_target_pool
 * google_dns_managed_zone
 * google_project
+* google_sql_user
 
 ### OpenStack
 

--- a/website/source/docs/providers/google/r/sql_user.html.markdown
+++ b/website/source/docs/providers/google/r/sql_user.html.markdown
@@ -64,11 +64,11 @@ Only the arguments listed above are exposed as attributes.
 Importing an SQL user is formatted as:
 
 ```bash
-terraform import google_sql_user.$RESOURCENAME $INSTANCENAME.$SQLUSERNAME
+terraform import google_sql_user.$RESOURCENAME $INSTANCENAME/$SQLUSERNAME
 ```
 
 For example, the sample at the top of this page could be imported with:
 
 ```bash
-terraform import google_sql_user.users master-instance.me
+terraform import google_sql_user.users master-instance/me
 ```

--- a/website/source/docs/providers/google/r/sql_user.html.markdown
+++ b/website/source/docs/providers/google/r/sql_user.html.markdown
@@ -11,7 +11,8 @@ description: |-
 Creates a new Google SQL User on a Google SQL User Instance. For more information, see the [official documentation](https://cloud.google.com/sql/), or the [JSON API](https://cloud.google.com/sql/docs/admin-api/v1beta4/users).
 
 ~> **Note:** All arguments including the username and password will be stored in the raw state as plain-text.
-[Read more about sensitive data in state](/docs/state/sensitive-data.html).
+[Read more about sensitive data in state](/docs/state/sensitive-data.html). Passwords will not be retrieved when running
+"terraform import".
 
 ## Example Usage
 

--- a/website/source/docs/providers/google/r/sql_user.html.markdown
+++ b/website/source/docs/providers/google/r/sql_user.html.markdown
@@ -58,3 +58,17 @@ The following arguments are supported:
 ## Attributes Reference
 
 Only the arguments listed above are exposed as attributes.
+
+## Import Format
+
+Importing an SQL user is formatted as:
+
+```bash
+terraform import google_sql_user.$RESOURCENAME $INSTANCENAME.$SQLUSERNAME
+```
+
+For example, the sample at the top of this page could be imported with:
+
+```bash
+terraform import google_sql_user.users master-instance.me
+```


### PR DESCRIPTION
Add support for "terraform import" with google_sql_user resources.

This uses a slightly different format than normal to support specifying the database instance name. The format is documented on the resource's page, along with a note that passwords are not retrieved