### PR TITLE
provider/aws: Set aws_subnet ipv6_cidr_block to computed

### DIFF
--- a/builtin/providers/aws/resource_aws_subnet.go
+++ b/builtin/providers/aws/resource_aws_subnet.go
@@ -41,6 +41,7 @@ func resourceAwsSubnet() *schema.Resource {
 			"ipv6_cidr_block": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 
 			"availability_zone": {


### PR DESCRIPTION
Fixes: #14361

An IPv6 CIDR block is option and can be added *after* a subnet has been
created. Therefore, we should set it to `Computed: true`

Otherwise, a manually created IPv6 association will be removed on the
next terraform run

```
% make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSSubnet_'                      
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/16 17:16:15 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSSubnet_ -timeout 120m
=== RUN   TestAccAWSSubnet_importBasic
--- PASS: TestAccAWSSubnet_importBasic (54.45s)
=== RUN   TestAccAWSSubnet_basic
--- PASS: TestAccAWSSubnet_basic (51.55s)
=== RUN   TestAccAWSSubnet_ipv6
--- PASS: TestAccAWSSubnet_ipv6 (124.00s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	230.024s
```