### PR TITLE
provider/aws: Only catch 'terminated' if we're not terminating instance

### DIFF
--- a/builtin/providers/aws/resource_aws_volume_attachment.go
+++ b/builtin/providers/aws/resource_aws_volume_attachment.go
@@ -83,7 +83,7 @@ func resourceAwsVolumeAttachmentCreate(d *schema.ResourceData, meta interface{})
 		stateConf := &resource.StateChangeConf{
 			Pending:    []string{"pending"},
 			Target:     []string{"running"},
-			Refresh:    InstanceStateRefreshFunc(conn, iID),
+			Refresh:    InstanceStateRefreshFunc(conn, iID, "terminated"),
 			Timeout:    10 * time.Minute,
 			Delay:      10 * time.Second,
 			MinTimeout: 3 * time.Second,


### PR DESCRIPTION
I didn't realize fully all different contexts the refresh function is being used in when implementing https://github.com/hashicorp/terraform/pull/14479

This in turn caused genuine and wanted terminations of instances into failures.

So I'm fixing it here 🙈 
