### PR TITLE
provider/aws: Override spot_instance_requests volume_tags schema

### DIFF
--- a/builtin/providers/aws/resource_aws_spot_instance_request.go
+++ b/builtin/providers/aws/resource_aws_spot_instance_request.go
@@ -25,10 +25,15 @@ func resourceAwsSpotInstanceRequest() *schema.Resource {
 
 			// Everything on a spot instance is ForceNew except tags
 			for k, v := range s {
-				if k == "tags" || k == "volume_tags" {
+				if k == "tags" {
 					continue
 				}
 				v.ForceNew = true
+			}
+
+			s["volume_tags"] = &schema.Schema{
+				Type:     schema.TypeMap,
+				Optional: true,
 			}
 
 			s["spot_price"] = &schema.Schema{


### PR DESCRIPTION
The acceptance tests for spot_instance_requests were showing falures as
follows:

```
------- Stdout: -------
=== RUN   TestAccAWSSpotInstanceRequest_basic
--- FAIL: TestAccAWSSpotInstanceRequest_basic (100.40s)
    testing.go:280: Step 0 error: After applying this step, the plan was not empty:

        DIFF:

        UPDATE: aws_spot_instance_request.foo
          volume_tags.%: "" => "<computed>"
```

This was because we were setting volume_tags as computed and thus the
diff. We needed to override the schema to make sure that it was not
being computed - it's only aws_instance that needs computed tags because
of EBS volumes

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSpotInstanceRequest_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/15 10:41:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSpotInstanceRequest_ -timeout 120m
=== RUN   TestAccAWSSpotInstanceRequest_basic
--- PASS: TestAccAWSSpotInstanceRequest_basic (86.93s)
=== RUN   TestAccAWSSpotInstanceRequest_withBlockDuration
--- PASS: TestAccAWSSpotInstanceRequest_withBlockDuration (97.47s)
=== RUN   TestAccAWSSpotInstanceRequest_vpc
--- PASS: TestAccAWSSpotInstanceRequest_vpc (234.56s)
=== RUN   TestAccAWSSpotInstanceRequest_SubnetAndSG
--- PASS: TestAccAWSSpotInstanceRequest_SubnetAndSG (146.16s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	565.131s
```