### PR TITLE
provider/aws: Allow Internet Gateway IPv6 routes

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -133,10 +133,18 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	switch setTarget {
 	case "gateway_id":
 		createOpts = &ec2.CreateRouteInput{
-			RouteTableId:         aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock: aws.String(d.Get("destination_cidr_block").(string)),
-			GatewayId:            aws.String(d.Get("gateway_id").(string)),
+			RouteTableId: aws.String(d.Get("route_table_id").(string)),
+			GatewayId:    aws.String(d.Get("gateway_id").(string)),
 		}
+
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+			createOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
+		}
+
 	case "egress_only_gateway_id":
 		createOpts = &ec2.CreateRouteInput{
 			RouteTableId:                aws.String(d.Get("route_table_id").(string)),


### PR DESCRIPTION
Fixes: #14006
Fixes: #14464

IPv6 wasn't supported for adding routes to the internet gateway.
Resulted in a message as follows:

```
Error creating route: MissingParameter: The request must contain the parameter destinationCidrBlock or destinationIpv6CidrBlock
```

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRoute_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/15 11:50:43 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRoute_ -timeout 120m
=== RUN   TestAccAWSRoute_basic
--- PASS: TestAccAWSRoute_basic (67.27s)
=== RUN   TestAccAWSRoute_ipv6Support
--- PASS: TestAccAWSRoute_ipv6Support (59.35s)
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
--- PASS: TestAccAWSRoute_ipv6ToInternetGateway (67.39s)
=== RUN   TestAccAWSRoute_changeCidr
--- PASS: TestAccAWSRoute_changeCidr (103.68s)
=== RUN   TestAccAWSRoute_noopdiff
--- PASS: TestAccAWSRoute_noopdiff (194.32s)
=== RUN   TestAccAWSRoute_doesNotCrashWithVPCEndpoint
--- PASS: TestAccAWSRoute_doesNotCrashWithVPCEndpoint (71.36s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	563.397s
```