### PR TITLE
fix the metric bound in sample

### DIFF
--- a/website/source/docs/providers/aws/r/appautoscaling_policy.html.markdown
+++ b/website/source/docs/providers/aws/r/appautoscaling_policy.html.markdown
@@ -32,7 +32,7 @@ resource "aws_appautoscaling_policy" "ecs_policy" {
   service_namespace       = "ecs"
 
   step_adjustment {
-    metric_interval_lower_bound = 0
+    metric_interval_upper_bound = 0
     scaling_adjustment          = -1
   }
 


### PR DESCRIPTION
The author made this mistake at the beginning. With the original sample, you can't create `aws_appautoscaling_policy` properly. No threshold data in it. It is hard to troubleshoot this issue because there is no error to run the sample with `metric_interval_lower_bound = 0'