### PR TITLE
provider/google: Add support for draining_timeout_sec to compute_backend_service.

### DIFF
--- a/builtin/providers/google/resource_compute_backend_service.go
+++ b/builtin/providers/google/resource_compute_backend_service.go
@@ -294,9 +294,9 @@ func resourceComputeBackendServiceUpdate(d *schema.ResourceData, meta interface{
 		service.TimeoutSec = int64(v.(int))
 	}
 
-	if v, ok := d.GetOk("connection_draining_timeout_sec"); ok {
+	if d.HasChange("connection_draining_timeout_sec") {
 		connectionDraining := &compute.ConnectionDraining{
-			DrainingTimeoutSec: int64(v.(int)),
+			DrainingTimeoutSec: int64(d.Get("connection_draining_timeout_sec").(int)),
 		}
 
 		service.ConnectionDraining = connectionDraining

--- a/builtin/providers/google/resource_compute_backend_service_test.go
+++ b/builtin/providers/google/resource_compute_backend_service_test.go
@@ -114,6 +114,31 @@ func TestAccComputeBackendService_withBackendAndUpdate(t *testing.T) {
 	}
 }
 
+func TestAccComputeBackendService_withConnectionDraining(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var svc compute.BackendService
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeBackendService_withConnectionDraining(serviceName, checkName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.foobar", &svc),
+				),
+			},
+		},
+	})
+
+	if svc.ConnectionDraining.DrainingTimeoutSec != 10 {
+		t.Errorf("Expected ConnectionDraining.DrainingTimeoutSec == 10, got %d", svc.ConnectionDraining.DrainingTimeoutSec)
+	}
+}
+
 func testAccCheckComputeBackendServiceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
@@ -341,4 +366,24 @@ resource "google_compute_http_health_check" "zero" {
   timeout_sec        = 1
 }
 `, serviceName, affinityName, checkName)
+}
+
+func testAccComputeBackendService_withConnectionDraining(serviceName, checkName string, drainingTimeout int64) string {
+	return fmt.Sprintf(`
+resource "google_compute_backend_service" "foobar" {
+  name          = "%s"
+  health_checks = ["${google_compute_http_health_check.zero.self_link}"]
+
+  connection_draining {
+  	draining_timeout_sec = %v
+  }
+}
+
+resource "google_compute_http_health_check" "zero" {
+  name               = "%s"
+  request_path       = "/"
+  check_interval_sec = 1
+  timeout_sec        = 1
+}
+`, serviceName, drainingTimeout, checkName)
 }

--- a/builtin/providers/google/resource_compute_backend_service_test.go
+++ b/builtin/providers/google/resource_compute_backend_service_test.go
@@ -139,6 +139,38 @@ func TestAccComputeBackendService_withConnectionDraining(t *testing.T) {
 	}
 }
 
+func TestAccComputeBackendService_withConnectionDrainingAndUpdate(t *testing.T) {
+	serviceName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	checkName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var svc compute.BackendService
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeBackendServiceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeBackendService_withConnectionDraining(serviceName, checkName, 10),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.foobar", &svc),
+				),
+			},
+			resource.TestStep{
+				Config: testAccComputeBackendService_basic(serviceName, checkName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeBackendServiceExists(
+						"google_compute_backend_service.foobar", &svc),
+				),
+			},
+		},
+	})
+
+	if svc.ConnectionDraining.DrainingTimeoutSec != 0 {
+		t.Errorf("Expected ConnectionDraining.DrainingTimeoutSec == 0, got %d", svc.ConnectionDraining.DrainingTimeoutSec)
+	}
+}
+
 func testAccCheckComputeBackendServiceDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 

--- a/builtin/providers/google/resource_compute_backend_service_test.go
+++ b/builtin/providers/google/resource_compute_backend_service_test.go
@@ -373,10 +373,7 @@ func testAccComputeBackendService_withConnectionDraining(serviceName, checkName 
 resource "google_compute_backend_service" "foobar" {
   name          = "%s"
   health_checks = ["${google_compute_http_health_check.zero.self_link}"]
-
-  connection_draining {
-  	draining_timeout_sec = %v
-  }
+  connection_draining_timeout_sec = %v
 }
 
 resource "google_compute_http_health_check" "zero" {

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # google\_compute\_backend\_service
 
-A Backend Service defines a group of virtual machines that will serve traffic for load balancing.
+A Backend Service defines a group of virtual machines that will serve traffic for load balancing. For more information 
+see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/http/backend-service)
+and the [API](https://cloud.google.com/compute/docs/reference/latest/backendServices).
 
 For internal load balancing, use a [google_compute_region_backend_service](/docs/providers/google/r/compute_region_backend_service.html).
 
@@ -72,8 +74,7 @@ The following arguments are supported:
 
 - - -
 
-* `backend` - (Optional) The list of backends that serve this BackendService.
-    See *Backend* below.
+* `backend` - (Optional) The list of backends that serve this BackendService. Structure is documented below.
 
 * `description` - (Optional) The textual description for the backend service.
 
@@ -94,8 +95,10 @@ The following arguments are supported:
 
 * `timeout_sec` - (Optional) The number of secs to wait for a backend to respond
     to a request before considering the request failed. Defaults to `30`.
+    
+* `connection_draining` - (Optional) Settings to do with connection draining. Structure is documented below.
 
-**Backend** supports the following attributes:
+The `backend` block supports:
 
 * `group` - (Required) The name or URI of a Compute Engine instance group
     (`google_compute_instance_group_manager.xyz.instance_group`) that can
@@ -120,6 +123,11 @@ The following arguments are supported:
 * `max_utilization` - (Optional) The target CPU utilization for the group as a
     float in the range [0.0, 1.0]. This flag can only be provided when the
     balancing mode is `UTILIZATION`. Defaults to `0.8`.
+
+The `connection_draining` block supports:
+
+* `draining_timeout_sec` - (Optional) Time for which instance will be drained (not accept new connections, but still
+ work to finish started). Defaults to `0`.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/google/r/compute_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_backend_service.html.markdown
@@ -96,7 +96,8 @@ The following arguments are supported:
 * `timeout_sec` - (Optional) The number of secs to wait for a backend to respond
     to a request before considering the request failed. Defaults to `30`.
     
-* `connection_draining` - (Optional) Settings to do with connection draining. Structure is documented below.
+* `connection_draining_timeout_sec` - (Optional) Time for which instance will be drained (not accept new connections, 
+but still work to finish started ones). Defaults to `0`.
 
 The `backend` block supports:
 
@@ -123,11 +124,6 @@ The `backend` block supports:
 * `max_utilization` - (Optional) The target CPU utilization for the group as a
     float in the range [0.0, 1.0]. This flag can only be provided when the
     balancing mode is `UTILIZATION`. Defaults to `0.8`.
-
-The `connection_draining` block supports:
-
-* `draining_timeout_sec` - (Optional) Time for which instance will be drained (not accept new connections, but still
- work to finish started). Defaults to `0`.
 
 ## Attributes Reference
 


### PR DESCRIPTION
Add support for the connection_draining block and draining_timeout_sec to compute_backend_service.

Part 1/2 of #13925.

@danawillow 