### PR TITLE
providers/heroku: import heroku_pipeline resource

### DIFF
--- a/builtin/providers/heroku/import_heroku_pipeline_test.go
+++ b/builtin/providers/heroku/import_heroku_pipeline_test.go
@@ -1,0 +1,30 @@
+package heroku
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccHerokuPipeline_importBasic(t *testing.T) {
+	pName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuPipelineDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuPipelineConfig_basic(pName),
+			},
+			{
+				ResourceName:            "heroku_pipeline.foobar",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"config_vars"},
+			},
+		},
+	})
+}

--- a/builtin/providers/heroku/resource_heroku_pipeline.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline.go
@@ -16,6 +16,10 @@ func resourceHerokuPipeline() *schema.Resource {
 		Read:   resourceHerokuPipelineRead,
 		Delete: resourceHerokuPipelineDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: resourceHerokuPipelineImport,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -23,6 +27,19 @@ func resourceHerokuPipeline() *schema.Resource {
 			},
 		},
 	}
+}
+
+func resourceHerokuPipelineImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*heroku.Service)
+
+	p, err := client.PipelineInfo(context.TODO(), d.Id())
+	if err != nil {
+		return nil, err
+	}
+
+	d.Set("name", p.Name)
+
+	return []*schema.ResourceData{d}, nil
 }
 
 func resourceHerokuPipelineCreate(d *schema.ResourceData, meta interface{}) error {


### PR DESCRIPTION
Adds support for importing pipelines with the heroku_pipeline resource.

Resolves #14485