### PR TITLE
provider/aws: Support filtering in ASG data source

### DIFF
--- a/builtin/providers/aws/data_source_aws_autoscaling_groups_test.go
+++ b/builtin/providers/aws/data_source_aws_autoscaling_groups_test.go
@@ -202,6 +202,16 @@ resource "aws_autoscaling_group" "barbaz" {
   }
 }
 
-data "aws_autoscaling_groups" "group_list" {}
+data "aws_autoscaling_groups" "group_list" {
+  filter {
+    name = "key"
+    values = ["Foo"]
+  }
+
+  filter {
+    name = "value"
+    values = ["foo-bar"]
+  }
+}
 `, rInt1, rInt2, rInt3)
 }

--- a/website/source/docs/providers/aws/d/autoscaling_groups.html.markdown
+++ b/website/source/docs/providers/aws/d/autoscaling_groups.html.markdown
@@ -14,7 +14,17 @@ ASGs within a specific region. This will allow you to pass a list of AutoScaling
 ## Example Usage
 
 ```hcl
-data "aws_autoscaling_groups" "groups" {}
+data "aws_autoscaling_groups" "groups" {
+  filter {
+    name = "key"
+    values = ["Team"]
+  }
+
+  filter {
+    name = "value"
+    values = ["Pets"]
+  }
+}
 
 resource "aws_autoscaling_notification" "slack_notifications" {
   group_names = ["${data.aws_autoscaling_groups.groups.names}"]
@@ -32,7 +42,9 @@ resource "aws_autoscaling_notification" "slack_notifications" {
 
 ## Argument Reference
 
-The data source currently takes no arguments as it uses the current region in which the provider is currently operating.
+* `filter` - (Optional) A filter used to scope the list e.g. by tags. See [related docs](http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_Filter.html).
+  * `name` - (Required) The name of the filter. The valid values are: `auto-scaling-group`, `key`, `value`, and `propagate-at-launch`.
+  * `values` - (Required) The value of the filter.
 
 ## Attributes Reference
 


### PR DESCRIPTION
The original intention was to fix the following test failure:
```
=== RUN   TestAccAWSAutoscalingGroups_basic
--- FAIL: TestAccAWSAutoscalingGroups_basic (77.99s)
    testing.go:280: Step 1 error: Check failed: Check 2/2 error: data.aws_autoscaling_groups.group_list: Attribute 'names.#' expected "3", got "5"
FAIL
```

Looking up all ASGs in the whole region in an account which may not be used just for tests is a bit naive as things may change all the time (ASGs come and go as people are testing things), so I added filtering which allows us to scope ASGs via tags.