### PR TITLE
[MS] 14058 single placement group tf

### DIFF
--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -78,6 +78,7 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+				ForceNew: true,
 			},
 
 			"os_profile": {
@@ -1131,17 +1132,17 @@ func expandAzureRMVirtualMachineScaleSetsStorageProfileOsDisk(d *schema.Resource
 			managedDisk.StorageAccountType = compute.StorageAccountTypes(managedDiskType)
 			osDisk.ManagedDisk = managedDisk
 		} else {
-			return nil, fmt.Errorf("[ERROR] Conflict between `name` and `managed_disk_type` (please set name to blank)")
+			return nil, fmt.Errorf("[ERROR] Conflict between `name` and `managed_disk_type` on `storage_profile_os_disk` (please set name to blank)")
 		}
 	}
 
 	//BEGIN: code to be removed after GH-13016 is merged
 	if image != "" && managedDiskType != "" {
-		return nil, fmt.Errorf("[ERROR] Conflict between `image` and `managed_disk_type` (only one or the other can be used)")
+		return nil, fmt.Errorf("[ERROR] Conflict between `image` and `managed_disk_type` on `storage_profile_os_disk` (only one or the other can be used)")
 	}
 
 	if len(vhd_containers) > 0 && managedDiskType != "" {
-		return nil, fmt.Errorf("[ERROR] Conflict between `vhd_containers` and `managed_disk_type` (only one or the other can be used)")
+		return nil, fmt.Errorf("[ERROR] Conflict between `vhd_containers` and `managed_disk_type` on `storage_profile_os_disk` (only one or the other can be used)")
 	}
 	//END: code to be removed after GH-13016 is merged
 

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set.go
@@ -74,6 +74,12 @@ func resourceArmVirtualMachineScaleSet() *schema.Resource {
 				Optional: true,
 			},
 
+			"single_placement_group": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+
 			"os_profile": {
 				Type:     schema.TypeSet,
 				Required: true,
@@ -463,6 +469,8 @@ func resourceArmVirtualMachineScaleSetCreate(d *schema.ResourceData, meta interf
 
 	updatePolicy := d.Get("upgrade_policy_mode").(string)
 	overprovision := d.Get("overprovision").(bool)
+	singlePlacementGroup := d.Get("single_placement_group").(bool)
+
 	scaleSetProps := compute.VirtualMachineScaleSetProperties{
 		UpgradePolicy: &compute.UpgradePolicy{
 			Mode: compute.UpgradeMode(updatePolicy),
@@ -473,7 +481,8 @@ func resourceArmVirtualMachineScaleSetCreate(d *schema.ResourceData, meta interf
 			OsProfile:        osProfile,
 			ExtensionProfile: extensions,
 		},
-		Overprovision: &overprovision,
+		Overprovision:        &overprovision,
+		SinglePlacementGroup: &singlePlacementGroup,
 	}
 
 	scaleSetParams := compute.VirtualMachineScaleSet{
@@ -533,6 +542,7 @@ func resourceArmVirtualMachineScaleSetRead(d *schema.ResourceData, meta interfac
 
 	d.Set("upgrade_policy_mode", properties.UpgradePolicy.Mode)
 	d.Set("overprovision", properties.Overprovision)
+	d.Set("single_placement_group", properties.SinglePlacementGroup)
 
 	osProfile, err := flattenAzureRMVirtualMachineScaleSetOsProfile(properties.VirtualMachineProfile.OsProfile)
 	if err != nil {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -211,12 +211,15 @@ func TestAccAzureRMVirtualMachineScaleSet_osDiskTypeConflict(t *testing.T) {
 	})
 }
 
-func testGetAzureRMVirtualMachineScaleSet(s *terraform.State, name string) (result *compute.VirtualMachineScaleSet, err error) {
+func testGetAzureRMVirtualMachineScaleSet(s *terraform.State, resourceName string) (result *compute.VirtualMachineScaleSet, err error) {
 	// Ensure we have enough information in state to look up in API
-	rs, ok := s.RootModule().Resources[name]
+	rs, ok := s.RootModule().Resources[resourceName]
 	if !ok {
-		return nil, fmt.Errorf("Not found: %s", name)
+		return nil, fmt.Errorf("Not found: %s", resourceName)
 	}
+
+	// Name of the actual scale set
+	name := rs.Primary.Attributes["name"]
 
 	resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
 	if !hasResourceGroup {

--- a/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
+++ b/builtin/providers/azurerm/resource_arm_virtual_machine_scale_set_test.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/arm/compute"
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -23,6 +24,28 @@ func TestAccAzureRMVirtualMachineScaleSet_basic(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+
+					// single placement group should default to true
+					testCheckAzureRMVirtualMachineScaleSetSinglePlacementGroup("azurerm_virtual_machine_scale_set.test", true),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAzureRMVirtualMachineScaleSet_singlePlacementGroupFalse(t *testing.T) {
+	ri := acctest.RandInt()
+	config := fmt.Sprintf(testAccAzureRMVirtualMachineScaleSet_singlePlacementGroupFalse, ri)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testCheckAzureRMVirtualMachineScaleSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					testCheckAzureRMVirtualMachineScaleSetExists("azurerm_virtual_machine_scale_set.test"),
+					testCheckAzureRMVirtualMachineScaleSetSinglePlacementGroup("azurerm_virtual_machine_scale_set.test", false),
 				),
 			},
 		},
@@ -188,32 +211,36 @@ func TestAccAzureRMVirtualMachineScaleSet_osDiskTypeConflict(t *testing.T) {
 	})
 }
 
+func testGetAzureRMVirtualMachineScaleSet(s *terraform.State, name string) (result *compute.VirtualMachineScaleSet, err error) {
+	// Ensure we have enough information in state to look up in API
+	rs, ok := s.RootModule().Resources[name]
+	if !ok {
+		return nil, fmt.Errorf("Not found: %s", name)
+	}
+
+	resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
+	if !hasResourceGroup {
+		return nil, fmt.Errorf("Bad: no resource group found in state for virtual machine: scale set %s", name)
+	}
+
+	conn := testAccProvider.Meta().(*ArmClient).vmScaleSetClient
+
+	vmss, err := conn.Get(resourceGroup, name)
+	if err != nil {
+		return nil, fmt.Errorf("Bad: Get on vmScaleSetClient: %s", err)
+	}
+
+	if vmss.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("Bad: VirtualMachineScaleSet %q (resource group: %q) does not exist", name, resourceGroup)
+	}
+
+	return &vmss, err
+}
+
 func testCheckAzureRMVirtualMachineScaleSetExists(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		name := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual machine: scale set %s", name)
-		}
-
-		conn := testAccProvider.Meta().(*ArmClient).vmScaleSetClient
-
-		resp, err := conn.Get(resourceGroup, name)
-		if err != nil {
-			return fmt.Errorf("Bad: Get on vmScaleSetClient: %s", err)
-		}
-
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: VirtualMachineScaleSet %q (resource group: %q) does not exist", name, resourceGroup)
-		}
-
-		return nil
+		_, err := testGetAzureRMVirtualMachineScaleSet(s, name)
+		return err
 	}
 }
 
@@ -269,26 +296,9 @@ func testCheckAzureRMVirtualMachineScaleSetDestroy(s *terraform.State) error {
 
 func testCheckAzureRMVirtualMachineScaleSetHasLoadbalancer(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		name := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual machine: scale set %s", name)
-		}
-
-		conn := testAccProvider.Meta().(*ArmClient).vmScaleSetClient
-		resp, err := conn.Get(resourceGroup, name)
+		resp, err := testGetAzureRMVirtualMachineScaleSet(s, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on vmScaleSetClient: %s", err)
-		}
-
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: VirtualMachineScaleSet %q (resource group: %q) does not exist", name, resourceGroup)
+			return err
 		}
 
 		n := resp.VirtualMachineProfile.NetworkProfile.NetworkInterfaceConfigurations
@@ -312,26 +322,9 @@ func testCheckAzureRMVirtualMachineScaleSetHasLoadbalancer(name string) resource
 
 func testCheckAzureRMVirtualMachineScaleSetOverprovision(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		name := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual machine: scale set %s", name)
-		}
-
-		conn := testAccProvider.Meta().(*ArmClient).vmScaleSetClient
-		resp, err := conn.Get(resourceGroup, name)
+		resp, err := testGetAzureRMVirtualMachineScaleSet(s, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on vmScaleSetClient: %s", err)
-		}
-
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: VirtualMachineScaleSet %q (resource group: %q) does not exist", name, resourceGroup)
+			return err
 		}
 
 		if *resp.Overprovision {
@@ -342,28 +335,26 @@ func testCheckAzureRMVirtualMachineScaleSetOverprovision(name string) resource.T
 	}
 }
 
+func testCheckAzureRMVirtualMachineScaleSetSinglePlacementGroup(name string, expectedSinglePlacementGroup bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		resp, err := testGetAzureRMVirtualMachineScaleSet(s, name)
+		if err != nil {
+			return err
+		}
+
+		if *resp.SinglePlacementGroup != expectedSinglePlacementGroup {
+			return fmt.Errorf("Bad: Overprovision should have been %t for scale set %v", expectedSinglePlacementGroup, name)
+		}
+
+		return nil
+	}
+}
+
 func testCheckAzureRMVirtualMachineScaleSetExtension(name string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		// Ensure we have enough information in state to look up in API
-		rs, ok := s.RootModule().Resources[name]
-		if !ok {
-			return fmt.Errorf("Not found: %s", name)
-		}
-
-		name := rs.Primary.Attributes["name"]
-		resourceGroup, hasResourceGroup := rs.Primary.Attributes["resource_group_name"]
-		if !hasResourceGroup {
-			return fmt.Errorf("Bad: no resource group found in state for virtual machine: scale set %s", name)
-		}
-
-		conn := testAccProvider.Meta().(*ArmClient).vmScaleSetClient
-		resp, err := conn.Get(resourceGroup, name)
+		resp, err := testGetAzureRMVirtualMachineScaleSet(s, name)
 		if err != nil {
-			return fmt.Errorf("Bad: Get on vmScaleSetClient: %s", err)
-		}
-
-		if resp.StatusCode == http.StatusNotFound {
-			return fmt.Errorf("Bad: VirtualMachineScaleSet %q (resource group: %q) does not exist", name, resourceGroup)
+			return err
 		}
 
 		n := resp.VirtualMachineProfile.ExtensionProfile.Extensions
@@ -457,6 +448,100 @@ resource "azurerm_virtual_machine_scale_set" "test" {
     caching       = "ReadWrite"
     create_option = "FromImage"
     vhd_containers = ["${azurerm_storage_account.test.primary_blob_endpoint}${azurerm_storage_container.test.name}"]
+  }
+
+  storage_profile_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "16.04-LTS"
+    version   = "latest"
+  }
+}
+`
+
+var testAccAzureRMVirtualMachineScaleSet_singlePlacementGroupFalse = `
+resource "azurerm_resource_group" "test" {
+    name = "acctestRG-%[1]d"
+    location = "West US 2"
+}
+
+resource "azurerm_virtual_network" "test" {
+    name = "acctvn-%[1]d"
+    address_space = ["10.0.0.0/16"]
+    location = "West US 2"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+}
+
+resource "azurerm_subnet" "test" {
+    name = "acctsub-%[1]d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    virtual_network_name = "${azurerm_virtual_network.test.name}"
+    address_prefix = "10.0.2.0/24"
+}
+
+resource "azurerm_network_interface" "test" {
+    name = "acctni-%[1]d"
+    location = "West US 2"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+
+    ip_configuration {
+    	name = "testconfiguration1"
+    	subnet_id = "${azurerm_subnet.test.id}"
+    	private_ip_address_allocation = "dynamic"
+    }
+}
+
+resource "azurerm_storage_account" "test" {
+    name = "accsa%[1]d"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    location = "West US 2"
+    account_type = "Standard_LRS"
+
+    tags {
+        environment = "staging"
+    }
+}
+
+resource "azurerm_storage_container" "test" {
+    name = "vhds"
+    resource_group_name = "${azurerm_resource_group.test.name}"
+    storage_account_name = "${azurerm_storage_account.test.name}"
+    container_access_type = "private"
+}
+
+resource "azurerm_virtual_machine_scale_set" "test" {
+  name = "acctvmss-%[1]d"
+  location = "West US 2"
+  resource_group_name = "${azurerm_resource_group.test.name}"
+  upgrade_policy_mode = "Manual"
+  single_placement_group = false
+
+  sku {
+    name = "Standard_D1_v2"
+    tier = "Standard"
+    capacity = 2
+  }
+
+  os_profile {
+    computer_name_prefix = "testvm-%[1]d"
+    admin_username = "myadmin"
+    admin_password = "Passwword1234"
+  }
+
+  network_profile {
+      name = "TestNetworkProfile-%[1]d"
+      primary = true
+      ip_configuration {
+        name = "TestIPConfiguration"
+        subnet_id = "${azurerm_subnet.test.id}"
+      }
+  }
+
+  storage_profile_os_disk {
+    name = ""
+    caching       = "ReadWrite"
+    create_option = "FromImage"
+    managed_disk_type = "Standard_LRS"
   }
 
   storage_profile_image_reference {

--- a/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
+++ b/website/source/docs/providers/azurerm/r/virtual_machine_scale_sets.html.markdown
@@ -240,6 +240,7 @@ The following arguments are supported:
 * `sku` - (Required) A sku block as documented below.
 * `upgrade_policy_mode` - (Required) Specifies the mode of an upgrade to virtual machines in the scale set. Possible values, `Manual` or `Automatic`.
 * `overprovision` - (Optional) Specifies whether the virtual machine scale set should be overprovisioned.
+* `single_placement_group` - (Optional) Specifies whether the scale set is limited to a single placement group with a maximum size of 100 virtual machines. If set to false, managed disks must be used. Default is true. See [documentation](http://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-placement-groups) for more information.
 * `os_profile` - (Required) A Virtual Machine OS Profile block as documented below.
 * `os_profile_secrets` - (Optional) A collection of Secret blocks as documented below.
 * `os_profile_windows_config` - (Required, when a windows machine) A Windows config block as documented below.


### PR DESCRIPTION
Fixes #14058 

Add single_placement_group property to VMSS (defaults to false).

All VMSS tests pass
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/15 19:20:00 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/azurerm -v -test.run TestAccAzureRMVirtualMachineScaleSet_ -timeout 120m
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importBasic
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importBasic (339.43s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importBasic_managedDisk
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importBasic_managedDisk (384.38s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importLinux
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importLinux (479.84s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importLoadBalancer
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importLoadBalancer (351.85s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importOverProvision
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importOverProvision (339.29s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importExtension
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importExtension (361.30s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_importMultipleExtensions
--- PASS: TestAccAzureRMVirtualMachineScaleSet_importMultipleExtensions (340.47s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basic
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basic (337.27s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_singlePlacementGroupFalse
--- PASS: TestAccAzureRMVirtualMachineScaleSet_singlePlacementGroupFalse (386.10s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_linuxUpdated
--- PASS: TestAccAzureRMVirtualMachineScaleSet_linuxUpdated (584.17s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDisk
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicLinux_managedDisk (368.67s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_basicLinux_disappears
--- PASS: TestAccAzureRMVirtualMachineScaleSet_basicLinux_disappears (346.90s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_loadBalancer
--- PASS: TestAccAzureRMVirtualMachineScaleSet_loadBalancer (351.02s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_overprovision
--- PASS: TestAccAzureRMVirtualMachineScaleSet_overprovision (338.97s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_extension
--- PASS: TestAccAzureRMVirtualMachineScaleSet_extension (340.38s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_multipleExtensions
--- PASS: TestAccAzureRMVirtualMachineScaleSet_multipleExtensions (339.52s)
=== RUN   TestAccAzureRMVirtualMachineScaleSet_osDiskTypeConflict
--- PASS: TestAccAzureRMVirtualMachineScaleSet_osDiskTypeConflict (90.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/azurerm	6080.525s
