### PR TITLE
Add namespcace ID attribute

### DIFF
--- a/builtin/providers/gitlab/resource_gitlab_project.go
+++ b/builtin/providers/gitlab/resource_gitlab_project.go
@@ -60,10 +60,6 @@ func resourceGitlabProject() *schema.Resource {
 				Default:      "private",
 			},
 
-			"id": {
-				Type:     schema.TypeInt,
-				Computed: true,
-			},
 			"ssh_url_to_repo": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -90,7 +86,6 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("snippets_enabled", project.SnippetsEnabled)
 	d.Set("visibility_level", visibilityLevelToString(project.VisibilityLevel))
 
-	d.Set("id", project.ID)
 	d.Set("ssh_url_to_repo", project.SSHURLToRepo)
 	d.Set("http_url_to_repo", project.HTTPURLToRepo)
 	d.Set("web_url", project.WebURL)

--- a/builtin/providers/gitlab/resource_gitlab_project.go
+++ b/builtin/providers/gitlab/resource_gitlab_project.go
@@ -95,11 +95,14 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 	client := meta.(*gitlab.Client)
 	options := &gitlab.CreateProjectOptions{
 		Name:                 gitlab.String(d.Get("name").(string)),
-		NamespaceID:          gitlab.Int(d.Get("namespace_id").(int)),
 		IssuesEnabled:        gitlab.Bool(d.Get("issues_enabled").(bool)),
 		MergeRequestsEnabled: gitlab.Bool(d.Get("merge_requests_enabled").(bool)),
 		WikiEnabled:          gitlab.Bool(d.Get("wiki_enabled").(bool)),
 		SnippetsEnabled:      gitlab.Bool(d.Get("snippets_enabled").(bool)),
+	}
+
+	if v, ok := d.GetOk("namespace_id"); ok {
+		options.NamespaceID = gitlab.Int(v.(int))
 	}
 
 	if v, ok := d.GetOk("description"); ok {

--- a/builtin/providers/gitlab/resource_gitlab_project.go
+++ b/builtin/providers/gitlab/resource_gitlab_project.go
@@ -21,6 +21,10 @@ func resourceGitlabProject() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"namespace_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -56,6 +60,10 @@ func resourceGitlabProject() *schema.Resource {
 				Default:      "private",
 			},
 
+			"id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"ssh_url_to_repo": {
 				Type:     schema.TypeString,
 				Computed: true,
@@ -82,6 +90,7 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("snippets_enabled", project.SnippetsEnabled)
 	d.Set("visibility_level", visibilityLevelToString(project.VisibilityLevel))
 
+	d.Set("id", project.ID)
 	d.Set("ssh_url_to_repo", project.SSHURLToRepo)
 	d.Set("http_url_to_repo", project.HTTPURLToRepo)
 	d.Set("web_url", project.WebURL)
@@ -91,6 +100,7 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 	client := meta.(*gitlab.Client)
 	options := &gitlab.CreateProjectOptions{
 		Name:                 gitlab.String(d.Get("name").(string)),
+		NamespaceID:          gitlab.Int(d.Get("namespace_id").(int)),
 		IssuesEnabled:        gitlab.Bool(d.Get("issues_enabled").(bool)),
 		MergeRequestsEnabled: gitlab.Bool(d.Get("merge_requests_enabled").(bool)),
 		WikiEnabled:          gitlab.Bool(d.Get("wiki_enabled").(bool)),

--- a/builtin/providers/gitlab/resource_gitlab_project_hook_test.go
+++ b/builtin/providers/gitlab/resource_gitlab_project_hook_test.go
@@ -186,8 +186,8 @@ resource "gitlab_project" "foo" {
 }
 
 resource "gitlab_project_hook" "foo" {
-	project = "${gitlab_project.foo.id}"
-	url = "https://example.com/hook-%d"
+  project = "${gitlab_project.foo.id}"
+  url = "https://example.com/hook-%d"
 }
 	`, rInt, rInt)
 }
@@ -204,17 +204,17 @@ resource "gitlab_project" "foo" {
 }
 
 resource "gitlab_project_hook" "foo" {
-	project = "${gitlab_project.foo.id}"
-	url = "https://example.com/hook-%d"
-	enable_ssl_verification = false
-	push_events = false
-	issues_events = true
-	merge_requests_events = true
-	tag_push_events = true
-	note_events = true
-	build_events = true
-	pipeline_events = true
-	wiki_page_events = true
+  project = "${gitlab_project.foo.id}"
+  url = "https://example.com/hook-%d"
+  enable_ssl_verification = false
+  push_events = false
+  issues_events = true
+  merge_requests_events = true
+  tag_push_events = true
+  note_events = true
+  build_events = true
+  pipeline_events = true
+  wiki_page_events = true
 }
 	`, rInt, rInt)
 }

--- a/builtin/providers/gitlab/resource_gitlab_project_test.go
+++ b/builtin/providers/gitlab/resource_gitlab_project_test.go
@@ -182,10 +182,10 @@ resource "gitlab_project" "foo" {
   # with no billing
   visibility_level = "public"
 
-	issues_enabled = false
-	merge_requests_enabled = false
-	wiki_enabled = false
-	snippets_enabled = false
+  issues_enabled = false
+  merge_requests_enabled = false
+  wiki_enabled = false
+  snippets_enabled = false
 }
 	`, rInt)
 }


### PR DESCRIPTION
This commit also introduce `id` comouted value which is numeric value
used by GitLab to iteract with repository. This should simplify use of
`gitlab_project_hook` usage and would allow to introduce other resources
as described in #14471