### PR TITLE
provider/ignition: Fix typo in documentation

### DIFF
--- a/website/source/docs/providers/ignition/d/config.html.md
+++ b/website/source/docs/providers/ignition/d/config.html.md
@@ -40,9 +40,9 @@ The following arguments are supported:
 
 * `groups` - (Optional) The list of groups to be added.
 
-* `append` - (Optional) A block with config that will replace the current.
+* `append` - (Optional) Any number of blocks with the configs to be appended to the current config.
 
-* `replace` - (Optional) Any number of blocks with the configs to be appended to the current config.
+* `replace` - (Optional) A block with config that will replace the current.
 
 
 The `append` and `replace` blocks supports:


### PR DESCRIPTION
`append` appends and `replace` replaces as per [ignition documentation](https://coreos.com/ignition/docs/latest/configuration-v2_0.html).