### PR TITLE
Create rule(s) for prefix-list-only AWS security group ingress/egress permissions on 'terraform import'

### DIFF
--- a/builtin/providers/aws/import_aws_security_group.go
+++ b/builtin/providers/aws/import_aws_security_group.go
@@ -118,6 +118,22 @@ func resourceAwsSecurityGroupImportStatePerm(sg *ec2.SecurityGroup, ruleType str
 			result = append(result, r)
 		}
 	}
+
+	if len(result) == 0 && len(perm.PrefixListIds) > 0 {
+		p := &ec2.IpPermission{
+			FromPort:      perm.FromPort,
+			IpProtocol:    perm.IpProtocol,
+			PrefixListIds: perm.PrefixListIds,
+			ToPort:        perm.ToPort,
+		}
+
+		r, err := resourceAwsSecurityGroupImportStatePermPair(sg, ruleType, p)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, r)
+	}
+
 	return result, nil
 }
 

--- a/builtin/providers/aws/import_aws_security_group_test.go
+++ b/builtin/providers/aws/import_aws_security_group_test.go
@@ -157,3 +157,31 @@ func TestAccAWSSecurityGroup_importIPRangesWithSameRules(t *testing.T) {
 		},
 	})
 }
+
+func TestAccAWSSecurityGroup_importPrefixList(t *testing.T) {
+	checkFn := func(s []*terraform.InstanceState) error {
+		// Expect 2: group, 1 rule
+		if len(s) != 2 {
+			return fmt.Errorf("expected 2 states: %#v", s)
+		}
+
+		return nil
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSSecurityGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSSecurityGroupConfigPrefixListEgress,
+			},
+
+			{
+				ResourceName:     "aws_security_group.egress",
+				ImportState:      true,
+				ImportStateCheck: checkFn,
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fixes https://github.com/hashicorp/terraform/issues/14527.
Acceptance test:
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSecurityGroup_importPrefixList'
```