### PR TITLE
provider/aws: Avoid IP space overlap in EIP acc test

### DIFF
--- a/builtin/providers/aws/resource_aws_eip_association_test.go
+++ b/builtin/providers/aws/resource_aws_eip_association_test.go
@@ -160,6 +160,7 @@ resource "aws_instance" "foo" {
 	availability_zone = "us-west-2a"
 	instance_type = "t1.micro"
 	subnet_id = "${aws_subnet.sub.id}"
+	private_ip = "192.168.0.${count.index+10}"
 }
 resource "aws_eip" "bar" {
 	count = 3
@@ -181,7 +182,7 @@ resource "aws_eip_association" "to_eni" {
 }
 resource "aws_network_interface" "baz" {
 	subnet_id = "${aws_subnet.sub.id}"
-	private_ips = ["192.168.0.10"]
+	private_ips = ["192.168.0.50"]
   depends_on = ["aws_instance.foo"]
 	attachment {
 		instance = "${aws_instance.foo.0.id}"


### PR DESCRIPTION
This is to fix the following flaky test:

```
=== RUN   TestAccAWSEIPAssociation_basic
--- FAIL: TestAccAWSEIPAssociation_basic (78.86s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_network_interface.baz: 1 error(s) occurred:
        
        * aws_network_interface.baz: Error creating ENI: InvalidIPAddress.InUse: The specified address is already in use.
            status code: 400, request id: 6cd28113-95fa-4080-a2c6-f3d9ede58955
FAIL
```

The EC2 instance inside the test creates its own ENI and randomly allocates IP address for it which may happen to be the same static IP we assign to the standalone ENI. Here I'm giving it an explicit IP address to avoid the overlap.