### PR TITLE
provider/aws: Handle LimitExceededException for subscriber limits

### DIFF
--- a/vendor/github.com/aws/aws-sdk-go/CHANGELOG.md
+++ b/vendor/github.com/aws/aws-sdk-go/CHANGELOG.md
@@ -1,3 +1,50 @@
+Release v1.8.25 (2017-05-17)
+===
+
+### Service Client Updates
+* `service/autoscaling`: Updates service documentation, paginators, and examples
+  * Various Auto Scaling documentation updates
+* `service/cloudwatchevents`: Updates service documentation
+  * Various CloudWatch Events documentation updates.
+* `service/cloudwatchlogs`: Updates service documentation and paginators
+  * Various CloudWatch Logs documentation updates.
+* `service/polly`: Updates service API
+  * Amazon Polly adds new German voice "Vicki"
+
+Release v1.8.24 (2017-05-16)
+===
+
+### Service Client Updates
+* `service/codedeploy`: Updates service API and documentation
+  * This release introduces the previousRevision field in the responses to the GetDeployment and BatchGetDeployments actions. previousRevision provides information about the application revision that was deployed to the deployment group before the most recent successful deployment.  Also, the fileExistsBehavior parameter has been added for CreateDeployment action requests. In the past, if the AWS CodeDeploy agent detected files in a target location that weren't part of the application revision from the most recent successful deployment, it would fail the current deployment by default. This new parameter provides options for how the agent handles these files: fail the deployment, retain the content, or overwrite the content.
+* `service/gamelift`: Updates service API and documentation
+  * Allow developers to specify how metrics are grouped in CloudWatch for their GameLift fleets. Developers can also specify how many concurrent game sessions activate on a per-instance basis.
+* `service/inspector`: Updates service API, documentation, paginators, and examples
+  * Adds ability to produce an assessment report that includes detailed and comprehensive results of a specified assessment run.
+* `service/kms`: Updates service documentation
+  * Update documentation for KMS.
+
+Release v1.8.23 (2017-05-15)
+===
+
+### Service Client Updates
+* `service/ssm`: Updates service API and documentation
+  * UpdateAssociation API now supports updating document name and targets of an association. GetAutomationExecution API can return FailureDetails as an optional field to the StepExecution Object, which contains failure type, failure stage as well as other failure related information for a failed step.
+
+### SDK Enhancements
+* `aws/session`: SDK should be able to load multiple custom shared config files. [#1258](https://github.com/aws/aws-sdk-go/issues/1258)
+  * This change adds a `SharedConfigFiles` field to the `session.Options` type that allows you to specify the files, and their order, the SDK will use for loading shared configuration and credentials from when the `Session` is created. Use the `NewSessionWithOptions` Session constructor to specify these options. You'll also most likely want to enable support for the shared configuration file's additional attributes by setting `session.Option`'s `SharedConfigState` to `session.SharedConfigEnabled`. 
+
+Release v1.8.22 (2017-05-11)
+===
+
+### Service Client Updates
+* `service/elb`: Updates service API, documentation, and paginators
+* `service/elbv2`: Updates service API and documentation
+* `service/lexmodelbuildingservice`: Updates service API and documentation
+* `service/organizations`: Updates service API, documentation, paginators, and examples
+  * AWS Organizations APIs that return an Account object now include the email address associated with the account’s root user.
+
 Release v1.8.21 (2017-05-09)
 ===
 

--- a/vendor/github.com/aws/aws-sdk-go/Makefile
+++ b/vendor/github.com/aws/aws-sdk-go/Makefile
@@ -153,6 +153,7 @@ get-deps-tests:
 	go get github.com/stretchr/testify
 	go get github.com/smartystreets/goconvey
 	go get golang.org/x/net/html
+	go get golang.org/x/net/http2
 
 get-deps-verify:
 	@echo "go get SDK verification utilities"

--- a/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/client/logger.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http/httputil"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+)
+
+const logReqMsg = `DEBUG: Request %s/%s Details:
+---[ REQUEST POST-SIGN ]-----------------------------
+%s
+-----------------------------------------------------`
+
+const logReqErrMsg = `DEBUG ERROR: Request %s/%s:
+---[ REQUEST DUMP ERROR ]-----------------------------
+%s
+------------------------------------------------------`
+
+type logWriter struct {
+	// Logger is what we will use to log the payload of a response.
+	Logger aws.Logger
+	// buf stores the contents of what has been read
+	buf *bytes.Buffer
+}
+
+func (logger *logWriter) Write(b []byte) (int, error) {
+	return logger.buf.Write(b)
+}
+
+type teeReaderCloser struct {
+	// io.Reader will be a tee reader that is used during logging.
+	// This structure will read from a body and write the contents to a logger.
+	io.Reader
+	// Source is used just to close when we are done reading.
+	Source io.ReadCloser
+}
+
+func (reader *teeReaderCloser) Close() error {
+	return reader.Source.Close()
+}
+
+func logRequest(r *request.Request) {
+	logBody := r.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody)
+	dumpedBody, err := httputil.DumpRequestOut(r.HTTPRequest, logBody)
+	if err != nil {
+		r.Config.Logger.Log(fmt.Sprintf(logReqErrMsg, r.ClientInfo.ServiceName, r.Operation.Name, err))
+		return
+	}
+
+	if logBody {
+		// Reset the request body because dumpRequest will re-wrap the r.HTTPRequest's
+		// Body as a NoOpCloser and will not be reset after read by the HTTP
+		// client reader.
+		r.ResetBody()
+	}
+
+	r.Config.Logger.Log(fmt.Sprintf(logReqMsg, r.ClientInfo.ServiceName, r.Operation.Name, string(dumpedBody)))
+}
+
+const logRespMsg = `DEBUG: Response %s/%s Details:
+---[ RESPONSE ]--------------------------------------
+%s
+-----------------------------------------------------`
+
+const logRespErrMsg = `DEBUG ERROR: Response %s/%s:
+---[ RESPONSE DUMP ERROR ]-----------------------------
+%s
+-----------------------------------------------------`
+
+func logResponse(r *request.Request) {
+	lw := &logWriter{r.Config.Logger, bytes.NewBuffer(nil)}
+	r.HTTPResponse.Body = &teeReaderCloser{
+		Reader: io.TeeReader(r.HTTPResponse.Body, lw),
+		Source: r.HTTPResponse.Body,
+	}
+
+	handlerFn := func(req *request.Request) {
+		body, err := httputil.DumpResponse(req.HTTPResponse, false)
+		if err != nil {
+			lw.Logger.Log(fmt.Sprintf(logRespErrMsg, req.ClientInfo.ServiceName, req.Operation.Name, err))
+			return
+		}
+
+		b, err := ioutil.ReadAll(lw.buf)
+		if err != nil {
+			lw.Logger.Log(fmt.Sprintf(logRespErrMsg, req.ClientInfo.ServiceName, req.Operation.Name, err))
+			return
+		}
+		lw.Logger.Log(fmt.Sprintf(logRespMsg, req.ClientInfo.ServiceName, req.Operation.Name, string(body)))
+		if req.Config.LogLevel.Matches(aws.LogDebugWithHTTPBody) {
+			lw.Logger.Log(string(b))
+		}
+	}
+
+	r.Handlers.Unmarshal.PushBack(handlerFn)
+	r.Handlers.UnmarshalError.PushBack(handlerFn)
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/connection_reset_error.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/connection_reset_error.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !appengine,!plan9
 
 package request
 

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/connection_reset_error_other.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/connection_reset_error_other.go
@@ -1,0 +1,11 @@
+// +build appengine plan9
+
+package request
+
+import (
+	"strings"
+)
+
+func isErrConnectionReset(err error) bool {
+	return strings.Contains(err.Error(), "connection reset")
+}

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request.go
@@ -368,7 +368,7 @@ func (r *Request) ResetBody() {
 	}
 
 	if l == 0 {
-		r.HTTPRequest.Body = noBodyReader
+		r.HTTPRequest.Body = NoBody
 	} else if l > 0 {
 		r.HTTPRequest.Body = r.safeBody
 	} else {
@@ -382,7 +382,7 @@ func (r *Request) ResetBody() {
 		// a io.Reader that was not also an io.Seeker.
 		switch r.Operation.HTTPMethod {
 		case "GET", "HEAD", "DELETE":
-			r.HTTPRequest.Body = noBodyReader
+			r.HTTPRequest.Body = NoBody
 		default:
 			r.HTTPRequest.Body = r.safeBody
 		}

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_7.go
@@ -16,6 +16,6 @@ func (noBody) Read([]byte) (int, error)         { return 0, io.EOF }
 func (noBody) Close() error                     { return nil }
 func (noBody) WriteTo(io.Writer) (int64, error) { return 0, nil }
 
-// Is an empty reader that will trigger the Go HTTP client to not include
+// NoBody is an empty reader that will trigger the Go HTTP client to not include
 // and body in the HTTP request.
-var noBodyReader = noBody{}
+var NoBody = noBody{}

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/request_1_8.go
@@ -2,8 +2,10 @@
 
 package request
 
-import "net/http"
+import (
+	"net/http"
+)
 
-// Is a http.NoBody reader instructing Go HTTP client to not include
+// NoBody is a http.NoBody reader instructing Go HTTP client to not include
 // and body in the HTTP request.
-var noBodyReader = http.NoBody
+var NoBody = http.NoBody

--- a/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/request/retryer.go
@@ -38,7 +38,6 @@ var throttleCodes = map[string]struct{}{
 	"ThrottlingException":                    {},
 	"RequestLimitExceeded":                   {},
 	"RequestThrottled":                       {},
-	"LimitExceededException":                 {}, // Deleting 10+ DynamoDb tables at once
 	"TooManyRequestsException":               {}, // Lambda functions
 	"PriorRequestNotComplete":                {}, // Route53
 }

--- a/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/session/session.go
@@ -155,6 +155,10 @@ type Options struct {
 	// and enable or disable the shared config functionality.
 	SharedConfigState SharedConfigState
 
+	// Ordered list of files the session will load configuration from.
+	// It will override environment variable AWS_SHARED_CREDENTIALS_FILE, AWS_CONFIG_FILE.
+	SharedConfigFiles []string
+
 	// When the SDK's shared config is configured to assume a role with MFA
 	// this option is required in order to provide the mechanism that will
 	// retrieve the MFA token. There is no default value for this field. If
@@ -304,13 +308,18 @@ func newSession(opts Options, envCfg envConfig, cfgs ...*aws.Config) (*Session, 
 	userCfg := &aws.Config{}
 	userCfg.MergeIn(cfgs...)
 
-	// Order config files will be loaded in with later files overwriting
+	// Ordered config files will be loaded in with later files overwriting
 	// previous config file values.
-	cfgFiles := []string{envCfg.SharedConfigFile, envCfg.SharedCredentialsFile}
-	if !envCfg.EnableSharedConfig {
-		// The shared config file (~/.aws/config) is only loaded if instructed
-		// to load via the envConfig.EnableSharedConfig (AWS_SDK_LOAD_CONFIG).
-		cfgFiles = cfgFiles[1:]
+	var cfgFiles []string
+	if opts.SharedConfigFiles != nil {
+		cfgFiles = opts.SharedConfigFiles
+	} else {
+		cfgFiles = []string{envCfg.SharedConfigFile, envCfg.SharedCredentialsFile}
+		if !envCfg.EnableSharedConfig {
+			// The shared config file (~/.aws/config) is only loaded if instructed
+			// to load via the envConfig.EnableSharedConfig (AWS_SDK_LOAD_CONFIG).
+			cfgFiles = cfgFiles[1:]
+		}
 	}
 
 	// Load additional config from file(s)

--- a/vendor/github.com/aws/aws-sdk-go/aws/version.go
+++ b/vendor/github.com/aws/aws-sdk-go/aws/version.go
@@ -5,4 +5,4 @@ package aws
 const SDKName = "aws-sdk-go"
 
 // SDKVersion is the version of this SDK
-const SDKVersion = "1.8.21"
+const SDKVersion = "1.8.25"

--- a/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/autoscaling/api.go
@@ -67,7 +67,7 @@ func (c *AutoScaling) AttachInstancesRequest(input *AttachInstancesInput) (req *
 // being attached plus the desired capacity of the group exceeds the maximum
 // size of the group, the operation fails.
 //
-// If there is a Classic load balancer attached to your Auto Scaling group,
+// If there is a Classic Load Balancer attached to your Auto Scaling group,
 // the instances are also registered with the load balancer. If there are target
 // groups attached to your Auto Scaling group, the instances are also registered
 // with the target groups.
@@ -243,10 +243,10 @@ func (c *AutoScaling) AttachLoadBalancersRequest(input *AttachLoadBalancersInput
 
 // AttachLoadBalancers API operation for Auto Scaling.
 //
-// Attaches one or more Classic load balancers to the specified Auto Scaling
+// Attaches one or more Classic Load Balancers to the specified Auto Scaling
 // group.
 //
-// To attach an Application load balancer instead, see AttachLoadBalancerTargetGroups.
+// To attach an Application Load Balancer instead, see AttachLoadBalancerTargetGroups.
 //
 // To describe the load balancers for an Auto Scaling group, use DescribeLoadBalancers.
 // To detach the load balancer from the Auto Scaling group, use DetachLoadBalancers.
@@ -2258,8 +2258,8 @@ func (c *AutoScaling) DescribeLoadBalancersRequest(input *DescribeLoadBalancersI
 //
 // Describes the load balancers for the specified Auto Scaling group.
 //
-// Note that this operation describes only Classic load balancers. If you have
-// Application load balancers, use DescribeLoadBalancerTargetGroups instead.
+// Note that this operation describes only Classic Load Balancers. If you have
+// Application Load Balancers, use DescribeLoadBalancerTargetGroups instead.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3299,13 +3299,13 @@ func (c *AutoScaling) DetachInstancesRequest(input *DetachInstancesInput) (req *
 //
 // Removes one or more instances from the specified Auto Scaling group.
 //
-// After the instances are detached, you can manage them independently from
-// the rest of the Auto Scaling group.
+// After the instances are detached, you can manage them independent of the
+// Auto Scaling group.
 //
 // If you do not specify the option to decrement the desired capacity, Auto
 // Scaling launches instances to replace the ones that are detached.
 //
-// If there is a Classic load balancer attached to the Auto Scaling group, the
+// If there is a Classic Load Balancer attached to the Auto Scaling group, the
 // instances are deregistered from the load balancer. If there are target groups
 // attached to the Auto Scaling group, the instances are deregistered from the
 // target groups.
@@ -3474,11 +3474,11 @@ func (c *AutoScaling) DetachLoadBalancersRequest(input *DetachLoadBalancersInput
 
 // DetachLoadBalancers API operation for Auto Scaling.
 //
-// Detaches one or more Classic load balancers from the specified Auto Scaling
+// Detaches one or more Classic Load Balancers from the specified Auto Scaling
 // group.
 //
-// Note that this operation detaches only Classic load balancers. If you have
-// Application load balancers, use DetachLoadBalancerTargetGroups instead.
+// Note that this operation detaches only Classic Load Balancers. If you have
+// Application Load Balancers, use DetachLoadBalancerTargetGroups instead.
 //
 // When you detach a load balancer, it enters the Removing state while deregistering
 // the instances in the group. When all instances are deregistered, then you
@@ -3732,9 +3732,10 @@ func (c *AutoScaling) EnterStandbyRequest(input *EnterStandbyInput) (req *reques
 
 // EnterStandby API operation for Auto Scaling.
 //
-// Moves the specified instances into Standby mode.
+// Moves the specified instances into the standby state.
 //
-// For more information, see Auto Scaling Lifecycle (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html)
+// For more information, see Temporarily Removing Instances from Your Auto Scaling
+// Group (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-enter-exit-standby.html)
 // in the Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -3903,9 +3904,10 @@ func (c *AutoScaling) ExitStandbyRequest(input *ExitStandbyInput) (req *request.
 
 // ExitStandby API operation for Auto Scaling.
 //
-// Moves the specified instances out of Standby mode.
+// Moves the specified instances out of the standby state.
 //
-// For more information, see Auto Scaling Lifecycle (http://docs.aws.amazon.com/autoscaling/latest/userguide/AutoScalingGroupLifecycle.html)
+// For more information, see Temporarily Removing Instances from Your Auto Scaling
+// Group (http://docs.aws.amazon.com/autoscaling/latest/userguide/as-enter-exit-standby.html)
 // in the Auto Scaling User Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -5039,14 +5041,13 @@ func (c *AutoScaling) UpdateAutoScalingGroupRequest(input *UpdateAutoScalingGrou
 //
 // Updates the configuration for the specified Auto Scaling group.
 //
+// The new settings take effect on any scaling activities after this call returns.
+// Scaling activities that are currently in progress aren't affected.
+//
 // To update an Auto Scaling group with a launch configuration with InstanceMonitoring
-// set to False, you must first disable the collection of group metrics. Otherwise,
+// set to false, you must first disable the collection of group metrics. Otherwise,
 // you will get an error. If you have previously enabled the collection of group
 // metrics, you can disable it using DisableMetricsCollection.
-//
-// The new settings are registered upon the completion of this call. Any launch
-// configuration settings take effect on any triggers after this call returns.
-// Scaling activities that are currently in progress aren't affected.
 //
 // Note the following:
 //
@@ -5281,7 +5282,6 @@ func (s *Alarm) SetAlarmName(v string) *Alarm {
 	return s
 }
 
-// Contains the parameters for AttachInstances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/AttachInstancesQuery
 type AttachInstancesInput struct {
 	_ struct{} `type:"structure"`
@@ -5348,7 +5348,6 @@ func (s AttachInstancesOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for AttachLoadBalancerTargetGroups.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/AttachLoadBalancerTargetGroupsType
 type AttachLoadBalancerTargetGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -5420,7 +5419,6 @@ func (s AttachLoadBalancerTargetGroupsOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for AttachLoadBalancers.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/AttachLoadBalancersType
 type AttachLoadBalancersInput struct {
 	_ struct{} `type:"structure"`
@@ -5477,7 +5475,6 @@ func (s *AttachLoadBalancersInput) SetLoadBalancerNames(v []*string) *AttachLoad
 	return s
 }
 
-// Contains the output of AttachLoadBalancers.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/AttachLoadBalancersResultType
 type AttachLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
@@ -5575,7 +5572,6 @@ func (s *BlockDeviceMapping) SetVirtualName(v string) *BlockDeviceMapping {
 	return s
 }
 
-// Contains the parameters for CompleteLifecycleAction.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/CompleteLifecycleActionType
 type CompleteLifecycleActionInput struct {
 	_ struct{} `type:"structure"`
@@ -5676,7 +5672,6 @@ func (s *CompleteLifecycleActionInput) SetLifecycleHookName(v string) *CompleteL
 	return s
 }
 
-// Contains the output of CompleteLifecycleAction.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/CompleteLifecycleActionAnswer
 type CompleteLifecycleActionOutput struct {
 	_ struct{} `type:"structure"`
@@ -5692,7 +5687,6 @@ func (s CompleteLifecycleActionOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for CreateAutoScalingGroup.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/CreateAutoScalingGroupType
 type CreateAutoScalingGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -5716,7 +5710,8 @@ type CreateAutoScalingGroupInput struct {
 
 	// The number of EC2 instances that should be running in the group. This number
 	// must be greater than or equal to the minimum size of the group and less than
-	// or equal to the maximum size of the group.
+	// or equal to the maximum size of the group. If you do not specify a desired
+	// capacity, the default is the minimum size of the group.
 	DesiredCapacity *int64 `type:"integer"`
 
 	// The amount of time, in seconds, that Auto Scaling waits before checking the
@@ -5754,7 +5749,7 @@ type CreateAutoScalingGroupInput struct {
 	// instead of a launch configuration.
 	LaunchConfigurationName *string `min:"1" type:"string"`
 
-	// One or more Classic load balancers. To specify an Application load balancer,
+	// One or more Classic Load Balancers. To specify an Application Load Balancer,
 	// use TargetGroupARNs instead.
 	//
 	// For more information, see Using a Load Balancer With an Auto Scaling Group
@@ -5986,7 +5981,6 @@ func (s CreateAutoScalingGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for CreateLaunchConfiguration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/CreateLaunchConfigurationType
 type CreateLaunchConfigurationInput struct {
 	_ struct{} `type:"structure"`
@@ -6043,14 +6037,18 @@ type CreateLaunchConfigurationInput struct {
 	IamInstanceProfile *string `min:"1" type:"string"`
 
 	// The ID of the Amazon Machine Image (AMI) to use to launch your EC2 instances.
+	//
+	// If you do not specify InstanceId, you must specify ImageId.
+	//
 	// For more information, see Finding an AMI (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/finding-an-ami.html)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	ImageId *string `min:"1" type:"string"`
 
-	// The ID of the instance to use to create the launch configuration.
+	// The ID of the instance to use to create the launch configuration. The new
+	// launch configuration derives attributes from the instance, with the exception
+	// of the block device mapping.
 	//
-	// The new launch configuration derives attributes from the instance, with the
-	// exception of the block device mapping.
+	// If you do not specify InstanceId, you must specify both ImageId and InstanceType.
 	//
 	// To create a launch configuration with a block device mapping or override
 	// any other instance attributes, specify them as part of the same request.
@@ -6061,11 +6059,15 @@ type CreateLaunchConfigurationInput struct {
 	InstanceId *string `min:"1" type:"string"`
 
 	// Enables detailed monitoring (true) or basic monitoring (false) for the Auto
-	// Scaling instances.
+	// Scaling instances. The default is true.
 	InstanceMonitoring *InstanceMonitoring `type:"structure"`
 
-	// The instance type of the EC2 instance. For information about available instance
-	// types, see  Available Instance Types (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes)
+	// The instance type of the EC2 instance.
+	//
+	// If you do not specify InstanceId, you must specify InstanceType.
+	//
+	// For information about available instance types, see Available Instance Types
+	// (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#AvailableInstanceTypes)
 	// in the Amazon Elastic Compute Cloud User Guide.
 	InstanceType *string `min:"1" type:"string"`
 
@@ -6316,7 +6318,6 @@ func (s CreateLaunchConfigurationOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for CreateOrUpdateTags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/CreateOrUpdateTagsType
 type CreateOrUpdateTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -6381,7 +6382,6 @@ func (s CreateOrUpdateTagsOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeleteAutoScalingGroup.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeleteAutoScalingGroupType
 type DeleteAutoScalingGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -6450,7 +6450,6 @@ func (s DeleteAutoScalingGroupOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeleteLaunchConfiguration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/LaunchConfigurationNameType
 type DeleteLaunchConfigurationInput struct {
 	_ struct{} `type:"structure"`
@@ -6508,7 +6507,6 @@ func (s DeleteLaunchConfigurationOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeleteLifecycleHook.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeleteLifecycleHookType
 type DeleteLifecycleHookInput struct {
 	_ struct{} `type:"structure"`
@@ -6568,7 +6566,6 @@ func (s *DeleteLifecycleHookInput) SetLifecycleHookName(v string) *DeleteLifecyc
 	return s
 }
 
-// Contains the output of DeleteLifecycleHook.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeleteLifecycleHookAnswer
 type DeleteLifecycleHookOutput struct {
 	_ struct{} `type:"structure"`
@@ -6584,7 +6581,6 @@ func (s DeleteLifecycleHookOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeleteNotificationConfiguration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeleteNotificationConfigurationType
 type DeleteNotificationConfigurationInput struct {
 	_ struct{} `type:"structure"`
@@ -6660,7 +6656,6 @@ func (s DeleteNotificationConfigurationOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeletePolicy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeletePolicyType
 type DeletePolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -6730,7 +6725,6 @@ func (s DeletePolicyOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeleteScheduledAction.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeleteScheduledActionType
 type DeleteScheduledActionInput struct {
 	_ struct{} `type:"structure"`
@@ -6805,7 +6799,6 @@ func (s DeleteScheduledActionOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DeleteTags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DeleteTagsType
 type DeleteTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -6885,7 +6878,6 @@ func (s DescribeAccountLimitsInput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DescribeAccountLimits.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeAccountLimitsAnswer
 type DescribeAccountLimitsOutput struct {
 	_ struct{} `type:"structure"`
@@ -6954,7 +6946,6 @@ func (s DescribeAdjustmentTypesInput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DescribeAdjustmentTypes.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeAdjustmentTypesAnswer
 type DescribeAdjustmentTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -6979,7 +6970,6 @@ func (s *DescribeAdjustmentTypesOutput) SetAdjustmentTypes(v []*AdjustmentType) 
 	return s
 }
 
-// Contains the parameters for DescribeAutoScalingGroups.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/GroupNamesType
 type DescribeAutoScalingGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -6988,7 +6978,8 @@ type DescribeAutoScalingGroupsInput struct {
 	// described.
 	AutoScalingGroupNames []*string `type:"list"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7024,7 +7015,6 @@ func (s *DescribeAutoScalingGroupsInput) SetNextToken(v string) *DescribeAutoSca
 	return s
 }
 
-// Contains the output for DescribeAutoScalingGroups.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/GroupsType
 type DescribeAutoScalingGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7061,7 +7051,6 @@ func (s *DescribeAutoScalingGroupsOutput) SetNextToken(v string) *DescribeAutoSc
 	return s
 }
 
-// Contains the parameters for DescribeAutoScalingInstances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeAutoScalingInstancesType
 type DescribeAutoScalingInstancesInput struct {
 	_ struct{} `type:"structure"`
@@ -7071,7 +7060,8 @@ type DescribeAutoScalingInstancesInput struct {
 	// not exist, it is ignored with no error.
 	InstanceIds []*string `type:"list"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7107,7 +7097,6 @@ func (s *DescribeAutoScalingInstancesInput) SetNextToken(v string) *DescribeAuto
 	return s
 }
 
-// Contains the output of DescribeAutoScalingInstances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/InstancesType
 type DescribeAutoScalingInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7157,7 +7146,6 @@ func (s DescribeAutoScalingNotificationTypesInput) GoString() string {
 	return s.String()
 }
 
-// Contains the output of DescribeAutoScalingNotificationTypes.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeAutoScalingNotificationTypesAnswer
 type DescribeAutoScalingNotificationTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7182,7 +7170,6 @@ func (s *DescribeAutoScalingNotificationTypesOutput) SetAutoScalingNotificationT
 	return s
 }
 
-// Contains the parameters for DescribeLaunchConfigurations.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/LaunchConfigurationNamesType
 type DescribeLaunchConfigurationsInput struct {
 	_ struct{} `type:"structure"`
@@ -7191,7 +7178,8 @@ type DescribeLaunchConfigurationsInput struct {
 	// are described.
 	LaunchConfigurationNames []*string `type:"list"`
 
-	// The maximum number of items to return with this call. The default is 100.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7227,7 +7215,6 @@ func (s *DescribeLaunchConfigurationsInput) SetNextToken(v string) *DescribeLaun
 	return s
 }
 
-// Contains the output of DescribeLaunchConfigurations.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/LaunchConfigurationsType
 type DescribeLaunchConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7279,7 +7266,6 @@ func (s DescribeLifecycleHookTypesInput) GoString() string {
 	return s.String()
 }
 
-// Contains the output of DescribeLifecycleHookTypes.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLifecycleHookTypesAnswer
 type DescribeLifecycleHookTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7304,7 +7290,6 @@ func (s *DescribeLifecycleHookTypesOutput) SetLifecycleHookTypes(v []*string) *D
 	return s
 }
 
-// Contains the parameters for DescribeLifecycleHooks.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLifecycleHooksType
 type DescribeLifecycleHooksInput struct {
 	_ struct{} `type:"structure"`
@@ -7357,7 +7342,6 @@ func (s *DescribeLifecycleHooksInput) SetLifecycleHookNames(v []*string) *Descri
 	return s
 }
 
-// Contains the output of DescribeLifecycleHooks.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLifecycleHooksAnswer
 type DescribeLifecycleHooksOutput struct {
 	_ struct{} `type:"structure"`
@@ -7382,7 +7366,6 @@ func (s *DescribeLifecycleHooksOutput) SetLifecycleHooks(v []*LifecycleHook) *De
 	return s
 }
 
-// Contains the parameters for DescribeLoadBalancerTargetGroups.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLoadBalancerTargetGroupsRequest
 type DescribeLoadBalancerTargetGroupsInput struct {
 	_ struct{} `type:"structure"`
@@ -7392,7 +7375,8 @@ type DescribeLoadBalancerTargetGroupsInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7444,7 +7428,6 @@ func (s *DescribeLoadBalancerTargetGroupsInput) SetNextToken(v string) *Describe
 	return s
 }
 
-// Contains the output of DescribeLoadBalancerTargetGroups.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLoadBalancerTargetGroupsResponse
 type DescribeLoadBalancerTargetGroupsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7479,7 +7462,6 @@ func (s *DescribeLoadBalancerTargetGroupsOutput) SetNextToken(v string) *Describ
 	return s
 }
 
-// Contains the parameters for DescribeLoadBalancers.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLoadBalancersRequest
 type DescribeLoadBalancersInput struct {
 	_ struct{} `type:"structure"`
@@ -7489,7 +7471,8 @@ type DescribeLoadBalancersInput struct {
 	// AutoScalingGroupName is a required field
 	AutoScalingGroupName *string `min:"1" type:"string" required:"true"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7541,7 +7524,6 @@ func (s *DescribeLoadBalancersInput) SetNextToken(v string) *DescribeLoadBalance
 	return s
 }
 
-// Contains the output of DescribeLoadBalancers.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeLoadBalancersResponse
 type DescribeLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
@@ -7591,7 +7573,6 @@ func (s DescribeMetricCollectionTypesInput) GoString() string {
 	return s.String()
 }
 
-// Contains the output of DescribeMetricsCollectionTypes.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeMetricCollectionTypesAnswer
 type DescribeMetricCollectionTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7625,7 +7606,6 @@ func (s *DescribeMetricCollectionTypesOutput) SetMetrics(v []*MetricCollectionTy
 	return s
 }
 
-// Contains the parameters for DescribeNotificationConfigurations.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeNotificationConfigurationsType
 type DescribeNotificationConfigurationsInput struct {
 	_ struct{} `type:"structure"`
@@ -7633,7 +7613,8 @@ type DescribeNotificationConfigurationsInput struct {
 	// The name of the group.
 	AutoScalingGroupNames []*string `type:"list"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7669,7 +7650,6 @@ func (s *DescribeNotificationConfigurationsInput) SetNextToken(v string) *Descri
 	return s
 }
 
-// Contains the output from DescribeNotificationConfigurations.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeNotificationConfigurationsAnswer
 type DescribeNotificationConfigurationsOutput struct {
 	_ struct{} `type:"structure"`
@@ -7706,7 +7686,6 @@ func (s *DescribeNotificationConfigurationsOutput) SetNotificationConfigurations
 	return s
 }
 
-// Contains the parameters for DescribePolicies.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribePoliciesType
 type DescribePoliciesInput struct {
 	_ struct{} `type:"structure"`
@@ -7714,7 +7693,8 @@ type DescribePoliciesInput struct {
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
-	// The maximum number of items to be returned with each call.
+	// The maximum number of items to be returned with each call. The default value
+	// is 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7784,7 +7764,6 @@ func (s *DescribePoliciesInput) SetPolicyTypes(v []*string) *DescribePoliciesInp
 	return s
 }
 
-// Contains the output of DescribePolicies.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PoliciesType
 type DescribePoliciesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7819,7 +7798,6 @@ func (s *DescribePoliciesOutput) SetScalingPolicies(v []*ScalingPolicy) *Describ
 	return s
 }
 
-// Contains the parameters for DescribeScalingActivities.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeScalingActivitiesType
 type DescribeScalingActivitiesInput struct {
 	_ struct{} `type:"structure"`
@@ -7834,7 +7812,8 @@ type DescribeScalingActivitiesInput struct {
 	// The name of the group.
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -7889,7 +7868,6 @@ func (s *DescribeScalingActivitiesInput) SetNextToken(v string) *DescribeScaling
 	return s
 }
 
-// Contains the output of DescribeScalingActivities.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ActivitiesType
 type DescribeScalingActivitiesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7942,7 +7920,6 @@ func (s DescribeScalingProcessTypesInput) GoString() string {
 	return s.String()
 }
 
-// Contains the output of DescribeScalingProcessTypes.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ProcessesType
 type DescribeScalingProcessTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -7967,7 +7944,6 @@ func (s *DescribeScalingProcessTypesOutput) SetProcesses(v []*ProcessType) *Desc
 	return s
 }
 
-// Contains the parameters for DescribeScheduledActions.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeScheduledActionsType
 type DescribeScheduledActionsInput struct {
 	_ struct{} `type:"structure"`
@@ -7979,7 +7955,8 @@ type DescribeScheduledActionsInput struct {
 	// provided, this parameter is ignored.
 	EndTime *time.Time `type:"timestamp" timestampFormat:"iso8601"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -8059,7 +8036,6 @@ func (s *DescribeScheduledActionsInput) SetStartTime(v time.Time) *DescribeSched
 	return s
 }
 
-// Contains the output of DescribeScheduledActions.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ScheduledActionsType
 type DescribeScheduledActionsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8094,7 +8070,6 @@ func (s *DescribeScheduledActionsOutput) SetScheduledUpdateGroupActions(v []*Sch
 	return s
 }
 
-// Contains the parameters for DescribeTags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeTagsType
 type DescribeTagsInput struct {
 	_ struct{} `type:"structure"`
@@ -8102,7 +8077,8 @@ type DescribeTagsInput struct {
 	// A filter used to scope the tags to return.
 	Filters []*Filter `type:"list"`
 
-	// The maximum number of items to return with this call.
+	// The maximum number of items to return with this call. The default value is
+	// 50 and the maximum value is 100.
 	MaxRecords *int64 `type:"integer"`
 
 	// The token for the next set of items to return. (You received this token from
@@ -8138,7 +8114,6 @@ func (s *DescribeTagsInput) SetNextToken(v string) *DescribeTagsInput {
 	return s
 }
 
-// Contains the output of DescribeTags.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/TagsType
 type DescribeTagsOutput struct {
 	_ struct{} `type:"structure"`
@@ -8188,7 +8163,6 @@ func (s DescribeTerminationPolicyTypesInput) GoString() string {
 	return s.String()
 }
 
-// Contains the output of DescribeTerminationPolicyTypes.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DescribeTerminationPolicyTypesAnswer
 type DescribeTerminationPolicyTypesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8214,7 +8188,6 @@ func (s *DescribeTerminationPolicyTypesOutput) SetTerminationPolicyTypes(v []*st
 	return s
 }
 
-// Contains the parameters for DetachInstances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DetachInstancesQuery
 type DetachInstancesInput struct {
 	_ struct{} `type:"structure"`
@@ -8281,7 +8254,6 @@ func (s *DetachInstancesInput) SetShouldDecrementDesiredCapacity(v bool) *Detach
 	return s
 }
 
-// Contains the output of DetachInstances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DetachInstancesAnswer
 type DetachInstancesOutput struct {
 	_ struct{} `type:"structure"`
@@ -8377,7 +8349,6 @@ func (s DetachLoadBalancerTargetGroupsOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DetachLoadBalancers.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DetachLoadBalancersType
 type DetachLoadBalancersInput struct {
 	_ struct{} `type:"structure"`
@@ -8434,7 +8405,6 @@ func (s *DetachLoadBalancersInput) SetLoadBalancerNames(v []*string) *DetachLoad
 	return s
 }
 
-// Contains the output for DetachLoadBalancers.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DetachLoadBalancersResultType
 type DetachLoadBalancersOutput struct {
 	_ struct{} `type:"structure"`
@@ -8450,7 +8420,6 @@ func (s DetachLoadBalancersOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for DisableMetricsCollection.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/DisableMetricsCollectionQuery
 type DisableMetricsCollectionInput struct {
 	_ struct{} `type:"structure"`
@@ -8647,7 +8616,6 @@ func (s *Ebs) SetVolumeType(v string) *Ebs {
 	return s
 }
 
-// Contains the parameters for EnableMetricsCollection.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/EnableMetricsCollectionQuery
 type EnableMetricsCollectionInput struct {
 	_ struct{} `type:"structure"`
@@ -8799,7 +8767,6 @@ func (s *EnabledMetric) SetMetric(v string) *EnabledMetric {
 	return s
 }
 
-// Contains the parameters for EnteStandby.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/EnterStandbyQuery
 type EnterStandbyInput struct {
 	_ struct{} `type:"structure"`
@@ -8869,7 +8836,6 @@ func (s *EnterStandbyInput) SetShouldDecrementDesiredCapacity(v bool) *EnterStan
 	return s
 }
 
-// Contains the output of EnterStandby.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/EnterStandbyAnswer
 type EnterStandbyOutput struct {
 	_ struct{} `type:"structure"`
@@ -8894,7 +8860,6 @@ func (s *EnterStandbyOutput) SetActivities(v []*Activity) *EnterStandbyOutput {
 	return s
 }
 
-// Contains the parameters for ExecutePolicy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ExecutePolicyType
 type ExecutePolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -9011,7 +8976,6 @@ func (s ExecutePolicyOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for ExitStandby.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ExitStandbyQuery
 type ExitStandbyInput struct {
 	_ struct{} `type:"structure"`
@@ -9063,7 +9027,6 @@ func (s *ExitStandbyInput) SetInstanceIds(v []*string) *ExitStandbyInput {
 	return s
 }
 
-// Contains the parameters for ExitStandby.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ExitStandbyAnswer
 type ExitStandbyOutput struct {
 	_ struct{} `type:"structure"`
@@ -9474,7 +9437,8 @@ type InstanceDetails struct {
 	// InstanceId is a required field
 	InstanceId *string `min:"1" type:"string" required:"true"`
 
-	// The launch configuration associated with the instance.
+	// The launch configuration used to launch the instance. This value is not available
+	// if you attached the instance to the Auto Scaling group.
 	//
 	// LaunchConfigurationName is a required field
 	LaunchConfigurationName *string `min:"1" type:"string" required:"true"`
@@ -9545,12 +9509,12 @@ func (s *InstanceDetails) SetProtectedFromScaleIn(v bool) *InstanceDetails {
 	return s
 }
 
-// Describes whether instance monitoring is enabled.
+// Describes whether detailed monitoring is enabled for the Auto Scaling instances.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/InstanceMonitoring
 type InstanceMonitoring struct {
 	_ struct{} `type:"structure"`
 
-	// If True, instance monitoring is enabled.
+	// If true, detailed monitoring is enabled. Otherwise, basic monitoring is enabled.
 	Enabled *bool `type:"boolean"`
 }
 
@@ -9908,7 +9872,7 @@ func (s *LifecycleHook) SetRoleARN(v string) *LifecycleHook {
 	return s
 }
 
-// Describes the state of a Classic load balancer.
+// Describes the state of a Classic Load Balancer.
 //
 // If you specify a load balancer when creating the Auto Scaling group, the
 // state of the load balancer is InService.
@@ -10189,7 +10153,6 @@ func (s *ProcessType) SetProcessName(v string) *ProcessType {
 	return s
 }
 
-// Contains the parameters for PutLifecycleHook.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PutLifecycleHookType
 type PutLifecycleHookInput struct {
 	_ struct{} `type:"structure"`
@@ -10335,7 +10298,6 @@ func (s *PutLifecycleHookInput) SetRoleARN(v string) *PutLifecycleHookInput {
 	return s
 }
 
-// Contains the output of PutLifecycleHook.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PutLifecycleHookAnswer
 type PutLifecycleHookOutput struct {
 	_ struct{} `type:"structure"`
@@ -10351,7 +10313,6 @@ func (s PutLifecycleHookOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for PutNotificationConfiguration.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PutNotificationConfigurationType
 type PutNotificationConfigurationInput struct {
 	_ struct{} `type:"structure"`
@@ -10442,7 +10403,6 @@ func (s PutNotificationConfigurationOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for PutScalingPolicy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PutScalingPolicyType
 type PutScalingPolicyInput struct {
 	_ struct{} `type:"structure"`
@@ -10639,7 +10599,6 @@ func (s *PutScalingPolicyInput) SetStepAdjustments(v []*StepAdjustment) *PutScal
 	return s
 }
 
-// Contains the output of PutScalingPolicy.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PolicyARNType
 type PutScalingPolicyOutput struct {
 	_ struct{} `type:"structure"`
@@ -10664,7 +10623,6 @@ func (s *PutScalingPolicyOutput) SetPolicyARN(v string) *PutScalingPolicyOutput 
 	return s
 }
 
-// Contains the parameters for PutScheduledUpdateGroupAction.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/PutScheduledUpdateGroupActionType
 type PutScheduledUpdateGroupActionInput struct {
 	_ struct{} `type:"structure"`
@@ -10814,7 +10772,6 @@ func (s PutScheduledUpdateGroupActionOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for RecordLifecycleActionHeartbeat.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/RecordLifecycleActionHeartbeatType
 type RecordLifecycleActionHeartbeatInput struct {
 	_ struct{} `type:"structure"`
@@ -10900,7 +10857,6 @@ func (s *RecordLifecycleActionHeartbeatInput) SetLifecycleHookName(v string) *Re
 	return s
 }
 
-// Contains the output of RecordLifecycleActionHeartBeat.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/RecordLifecycleActionHeartbeatAnswer
 type RecordLifecycleActionHeartbeatOutput struct {
 	_ struct{} `type:"structure"`
@@ -10947,7 +10903,7 @@ type ScalingPolicy struct {
 	AutoScalingGroupName *string `min:"1" type:"string"`
 
 	// The amount of time, in seconds, after a scaling activity completes before
-	// any further trigger-related scaling activities can start.
+	// any further dynamic scaling activities can start.
 	Cooldown *int64 `type:"integer"`
 
 	// The estimated time, in seconds, until a newly launched instance can contribute
@@ -11074,7 +11030,6 @@ func (s *ScalingPolicy) SetStepAdjustments(v []*StepAdjustment) *ScalingPolicy {
 	return s
 }
 
-// Contains the parameters for SuspendProcesses and ResumeProcesses.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ScalingProcessQuery
 type ScalingProcessQuery struct {
 	_ struct{} `type:"structure"`
@@ -11254,7 +11209,6 @@ func (s *ScheduledUpdateGroupAction) SetTime(v time.Time) *ScheduledUpdateGroupA
 	return s
 }
 
-// Contains the parameters for SetDesiredCapacity.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/SetDesiredCapacityType
 type SetDesiredCapacityInput struct {
 	_ struct{} `type:"structure"`
@@ -11338,7 +11292,6 @@ func (s SetDesiredCapacityOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for SetInstanceHealth.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/SetInstanceHealthQuery
 type SetInstanceHealthInput struct {
 	_ struct{} `type:"structure"`
@@ -11430,7 +11383,6 @@ func (s SetInstanceHealthOutput) GoString() string {
 	return s.String()
 }
 
-// Contains the parameters for SetInstanceProtection.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/SetInstanceProtectionQuery
 type SetInstanceProtectionInput struct {
 	_ struct{} `type:"structure"`
@@ -11502,7 +11454,6 @@ func (s *SetInstanceProtectionInput) SetProtectedFromScaleIn(v bool) *SetInstanc
 	return s
 }
 
-// Contains the output of SetInstanceProtection.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/SetInstanceProtectionAnswer
 type SetInstanceProtectionOutput struct {
 	_ struct{} `type:"structure"`
@@ -11808,7 +11759,6 @@ func (s *TagDescription) SetValue(v string) *TagDescription {
 	return s
 }
 
-// Contains the parameters for TerminateInstanceInAutoScalingGroup.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/TerminateInstanceInAutoScalingGroupType
 type TerminateInstanceInAutoScalingGroupInput struct {
 	_ struct{} `type:"structure"`
@@ -11866,7 +11816,6 @@ func (s *TerminateInstanceInAutoScalingGroupInput) SetShouldDecrementDesiredCapa
 	return s
 }
 
-// Contains the output of TerminateInstancesInAutoScalingGroup.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/ActivityType
 type TerminateInstanceInAutoScalingGroupOutput struct {
 	_ struct{} `type:"structure"`
@@ -11891,7 +11840,6 @@ func (s *TerminateInstanceInAutoScalingGroupOutput) SetActivity(v *Activity) *Te
 	return s
 }
 
-// Contains the parameters for UpdateAutoScalingGroup.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/autoscaling-2011-01-01/UpdateAutoScalingGroupType
 type UpdateAutoScalingGroupInput struct {
 	_ struct{} `type:"structure"`

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudwatchevents/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudwatchevents/api.go
@@ -889,9 +889,17 @@ func (c *CloudWatchEvents) PutTargetsRequest(input *PutTargetsInput) (req *reque
 //    are extracted from the event and used as values in a template that you
 //    specify as the input to the target.
 //
+// When you specify Input, InputPath, or InputTransformer, you must use JSON
+// dot notation, not bracket notation.
+//
 // When you add targets to a rule and the associated rule triggers soon after,
 // new or updated targets might not be immediately invoked. Please allow a short
 // period of time for changes to take effect.
+//
+// This action can partially fail if too many requests are made at the same
+// time. If that happens, FailedEntryCount is non-zero in the response and each
+// entry in FailedEntries provides the ID of the failed target and the error
+// code.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -986,6 +994,11 @@ func (c *CloudWatchEvents) RemoveTargetsRequest(input *RemoveTargetsInput) (req 
 // When you remove a target, when the associated rule triggers, removed targets
 // might continue to be invoked. Please allow a short period of time for changes
 // to take effect.
+//
+// This action can partially fail if too many requests are made at the same
+// time. If that happens, FailedEntryCount is non-zero in the response and each
+// entry in FailedEntries provides the ID of the failed target and the error
+// code.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1223,7 +1236,8 @@ type DescribeRuleOutput struct {
 	// The description of the rule.
 	Description *string `type:"string"`
 
-	// The event pattern.
+	// The event pattern. For more information, see Events and Event Patterns (http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html)
+	// in the Amazon CloudWatch Events User Guide.
 	EventPattern *string `type:"string"`
 
 	// The name of the rule.
@@ -1469,7 +1483,8 @@ type InputTransformer struct {
 	_ struct{} `type:"structure"`
 
 	// Map of JSON paths to be extracted from the event. These are key-value pairs,
-	// where each value is a JSON path.
+	// where each value is a JSON path. You must use JSON dot notation, not bracket
+	// notation.
 	InputPathsMap map[string]*string `type:"map"`
 
 	// Input template where you can use the values of the keys from InputPathsMap
@@ -2050,7 +2065,8 @@ type PutRuleInput struct {
 	// A description of the rule.
 	Description *string `type:"string"`
 
-	// The event pattern.
+	// The event pattern. For more information, see Events and Event Patterns (http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html)
+	// in the Amazon CloudWatch Events User Guide.
 	EventPattern *string `type:"string"`
 
 	// The name of the rule that you are creating or updating.
@@ -2264,7 +2280,9 @@ func (s *PutTargetsOutput) SetFailedEntryCount(v int64) *PutTargetsOutput {
 type PutTargetsResultEntry struct {
 	_ struct{} `type:"structure"`
 
-	// The error code that indicates why the target addition failed.
+	// The error code that indicates why the target addition failed. If the value
+	// is ConcurrentModificationException, too many requests were made at the same
+	// time.
 	ErrorCode *string `type:"string"`
 
 	// The error message that explains why the target addition failed.
@@ -2399,7 +2417,9 @@ func (s *RemoveTargetsOutput) SetFailedEntryCount(v int64) *RemoveTargetsOutput 
 type RemoveTargetsResultEntry struct {
 	_ struct{} `type:"structure"`
 
-	// The error code that indicates why the target removal failed.
+	// The error code that indicates why the target removal failed. If the value
+	// is ConcurrentModificationException, too many requests were made at the same
+	// time.
 	ErrorCode *string `type:"string"`
 
 	// The error message that explains why the target removal failed.
@@ -2448,7 +2468,9 @@ type Rule struct {
 	// The description of the rule.
 	Description *string `type:"string"`
 
-	// The event pattern of the rule.
+	// The event pattern of the rule. For more information, see Events and Event
+	// Patterns (http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html)
+	// in the Amazon CloudWatch Events User Guide.
 	EventPattern *string `type:"string"`
 
 	// The name of the rule.
@@ -2659,13 +2681,14 @@ type Target struct {
 	Id *string `min:"1" type:"string" required:"true"`
 
 	// Valid JSON text passed to the target. In this case, nothing from the event
-	// itself is passed to the target. For more information, see The JavaScript
-	// Object Notation (JSON) Data Interchange Format (http://www.rfc-editor.org/rfc/rfc7159.txt).
+	// itself is passed to the target. You must use JSON dot notation, not bracket
+	// notation. For more information, see The JavaScript Object Notation (JSON)
+	// Data Interchange Format (http://www.rfc-editor.org/rfc/rfc7159.txt).
 	Input *string `type:"string"`
 
 	// The value of the JSONPath that is used for extracting part of the matched
-	// event when passing it to the target. For more information about JSON paths,
-	// see JSONPath (http://goessner.net/articles/JsonPath/).
+	// event when passing it to the target. You must use JSON dot notation, not
+	// bracket notation. For more information about JSON paths, see JSONPath (http://goessner.net/articles/JsonPath/).
 	InputPath *string `type:"string"`
 
 	// Settings to enable you to provide custom input to a target based on certain
@@ -2805,7 +2828,8 @@ type TestEventPatternInput struct {
 	// Event is a required field
 	Event *string `type:"string" required:"true"`
 
-	// The event pattern.
+	// The event pattern. For more information, see Events and Event Patterns (http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html)
+	// in the Amazon CloudWatch Events User Guide.
 	//
 	// EventPattern is a required field
 	EventPattern *string `type:"string" required:"true"`

--- a/vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/cloudwatchlogs/api.go
@@ -2713,7 +2713,10 @@ func (c *CloudWatchLogs) PutSubscriptionFilterRequest(input *PutSubscriptionFilt
 //    * An AWS Lambda function that belongs to the same account as the subscription
 //    filter, for same-account delivery.
 //
-// There can only be one subscription filter associated with a log group.
+// There can only be one subscription filter associated with a log group. If
+// you are updating an existing filter, you must specify the correct name in
+// filterName. Otherwise, the call will fail because you cannot associate a
+// second filter with a log group.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -4101,6 +4104,12 @@ type DescribeLogStreamsInput struct {
 	//
 	// If you order the results by event time, you cannot specify the logStreamNamePrefix
 	// parameter.
+	//
+	// lastEventTimestamp represents the time of the most recent log event in the
+	// log stream in CloudWatch Logs. This number is expressed as the number of
+	// milliseconds since Jan 1, 1970 00:00:00 UTC. lastEventTimeStamp updates on
+	// an eventual consistency basis. It typically updates in less than an hour
+	// from ingestion, but may take longer in some rare situations.
 	OrderBy *string `locationName:"orderBy" type:"string" enum:"OrderBy"`
 }
 
@@ -4462,7 +4471,8 @@ type Destination struct {
 	// The ARN of this destination.
 	Arn *string `locationName:"arn" type:"string"`
 
-	// The creation time of the destination.
+	// The creation time of the destination, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
 
 	// The name of the destination.
@@ -4626,10 +4636,12 @@ func (s *ExportTask) SetTo(v int64) *ExportTask {
 type ExportTaskExecutionInfo struct {
 	_ struct{} `type:"structure"`
 
-	// The completion time of the export task.
+	// The completion time of the export task, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	CompletionTime *int64 `locationName:"completionTime" type:"long"`
 
-	// The creation time of the export task.
+	// The creation time of the export task, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
 }
 
@@ -4864,7 +4876,8 @@ type FilteredLogEvent struct {
 	// The ID of the event.
 	EventId *string `locationName:"eventId" type:"string"`
 
-	// The time the event was ingested.
+	// The time the event was ingested, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	IngestionTime *int64 `locationName:"ingestionTime" type:"long"`
 
 	// The name of the log stream this event belongs to.
@@ -5214,7 +5227,8 @@ type LogGroup struct {
 	// The Amazon Resource Name (ARN) of the log group.
 	Arn *string `locationName:"arn" type:"string"`
 
-	// The creation time of the log group.
+	// The creation time of the log group, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
 
 	// The name of the log group.
@@ -5287,18 +5301,23 @@ type LogStream struct {
 	// The Amazon Resource Name (ARN) of the log stream.
 	Arn *string `locationName:"arn" type:"string"`
 
-	// The creation time of the stream.
+	// The creation time of the stream, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
 
 	// The time of the first event, expressed as the number of milliseconds since
 	// Jan 1, 1970 00:00:00 UTC.
 	FirstEventTimestamp *int64 `locationName:"firstEventTimestamp" type:"long"`
 
-	// The time of the last event, expressed as the number of milliseconds since
-	// Jan 1, 1970 00:00:00 UTC.
+	// the time of the most recent log event in the log stream in CloudWatch Logs.
+	// This number is expressed as the number of milliseconds since Jan 1, 1970
+	// 00:00:00 UTC. lastEventTime updates on an eventual consistency basis. It
+	// typically updates in less than an hour from ingestion, but may take longer
+	// in some rare situations.
 	LastEventTimestamp *int64 `locationName:"lastEventTimestamp" type:"long"`
 
-	// The ingestion time.
+	// The ingestion time, expressed as the number of milliseconds since Jan 1,
+	// 1970 00:00:00 UTC.
 	LastIngestionTime *int64 `locationName:"lastIngestionTime" type:"long"`
 
 	// The name of the log stream.
@@ -5376,7 +5395,8 @@ func (s *LogStream) SetUploadSequenceToken(v string) *LogStream {
 type MetricFilter struct {
 	_ struct{} `type:"structure"`
 
-	// The creation time of the metric filter.
+	// The creation time of the metric filter, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
 
 	// The name of the metric filter.
@@ -5563,7 +5583,8 @@ func (s *MetricTransformation) SetMetricValue(v string) *MetricTransformation {
 type OutputLogEvent struct {
 	_ struct{} `type:"structure"`
 
-	// The time the event was ingested.
+	// The time the event was ingested, expressed as the number of milliseconds
+	// since Jan 1, 1970 00:00:00 UTC.
 	IngestionTime *int64 `locationName:"ingestionTime" type:"long"`
 
 	// The data contained in the log event.
@@ -6124,7 +6145,10 @@ type PutSubscriptionFilterInput struct {
 	// For a more even distribution, you can group log data randomly.
 	Distribution *string `locationName:"distribution" type:"string" enum:"Distribution"`
 
-	// A name for the subscription filter.
+	// A name for the subscription filter. If you are updating an existing filter,
+	// you must specify the correct name in filterName. Otherwise, the call will
+	// fail because you cannot associate a second filter with a log group. To find
+	// the name of the filter currently associated with a log group, use DescribeSubscriptionFilters.
 	//
 	// FilterName is a required field
 	FilterName *string `locationName:"filterName" min:"1" type:"string" required:"true"`
@@ -6323,7 +6347,8 @@ func (s *SearchedLogStream) SetSearchedCompletely(v bool) *SearchedLogStream {
 type SubscriptionFilter struct {
 	_ struct{} `type:"structure"`
 
-	// The creation time of the subscription filter.
+	// The creation time of the subscription filter, expressed as the number of
+	// milliseconds since Jan 1, 1970 00:00:00 UTC.
 	CreationTime *int64 `locationName:"creationTime" type:"long"`
 
 	// The Amazon Resource Name (ARN) of the destination.

--- a/vendor/github.com/aws/aws-sdk-go/service/codedeploy/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codedeploy/api.go
@@ -704,11 +704,12 @@ func (c *CodeDeploy) ContinueDeploymentRequest(input *ContinueDeploymentInput) (
 
 // ContinueDeployment API operation for AWS CodeDeploy.
 //
-// Starts the process of rerouting traffic from instances in the original environment
-// to instances in thereplacement environment without waiting for a specified
-// wait time to elapse. (Traffic rerouting, which is achieved by registering
-// instances in the replacement environment with the load balancer, can start
-// as soon as all instances have a status of Ready.)
+// For a blue/green deployment, starts the process of rerouting traffic from
+// instances in the original environment to instances in the replacement environment
+// without waiting for a specified wait time to elapse. (Traffic rerouting,
+// which is achieved by registering instances in the replacement environment
+// with the load balancer, can start as soon as all instances have a status
+// of Ready.)
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -964,6 +965,12 @@ func (c *CodeDeploy) CreateDeploymentRequest(input *CreateDeploymentInput) (req 
 //   * ErrCodeInvalidLoadBalancerInfoException "InvalidLoadBalancerInfoException"
 //   An invalid load balancer name, or no load balancer name, was specified.
 //
+//   * ErrCodeInvalidFileExistsBehaviorException "InvalidFileExistsBehaviorException"
+//   An invalid fileExistsBehavior option was specified to determine how AWS CodeDeploy
+//   handles files or directories that already exist in a deployment target location
+//   but weren't part of the previous successful deployment. Valid values include
+//   "DISALLOW", "OVERWRITE", and "RETAIN".
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/CreateDeployment
 func (c *CodeDeploy) CreateDeployment(input *CreateDeploymentInput) (*CreateDeploymentOutput, error) {
 	req, out := c.CreateDeploymentRequest(input)
@@ -1215,8 +1222,8 @@ func (c *CodeDeploy) CreateDeploymentGroupRequest(input *CreateDeploymentGroupIn
 //
 //   * ErrCodeInvalidDeploymentStyleException "InvalidDeploymentStyleException"
 //   An invalid deployment style was specified. Valid deployment types include
-//   "IN_PLACE" and "BLUE_GREEN". Valid deployment options for blue/green deployments
-//   include "WITH_TRAFFIC_CONTROL" and "WITHOUT_TRAFFIC_CONTROL".
+//   "IN_PLACE" and "BLUE_GREEN". Valid deployment options include "WITH_TRAFFIC_CONTROL"
+//   and "WITHOUT_TRAFFIC_CONTROL".
 //
 //   * ErrCodeInvalidBlueGreenDeploymentConfigurationException "InvalidBlueGreenDeploymentConfigurationException"
 //   The configuration for the blue/green deployment group was provided in an
@@ -2901,6 +2908,10 @@ func (c *CodeDeploy) ListDeploymentInstancesRequest(input *ListDeploymentInstanc
 //   Valid values include "Blue" for an original environment and "Green" for a
 //   replacement environment.
 //
+//   * ErrCodeInvalidDeploymentInstanceTypeException "InvalidDeploymentInstanceTypeException"
+//   An instance type was specified for an in-place deployment. Instance types
+//   are supported for blue/green deployments only.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ListDeploymentInstances
 func (c *CodeDeploy) ListDeploymentInstances(input *ListDeploymentInstancesInput) (*ListDeploymentInstancesOutput, error) {
 	req, out := c.ListDeploymentInstancesRequest(input)
@@ -3948,8 +3959,8 @@ func (c *CodeDeploy) UpdateDeploymentGroupRequest(input *UpdateDeploymentGroupIn
 //
 //   * ErrCodeInvalidDeploymentStyleException "InvalidDeploymentStyleException"
 //   An invalid deployment style was specified. Valid deployment types include
-//   "IN_PLACE" and "BLUE_GREEN". Valid deployment options for blue/green deployments
-//   include "WITH_TRAFFIC_CONTROL" and "WITHOUT_TRAFFIC_CONTROL".
+//   "IN_PLACE" and "BLUE_GREEN". Valid deployment options include "WITH_TRAFFIC_CONTROL"
+//   and "WITHOUT_TRAFFIC_CONTROL".
 //
 //   * ErrCodeInvalidBlueGreenDeploymentConfigurationException "InvalidBlueGreenDeploymentConfigurationException"
 //   The configuration for the blue/green deployment group was provided in an
@@ -5008,7 +5019,7 @@ type CreateDeploymentGroupInput struct {
 	// group.
 	//
 	// For more information about the predefined deployment configurations in AWS
-	// CodeDeploy, see see Working with Deployment Groups in AWS CodeDeploy (http://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html)
+	// CodeDeploy, see Working with Deployment Groups in AWS CodeDeploy (http://docs.aws.amazon.com/codedeploy/latest/userguide/deployment-configurations.html)
 	// in the AWS CodeDeploy User Guide.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string"`
 
@@ -5017,17 +5028,19 @@ type CreateDeploymentGroupInput struct {
 	// DeploymentGroupName is a required field
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string" required:"true"`
 
-	// Information about the type of deployment, standard or blue/green, that you
+	// Information about the type of deployment, in-place or blue/green, that you
 	// want to run and whether to route deployment traffic behind a load balancer.
 	DeploymentStyle *DeploymentStyle `locationName:"deploymentStyle" type:"structure"`
 
-	// The Amazon EC2 tags on which to filter.
+	// The Amazon EC2 tags on which to filter. The deployment group will include
+	// EC2 instances with any of the specified tags.
 	Ec2TagFilters []*EC2TagFilter `locationName:"ec2TagFilters" type:"list"`
 
-	// Information about the load balancer used in a blue/green deployment.
+	// Information about the load balancer used in a deployment.
 	LoadBalancerInfo *LoadBalancerInfo `locationName:"loadBalancerInfo" type:"structure"`
 
-	// The on-premises instance tags on which to filter.
+	// The on-premises instance tags on which to filter. The deployment group will
+	// include on-premises instances with any of the specified tags.
 	OnPremisesInstanceTagFilters []*TagFilter `locationName:"onPremisesInstanceTagFilters" type:"list"`
 
 	// A service role ARN that allows AWS CodeDeploy to act on the user's behalf
@@ -5212,6 +5225,22 @@ type CreateDeploymentInput struct {
 	// A comment about the deployment.
 	Description *string `locationName:"description" type:"string"`
 
+	// Information about how AWS CodeDeploy handles files that already exist in
+	// a deployment target location but weren't part of the previous successful
+	// deployment.
+	//
+	// The fileExistsBehavior parameter takes any of the following values:
+	//
+	//    * DISALLOW: The deployment fails. This is also the default behavior if
+	//    no option is specified.
+	//
+	//    * OVERWRITE: The version of the file from the application revision currently
+	//    being deployed replaces the version already on the instance.
+	//
+	//    * RETAIN: The version of the file already on the instance is kept and
+	//    used as part of the new deployment.
+	FileExistsBehavior *string `locationName:"fileExistsBehavior" type:"string" enum:"FileExistsBehavior"`
+
 	// If set to true, then if the deployment causes the ApplicationStop deployment
 	// lifecycle event to an instance to fail, the deployment to that instance will
 	// not be considered to have failed at that point and will continue on to the
@@ -5294,6 +5323,12 @@ func (s *CreateDeploymentInput) SetDeploymentGroupName(v string) *CreateDeployme
 // SetDescription sets the Description field's value.
 func (s *CreateDeploymentInput) SetDescription(v string) *CreateDeploymentInput {
 	s.Description = &v
+	return s
+}
+
+// SetFileExistsBehavior sets the FileExistsBehavior field's value.
+func (s *CreateDeploymentInput) SetFileExistsBehavior(v string) *CreateDeploymentInput {
+	s.FileExistsBehavior = &v
 	return s
 }
 
@@ -5637,14 +5672,14 @@ type DeploymentGroupInfo struct {
 	// The deployment group name.
 	DeploymentGroupName *string `locationName:"deploymentGroupName" min:"1" type:"string"`
 
-	// Information about the type of deployment, either standard or blue/green,
+	// Information about the type of deployment, either in-place or blue/green,
 	// you want to run and whether to route deployment traffic behind a load balancer.
 	DeploymentStyle *DeploymentStyle `locationName:"deploymentStyle" type:"structure"`
 
 	// The Amazon EC2 tags on which to filter.
 	Ec2TagFilters []*EC2TagFilter `locationName:"ec2TagFilters" type:"list"`
 
-	// Information about the load balancer to use in a blue/green deployment.
+	// Information about the load balancer to use in a deployment.
 	LoadBalancerInfo *LoadBalancerInfo `locationName:"loadBalancerInfo" type:"structure"`
 
 	// The on-premises instance tags on which to filter.
@@ -5807,7 +5842,7 @@ type DeploymentInfo struct {
 	// A summary of the deployment status of the instances in the deployment.
 	DeploymentOverview *DeploymentOverview `locationName:"deploymentOverview" type:"structure"`
 
-	// Information about the type of deployment, either standard or blue/green,
+	// Information about the type of deployment, either in-place or blue/green,
 	// you want to run and whether to route deployment traffic behind a load balancer.
 	DeploymentStyle *DeploymentStyle `locationName:"deploymentStyle" type:"structure"`
 
@@ -5816,6 +5851,20 @@ type DeploymentInfo struct {
 
 	// Information about any error associated with this deployment.
 	ErrorInformation *ErrorInformation `locationName:"errorInformation" type:"structure"`
+
+	// Information about how AWS CodeDeploy handles files that already exist in
+	// a deployment target location but weren't part of the previous successful
+	// deployment.
+	//
+	//    * DISALLOW: The deployment fails. This is also the default behavior if
+	//    no option is specified.
+	//
+	//    * OVERWRITE: The version of the file from the application revision currently
+	//    being deployed replaces the version already on the instance.
+	//
+	//    * RETAIN: The version of the file already on the instance is kept and
+	//    used as part of the new deployment.
+	FileExistsBehavior *string `locationName:"fileExistsBehavior" type:"string" enum:"FileExistsBehavior"`
 
 	// If true, then if the deployment causes the ApplicationStop deployment lifecycle
 	// event to an instance to fail, the deployment to that instance will not be
@@ -5834,8 +5883,12 @@ type DeploymentInfo struct {
 	// starts.
 	InstanceTerminationWaitTimeStarted *bool `locationName:"instanceTerminationWaitTimeStarted" type:"boolean"`
 
-	// Information about the load balancer used in this blue/green deployment.
+	// Information about the load balancer used in the deployment.
 	LoadBalancerInfo *LoadBalancerInfo `locationName:"loadBalancerInfo" type:"structure"`
+
+	// Information about the application revision that was deployed to the deployment
+	// group before the most recent successful deployment.
+	PreviousRevision *RevisionLocation `locationName:"previousRevision" type:"structure"`
 
 	// Information about the location of stored application artifacts and the service
 	// from which to retrieve them.
@@ -5958,6 +6011,12 @@ func (s *DeploymentInfo) SetErrorInformation(v *ErrorInformation) *DeploymentInf
 	return s
 }
 
+// SetFileExistsBehavior sets the FileExistsBehavior field's value.
+func (s *DeploymentInfo) SetFileExistsBehavior(v string) *DeploymentInfo {
+	s.FileExistsBehavior = &v
+	return s
+}
+
 // SetIgnoreApplicationStopFailures sets the IgnoreApplicationStopFailures field's value.
 func (s *DeploymentInfo) SetIgnoreApplicationStopFailures(v bool) *DeploymentInfo {
 	s.IgnoreApplicationStopFailures = &v
@@ -5973,6 +6032,12 @@ func (s *DeploymentInfo) SetInstanceTerminationWaitTimeStarted(v bool) *Deployme
 // SetLoadBalancerInfo sets the LoadBalancerInfo field's value.
 func (s *DeploymentInfo) SetLoadBalancerInfo(v *LoadBalancerInfo) *DeploymentInfo {
 	s.LoadBalancerInfo = v
+	return s
+}
+
+// SetPreviousRevision sets the PreviousRevision field's value.
+func (s *DeploymentInfo) SetPreviousRevision(v *RevisionLocation) *DeploymentInfo {
+	s.PreviousRevision = v
 	return s
 }
 
@@ -6131,7 +6196,7 @@ func (s *DeploymentReadyOption) SetWaitTimeInMinutes(v int64) *DeploymentReadyOp
 	return s
 }
 
-// Information about the type of deployment, either standard or blue/green,
+// Information about the type of deployment, either in-place or blue/green,
 // you want to run and whether to route deployment traffic behind a load balancer.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/DeploymentStyle
 type DeploymentStyle struct {
@@ -6140,7 +6205,7 @@ type DeploymentStyle struct {
 	// Indicates whether to route deployment traffic behind a load balancer.
 	DeploymentOption *string `locationName:"deploymentOption" type:"string" enum:"DeploymentOption"`
 
-	// Indicates whether to run a standard deployment or a blue/green deployment.
+	// Indicates whether to run an in-place deployment or a blue/green deployment.
 	DeploymentType *string `locationName:"deploymentType" type:"string" enum:"DeploymentType"`
 }
 
@@ -6290,7 +6355,7 @@ func (s *Diagnostics) SetScriptName(v string) *Diagnostics {
 	return s
 }
 
-// Information about a tag filter.
+// Information about an EC2 tag filter.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/EC2TagFilter
 type EC2TagFilter struct {
 	_ struct{} `type:"structure"`
@@ -6339,14 +6404,16 @@ func (s *EC2TagFilter) SetValue(v string) *EC2TagFilter {
 	return s
 }
 
-// Information about a load balancer in Elastic Load Balancing to use in a blue/green
-// deployment.
+// Information about a load balancer in Elastic Load Balancing to use in a deployment.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/ELBInfo
 type ELBInfo struct {
 	_ struct{} `type:"structure"`
 
-	// The name of the load balancer that will be used to route traffic from original
-	// instances to replacement instances in a blue/green deployment.
+	// For blue/green deployments, the name of the load balancer that will be used
+	// to route traffic from original instances to replacement instances in a blue/green
+	// deployment. For in-place deployments, the name of the load balancer that
+	// instances are deregistered from so they are not serving traffic during a
+	// deployment, and then re-registered with after the deployment completes.
 	Name *string `locationName:"name" type:"string"`
 }
 
@@ -8065,13 +8132,13 @@ func (s *ListOnPremisesInstancesOutput) SetNextToken(v string) *ListOnPremisesIn
 	return s
 }
 
-// Information about the load balancer used in a blue/green deployment.
+// Information about the load balancer used in a deployment.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06/LoadBalancerInfo
 type LoadBalancerInfo struct {
 	_ struct{} `type:"structure"`
 
 	// An array containing information about the load balancer in Elastic Load Balancing
-	// to use in a blue/green deployment.
+	// to use in a deployment.
 	ElbInfoList []*ELBInfo `locationName:"elbInfoList" type:"list"`
 }
 
@@ -8119,6 +8186,9 @@ type MinimumHealthyHosts struct {
 	// Although this allows one instance at a time to be taken offline for a new
 	// deployment, it also means that if the deployment to the last instance fails,
 	// the overall deployment still succeeds.
+	//
+	// For more information, see AWS CodeDeploy Instance Health (http://docs.aws.amazon.com/codedeploy/latest/userguide/instances-health.html)
+	// in the AWS CodeDeploy User Guide.
 	Type *string `locationName:"type" type:"string" enum:"MinimumHealthyHostsType"`
 
 	// The minimum healthy instance value.
@@ -9009,7 +9079,7 @@ type UpdateDeploymentGroupInput struct {
 	// it.
 	DeploymentConfigName *string `locationName:"deploymentConfigName" min:"1" type:"string"`
 
-	// Information about the type of deployment, either standard or blue/green,
+	// Information about the type of deployment, either in-place or blue/green,
 	// you want to run and whether to route deployment traffic behind a load balancer.
 	DeploymentStyle *DeploymentStyle `locationName:"deploymentStyle" type:"structure"`
 
@@ -9018,7 +9088,7 @@ type UpdateDeploymentGroupInput struct {
 	// do not enter any tag names.
 	Ec2TagFilters []*EC2TagFilter `locationName:"ec2TagFilters" type:"list"`
 
-	// Information about the load balancer used in a blue/green deployment.
+	// Information about the load balancer used in a deployment.
 	LoadBalancerInfo *LoadBalancerInfo `locationName:"loadBalancerInfo" type:"structure"`
 
 	// The new name of the deployment group, if you want to change it.
@@ -9345,6 +9415,17 @@ const (
 
 	// ErrorCodeManualStop is a ErrorCode enum value
 	ErrorCodeManualStop = "MANUAL_STOP"
+)
+
+const (
+	// FileExistsBehaviorDisallow is a FileExistsBehavior enum value
+	FileExistsBehaviorDisallow = "DISALLOW"
+
+	// FileExistsBehaviorOverwrite is a FileExistsBehavior enum value
+	FileExistsBehaviorOverwrite = "OVERWRITE"
+
+	// FileExistsBehaviorRetain is a FileExistsBehavior enum value
+	FileExistsBehaviorRetain = "RETAIN"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/codedeploy/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codedeploy/doc.go
@@ -3,59 +3,60 @@
 // Package codedeploy provides the client and types for making API
 // requests to AWS CodeDeploy.
 //
-// Overview
+// AWS CodeDeploy is a deployment service that automates application deployments
+// to Amazon EC2 instances or on-premises instances running in your own facility.
 //
-// This reference guide provides descriptions of the AWS CodeDeploy APIs. For
-// more information about AWS CodeDeploy, see the AWS CodeDeploy User Guide
-// (http://docs.aws.amazon.com/codedeploy/latest/userguide).
+// You can deploy a nearly unlimited variety of application content, such as
+// code, web and configuration files, executables, packages, scripts, multimedia
+// files, and so on. AWS CodeDeploy can deploy application content stored in
+// Amazon S3 buckets, GitHub repositories, or Bitbucket repositories. You do
+// not need to make changes to your existing code before you can use AWS CodeDeploy.
 //
-// Using the APIs
+// AWS CodeDeploy makes it easier for you to rapidly release new features, helps
+// you avoid downtime during application deployment, and handles the complexity
+// of updating your applications, without many of the risks associated with
+// error-prone manual deployments.
 //
-// You can use the AWS CodeDeploy APIs to work with the following:
+// AWS CodeDeploy Components
 //
-//    * Applications are unique identifiers used by AWS CodeDeploy to ensure
-//    the correct combinations of revisions, deployment configurations, and
-//    deployment groups are being referenced during deployments.
+// Use the information in this guide to help you work with the following AWS
+// CodeDeploy components:
 //
-// You can use the AWS CodeDeploy APIs to create, delete, get, list, and update
-//    applications.
+//    * Application: A name that uniquely identifies the application you want
+//    to deploy. AWS CodeDeploy uses this name, which functions as a container,
+//    to ensure the correct combination of revision, deployment configuration,
+//    and deployment group are referenced during a deployment.
 //
-//    * Deployment configurations are sets of deployment rules and success and
-//    failure conditions used by AWS CodeDeploy during deployments.
+//    * Deployment group: A set of individual instances. A deployment group
+//    contains individually tagged instances, Amazon EC2 instances in Auto Scaling
+//    groups, or both.
 //
-// You can use the AWS CodeDeploy APIs to create, delete, get, and list deployment
-//    configurations.
+//    * Deployment configuration: A set of deployment rules and deployment success
+//    and failure conditions used by AWS CodeDeploy during a deployment.
 //
-//    * Deployment groups are groups of instances to which application revisions
-//    can be deployed.
+//    * Deployment: The process, and the components involved in the process,
+//    of installing content on one or more instances.
 //
-// You can use the AWS CodeDeploy APIs to create, delete, get, list, and update
-//    deployment groups.
+//    * Application revisions: An archive file containing source content—source
+//    code, web pages, executable files, and deployment scripts—along with an
+//    application specification file (AppSpec file). Revisions are stored in
+//    Amazon S3 buckets or GitHub repositories. For Amazon S3, a revision is
+//    uniquely identified by its Amazon S3 object key and its ETag, version,
+//    or both. For GitHub, a revision is uniquely identified by its commit ID.
 //
-//    * Instances represent Amazon EC2 instances to which application revisions
-//    are deployed. Instances are identified by their Amazon EC2 tags or Auto
-//    Scaling group names. Instances belong to deployment groups.
+// This guide also contains information to help you get details about the instances
+// in your deployments and to make on-premises instances available for AWS CodeDeploy
+// deployments.
 //
-// You can use the AWS CodeDeploy APIs to get and list instance.
+// AWS CodeDeploy Information Resources
 //
-//    * Deployments represent the process of deploying revisions to instances.
+//    * AWS CodeDeploy User Guide (http://docs.aws.amazon.com/codedeploy/latest/userguide)
 //
-// You can use the AWS CodeDeploy APIs to create, get, list, and stop deployments.
+//    * AWS CodeDeploy API Reference Guide (http://docs.aws.amazon.com/codedeploy/latest/APIReference/)
 //
-//    * Application revisions are archive files stored in Amazon S3 buckets
-//    or GitHub repositories. These revisions contain source content (such as
-//    source code, web pages, executable files, and deployment scripts) along
-//    with an application specification (AppSpec) file. (The AppSpec file is
-//    unique to AWS CodeDeploy; it defines the deployment actions you want AWS
-//    CodeDeploy to execute.) For application revisions stored in Amazon S3
-//    buckets, an application revision is uniquely identified by its Amazon
-//    S3 object key and its ETag, version, or both. For application revisions
-//    stored in GitHub repositories, an application revision is uniquely identified
-//    by its repository name and commit ID. Application revisions are deployed
-//    through deployment groups.
+//    * AWS CLI Reference for AWS CodeDeploy (http://docs.aws.amazon.com/cli/latest/reference/deploy/index.html)
 //
-// You can use the AWS CodeDeploy APIs to get, list, and register application
-//    revisions.
+//    * AWS CodeDeploy Developer Forum (https://forums.aws.amazon.com/forum.jspa?forumID=179)
 //
 // See https://docs.aws.amazon.com/goto/WebAPI/codedeploy-2014-10-06 for more information on this service.
 //

--- a/vendor/github.com/aws/aws-sdk-go/service/codedeploy/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/codedeploy/errors.go
@@ -284,6 +284,13 @@ const (
 	// At least one of the deployment IDs was specified in an invalid format.
 	ErrCodeInvalidDeploymentIdException = "InvalidDeploymentIdException"
 
+	// ErrCodeInvalidDeploymentInstanceTypeException for service response error code
+	// "InvalidDeploymentInstanceTypeException".
+	//
+	// An instance type was specified for an in-place deployment. Instance types
+	// are supported for blue/green deployments only.
+	ErrCodeInvalidDeploymentInstanceTypeException = "InvalidDeploymentInstanceTypeException"
+
 	// ErrCodeInvalidDeploymentStatusException for service response error code
 	// "InvalidDeploymentStatusException".
 	//
@@ -294,8 +301,8 @@ const (
 	// "InvalidDeploymentStyleException".
 	//
 	// An invalid deployment style was specified. Valid deployment types include
-	// "IN_PLACE" and "BLUE_GREEN". Valid deployment options for blue/green deployments
-	// include "WITH_TRAFFIC_CONTROL" and "WITHOUT_TRAFFIC_CONTROL".
+	// "IN_PLACE" and "BLUE_GREEN". Valid deployment options include "WITH_TRAFFIC_CONTROL"
+	// and "WITHOUT_TRAFFIC_CONTROL".
 	ErrCodeInvalidDeploymentStyleException = "InvalidDeploymentStyleException"
 
 	// ErrCodeInvalidEC2TagException for service response error code
@@ -303,6 +310,15 @@ const (
 	//
 	// The tag was specified in an invalid format.
 	ErrCodeInvalidEC2TagException = "InvalidEC2TagException"
+
+	// ErrCodeInvalidFileExistsBehaviorException for service response error code
+	// "InvalidFileExistsBehaviorException".
+	//
+	// An invalid fileExistsBehavior option was specified to determine how AWS CodeDeploy
+	// handles files or directories that already exist in a deployment target location
+	// but weren't part of the previous successful deployment. Valid values include
+	// "DISALLOW", "OVERWRITE", and "RETAIN".
+	ErrCodeInvalidFileExistsBehaviorException = "InvalidFileExistsBehaviorException"
 
 	// ErrCodeInvalidIamSessionArnException for service response error code
 	// "InvalidIamSessionArnException".

--- a/vendor/github.com/aws/aws-sdk-go/service/elb/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elb/api.go
@@ -63,7 +63,7 @@ func (c *ELB) AddTagsRequest(input *AddTagsInput) (req *request.Request, output 
 // key is already associated with the load balancer, AddTags updates its value.
 //
 // For more information, see Tag Your Classic Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/add-remove-tags.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -155,7 +155,7 @@ func (c *ELB) ApplySecurityGroupsToLoadBalancerRequest(input *ApplySecurityGroup
 // associated security groups.
 //
 // For more information, see Security Groups for Load Balancers in a VPC (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-security-groups.html#elb-vpc-security-groups)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -247,7 +247,7 @@ func (c *ELB) AttachLoadBalancerToSubnetsRequest(input *AttachLoadBalancerToSubn
 // The load balancer evenly distributes requests across all registered subnets.
 // For more information, see Add or Remove Subnets for Your Load Balancer in
 // a VPC (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-manage-subnets.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -341,7 +341,7 @@ func (c *ELB) ConfigureHealthCheckRequest(input *ConfigureHealthCheckInput) (req
 //
 // For more information, see Configure Health Checks for Your Load Balancer
 // (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-healthchecks.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -435,7 +435,7 @@ func (c *ELB) CreateAppCookieStickinessPolicyRequest(input *CreateAppCookieStick
 // being sticky until a new application cookie is issued.
 //
 // For more information, see Application-Controlled Session Stickiness (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-application)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -540,7 +540,7 @@ func (c *ELB) CreateLBCookieStickinessPolicyRequest(input *CreateLBCookieStickin
 // cookie expiration time, which is specified in the policy configuration.
 //
 // For more information, see Duration-Based Session Stickiness (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-duration)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -629,7 +629,7 @@ func (c *ELB) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *re
 
 // CreateLoadBalancer API operation for Elastic Load Balancing.
 //
-// Creates a Classic load balancer.
+// Creates a Classic Load Balancer.
 //
 // You can add listeners, security groups, subnets, and tags when you create
 // your load balancer, or you can add them later using CreateLoadBalancerListeners,
@@ -641,7 +641,7 @@ func (c *ELB) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *re
 // You can create up to 20 load balancers per region per account. You can request
 // an increase for the number of load balancers for your account. For more information,
 // see Limits for Your Classic Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-limits.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -687,6 +687,7 @@ func (c *ELB) CreateLoadBalancerRequest(input *CreateLoadBalancerInput) (req *re
 //   A tag key was specified more than once.
 //
 //   * ErrCodeUnsupportedProtocolException "UnsupportedProtocol"
+//   The specified protocol or signature version is not supported.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/CreateLoadBalancer
 func (c *ELB) CreateLoadBalancer(input *CreateLoadBalancerInput) (*CreateLoadBalancerOutput, error) {
@@ -761,7 +762,7 @@ func (c *ELB) CreateLoadBalancerListenersRequest(input *CreateLoadBalancerListen
 // listener.
 //
 // For more information, see Listeners for Your Classic Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -788,6 +789,7 @@ func (c *ELB) CreateLoadBalancerListenersRequest(input *CreateLoadBalancerListen
 //   The requested configuration change is not valid.
 //
 //   * ErrCodeUnsupportedProtocolException "UnsupportedProtocol"
+//   The specified protocol or signature version is not supported.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/CreateLoadBalancerListeners
 func (c *ELB) CreateLoadBalancerListeners(input *CreateLoadBalancerListenersInput) (*CreateLoadBalancerListenersOutput, error) {
@@ -1208,7 +1210,7 @@ func (c *ELB) DeregisterInstancesFromLoadBalancerRequest(input *DeregisterInstan
 // from the load balancer.
 //
 // For more information, see Register or De-Register EC2 Instances (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-deregister-register-instances.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -1241,6 +1243,85 @@ func (c *ELB) DeregisterInstancesFromLoadBalancer(input *DeregisterInstancesFrom
 // for more information on using Contexts.
 func (c *ELB) DeregisterInstancesFromLoadBalancerWithContext(ctx aws.Context, input *DeregisterInstancesFromLoadBalancerInput, opts ...request.Option) (*DeregisterInstancesFromLoadBalancerOutput, error) {
 	req, out := c.DeregisterInstancesFromLoadBalancerRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
+const opDescribeAccountLimits = "DescribeAccountLimits"
+
+// DescribeAccountLimitsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeAccountLimits operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeAccountLimits for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeAccountLimits method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeAccountLimitsRequest method.
+//    req, resp := client.DescribeAccountLimitsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DescribeAccountLimits
+func (c *ELB) DescribeAccountLimitsRequest(input *DescribeAccountLimitsInput) (req *request.Request, output *DescribeAccountLimitsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeAccountLimits,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeAccountLimitsInput{}
+	}
+
+	output = &DescribeAccountLimitsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeAccountLimits API operation for Elastic Load Balancing.
+//
+// Describes the current Elastic Load Balancing resource limits for your AWS
+// account.
+//
+// For more information, see Limits for Your Classic Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-limits.html)
+// in the Classic Load Balancer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Elastic Load Balancing's
+// API operation DescribeAccountLimits for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DescribeAccountLimits
+func (c *ELB) DescribeAccountLimits(input *DescribeAccountLimitsInput) (*DescribeAccountLimitsOutput, error) {
+	req, out := c.DescribeAccountLimitsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeAccountLimitsWithContext is the same as DescribeAccountLimits with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeAccountLimits for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ELB) DescribeAccountLimitsWithContext(ctx aws.Context, input *DescribeAccountLimitsInput, opts ...request.Option) (*DescribeAccountLimitsOutput, error) {
+	req, out := c.DescribeAccountLimitsRequest(input)
 	req.SetContext(ctx)
 	req.ApplyOptions(opts...)
 	return out, req.Send()
@@ -1960,7 +2041,7 @@ func (c *ELB) DisableAvailabilityZonesForLoadBalancerRequest(input *DisableAvail
 // the traffic among its remaining Availability Zones.
 //
 // For more information, see Add or Remove Availability Zones (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-az.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2050,7 +2131,7 @@ func (c *ELB) EnableAvailabilityZonesForLoadBalancerRequest(input *EnableAvailab
 // Zones that contain instances.
 //
 // For more information, see Add or Remove Availability Zones (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-az.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2137,7 +2218,7 @@ func (c *ELB) ModifyLoadBalancerAttributesRequest(input *ModifyLoadBalancerAttri
 // can modify the load balancer attribute ConnectionSettings by specifying an
 // idle connection timeout value for your load balancer.
 //
-// For more information, see the following in the Classic Load Balancers Guide:
+// For more information, see the following in the Classic Load Balancer Guide:
 //
 //    * Cross-Zone Load Balancing (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-crosszone-lb.html)
 //
@@ -2253,7 +2334,7 @@ func (c *ELB) RegisterInstancesWithLoadBalancerRequest(input *RegisterInstancesW
 // To deregister instances from a load balancer, use DeregisterInstancesFromLoadBalancer.
 //
 // For more information, see Register or De-Register EC2 Instances (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-deregister-register-instances.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2422,7 +2503,7 @@ func (c *ELB) SetLoadBalancerListenerSSLCertificateRequest(input *SetLoadBalance
 //
 // For more information about updating your SSL certificate, see Replace the
 // SSL Certificate for Your Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-update-ssl-cert.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2448,6 +2529,7 @@ func (c *ELB) SetLoadBalancerListenerSSLCertificateRequest(input *SetLoadBalance
 //   The requested configuration change is not valid.
 //
 //   * ErrCodeUnsupportedProtocolException "UnsupportedProtocol"
+//   The specified protocol or signature version is not supported.
 //
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/SetLoadBalancerListenerSSLCertificate
 func (c *ELB) SetLoadBalancerListenerSSLCertificate(input *SetLoadBalancerListenerSSLCertificateInput) (*SetLoadBalancerListenerSSLCertificateOutput, error) {
@@ -2529,9 +2611,9 @@ func (c *ELB) SetLoadBalancerPoliciesForBackendServerRequest(input *SetLoadBalan
 //
 // For more information about enabling back-end instance authentication, see
 // Configure Back-end Instance Authentication (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-create-https-ssl-load-balancer.html#configure_backendauth_clt)
-// in the Classic Load Balancers Guide. For more information about Proxy Protocol,
+// in the Classic Load Balancer Guide. For more information about Proxy Protocol,
 // see Configure Proxy Protocol Support (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-proxy-protocol.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2626,7 +2708,7 @@ func (c *ELB) SetLoadBalancerPoliciesOfListenerRequest(input *SetLoadBalancerPol
 // Configuration (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/ssl-config-update.html),
 // Duration-Based Session Stickiness (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-duration),
 // and Application-Controlled Session Stickiness (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-sticky-sessions.html#enable-sticky-sessions-application)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -3452,7 +3534,7 @@ type CreateLoadBalancerInput struct {
 	// The listeners.
 	//
 	// For more information, see Listeners for Your Classic Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html)
-	// in the Classic Load Balancers Guide.
+	// in the Classic Load Balancer Guide.
 	//
 	// Listeners is a required field
 	Listeners []*Listener `type:"list" required:"true"`
@@ -3489,7 +3571,7 @@ type CreateLoadBalancerInput struct {
 	//
 	// For more information about tagging your load balancer, see Tag Your Classic
 	// Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/add-remove-tags.html)
-	// in the Classic Load Balancers Guide.
+	// in the Classic Load Balancer Guide.
 	Tags []*Tag `min:"1" type:"list"`
 }
 
@@ -4095,6 +4177,87 @@ func (s DeregisterInstancesFromLoadBalancerOutput) GoString() string {
 // SetInstances sets the Instances field's value.
 func (s *DeregisterInstancesFromLoadBalancerOutput) SetInstances(v []*Instance) *DeregisterInstancesFromLoadBalancerOutput {
 	s.Instances = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DescribeAccountLimitsInput
+type DescribeAccountLimitsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The marker for the next set of results. (You received this marker from a
+	// previous call.)
+	Marker *string `type:"string"`
+
+	// The maximum number of results to return with this call.
+	PageSize *int64 `min:"1" type:"integer"`
+}
+
+// String returns the string representation
+func (s DescribeAccountLimitsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountLimitsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAccountLimitsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAccountLimitsInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeAccountLimitsInput) SetMarker(v string) *DescribeAccountLimitsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeAccountLimitsInput) SetPageSize(v int64) *DescribeAccountLimitsInput {
+	s.PageSize = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/DescribeAccountLimitsOutput
+type DescribeAccountLimitsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the limits.
+	Limits []*Limit `type:"list"`
+
+	// The marker to use when requesting the next set of results. If there are no
+	// additional results, the string is empty.
+	NextMarker *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeAccountLimitsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountLimitsOutput) GoString() string {
+	return s.String()
+}
+
+// SetLimits sets the Limits field's value.
+func (s *DescribeAccountLimitsOutput) SetLimits(v []*Limit) *DescribeAccountLimitsOutput {
+	s.Limits = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeAccountLimitsOutput) SetNextMarker(v string) *DescribeAccountLimitsOutput {
+	s.NextMarker = &v
 	return s
 }
 
@@ -5023,11 +5186,49 @@ func (s *LBCookieStickinessPolicy) SetPolicyName(v string) *LBCookieStickinessPo
 	return s
 }
 
+// Information about an Elastic Load Balancing resource limit for your AWS account.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/Limit
+type Limit struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum value of the limit.
+	Max *string `type:"string"`
+
+	// The name of the limit. The possible values are:
+	//
+	//    * classic-listeners
+	//
+	//    * classic-load-balancers
+	Name *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Limit) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Limit) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *Limit) SetMax(v string) *Limit {
+	s.Max = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Limit) SetName(v string) *Limit {
+	s.Name = &v
+	return s
+}
+
 // Information about a listener.
 //
 // For information about the protocols and the ports supported by Elastic Load
 // Balancing, see Listeners for Your Classic Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html)
-// in the Classic Load Balancers Guide.
+// in the Classic Load Balancer Guide.
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancing-2012-06-01/Listener
 type Listener struct {
 	_ struct{} `type:"structure"`
@@ -5134,11 +5335,7 @@ func (s *Listener) SetSSLCertificateId(v string) *Listener {
 type ListenerDescription struct {
 	_ struct{} `type:"structure"`
 
-	// Information about a listener.
-	//
-	// For information about the protocols and the ports supported by Elastic Load
-	// Balancing, see Listeners for Your Classic Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/elb-listener-config.html)
-	// in the Classic Load Balancers Guide.
+	// The listener.
 	Listener *Listener `type:"structure"`
 
 	// The policies. If there are no policies enabled, the list is empty.
@@ -5176,7 +5373,7 @@ type LoadBalancerAttributes struct {
 	// and delivers the information to the Amazon S3 bucket that you specify.
 	//
 	// For more information, see Enable Access Logs (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html)
-	// in the Classic Load Balancers Guide.
+	// in the Classic Load Balancer Guide.
 	AccessLog *AccessLog `type:"structure"`
 
 	// This parameter is reserved.
@@ -5186,7 +5383,7 @@ type LoadBalancerAttributes struct {
 	// the load balancer shifts traffic away from a deregistered or unhealthy instance.
 	//
 	// For more information, see Configure Connection Draining (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-conn-drain.html)
-	// in the Classic Load Balancers Guide.
+	// in the Classic Load Balancer Guide.
 	ConnectionDraining *ConnectionDraining `type:"structure"`
 
 	// If enabled, the load balancer allows the connections to remain idle (no data
@@ -5195,14 +5392,14 @@ type LoadBalancerAttributes struct {
 	// By default, Elastic Load Balancing maintains a 60-second idle connection
 	// timeout for both front-end and back-end connections of your load balancer.
 	// For more information, see Configure Idle Connection Timeout (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/config-idle-timeout.html)
-	// in the Classic Load Balancers Guide.
+	// in the Classic Load Balancer Guide.
 	ConnectionSettings *ConnectionSettings `type:"structure"`
 
 	// If enabled, the load balancer routes the request traffic evenly across all
 	// instances regardless of the Availability Zones.
 	//
 	// For more information, see Configure Cross-Zone Load Balancing (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-disable-crosszone-lb.html)
-	// in the Classic Load Balancers Guide.
+	// in the Classic Load Balancer Guide.
 	CrossZoneLoadBalancing *CrossZoneLoadBalancing `type:"structure"`
 }
 
@@ -5290,7 +5487,7 @@ type LoadBalancerDescription struct {
 	// The DNS name of the load balancer.
 	//
 	// For more information, see Configure a Custom Domain Name (http://docs.aws.amazon.com/elasticloadbalancing/latest/classic/using-domain-names-with-elb.html)
-	// in the Classic Load Balancers Guide.
+	// in the Classic Load Balancer Guide.
 	CanonicalHostedZoneName *string `type:"string"`
 
 	// The ID of the Amazon Route 53 hosted zone for the load balancer.
@@ -5454,7 +5651,7 @@ func (s *LoadBalancerDescription) SetVPCId(v string) *LoadBalancerDescription {
 type ModifyLoadBalancerAttributesInput struct {
 	_ struct{} `type:"structure"`
 
-	// The attributes of the load balancer.
+	// The attributes for the load balancer.
 	//
 	// LoadBalancerAttributes is a required field
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure" required:"true"`
@@ -5513,7 +5710,7 @@ func (s *ModifyLoadBalancerAttributesInput) SetLoadBalancerName(v string) *Modif
 type ModifyLoadBalancerAttributesOutput struct {
 	_ struct{} `type:"structure"`
 
-	// The attributes for a load balancer.
+	// Information about the load balancer attributes.
 	LoadBalancerAttributes *LoadBalancerAttributes `type:"structure"`
 
 	// The name of the load balancer.

--- a/vendor/github.com/aws/aws-sdk-go/service/elb/doc.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elb/doc.go
@@ -12,17 +12,18 @@
 // the load balancer and a protocol and port number for connections from the
 // load balancer to the instances.
 //
-// Elastic Load Balancing supports two types of load balancers: Classic load
-// balancers and Application load balancers (new). A Classic load balancer makes
+// Elastic Load Balancing supports two types of load balancers: Classic Load
+// Balancers and Application Load Balancers (new). A Classic Load Balancer makes
 // routing and load balancing decisions either at the transport layer (TCP/SSL)
 // or the application layer (HTTP/HTTPS), and supports either EC2-Classic or
-// a VPC. An Application load balancer makes routing and load balancing decisions
+// a VPC. An Application Load Balancer makes routing and load balancing decisions
 // at the application layer (HTTP/HTTPS), supports path-based routing, and can
 // route requests to one or more ports on each EC2 instance or container instance
-// in your virtual private cloud (VPC). For more information, see the .
+// in your virtual private cloud (VPC). For more information, see the Elastic
+// Load Balancing User Guide (http://docs.aws.amazon.com/elasticloadbalancing/latest/userguide/what-is-load-balancing.html).
 //
-// This reference covers the 2012-06-01 API, which supports Classic load balancers.
-// The 2015-12-01 API supports Application load balancers.
+// This reference covers the 2012-06-01 API, which supports Classic Load Balancers.
+// The 2015-12-01 API supports Application Load Balancers.
 //
 // To get started, create a load balancer with one or more listeners using CreateLoadBalancer.
 // Register your instances with the load balancer using RegisterInstancesWithLoadBalancer.

--- a/vendor/github.com/aws/aws-sdk-go/service/elb/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elb/errors.go
@@ -130,5 +130,7 @@ const (
 
 	// ErrCodeUnsupportedProtocolException for service response error code
 	// "UnsupportedProtocol".
+	//
+	// The specified protocol or signature version is not supported.
 	ErrCodeUnsupportedProtocolException = "UnsupportedProtocol"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/elbv2/api.go
@@ -985,6 +985,85 @@ func (c *ELBV2) DeregisterTargetsWithContext(ctx aws.Context, input *DeregisterT
 	return out, req.Send()
 }
 
+const opDescribeAccountLimits = "DescribeAccountLimits"
+
+// DescribeAccountLimitsRequest generates a "aws/request.Request" representing the
+// client's request for the DescribeAccountLimits operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See DescribeAccountLimits for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the DescribeAccountLimits method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the DescribeAccountLimitsRequest method.
+//    req, resp := client.DescribeAccountLimitsRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeAccountLimits
+func (c *ELBV2) DescribeAccountLimitsRequest(input *DescribeAccountLimitsInput) (req *request.Request, output *DescribeAccountLimitsOutput) {
+	op := &request.Operation{
+		Name:       opDescribeAccountLimits,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &DescribeAccountLimitsInput{}
+	}
+
+	output = &DescribeAccountLimitsOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// DescribeAccountLimits API operation for Elastic Load Balancing.
+//
+// Describes the current Elastic Load Balancing resource limits for your AWS
+// account.
+//
+// For more information, see Limits for Your Application Load Balancer (http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-limits.html)
+// in the Application Load Balancer Guide.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Elastic Load Balancing's
+// API operation DescribeAccountLimits for usage and error information.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeAccountLimits
+func (c *ELBV2) DescribeAccountLimits(input *DescribeAccountLimitsInput) (*DescribeAccountLimitsOutput, error) {
+	req, out := c.DescribeAccountLimitsRequest(input)
+	return out, req.Send()
+}
+
+// DescribeAccountLimitsWithContext is the same as DescribeAccountLimits with the addition of
+// the ability to pass a context and additional request options.
+//
+// See DescribeAccountLimits for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *ELBV2) DescribeAccountLimitsWithContext(ctx aws.Context, input *DescribeAccountLimitsInput, opts ...request.Option) (*DescribeAccountLimitsOutput, error) {
+	req, out := c.DescribeAccountLimitsRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opDescribeListeners = "DescribeListeners"
 
 // DescribeListenersRequest generates a "aws/request.Request" representing the
@@ -4094,6 +4173,87 @@ func (s DeregisterTargetsOutput) GoString() string {
 	return s.String()
 }
 
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeAccountLimitsInput
+type DescribeAccountLimitsInput struct {
+	_ struct{} `type:"structure"`
+
+	// The marker for the next set of results. (You received this marker from a
+	// previous call.)
+	Marker *string `type:"string"`
+
+	// The maximum number of results to return with this call.
+	PageSize *int64 `min:"1" type:"integer"`
+}
+
+// String returns the string representation
+func (s DescribeAccountLimitsInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountLimitsInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *DescribeAccountLimitsInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "DescribeAccountLimitsInput"}
+	if s.PageSize != nil && *s.PageSize < 1 {
+		invalidParams.Add(request.NewErrParamMinValue("PageSize", 1))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetMarker sets the Marker field's value.
+func (s *DescribeAccountLimitsInput) SetMarker(v string) *DescribeAccountLimitsInput {
+	s.Marker = &v
+	return s
+}
+
+// SetPageSize sets the PageSize field's value.
+func (s *DescribeAccountLimitsInput) SetPageSize(v int64) *DescribeAccountLimitsInput {
+	s.PageSize = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeAccountLimitsOutput
+type DescribeAccountLimitsOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Information about the limits.
+	Limits []*Limit `type:"list"`
+
+	// The marker to use when requesting the next set of results. If there are no
+	// additional results, the string is empty.
+	NextMarker *string `type:"string"`
+}
+
+// String returns the string representation
+func (s DescribeAccountLimitsOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s DescribeAccountLimitsOutput) GoString() string {
+	return s.String()
+}
+
+// SetLimits sets the Limits field's value.
+func (s *DescribeAccountLimitsOutput) SetLimits(v []*Limit) *DescribeAccountLimitsOutput {
+	s.Limits = v
+	return s
+}
+
+// SetNextMarker sets the NextMarker field's value.
+func (s *DescribeAccountLimitsOutput) SetNextMarker(v string) *DescribeAccountLimitsOutput {
+	s.NextMarker = &v
+	return s
+}
+
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/DescribeListenersInput
 type DescribeListenersInput struct {
 	_ struct{} `type:"structure"`
@@ -4816,6 +4976,50 @@ func (s DescribeTargetHealthOutput) GoString() string {
 // SetTargetHealthDescriptions sets the TargetHealthDescriptions field's value.
 func (s *DescribeTargetHealthOutput) SetTargetHealthDescriptions(v []*TargetHealthDescription) *DescribeTargetHealthOutput {
 	s.TargetHealthDescriptions = v
+	return s
+}
+
+// Information about an Elastic Load Balancing resource limit for your AWS account.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/elasticloadbalancingv2-2015-12-01/Limit
+type Limit struct {
+	_ struct{} `type:"structure"`
+
+	// The maximum value of the limit.
+	Max *string `type:"string"`
+
+	// The name of the limit. The possible values are:
+	//
+	//    * application-load-balancers
+	//
+	//    * listeners-per-application-load-balancer
+	//
+	//    * rules-per-application-load-balancer
+	//
+	//    * target-groups
+	//
+	//    * targets-per-application-load-balancer
+	Name *string `type:"string"`
+}
+
+// String returns the string representation
+func (s Limit) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s Limit) GoString() string {
+	return s.String()
+}
+
+// SetMax sets the Max field's value.
+func (s *Limit) SetMax(v string) *Limit {
+	s.Max = &v
+	return s
+}
+
+// SetName sets the Name field's value.
+func (s *Limit) SetName(v string) *Limit {
+	s.Name = &v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/inspector/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/inspector/api.go
@@ -1276,6 +1276,109 @@ func (c *Inspector) DescribeRulesPackagesWithContext(ctx aws.Context, input *Des
 	return out, req.Send()
 }
 
+const opGetAssessmentReport = "GetAssessmentReport"
+
+// GetAssessmentReportRequest generates a "aws/request.Request" representing the
+// client's request for the GetAssessmentReport operation. The "output" return
+// value can be used to capture response data after the request's "Send" method
+// is called.
+//
+// See GetAssessmentReport for usage and error information.
+//
+// Creating a request object using this method should be used when you want to inject
+// custom logic into the request's lifecycle using a custom handler, or if you want to
+// access properties on the request object before or after sending the request. If
+// you just want the service response, call the GetAssessmentReport method directly
+// instead.
+//
+// Note: You must call the "Send" method on the returned request object in order
+// to execute the request.
+//
+//    // Example sending a request using the GetAssessmentReportRequest method.
+//    req, resp := client.GetAssessmentReportRequest(params)
+//
+//    err := req.Send()
+//    if err == nil { // resp is now filled
+//        fmt.Println(resp)
+//    }
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/inspector-2016-02-16/GetAssessmentReport
+func (c *Inspector) GetAssessmentReportRequest(input *GetAssessmentReportInput) (req *request.Request, output *GetAssessmentReportOutput) {
+	op := &request.Operation{
+		Name:       opGetAssessmentReport,
+		HTTPMethod: "POST",
+		HTTPPath:   "/",
+	}
+
+	if input == nil {
+		input = &GetAssessmentReportInput{}
+	}
+
+	output = &GetAssessmentReportOutput{}
+	req = c.newRequest(op, input, output)
+	return
+}
+
+// GetAssessmentReport API operation for Amazon Inspector.
+//
+// Produces an assessment report that includes detailed and comprehensive results
+// of a specified assessment run.
+//
+// Returns awserr.Error for service API and SDK errors. Use runtime type assertions
+// with awserr.Error's Code and Message methods to get detailed information about
+// the error.
+//
+// See the AWS API reference guide for Amazon Inspector's
+// API operation GetAssessmentReport for usage and error information.
+//
+// Returned Error Codes:
+//   * ErrCodeInternalException "InternalException"
+//   Internal server error.
+//
+//   * ErrCodeInvalidInputException "InvalidInputException"
+//   The request was rejected because an invalid or out-of-range value was supplied
+//   for an input parameter.
+//
+//   * ErrCodeAccessDeniedException "AccessDeniedException"
+//   You do not have required permissions to access the requested resource.
+//
+//   * ErrCodeNoSuchEntityException "NoSuchEntityException"
+//   The request was rejected because it referenced an entity that does not exist.
+//   The error code describes the entity.
+//
+//   * ErrCodeAssessmentRunInProgressException "AssessmentRunInProgressException"
+//   You cannot perform a specified action if an assessment run is currently in
+//   progress.
+//
+//   * ErrCodeUnsupportedFeatureException "UnsupportedFeatureException"
+//   Used by the GetAssessmentReport API. The request was rejected because you
+//   tried to generate a report for an assessment run that existed before reporting
+//   was supported in Amazon Inspector. You can only generate reports for assessment
+//   runs that took place or will take place after generating reports in Amazon
+//   Inspector became available.
+//
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/inspector-2016-02-16/GetAssessmentReport
+func (c *Inspector) GetAssessmentReport(input *GetAssessmentReportInput) (*GetAssessmentReportOutput, error) {
+	req, out := c.GetAssessmentReportRequest(input)
+	return out, req.Send()
+}
+
+// GetAssessmentReportWithContext is the same as GetAssessmentReport with the addition of
+// the ability to pass a context and additional request options.
+//
+// See GetAssessmentReport for details on how to use this API operation.
+//
+// The context must be non-nil and will be used for request cancellation. If
+// the context is nil a panic will occur. In the future the SDK may create
+// sub-contexts for http.Requests. See https://golang.org/pkg/context/
+// for more information on using Contexts.
+func (c *Inspector) GetAssessmentReportWithContext(ctx aws.Context, input *GetAssessmentReportInput, opts ...request.Option) (*GetAssessmentReportOutput, error) {
+	req, out := c.GetAssessmentReportRequest(input)
+	req.SetContext(ctx)
+	req.ApplyOptions(opts...)
+	return out, req.Send()
+}
+
 const opGetTelemetryMetadata = "GetTelemetryMetadata"
 
 // GetTelemetryMetadataRequest generates a "aws/request.Request" representing the
@@ -3222,6 +3325,11 @@ type AssessmentRun struct {
 	// DurationInSeconds is a required field
 	DurationInSeconds *int64 `locationName:"durationInSeconds" min:"180" type:"integer" required:"true"`
 
+	// Provides a total count of generated findings per severity.
+	//
+	// FindingCounts is a required field
+	FindingCounts map[string]*int64 `locationName:"findingCounts" type:"map" required:"true"`
+
 	// The auto-generated name for the assessment run.
 	//
 	// Name is a required field
@@ -3305,6 +3413,12 @@ func (s *AssessmentRun) SetDataCollected(v bool) *AssessmentRun {
 // SetDurationInSeconds sets the DurationInSeconds field's value.
 func (s *AssessmentRun) SetDurationInSeconds(v int64) *AssessmentRun {
 	s.DurationInSeconds = &v
+	return s
+}
+
+// SetFindingCounts sets the FindingCounts field's value.
+func (s *AssessmentRun) SetFindingCounts(v map[string]*int64) *AssessmentRun {
+	s.FindingCounts = v
 	return s
 }
 
@@ -3580,6 +3694,7 @@ type AssessmentRunNotification struct {
 	// Event is a required field
 	Event *string `locationName:"event" type:"string" required:"true" enum:"Event"`
 
+	// The message included in the notification.
 	Message *string `locationName:"message" type:"string"`
 
 	// The status code of the SNS notification.
@@ -5570,6 +5685,116 @@ func (s *FindingFilter) SetSeverities(v []*string) *FindingFilter {
 // SetUserAttributes sets the UserAttributes field's value.
 func (s *FindingFilter) SetUserAttributes(v []*Attribute) *FindingFilter {
 	s.UserAttributes = v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/inspector-2016-02-16/GetAssessmentReportRequest
+type GetAssessmentReportInput struct {
+	_ struct{} `type:"structure"`
+
+	// The ARN that specifies the assessment run for which you want to generate
+	// a report.
+	//
+	// AssessmentRunArn is a required field
+	AssessmentRunArn *string `locationName:"assessmentRunArn" min:"1" type:"string" required:"true"`
+
+	// Specifies the file format (html or pdf) of the assessment report that you
+	// want to generate.
+	//
+	// ReportFileFormat is a required field
+	ReportFileFormat *string `locationName:"reportFileFormat" type:"string" required:"true" enum:"ReportFileFormat"`
+
+	// Specifies the type of the assessment report that you want to generate. There
+	// are two types of assessment reports: a finding report and a full report.
+	// For more information, see Assessment Reports (http://docs.aws.amazon.com/inspector/latest/userguide/inspector_reports.html).
+	//
+	// ReportType is a required field
+	ReportType *string `locationName:"reportType" type:"string" required:"true" enum:"ReportType"`
+}
+
+// String returns the string representation
+func (s GetAssessmentReportInput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAssessmentReportInput) GoString() string {
+	return s.String()
+}
+
+// Validate inspects the fields of the type to determine if they are valid.
+func (s *GetAssessmentReportInput) Validate() error {
+	invalidParams := request.ErrInvalidParams{Context: "GetAssessmentReportInput"}
+	if s.AssessmentRunArn == nil {
+		invalidParams.Add(request.NewErrParamRequired("AssessmentRunArn"))
+	}
+	if s.AssessmentRunArn != nil && len(*s.AssessmentRunArn) < 1 {
+		invalidParams.Add(request.NewErrParamMinLen("AssessmentRunArn", 1))
+	}
+	if s.ReportFileFormat == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReportFileFormat"))
+	}
+	if s.ReportType == nil {
+		invalidParams.Add(request.NewErrParamRequired("ReportType"))
+	}
+
+	if invalidParams.Len() > 0 {
+		return invalidParams
+	}
+	return nil
+}
+
+// SetAssessmentRunArn sets the AssessmentRunArn field's value.
+func (s *GetAssessmentReportInput) SetAssessmentRunArn(v string) *GetAssessmentReportInput {
+	s.AssessmentRunArn = &v
+	return s
+}
+
+// SetReportFileFormat sets the ReportFileFormat field's value.
+func (s *GetAssessmentReportInput) SetReportFileFormat(v string) *GetAssessmentReportInput {
+	s.ReportFileFormat = &v
+	return s
+}
+
+// SetReportType sets the ReportType field's value.
+func (s *GetAssessmentReportInput) SetReportType(v string) *GetAssessmentReportInput {
+	s.ReportType = &v
+	return s
+}
+
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/inspector-2016-02-16/GetAssessmentReportResponse
+type GetAssessmentReportOutput struct {
+	_ struct{} `type:"structure"`
+
+	// Specifies the status of the request to generate an assessment report.
+	//
+	// Status is a required field
+	Status *string `locationName:"status" type:"string" required:"true" enum:"ReportStatus"`
+
+	// Specifies the URL where you can find the generated assessment report. This
+	// parameter is only returned if the report is successfully generated.
+	Url *string `locationName:"url" type:"string"`
+}
+
+// String returns the string representation
+func (s GetAssessmentReportOutput) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s GetAssessmentReportOutput) GoString() string {
+	return s.String()
+}
+
+// SetStatus sets the Status field's value.
+func (s *GetAssessmentReportOutput) SetStatus(v string) *GetAssessmentReportOutput {
+	s.Status = &v
+	return s
+}
+
+// SetUrl sets the Url field's value.
+func (s *GetAssessmentReportOutput) SetUrl(v string) *GetAssessmentReportOutput {
+	s.Url = &v
 	return s
 }
 
@@ -7717,11 +7942,17 @@ const (
 	// AssessmentRunStateDataCollected is a AssessmentRunState enum value
 	AssessmentRunStateDataCollected = "DATA_COLLECTED"
 
+	// AssessmentRunStateStartEvaluatingRulesPending is a AssessmentRunState enum value
+	AssessmentRunStateStartEvaluatingRulesPending = "START_EVALUATING_RULES_PENDING"
+
 	// AssessmentRunStateEvaluatingRules is a AssessmentRunState enum value
 	AssessmentRunStateEvaluatingRules = "EVALUATING_RULES"
 
 	// AssessmentRunStateFailed is a AssessmentRunState enum value
 	AssessmentRunStateFailed = "FAILED"
+
+	// AssessmentRunStateError is a AssessmentRunState enum value
+	AssessmentRunStateError = "ERROR"
 
 	// AssessmentRunStateCompleted is a AssessmentRunState enum value
 	AssessmentRunStateCompleted = "COMPLETED"
@@ -7990,6 +8221,33 @@ const (
 
 	// NoSuchEntityErrorCodeIamRoleDoesNotExist is a NoSuchEntityErrorCode enum value
 	NoSuchEntityErrorCodeIamRoleDoesNotExist = "IAM_ROLE_DOES_NOT_EXIST"
+)
+
+const (
+	// ReportFileFormatHtml is a ReportFileFormat enum value
+	ReportFileFormatHtml = "HTML"
+
+	// ReportFileFormatPdf is a ReportFileFormat enum value
+	ReportFileFormatPdf = "PDF"
+)
+
+const (
+	// ReportStatusWorkInProgress is a ReportStatus enum value
+	ReportStatusWorkInProgress = "WORK_IN_PROGRESS"
+
+	// ReportStatusFailed is a ReportStatus enum value
+	ReportStatusFailed = "FAILED"
+
+	// ReportStatusCompleted is a ReportStatus enum value
+	ReportStatusCompleted = "COMPLETED"
+)
+
+const (
+	// ReportTypeFinding is a ReportType enum value
+	ReportTypeFinding = "FINDING"
+
+	// ReportTypeFull is a ReportType enum value
+	ReportTypeFull = "FULL"
 )
 
 const (

--- a/vendor/github.com/aws/aws-sdk-go/service/inspector/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/inspector/errors.go
@@ -57,4 +57,14 @@ const (
 	// The request was rejected because it referenced an entity that does not exist.
 	// The error code describes the entity.
 	ErrCodeNoSuchEntityException = "NoSuchEntityException"
+
+	// ErrCodeUnsupportedFeatureException for service response error code
+	// "UnsupportedFeatureException".
+	//
+	// Used by the GetAssessmentReport API. The request was rejected because you
+	// tried to generate a report for an assessment run that existed before reporting
+	// was supported in Amazon Inspector. You can only generate reports for assessment
+	// runs that took place or will take place after generating reports in Amazon
+	// Inspector became available.
+	ErrCodeUnsupportedFeatureException = "UnsupportedFeatureException"
 )

--- a/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/kms/api.go
@@ -4336,9 +4336,9 @@ type CreateGrantInput struct {
 	//
 	// To specify the principal, use the Amazon Resource Name (ARN) (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 	// of an AWS principal. Valid AWS principals include AWS accounts (root), IAM
-	// users, federated users, and assumed role users. For examples of the ARN syntax
-	// to use for specifying a principal, see AWS Identity and Access Management
-	// (IAM) (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
+	// users, IAM roles, federated users, and assumed role users. For examples of
+	// the ARN syntax to use for specifying a principal, see AWS Identity and Access
+	// Management (IAM) (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arn-syntax-iam)
 	// in the Example ARNs section of the AWS General Reference.
 	//
 	// GranteePrincipal is a required field

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/api.go
@@ -57,14 +57,16 @@ func (c *SSM) AddTagsToResourceRequest(input *AddTagsToResourceInput) (req *requ
 // AddTagsToResource API operation for Amazon Simple Systems Manager (SSM).
 //
 // Adds or overwrites one or more tags for the specified resource. Tags are
-// metadata that you assign to your managed instances. Tags enable you to categorize
-// your managed instances in different ways, for example, by purpose, owner,
-// or environment. Each tag consists of a key and an optional value, both of
-// which you define. For example, you could define a set of tags for your account's
-// managed instances that helps you track each instance's owner and stack level.
-// For example: Key=Owner and Value=DbAdmin, SysAdmin, or Dev. Or Key=Stack
-// and Value=Production, Pre-Production, or Test. Each resource can have a maximum
-// of 10 tags.
+// metadata that you assign to your managed instances, Maintenance Windows,
+// or Parameter Store parameters. Tags enable you to categorize your resources
+// in different ways, for example, by purpose, owner, or environment. Each tag
+// consists of a key and an optional value, both of which you define. For example,
+// you could define a set of tags for your account's managed instances that
+// helps you track each instance's owner and stack level. For example: Key=Owner
+// and Value=DbAdmin, SysAdmin, or Dev. Or Key=Stack and Value=Production, Pre-Production,
+// or Test.
+//
+// Each resource can have a maximum of 10 tags.
 //
 // We recommend that you devise a set of tag keys that meets your needs for
 // each resource type. Using a consistent set of tag keys makes it easier for
@@ -726,7 +728,7 @@ func (c *SSM) CreateMaintenanceWindowRequest(input *CreateMaintenanceWindowInput
 // Returned Error Codes:
 //   * ErrCodeIdempotentParameterMismatch "IdempotentParameterMismatch"
 //   Error returned when an idempotent operation is retried and the parameters
-//   don’t match the original call to the API with the same idempotency token.
+//   don't match the original call to the API with the same idempotency token.
 //
 //   * ErrCodeResourceLimitExceededException "ResourceLimitExceededException"
 //   Error returned when the caller has exceeded the default resource limits (e.g.
@@ -814,7 +816,7 @@ func (c *SSM) CreatePatchBaselineRequest(input *CreatePatchBaselineInput) (req *
 // Returned Error Codes:
 //   * ErrCodeIdempotentParameterMismatch "IdempotentParameterMismatch"
 //   Error returned when an idempotent operation is retried and the parameters
-//   don’t match the original call to the API with the same idempotency token.
+//   don't match the original call to the API with the same idempotency token.
 //
 //   * ErrCodeResourceLimitExceededException "ResourceLimitExceededException"
 //   Error returned when the caller has exceeded the default resource limits (e.g.
@@ -1434,7 +1436,7 @@ func (c *SSM) DeregisterManagedInstanceRequest(input *DeregisterManagedInstanceI
 // DeregisterManagedInstance API operation for Amazon Simple Systems Manager (SSM).
 //
 // Removes the server or virtual machine from the list of registered servers.
-// You can reregister the instance again at any time. If you don’t plan to use
+// You can reregister the instance again at any time. If you don't plan to use
 // Run Command on the server, we suggest uninstalling the SSM Agent first.
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
@@ -1626,7 +1628,7 @@ func (c *SSM) DeregisterTargetFromMaintenanceWindowRequest(input *DeregisterTarg
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -1710,7 +1712,7 @@ func (c *SSM) DeregisterTaskFromMaintenanceWindowRequest(input *DeregisterTaskFr
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -2280,7 +2282,7 @@ func (c *SSM) DescribeDocumentPermissionRequest(input *DescribeDocumentPermissio
 //
 // Describes the permissions for a Systems Manager document. If you created
 // the document, you are the owner. If a document is shared, it can either be
-// shared privately (by specifying a user’s AWS account ID) or publicly (All).
+// shared privately (by specifying a user's AWS account ID) or publicly (All).
 //
 // Returns awserr.Error for service API and SDK errors. Use runtime type assertions
 // with awserr.Error's Code and Message methods to get detailed information about
@@ -2482,7 +2484,7 @@ func (c *SSM) DescribeEffectivePatchesForPatchBaselineRequest(input *DescribeEff
 //
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -3104,7 +3106,7 @@ func (c *SSM) DescribeMaintenanceWindowExecutionTaskInvocationsRequest(input *De
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -3188,7 +3190,7 @@ func (c *SSM) DescribeMaintenanceWindowExecutionTasksRequest(input *DescribeMain
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -3354,7 +3356,7 @@ func (c *SSM) DescribeMaintenanceWindowTargetsRequest(input *DescribeMaintenance
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -3438,7 +3440,7 @@ func (c *SSM) DescribeMaintenanceWindowTasksRequest(input *DescribeMaintenanceWi
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -4548,7 +4550,7 @@ func (c *SSM) GetMaintenanceWindowRequest(input *GetMaintenanceWindowInput) (req
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -4633,7 +4635,7 @@ func (c *SSM) GetMaintenanceWindowExecutionRequest(input *GetMaintenanceWindowEx
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -4718,7 +4720,7 @@ func (c *SSM) GetMaintenanceWindowExecutionTaskRequest(input *GetMaintenanceWind
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -4968,7 +4970,7 @@ func (c *SSM) GetPatchBaselineRequest(input *GetPatchBaselineInput) (req *reques
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInvalidResourceId "InvalidResourceId"
 //   The resource ID is not valid. Verify that you entered the correct ID and
@@ -6339,7 +6341,7 @@ func (c *SSM) RegisterDefaultPatchBaselineRequest(input *RegisterDefaultPatchBas
 //
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -6427,7 +6429,7 @@ func (c *SSM) RegisterPatchBaselineForPatchGroupRequest(input *RegisterPatchBase
 //
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInvalidResourceId "InvalidResourceId"
 //   The resource ID is not valid. Verify that you entered the correct ID and
@@ -6519,11 +6521,11 @@ func (c *SSM) RegisterTargetWithMaintenanceWindowRequest(input *RegisterTargetWi
 // Returned Error Codes:
 //   * ErrCodeIdempotentParameterMismatch "IdempotentParameterMismatch"
 //   Error returned when an idempotent operation is retried and the parameters
-//   don’t match the original call to the API with the same idempotency token.
+//   don't match the original call to the API with the same idempotency token.
 //
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeResourceLimitExceededException "ResourceLimitExceededException"
 //   Error returned when the caller has exceeded the default resource limits (e.g.
@@ -6611,11 +6613,11 @@ func (c *SSM) RegisterTaskWithMaintenanceWindowRequest(input *RegisterTaskWithMa
 // Returned Error Codes:
 //   * ErrCodeIdempotentParameterMismatch "IdempotentParameterMismatch"
 //   Error returned when an idempotent operation is retried and the parameters
-//   don’t match the original call to the API with the same idempotency token.
+//   don't match the original call to the API with the same idempotency token.
 //
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeResourceLimitExceededException "ResourceLimitExceededException"
 //   Error returned when the caller has exceeded the default resource limits (e.g.
@@ -7121,6 +7123,13 @@ func (c *SSM) UpdateAssociationRequest(input *UpdateAssociationInput) (req *requ
 //   There are concurrent updates for a resource that supports one update at a
 //   time.
 //
+//   * ErrCodeInvalidDocument "InvalidDocument"
+//   The specified document does not exist.
+//
+//   * ErrCodeInvalidTarget "InvalidTarget"
+//   The target is not valid or does not exist. It might not be configured for
+//   EC2 Systems Manager or you might not have permission to perform the operation.
+//
 // Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/UpdateAssociation
 func (c *SSM) UpdateAssociation(input *UpdateAssociationInput) (*UpdateAssociationOutput, error) {
 	req, out := c.UpdateAssociationRequest(input)
@@ -7501,7 +7510,7 @@ func (c *SSM) UpdateMaintenanceWindowRequest(input *UpdateMaintenanceWindowInput
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -7682,7 +7691,7 @@ func (c *SSM) UpdatePatchBaselineRequest(input *UpdatePatchBaselineInput) (req *
 // Returned Error Codes:
 //   * ErrCodeDoesNotExistException "DoesNotExistException"
 //   Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-//   doesn’t exist.
+//   doesn't exist.
 //
 //   * ErrCodeInternalServerError "InternalServerError"
 //   An error occurred on the server side.
@@ -8734,31 +8743,31 @@ type Command struct {
 	// For more information about these statuses, see Run Command Status (http://docs.aws.amazon.com/systems-manager/latest/userguide/monitor-about-status.html).
 	// StatusDetails can be one of the following values:
 	//
-	//    * Pending – The command has not been sent to any instances.
+	//    * Pending: The command has not been sent to any instances.
 	//
-	//    * In Progress – The command has been sent to at least one instance but
+	//    * In Progress: The command has been sent to at least one instance but
 	//    has not reached a final state on all instances.
 	//
-	//    * Success – The command successfully executed on all invocations. This
+	//    * Success: The command successfully executed on all invocations. This
 	//    is a terminal state.
 	//
-	//    * Delivery Timed Out – The value of MaxErrors or more command invocations
+	//    * Delivery Timed Out: The value of MaxErrors or more command invocations
 	//    shows a status of Delivery Timed Out. This is a terminal state.
 	//
-	//    * Execution Timed Out – The value of MaxErrors or more command invocations
+	//    * Execution Timed Out: The value of MaxErrors or more command invocations
 	//    shows a status of Execution Timed Out. This is a terminal state.
 	//
-	//    * Failed – The value of MaxErrors or more command invocations shows a
-	//    status of Failed. This is a terminal state.
+	//    * Failed: The value of MaxErrors or more command invocations shows a status
+	//    of Failed. This is a terminal state.
 	//
-	//    * Incomplete – The command was attempted on all instances and one or more
+	//    * Incomplete: The command was attempted on all instances and one or more
 	//    invocations does not have a value of Success but not enough invocations
 	//    failed for the status to be Failed. This is a terminal state.
 	//
-	//    * Canceled – The command was terminated before it was completed. This
-	//    is a terminal state.
+	//    * Canceled: The command was terminated before it was completed. This is
+	//    a terminal state.
 	//
-	//    * Rate Exceeded – The number of instances targeted by the command exceeded
+	//    * Rate Exceeded: The number of instances targeted by the command exceeded
 	//    the account limit for pending invocations. The system has canceled the
 	//    command before executing it on any instance. This is a terminal state.
 	StatusDetails *string `type:"string"`
@@ -8999,13 +9008,13 @@ type CommandInvocation struct {
 	// notifications about command status changes on a per instance basis.
 	ServiceRole *string `type:"string"`
 
-	// The URL to the plugin’s StdErr file in Amazon S3, if the Amazon S3 bucket
+	// The URL to the plugin's StdErr file in Amazon S3, if the Amazon S3 bucket
 	// was defined for the parent command. For an invocation, StandardErrorUrl is
 	// populated if there is just one plugin defined for the command, and the Amazon
 	// S3 bucket was defined for the command.
 	StandardErrorUrl *string `type:"string"`
 
-	// The URL to the plugin’s StdOut file in Amazon S3, if the Amazon S3 bucket
+	// The URL to the plugin's StdOut file in Amazon S3, if the Amazon S3 bucket
 	// was defined for the parent command. For an invocation, StandardOutputUrl
 	// is populated if there is just one plugin defined for the command, and the
 	// Amazon S3 bucket was defined for the command.
@@ -9021,40 +9030,40 @@ type CommandInvocation struct {
 	// about these statuses, see Run Command Status (http://docs.aws.amazon.com/systems-manager/latest/userguide/monitor-about-status.html).
 	// StatusDetails can be one of the following values:
 	//
-	//    * Pending – The command has not been sent to the instance.
+	//    * Pending: The command has not been sent to the instance.
 	//
-	//    * In Progress – The command has been sent to the instance but has not
-	//    reached a terminal state.
+	//    * In Progress: The command has been sent to the instance but has not reached
+	//    a terminal state.
 	//
-	//    * Success – The execution of the command or plugin was successfully completed.
+	//    * Success: The execution of the command or plugin was successfully completed.
 	//    This is a terminal state.
 	//
-	//    * Delivery Timed Out – The command was not delivered to the instance before
+	//    * Delivery Timed Out: The command was not delivered to the instance before
 	//    the delivery timeout expired. Delivery timeouts do not count against the
-	//    parent command’s MaxErrors limit, but they do contribute to whether the
+	//    parent command's MaxErrors limit, but they do contribute to whether the
 	//    parent command status is Success or Incomplete. This is a terminal state.
 	//
-	//    * Execution Timed Out – Command execution started on the instance, but
+	//    * Execution Timed Out: Command execution started on the instance, but
 	//    the execution was not complete before the execution timeout expired. Execution
 	//    timeouts count against the MaxErrors limit of the parent command. This
 	//    is a terminal state.
 	//
-	//    * Failed – The command was not successful on the instance. For a plugin,
+	//    * Failed: The command was not successful on the instance. For a plugin,
 	//    this indicates that the result code was not zero. For a command invocation,
 	//    this indicates that the result code for one or more plugins was not zero.
 	//    Invocation failures count against the MaxErrors limit of the parent command.
 	//    This is a terminal state.
 	//
-	//    * Canceled – The command was terminated before it was completed. This
-	//    is a terminal state.
+	//    * Canceled: The command was terminated before it was completed. This is
+	//    a terminal state.
 	//
-	//    * Undeliverable – The command can't be delivered to the instance. The
-	//    instance might not exist or might not be responding. Undeliverable invocations
-	//    don't count against the parent command’s MaxErrors limit and don't contribute
+	//    * Undeliverable: The command can't be delivered to the instance. The instance
+	//    might not exist or might not be responding. Undeliverable invocations
+	//    don't count against the parent command's MaxErrors limit and don't contribute
 	//    to whether the parent command status is Success or Incomplete. This is
 	//    a terminal state.
 	//
-	//    * Terminated – The parent command exceeded its MaxErrors limit and subsequent
+	//    * Terminated: The parent command exceeded its MaxErrors limit and subsequent
 	//    command invocations were canceled by the system. This is a terminal state.
 	StatusDetails *string `type:"string"`
 
@@ -9230,40 +9239,40 @@ type CommandPlugin struct {
 	// For more information about these statuses, see Run Command Status (http://docs.aws.amazon.com/systems-manager/latest/userguide/monitor-about-status.html).
 	// StatusDetails can be one of the following values:
 	//
-	//    * Pending – The command has not been sent to the instance.
+	//    * Pending: The command has not been sent to the instance.
 	//
-	//    * In Progress – The command has been sent to the instance but has not
-	//    reached a terminal state.
+	//    * In Progress: The command has been sent to the instance but has not reached
+	//    a terminal state.
 	//
-	//    * Success – The execution of the command or plugin was successfully completed.
+	//    * Success: The execution of the command or plugin was successfully completed.
 	//    This is a terminal state.
 	//
-	//    * Delivery Timed Out – The command was not delivered to the instance before
+	//    * Delivery Timed Out: The command was not delivered to the instance before
 	//    the delivery timeout expired. Delivery timeouts do not count against the
-	//    parent command’s MaxErrors limit, but they do contribute to whether the
+	//    parent command's MaxErrors limit, but they do contribute to whether the
 	//    parent command status is Success or Incomplete. This is a terminal state.
 	//
-	//    * Execution Timed Out – Command execution started on the instance, but
+	//    * Execution Timed Out: Command execution started on the instance, but
 	//    the execution was not complete before the execution timeout expired. Execution
 	//    timeouts count against the MaxErrors limit of the parent command. This
 	//    is a terminal state.
 	//
-	//    * Failed – The command was not successful on the instance. For a plugin,
+	//    * Failed: The command was not successful on the instance. For a plugin,
 	//    this indicates that the result code was not zero. For a command invocation,
 	//    this indicates that the result code for one or more plugins was not zero.
 	//    Invocation failures count against the MaxErrors limit of the parent command.
 	//    This is a terminal state.
 	//
-	//    * Canceled – The command was terminated before it was completed. This
-	//    is a terminal state.
+	//    * Canceled: The command was terminated before it was completed. This is
+	//    a terminal state.
 	//
-	//    * Undeliverable – The command can't be delivered to the instance. The
-	//    instance might not exist, or it might not be responding. Undeliverable
-	//    invocations don't count against the parent command’s MaxErrors limit,
-	//    and they don't contribute to whether the parent command status is Success
-	//    or Incomplete. This is a terminal state.
+	//    * Undeliverable: The command can't be delivered to the instance. The instance
+	//    might not exist, or it might not be responding. Undeliverable invocations
+	//    don't count against the parent command's MaxErrors limit, and they don't
+	//    contribute to whether the parent command status is Success or Incomplete.
+	//    This is a terminal state.
 	//
-	//    * Terminated – The parent command exceeded its MaxErrors limit and subsequent
+	//    * Terminated: The parent command exceeded its MaxErrors limit and subsequent
 	//    command invocations were canceled by the system. This is a terminal state.
 	StatusDetails *string `type:"string"`
 }
@@ -9358,7 +9367,7 @@ type CreateActivationInput struct {
 	// EC2 console or when you use the AWS command line tools to list EC2 resources.
 	DefaultInstanceName *string `type:"string"`
 
-	// A user-defined description of the resource that you want to register with
+	// A userdefined description of the resource that you want to register with
 	// Amazon EC2.
 	Description *string `type:"string"`
 
@@ -9682,25 +9691,15 @@ type CreateAssociationInput struct {
 	Name *string `type:"string" required:"true"`
 
 	// An Amazon S3 bucket where you want to store the output details of the request.
-	// For example:
-	//
-	// "{ \"S3Location\": { \"OutputS3Region\": \"<region>\", \"OutputS3BucketName\":
-	// \"bucket name\", \"OutputS3KeyPrefix\": \"folder name\" } }"
 	OutputLocation *InstanceAssociationOutputLocation `type:"structure"`
 
 	// The parameters for the documents runtime configuration.
 	Parameters map[string][]*string `type:"map"`
 
 	// A cron expression when the association will be applied to the target(s).
-	// Supported expressions are every half, 1, 2, 4, 8 or 12 hour(s); every specified
-	// day and time of the week. For example: cron(0 0/30 * 1/1 * ? *) to run every
-	// thirty minutes; cron(0 0 0/4 1/1 * ? *) to run every four hours; and cron(0
-	// 0 10 ? * SUN *) to run every Sunday at 10 a.m.
 	ScheduleExpression *string `min:"1" type:"string"`
 
-	// The targets (either instances or tags) for the association. Instances are
-	// specified using Key=instanceids,Values=<instanceid1>,<instanceid2>. Tags
-	// are specified using Key=<tag name>,Values=<tag value>.
+	// The targets (either instances or tags) for the association.
 	Targets []*Target `type:"list"`
 }
 
@@ -10053,7 +10052,7 @@ type CreatePatchBaselineInput struct {
 	// A list of explicitly approved patches for the baseline.
 	ApprovedPatches []*string `type:"list"`
 
-	// Caller-provided idempotency token.
+	// User-provided idempotency token.
 	ClientToken *string `min:"1" type:"string" idempotencyToken:"true"`
 
 	// A description of the patch baseline.
@@ -11831,11 +11830,11 @@ type DescribeInstancePatchStatesForPatchGroupInput struct {
 
 	// Each entry in the array is a structure containing:
 	//
-	// Key (string 1 ≤ length ≤ 200)
+	// Key (string between 1 and 200 characters)
 	//
 	// Values (array containing a single string)
 	//
-	// Type (string “Equal”, “NotEqual”, “LessThan”, “GreaterThan”)
+	// Type (string "Equal", "NotEqual", "LessThan", "GreaterThan")
 	Filters []*InstancePatchStateFilter `type:"list"`
 
 	// The maximum number of patches to return (per page).
@@ -12050,9 +12049,9 @@ type DescribeInstancePatchesInput struct {
 
 	// Each entry in the array is a structure containing:
 	//
-	// Key (string, 1 ≤ length ≤ 128)
+	// Key (string, between 1 and 128 characters)
 	//
-	// Values (array of strings 1 ≤ length ≤ 256)
+	// Values (array of strings, each string between 1 and 256 characters)
 	Filters []*PatchOrchestratorFilter `type:"list"`
 
 	// The ID of the instance whose patch state information should be retrieved.
@@ -12146,8 +12145,8 @@ type DescribeInstancePatchesOutput struct {
 	//
 	// Severity (string)
 	//
-	// State (string – “INSTALLED”, “INSTALLED_OTHER”, “MISSING”, “NOT_APPLICABLE”,
-	// “FAILED”)
+	// State (string: "INSTALLED", "INSTALLED OTHER", "MISSING", "NOT APPLICABLE",
+	// "FAILED")
 	//
 	// InstalledTime (DateTime)
 	//
@@ -12444,9 +12443,9 @@ type DescribeMaintenanceWindowExecutionsInput struct {
 
 	// Each entry in the array is a structure containing:
 	//
-	// Key (string, 1 ≤ length ≤ 128)
+	// Key (string, between 1 and 128 characters)
 	//
-	// Values (array of strings 1 ≤ length ≤ 256)
+	// Values (array of strings, each string is between 1 and 256 characters)
 	//
 	// The supported Keys are ExecutedBefore and ExecutedAfter with the value being
 	// a date/time string such as 2016-11-04T05:00:00Z.
@@ -13015,9 +13014,9 @@ type DescribePatchBaselinesInput struct {
 
 	// Each element in the array is a structure containing:
 	//
-	// Key: (string, “NAME_PREFIX” or “OWNER”)
+	// Key: (string, "NAME_PREFIX" or "OWNER")
 	//
-	// Value: (array of strings, exactly 1 entry, 1 ≤ length ≤ 255)
+	// Value: (array of strings, exactly 1 entry, between 1 and 255 characters)
 	Filters []*PatchOrchestratorFilter `type:"list"`
 
 	// The maximum number of patch baselines to return (per page).
@@ -13166,7 +13165,7 @@ type DescribePatchGroupStateOutput struct {
 	// to install.
 	InstancesWithFailedPatches *int64 `type:"integer"`
 
-	// The number of instances with patches installed that aren’t defined in the
+	// The number of instances with patches installed that aren't defined in the
 	// patch baseline.
 	InstancesWithInstalledOtherPatches *int64 `type:"integer"`
 
@@ -13176,7 +13175,7 @@ type DescribePatchGroupStateOutput struct {
 	// The number of instances with missing patches from the patch baseline.
 	InstancesWithMissingPatches *int64 `type:"integer"`
 
-	// The number of instances with patches that aren’t applicable.
+	// The number of instances with patches that aren't applicable.
 	InstancesWithNotApplicablePatches *int64 `type:"integer"`
 }
 
@@ -13279,7 +13278,7 @@ type DescribePatchGroupsOutput struct {
 
 	// Each entry in the array contains:
 	//
-	// PatchGroup: string (1 ≤ length ≤ 256, Regex: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$)
+	// PatchGroup: string (between 1 and 256 characters, Regex: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$)
 	//
 	// PatchBaselineIdentity: A PatchBaselineIdentity element.
 	Mappings []*PatchGroupPatchBaselineMapping `type:"list"`
@@ -13644,7 +13643,7 @@ type DocumentParameter struct {
 	// The name of the parameter.
 	Name *string `type:"string"`
 
-	// The type of parameter. The type can be either “String” or “StringList”.
+	// The type of parameter. The type can be either String or StringList.
 	Type *string `type:"string" enum:"DocumentParameterType"`
 }
 
@@ -13816,6 +13815,51 @@ func (s *FailedCreateAssociation) SetFault(v string) *FailedCreateAssociation {
 // SetMessage sets the Message field's value.
 func (s *FailedCreateAssociation) SetMessage(v string) *FailedCreateAssociation {
 	s.Message = &v
+	return s
+}
+
+// Information about an Automation failure.
+// Please also see https://docs.aws.amazon.com/goto/WebAPI/ssm-2014-11-06/FailureDetails
+type FailureDetails struct {
+	_ struct{} `type:"structure"`
+
+	// Detailed information about the Automation step failure.
+	Details map[string][]*string `min:"1" type:"map"`
+
+	// The stage of the Automation execution when the failure occurred. The stages
+	// include the following: InputValidation, PreVerification, Invocation, PostVerification.
+	FailureStage *string `type:"string"`
+
+	// The type of Automation failure. Failure types include the following: Action,
+	// Permission, Throttling, Verification, Internal.
+	FailureType *string `type:"string"`
+}
+
+// String returns the string representation
+func (s FailureDetails) String() string {
+	return awsutil.Prettify(s)
+}
+
+// GoString returns the string representation
+func (s FailureDetails) GoString() string {
+	return s.String()
+}
+
+// SetDetails sets the Details field's value.
+func (s *FailureDetails) SetDetails(v map[string][]*string) *FailureDetails {
+	s.Details = v
+	return s
+}
+
+// SetFailureStage sets the FailureStage field's value.
+func (s *FailureDetails) SetFailureStage(v string) *FailureDetails {
+	s.FailureStage = &v
+	return s
+}
+
+// SetFailureType sets the FailureType field's value.
+func (s *FailureDetails) SetFailureType(v string) *FailureDetails {
+	s.FailureType = &v
 	return s
 }
 
@@ -14027,45 +14071,45 @@ type GetCommandInvocationOutput struct {
 	// Status (http://docs.aws.amazon.com/systems-manager/latest/userguide/monitor-about-status.html).
 	// StatusDetails can be one of the following values:
 	//
-	//    * Pending – The command has not been sent to the instance.
+	//    * Pending: The command has not been sent to the instance.
 	//
-	//    * In Progress – The command has been sent to the instance but has not
-	//    reached a terminal state.
+	//    * In Progress: The command has been sent to the instance but has not reached
+	//    a terminal state.
 	//
-	//    * Delayed – The system attempted to send the command to the target, but
+	//    * Delayed: The system attempted to send the command to the target, but
 	//    the target was not available. The instance might not be available because
 	//    of network issues, the instance was stopped, etc. The system will try
 	//    to deliver the command again.
 	//
-	//    * Success – The command or plugin was executed successfully. This is a
+	//    * Success: The command or plugin was executed successfully. This is a
 	//    terminal state.
 	//
-	//    * Delivery Timed Out – The command was not delivered to the instance before
+	//    * Delivery Timed Out: The command was not delivered to the instance before
 	//    the delivery timeout expired. Delivery timeouts do not count against the
-	//    parent command’s MaxErrors limit, but they do contribute to whether the
+	//    parent command's MaxErrors limit, but they do contribute to whether the
 	//    parent command status is Success or Incomplete. This is a terminal state.
 	//
-	//    * Execution Timed Out – The command started to execute on the instance,
+	//    * Execution Timed Out: The command started to execute on the instance,
 	//    but the execution was not complete before the timeout expired. Execution
 	//    timeouts count against the MaxErrors limit of the parent command. This
 	//    is a terminal state.
 	//
-	//    * Failed – The command wasn't executed successfully on the instance. For
+	//    * Failed: The command wasn't executed successfully on the instance. For
 	//    a plugin, this indicates that the result code was not zero. For a command
 	//    invocation, this indicates that the result code for one or more plugins
 	//    was not zero. Invocation failures count against the MaxErrors limit of
 	//    the parent command. This is a terminal state.
 	//
-	//    * Canceled – The command was terminated before it was completed. This
-	//    is a terminal state.
+	//    * Canceled: The command was terminated before it was completed. This is
+	//    a terminal state.
 	//
-	//    * Undeliverable – The command can't be delivered to the instance. The
-	//    instance might not exist or might not be responding. Undeliverable invocations
-	//    don't count against the parent command’s MaxErrors limit and don't contribute
+	//    * Undeliverable: The command can't be delivered to the instance. The instance
+	//    might not exist or might not be responding. Undeliverable invocations
+	//    don't count against the parent command's MaxErrors limit and don't contribute
 	//    to whether the parent command status is Success or Incomplete. This is
 	//    a terminal state.
 	//
-	//    * Terminated – The parent command exceeded its MaxErrors limit and subsequent
+	//    * Terminated: The parent command exceeded its MaxErrors limit and subsequent
 	//    command invocations were canceled by the system. This is a terminal state.
 	StatusDetails *string `type:"string"`
 }
@@ -14836,9 +14880,9 @@ type GetMaintenanceWindowExecutionTaskOutput struct {
 	// The parameters passed to the task when it was executed. The map has the following
 	// format:
 	//
-	// Key: string, 1 ≤ length ≤ 255
+	// Key: string, between 1 and 255 characters
 	//
-	// Value: an array of strings where each string 1 ≤ length ≤ 255
+	// Value: an array of strings, each string is between 1 and 255 characters
 	TaskParameters []map[string]*MaintenanceWindowTaskParameterValueExpression `type:"list"`
 
 	// The type of task executed.
@@ -15996,8 +16040,8 @@ type InstanceInformationStringFilter struct {
 
 	// The filter key name to describe your instances. For example:
 	//
-	// "InstanceIds"|"AgentVersion"|"PingStatus"|"PlatformTypes"|"ActivationIds"|"IamRole"|"ResourceType"|”AssociationStatus”|”Tag
-	// Key”
+	// "InstanceIds"|"AgentVersion"|"PingStatus"|"PlatformTypes"|"ActivationIds"|"IamRole"|"ResourceType"|"AssociationStatus"|"Tag
+	// Key"
 	//
 	// Key is a required field
 	Key *string `min:"1" type:"string" required:"true"`
@@ -16083,11 +16127,11 @@ type InstancePatchState struct {
 	InstanceId *string `type:"string" required:"true"`
 
 	// The number of patches from the patch baseline that are applicable for the
-	// instance but aren’t currently installed.
+	// instance but aren't currently installed.
 	MissingCount *int64 `type:"integer"`
 
-	// The number of patches from the patch baseline that aren’t applicable for
-	// the instance and hence aren’t installed on the instance.
+	// The number of patches from the patch baseline that aren't applicable for
+	// the instance and hence aren't installed on the instance.
 	NotApplicableCount *int64 `type:"integer"`
 
 	// The type of patching operation that was performed: SCAN (assess patch compliance
@@ -18544,7 +18588,7 @@ type Patch struct {
 	// The Microsoft Knowledge Base ID of the patch.
 	KbNumber *string `type:"string"`
 
-	// The language of the patch if it’s language-specific.
+	// The language of the patch if it's language-specific.
 	Language *string `type:"string"`
 
 	// The ID of the MSRC bulletin the patch is related to.
@@ -19921,8 +19965,8 @@ func (s RemoveTagsFromResourceOutput) GoString() string {
 type ResultAttribute struct {
 	_ struct{} `type:"structure"`
 
-	// Name of the inventory item type. Valid value: “AWS:InstanceInformation”.
-	// Default Value: “AWS:InstanceInformation”.
+	// Name of the inventory item type. Valid value: AWS:InstanceInformation. Default
+	// Value: AWS:InstanceInformation.
 	//
 	// TypeName is a required field
 	TypeName *string `min:"1" type:"string" required:"true"`
@@ -20070,21 +20114,23 @@ type SendCommandInput struct {
 	// DocumentName is a required field
 	DocumentName *string `type:"string" required:"true"`
 
-	// Required. The instance IDs where the command should execute. You can specify
-	// a maximum of 50 IDs.
+	// The instance IDs where the command should execute. You can specify a maximum
+	// of 50 IDs. If you prefer not to list individual instance IDs, you can instead
+	// send commands to a fleet of instances using the Targets parameter, which
+	// accepts EC2 tags.
 	InstanceIds []*string `type:"list"`
 
 	// (Optional) The maximum number of instances that are allowed to execute the
-	// command at the same time. You can specify a number such as “10” or a percentage
-	// such as “10%”. The default value is 50. For more information about how to
-	// use MaxConcurrency, see Executing a Command Using Systems Manager Run Command
+	// command at the same time. You can specify a number such as 10 or a percentage
+	// such as 10%. The default value is 50. For more information about how to use
+	// MaxConcurrency, see Executing a Command Using Systems Manager Run Command
 	// (http://docs.aws.amazon.com/systems-manager/latest/userguide/run-command.html).
 	MaxConcurrency *string `min:"1" type:"string"`
 
 	// The maximum number of errors allowed without the command failing. When the
 	// command fails one more time beyond the value of MaxErrors, the systems stops
 	// sending the command to additional targets. You can specify a number like
-	// “10” or a percentage like “10%”. The default value is 50. For more information
+	// 10 or a percentage like 10%. The default value is 50. For more information
 	// about how to use MaxErrors, see Executing a Command Using Systems Manager
 	// Run Command (http://docs.aws.amazon.com/systems-manager/latest/userguide/run-command.html).
 	MaxErrors *string `min:"1" type:"string"`
@@ -20386,6 +20432,9 @@ type StepExecution struct {
 	// the step is in Pending status, this field is not populated.
 	ExecutionStartTime *time.Time `type:"timestamp" timestampFormat:"unix"`
 
+	// Information about the Automation failure.
+	FailureDetails *FailureDetails `type:"structure"`
+
 	// If a step failed, this message explains why the execution failed.
 	FailureMessage *string `type:"string"`
 
@@ -20434,6 +20483,12 @@ func (s *StepExecution) SetExecutionEndTime(v time.Time) *StepExecution {
 // SetExecutionStartTime sets the ExecutionStartTime field's value.
 func (s *StepExecution) SetExecutionStartTime(v time.Time) *StepExecution {
 	s.ExecutionStartTime = &v
+	return s
+}
+
+// SetFailureDetails sets the FailureDetails field's value.
+func (s *StepExecution) SetFailureDetails(v *FailureDetails) *StepExecution {
+	s.FailureDetails = v
 	return s
 }
 
@@ -20666,10 +20721,10 @@ type UpdateAssociationInput struct {
 	// The document version you want update for the association.
 	DocumentVersion *string `type:"string"`
 
+	// The name of the association document.
+	Name *string `type:"string"`
+
 	// An Amazon S3 bucket where you want to store the results of this request.
-	//
-	// "{ \"S3Location\": { \"OutputS3Region\": \"<region>\", \"OutputS3BucketName\":
-	// \"bucket name\", \"OutputS3KeyPrefix\": \"folder name\" } }"
 	OutputLocation *InstanceAssociationOutputLocation `type:"structure"`
 
 	// The parameters you want to update for the association. If you create a parameter
@@ -20677,11 +20732,10 @@ type UpdateAssociationInput struct {
 	Parameters map[string][]*string `type:"map"`
 
 	// The cron expression used to schedule the association that you want to update.
-	// Supported expressions are every half, 1, 2, 4, 8 or 12 hour(s); every specified
-	// day and time of the week. For example: cron(0 0/30 * 1/1 * ? *) to run every
-	// thirty minutes; cron(0 0 0/4 1/1 * ? *) to run every four hours; and cron(0
-	// 0 10 ? * SUN *) to run every Sunday at 10 a.m.
 	ScheduleExpression *string `min:"1" type:"string"`
+
+	// The targets of the association.
+	Targets []*Target `type:"list"`
 }
 
 // String returns the string representation
@@ -20708,6 +20762,16 @@ func (s *UpdateAssociationInput) Validate() error {
 			invalidParams.AddNested("OutputLocation", err.(request.ErrInvalidParams))
 		}
 	}
+	if s.Targets != nil {
+		for i, v := range s.Targets {
+			if v == nil {
+				continue
+			}
+			if err := v.Validate(); err != nil {
+				invalidParams.AddNested(fmt.Sprintf("%s[%v]", "Targets", i), err.(request.ErrInvalidParams))
+			}
+		}
+	}
 
 	if invalidParams.Len() > 0 {
 		return invalidParams
@@ -20727,6 +20791,12 @@ func (s *UpdateAssociationInput) SetDocumentVersion(v string) *UpdateAssociation
 	return s
 }
 
+// SetName sets the Name field's value.
+func (s *UpdateAssociationInput) SetName(v string) *UpdateAssociationInput {
+	s.Name = &v
+	return s
+}
+
 // SetOutputLocation sets the OutputLocation field's value.
 func (s *UpdateAssociationInput) SetOutputLocation(v *InstanceAssociationOutputLocation) *UpdateAssociationInput {
 	s.OutputLocation = v
@@ -20742,6 +20812,12 @@ func (s *UpdateAssociationInput) SetParameters(v map[string][]*string) *UpdateAs
 // SetScheduleExpression sets the ScheduleExpression field's value.
 func (s *UpdateAssociationInput) SetScheduleExpression(v string) *UpdateAssociationInput {
 	s.ScheduleExpression = &v
+	return s
+}
+
+// SetTargets sets the Targets field's value.
+func (s *UpdateAssociationInput) SetTargets(v []*Target) *UpdateAssociationInput {
+	s.Targets = v
 	return s
 }
 

--- a/vendor/github.com/aws/aws-sdk-go/service/ssm/errors.go
+++ b/vendor/github.com/aws/aws-sdk-go/service/ssm/errors.go
@@ -100,7 +100,7 @@ const (
 	// "DoesNotExistException".
 	//
 	// Error returned when the ID specified for a resource (e.g. a Maintenance Window)
-	// doesn’t exist.
+	// doesn't exist.
 	ErrCodeDoesNotExistException = "DoesNotExistException"
 
 	// ErrCodeDuplicateDocumentContent for service response error code
@@ -120,7 +120,7 @@ const (
 	// "IdempotentParameterMismatch".
 	//
 	// Error returned when an idempotent operation is retried and the parameters
-	// don’t match the original call to the API with the same idempotency token.
+	// don't match the original call to the API with the same idempotency token.
 	ErrCodeIdempotentParameterMismatch = "IdempotentParameterMismatch"
 
 	// ErrCodeInternalServerError for service response error code

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -509,648 +509,652 @@
 			"revisionTime": "2017-01-23T00:46:44Z"
 		},
 		{
-			"checksumSHA1": "cUxWuMqpGXK4DL+O5BaYeBkYcmI=",
+			"checksumSHA1": "PGIgHSoZK8yT9WZ6UGQEhSFeLwU=",
 			"path": "github.com/aws/aws-sdk-go",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "YKM6cWvi6ApzANaRZZJcQldOZH4=",
+			"checksumSHA1": "hEzUQFPuW6Mkgm3wVOzsYYkDsOs=",
 			"path": "github.com/aws/aws-sdk-go/aws",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "Y9W+4GimK4Fuxq+vyIskVYFRnX4=",
 			"path": "github.com/aws/aws-sdk-go/aws/awserr",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "yyYr41HZ1Aq0hWc3J5ijXwYEcac=",
 			"path": "github.com/aws/aws-sdk-go/aws/awsutil",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "lSxSARUjHuYCz1/axwEuQ7IiGxk=",
+			"checksumSHA1": "U1xxXRUP7urOrplUC4G6znib8rU=",
 			"path": "github.com/aws/aws-sdk-go/aws/client",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "ieAJ+Cvp/PKv1LpUEnUXpc3OI6E=",
 			"path": "github.com/aws/aws-sdk-go/aws/client/metadata",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "uPsFA3K/51L3fy0FgMCoSGsiAoc=",
+			"checksumSHA1": "7/8j/q0TWtOgXyvEcv4B2Dhl00o=",
 			"path": "github.com/aws/aws-sdk-go/aws/corehandlers",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "F52sZ5zdDeALnul8vxcodVchWi0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "u3GOAJLmdvbuNUeUEcZSEAOeL/0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "NUJUTWlc1sV8b7WjfiYc4JZbXl0=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/endpointcreds",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "JEYqmF83O5n5bHkupAzA6STm0no=",
 			"path": "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "k4IMA27NIDHgZgvBxrKyJy16Y20=",
 			"path": "github.com/aws/aws-sdk-go/aws/defaults",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "/EXbk/z2TWjWc1Hvb4QYs3Wmhb8=",
 			"path": "github.com/aws/aws-sdk-go/aws/ec2metadata",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "M3m80XNHPV23xy6lIrjxFwHyXhc=",
 			"path": "github.com/aws/aws-sdk-go/aws/endpoints",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "dsVwPNbrXbXMAXZY9ZkXG7vR+Oc=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "fed27f4bd16c8c63d01003b978e5bc85fe727519",
-			"revisionTime": "2017-05-16T23:28:54Z"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "sxShwDYt1duG922FOwU0/hbu/uc=",
+			"checksumSHA1": "1EOQCPnx1LFTbJG/6EgXFON67rE=",
 			"path": "github.com/aws/aws-sdk-go/aws/session",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "SvIsunO8D9MEKbetMENA4WRnyeE=",
 			"path": "github.com/aws/aws-sdk-go/aws/signer/v4",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "wk7EyvDaHwb5qqoOP/4d3cV0708=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "1QmQ3FqV37w0Zi44qv8pA1GeR0A=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/ec2query",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "O6hcK24yI6w7FA+g4Pbr+eQ7pys=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/json/jsonutil",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "R00RL5jJXRYq1iiK1+PGvMfvXyM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/jsonrpc",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "ZqY5RWavBLWTo6j9xqdyBEaNFRk=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "Drt1JfLMa0DQEZLWrnMlTWaIcC8=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/query/queryutil",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "VCTh+dEaqqhog5ncy/WTt9+/gFM=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/rest",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "Rpu8KBtHZgvhkwHxUfaky+qW+G4=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restjson",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "ODo+ko8D6unAxZuN1jGzMcN4QCc=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/restxml",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "0qYPUga28aQVkxZgBR3Z86AbGUQ=",
 			"path": "github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "F6mth+G7dXN1GI+nktaGo8Lx8aE=",
 			"path": "github.com/aws/aws-sdk-go/private/signer/v2",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "RihpzjL86Zqrq7caZqddkGmpS/U=",
 			"path": "github.com/aws/aws-sdk-go/service/acm",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "Vty8Iim26/C2eW4v5ID75vXoQj0=",
 			"path": "github.com/aws/aws-sdk-go/service/apigateway",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "kq7a1zUsytCRQV+Q9KZf5Tzkv4s=",
 			"path": "github.com/aws/aws-sdk-go/service/applicationautoscaling",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "p3K4i8bQWFjik0j7jHePuY+0Ua4=",
+			"checksumSHA1": "y1rEAHCCFNKFXtzGeNTuSkxdxnw=",
 			"path": "github.com/aws/aws-sdk-go/service/autoscaling",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "H36nvtC7Uxl6I3NlRbgSYHqIhyQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudformation",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "Xa4HENUzQxHSsx5HoabaxdUpVrg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudfront",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "hj0mJrjPfyAc8kHGDcXnMuMVozg=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudtrail",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "dqRrfGewSrIfajRNmsx1ugEYSuw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatch",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "tMBMIUhm49FQkKNpdE/qDuS/iT0=",
+			"checksumSHA1": "uQXi6iOpIf22Hz1VP4qLb3jfAqw=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchevents",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "44PZVYbhlb3/Rl5uT/j+4R38YZk=",
+			"checksumSHA1": "eJJjXlK7MLOlZhu8741//GZj0ZQ=",
 			"path": "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "fkA9YVQMcsQ0qQlGSUw3iN/BhR4=",
 			"path": "github.com/aws/aws-sdk-go/service/codebuild",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "BsfbsSZlJdNvYlM/ykGHTZVoLY0=",
 			"path": "github.com/aws/aws-sdk-go/service/codecommit",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "HrlWGohhsxQPcuaR+HvaTLERQcQ=",
+			"checksumSHA1": "HJea/EFVsUxxjXB3tpG6WWeEl44=",
 			"path": "github.com/aws/aws-sdk-go/service/codedeploy",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "bZ5Dg5Pww7RsjVhgKqmGIzoFkug=",
 			"path": "github.com/aws/aws-sdk-go/service/codepipeline",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "W+yGe3hYhzKMlRE/0jR4B6FpDJY=",
 			"path": "github.com/aws/aws-sdk-go/service/cognitoidentity",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "eSqx7hsdmEMqD9K2l36FE/PlgHM=",
 			"path": "github.com/aws/aws-sdk-go/service/configservice",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "8TVmfSkvfEXobuvakOFg9sMm7vQ=",
 			"path": "github.com/aws/aws-sdk-go/service/databasemigrationservice",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "JsCuHtHM4ql9lVjpCJ869L7irZk=",
 			"path": "github.com/aws/aws-sdk-go/service/devicefarm",
-			"revision": "a5b389b7b05c59adf7ac44f50d0d8be6e0c85710",
-			"revisionTime": "2017-05-04T23:50:54Z"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "nZ0ZiiZ29v0HiVleXACY3m6bXgI=",
 			"path": "github.com/aws/aws-sdk-go/service/directoryservice",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "dcUwKQHxD9+ap+/MP9gZ6kT/lXI=",
 			"path": "github.com/aws/aws-sdk-go/service/dynamodb",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "RGW6Tn0SO0m9m0pNQAY9OhdJ3tI=",
 			"path": "github.com/aws/aws-sdk-go/service/ec2",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "Lwqoi9aWc+j6dzkgt06LLR7i1XA=",
 			"path": "github.com/aws/aws-sdk-go/service/ecr",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "xK333jTw5R1dnr9mt+yxsEHg3/A=",
 			"path": "github.com/aws/aws-sdk-go/service/ecs",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "WJ0qqKev5awu3aOPmYEmLz2B7Tw=",
 			"path": "github.com/aws/aws-sdk-go/service/efs",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "aO69igvJSXy8Hw3zCP2g9d/icv4=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticache",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "bnl0q1BLkaBD6rD7n1tWemceVzI=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticbeanstalk",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "omf+Wesp5JG8FrhzLXJgItIYAHk=",
 			"path": "github.com/aws/aws-sdk-go/service/elasticsearchservice",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "VWn6yZTaOgD0daNMBAQWnc5tOp4=",
 			"path": "github.com/aws/aws-sdk-go/service/elastictranscoder",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "HhGr/K7gTwqgjySY6Axnx0l/mFI=",
+			"checksumSHA1": "i/ykCvWenrw5U3O3xb9hJ9tfFa8=",
 			"path": "github.com/aws/aws-sdk-go/service/elb",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "6ORdnbJaMfYlFY2P7bz4lBVHoz8=",
+			"checksumSHA1": "03QX7X3DzyHiZ1bAB2edifrCJ6Y=",
 			"path": "github.com/aws/aws-sdk-go/service/elbv2",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "TJDUTql/Ls5Ds86pLO1F2b/DqdA=",
 			"path": "github.com/aws/aws-sdk-go/service/emr",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "FCPGPaaFgN9iWup3dVCDVt0Yqp0=",
 			"path": "github.com/aws/aws-sdk-go/service/firehose",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "g/B0cturzQMWZN+VJwm9izYoQ5Q=",
 			"path": "github.com/aws/aws-sdk-go/service/glacier",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "sUTXkrAohDlfGKgkLEYh9UawmL0=",
 			"path": "github.com/aws/aws-sdk-go/service/iam",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "KRMkAiqqsT9WBClJH1J7yH7DIkE=",
+			"checksumSHA1": "oYVrMzwK3o8fi9ejIhN9R5h4KRc=",
 			"path": "github.com/aws/aws-sdk-go/service/inspector",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "KJuPA/SLv0fLME23SmxVP4410BE=",
 			"path": "github.com/aws/aws-sdk-go/service/kinesis",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "474AbAwNH6TnuM54+Ej2/VdYexQ=",
+			"checksumSHA1": "DlyhlgQf94WXnPSpGy1WlzdNkkE=",
 			"path": "github.com/aws/aws-sdk-go/service/kms",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "qnpJf/YILf+JOxp4vM8oOgQAQ28=",
 			"path": "github.com/aws/aws-sdk-go/service/lambda",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "UtyTfF6oXj5KPfXr8H+ivJ0XTgs=",
 			"path": "github.com/aws/aws-sdk-go/service/lightsail",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "O2MqFCP7z1x6cC59NxiXVOZiUfY=",
 			"path": "github.com/aws/aws-sdk-go/service/opsworks",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "hOMvmDsta9bUZXcE59EYXAF2lMM=",
 			"path": "github.com/aws/aws-sdk-go/service/rds",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "Q8CPmpN6L73bkhA7rEy1ciy6izo=",
 			"path": "github.com/aws/aws-sdk-go/service/redshift",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "g/d8eqqotx1ITOpxwyk4PWDXiVk=",
 			"path": "github.com/aws/aws-sdk-go/service/route53",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "krqUUMDYRN2ohYcumxZl8BTR5EQ=",
 			"path": "github.com/aws/aws-sdk-go/service/s3",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "wCql3QDkXRHDY6Cm6GSUijoeDcg=",
 			"path": "github.com/aws/aws-sdk-go/service/ses",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "EPVYa41c+FwHj5as9Px5zCZmxlQ=",
 			"path": "github.com/aws/aws-sdk-go/service/sfn",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "qbJgxyoq6VmwEtQR5uT9KVYqV6I=",
 			"path": "github.com/aws/aws-sdk-go/service/simpledb",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "vP/0ADSA7kkW5CCadIpV3Q6s+DQ=",
 			"path": "github.com/aws/aws-sdk-go/service/sns",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "/2BKYAF4iJKOIiOixgXWb0tVclE=",
 			"path": "github.com/aws/aws-sdk-go/service/sqs",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
-			"checksumSHA1": "b3EF4M5zx5vSw6wGE2Vbucf8a2g=",
+			"checksumSHA1": "TUxh01D/FrlX+12NTF5M8f+tYYA=",
 			"path": "github.com/aws/aws-sdk-go/service/ssm",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "fbROB+q5aRgvH79KOnEqr63ahRE=",
 			"path": "github.com/aws/aws-sdk-go/service/sts",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "MXy2G+JW109dosdS5rhbWj7X1Dg=",
 			"path": "github.com/aws/aws-sdk-go/service/waf",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "s5N7qUhc2Zs1Nj2bwpZCy4QQRlo=",
 			"path": "github.com/aws/aws-sdk-go/service/wafregional",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "3cf3ede801c0c4b8b0f6f65b7be60a61a55ef91c",
+			"revisionTime": "2017-05-17T22:36:48Z",
+			"version": "v1.8.25",
+			"versionExact": "v1.8.25"
 		},
 		{
 			"checksumSHA1": "nqw2Qn5xUklssHTubS5HDvEL9L4=",

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -621,12 +621,10 @@
 			"versionExact": "v1.8.21"
 		},
 		{
-			"checksumSHA1": "4y3OXdVeAE/Upux6FZp/0T0gAz4=",
+			"checksumSHA1": "dsVwPNbrXbXMAXZY9ZkXG7vR+Oc=",
 			"path": "github.com/aws/aws-sdk-go/aws/request",
-			"revision": "49c7a5e645b5eca5aabd1fd6a676dbddaf7b2a1a",
-			"revisionTime": "2017-05-09T17:42:03Z",
-			"version": "v1.8.21",
-			"versionExact": "v1.8.21"
+			"revision": "fed27f4bd16c8c63d01003b978e5bc85fe727519",
+			"revisionTime": "2017-05-16T23:28:54Z"
 		},
 		{
 			"checksumSHA1": "sxShwDYt1duG922FOwU0/hbu/uc=",


### PR DESCRIPTION
 - Updates aws-sdk-go/request for retryer fix
 - Fixes dynamoDB exception handling to catch subscriber limit error

When the `aws-sdk-go` dep releases the next release, we can tag the vendor with the new
release version, and merge this. Until then, soft-updated the vendor solely for the `request` package to post fix.

`aws-sdk-go` was patched from this issue: https://github.com/aws/aws-sdk-go/issues/1271

DynamoDB Fix:
```
aws_dynamodb_table.bar: Creating...
  arn:                       "" => "<computed>"
  attribute.#:               "" => "1"
  attribute.4228504427.name: "" => "id"
  attribute.4228504427.type: "" => "S"
  hash_key:                  "" => "id"
  name:                      "" => "over-cap-test"
  read_capacity:             "" => "5"
  stream_arn:                "" => "<computed>"
  stream_enabled:            "" => "<computed>"
  stream_view_type:          "" => "<computed>"
  write_capacity:            "" => "5"
Error applying plan:

1 error(s) occurred:

* aws_dynamodb_table.bar: 1 error(s) occurred:

* aws_dynamodb_table.bar: AWS Error creating DynamoDB table: LimitExceededException: Subscriber limit exceeded: There is a limit of 256 tables per subscriber
        status code: 400, request id: J2MC7MR060VKBPHP9P6JG5B6Q3VV4KQNSO5AEMVJF66Q9ASUAAJG
```

The open issues, with the exception of the DynamoDB issue, don't check for the `LimitExceededException` error code, and should now fail accurately with the appropriate error message. 

Fixes: #13339, #13802, #11143, #11654