### PR TITLE
provider/opc: Correctly export `ip_address` in IP Addr Reservation

### DIFF
--- a/builtin/providers/opc/resource_ip_address_reservation.go
+++ b/builtin/providers/opc/resource_ip_address_reservation.go
@@ -92,6 +92,7 @@ func resourceOPCIPAddressReservationRead(d *schema.ResourceData, meta interface{
 	d.Set("name", result.Name)
 	d.Set("description", result.Description)
 	d.Set("ip_address_pool", result.IPAddressPool)
+	d.Set("ip_address", result.IPAddress)
 	d.Set("uri", result.Uri)
 
 	if err := setStringList(d, "tags", result.Tags); err != nil {

--- a/builtin/providers/opc/resource_ip_address_reservation_test.go
+++ b/builtin/providers/opc/resource_ip_address_reservation_test.go
@@ -24,6 +24,7 @@ func TestAccOPCIPAddressReservation_Basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccOPCCheckIPAddressReservationExists,
 					resource.TestCheckResourceAttr(resName, "name", fmt.Sprintf("testing-ip-address-reservation-%d", rInt)),
+					resource.TestCheckResourceAttrSet(resName, "ip_address"),
 				),
 			},
 		},

--- a/website/source/docs/providers/opc/r/opc_compute_ip_address_reservation.html.markdown
+++ b/website/source/docs/providers/opc/r/opc_compute_ip_address_reservation.html.markdown
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the ip address reservation.
 
-* `ip_address_pool` - (Required) The IP address pool from which you want to reserve an IP address.
+* `ip_address_pool` - (Required) The IP address pool from which you want to reserve an IP address. Must be either `public-ippool` or `cloud-ippool`.
 
 * `description` - (Optional) A description of the ip address reservation.
 


### PR DESCRIPTION
Correctly sets the attribute `ip_address` in the `opc_compute_ip_address_reservation` resource.
Also updates documentation for the `ip_address_pool` attribute.

```
$ make testacc TEST=./builtin/providers/opc TESTARGS="-run=TestAccOPCIPAddressReservation_Basic"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/16 10:15:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/opc -v -run=TestAccOPCIPAddressReservation_Basic -timeout 120m
=== RUN   TestAccOPCIPAddressReservation_Basic
--- PASS: TestAccOPCIPAddressReservation_Basic (22.60s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/opc    22.604s
```
Fixes: https://github.com/hashicorp/terraform-provider-opc/issues/1