### PR TITLE
provider/aws: Add 'aws_default_subnet' resource

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -437,6 +437,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_sns_topic_subscription":                   resourceAwsSnsTopicSubscription(),
 			"aws_sfn_activity":                             resourceAwsSfnActivity(),
 			"aws_sfn_state_machine":                        resourceAwsSfnStateMachine(),
+			"aws_default_subnet":                           resourceAwsDefaultSubnet(),
 			"aws_subnet":                                   resourceAwsSubnet(),
 			"aws_volume_attachment":                        resourceAwsVolumeAttachment(),
 			"aws_vpc_dhcp_options_association":             resourceAwsVpcDhcpOptionsAssociation(),

--- a/builtin/providers/aws/resource_aws_default_subnet.go
+++ b/builtin/providers/aws/resource_aws_default_subnet.go
@@ -1,0 +1,85 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsDefaultSubnet() *schema.Resource {
+	// reuse aws_subnet schema, and methods for READ, UPDATE
+	dsubnet := resourceAwsSubnet()
+	dsubnet.Create = resourceAwsDefaultSubnetCreate
+	dsubnet.Delete = resourceAwsDefaultSubnetDelete
+
+	// vpc_id is a required value for Default Subnets
+	dsubnet.Schema["availability_zone"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Required: true,
+	}
+	// vpc_id is a computed value for Default Subnets
+	dsubnet.Schema["vpc_id"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	// cidr_block is a computed value for Default Subnets
+	dsubnet.Schema["cidr_block"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	// ipv6_cidr_block is a computed value for Default Subnets
+	dsubnet.Schema["ipv6_cidr_block"] = &schema.Schema{
+		Type:     schema.TypeString,
+		Computed: true,
+	}
+	// map_public_ip_on_launch is a computed value for Default Subnets
+	dsubnet.Schema["map_public_ip_on_launch"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Computed: true,
+	}
+	// assign_ipv6_address_on_creation is a computed value for Default Subnets
+	dsubnet.Schema["assign_ipv6_address_on_creation"] = &schema.Schema{
+		Type:     schema.TypeBool,
+		Computed: true,
+	}
+
+	return dsubnet
+}
+
+func resourceAwsDefaultSubnetCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	req := &ec2.DescribeSubnetsInput{
+		Filters: []*ec2.Filter{
+			&ec2.Filter{
+				Name:   aws.String("availabilityZone"),
+				Values: aws.StringSlice([]string{d.Get("availability_zone").(string)}),
+			},
+			&ec2.Filter{
+				Name:   aws.String("defaultForAz"),
+				Values: aws.StringSlice([]string{"true"}),
+			},
+		},
+	}
+
+	resp, err := conn.DescribeSubnets(req)
+	if err != nil {
+		return err
+	}
+
+	if len(resp.Subnets) != 1 || resp.Subnets[0] == nil {
+		return fmt.Errorf("Default subnet not found")
+	}
+
+	d.SetId(aws.StringValue(resp.Subnets[0].SubnetId))
+
+	return resourceAwsSubnetUpdate(d, meta)
+}
+
+func resourceAwsDefaultSubnetDelete(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[WARN] Cannot destroy Default Subnet. Terraform will remove this resource from the state file, however resources may remain.")
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/aws/resource_aws_default_subnet_test.go
+++ b/builtin/providers/aws/resource_aws_default_subnet_test.go
@@ -1,0 +1,56 @@
+// make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSDefaultVpc_'
+package aws
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAWSDefaultSubnet_basic(t *testing.T) {
+	var v ec2.Subnet
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDefaultSubnetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDefaultSubnetConfigBasic,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckSubnetExists("aws_default_subnet.foo", &v),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "availability_zone", "us-west-2a"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "map_public_ip_on_launch", "true"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "assign_ipv6_address_on_creation", "false"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.%", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_default_subnet.foo", "tags.Name", "Default subnet for us-west-2a"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAWSDefaultSubnetDestroy(s *terraform.State) error {
+	// We expect subnet to still exist
+	return nil
+}
+
+const testAccAWSDefaultSubnetConfigBasic = `
+provider "aws" {
+    region = "us-west-2"
+}
+
+resource "aws_default_subnet" "foo" {
+	availability_zone = "us-west-2a"
+	tags {
+		Name = "Default subnet for us-west-2a"
+	}
+}
+`

--- a/website/source/docs/providers/aws/r/default_subnet.html.markdown
+++ b/website/source/docs/providers/aws/r/default_subnet.html.markdown
@@ -1,0 +1,57 @@
+---
+layout: "aws"
+page_title: "AWS: aws_default_subnet"
+sidebar_current: "docs-aws-resource-default-subnet"
+description: |-
+  Manage a default VPC subnet resource.
+---
+
+# aws\_default\_subnet
+
+Provides a resource to manage a [default AWS VPC subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-basics)
+in the current region.
+
+The `aws_default_subnet` behaves differently from normal resources, in that
+Terraform does not _create_ this resource, but instead "adopts" it
+into management. 
+
+## Example Usage
+
+Basic usage with tags:
+
+```
+resource "aws_default_subnet" "default_az1" {
+  availability_zone = "us-west-2a"
+
+	tags {
+		Name = "Default subnet for us-west-2a"
+	}
+}
+```
+
+## Argument Reference
+
+The arguments of an `aws_default_subnet` differ from `aws_subnet` resources.
+Namely, the `availability_zone` argument is required and the `vpc_id`, `cidr_block`, `ipv6_cidr_block`,
+`map_public_ip_on_launch` and `assign_ipv6_address_on_creation` arguments are computed.
+The following arguments are still supported: 
+
+* `tags` - (Optional) A mapping of tags to assign to the resource.
+
+### Removing `aws_default_subnet` from your configuration
+
+The `aws_default_subnet` resource allows you to manage a region's default VPC subnet,
+but Terraform cannot destroy it. Removing this resource from your configuration
+will remove it from your statefile and management, but will not destroy the subnet.
+You can resume managing the subnet via the AWS Console.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the subnet
+* `availability_zone`- The AZ for the subnet.
+* `cidr_block` - The CIDR block for the subnet.
+* `vpc_id` - The VPC ID.
+* `ipv6_association_id` - The association ID for the IPv6 CIDR block.
+* `ipv6_cidr_block` - The IPv6 CIDR block.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1339,6 +1339,10 @@
                             <a href="/docs/providers/aws/r/default_security_group.html">aws_default_security_group</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-default-subnet") %>>
+                            <a href="/docs/providers/aws/r/default_subnet.html">aws_default_subnet</a>
+                        </li>
+
                         <li<%= sidebar_current("docs-aws-resource-egress-only-internet-gateway") %>>
                           <a href="/docs/providers/aws/r/egress_only_internet_gateway.html">aws_egress_only_internet_gateway</a>
                         </li>


### PR DESCRIPTION
Provides a resource to manage a [default AWS VPC subnet](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/default-vpc.html#default-vpc-basics) in the current region.
Acceptance tests:
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDefaultSubnet_'
```