### PR TITLE
[WIP] provider/aws: Add support for Server-Side Encryption to SQS

### DIFF
--- a/builtin/providers/aws/import_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/import_aws_sqs_queue_test.go
@@ -56,3 +56,27 @@ func TestAccAWSSQSQueue_importFifo(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAWSSQSQueue_importEncryption(t *testing.T) {
+	resourceName := "aws_sqs_queue.queue"
+	queueName := fmt.Sprintf("sqs-queue-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigWithEncryption(queueName),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "kms_master_key_id", "alias/aws/sqs"),
+				),
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_sqs_queue.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue.go
@@ -16,16 +16,18 @@ import (
 )
 
 var AttributeMap = map[string]string{
-	"delay_seconds":               "DelaySeconds",
-	"max_message_size":            "MaximumMessageSize",
-	"message_retention_seconds":   "MessageRetentionPeriod",
-	"receive_wait_time_seconds":   "ReceiveMessageWaitTimeSeconds",
-	"visibility_timeout_seconds":  "VisibilityTimeout",
-	"policy":                      "Policy",
-	"redrive_policy":              "RedrivePolicy",
-	"arn":                         "QueueArn",
-	"fifo_queue":                  "FifoQueue",
-	"content_based_deduplication": "ContentBasedDeduplication",
+	"delay_seconds":                     "DelaySeconds",
+	"max_message_size":                  "MaximumMessageSize",
+	"message_retention_seconds":         "MessageRetentionPeriod",
+	"receive_wait_time_seconds":         "ReceiveMessageWaitTimeSeconds",
+	"visibility_timeout_seconds":        "VisibilityTimeout",
+	"policy":                            "Policy",
+	"redrive_policy":                    "RedrivePolicy",
+	"arn":                               "QueueArn",
+	"fifo_queue":                        "FifoQueue",
+	"content_based_deduplication":       "ContentBasedDeduplication",
+	"kms_master_key_id":                 "KmsMasterKeyId",
+	"kms_data_key_reuse_period_seconds": "KmsDataKeyReusePeriodSeconds",
 }
 
 // A number of these are marked as computed because if you don't
@@ -101,6 +103,15 @@ func resourceAwsSqsQueue() *schema.Resource {
 			"content_based_deduplication": {
 				Type:     schema.TypeBool,
 				Default:  false,
+				Optional: true,
+			},
+			"kms_master_key_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"kms_data_key_reuse_period_seconds": {
+				Type:     schema.TypeInt,
+				Computed: true,
 				Optional: true,
 			},
 		},

--- a/builtin/providers/aws/resource_aws_sqs_queue_test.go
+++ b/builtin/providers/aws/resource_aws_sqs_queue_test.go
@@ -349,6 +349,24 @@ func testAccCheckAWSSQSExistsWithOverrides(n string) resource.TestCheckFunc {
 	}
 }
 
+func TestAccAWSSQSQueue_Encryption(t *testing.T) {
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSQSQueueDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSQSConfigWithEncryption(acctest.RandString(10)),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSSQSExists("aws_sqs_queue.queue"),
+					resource.TestCheckResourceAttr("aws_sqs_queue.queue", "kms_master_key_id", "alias/aws/sqs"),
+				),
+			},
+		},
+	})
+}
+
 func testAccAWSSQSConfigWithDefaults(r string) string {
 	return fmt.Sprintf(`
 resource "aws_sqs_queue" "queue" {
@@ -485,6 +503,16 @@ func testAccExpectContentBasedDeduplicationError(queue string) string {
 resource "aws_sqs_queue" "queue" {
   name                        = "%s"
   content_based_deduplication = true
+}
+`, queue)
+}
+
+func testAccAWSSQSConfigWithEncryption(queue string) string {
+	return fmt.Sprintf(`
+resource "aws_sqs_queue" "queue" {
+  name                              = "%s"
+  kms_master_key_id                 = "alias/aws/sqs"
+	kms_data_key_reuse_period_seconds = 300
 }
 `, queue)
 }

--- a/website/source/docs/providers/aws/r/sqs_queue.html.markdown
+++ b/website/source/docs/providers/aws/r/sqs_queue.html.markdown
@@ -31,6 +31,16 @@ resource "aws_sqs_queue" "terraform_queue" {
 }
 ```
 
+## Server-side encryption (SSE)
+
+```hcl
+resource "aws_sqs_queue" "terraform_queue" {
+  name                              = "terraform-example-queue"
+  kms_master_key_id                 = "alias/aws/sqs"
+  kms_data_key_reuse_period_seconds = 300
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -45,6 +55,8 @@ The following arguments are supported:
 * `redrive_policy` - (Optional) The JSON policy to set up the Dead Letter Queue, see [AWS docs](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/SQSDeadLetterQueue.html). **Note:** when specifying `maxReceiveCount`, you must specify it as an integer (`5`), and not a string (`"5"`).
 * `fifo_queue` - (Optional) Boolean designating a FIFO queue. If not set, it defaults to `false` making it standard.
 * `content_based_deduplication` - (Optional) Enables content-based deduplication for FIFO queues. For more information, see the [related documentation](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues.html#FIFO-queues-exactly-once-processing)
+* `kms_master_key_id` - (Optional) The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK. For more information, see [Key Terms](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-server-side-encryption.html#sqs-sse-key-terms).
+* `kms_data_key_reuse_period_seconds` - (Optional) The length of time, in seconds, for which Amazon SQS can reuse a data key to encrypt or decrypt messages before calling AWS KMS again. An integer representing seconds, between 60 seconds (1 minute) and 86,400 seconds (24 hours). The default is 300 (5 minutes).
 
 ## Attributes Reference
 


### PR DESCRIPTION
AWS recently added support for server-side encryption (SSE to SQS. This updates the `aws_sqs_queue` resource to include two SSE attributes. Updated code, tests, and docs. Ran acceptance tests.

Marked as a WIP for a couple reasons:

* First time contributing to the project. No idea if I missed anything.
* There is an edge case with `KmsDataKeyReusePeriodSeconds` that I need advice on how to handle. In the AWS API, when `KmsDataKeyReusePeriodSeconds` is set, but `KmsMasterKeyId` is not set, the API does not encrypt the queue and ignores `KmsDataKeyReusePeriodSeconds`. The code as it stands makes the API call and silently saves `kms_data_key_reuse_period_seconds` to the state even though it's not used.