### PR TITLE
Document AWS IPv6 address access

### DIFF
--- a/website/source/docs/providers/aws/d/instance.html.markdown
+++ b/website/source/docs/providers/aws/d/instance.html.markdown
@@ -70,6 +70,7 @@ interpolation.
   * `no_device` - Whether the specified device included in the device mapping was suppressed or not (Boolean).
   * `virtual_name` - The virtual device name.
 * `iam_instance_profile` - The name of the instance profile associated with the Instance.
+* `ipv6_addresses` - The IPv6 addresses associated to the Instance, if applicable. **NOTE**: Unlike the IPv4 address, this doesn't change if you attach an EIP to the instance.
 * `instance_type` - The type of the Instance.
 * `key_name` - The key name of the Instance.
 * `monitoring` - Whether detailed monitoring is enabled or disabled for the Instance (Boolean).


### PR DESCRIPTION
The current stable release includes a data source attribute for accessing the IPv6 addresses of an EC2 instance, but it is not documented. I spent quite some time working out how to get at this information, trying to see if it was in the underlying AWS Go SDK etc., so to save everyone else the same effort it would be nice if it was documented. 

I have tested the attribute in question and it is working fine for me - presumably it was tested when introduced.