### PR TITLE
GitHub user

### DIFF
--- a/builtin/providers/github/data_source_github_user.go
+++ b/builtin/providers/github/data_source_github_user.go
@@ -1,0 +1,118 @@
+package github
+
+import (
+	"context"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceGithubUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGithubUserRead,
+
+		Schema: map[string]*schema.Schema{
+			"username": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"login": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"avatar_url": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"gravatar_id": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"site_admin": &schema.Schema{
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"name": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"company": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"blog": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"location": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"email": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bio": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"public_repos": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"public_gists": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"followers": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"following": &schema.Schema{
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"updated_at": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGithubUserRead(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[INFO] Refreshing Gitub User: %s", d.Id())
+
+	username := d.Get("username").(string)
+	client := meta.(*Organization).client
+
+	user, _, err := client.Users.Get(context.TODO(), username)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(*user.ID))
+	d.Set("login", *user.Login)
+	d.Set("avatar_url", *user.AvatarURL)
+	d.Set("gravatar_id", *user.GravatarID)
+	d.Set("site_admin", *user.SiteAdmin)
+	d.Set("company", *user.Company)
+	d.Set("blog", *user.Blog)
+	d.Set("location", *user.Location)
+	d.Set("name", *user.Name)
+	d.Set("email", *user.Email)
+	d.Set("bio", *user.Bio)
+	d.Set("public_repos", *user.PublicRepos)
+	d.Set("public_gists", *user.PublicGists)
+	d.Set("followers", *user.Followers)
+	d.Set("following", *user.Following)
+	d.Set("created_at", *user.CreatedAt)
+	d.Set("updated_at", *user.UpdatedAt)
+
+	return nil
+}

--- a/builtin/providers/github/data_source_github_user.go
+++ b/builtin/providers/github/data_source_github_user.go
@@ -86,9 +86,9 @@ func dataSourceGithubUser() *schema.Resource {
 }
 
 func dataSourceGithubUserRead(d *schema.ResourceData, meta interface{}) error {
-	log.Printf("[INFO] Refreshing Gitub User: %s", d.Id())
-
 	username := d.Get("username").(string)
+	log.Printf("[INFO] Refreshing Gitub User: %s", username)
+
 	client := meta.(*Organization).client
 
 	user, _, err := client.Users.Get(context.TODO(), username)

--- a/builtin/providers/github/data_source_github_user_test.go
+++ b/builtin/providers/github/data_source_github_user_test.go
@@ -1,0 +1,53 @@
+package github
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccGithubUserDataSource_noMatchReturnsError(t *testing.T) {
+	username := "admin"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccCheckGithubUserDataSourceConfig(username),
+				ExpectError: regexp.MustCompile(`Not Found`),
+			},
+		},
+	})
+}
+
+func TestAccGithubUserDataSource_existing(t *testing.T) {
+	username := "raphink"
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheck(t)
+		},
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckGithubUserDataSourceConfig(username),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.github_user.test", "name"),
+					resource.TestCheckResourceAttr("data.github_user.test", "id", "650430"),
+					resource.TestCheckResourceAttr("data.github_user.test", "name", "Raphaël Pinson"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGithubUserDataSourceConfig(username string) string {
+	return fmt.Sprintf(`
+data "github_user" "test" {
+	username = "%s"
+}
+`, username)
+}

--- a/builtin/providers/github/provider.go
+++ b/builtin/providers/github/provider.go
@@ -44,6 +44,10 @@ func Provider() terraform.ResourceProvider {
 			"github_branch_protection":       resourceGithubBranchProtection(),
 		},
 
+		DataSourcesMap: map[string]*schema.Resource{
+			"github_user": dataSourceGithubUser(),
+		},
+
 		ConfigureFunc: providerConfigure,
 	}
 }

--- a/website/source/docs/providers/github/d/user.html.markdown
+++ b/website/source/docs/providers/github/d/user.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "github"
+page_title: "Github: github_user"
+sidebar_current: "docs-github-datasource-user"
+description: |-
+  Get information on a Github user.
+---
+
+# github\_user
+
+Use this data source to retrieve information about a Github user.
+
+## Example Usage
+
+```
+data "github_user" "example" {
+  username = "example"
+}
+```
+
+## Argument Reference
+
+ * `username` - (Required) The username.
+
+## Attributes Reference
+
+ * `login` - the user's login.
+ * `avatar_url` - the user's avatar URL.
+ * `gravatar_id` - the user's gravatar ID.
+ * `site_admin` - whether the user is a Github admin.
+ * `name` - the user's full name.
+ * `company` - the user's company name.
+ * `blog` - the user's blog location.
+ * `location` - the user's location.
+ * `email` - the user's email.
+ * `bio` - the user's bio.
+ * `public_repos` - the number of public repositories.
+ * `public_gists` - the number of public gists.
+ * `followers` - the number of followers.
+ * `following` - the number of following users.
+ * `created_at` - the creation date.
+ * `updated_at` - the update date.
+

--- a/website/source/layouts/github.erb
+++ b/website/source/layouts/github.erb
@@ -10,6 +10,16 @@
         <a href="/docs/providers/github/index.html">GitHub Provider</a>
         </li>
 
+        <li<%= sidebar_current(/^docs-github-datasource/) %>>
+          <a href="#">Data Sources</a>
+          <ul class="nav nav-visible">
+
+            <li<%= sidebar_current("docs-github-datasource-user") %>>
+              <a href="/docs/providers/github/d/user.html">github_user</a>
+            </li>
+          </ul>
+        </li>
+
         <li<%= sidebar_current("docs-github-resource") %>>
         <a href="#">Resources</a>
         <ul class="nav nav-visible">


### PR DESCRIPTION
This PR adds a `github_user` data source to the `github` provider, eg:

```
data github_user "raphink" {
  username = "raphink"
}
```

```
$ terraform state show github_user.raphink
id           = 650430
avatar_url   = https://avatars1.githubusercontent.com/u/650430?v=3
bio          = Automate all the things!

Augeas developer, Puppet contributor, LaTeX fanboy.

Happily working at @camptocamp.
blog         = http://raphink.info
company      = Camptocamp SA
email        = raphael.pinson@camptocamp.com
followers    = 105
following    = 57
gravatar_id  = 
location     = Chambéry, France
login        = raphink
name         = Raphaël Pinson
public_gists = 207
public_repos = 236
site_admin   = false
username     = raphink
```
