### PR TITLE
provider/gitlab:  Add `gitlab_group` resource

### DIFF
--- a/builtin/providers/gitlab/provider.go
+++ b/builtin/providers/gitlab/provider.go
@@ -25,6 +25,7 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
+			"gitlab_group":        resourceGitlabGroup(),
 			"gitlab_project":      resourceGitlabProject(),
 			"gitlab_project_hook": resourceGitlabProjectHook(),
 		},

--- a/builtin/providers/gitlab/resource_gitlab_group.go
+++ b/builtin/providers/gitlab/resource_gitlab_group.go
@@ -1,0 +1,153 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/validation"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabGroup() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabGroupCreate,
+		Read:   resourceGitlabGroupRead,
+		Update: resourceGitlabGroupUpdate,
+		Delete: resourceGitlabGroupDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"path": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"lfs_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"request_access_enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"visibility_level": {
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"private", "internal", "public"}, true),
+				Default:      "private",
+			},
+		},
+	}
+}
+
+func resourceGitlabGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	options := &gitlab.CreateGroupOptions{
+		Name:                 gitlab.String(d.Get("name").(string)),
+		LFSEnabled:           gitlab.Bool(d.Get("lfs_enabled").(bool)),
+		RequestAccessEnabled: gitlab.Bool(d.Get("request_access_enabled").(bool)),
+	}
+
+	if v, ok := d.GetOk("path"); ok {
+		options.Path = gitlab.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		options.Description = gitlab.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("visibility_level"); ok {
+		options.VisibilityLevel = stringToVisibilityLevel(v.(string))
+	}
+
+	log.Printf("[DEBUG] create gitlab group %q", options.Name)
+
+	group, _, err := client.Groups.CreateGroup(options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%d", group.ID))
+
+	return resourceGitlabGroupRead(d, meta)
+}
+
+func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	log.Printf("[DEBUG] read gitlab group %s", d.Id())
+
+	group, response, err := client.Groups.GetGroup(d.Id())
+	if err != nil {
+		if response.StatusCode == 404 {
+			log.Printf("[WARN] removing group %s from state because it no longer exists in gitlab", d.Id())
+			d.SetId("")
+			return nil
+		}
+
+		return err
+	}
+
+	d.Set("name", group.Name)
+	d.Set("path", group.Path)
+	d.Set("description", group.Description)
+	d.Set("lfs_enabled", group.LFSEnabled)
+	d.Set("request_access_enabled", group.RequestAccessEnabled)
+
+	return nil
+}
+
+func resourceGitlabGroupUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	options := &gitlab.UpdateGroupOptions{}
+
+	if d.HasChange("name") {
+		options.Name = gitlab.String(d.Get("name").(string))
+	}
+
+	if d.HasChange("path") {
+		options.Path = gitlab.String(d.Get("path").(string))
+	}
+
+	if d.HasChange("description") {
+		options.Description = gitlab.String(d.Get("description").(string))
+	}
+
+	if d.HasChange("lfs_enabled") {
+		options.LFSEnabled = gitlab.Bool(d.Get("lfs_enabled").(bool))
+	}
+
+	if d.HasChange("request_access_enabled") {
+		options.RequestAccessEnabled = gitlab.Bool(d.Get("request_access_enabled").(bool))
+	}
+
+	if d.HasChange("visibility_level") {
+		options.VisibilityLevel = stringToVisibilityLevel(d.Get("visibility_level").(string))
+	}
+
+	log.Printf("[DEBUG] update gitlab group %s", d.Id())
+
+	_, _, err := client.Groups.UpdateGroup(d.Id(), options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabGroupRead(d, meta)
+}
+
+func resourceGitlabGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	log.Printf("[DEBUG] Delete gitlab group %s", d.Id())
+
+	_, err := client.Groups.DeleteGroup(d.Id())
+	return err
+}

--- a/builtin/providers/gitlab/resource_gitlab_group_test.go
+++ b/builtin/providers/gitlab/resource_gitlab_group_test.go
@@ -1,0 +1,171 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabGroup_basic(t *testing.T) {
+	var group gitlab.Group
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabGroupDestroy,
+		Steps: []resource.TestStep{
+			// Create a group
+			{
+				Config: testAccGitlabGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGitlabGroupAttributes(&group, &testAccGitlabGroupExpectedAttributes{
+						Name:        fmt.Sprintf("foo-name-%d", rInt),
+						Path:        fmt.Sprintf("foo-path-%d", rInt),
+						Description: "Terraform acceptance tests",
+						LFSEnabled:  true,
+					}),
+				),
+			},
+			// Update the group to change the description
+			{
+				Config: testAccGitlabGroupUpdateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGitlabGroupAttributes(&group, &testAccGitlabGroupExpectedAttributes{
+						Name:                 fmt.Sprintf("bar-name-%d", rInt),
+						Path:                 fmt.Sprintf("bar-path-%d", rInt),
+						Description:          "Terraform acceptance tests! Updated description",
+						RequestAccessEnabled: true,
+					}),
+				),
+			},
+			// Update the group to put the anem and description back
+			{
+				Config: testAccGitlabGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGitlabGroupAttributes(&group, &testAccGitlabGroupExpectedAttributes{
+						Name:        fmt.Sprintf("foo-name-%d", rInt),
+						Path:        fmt.Sprintf("foo-path-%d", rInt),
+						Description: "Terraform acceptance tests",
+						LFSEnabled:  true,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabGroupExists(n string, group *gitlab.Group) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		groupID := rs.Primary.ID
+		if groupID == "" {
+			return fmt.Errorf("No group ID is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		gotGroup, _, err := conn.Groups.GetGroup(groupID)
+		if err != nil {
+			return err
+		}
+		*group = *gotGroup
+		return nil
+	}
+}
+
+type testAccGitlabGroupExpectedAttributes struct {
+	Name                 string
+	Path                 string
+	Description          string
+	LFSEnabled           bool
+	RequestAccessEnabled bool
+}
+
+func testAccCheckGitlabGroupAttributes(group *gitlab.Group, want *testAccGitlabGroupExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if group.Name != want.Name {
+			return fmt.Errorf("got repo %q; want %q", group.Name, want.Name)
+		}
+
+		if group.Path != want.Path {
+			return fmt.Errorf("got path %q; want %q", group.Path, want.Path)
+		}
+
+		if group.Description != want.Description {
+			return fmt.Errorf("got description %q; want %q", group.Description, want.Description)
+		}
+
+		if group.LFSEnabled != want.LFSEnabled {
+			return fmt.Errorf("got lfs_enabled %t; want %t", group.LFSEnabled, want.LFSEnabled)
+		}
+
+		if group.RequestAccessEnabled != want.RequestAccessEnabled {
+			return fmt.Errorf("got request_access_enabled %t; want %t", group.RequestAccessEnabled, want.RequestAccessEnabled)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabGroupDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_group" {
+			continue
+		}
+
+		group, resp, err := conn.Groups.GetGroup(rs.Primary.ID)
+		if err == nil {
+			if group != nil && fmt.Sprintf("%d", group.ID) == rs.Primary.ID {
+				return fmt.Errorf("Group still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabGroupConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "foo" {
+  name = "foo-name-%d"
+  path = "foo-path-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+  `, rInt, rInt)
+}
+
+func testAccGitlabGroupUpdateConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "foo" {
+  name = "bar-name-%d"
+  path = "bar-path-%d"
+  description = "Terraform acceptance tests! Updated description"
+  lfs_enabled = false
+  request_access_enabled = true
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+  `, rInt, rInt)
+}

--- a/vendor/github.com/xanzy/go-gitlab/README.md
+++ b/vendor/github.com/xanzy/go-gitlab/README.md
@@ -35,6 +35,7 @@ includes all calls to the following services:
 - [x] Namespaces
 - [x] Settings
 - [x] Pipelines
+- [x] Version
 
 ## Usage
 

--- a/vendor/github.com/xanzy/go-gitlab/branches.go
+++ b/vendor/github.com/xanzy/go-gitlab/branches.go
@@ -24,37 +24,50 @@ import (
 // BranchesService handles communication with the branch related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/branches.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md
 type BranchesService struct {
 	client *Client
 }
 
 // Branch represents a GitLab branch.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/branches.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md
 type Branch struct {
-	Commit    *Commit `json:"commit"`
-	Name      string  `json:"name"`
-	Protected bool    `json:"protected"`
+	Commit             *Commit `json:"commit"`
+	Name               string  `json:"name"`
+	Protected          bool    `json:"protected"`
+	Merged             bool    `json:"merged"`
+	DevelopersCanPush  bool    `json:"developers_can_push"`
+	DevelopersCanMerge bool    `json:"developers_can_merge"`
 }
 
 func (b Branch) String() string {
 	return Stringify(b)
 }
 
+// ListBranchesOptions represents the available ListBranches() options.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#list-repository-branches
+type ListBranchesOptions struct {
+	ListOptions
+}
+
 // ListBranches gets a list of repository branches from a project, sorted by
 // name alphabetically.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#list-repository-branches
-func (s *BranchesService) ListBranches(pid interface{}, options ...OptionFunc) ([]*Branch, *Response, error) {
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#list-repository-branches
+func (s *BranchesService) ListBranches(pid interface{}, opts *ListBranchesOptions, options ...OptionFunc) ([]*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,7 +84,7 @@ func (s *BranchesService) ListBranches(pid interface{}, options ...OptionFunc) (
 // GetBranch gets a single project repository branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#get-single-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#get-single-repository-branch
 func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -93,20 +106,29 @@ func (s *BranchesService) GetBranch(pid interface{}, branch string, options ...O
 	return b, resp, err
 }
 
+// ProtectBranchOptions represents the available ProtectBranch() options.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#protect-repository-branch
+type ProtectBranchOptions struct {
+	DevelopersCanPush  *bool `url:"developers_can_push,omitempty" json:"developers_can_push,omitempty"`
+	DevelopersCanMerge *bool `url:"developers_can_merge,omitempty" json:"developers_can_merge,omitempty"`
+}
+
 // ProtectBranch protects a single project repository branch. This is an
 // idempotent function, protecting an already protected repository branch
 // still returns a 200 OK status code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#protect-repository-branch
-func (s *BranchesService) ProtectBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#protect-repository-branch
+func (s *BranchesService) ProtectBranch(pid interface{}, branch string, opts *ProtectBranchOptions, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s/protect", url.QueryEscape(project), branch)
 
-	req, err := s.client.NewRequest("PUT", u, nil, options)
+	req, err := s.client.NewRequest("PUT", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -125,7 +147,7 @@ func (s *BranchesService) ProtectBranch(pid interface{}, branch string, options 
 // still returns a 200 OK status code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#unprotect-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#unprotect-repository-branch
 func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -150,7 +172,7 @@ func (s *BranchesService) UnprotectBranch(pid interface{}, branch string, option
 // CreateBranchOptions represents the available CreateBranch() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#create-repository-branch
 type CreateBranchOptions struct {
 	BranchName *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
 	Ref        *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -159,7 +181,7 @@ type CreateBranchOptions struct {
 // CreateBranch creates branch from commit SHA or existing branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#create-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#create-repository-branch
 func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions, options ...OptionFunc) (*Branch, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -184,13 +206,32 @@ func (s *BranchesService) CreateBranch(pid interface{}, opt *CreateBranchOptions
 // DeleteBranch deletes an existing branch.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/branches.html#delete-repository-branch
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#delete-repository-branch
 func (s *BranchesService) DeleteBranch(pid interface{}, branch string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, err
 	}
 	u := fmt.Sprintf("projects/%s/repository/branches/%s", url.QueryEscape(project), branch)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// DeleteMergedBranches deletes all branches that are merged into the project's default branch.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/branches.md#delete-merged-branches
+func (s *BranchesService) DeleteMergedBranches(pid interface{}, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/repository/merged_branches", url.QueryEscape(project))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/build_variables.go
+++ b/vendor/github.com/xanzy/go-gitlab/build_variables.go
@@ -8,14 +8,14 @@ import (
 // BuildVariablesService handles communication with the project variables related methods
 // of the Gitlab API
 //
-// Gitlab API Docs : https://docs.gitlab.com/ce/api/build_variables.html
+// Gitlab API Docs : https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md
 type BuildVariablesService struct {
 	client *Client
 }
 
 // BuildVariable represents a variable available for each build of the given project
 //
-// Gitlab API Docs : https://docs.gitlab.com/ce/api/build_variables.html
+// Gitlab API Docs : https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md
 type BuildVariable struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
@@ -25,18 +25,26 @@ func (v BuildVariable) String() string {
 	return Stringify(v)
 }
 
+// ListBuildVariablesOptions are the parameters to ListBuildVariables()
+//
+// Gitlab API Docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md#list-project-variables
+type ListBuildVariablesOptions struct {
+	ListOptions
+}
+
 // ListBuildVariables gets the a list of project variables in a project
 //
 // Gitlab API Docs:
-// https://docs.gitlab.com/ce/api/build_variables.html#list-project-variables
-func (s *BuildVariablesService) ListBuildVariables(pid interface{}, options ...OptionFunc) ([]*BuildVariable, *Response, error) {
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md#list-project-variables
+func (s *BuildVariablesService) ListBuildVariables(pid interface{}, opts *ListBuildVariablesOptions, options ...OptionFunc) ([]*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
 		return nil, nil, err
 	}
 	u := fmt.Sprintf("projects/%s/variables", url.QueryEscape(project))
 
-	req, err := s.client.NewRequest("GET", u, nil, options)
+	req, err := s.client.NewRequest("GET", u, opts, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -53,7 +61,7 @@ func (s *BuildVariablesService) ListBuildVariables(pid interface{}, options ...O
 // GetBuildVariable gets a single project variable of a project
 //
 // Gitlab API Docs:
-// https://docs.gitlab.com/ce/api/build_variables.html#show-variable-details
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md#show-variable-details
 func (s *BuildVariablesService) GetBuildVariable(pid interface{}, key string, options ...OptionFunc) (*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -78,7 +86,7 @@ func (s *BuildVariablesService) GetBuildVariable(pid interface{}, key string, op
 // CreateBuildVariable creates a variable for a given project
 //
 // Gitlab API Docs:
-// https://docs.gitlab.com/ce/api/build_variables.html#create-variable
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md#create-variable
 func (s *BuildVariablesService) CreateBuildVariable(pid interface{}, key, value string, options ...OptionFunc) (*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -104,7 +112,7 @@ func (s *BuildVariablesService) CreateBuildVariable(pid interface{}, key, value 
 // The variable key must exist
 //
 // Gitlab API Docs:
-// https://docs.gitlab.com/ce/api/build_variables.html#update-variable
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md#update-variable
 func (s *BuildVariablesService) UpdateBuildVariable(pid interface{}, key, value string, options ...OptionFunc) (*BuildVariable, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -129,7 +137,7 @@ func (s *BuildVariablesService) UpdateBuildVariable(pid interface{}, key, value 
 // RemoveBuildVariable removes a project variable of a given project identified by its key
 //
 // Gitlab API Docs:
-// https://docs.gitlab.com/ce/api/build_variables.html#remove-variable
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_variables.md#remove-variable
 func (s *BuildVariablesService) RemoveBuildVariable(pid interface{}, key string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/builds.go
+++ b/vendor/github.com/xanzy/go-gitlab/builds.go
@@ -33,14 +33,16 @@ type ListBuildsOptions struct {
 // BuildsService handles communication with the ci builds related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/builds.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md
 type BuildsService struct {
 	client *Client
 }
 
 // Build represents a ci build.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/builds.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md
 type Build struct {
 	Commit        *Commit    `json:"commit"`
 	CreatedAt     *time.Time `json:"created_at"`
@@ -72,7 +74,7 @@ type Build struct {
 // failed, success, canceled; showing all builds if none provided.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#list-project-builds
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#list-project-builds
 func (s *BuildsService) ListProjectBuilds(pid interface{}, opts *ListBuildsOptions, options ...OptionFunc) ([]Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -98,7 +100,7 @@ func (s *BuildsService) ListProjectBuilds(pid interface{}, opts *ListBuildsOptio
 // project. If the commit SHA is not found, it will respond with 404.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#list-commit-builds
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#list-commit-builds
 func (s *BuildsService) ListCommitBuilds(pid interface{}, sha string, opts *ListBuildsOptions, options ...OptionFunc) ([]Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -123,7 +125,7 @@ func (s *BuildsService) ListCommitBuilds(pid interface{}, sha string, opts *List
 // GetBuild gets a single build of a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#get-a-single-build
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#get-a-single-build
 func (s *BuildsService) GetBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -148,7 +150,7 @@ func (s *BuildsService) GetBuild(pid interface{}, buildID int, options ...Option
 // GetBuildArtifacts get builds artifacts of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#get-build-artifacts
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#get-build-artifacts
 func (s *BuildsService) GetBuildArtifacts(pid interface{}, buildID int, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -174,7 +176,7 @@ func (s *BuildsService) GetBuildArtifacts(pid interface{}, buildID int, options 
 // reference name and job provided the build finished successfully.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#download-the-artifacts-file
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#download-the-artifacts-file
 func (s *BuildsService) DownloadArtifactsFile(pid interface{}, refName string, job string, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -199,7 +201,7 @@ func (s *BuildsService) DownloadArtifactsFile(pid interface{}, refName string, j
 // GetTraceFile gets a trace of a specific build of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#get-a-trace-file
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#get-a-trace-file
 func (s *BuildsService) GetTraceFile(pid interface{}, buildID int, options ...OptionFunc) (io.Reader, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -224,7 +226,7 @@ func (s *BuildsService) GetTraceFile(pid interface{}, buildID int, options ...Op
 // CancelBuild cancels a single build of a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#cancel-a-build
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#cancel-a-build
 func (s *BuildsService) CancelBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -249,7 +251,7 @@ func (s *BuildsService) CancelBuild(pid interface{}, buildID int, options ...Opt
 // RetryBuild retries a single build of a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#retry-a-build
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#retry-a-build
 func (s *BuildsService) RetryBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -275,7 +277,7 @@ func (s *BuildsService) RetryBuild(pid interface{}, buildID int, options ...Opti
 // artifacts and a build trace.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#erase-a-build
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#erase-a-build
 func (s *BuildsService) EraseBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -301,7 +303,7 @@ func (s *BuildsService) EraseBuild(pid interface{}, buildID int, options ...Opti
 // expiration is set.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#keep-artifacts
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#keep-artifacts
 func (s *BuildsService) KeepArtifacts(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -326,7 +328,7 @@ func (s *BuildsService) KeepArtifacts(pid interface{}, buildID int, options ...O
 // PlayBuild triggers a nanual action to start a build.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/builds.html#play-a-build
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/builds.md#play-a-build
 func (s *BuildsService) PlayBuild(pid interface{}, buildID int, options ...OptionFunc) (*Build, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/commits.go
+++ b/vendor/github.com/xanzy/go-gitlab/commits.go
@@ -25,14 +25,16 @@ import (
 // CommitsService handles communication with the commit related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md
 type CommitsService struct {
 	client *Client
 }
 
 // Commit represents a GitLab commit.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md
 type Commit struct {
 	ID             string       `json:"id"`
 	ShortID        string       `json:"short_id"`
@@ -52,7 +54,8 @@ type Commit struct {
 
 // CommitStats represents the number of added and deleted files in a commit.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md
 type CommitStats struct {
 	Additions int `json:"additions"`
 	Deletions int `json:"deletions"`
@@ -65,7 +68,8 @@ func (c Commit) String() string {
 
 // ListCommitsOptions represents the available ListCommits() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#list-repository-commits
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#list-repository-commits
 type ListCommitsOptions struct {
 	ListOptions
 	RefName *string   `url:"ref_name,omitempty" json:"ref_name,omitempty"`
@@ -75,7 +79,8 @@ type ListCommitsOptions struct {
 
 // ListCommits gets a list of repository commits in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#list-commits
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#list-commits
 func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, options ...OptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -99,7 +104,8 @@ func (s *CommitsService) ListCommits(pid interface{}, opt *ListCommitsOptions, o
 
 // FileAction represents the available actions that can be performed on a file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#create-a-commit-with-multiple-files-and-actions
 type FileAction string
 
 // The available file actions.
@@ -121,7 +127,8 @@ type CommitAction struct {
 
 // CreateCommitOptions represents the available options for a new commit.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#create-a-commit-with-multiple-files-and-actions
 type CreateCommitOptions struct {
 	BranchName    *string         `url:"branch_name" json:"branch_name,omitempty"`
 	CommitMessage *string         `url:"commit_message" json:"commit_message,omitempty"`
@@ -132,7 +139,8 @@ type CreateCommitOptions struct {
 
 // CreateCommit creates a commit with multiple files and actions.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#create-a-commit-with-multiple-files-and-actions
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#create-a-commit-with-multiple-files-and-actions
 func (s *CommitsService) CreateCommit(pid interface{}, opt *CreateCommitOptions, options ...OptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -157,7 +165,8 @@ func (s *CommitsService) CreateCommit(pid interface{}, opt *CreateCommitOptions,
 // GetCommit gets a specific commit identified by the commit hash or name of a
 // branch or tag.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-a-single-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#get-a-single-commit
 func (s *CommitsService) GetCommit(pid interface{}, sha string, options ...OptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -181,7 +190,8 @@ func (s *CommitsService) GetCommit(pid interface{}, sha string, options ...Optio
 
 // Diff represents a GitLab diff.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md
 type Diff struct {
 	Diff        string `json:"diff"`
 	NewPath     string `json:"new_path"`
@@ -200,7 +210,7 @@ func (d Diff) String() string {
 // GetCommitDiff gets the diff of a commit in a project..
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-the-diff-of-a-commit
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#get-the-diff-of-a-commit
 func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, options ...OptionFunc) ([]*Diff, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -224,7 +234,8 @@ func (s *CommitsService) GetCommitDiff(pid interface{}, sha string, options ...O
 
 // CommitComment represents a GitLab commit comment.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md
 type CommitComment struct {
 	Note     string `json:"note"`
 	Path     string `json:"path"`
@@ -251,7 +262,7 @@ func (c CommitComment) String() string {
 // GetCommitComments gets the comments of a commit in a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#get-the-comments-of-a-commit
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#get-the-comments-of-a-commit
 func (s *CommitsService) GetCommitComments(pid interface{}, sha string, options ...OptionFunc) ([]*CommitComment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -277,7 +288,7 @@ func (s *CommitsService) GetCommitComments(pid interface{}, sha string, options 
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#post-comment-to-commit
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#post-comment-to-commit
 type PostCommitCommentOptions struct {
 	Note     *string `url:"note,omitempty" json:"note,omitempty"`
 	Path     *string `url:"path" json:"path"`
@@ -290,7 +301,7 @@ type PostCommitCommentOptions struct {
 // line_old are required.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/commits.html#post-comment-to-commit
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#post-comment-to-commit
 func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *PostCommitCommentOptions, options ...OptionFunc) (*CommitComment, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -314,7 +325,8 @@ func (s *CommitsService) PostCommitComment(pid interface{}, sha string, opt *Pos
 
 // GetCommitStatusesOptions represents the available GetCommitStatuses() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#get-the-status-of-a-commit
 type GetCommitStatusesOptions struct {
 	Ref   *string `url:"ref,omitempty" json:"ref,omitempty"`
 	Stage *string `url:"stage,omitempty" json:"stage,omitempty"`
@@ -324,7 +336,8 @@ type GetCommitStatusesOptions struct {
 
 // CommitStatus represents a GitLab commit status.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#get-the-status-of-a-commit
 type CommitStatus struct {
 	ID          int        `json:"id"`
 	SHA         string     `json:"sha"`
@@ -341,7 +354,8 @@ type CommitStatus struct {
 
 // GetCommitStatuses gets the statuses of a commit in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#get-the-status-of-a-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#get-the-status-of-a-commit
 func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *GetCommitStatusesOptions, options ...OptionFunc) ([]*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -365,7 +379,8 @@ func (s *CommitsService) GetCommitStatuses(pid interface{}, sha string, opt *Get
 
 // SetCommitStatusOptions represents the available SetCommitStatus() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#post-the-status-to-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#post-the-status-to-commit
 type SetCommitStatusOptions struct {
 	State       BuildState `url:"state" json:"state"`
 	Ref         *string    `url:"ref,omitempty" json:"ref,omitempty"`
@@ -389,7 +404,8 @@ const (
 
 // SetCommitStatus sets the status of a commit in a project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#post-the-status-to-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#post-the-status-to-commit
 func (s *CommitsService) SetCommitStatus(pid interface{}, sha string, opt *SetCommitStatusOptions, options ...OptionFunc) (*CommitStatus, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -413,14 +429,16 @@ func (s *CommitsService) SetCommitStatus(pid interface{}, sha string, opt *SetCo
 
 // CherryPickCommitOptions represents the available options for cherry-picking a commit.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#cherry-pick-a-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#cherry-pick-a-commit
 type CherryPickCommitOptions struct {
 	TargetBranch *string `url:"branch" json:"branch,omitempty"`
 }
 
 // CherryPickCommit sherry picks a commit to a given branch.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/commits.html#cherry-pick-a-commit
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/commits.md#cherry-pick-a-commit
 func (s *CommitsService) CherryPickCommit(pid interface{}, sha string, opt *CherryPickCommitOptions, options ...OptionFunc) (*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/deploy_keys.go
+++ b/vendor/github.com/xanzy/go-gitlab/deploy_keys.go
@@ -25,7 +25,8 @@ import (
 // DeployKeysService handles communication with the keys related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/deploy_keys.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/deploy_keys.md
 type DeployKeysService struct {
 	client *Client
 }
@@ -46,7 +47,7 @@ func (k DeployKey) String() string {
 // ListDeployKeys gets a list of a project's deploy keys
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#list-deploy-keys
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/deploy_keys.md#list-deploy-keys
 func (s *DeployKeysService) ListDeployKeys(pid interface{}, options ...OptionFunc) ([]*DeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -71,7 +72,7 @@ func (s *DeployKeysService) ListDeployKeys(pid interface{}, options ...OptionFun
 // GetDeployKey gets a single deploy key.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#single-deploy-key
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/deploy_keys.md#single-deploy-key
 func (s *DeployKeysService) GetDeployKey(pid interface{}, deployKey int, options ...OptionFunc) (*DeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -96,7 +97,7 @@ func (s *DeployKeysService) GetDeployKey(pid interface{}, deployKey int, options
 // AddDeployKeyOptions represents the available ADDDeployKey() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#add-deploy-key
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/deploy_keys.md#add-deploy-key
 type AddDeployKeyOptions struct {
 	Title   *string `url:"title,omitempty" json:"title,omitempty"`
 	Key     *string `url:"key,omitempty" json:"key,omitempty"`
@@ -108,7 +109,7 @@ type AddDeployKeyOptions struct {
 // original one was is accessible by same user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#add-deploy-key
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/deploy_keys.md#add-deploy-key
 func (s *DeployKeysService) AddDeployKey(pid interface{}, opt *AddDeployKeyOptions, options ...OptionFunc) (*DeployKey, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -133,7 +134,7 @@ func (s *DeployKeysService) AddDeployKey(pid interface{}, opt *AddDeployKeyOptio
 // DeleteDeployKey deletes a deploy key from a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/deploy_keys.html#delete-deploy-key
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/deploy_keys.md#delete-deploy-key
 func (s *DeployKeysService) DeleteDeployKey(pid interface{}, deployKey int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/events.go
+++ b/vendor/github.com/xanzy/go-gitlab/events.go
@@ -21,7 +21,7 @@ import "time"
 // PushEvent represents a push event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#push-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#push-events
 type PushEvent struct {
 	ObjectKind  string `json:"object_kind"`
 	Before      string `json:"before"`
@@ -57,7 +57,7 @@ type PushEvent struct {
 // TagEvent represents a tag event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#tag-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#tag-events
 type TagEvent struct {
 	ObjectKind  string `json:"object_kind"`
 	Before      string `json:"before"`
@@ -92,7 +92,7 @@ type TagEvent struct {
 // IssueEvent represents a issue event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#issues-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#issues-events
 type IssueEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -140,7 +140,7 @@ type IssueEvent struct {
 // CommitCommentEvent represents a comment on a commit event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-commit
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#comment-on-commit
 type CommitCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -192,7 +192,7 @@ type CommitCommentEvent struct {
 // MergeCommentEvent represents a comment on a merge event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-merge-request
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#comment-on-merge-request
 type MergeCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -236,7 +236,7 @@ type MergeCommentEvent struct {
 // IssueCommentEvent represents a comment on an issue event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-issue
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#comment-on-issue
 type IssueCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -280,7 +280,7 @@ type IssueCommentEvent struct {
 // SnippetCommentEvent represents a comment on a snippet event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#comment-on-code-snippet
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#comment-on-code-snippet
 type SnippetCommentEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -324,7 +324,7 @@ type SnippetCommentEvent struct {
 // MergeEvent represents a merge event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#merge-request-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#merge-request-events
 type MergeEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -407,7 +407,7 @@ type MergeEvent struct {
 // WikiPageEvent represents a wiki page event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#wiki-page-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#wiki-page-events
 type WikiPageEvent struct {
 	ObjectKind string `json:"object_kind"`
 	User       *User  `json:"user"`
@@ -448,7 +448,7 @@ type WikiPageEvent struct {
 // PipelineEvent represents a pipeline event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#pipeline-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#pipeline-events
 type PipelineEvent struct {
 	ObjectKind       string `json:"object_kind"`
 	ObjectAttributes struct {
@@ -520,7 +520,7 @@ type PipelineEvent struct {
 //BuildEvent represents a build event
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/web_hooks/web_hooks.html#build-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/web_hooks/web_hooks.md#build-events
 type BuildEvent struct {
 	ObjectKind        string `json:"object_kind"`
 	Ref               string `json:"ref"`

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -40,12 +40,14 @@ const (
 
 // tokenType represents a token type within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/
 type tokenType int
 
 // List of available token type
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/
 const (
 	privateToken tokenType = iota
 	oAuthToken
@@ -53,12 +55,14 @@ const (
 
 // AccessLevelValue represents a permission level within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/permissions/permissions.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/permissions/permissions.md
 type AccessLevelValue int
 
 // List of available access levels
 //
-// GitLab API docs: https://docs.gitlab.com/ce/permissions/permissions.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/permissions/permissions.md
 const (
 	GuestPermissions     AccessLevelValue = 10
 	ReporterPermissions  AccessLevelValue = 20
@@ -129,12 +133,14 @@ var notificationLevelTypes = map[string]NotificationLevelValue{
 
 // VisibilityLevelValue represents a visibility level within GitLab.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/
 type VisibilityLevelValue int
 
 // List of available visibility levels
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/
 const (
 	PrivateVisibility  VisibilityLevelValue = 0
 	InternalVisibility VisibilityLevelValue = 10
@@ -186,6 +192,7 @@ type Client struct {
 	Tags                 *TagsService
 	TimeStats            *TimeStatsService
 	Users                *UsersService
+	Version              *VersionService
 }
 
 // ListOptions specifies the optional parameters to various List methods that
@@ -248,6 +255,7 @@ func newClient(httpClient *http.Client, tokenType tokenType, token string) *Clie
 	c.Tags = &TagsService{client: c}
 	c.TimeStats = &TimeStatsService{client: c}
 	c.Users = &UsersService{client: c}
+	c.Version = &VersionService{client: c}
 
 	return c
 }
@@ -449,7 +457,7 @@ func parseID(id interface{}) (string, error) {
 // An ErrorResponse reports one or more errors caused by an API request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/README.html#data-validation-and-error-reporting
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/README.md#data-validation-and-error-reporting
 type ErrorResponse struct {
 	Response *http.Response
 	Message  string
@@ -518,7 +526,7 @@ func parseError(raw interface{}) string {
 			errs = append(errs, fmt.Sprintf("{%s: %s}", k, parseError(v)))
 		}
 		sort.Strings(errs)
-		return fmt.Sprintf("%s", strings.Join(errs, ", "))
+		return strings.Join(errs, ", ")
 
 	default:
 		return fmt.Sprintf("failed to parse unexpected error type: %T", raw)
@@ -528,7 +536,7 @@ func parseError(raw interface{}) string {
 // OptionFunc can be passed to all API requests to make the API call as if you were
 // another user, provided your private token is from an administrator account.
 //
-// GitLab docs: https://docs.gitlab.com/ce/api/README.html#sudo
+// GitLab docs: https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/README.md#sudo
 type OptionFunc func(*http.Request) error
 
 // WithSudo takes either a username or user ID and sets the SUDO request header

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -18,32 +18,41 @@ package gitlab
 
 import (
 	"fmt"
+	"net/url"
 	"time"
 )
 
 // GroupsService handles communication with the group related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md
 type GroupsService struct {
 	client *Client
 }
 
 // Group represents a GitLab group.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md
 type Group struct {
-	ID          int                `json:"id"`
-	Name        string             `json:"name"`
-	Path        string             `json:"path"`
-	Description string             `json:"description"`
-	Projects    []*Project         `json:"projects"`
-	Statistics  *StorageStatistics `json:"statistics"`
+	ID                   int                  `json:"id"`
+	Name                 string               `json:"name"`
+	Path                 string               `json:"path"`
+	Description          string               `json:"description"`
+	AvatarURL            string               `json:"avatar_url"`
+	LFSEnabled           bool                 `json:"lfs_enabled"`
+	Projects             []*Project           `json:"projects"`
+	Statistics           *StorageStatistics   `json:"statistics"`
+	RequestAccessEnabled bool                 `json:"request_access_enabled"`
+	VisibilityLevel      VisibilityLevelValue `json:"visibility_level"`
+	WebURL               string               `json:"web_url"`
 }
 
 // ListGroupsOptions represents the available ListGroups() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#list-project-groups
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-project-groups
 type ListGroupsOptions struct {
 	ListOptions
 	Search     *string `url:"search,omitempty" json:"search,omitempty"`
@@ -53,7 +62,7 @@ type ListGroupsOptions struct {
 // ListGroups gets a list of groups. (As user: my groups, as admin: all groups)
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-project-groups
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-project-groups
 func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...OptionFunc) ([]*Group, *Response, error) {
 	req, err := s.client.NewRequest("GET", "groups", opt, options)
 	if err != nil {
@@ -71,13 +80,14 @@ func (s *GroupsService) ListGroups(opt *ListGroupsOptions, options ...OptionFunc
 
 // GetGroup gets all details of a group.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#details-of-a-group
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#details-of-a-group
 func (s *GroupsService) GetGroup(gid interface{}, options ...OptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s", group)
+	u := fmt.Sprintf("groups/%s", url.QueryEscape(group))
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -95,20 +105,57 @@ func (s *GroupsService) GetGroup(gid interface{}, options ...OptionFunc) (*Group
 
 // CreateGroupOptions represents the available CreateGroup() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#new-group
 type CreateGroupOptions struct {
-	Name            *string               `url:"name,omitempty" json:"name,omitempty"`
-	Path            *string               `url:"path,omitempty" json:"path,omitempty"`
-	Description     *string               `url:"description,omitempty" json:"description,omitempty"`
-	VisibilityLevel *VisibilityLevelValue `url:"visibility_level" json:"visibility_level,omitempty"`
+	Name                 *string               `url:"name,omitempty" json:"name,omitempty"`
+	Path                 *string               `url:"path,omitempty" json:"path,omitempty"`
+	Description          *string               `url:"description,omitempty" json:"description,omitempty"`
+	LFSEnabled           *bool                 `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
+	RequestAccessEnabled *bool                 `url:"request_access_enabled,omitempty" json:"request_access_enabled,omitempty"`
+	VisibilityLevel      *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
 }
 
 // CreateGroup creates a new project group. Available only for users who can
 // create groups.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#new-group
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#new-group
 func (s *GroupsService) CreateGroup(opt *CreateGroupOptions, options ...OptionFunc) (*Group, *Response, error) {
 	req, err := s.client.NewRequest("POST", "groups", opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	g := new(Group)
+	resp, err := s.client.Do(req, g)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return g, resp, err
+}
+
+// UpdateGroupOptions represents the set of available options to update a Group;
+// as of today these are exactly the same available when creating a new Group.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#update-group
+type UpdateGroupOptions CreateGroupOptions
+
+// UpdateGroup updates an existing group; only available to group owners and
+// administrators.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#update-group
+func (s *GroupsService) UpdateGroup(gid interface{}, opt *UpdateGroupOptions, options ...OptionFunc) (*Group, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s", url.QueryEscape(group))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -126,13 +173,13 @@ func (s *GroupsService) CreateGroup(opt *CreateGroupOptions, options ...OptionFu
 // for admin.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#transfer-project-to-group
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#transfer-project-to-group
 func (s *GroupsService) TransferGroup(gid interface{}, project int, options ...OptionFunc) (*Group, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/projects/%d", group, project)
+	u := fmt.Sprintf("groups/%s/projects/%d", url.QueryEscape(group), project)
 
 	req, err := s.client.NewRequest("POST", u, nil, options)
 	if err != nil {
@@ -150,13 +197,14 @@ func (s *GroupsService) TransferGroup(gid interface{}, project int, options ...O
 
 // DeleteGroup removes group with all projects inside.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#remove-group
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#remove-group
 func (s *GroupsService) DeleteGroup(gid interface{}, options ...OptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("groups/%s", group)
+	u := fmt.Sprintf("groups/%s", url.QueryEscape(group))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {
@@ -168,7 +216,8 @@ func (s *GroupsService) DeleteGroup(gid interface{}, options ...OptionFunc) (*Re
 
 // SearchGroup get all groups that match your string in their name or path.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#search-for-group
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#search-for-group
 func (s *GroupsService) SearchGroup(query string, options ...OptionFunc) ([]*Group, *Response, error) {
 	var q struct {
 		Search string `url:"search,omitempty" json:"search,omitempty"`
@@ -191,7 +240,8 @@ func (s *GroupsService) SearchGroup(query string, options ...OptionFunc) ([]*Gro
 
 // GroupMember represents a GitLab group member.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md
 type GroupMember struct {
 	ID          int              `json:"id"`
 	Username    string           `json:"username"`
@@ -206,7 +256,7 @@ type GroupMember struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-group-members
 type ListGroupMembersOptions struct {
 	ListOptions
 }
@@ -215,13 +265,13 @@ type ListGroupMembersOptions struct {
 // user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-group-members
 func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersOptions, options ...OptionFunc) ([]*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/members", group)
+	u := fmt.Sprintf("groups/%s/members", url.QueryEscape(group))
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
@@ -241,7 +291,7 @@ func (s *GroupsService) ListGroupMembers(gid interface{}, opt *ListGroupMembersO
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-group-s-projects
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-a-group-s-projects
 type ListGroupProjectsOptions struct {
 	ListOptions
 }
@@ -249,13 +299,13 @@ type ListGroupProjectsOptions struct {
 // ListGroupProjects get a list of group projects
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-a-group-s-projects
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-a-group-s-projects
 func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/projects", group)
+	u := fmt.Sprintf("groups/%s/projects", url.QueryEscape(group))
 
 	req, err := s.client.NewRequest("GET", u, opt, options)
 	if err != nil {
@@ -273,7 +323,8 @@ func (s *GroupsService) ListGroupProjects(gid interface{}, opt *ListGroupProject
 
 // AddGroupMemberOptions represents the available AddGroupMember() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/groups.html#add-group-member
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#add-group-member
 type AddGroupMemberOptions struct {
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
@@ -282,13 +333,13 @@ type AddGroupMemberOptions struct {
 // AddGroupMember adds a user to the list of group members.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-group-members
 func (s *GroupsService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/members", group)
+	u := fmt.Sprintf("groups/%s/members", url.QueryEscape(group))
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {
@@ -308,7 +359,7 @@ func (s *GroupsService) AddGroupMember(gid interface{}, opt *AddGroupMemberOptio
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#edit-group-team-member
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#edit-group-team-member
 type UpdateGroupMemberOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
@@ -316,13 +367,13 @@ type UpdateGroupMemberOptions struct {
 // UpdateGroupMember updates a group team member to a specified access level.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#list-group-members
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#list-group-members
 func (s *GroupsService) UpdateGroupMember(gid interface{}, user int, opt *UpdateGroupMemberOptions, options ...OptionFunc) (*GroupMember, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, nil, err
 	}
-	u := fmt.Sprintf("groups/%s/members/%d", group, user)
+	u := fmt.Sprintf("groups/%s/members/%d", url.QueryEscape(group), user)
 
 	req, err := s.client.NewRequest("PUT", u, opt, options)
 	if err != nil {
@@ -341,13 +392,13 @@ func (s *GroupsService) UpdateGroupMember(gid interface{}, user int, opt *Update
 // RemoveGroupMember removes user from user team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/groups.html#remove-user-from-user-team
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/groups.md#remove-user-from-user-team
 func (s *GroupsService) RemoveGroupMember(gid interface{}, user int, options ...OptionFunc) (*Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("groups/%s/members/%d", group, user)
+	u := fmt.Sprintf("groups/%s/members/%d", url.QueryEscape(group), user)
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/issues.go
+++ b/vendor/github.com/xanzy/go-gitlab/issues.go
@@ -27,14 +27,16 @@ import (
 // IssuesService handles communication with the issue related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md
 type IssuesService struct {
 	client *Client
 }
 
 // Issue represents a GitLab issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md
 type Issue struct {
 	ID          int        `json:"id"`
 	IID         int        `json:"iid"`
@@ -83,7 +85,8 @@ func (l *Labels) MarshalJSON() ([]byte, error) {
 
 // ListIssuesOptions represents the available ListIssues() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#list-issues
 type ListIssuesOptions struct {
 	ListOptions
 	State   *string `url:"state,omitempty" json:"state,omitempty"`
@@ -95,7 +98,8 @@ type ListIssuesOptions struct {
 // ListIssues gets all issues created by authenticated user. This function
 // takes pagination parameters page and per_page to restrict the list of issues.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#list-issues
 func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
 	req, err := s.client.NewRequest("GET", "issues", opt, options)
 	if err != nil {
@@ -113,7 +117,8 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...OptionFunc
 
 // ListProjectIssuesOptions represents the available ListProjectIssues() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#list-issues
 type ListProjectIssuesOptions struct {
 	ListOptions
 	IID       *int    `url:"iid,omitempty" json:"iid,omitempty"`
@@ -127,7 +132,8 @@ type ListProjectIssuesOptions struct {
 // ListProjectIssues gets a list of project issues. This function accepts
 // pagination parameters page and per_page to return the list of project issues.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-project-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#list-project-issues
 func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -151,7 +157,8 @@ func (s *IssuesService) ListProjectIssues(pid interface{}, opt *ListProjectIssue
 
 // GetIssue gets a single project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#single-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#single-issues
 func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...OptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -175,7 +182,8 @@ func (s *IssuesService) GetIssue(pid interface{}, issue int, options ...OptionFu
 
 // CreateIssueOptions represents the available CreateIssue() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#new-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#new-issues
 type CreateIssueOptions struct {
 	Title       *string `url:"title,omitempty" json:"title,omitempty"`
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
@@ -186,7 +194,8 @@ type CreateIssueOptions struct {
 
 // CreateIssue creates a new project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#new-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#new-issues
 func (s *IssuesService) CreateIssue(pid interface{}, opt *CreateIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -210,7 +219,8 @@ func (s *IssuesService) CreateIssue(pid interface{}, opt *CreateIssueOptions, op
 
 // UpdateIssueOptions represents the available UpdateIssue() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#edit-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#edit-issues
 type UpdateIssueOptions struct {
 	Title       *string `url:"title,omitempty" json:"title,omitempty"`
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
@@ -223,7 +233,8 @@ type UpdateIssueOptions struct {
 // UpdateIssue updates an existing project issue. This function is also used
 // to mark an issue as closed.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#edit-issues
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#edit-issues
 func (s *IssuesService) UpdateIssue(pid interface{}, issue int, opt *UpdateIssueOptions, options ...OptionFunc) (*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -247,7 +258,8 @@ func (s *IssuesService) UpdateIssue(pid interface{}, issue int, opt *UpdateIssue
 
 // DeleteIssue deletes a single project issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#delete-an-issue
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#delete-an-issue
 func (s *IssuesService) DeleteIssue(pid interface{}, issue int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/labels.go
+++ b/vendor/github.com/xanzy/go-gitlab/labels.go
@@ -24,14 +24,16 @@ import (
 // LabelsService handles communication with the label related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md
 type LabelsService struct {
 	client *Client
 }
 
 // Label represents a GitLab label.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md
 type Label struct {
 	Name                   string `json:"name"`
 	Color                  string `json:"color"`
@@ -47,7 +49,8 @@ func (l Label) String() string {
 
 // ListLabels gets all labels for given project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#list-labels
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md#list-labels
 func (s *LabelsService) ListLabels(pid interface{}, options ...OptionFunc) ([]*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -71,7 +74,8 @@ func (s *LabelsService) ListLabels(pid interface{}, options ...OptionFunc) ([]*L
 
 // CreateLabelOptions represents the available CreateLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#create-a-new-label
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md#create-a-new-label
 type CreateLabelOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	Color       *string `url:"color,omitempty" json:"color,omitempty"`
@@ -81,7 +85,8 @@ type CreateLabelOptions struct {
 // CreateLabel creates a new label for given repository with given name and
 // color.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#create-a-new-label
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md#create-a-new-label
 func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, options ...OptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -105,14 +110,16 @@ func (s *LabelsService) CreateLabel(pid interface{}, opt *CreateLabelOptions, op
 
 // DeleteLabelOptions represents the available DeleteLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md#delete-a-label
 type DeleteLabelOptions struct {
 	Name *string `url:"name,omitempty" json:"name,omitempty"`
 }
 
 // DeleteLabel deletes a label given by its name.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md#delete-a-label
 func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -130,7 +137,8 @@ func (s *LabelsService) DeleteLabel(pid interface{}, opt *DeleteLabelOptions, op
 
 // UpdateLabelOptions represents the available UpdateLabel() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#delete-a-label
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md#delete-a-label
 type UpdateLabelOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	NewName     *string `url:"new_name,omitempty" json:"new_name,omitempty"`
@@ -141,7 +149,8 @@ type UpdateLabelOptions struct {
 // UpdateLabel updates an existing label with new name or now color. At least
 // one parameter is required, to update the label.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/labels.html#edit-an-existing-label
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/labels.md#edit-an-existing-label
 func (s *LabelsService) UpdateLabel(pid interface{}, opt *UpdateLabelOptions, options ...OptionFunc) (*Label, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -25,14 +25,16 @@ import (
 // MergeRequestsService handles communication with the merge requests related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/merge_requests.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md
 type MergeRequestsService struct {
 	client *Client
 }
 
 // MergeRequest represents a GitLab merge request.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/merge_requests.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md
 type MergeRequest struct {
 	ID             int        `json:"id"`
 	IID            int        `json:"iid"`
@@ -102,7 +104,7 @@ func (m MergeRequest) String() string {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#list-merge-requests
 type ListMergeRequestsOptions struct {
 	ListOptions
 	IID     *int    `url:"iid,omitempty" json:"iid,omitempty"`
@@ -117,7 +119,7 @@ type ListMergeRequestsOptions struct {
 // per_page can be used to restrict the list of merge requests.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#list-merge-requests
 func (s *MergeRequestsService) ListMergeRequests(pid interface{}, opt *ListMergeRequestsOptions, options ...OptionFunc) ([]*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -142,7 +144,7 @@ func (s *MergeRequestsService) ListMergeRequests(pid interface{}, opt *ListMerge
 // GetMergeRequest shows information about a single merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#get-single-mr
 func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -167,7 +169,7 @@ func (s *MergeRequestsService) GetMergeRequest(pid interface{}, mergeRequest int
 // GetMergeRequestCommits gets a list of merge request commits.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-commits
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#get-single-mr-commits
 func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequest int, options ...OptionFunc) ([]*Commit, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -193,7 +195,7 @@ func (s *MergeRequestsService) GetMergeRequestCommits(pid interface{}, mergeRequ
 // its files and changes.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#get-single-mr-changes
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#get-single-mr-changes
 func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequest int, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -219,7 +221,7 @@ func (s *MergeRequestsService) GetMergeRequestChanges(pid interface{}, mergeRequ
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#create-mr
 type CreateMergeRequestOptions struct {
 	Title           *string `url:"title,omitempty" json:"title,omitempty"`
 	Description     *string `url:"description,omitempty" json:"description,omitempty"`
@@ -232,7 +234,7 @@ type CreateMergeRequestOptions struct {
 // CreateMergeRequest creates a new merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#create-mr
 func (s *MergeRequestsService) CreateMergeRequest(pid interface{}, opt *CreateMergeRequestOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -258,7 +260,7 @@ func (s *MergeRequestsService) CreateMergeRequest(pid interface{}, opt *CreateMe
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#update-mr
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#update-mr
 type UpdateMergeRequestOptions struct {
 	Title        *string `url:"title,omitempty" json:"title,omitempty"`
 	Description  *string `url:"description,omitempty" json:"description,omitempty"`
@@ -270,7 +272,7 @@ type UpdateMergeRequestOptions struct {
 // UpdateMergeRequest updates an existing project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#update-mr
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#update-mr
 func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest int, opt *UpdateMergeRequestOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -296,7 +298,7 @@ func (s *MergeRequestsService) UpdateMergeRequest(pid interface{}, mergeRequest 
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#accept-mr
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#accept-mr
 type AcceptMergeRequestOptions struct {
 	MergeCommitMessage       *string `url:"merge_commit_message,omitempty" json:"merge_commit_message,omitempty"`
 	ShouldRemoveSourceBranch *bool   `url:"should_remove_source_branch,omitempty" json:"should_remove_source_branch,omitempty"`
@@ -310,7 +312,7 @@ type AcceptMergeRequestOptions struct {
 // already merged or closed - you get 405 and error message 'Method Not Allowed'
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/merge_requests.html#accept-mr
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/merge_requests.md#accept-mr
 func (s *MergeRequestsService) AcceptMergeRequest(pid interface{}, mergeRequest int, opt *AcceptMergeRequestOptions, options ...OptionFunc) (*MergeRequest, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/milestones.go
+++ b/vendor/github.com/xanzy/go-gitlab/milestones.go
@@ -25,14 +25,16 @@ import (
 // MilestonesService handles communication with the milestone related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/milestones.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md
 type MilestonesService struct {
 	client *Client
 }
 
 // Milestone represents a GitLab milestone.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/milestones.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md
 type Milestone struct {
 	ID          int        `json:"id"`
 	Iid         int        `json:"iid"`
@@ -53,7 +55,7 @@ func (m Milestone) String() string {
 // ListMilestonesOptions represents the available ListMilestones() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#list-project-milestones
 type ListMilestonesOptions struct {
 	ListOptions
 	IID *int `url:"iid,omitempty" json:"iid,omitempty"`
@@ -62,7 +64,7 @@ type ListMilestonesOptions struct {
 // ListMilestones returns a list of project milestones.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#list-project-milestones
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#list-project-milestones
 func (s *MilestonesService) ListMilestones(pid interface{}, opt *ListMilestonesOptions, options ...OptionFunc) ([]*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -87,7 +89,7 @@ func (s *MilestonesService) ListMilestones(pid interface{}, opt *ListMilestonesO
 // GetMilestone gets a single project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-single-milestone
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#get-single-milestone
 func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, options ...OptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -112,7 +114,7 @@ func (s *MilestonesService) GetMilestone(pid interface{}, milestone int, options
 // CreateMilestoneOptions represents the available CreateMilestone() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#create-new-milestone
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#create-new-milestone
 type CreateMilestoneOptions struct {
 	Title       *string `url:"title,omitempty" json:"title,omitempty"`
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
@@ -123,7 +125,7 @@ type CreateMilestoneOptions struct {
 // CreateMilestone creates a new project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#create-new-milestone
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#create-new-milestone
 func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMilestoneOptions, options ...OptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -148,7 +150,7 @@ func (s *MilestonesService) CreateMilestone(pid interface{}, opt *CreateMileston
 // UpdateMilestoneOptions represents the available UpdateMilestone() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#edit-milestone
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#edit-milestone
 type UpdateMilestoneOptions struct {
 	Title       *string `url:"title,omitempty" json:"title,omitempty"`
 	Description *string `url:"description,omitempty" json:"description,omitempty"`
@@ -160,7 +162,7 @@ type UpdateMilestoneOptions struct {
 // UpdateMilestone updates an existing project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#edit-milestone
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#edit-milestone
 func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt *UpdateMilestoneOptions, options ...OptionFunc) (*Milestone, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -185,7 +187,7 @@ func (s *MilestonesService) UpdateMilestone(pid interface{}, milestone int, opt 
 // GetMilestoneIssuesOptions represents the available GetMilestoneIssues() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#get-all-issues-assigned-to-a-single-milestone
 type GetMilestoneIssuesOptions struct {
 	ListOptions
 }
@@ -193,7 +195,7 @@ type GetMilestoneIssuesOptions struct {
 // GetMilestoneIssues gets all issues assigned to a single project milestone.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/milestones.html#get-all-issues-assigned-to-a-single-milestone
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/milestones.md#get-all-issues-assigned-to-a-single-milestone
 func (s *MilestonesService) GetMilestoneIssues(pid interface{}, milestone int, opt *GetMilestoneIssuesOptions, options ...OptionFunc) ([]*Issue, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/namespaces.go
+++ b/vendor/github.com/xanzy/go-gitlab/namespaces.go
@@ -19,14 +19,16 @@ package gitlab
 // NamespacesService handles communication with the namespace related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/namespaces.md
 type NamespacesService struct {
 	client *Client
 }
 
 // Namespace represents a GitLab namespace.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/namespaces.md
 type Namespace struct {
 	ID   int    `json:"id"`
 	Path string `json:"path"`
@@ -39,7 +41,8 @@ func (n Namespace) String() string {
 
 // ListNamespacesOptions represents the available ListNamespaces() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html#list-namespaces
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/namespaces.md#list-namespaces
 type ListNamespacesOptions struct {
 	ListOptions
 	Search *string `url:"search,omitempty" json:"search,omitempty"`
@@ -47,7 +50,8 @@ type ListNamespacesOptions struct {
 
 // ListNamespaces gets a list of projects accessible by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/namespaces.html#list-namespaces
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/namespaces.md#list-namespaces
 func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, options ...OptionFunc) ([]*Namespace, *Response, error) {
 	req, err := s.client.NewRequest("GET", "namespaces", opt, options)
 	if err != nil {
@@ -67,7 +71,7 @@ func (s *NamespacesService) ListNamespaces(opt *ListNamespacesOptions, options .
 // or path.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/namespaces.html#search-for-namespace
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/namespaces.md#search-for-namespace
 func (s *NamespacesService) SearchNamespace(query string, options ...OptionFunc) ([]*Namespace, *Response, error) {
 	var q struct {
 		Search string `url:"search,omitempty" json:"search,omitempty"`

--- a/vendor/github.com/xanzy/go-gitlab/notes.go
+++ b/vendor/github.com/xanzy/go-gitlab/notes.go
@@ -25,14 +25,16 @@ import (
 // NotesService handles communication with the notes related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/notes.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md
 type NotesService struct {
 	client *Client
 }
 
 // Note represents a GitLab note.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/notes.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md
 type Note struct {
 	ID         int    `json:"id"`
 	Body       string `json:"body"`
@@ -59,7 +61,7 @@ func (n Note) String() string {
 // ListIssueNotesOptions represents the available ListIssueNotes() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-project-issue-notes
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#list-project-issue-notes
 type ListIssueNotesOptions struct {
 	ListOptions
 }
@@ -67,7 +69,7 @@ type ListIssueNotesOptions struct {
 // ListIssueNotes gets a list of all notes for a single issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-project-issue-notes
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#list-project-issue-notes
 func (s *NotesService) ListIssueNotes(pid interface{}, issue int, opt *ListIssueNotesOptions, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -92,7 +94,7 @@ func (s *NotesService) ListIssueNotes(pid interface{}, issue int, opt *ListIssue
 // GetIssueNote returns a single note for a specific project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#get-single-issue-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#get-single-issue-note
 func (s *NotesService) GetIssueNote(pid interface{}, issue int, note int, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -118,7 +120,7 @@ func (s *NotesService) GetIssueNote(pid interface{}, issue int, note int, option
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-issue-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#create-new-issue-note
 type CreateIssueNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -126,7 +128,7 @@ type CreateIssueNoteOptions struct {
 // CreateIssueNote creates a new note to a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-issue-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#create-new-issue-note
 func (s *NotesService) CreateIssueNote(pid interface{}, issue int, opt *CreateIssueNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -152,14 +154,14 @@ func (s *NotesService) CreateIssueNote(pid interface{}, issue int, opt *CreateIs
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-issue-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#modify-existing-issue-note
 type UpdateIssueNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // UpdateIssueNote modifies existing note of an issue.
 //
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-issue-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#modify-existing-issue-note
 func (s *NotesService) UpdateIssueNote(pid interface{}, issue int, note int, opt *UpdateIssueNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -185,7 +187,7 @@ func (s *NotesService) UpdateIssueNote(pid interface{}, issue int, note int, opt
 // notes are comments users can post to a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-all-snippet-notes
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#list-all-snippet-notes
 func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -210,7 +212,7 @@ func (s *NotesService) ListSnippetNotes(pid interface{}, snippet int, options ..
 // GetSnippetNote returns a single note for a given snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#get-single-snippet-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#get-single-snippet-note
 func (s *NotesService) GetSnippetNote(pid interface{}, snippet int, note int, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -236,7 +238,7 @@ func (s *NotesService) GetSnippetNote(pid interface{}, snippet int, note int, op
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-snippet-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#create-new-snippet-note
 type CreateSnippetNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -245,7 +247,7 @@ type CreateSnippetNoteOptions struct {
 // comments users can post to a snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-snippet-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#create-new-snippet-note
 func (s *NotesService) CreateSnippetNote(pid interface{}, snippet int, opt *CreateSnippetNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -271,14 +273,14 @@ func (s *NotesService) CreateSnippetNote(pid interface{}, snippet int, opt *Crea
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-snippet-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#modify-existing-snippet-note
 type UpdateSnippetNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // UpdateSnippetNote modifies existing note of a snippet.
 //
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-snippet-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#modify-existing-snippet-note
 func (s *NotesService) UpdateSnippetNote(pid interface{}, snippet int, note int, opt *UpdateSnippetNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -303,7 +305,7 @@ func (s *NotesService) UpdateSnippetNote(pid interface{}, snippet int, note int,
 // ListMergeRequestNotes gets a list of all notes for a single merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#list-all-merge-request-notes
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#list-all-merge-request-notes
 func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, options ...OptionFunc) ([]*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -328,7 +330,7 @@ func (s *NotesService) ListMergeRequestNotes(pid interface{}, mergeRequest int, 
 // GetMergeRequestNote returns a single note for a given merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#get-single-merge-request-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#get-single-merge-request-note
 func (s *NotesService) GetMergeRequestNote(pid interface{}, mergeRequest int, note int, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -354,7 +356,7 @@ func (s *NotesService) GetMergeRequestNote(pid interface{}, mergeRequest int, no
 // CreateMergeRequestNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-merge-request-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#create-new-merge-request-note
 type CreateMergeRequestNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
@@ -362,7 +364,7 @@ type CreateMergeRequestNoteOptions struct {
 // CreateMergeRequestNote creates a new note for a single merge request.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#create-new-merge-request-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#create-new-merge-request-note
 func (s *NotesService) CreateMergeRequestNote(pid interface{}, mergeRequest int, opt *CreateMergeRequestNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -388,14 +390,14 @@ func (s *NotesService) CreateMergeRequestNote(pid interface{}, mergeRequest int,
 // UpdateMergeRequestNote() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-merge-request-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#modify-existing-merge-request-note
 type UpdateMergeRequestNoteOptions struct {
 	Body *string `url:"body,omitempty" json:"body,omitempty"`
 }
 
 // UpdateMergeRequestNote modifies existing note of a merge request.
 //
-// https://docs.gitlab.com/ce/api/notes.html#modify-existing-merge-request-note
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notes.md#modify-existing-merge-request-note
 func (s *NotesService) UpdateMergeRequestNote(pid interface{}, mergeRequest int, note int, opt *UpdateMergeRequestNoteOptions, options ...OptionFunc) (*Note, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/notifications.go
+++ b/vendor/github.com/xanzy/go-gitlab/notifications.go
@@ -9,7 +9,8 @@ import (
 // NotificationSettingsService handles communication with the notification settings
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/notification_settings.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md
 type NotificationSettingsService struct {
 	client *Client
 }
@@ -17,7 +18,7 @@ type NotificationSettingsService struct {
 // NotificationSettings represents the Gitlab notification setting.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#notification-settings
 type NotificationSettings struct {
 	Level             NotificationLevelValue `json:"level"`
 	NotificationEmail string                 `json:"notification_email"`
@@ -27,7 +28,7 @@ type NotificationSettings struct {
 // NotificationEvents represents the avialable notification setting events.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#notification-settings
 type NotificationEvents struct {
 	CloseIssue           bool `json:"close_issue"`
 	CloseMergeRequest    bool `json:"close_merge_request"`
@@ -50,7 +51,7 @@ func (ns NotificationSettings) String() string {
 // GetGlobalSettings returns current notification settings and email address.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#global-notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#global-notification-settings
 func (s *NotificationSettingsService) GetGlobalSettings(options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	u := "notification_settings"
 
@@ -90,7 +91,7 @@ type NotificationSettingsOptions struct {
 // UpdateGlobalSettings updates current notification settings and email address.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#update-global-notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#update-global-notification-settings
 func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSettingsOptions, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	if opt.Level != nil && *opt.Level == GlobalNotificationLevel {
 		return nil, nil, errors.New(
@@ -116,7 +117,7 @@ func (s *NotificationSettingsService) UpdateGlobalSettings(opt *NotificationSett
 // GetSettingsForGroup returns current group notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#group-project-level-notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#group-project-level-notification-settings
 func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -141,7 +142,7 @@ func (s *NotificationSettingsService) GetSettingsForGroup(gid interface{}, optio
 // GetSettingsForProject returns current project notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#group-project-level-notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#group-project-level-notification-settings
 func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -166,7 +167,7 @@ func (s *NotificationSettingsService) GetSettingsForProject(pid interface{}, opt
 // UpdateSettingsForGroup updates current group notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#update-group-project-level-notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#update-group-project-level-notification-settings
 func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, opt *NotificationSettingsOptions, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	group, err := parseID(gid)
 	if err != nil {
@@ -191,7 +192,7 @@ func (s *NotificationSettingsService) UpdateSettingsForGroup(gid interface{}, op
 // UpdateSettingsForProject updates current project notification settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/notification_settings.html#update-group-project-level-notification-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/notification_settings.md#update-group-project-level-notification-settings
 func (s *NotificationSettingsService) UpdateSettingsForProject(pid interface{}, opt *NotificationSettingsOptions, options ...OptionFunc) (*NotificationSettings, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/pipelines.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipelines.go
@@ -25,14 +25,16 @@ import (
 // PipelinesService handles communication with the repositories related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md
 type PipelinesService struct {
 	client *Client
 }
 
 // Pipeline represents a GitLab pipeline.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md
 type Pipeline struct {
 	ID         int    `json:"id"`
 	Status     string `json:"status"`
@@ -64,7 +66,8 @@ func (i Pipeline) String() string {
 
 // ListProjectPipelines gets a list of project piplines.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#list-project-pipelines
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md#list-project-pipelines
 func (s *PipelinesService) ListProjectPipelines(pid interface{}, options ...OptionFunc) ([]*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -87,7 +90,8 @@ func (s *PipelinesService) ListProjectPipelines(pid interface{}, options ...Opti
 
 // GetPipeline gets a single project pipeline.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#get-a-single-pipeline
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md#get-a-single-pipeline
 func (s *PipelinesService) GetPipeline(pid interface{}, pipeline int, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -111,14 +115,16 @@ func (s *PipelinesService) GetPipeline(pid interface{}, pipeline int, options ..
 
 // CreatePipelineOptions represents the available CreatePipeline() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#create-a-new-pipeline
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md#create-a-new-pipeline
 type CreatePipelineOptions struct {
 	Ref *string `url:"ref,omitempty" json:"ref"`
 }
 
 // CreatePipeline creates a new project pipeline.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/pipelines.html#create-a-new-pipeline
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md#create-a-new-pipeline
 func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOptions, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -143,7 +149,7 @@ func (s *PipelinesService) CreatePipeline(pid interface{}, opt *CreatePipelineOp
 // RetryPipelineBuild retries failed builds in a pipeline
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/pipelines.html#retry-failed-builds-in-a-pipeline
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md#retry-failed-builds-in-a-pipeline
 func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipelineID int, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -168,7 +174,7 @@ func (s *PipelinesService) RetryPipelineBuild(pid interface{}, pipelineID int, o
 // CancelPipelineBuild cancels a pipeline builds
 //
 // GitLab API docs:
-//https://docs.gitlab.com/ce/api/pipelines.html#cancel-a-pipelines-builds
+//https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/pipelines.md#cancel-a-pipelines-builds
 func (s *PipelinesService) CancelPipelineBuild(pid interface{}, pipelineID int, options ...OptionFunc) (*Pipeline, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/project_snippets.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_snippets.go
@@ -26,14 +26,16 @@ import (
 // ProjectSnippetsService handles communication with the project snippets
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md
 type ProjectSnippetsService struct {
 	client *Client
 }
 
 // Snippet represents a GitLab project snippet.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md
 type Snippet struct {
 	ID       int    `json:"id"`
 	Title    string `json:"title"`
@@ -57,14 +59,16 @@ func (s Snippet) String() string {
 
 // ListSnippetsOptions represents the available ListSnippets() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html#list-snippets
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#list-snippets
 type ListSnippetsOptions struct {
 	ListOptions
 }
 
 // ListSnippets gets a list of project snippets.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/project_snippets.html#list-snippets
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#list-snippets
 func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListSnippetsOptions, options ...OptionFunc) ([]*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -89,7 +93,7 @@ func (s *ProjectSnippetsService) ListSnippets(pid interface{}, opt *ListSnippets
 // GetSnippet gets a single project snippet
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#single-snippet
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#single-snippet
 func (s *ProjectSnippetsService) GetSnippet(pid interface{}, snippet int, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -114,7 +118,7 @@ func (s *ProjectSnippetsService) GetSnippet(pid interface{}, snippet int, option
 // CreateSnippetOptions represents the available CreateSnippet() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#create-new-snippet
 type CreateSnippetOptions struct {
 	Title           *string               `url:"title,omitempty" json:"title,omitempty"`
 	FileName        *string               `url:"file_name,omitempty" json:"file_name,omitempty"`
@@ -126,7 +130,7 @@ type CreateSnippetOptions struct {
 // to create new snippets.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#create-new-snippet
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#create-new-snippet
 func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -151,7 +155,7 @@ func (s *ProjectSnippetsService) CreateSnippet(pid interface{}, opt *CreateSnipp
 // UpdateSnippetOptions represents the available UpdateSnippet() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#update-snippet
 type UpdateSnippetOptions struct {
 	Title           *string               `url:"title,omitempty" json:"title,omitempty"`
 	FileName        *string               `url:"file_name,omitempty" json:"file_name,omitempty"`
@@ -163,7 +167,7 @@ type UpdateSnippetOptions struct {
 // permission to change an existing snippet.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#update-snippet
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#update-snippet
 func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt *UpdateSnippetOptions, options ...OptionFunc) (*Snippet, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -190,7 +194,7 @@ func (s *ProjectSnippetsService) UpdateSnippet(pid interface{}, snippet int, opt
 // code.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#delete-snippet
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#delete-snippet
 func (s *ProjectSnippetsService) DeleteSnippet(pid interface{}, snippet int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -209,7 +213,7 @@ func (s *ProjectSnippetsService) DeleteSnippet(pid interface{}, snippet int, opt
 // SnippetContent returns the raw project snippet as plain text.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/project_snippets.html#snippet-content
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/project_snippets.md#snippet-content
 func (s *ProjectSnippetsService) SnippetContent(pid interface{}, snippet int, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -25,14 +25,16 @@ import (
 // ProjectsService handles communication with the repositories related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md
 type ProjectsService struct {
 	client *Client
 }
 
 // Project represents a GitLab project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md
 type Project struct {
 	ID                                        int                  `json:"id"`
 	Description                               string               `json:"description"`
@@ -72,6 +74,7 @@ type Project struct {
 	OnlyAllowMergeIfAllDiscussionsAreResolved bool                 `json:"only_allow_merge_if_all_discussions_are_resolved"`
 	LFSEnabled                                bool                 `json:"lfs_enabled"`
 	RequestAccessEnabled                      bool                 `json:"request_access_enabled"`
+	ForkedFromProject                         *ForkParent          `json:"forked_from_project"`
 	SharedWithGroups                          []struct {
 		GroupID          int    `json:"group_id"`
 		GroupName        string `json:"group_name"`
@@ -141,13 +144,25 @@ type GroupAccess struct {
 	NotificationLevel NotificationLevelValue `json:"notification_level"`
 }
 
+// ForkParent represents the parent project when this is a fork.
+type ForkParent struct {
+	HTTPURLToRepo     string `json:"http_url_to_repo"`
+	ID                int    `json:"id"`
+	Name              string `json:"name"`
+	NameWithNamespace string `json:"name_with_namespace"`
+	Path              string `json:"path"`
+	PathWithNamespace string `json:"path_with_namespace"`
+	WebURL            string `json:"web_url"`
+}
+
 func (s Project) String() string {
 	return Stringify(s)
 }
 
 // ListProjectsOptions represents the available ListProjects() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-projects
 type ListProjectsOptions struct {
 	ListOptions
 	Archived   *bool   `url:"archived,omitempty" json:"archived,omitempty"`
@@ -161,7 +176,8 @@ type ListProjectsOptions struct {
 
 // ListProjects gets a list of projects accessible by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-projects
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-projects
 func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	req, err := s.client.NewRequest("GET", "projects", opt, options)
 	if err != nil {
@@ -181,7 +197,7 @@ func (s *ProjectsService) ListProjects(opt *ListProjectsOptions, options ...Opti
 // authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-owned-projects
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-owned-projects
 func (s *ProjectsService) ListOwnedProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	req, err := s.client.NewRequest("GET", "projects/owned", opt, options)
 	if err != nil {
@@ -201,7 +217,7 @@ func (s *ProjectsService) ListOwnedProjects(opt *ListProjectsOptions, options ..
 // authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-starred-projects
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-starred-projects
 func (s *ProjectsService) ListStarredProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	req, err := s.client.NewRequest("GET", "projects/starred", opt, options)
 	if err != nil {
@@ -220,7 +236,7 @@ func (s *ProjectsService) ListStarredProjects(opt *ListProjectsOptions, options 
 // ListAllProjects gets a list of all GitLab projects (admin only).
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-all-projects
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-all-projects
 func (s *ProjectsService) ListAllProjects(opt *ListProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	req, err := s.client.NewRequest("GET", "projects/all", opt, options)
 	if err != nil {
@@ -240,7 +256,7 @@ func (s *ProjectsService) ListAllProjects(opt *ListProjectsOptions, options ...O
 // NAMESPACE/PROJECT_NAME, which is owned by the authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-single-project
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#get-single-project
 func (s *ProjectsService) GetProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -265,7 +281,7 @@ func (s *ProjectsService) GetProject(pid interface{}, options ...OptionFunc) (*P
 // SearchProjectsOptions represents the available SearchProjects() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#search-for-projects-by-name
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#search-for-projects-by-name
 type SearchProjectsOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
@@ -276,7 +292,7 @@ type SearchProjectsOptions struct {
 // authenticated user.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#search-for-projects-by-name
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#search-for-projects-by-name
 func (s *ProjectsService) SearchProjects(query string, opt *SearchProjectsOptions, options ...OptionFunc) ([]*Project, *Response, error) {
 	u := fmt.Sprintf("projects/search/%s", query)
 
@@ -297,7 +313,7 @@ func (s *ProjectsService) SearchProjects(query string, opt *SearchProjectsOption
 // ProjectEvent represents a GitLab project event.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#get-project-events
 type ProjectEvent struct {
 	Title          interface{} `json:"title"`
 	ProjectID      int         `json:"project_id"`
@@ -326,7 +342,7 @@ func (s ProjectEvent) String() string {
 // GetProjectEventsOptions represents the available GetProjectEvents() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#get-project-events
 type GetProjectEventsOptions struct {
 	ListOptions
 }
@@ -335,7 +351,7 @@ type GetProjectEventsOptions struct {
 // newest to latest.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-events
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#get-project-events
 func (s *ProjectsService) GetProjectEvents(pid interface{}, opt *GetProjectEventsOptions, options ...OptionFunc) ([]*ProjectEvent, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -359,31 +375,35 @@ func (s *ProjectsService) GetProjectEvents(pid interface{}, opt *GetProjectEvent
 
 // CreateProjectOptions represents the available CreateProjects() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#create-project
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#create-project
 type CreateProjectOptions struct {
-	Name                          *string               `url:"name,omitempty" json:"name,omitempty"`
-	Path                          *string               `url:"path,omitempty" json:"path,omitempty"`
-	NamespaceID                   *int                  `url:"namespace_id,omitempty" json:"namespace_id,omitempty"`
-	Description                   *string               `url:"description,omitempty" json:"description,omitempty"`
-	IssuesEnabled                 *bool                 `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled          *bool                 `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	BuildsEnabled                 *bool                 `url:"builds_enabled,omitempty" json:"builds_enabled,omitempty"`
-	WikiEnabled                   *bool                 `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled               *bool                 `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	ContainerRegistryEnabled      *bool                 `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
-	SharedRunnersEnabled          *bool                 `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
-	Public                        *bool                 `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel               *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
-	ImportURL                     *string               `url:"import_url,omitempty" json:"import_url,omitempty"`
-	PublicBuilds                  *bool                 `url:"public_builds,omitempty" json:"public_builds,omitempty"`
-	OnlyAllowMergeIfBuildSucceeds *bool                 `url:"only_allow_merge_if_build_succeeds,omitempty" json:"only_allow_merge_if_build_succeeds,omitempty"`
-	LFSEnabled                    *bool                 `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
-	RequestAccessEnabled          *bool                 `url:"request_access_enabled,omitempty" json:"request_access_enabled,omitempty"`
+	Name                                      *string               `url:"name,omitempty" json:"name,omitempty"`
+	Path                                      *string               `url:"path,omitempty" json:"path,omitempty"`
+	DefaultBranch                             *string               `url:"default_branch,omitempty" json:"default_branch,omitempty"` // note: this does not work
+	NamespaceID                               *int                  `url:"namespace_id,omitempty" json:"namespace_id,omitempty"`
+	Description                               *string               `url:"description,omitempty" json:"description,omitempty"`
+	IssuesEnabled                             *bool                 `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
+	MergeRequestsEnabled                      *bool                 `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
+	BuildsEnabled                             *bool                 `url:"builds_enabled,omitempty" json:"builds_enabled,omitempty"`
+	WikiEnabled                               *bool                 `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
+	SnippetsEnabled                           *bool                 `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
+	ContainerRegistryEnabled                  *bool                 `url:"container_registry_enabled,omitempty" json:"container_registry_enabled,omitempty"`
+	SharedRunnersEnabled                      *bool                 `url:"shared_runners_enabled,omitempty" json:"shared_runners_enabled,omitempty"`
+	Public                                    *bool                 `url:"public,omitempty" json:"public,omitempty"`
+	VisibilityLevel                           *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
+	ImportURL                                 *string               `url:"import_url,omitempty" json:"import_url,omitempty"`
+	PublicBuilds                              *bool                 `url:"public_builds,omitempty" json:"public_builds,omitempty"`
+	OnlyAllowMergeIfBuildSucceeds             *bool                 `url:"only_allow_merge_if_build_succeeds,omitempty" json:"only_allow_merge_if_build_succeeds,omitempty"`
+	OnlyAllowMergeIfAllDiscussionsAreResolved *bool                 `url:"only_allow_merge_if_all_discussions_are_resolved,omitempty" json:"only_allow_merge_if_all_discussions_are_resolved,omitempty"`
+	LFSEnabled                                *bool                 `url:"lfs_enabled,omitempty" json:"lfs_enabled,omitempty"`
+	RequestAccessEnabled                      *bool                 `url:"request_access_enabled,omitempty" json:"request_access_enabled,omitempty"`
 }
 
 // CreateProject creates a new project owned by the authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#create-project
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#create-project
 func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
 	req, err := s.client.NewRequest("POST", "projects", opt, options)
 	if err != nil {
@@ -400,28 +420,18 @@ func (s *ProjectsService) CreateProject(opt *CreateProjectOptions, options ...Op
 }
 
 // CreateProjectForUserOptions represents the available CreateProjectForUser()
-// options.
+// options; these are identical to those for an ordinary Project, since the
+// required "user_id" parameter is provided in the request URL.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#create-project-for-user
-type CreateProjectForUserOptions struct {
-	Name                 *string               `url:"name,omitempty" json:"name,omitempty"`
-	Description          *string               `url:"description,omitempty" json:"description,omitempty"`
-	DefaultBranch        *string               `url:"default_branch,omitempty" json:"default_branch,omitempty"`
-	IssuesEnabled        *bool                 `url:"issues_enabled,omitempty" json:"issues_enabled,omitempty"`
-	MergeRequestsEnabled *bool                 `url:"merge_requests_enabled,omitempty" json:"merge_requests_enabled,omitempty"`
-	WikiEnabled          *bool                 `url:"wiki_enabled,omitempty" json:"wiki_enabled,omitempty"`
-	SnippetsEnabled      *bool                 `url:"snippets_enabled,omitempty" json:"snippets_enabled,omitempty"`
-	Public               *bool                 `url:"public,omitempty" json:"public,omitempty"`
-	VisibilityLevel      *VisibilityLevelValue `url:"visibility_level,omitempty" json:"visibility_level,omitempty"`
-	ImportURL            *string               `url:"import_url,omitempty" json:"import_url,omitempty"`
-}
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#create-project-for-user
+type CreateProjectForUserOptions CreateProjectOptions
 
 // CreateProjectForUser creates a new project owned by the specified user.
 // Available only for admins.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#create-project-for-user
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#create-project-for-user
 func (s *ProjectsService) CreateProjectForUser(user int, opt *CreateProjectForUserOptions, options ...OptionFunc) (*Project, *Response, error) {
 	u := fmt.Sprintf("projects/user/%d", user)
 
@@ -441,7 +451,8 @@ func (s *ProjectsService) CreateProjectForUser(user int, opt *CreateProjectForUs
 
 // EditProjectOptions represents the available EditProject() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#edit-project
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#edit-project
 type EditProjectOptions struct {
 	Name                                      *string               `url:"name,omitempty" json:"name,omitempty"`
 	Path                                      *string               `url:"path,omitempty" json:"path,omitempty"`
@@ -467,7 +478,8 @@ type EditProjectOptions struct {
 
 // EditProject updates an existing project.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#edit-project
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#edit-project
 func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -492,7 +504,8 @@ func (s *ProjectsService) EditProject(pid interface{}, opt *EditProjectOptions, 
 // ForkProject forks a project into the user namespace of the authenticated
 // user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#fork-project
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#fork-project
 func (s *ProjectsService) ForkProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -517,7 +530,8 @@ func (s *ProjectsService) ForkProject(pid interface{}, options ...OptionFunc) (*
 // DeleteProject removes a project including all associated resources
 // (issues, merge requests etc.)
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#remove-project
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#remove-project
 func (s *ProjectsService) DeleteProject(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -536,7 +550,7 @@ func (s *ProjectsService) DeleteProject(pid interface{}, options ...OptionFunc) 
 // ProjectMember represents a project member.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-team-members
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-project-team-members
 type ProjectMember struct {
 	ID          int              `json:"id"`
 	Username    string           `json:"username"`
@@ -551,7 +565,7 @@ type ProjectMember struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-team-members
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-project-team-members
 type ListProjectMembersOptions struct {
 	ListOptions
 	Query *string `url:"query,omitempty" json:"query,omitempty"`
@@ -560,7 +574,7 @@ type ListProjectMembersOptions struct {
 // ListProjectMembers gets a list of a project's team members.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-team-members
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-project-team-members
 func (s *ProjectsService) ListProjectMembers(pid interface{}, opt *ListProjectMembersOptions, options ...OptionFunc) ([]*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -585,7 +599,7 @@ func (s *ProjectsService) ListProjectMembers(pid interface{}, opt *ListProjectMe
 // GetProjectMember gets a project team member.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-team-member
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#get-project-team-member
 func (s *ProjectsService) GetProjectMember(pid interface{}, user int, options ...OptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -610,7 +624,7 @@ func (s *ProjectsService) GetProjectMember(pid interface{}, user int, options ..
 // AddProjectMemberOptions represents the available AddProjectMember() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#add-project-team-member
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#add-project-team-member
 type AddProjectMemberOptions struct {
 	UserID      *int              `url:"user_id,omitempty" json:"user_id,omitempty"`
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
@@ -622,7 +636,7 @@ type AddProjectMemberOptions struct {
 // existing membership.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#add-project-team-member
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#add-project-team-member
 func (s *ProjectsService) AddProjectMember(pid interface{}, opt *AddProjectMemberOptions, options ...OptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -647,7 +661,7 @@ func (s *ProjectsService) AddProjectMember(pid interface{}, opt *AddProjectMembe
 // EditProjectMemberOptions represents the available EditProjectMember() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#edit-project-team-member
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#edit-project-team-member
 type EditProjectMemberOptions struct {
 	AccessLevel *AccessLevelValue `url:"access_level,omitempty" json:"access_level,omitempty"`
 }
@@ -655,7 +669,7 @@ type EditProjectMemberOptions struct {
 // EditProjectMember updates a project team member to a specified access level..
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#edit-project-team-member
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#edit-project-team-member
 func (s *ProjectsService) EditProjectMember(pid interface{}, user int, opt *EditProjectMemberOptions, options ...OptionFunc) (*ProjectMember, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -680,7 +694,7 @@ func (s *ProjectsService) EditProjectMember(pid interface{}, user int, opt *Edit
 // DeleteProjectMember removes a user from a project team.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#remove-project-team-member
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#remove-project-team-member
 func (s *ProjectsService) DeleteProjectMember(pid interface{}, user int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -699,7 +713,7 @@ func (s *ProjectsService) DeleteProjectMember(pid interface{}, user int, options
 // ProjectHook represents a project hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-project-hooks
 type ProjectHook struct {
 	ID                    int        `json:"id"`
 	URL                   string     `json:"url"`
@@ -718,7 +732,8 @@ type ProjectHook struct {
 
 // ListProjectHooksOptions represents the available ListProjectHooks() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-project-hooks
 type ListProjectHooksOptions struct {
 	ListOptions
 }
@@ -726,7 +741,7 @@ type ListProjectHooksOptions struct {
 // ListProjectHooks gets a list of project hooks.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#list-project-hooks
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#list-project-hooks
 func (s *ProjectsService) ListProjectHooks(pid interface{}, opt *ListProjectHooksOptions, options ...OptionFunc) ([]*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -751,7 +766,7 @@ func (s *ProjectsService) ListProjectHooks(pid interface{}, opt *ListProjectHook
 // GetProjectHook gets a specific hook for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#get-project-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#get-project-hook
 func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...OptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -776,7 +791,7 @@ func (s *ProjectsService) GetProjectHook(pid interface{}, hook int, options ...O
 // AddProjectHookOptions represents the available AddProjectHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#add-project-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#add-project-hook
 type AddProjectHookOptions struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
 	PushEvents            *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
@@ -794,7 +809,7 @@ type AddProjectHookOptions struct {
 // AddProjectHook adds a hook to a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#add-project-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#add-project-hook
 func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOptions, options ...OptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -819,7 +834,7 @@ func (s *ProjectsService) AddProjectHook(pid interface{}, opt *AddProjectHookOpt
 // EditProjectHookOptions represents the available EditProjectHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#edit-project-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#edit-project-hook
 type EditProjectHookOptions struct {
 	URL                   *string `url:"url,omitempty" json:"url,omitempty"`
 	PushEvents            *bool   `url:"push_events,omitempty" json:"push_events,omitempty"`
@@ -837,7 +852,7 @@ type EditProjectHookOptions struct {
 // EditProjectHook edits a hook for a specified project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#edit-project-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#edit-project-hook
 func (s *ProjectsService) EditProjectHook(pid interface{}, hook int, opt *EditProjectHookOptions, options ...OptionFunc) (*ProjectHook, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -863,7 +878,7 @@ func (s *ProjectsService) EditProjectHook(pid interface{}, hook int, opt *EditPr
 // method and can be called multiple times. Either the hook is available or not.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#delete-project-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#delete-project-hook
 func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -879,10 +894,124 @@ func (s *ProjectsService) DeleteProjectHook(pid interface{}, hook int, options .
 	return s.client.Do(req, nil)
 }
 
+// BuildTrigger represents a project build trigger.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#build-triggers
+type BuildTrigger struct {
+	CreatedAt *time.Time `json:"created_at"`
+	DeletedAt *time.Time `json:"deleted_at"`
+	LastUsed  *time.Time `json:"last_used"`
+	Token     string     `json:"token"`
+	UpdatedAt *time.Time `json:"updated_at"`
+}
+
+// ListBuildTriggersOptions represents the available ListBuildTriggers() options.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#list-project-triggers
+type ListBuildTriggersOptions struct {
+	ListOptions
+}
+
+// ListBuildTriggers gets a list of project triggers.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#list-project-triggers
+func (s *ProjectsService) ListBuildTriggers(pid interface{}, opt *ListBuildTriggersOptions, options ...OptionFunc) ([]*BuildTrigger, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var bt []*BuildTrigger
+	resp, err := s.client.Do(req, &bt)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bt, resp, err
+}
+
+// GetBuildTrigger gets a specific build trigger for a project.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#get-trigger-details
+func (s *ProjectsService) GetBuildTrigger(pid interface{}, token string, options ...OptionFunc) (*BuildTrigger, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers/%v", url.QueryEscape(project), token)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bt := new(BuildTrigger)
+	resp, err := s.client.Do(req, bt)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bt, resp, err
+}
+
+// AddBuildTrigger adds a build trigger to a specified project.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#create-a-project-trigger
+func (s *ProjectsService) AddBuildTrigger(pid interface{}, options ...OptionFunc) (*BuildTrigger, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers", url.QueryEscape(project))
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	bt := new(BuildTrigger)
+	resp, err := s.client.Do(req, bt)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bt, resp, err
+}
+
+// DeleteBuildTrigger removes a trigger from a project.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/build_triggers.md#remove-a-project-trigger
+func (s *ProjectsService) DeleteBuildTrigger(pid interface{}, token string, options ...OptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/triggers/%s", url.QueryEscape(project), token)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // ProjectForkRelation represents a project fork relationship.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#admin-fork-relation
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#admin-fork-relation
 type ProjectForkRelation struct {
 	ID                  int        `json:"id"`
 	ForkedToProjectID   int        `json:"forked_to_project_id"`
@@ -895,7 +1024,7 @@ type ProjectForkRelation struct {
 // existing projects.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#create-a-forked-fromto-relation-between-existing-projects.
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#create-a-forked-fromto-relation-between-existing-projects.
 func (s *ProjectsService) CreateProjectForkRelation(pid int, fork int, options ...OptionFunc) (*ProjectForkRelation, *Response, error) {
 	u := fmt.Sprintf("projects/%d/fork/%d", pid, fork)
 
@@ -916,7 +1045,7 @@ func (s *ProjectsService) CreateProjectForkRelation(pid int, fork int, options .
 // DeleteProjectForkRelation deletes an existing forked from relationship.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#delete-an-existing-forked-from-relationship
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#delete-an-existing-forked-from-relationship
 func (s *ProjectsService) DeleteProjectForkRelation(pid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("projects/%d/fork", pid)
 
@@ -932,7 +1061,7 @@ func (s *ProjectsService) DeleteProjectForkRelation(pid int, options ...OptionFu
 // project owner of this project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#archive-a-project
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#archive-a-project
 func (s *ProjectsService) ArchiveProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -958,7 +1087,7 @@ func (s *ProjectsService) ArchiveProject(pid interface{}, options ...OptionFunc)
 // the project owner of this project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/projects.html#unarchive-a-project
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#unarchive-a-project
 func (s *ProjectsService) UnarchiveProject(pid interface{}, options ...OptionFunc) (*Project, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/repositories.go
+++ b/vendor/github.com/xanzy/go-gitlab/repositories.go
@@ -25,14 +25,16 @@ import (
 // RepositoriesService handles communication with the repositories related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md
 type RepositoriesService struct {
 	client *Client
 }
 
 // TreeNode represents a GitLab repository file or directory.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md
 type TreeNode struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
@@ -47,7 +49,7 @@ func (t TreeNode) String() string {
 // ListTreeOptions represents the available ListTree() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#list-repository-tree
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#list-repository-tree
 type ListTreeOptions struct {
 	Path    *string `url:"path,omitempty" json:"path,omitempty"`
 	RefName *string `url:"ref_name,omitempty" json:"ref_name,omitempty"`
@@ -56,7 +58,7 @@ type ListTreeOptions struct {
 // ListTree gets a list of repository files and directories in a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#list-repository-tree
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#list-repository-tree
 func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, options ...OptionFunc) ([]*TreeNode, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -81,7 +83,7 @@ func (s *RepositoriesService) ListTree(pid interface{}, opt *ListTreeOptions, op
 // RawFileContentOptions represents the available RawFileContent() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#raw-file-content
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#raw-file-content
 type RawFileContentOptions struct {
 	FilePath *string `url:"filepath,omitempty" json:"filepath,omitempty"`
 }
@@ -89,7 +91,7 @@ type RawFileContentOptions struct {
 // RawFileContent gets the raw file contents for a file by commit SHA and path
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#raw-file-content
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#raw-file-content
 func (s *RepositoriesService) RawFileContent(pid interface{}, sha string, opt *RawFileContentOptions, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -114,7 +116,7 @@ func (s *RepositoriesService) RawFileContent(pid interface{}, sha string, opt *R
 // RawBlobContent gets the raw file contents for a blob by blob SHA.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#raw-blob-content
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#raw-blob-content
 func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -139,7 +141,7 @@ func (s *RepositoriesService) RawBlobContent(pid interface{}, sha string, option
 // ArchiveOptions represents the available Archive() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#get-file-archive
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#get-file-archive
 type ArchiveOptions struct {
 	SHA *string `url:"sha,omitempty" json:"sha,omitempty"`
 }
@@ -147,7 +149,7 @@ type ArchiveOptions struct {
 // Archive gets an archive of the repository.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#get-file-archive
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#get-file-archive
 func (s *RepositoriesService) Archive(pid interface{}, opt *ArchiveOptions, options ...OptionFunc) ([]byte, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -172,7 +174,7 @@ func (s *RepositoriesService) Archive(pid interface{}, opt *ArchiveOptions, opti
 // Compare represents the result of a comparison of branches, tags or commits.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#compare-branches-tags-or-commits
 type Compare struct {
 	Commit         *Commit   `json:"commit"`
 	Commits        []*Commit `json:"commits"`
@@ -188,7 +190,7 @@ func (c Compare) String() string {
 // CompareOptions represents the available Compare() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#compare-branches-tags-or-commits
 type CompareOptions struct {
 	From *string `url:"from,omitempty" json:"from,omitempty"`
 	To   *string `url:"to,omitempty" json:"to,omitempty"`
@@ -197,7 +199,7 @@ type CompareOptions struct {
 // Compare compares branches, tags or commits.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repositories.html#compare-branches-tags-or-commits
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#compare-branches-tags-or-commits
 func (s *RepositoriesService) Compare(pid interface{}, opt *CompareOptions, options ...OptionFunc) (*Compare, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -221,7 +223,8 @@ func (s *RepositoriesService) Compare(pid interface{}, opt *CompareOptions, opti
 
 // Contributor represents a GitLap contributor.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributer
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#contributer
 type Contributor struct {
 	Name      string `json:"name,omitempty"`
 	Email     string `json:"email,omitempty"`
@@ -236,7 +239,8 @@ func (c Contributor) String() string {
 
 // Contributors gets the repository contributors list.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repositories.html#contributer
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repositories.md#contributer
 func (s *RepositoriesService) Contributors(pid interface{}, options ...OptionFunc) ([]*Contributor, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/repository_files.go
+++ b/vendor/github.com/xanzy/go-gitlab/repository_files.go
@@ -24,14 +24,16 @@ import (
 // RepositoryFilesService handles communication with the repository files
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md
 type RepositoryFilesService struct {
 	client *Client
 }
 
 // File represents a GitLab repository file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md
 type File struct {
 	FileName string `json:"file_name"`
 	FilePath string `json:"file_path"`
@@ -50,7 +52,7 @@ func (r File) String() string {
 // GetFileOptions represents the available GetFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-respository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#get-file-from-respository
 type GetFileOptions struct {
 	FilePath *string `url:"file_path,omitempty" json:"file_path,omitempty"`
 	Ref      *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -60,7 +62,7 @@ type GetFileOptions struct {
 // name, size, content. Note that file content is Base64 encoded.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#get-file-from-respository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#get-file-from-respository
 func (s *RepositoryFilesService) GetFile(pid interface{}, opt *GetFileOptions, options ...OptionFunc) (*File, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -84,7 +86,8 @@ func (s *RepositoryFilesService) GetFile(pid interface{}, opt *GetFileOptions, o
 
 // FileInfo represents file details of a GitLab repository file.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/repository_files.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md
 type FileInfo struct {
 	FilePath   string `json:"file_path"`
 	BranchName string `json:"branch_name"`
@@ -97,7 +100,7 @@ func (r FileInfo) String() string {
 // CreateFileOptions represents the available CreateFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#create-new-file-in-repository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#create-new-file-in-repository
 type CreateFileOptions struct {
 	FilePath      *string `url:"file_path,omitempty" json:"file_path,omitempty"`
 	BranchName    *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
@@ -111,7 +114,7 @@ type CreateFileOptions struct {
 // CreateFile creates a new file in a repository.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#create-new-file-in-repository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#create-new-file-in-repository
 func (s *RepositoryFilesService) CreateFile(pid interface{}, opt *CreateFileOptions, options ...OptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -136,7 +139,7 @@ func (s *RepositoryFilesService) CreateFile(pid interface{}, opt *CreateFileOpti
 // UpdateFileOptions represents the available UpdateFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#update-existing-file-in-repository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#update-existing-file-in-repository
 type UpdateFileOptions struct {
 	FilePath      *string `url:"file_path,omitempty" json:"file_path,omitempty"`
 	BranchName    *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
@@ -150,7 +153,7 @@ type UpdateFileOptions struct {
 // UpdateFile updates an existing file in a repository
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#update-existing-file-in-repository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#update-existing-file-in-repository
 func (s *RepositoryFilesService) UpdateFile(pid interface{}, opt *UpdateFileOptions, options ...OptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -175,7 +178,7 @@ func (s *RepositoryFilesService) UpdateFile(pid interface{}, opt *UpdateFileOpti
 // DeleteFileOptions represents the available DeleteFile() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#delete-existing-file-in-repository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#delete-existing-file-in-repository
 type DeleteFileOptions struct {
 	FilePath      *string `url:"file_path,omitempty" json:"file_path,omitempty"`
 	BranchName    *string `url:"branch_name,omitempty" json:"branch_name,omitempty"`
@@ -187,7 +190,7 @@ type DeleteFileOptions struct {
 // DeleteFile deletes an existing file in a repository
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/repository_files.html#delete-existing-file-in-repository
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/repository_files.md#delete-existing-file-in-repository
 func (s *RepositoryFilesService) DeleteFile(pid interface{}, opt *DeleteFileOptions, options ...OptionFunc) (*FileInfo, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/services.go
+++ b/vendor/github.com/xanzy/go-gitlab/services.go
@@ -25,14 +25,16 @@ import (
 // ServicesService handles communication with the services related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/services.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md
 type ServicesService struct {
 	client *Client
 }
 
 // Service represents a GitLab service.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/services.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md
 type Service struct {
 	ID                  *int       `json:"id"`
 	Title               *string    `json:"title"`
@@ -50,7 +52,7 @@ type Service struct {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#edit-gitlab-ci-service
 type SetGitLabCIServiceOptions struct {
 	Token      *string `url:"token,omitempty" json:"token,omitempty"`
 	ProjectURL *string `url:"project_url,omitempty" json:"project_url,omitempty"`
@@ -59,7 +61,7 @@ type SetGitLabCIServiceOptions struct {
 // SetGitLabCIService sets GitLab CI service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-gitlab-ci-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#edit-gitlab-ci-service
 func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCIServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -78,7 +80,7 @@ func (s *ServicesService) SetGitLabCIService(pid interface{}, opt *SetGitLabCISe
 // DeleteGitLabCIService deletes GitLab CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-gitlab-ci-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#delete-gitlab-ci-service
 func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -98,7 +100,7 @@ func (s *ServicesService) DeleteGitLabCIService(pid interface{}, options ...Opti
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-hipchat-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#edit-hipchat-service
 type SetHipChatServiceOptions struct {
 	Token *string `url:"token,omitempty" json:"token,omitempty" `
 	Room  *string `url:"room,omitempty" json:"room,omitempty"`
@@ -107,7 +109,7 @@ type SetHipChatServiceOptions struct {
 // SetHipChatService sets HipChat service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-hipchat-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#edit-hipchat-service
 func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -126,7 +128,7 @@ func (s *ServicesService) SetHipChatService(pid interface{}, opt *SetHipChatServ
 // DeleteHipChatService deletes HipChat service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-hipchat-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#delete-hipchat-service
 func (s *ServicesService) DeleteHipChatService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -146,7 +148,7 @@ func (s *ServicesService) DeleteHipChatService(pid interface{}, options ...Optio
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#createedit-drone-ci-service
 type SetDroneCIServiceOptions struct {
 	Token                 *string `url:"token" json:"token" `
 	DroneURL              *string `url:"drone_url" json:"drone_url"`
@@ -156,7 +158,7 @@ type SetDroneCIServiceOptions struct {
 // SetDroneCIService sets Drone CI service for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#createedit-drone-ci-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#createedit-drone-ci-service
 func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -175,7 +177,7 @@ func (s *ServicesService) SetDroneCIService(pid interface{}, opt *SetDroneCIServ
 // DeleteDroneCIService deletes Drone CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-drone-ci-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#delete-drone-ci-service
 func (s *ServicesService) DeleteDroneCIService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -207,7 +209,7 @@ type DroneCIService struct {
 // GetDroneCIService gets Drone CI service settings for a project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#get-drone-ci-service-settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#get-drone-ci-service-settings
 func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFunc) (*DroneCIService, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -233,7 +235,7 @@ func (s *ServicesService) GetDroneCIService(pid interface{}, options ...OptionFu
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-slack-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#edit-slack-service
 type SetSlackServiceOptions struct {
 	WebHook  *string `url:"webhook,omitempty" json:"webhook,omitempty" `
 	Username *string `url:"username,omitempty" json:"username,omitempty" `
@@ -243,7 +245,7 @@ type SetSlackServiceOptions struct {
 // SetSlackService sets Slack service for a project
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#edit-slack-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#edit-slack-service
 func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceOptions, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -262,7 +264,7 @@ func (s *ServicesService) SetSlackService(pid interface{}, opt *SetSlackServiceO
 // DeleteSlackService deletes Slack service for project.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/services.html#delete-slack-service
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/services.md#delete-slack-service
 func (s *ServicesService) DeleteSlackService(pid interface{}, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/session.go
+++ b/vendor/github.com/xanzy/go-gitlab/session.go
@@ -21,14 +21,16 @@ import "time"
 // SessionService handles communication with the session related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/session.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/session.md
 type SessionService struct {
 	client *Client
 }
 
 // Session represents a GitLab session.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/session.html#session
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/session.md#session
 type Session struct {
 	ID               int         `json:"id"`
 	Username         string      `json:"username"`
@@ -52,7 +54,8 @@ type Session struct {
 
 // GetSessionOptions represents the available Session() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/session.html#session
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/session.md#session
 type GetSessionOptions struct {
 	Login    *string `url:"login,omitempty" json:"login,omitempty"`
 	Email    *string `url:"email,omitempty" json:"email,omitempty"`
@@ -61,7 +64,8 @@ type GetSessionOptions struct {
 
 // GetSession logs in to get private token.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/session.html#session
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/session.md#session
 func (s *SessionService) GetSession(opt *GetSessionOptions, options ...OptionFunc) (*Session, *Response, error) {
 	req, err := s.client.NewRequest("POST", "session", opt, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/settings.go
+++ b/vendor/github.com/xanzy/go-gitlab/settings.go
@@ -21,14 +21,16 @@ import "time"
 // SettingsService handles communication with the application SettingsService
 // related methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/settings.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/settings.md
 type SettingsService struct {
 	client *Client
 }
 
 // Settings represents the GitLab application settings.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/settings.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/settings.md
 type Settings struct {
 	ID                         int                    `json:"id"`
 	DefaultProjectsLimit       int                    `json:"default_projects_limit"`
@@ -58,7 +60,7 @@ func (s Settings) String() string {
 // GetSettings gets the current application settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/settings.html#get-current-application.settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/settings.md#get-current-application.settings
 func (s *SettingsService) GetSettings(options ...OptionFunc) (*Settings, *Response, error) {
 	req, err := s.client.NewRequest("GET", "application/settings", nil, options)
 	if err != nil {
@@ -77,7 +79,7 @@ func (s *SettingsService) GetSettings(options ...OptionFunc) (*Settings, *Respon
 // UpdateSettingsOptions represents the available UpdateSettings() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/settings.html#change-application.settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/settings.md#change-application.settings
 type UpdateSettingsOptions struct {
 	DefaultProjectsLimit       *int                   `url:"default_projects_limit,omitempty" json:"default_projects_limit,omitempty"`
 	SignupEnabled              *bool                  `url:"signup_enabled,omitempty" json:"signup_enabled,omitempty"`
@@ -100,7 +102,7 @@ type UpdateSettingsOptions struct {
 // UpdateSettings updates the application settings.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/settings.html#change-application.settings
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/settings.md#change-application.settings
 func (s *SettingsService) UpdateSettings(opt *UpdateSettingsOptions, options ...OptionFunc) (*Settings, *Response, error) {
 	req, err := s.client.NewRequest("PUT", "application/settings", opt, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/system_hooks.go
+++ b/vendor/github.com/xanzy/go-gitlab/system_hooks.go
@@ -24,14 +24,16 @@ import (
 // SystemHooksService handles communication with the system hooks related
 // methods of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/system_hooks.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md
 type SystemHooksService struct {
 	client *Client
 }
 
 // Hook represents a GitLap system hook.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/system_hooks.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md
 type Hook struct {
 	ID        int        `json:"id"`
 	URL       string     `json:"url"`
@@ -45,7 +47,7 @@ func (h Hook) String() string {
 // ListHooks gets a list of system hooks.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#list-system-hooks
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md#list-system-hooks
 func (s *SystemHooksService) ListHooks(options ...OptionFunc) ([]*Hook, *Response, error) {
 	req, err := s.client.NewRequest("GET", "hooks", nil, options)
 	if err != nil {
@@ -64,7 +66,7 @@ func (s *SystemHooksService) ListHooks(options ...OptionFunc) ([]*Hook, *Respons
 // AddHookOptions represents the available AddHook() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#add-new-system-hook-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md#add-new-system-hook-hook
 type AddHookOptions struct {
 	URL *string `url:"url,omitempty" json:"url,omitempty"`
 }
@@ -72,7 +74,7 @@ type AddHookOptions struct {
 // AddHook adds a new system hook hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#add-new-system-hook-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md#add-new-system-hook-hook
 func (s *SystemHooksService) AddHook(opt *AddHookOptions, options ...OptionFunc) (*Hook, *Response, error) {
 	req, err := s.client.NewRequest("POST", "hooks", opt, options)
 	if err != nil {
@@ -90,7 +92,8 @@ func (s *SystemHooksService) AddHook(opt *AddHookOptions, options ...OptionFunc)
 
 // HookEvent represents an event triggert by a GitLab system hook.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/system_hooks.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md
 type HookEvent struct {
 	EventName  string `json:"event_name"`
 	Name       string `json:"name"`
@@ -107,7 +110,7 @@ func (h HookEvent) String() string {
 // TestHook tests a system hook.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#test-system-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md#test-system-hook
 func (s *SystemHooksService) TestHook(hook int, options ...OptionFunc) (*HookEvent, *Response, error) {
 	u := fmt.Sprintf("hooks/%d", hook)
 
@@ -130,7 +133,7 @@ func (s *SystemHooksService) TestHook(hook int, options ...OptionFunc) (*HookEve
 // is also returned as JSON.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/system_hooks.html#delete-system-hook
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/system_hooks.md#delete-system-hook
 func (s *SystemHooksService) DeleteHook(hook int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("hooks/%d", hook)
 

--- a/vendor/github.com/xanzy/go-gitlab/tags.go
+++ b/vendor/github.com/xanzy/go-gitlab/tags.go
@@ -24,14 +24,16 @@ import (
 // TagsService handles communication with the tags related methods
 // of the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/tags.md
 type TagsService struct {
 	client *Client
 }
 
 // Tag represents a GitLab tag.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/tags.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/tags.md
 type Tag struct {
 	Commit  *Commit `json:"commit"`
 	Name    string  `json:"name"`
@@ -46,7 +48,7 @@ func (r Tag) String() string {
 // alphabetical order.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#list-project-repository-tags
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/tags.md#list-project-repository-tags
 func (s *TagsService) ListTags(pid interface{}, options ...OptionFunc) ([]*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -72,7 +74,7 @@ func (s *TagsService) ListTags(pid interface{}, options ...OptionFunc) ([]*Tag, 
 // with the tag information if the tag exists. It returns 404 if the tag does not exist.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#get-a-single-repository-tag
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/tags.md#get-a-single-repository-tag
 func (s *TagsService) GetTag(pid interface{}, tag string, options ...OptionFunc) (*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -97,7 +99,7 @@ func (s *TagsService) GetTag(pid interface{}, tag string, options ...OptionFunc)
 // CreateTagOptions represents the available CreateTag() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/tags.md#create-a-new-tag
 type CreateTagOptions struct {
 	TagName *string `url:"tag_name,omitempty" json:"tag_name,omitempty"`
 	Ref     *string `url:"ref,omitempty" json:"ref,omitempty"`
@@ -107,7 +109,7 @@ type CreateTagOptions struct {
 // CreateTag creates a new tag in the repository that points to the supplied ref.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#create-a-new-tag
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/tags.md#create-a-new-tag
 func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options ...OptionFunc) (*Tag, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -132,7 +134,7 @@ func (s *TagsService) CreateTag(pid interface{}, opt *CreateTagOptions, options 
 // DeleteTag deletes a tag of a repository with given name.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/tags.html#delete-a-tag
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/tags.md#delete-a-tag
 func (s *TagsService) DeleteTag(pid interface{}, tag string, options ...OptionFunc) (*Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/time_stats.go
+++ b/vendor/github.com/xanzy/go-gitlab/time_stats.go
@@ -8,15 +8,17 @@ import (
 // TimeStatsService handles communication with the time tracking related
 // methods of the GitLab API.
 //
-// GitLab docs: https://docs.gitlab.com/ce/workflow/time_tracking.html
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
+// GitLab docs: https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/workflow/time_tracking.md
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md
 type TimeStatsService struct {
 	client *Client
 }
 
 // TimeStats represents the time estimates and time spent for an issue.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/issues.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md
 type TimeStats struct {
 	HumanTimeEstimate   string `json:"human_time_estimate"`
 	HumanTotalTimeSpent string `json:"human_total_time_spent"`
@@ -32,7 +34,7 @@ func (t TimeStats) String() string {
 // options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#set-a-time-estimate-for-an-issue
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#set-a-time-estimate-for-an-issue
 type SetTimeEstimateOptions struct {
 	Duration *string `url:"duration,omitempty" json:"duration,omitempty"`
 }
@@ -40,7 +42,7 @@ type SetTimeEstimateOptions struct {
 // SetTimeEstimate sets the time estimate for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#set-a-time-estimate-for-an-issue
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#set-a-time-estimate-for-an-issue
 func (s *TimeStatsService) SetTimeEstimate(pid interface{}, issue int, opt *SetTimeEstimateOptions, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -65,7 +67,7 @@ func (s *TimeStatsService) SetTimeEstimate(pid interface{}, issue int, opt *SetT
 // ResetTimeEstimate resets the time estimate for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#reset-the-time-estimate-for-an-issue
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#reset-the-time-estimate-for-an-issue
 func (s *TimeStatsService) ResetTimeEstimate(pid interface{}, issue int, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -90,7 +92,7 @@ func (s *TimeStatsService) ResetTimeEstimate(pid interface{}, issue int, options
 // AddSpentTimeOptions represents the available AddSpentTime() options.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#add-spent-time-for-an-issue
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#add-spent-time-for-an-issue
 type AddSpentTimeOptions struct {
 	Duration *string `url:"duration,omitempty" json:"duration,omitempty"`
 }
@@ -98,7 +100,7 @@ type AddSpentTimeOptions struct {
 // AddSpentTime adds spent time for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#add-spent-time-for-an-issue
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#add-spent-time-for-an-issue
 func (s *TimeStatsService) AddSpentTime(pid interface{}, issue int, opt *AddSpentTimeOptions, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -123,7 +125,7 @@ func (s *TimeStatsService) AddSpentTime(pid interface{}, issue int, opt *AddSpen
 // ResetSpentTime resets the spent time for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#reset-spent-time-for-an-issue
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#reset-spent-time-for-an-issue
 func (s *TimeStatsService) ResetSpentTime(pid interface{}, issue int, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {
@@ -148,7 +150,7 @@ func (s *TimeStatsService) ResetSpentTime(pid interface{}, issue int, options ..
 // GetTimeSpent gets the spent time for a single project issue.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/issues.html#get-time-tracking-stats
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/issues.md#get-time-tracking-stats
 func (s *TimeStatsService) GetTimeSpent(pid interface{}, issue int, options ...OptionFunc) (*TimeStats, *Response, error) {
 	project, err := parseID(pid)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -25,14 +25,16 @@ import (
 // UsersService handles communication with the user related methods of
 // the GitLab API.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md
 type UsersService struct {
 	client *Client
 }
 
 // User represents a GitLab user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md
 type User struct {
 	ID               int             `json:"id"`
 	Username         string          `json:"username"`
@@ -68,7 +70,8 @@ type UserIdentity struct {
 
 // ListUsersOptions represents the available ListUsers() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-users
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#list-users
 type ListUsersOptions struct {
 	ListOptions
 	Active   *bool   `url:"active,omitempty" json:"active,omitempty"`
@@ -78,7 +81,8 @@ type ListUsersOptions struct {
 
 // ListUsers gets a list of users.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-users
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#list-users
 func (s *UsersService) ListUsers(opt *ListUsersOptions, options ...OptionFunc) ([]*User, *Response, error) {
 	req, err := s.client.NewRequest("GET", "users", opt, options)
 	if err != nil {
@@ -96,7 +100,8 @@ func (s *UsersService) ListUsers(opt *ListUsersOptions, options ...OptionFunc) (
 
 // GetUser gets a single user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-user
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#single-user
 func (s *UsersService) GetUser(user int, options ...OptionFunc) (*User, *Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
@@ -116,7 +121,8 @@ func (s *UsersService) GetUser(user int, options ...OptionFunc) (*User, *Respons
 
 // CreateUserOptions represents the available CreateUser() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-creation
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#user-creation
 type CreateUserOptions struct {
 	Email          *string `url:"email,omitempty" json:"email,omitempty"`
 	Password       *string `url:"password,omitempty" json:"password,omitempty"`
@@ -137,7 +143,8 @@ type CreateUserOptions struct {
 
 // CreateUser creates a new user. Note only administrators can create new users.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-creation
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#user-creation
 func (s *UsersService) CreateUser(opt *CreateUserOptions, options ...OptionFunc) (*User, *Response, error) {
 	req, err := s.client.NewRequest("POST", "users", opt, options)
 	if err != nil {
@@ -155,7 +162,8 @@ func (s *UsersService) CreateUser(opt *CreateUserOptions, options ...OptionFunc)
 
 // ModifyUserOptions represents the available ModifyUser() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-modification
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#user-modification
 type ModifyUserOptions struct {
 	Email          *string `url:"email,omitempty" json:"email,omitempty"`
 	Password       *string `url:"password,omitempty" json:"password,omitempty"`
@@ -176,7 +184,8 @@ type ModifyUserOptions struct {
 // ModifyUser modifies an existing user. Only administrators can change attributes
 // of a user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-modification
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#user-modification
 func (s *UsersService) ModifyUser(user int, opt *ModifyUserOptions, options ...OptionFunc) (*User, *Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
@@ -200,7 +209,8 @@ func (s *UsersService) ModifyUser(user int, opt *ModifyUserOptions, options ...O
 // actually deleted or not. In the former the user is returned and in the
 // latter not.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#user-deletion
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#user-deletion
 func (s *UsersService) DeleteUser(user int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d", user)
 
@@ -214,7 +224,8 @@ func (s *UsersService) DeleteUser(user int, options ...OptionFunc) (*Response, e
 
 // CurrentUser gets currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#current-user
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#current-user
 func (s *UsersService) CurrentUser(options ...OptionFunc) (*User, *Response, error) {
 	req, err := s.client.NewRequest("GET", "user", nil, options)
 	if err != nil {
@@ -232,7 +243,8 @@ func (s *UsersService) CurrentUser(options ...OptionFunc) (*User, *Response, err
 
 // SSHKey represents a SSH key.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-ssh-keys
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#list-ssh-keys
 type SSHKey struct {
 	ID        int        `json:"id"`
 	Title     string     `json:"title"`
@@ -242,7 +254,8 @@ type SSHKey struct {
 
 // ListSSHKeys gets a list of currently authenticated user's SSH keys.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-ssh-keys
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#list-ssh-keys
 func (s *UsersService) ListSSHKeys(options ...OptionFunc) ([]*SSHKey, *Response, error) {
 	req, err := s.client.NewRequest("GET", "user/keys", nil, options)
 	if err != nil {
@@ -262,7 +275,7 @@ func (s *UsersService) ListSSHKeys(options ...OptionFunc) ([]*SSHKey, *Response,
 // only for admin
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#list-ssh-keys-for-user
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#list-ssh-keys-for-user
 func (s *UsersService) ListSSHKeysForUser(user int, options ...OptionFunc) ([]*SSHKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/keys", user)
 
@@ -282,7 +295,8 @@ func (s *UsersService) ListSSHKeysForUser(user int, options ...OptionFunc) ([]*S
 
 // GetSSHKey gets a single key.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-ssh-key
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#single-ssh-key
 func (s *UsersService) GetSSHKey(kid int, options ...OptionFunc) (*SSHKey, *Response, error) {
 	u := fmt.Sprintf("user/keys/%d", kid)
 
@@ -302,7 +316,8 @@ func (s *UsersService) GetSSHKey(kid int, options ...OptionFunc) (*SSHKey, *Resp
 
 // AddSSHKeyOptions represents the available AddSSHKey() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#add-ssh-key
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#add-ssh-key
 type AddSSHKeyOptions struct {
 	Title *string `url:"title,omitempty" json:"title,omitempty"`
 	Key   *string `url:"key,omitempty" json:"key,omitempty"`
@@ -310,7 +325,8 @@ type AddSSHKeyOptions struct {
 
 // AddSSHKey creates a new key owned by the currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-ssh-key
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#add-ssh-key
 func (s *UsersService) AddSSHKey(opt *AddSSHKeyOptions, options ...OptionFunc) (*SSHKey, *Response, error) {
 	req, err := s.client.NewRequest("POST", "user/keys", opt, options)
 	if err != nil {
@@ -329,7 +345,8 @@ func (s *UsersService) AddSSHKey(opt *AddSSHKeyOptions, options ...OptionFunc) (
 // AddSSHKeyForUser creates new key owned by specified user. Available only for
 // admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-ssh-key-for-user
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#add-ssh-key-for-user
 func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, options ...OptionFunc) (*SSHKey, *Response, error) {
 	u := fmt.Sprintf("users/%d/keys", user)
 
@@ -352,7 +369,7 @@ func (s *UsersService) AddSSHKeyForUser(user int, opt *AddSSHKeyOptions, options
 // available results in 200 OK.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-ssh-key-for-current-owner
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#delete-ssh-key-for-current-owner
 func (s *UsersService) DeleteSSHKey(kid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/keys/%d", kid)
 
@@ -368,7 +385,7 @@ func (s *UsersService) DeleteSSHKey(kid int, options ...OptionFunc) (*Response, 
 // for admin.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-ssh-key-for-given-user
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#delete-ssh-key-for-given-user
 func (s *UsersService) DeleteSSHKeyForUser(user int, kid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/keys/%d", user, kid)
 
@@ -382,7 +399,8 @@ func (s *UsersService) DeleteSSHKeyForUser(user int, kid int, options ...OptionF
 
 // BlockUser blocks the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#block-user
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#block-user
 func (s *UsersService) BlockUser(user int, options ...OptionFunc) error {
 	u := fmt.Sprintf("users/%d/block", user)
 
@@ -402,7 +420,7 @@ func (s *UsersService) BlockUser(user int, options ...OptionFunc) error {
 	case 403:
 		return errors.New("Cannot block a user that is already blocked by LDAP synchronization")
 	case 404:
-		return errors.New("User does not exists")
+		return errors.New("User does not exist")
 	default:
 		return fmt.Errorf("Received unexpected result code: %d", resp.StatusCode)
 	}
@@ -410,7 +428,8 @@ func (s *UsersService) BlockUser(user int, options ...OptionFunc) error {
 
 // UnblockUser unblocks the specified user. Available only for admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#unblock-user
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#unblock-user
 func (s *UsersService) UnblockUser(user int, options ...OptionFunc) error {
 	u := fmt.Sprintf("users/%d/unblock", user)
 
@@ -430,7 +449,7 @@ func (s *UsersService) UnblockUser(user int, options ...OptionFunc) error {
 	case 403:
 		return errors.New("Cannot unblock a user that is blocked by LDAP synchronization")
 	case 404:
-		return errors.New("User does not exists")
+		return errors.New("User does not exist")
 	default:
 		return fmt.Errorf("Received unexpected result code: %d", resp.StatusCode)
 	}
@@ -446,7 +465,8 @@ type Email struct {
 
 // ListEmails gets a list of currently authenticated user's Emails.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#list-emails
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#list-emails
 func (s *UsersService) ListEmails(options ...OptionFunc) ([]*Email, *Response, error) {
 	req, err := s.client.NewRequest("GET", "user/emails", nil, options)
 	if err != nil {
@@ -466,7 +486,7 @@ func (s *UsersService) ListEmails(options ...OptionFunc) ([]*Email, *Response, e
 // only for admin
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#list-emails-for-user
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#list-emails-for-user
 func (s *UsersService) ListEmailsForUser(uid int, options ...OptionFunc) ([]*Email, *Response, error) {
 	u := fmt.Sprintf("users/%d/emails", uid)
 
@@ -486,7 +506,8 @@ func (s *UsersService) ListEmailsForUser(uid int, options ...OptionFunc) ([]*Ema
 
 // GetEmail gets a single email.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#single-email
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#single-email
 func (s *UsersService) GetEmail(eid int, options ...OptionFunc) (*Email, *Response, error) {
 	u := fmt.Sprintf("user/emails/%d", eid)
 
@@ -506,14 +527,16 @@ func (s *UsersService) GetEmail(eid int, options ...OptionFunc) (*Email, *Respon
 
 // AddEmailOptions represents the available AddEmail() options.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/projects.html#add-email
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/projects.md#add-email
 type AddEmailOptions struct {
 	Email *string `url:"email,omitempty" json:"email,omitempty"`
 }
 
 // AddEmail creates a new email owned by the currently authenticated user.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#add-email
 func (s *UsersService) AddEmail(opt *AddEmailOptions, options ...OptionFunc) (*Email, *Response, error) {
 	req, err := s.client.NewRequest("POST", "user/emails", opt, options)
 	if err != nil {
@@ -532,7 +555,8 @@ func (s *UsersService) AddEmail(opt *AddEmailOptions, options ...OptionFunc) (*E
 // AddEmailForUser creates new email owned by specified user. Available only for
 // admin.
 //
-// GitLab API docs: https://docs.gitlab.com/ce/api/users.html#add-email-for-user
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#add-email-for-user
 func (s *UsersService) AddEmailForUser(uid int, opt *AddEmailOptions, options ...OptionFunc) (*Email, *Response, error) {
 	u := fmt.Sprintf("users/%d/emails", uid)
 
@@ -555,7 +579,7 @@ func (s *UsersService) AddEmailForUser(uid int, opt *AddEmailOptions, options ..
 // available results in 200 OK.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-email-for-current-owner
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#delete-email-for-current-owner
 func (s *UsersService) DeleteEmail(eid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("user/emails/%d", eid)
 
@@ -571,7 +595,7 @@ func (s *UsersService) DeleteEmail(eid int, options ...OptionFunc) (*Response, e
 // for admin.
 //
 // GitLab API docs:
-// https://docs.gitlab.com/ce/api/users.html#delete-email-for-given-user
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/users.md#delete-email-for-given-user
 func (s *UsersService) DeleteEmailForUser(uid int, eid int, options ...OptionFunc) (*Response, error) {
 	u := fmt.Sprintf("users/%d/emails/%d", uid, eid)
 

--- a/vendor/github.com/xanzy/go-gitlab/version.go
+++ b/vendor/github.com/xanzy/go-gitlab/version.go
@@ -1,0 +1,59 @@
+//
+// Copyright 2017, Andrea Funto'
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+// VersionService handles communication with the GitLab server instance to
+// retrieve its version information via the GitLab API.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/version.md
+type VersionService struct {
+	client *Client
+}
+
+// Version represents a GitLab instance version.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/version.md
+type Version struct {
+	Version  string `json:"version"`
+	Revision string `json:"revision"`
+}
+
+func (s Version) String() string {
+	return Stringify(s)
+}
+
+// GetVersion gets a GitLab server instance version; it is only available to
+// authenticated users.
+//
+// GitLab API docs:
+// https://gitlab.com/gitlab-org/gitlab-ce/blob/8-16-stable/doc/api/version.md
+func (s *VersionService) GetVersion() (*Version, *Response, error) {
+	req, err := s.client.NewRequest("GET", "version", nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(Version)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3090,10 +3090,10 @@
 			"revisionTime": "2017-05-11T07:54:48Z"
 		},
 		{
-			"checksumSHA1": "1mR4/KWIQEL8rzyDlCR4CRrTqGQ=",
+			"checksumSHA1": "kFgPDwAreL0jsQ7+FoQhRJfbN4I=",
 			"path": "github.com/xanzy/go-gitlab",
-			"revision": "5b756e2fdc9f21fd4791fa1453b8fe01af0f82e2",
-			"revisionTime": "2017-03-22T12:21:15Z"
+			"revision": "e6c11edf9a78fdfa4e0fbbc8263e325b5ae50100",
+			"revisionTime": "2017-05-18T07:32:22Z"
 		},
 		{
 			"checksumSHA1": "iHiMTBffQvWYlOLu3130JXuQpgQ=",

--- a/website/source/docs/providers/gitlab/r/group.html.markdown
+++ b/website/source/docs/providers/gitlab/r/group.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_group"
+sidebar_current: "docs-gitlab-resource-group"
+description: |-
+Creates and manages GitLab groups
+---
+
+# gitlab\_group
+
+This resource allows you to create and manage GitLab groups.
+Note your provider will need to be configured with admin-level access for this resource to work.
+
+## Example Usage
+
+```hcl
+resource "gitlab_group" "example" {
+  name        = "example"
+  path        = "example"
+  description = "An example group"
+}
+
+// Create a project in the example group
+resource "gitlab_project" "example" {
+  name         = "example"
+  description  = "An example project"
+  namespace_id = "${gitlab_group.example.id}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of this group.
+
+* `path` - (Required) The url of the hook to invoke.
+
+* `description` - (Optional) The description of the group.
+
+* `lfs_enabled` - (Optional) Boolean, defaults to true.  Whether to enable LFS
+support for projects in this group.
+
+* `request_access_enabled` - (Optional) Boolean, defaults to false.  Whether to
+enable users to request access to the group.
+
+* `visibility_level` - (Optional) Set to `public` to create a public group.
+  Valid values are `private`, `internal`, `public`.
+  Groups are created as private by default.
+
+## Attributes Reference
+
+The resource exports the following attributes:
+
+* `id` - The unique id assigned to the group by the GitLab server.  Serves as a
+  namespace id where one is needed.


### PR DESCRIPTION
This adds a gitlab_group resource, as suggested in #14471

This combined with #14483 should allow you to create projects in a
group (untested)

The implementation of this is a little ugly as go-gitlab doesn't have a
function already present for EditGroup, so we hack it into being as part
of the implementation of  resourceGitlabGroupUpdate