### PR TITLE
provider/scaleway: allow public_ip to be set on server resource

### DIFF
--- a/builtin/providers/scaleway/resource_scaleway_ip.go
+++ b/builtin/providers/scaleway/resource_scaleway_ip.go
@@ -21,6 +21,7 @@ func resourceScalewayIP() *schema.Resource {
 			"server": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"ip": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
this allows the `scaleway_ip` <-> `scaleway_server` relationship to be inverted as requested by #14175.

You can now assign `scaleway_server` and `scaleway_ip` in two ways:

### server dependency

```
resource "scaleway_ip" "base" {}

resource "scaleway_server" "base" {
  name = "test"
  # ubuntu 14.04
  image = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
  type = "C1"
  tags = [ "terraform-test" ]
  public_ip = "${scaleway_ip.base.ip}"
}
```

### ip dependency

```
resource "scaleway_ip" "base" {
  server = "${scaleway_server.base.id}
}

resource "scaleway_server" "base" {
  name = "test"
  # ubuntu 14.04
  image = "5faef9cd-ea9b-4a63-9171-9e26bec03dbc"
  type = "C1"
  tags = [ "terraform-test" ]
}
```

the "server dependency" is important when you want to provision a server which should receive a static ip, like a gateway (hence the `scaleway_ip` resource and not the `dynamic_ip_required` attribute).

previously this would break the provider provisioning as servers with private IPs are not accessible outside the Scaleway network.

@tinoadams would be great to get your feedback on if this solves your issue.