### PR TITLE
provider/github: Randomize acceptance tests

### DIFF
--- a/builtin/providers/github/provider_test.go
+++ b/builtin/providers/github/provider_test.go
@@ -8,8 +8,6 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-const testRepo string = "test-repo"
-
 var testUser string = os.Getenv("GITHUB_TEST_USER")
 var testCollaborator string = os.Getenv("GITHUB_TEST_COLLABORATOR")
 

--- a/builtin/providers/github/resource_github_issue_label_test.go
+++ b/builtin/providers/github/resource_github_issue_label_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/google/go-github/github"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -13,27 +14,45 @@ import (
 func TestAccGithubIssueLabel_basic(t *testing.T) {
 	var label github.Label
 
+	rString := acctest.RandString(5)
+	repoName := fmt.Sprintf("tf-acc-test-branch-issue-label-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubIssueLabelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubIssueLabelConfig,
+				Config: testAccGithubIssueLabelConfig(repoName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubIssueLabelExists("github_issue_label.test", &label),
 					testAccCheckGithubIssueLabelAttributes(&label, "foo", "000000"),
 				),
 			},
 			{
-				Config: testAccGithubIssueLabelUpdateConfig,
+				Config: testAccGithubIssueLabelUpdateConfig(repoName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubIssueLabelExists("github_issue_label.test", &label),
 					testAccCheckGithubIssueLabelAttributes(&label, "bar", "FFFFFF"),
 				),
 			},
+		},
+	})
+}
+
+func TestAccGithubIssueLabel_existingLabel(t *testing.T) {
+	var label github.Label
+
+	rString := acctest.RandString(5)
+	repoName := fmt.Sprintf("tf-acc-test-branch-issue-label-%s", rString)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGithubIssueLabelDestroy,
+		Steps: []resource.TestStep{
 			{
-				Config: testAccGitHubIssueLabelExistsConfig,
+				Config: testAccGitHubIssueLabelExistsConfig(repoName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubIssueLabelExists("github_issue_label.test", &label),
 					testAccCheckGithubIssueLabelAttributes(&label, "enhancement", "FF00FF"),
@@ -44,13 +63,16 @@ func TestAccGithubIssueLabel_basic(t *testing.T) {
 }
 
 func TestAccGithubIssueLabel_importBasic(t *testing.T) {
+	rString := acctest.RandString(5)
+	repoName := fmt.Sprintf("tf-acc-test-branch-issue-label-%s", rString)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccGithubIssueLabelDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubIssueLabelConfig,
+				Config: testAccGithubIssueLabelConfig(repoName),
 			},
 			{
 				ResourceName:      "github_issue_label.test",
@@ -126,26 +148,39 @@ func testAccGithubIssueLabelDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccGithubIssueLabelConfig string = fmt.Sprintf(`
+func testAccGithubIssueLabelConfig(repoName string) string {
+	return fmt.Sprintf(`
+resource "github_repository" "test" {
+  name = "%s"
+}
+
 resource "github_issue_label" "test" {
-  repository = "%s"
+  repository = "${github_repository.test.name}"
   name       = "foo"
   color      = "000000"
 }
-`, testRepo)
+`, repoName)
+}
 
-var testAccGithubIssueLabelUpdateConfig string = fmt.Sprintf(`
+func testAccGithubIssueLabelUpdateConfig(repoName string) string {
+	return fmt.Sprintf(`
+resource "github_repository" "test" {
+  name = "%s"
+}
+
 resource "github_issue_label" "test" {
-  repository = "%s"
+  repository = "${github_repository.test.name}"
   name       = "bar"
   color      = "FFFFFF"
 }
-`, testRepo)
+`, repoName)
+}
 
-var testAccGitHubIssueLabelExistsConfig string = fmt.Sprintf(`
+func testAccGitHubIssueLabelExistsConfig(repoName string) string {
+	return fmt.Sprintf(`
 // Create a repository which has the default labels
 resource "github_repository" "test" {
-  name = "tf-acc-repo-label-abc1234"
+  name = "%s"
 }
 
 resource "github_issue_label" "test" {
@@ -153,4 +188,5 @@ resource "github_issue_label" "test" {
   name       = "enhancement" // Important! This is a pre-created label
   color      = "FF00FF"
 }
-`)
+`, repoName)
+}

--- a/builtin/providers/github/resource_github_repository_collaborator_test.go
+++ b/builtin/providers/github/resource_github_repository_collaborator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -12,13 +13,15 @@ import (
 const expectedPermission string = "admin"
 
 func TestAccGithubRepositoryCollaborator_basic(t *testing.T) {
+	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryCollaboratorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubRepositoryCollaboratorConfig,
+				Config: testAccGithubRepositoryCollaboratorConfig(repoName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubRepositoryCollaboratorExists("github_repository_collaborator.test_repo_collaborator"),
 					testAccCheckGithubRepositoryCollaboratorPermission("github_repository_collaborator.test_repo_collaborator"),
@@ -29,13 +32,15 @@ func TestAccGithubRepositoryCollaborator_basic(t *testing.T) {
 }
 
 func TestAccGithubRepositoryCollaborator_importBasic(t *testing.T) {
+	repoName := fmt.Sprintf("tf-acc-test-collab-%s", acctest.RandString(5))
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGithubRepositoryCollaboratorDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubRepositoryCollaboratorConfig,
+				Config: testAccGithubRepositoryCollaboratorConfig(repoName),
 			},
 			{
 				ResourceName:      "github_repository_collaborator.test_repo_collaborator",
@@ -148,10 +153,16 @@ func testAccCheckGithubRepositoryCollaboratorPermission(n string) resource.TestC
 	}
 }
 
-var testAccGithubRepositoryCollaboratorConfig string = fmt.Sprintf(`
+func testAccGithubRepositoryCollaboratorConfig(repoName string) string {
+	return fmt.Sprintf(`
+resource "github_repository" "test" {
+	name = "%s"
+}
+
   resource "github_repository_collaborator" "test_repo_collaborator" {
-    repository = "%s"
+    repository = "${github_repository.test.name}"
     username = "%s"
     permission = "%s"
   }
-`, testRepo, testCollaborator, expectedPermission)
+`, repoName, testCollaborator, expectedPermission)
+}

--- a/builtin/providers/github/resource_github_team_repository_test.go
+++ b/builtin/providers/github/resource_github_team_repository_test.go
@@ -13,7 +13,9 @@ import (
 
 func TestAccGithubTeamRepository_basic(t *testing.T) {
 	var repository github.Repository
+
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	repoName := fmt.Sprintf("tf-acc-test-team-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,14 +23,14 @@ func TestAccGithubTeamRepository_basic(t *testing.T) {
 		CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamRepositoryConfig(randString, testRepo),
+				Config: testAccGithubTeamRepositoryConfig(randString, repoName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamRepositoryExists("github_team_repository.test_team_test_repo", &repository),
 					testAccCheckGithubTeamRepositoryRoleState("pull", &repository),
 				),
 			},
 			{
-				Config: testAccGithubTeamRepositoryUpdateConfig(randString, testRepo),
+				Config: testAccGithubTeamRepositoryUpdateConfig(randString, repoName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubTeamRepositoryExists("github_team_repository.test_team_test_repo", &repository),
 					testAccCheckGithubTeamRepositoryRoleState("push", &repository),
@@ -40,6 +42,7 @@ func TestAccGithubTeamRepository_basic(t *testing.T) {
 
 func TestAccGithubTeamRepository_importBasic(t *testing.T) {
 	randString := acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	repoName := fmt.Sprintf("tf-acc-test-team-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -47,7 +50,7 @@ func TestAccGithubTeamRepository_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckGithubTeamRepositoryDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGithubTeamRepositoryConfig(randString, testRepo),
+				Config: testAccGithubTeamRepositoryConfig(randString, repoName),
 			},
 			{
 				ResourceName:      "github_team_repository.test_team_test_repo",
@@ -159,9 +162,13 @@ resource "github_team" "test_team" {
 	description = "Terraform acc test group"
 }
 
+resource "github_repository" "test" {
+	name = "%s"
+}
+
 resource "github_team_repository" "test_team_test_repo" {
 	team_id = "${github_team.test_team.id}"
-	repository = "%s"
+	repository = "${github_repository.test.name}"
 	permission = "pull"
 }
 `, randString, repoName)
@@ -174,9 +181,13 @@ resource "github_team" "test_team" {
 	description = "Terraform acc test group"
 }
 
+resource "github_repository" "test" {
+	name = "%s"
+}
+
 resource "github_team_repository" "test_team_test_repo" {
 	team_id = "${github_team.test_team.id}"
-	repository = "%s"
+	repository = "${github_repository.test.name}"
 	permission = "push"
 }
 `, randString, repoName)


### PR DESCRIPTION
This is to get rid of dependency on a static repository name `test-repo` and make acceptance tests work in any organisation without extra manual setup.

### Test plan

```
make testacc TEST=./builtin/providers/github TESTARGS='-run=TestAccGithub'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/13 11:13:51 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/github -v -run=TestAccGithub -timeout 120m
=== RUN   TestAccGithubBranchProtection_basic
--- FAIL: TestAccGithubBranchProtection_basic (6.76s)
	testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:

		* github_branch_protection.master: 1 error(s) occurred:

		* github_branch_protection.master: PUT https://api.github.com/repos/terraformtesting/tf-acc-test-branch-prot-hwut9/branches/master/protection: 422 Invalid request.

		"enforce_admins" wasn't supplied. []
=== RUN   TestAccGithubBranchProtection_importBasic
--- FAIL: TestAccGithubBranchProtection_importBasic (1.95s)
	testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:

		* github_branch_protection.master: 1 error(s) occurred:

		* github_branch_protection.master: PUT https://api.github.com/repos/terraformtesting/cp9by/branches/master/protection: 422 Invalid request.

		"enforce_admins" wasn't supplied. []
=== RUN   TestAccGithubIssueLabel_basic
--- PASS: TestAccGithubIssueLabel_basic (4.88s)
=== RUN   TestAccGithubIssueLabel_existingLabel
--- PASS: TestAccGithubIssueLabel_existingLabel (3.38s)
=== RUN   TestAccGithubIssueLabel_importBasic
--- PASS: TestAccGithubIssueLabel_importBasic (3.38s)
=== RUN   TestAccGithubMembership_basic
--- PASS: TestAccGithubMembership_basic (1.74s)
=== RUN   TestAccGithubMembership_importBasic
--- PASS: TestAccGithubMembership_importBasic (1.64s)
=== RUN   TestAccGithubOrganizationWebhook_basic
--- PASS: TestAccGithubOrganizationWebhook_basic (3.07s)
=== RUN   TestAccGithubRepositoryCollaborator_basic
--- PASS: TestAccGithubRepositoryCollaborator_basic (3.58s)
=== RUN   TestAccGithubRepositoryCollaborator_importBasic
--- PASS: TestAccGithubRepositoryCollaborator_importBasic (3.38s)
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (3.07s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (2.15s)
=== RUN   TestAccGithubRepositoryWebhook_basic
--- PASS: TestAccGithubRepositoryWebhook_basic (4.45s)
=== RUN   TestAccGithubTeamMembership_basic
--- PASS: TestAccGithubTeamMembership_basic (5.48s)
=== RUN   TestAccGithubTeamMembership_importBasic
--- PASS: TestAccGithubTeamMembership_importBasic (2.50s)
=== RUN   TestAccGithubTeamRepository_basic
--- PASS: TestAccGithubTeamRepository_basic (4.50s)
=== RUN   TestAccGithubTeamRepository_importBasic
--- PASS: TestAccGithubTeamRepository_importBasic (2.83s)
=== RUN   TestAccGithubTeam_basic
--- PASS: TestAccGithubTeam_basic (4.10s)
=== RUN   TestAccGithubTeam_importBasic
--- PASS: TestAccGithubTeam_importBasic (1.42s)
=== RUN   TestAccGithubUtilRole_validation
--- PASS: TestAccGithubUtilRole_validation (0.00s)
=== RUN   TestAccGithubUtilTwoPartID
--- PASS: TestAccGithubUtilTwoPartID (0.00s)
FAIL
exit status 1
FAIL	github.com/hashicorp/terraform/builtin/providers/github	64.311s
make: *** [testacc] Error 1
```

The two failures are caused by a breaking change in the upstream API, related PR: https://github.com/hashicorp/terraform/pull/14195