### PR TITLE
rancher_environment: add member support

### DIFF
--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -107,7 +107,7 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[INFO] Environment ID: %s", d.Id())
 
 	// Add members
-	if v, ok := d.GetOk("members"); ok {
+	if v, ok := d.GetOk("member"); ok {
 		envClient, err := meta.(*Config).EnvironmentClient(d.Id())
 		if err != nil {
 			return err

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -1,13 +1,11 @@
 package rancher
 
 import (
-	"bytes"
 	"fmt"
 	"log"
 	"strings"
 	"time"
 
-	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
@@ -63,7 +61,6 @@ func resourceRancherEnvironment() *schema.Resource {
 						},
 					},
 				},
-				Set: memberHash,
 			},
 		},
 	}
@@ -286,14 +283,6 @@ func makeProjectMembers(in []interface{}) (out []interface{}) {
 		out = append(out, mm)
 	}
 	return
-}
-
-func memberHash(member interface{}) int {
-	var buf bytes.Buffer
-	m := member.(map[string]interface{})
-	buf.WriteString(fmt.Sprintf("%s-", m["external_id_type"]))
-	buf.WriteString(fmt.Sprintf("%s-", m["external_id"]))
-	return hashcode.String(buf.String())
 }
 
 // EnvironmentStateRefreshFunc returns a resource.StateRefreshFunc that is used to watch

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -107,11 +107,11 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 	log.Printf("[INFO] Environment ID: %s", d.Id())
 
 	// Add members
-	envClient, err := meta.(*Config).EnvironmentClient(d.Id())
-	if err != nil {
-		return err
-	}
 	if v, ok := d.GetOk("members"); ok {
+		envClient, err := meta.(*Config).EnvironmentClient(d.Id())
+		if err != nil {
+			return err
+		}
 		members := v.([]interface{})
 		_, err = envClient.Project.ActionSetmembers(&newEnv, &rancherClient.SetProjectMembersInput{
 			Members: members,

--- a/builtin/providers/rancher/resource_rancher_environment.go
+++ b/builtin/providers/rancher/resource_rancher_environment.go
@@ -114,12 +114,14 @@ func resourceRancherEnvironmentCreate(d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return err
 	}
-	members := d.Get("members").([]interface{})
-	_, err = envClient.Project.ActionSetmembers(&newEnv, &rancherClient.SetProjectMembersInput{
-		Members: members,
-	})
-	if err != nil {
-		return err
+	if v, ok := d.GetOk("members"); ok {
+		members := v.([]interface{})
+		_, err = envClient.Project.ActionSetmembers(&newEnv, &rancherClient.SetProjectMembersInput{
+			Members: members,
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	return resourceRancherEnvironmentRead(d, meta)

--- a/website/source/docs/providers/rancher/r/environment.html.md
+++ b/website/source/docs/providers/rancher/r/environment.html.md
@@ -18,6 +18,18 @@ resource "rancher_environment" "default" {
   name = "staging"
   description = "The staging environment"
   orchestration = "cattle"
+
+  member {
+    external_id = "650430"
+    external_id_type = "github_user"
+    role = "owner"
+  }
+
+  member {
+    external_id = "1234"
+    external_id_type = "github_team"
+    role = "member"
+  }
 }
 ```
 
@@ -28,6 +40,7 @@ The following arguments are supported:
 * `name` - (Required) The name of the environment.
 * `description` - (Optional) An environment description.
 * `orchestration` - (Optional) Must be one of **cattle**, **swarm**, **mesos** or **kubernetes**. Defaults to **cattle**.
+* `member` - (Optional) Members to add to the environment. Each member has `external_id`, `external_id_type` and `role` values.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/rancher/r/environment.html.md
+++ b/website/source/docs/providers/rancher/r/environment.html.md
@@ -40,7 +40,16 @@ The following arguments are supported:
 * `name` - (Required) The name of the environment.
 * `description` - (Optional) An environment description.
 * `orchestration` - (Optional) Must be one of **cattle**, **swarm**, **mesos** or **kubernetes**. Defaults to **cattle**.
-* `member` - (Optional) Members to add to the environment. Each member has `external_id`, `external_id_type` and `role` values.
+* `member` - (Optional) Members to add to the environment.
+
+### Member Parameters Reference
+
+A `member` takes three parameters:
+
+* `external_id` - (Required) The external ID of the member.
+* `external_id_type` - (Required) The external ID type of the member.
+* `role` - (Required) The role of the member in the environment.
+
 
 ## Attributes Reference
 


### PR DESCRIPTION
This PR adds member support to rancher_environments, eg:

```
resource rancher_environment "test" {
  name           = "test"

  member {
    external_id = "650430"
    external_id_type = "github_user"
    role = "owner"
  }

  member {
    external_id = "1234"
    external_id_type = "github_team"
    role = "owner"
  }
}
```