### PR TITLE
convert dns tests back to acceptance tests

### DIFF
--- a/builtin/providers/dns/data_dns_a_record_set_test.go
+++ b/builtin/providers/dns/data_dns_a_record_set_test.go
@@ -43,7 +43,7 @@ func TestAccDataDnsARecordSet_Basic(t *testing.T) {
 	for _, test := range tests {
 		recordName := fmt.Sprintf("data.dns_a_record_set.%s", test.DataSourceName)
 
-		resource.UnitTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				resource.TestStep{

--- a/builtin/providers/dns/data_dns_cname_record_set_test.go
+++ b/builtin/providers/dns/data_dns_cname_record_set_test.go
@@ -3,7 +3,7 @@ package dns
 import (
 	"testing"
 
-	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccDnsCnameRecordSet_Basic(t *testing.T) {
@@ -24,19 +24,19 @@ func TestAccDnsCnameRecordSet_Basic(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r.Test(t, r.TestCase{
+		resource.Test(t, resource.TestCase{
 			Providers: testAccProviders,
-			Steps: []r.TestStep{
-				r.TestStep{
+			Steps: []resource.TestStep{
+				resource.TestStep{
 					Config: test.DataSourceBlock,
-					Check: r.ComposeTestCheckFunc(
-						r.TestCheckResourceAttr("data.dns_cname_record_set.foo", "cname", test.Expected),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.dns_cname_record_set.foo", "cname", test.Expected),
 					),
 				},
-				r.TestStep{
+				resource.TestStep{
 					Config: test.DataSourceBlock,
-					Check: r.ComposeTestCheckFunc(
-						r.TestCheckResourceAttr("data.dns_cname_record_set.foo", "id", test.Host),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.dns_cname_record_set.foo", "id", test.Host),
 					),
 				},
 			},

--- a/builtin/providers/dns/data_dns_cname_record_set_test.go
+++ b/builtin/providers/dns/data_dns_cname_record_set_test.go
@@ -24,7 +24,7 @@ func TestAccDnsCnameRecordSet_Basic(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r.UnitTest(t, r.TestCase{
+		r.Test(t, r.TestCase{
 			Providers: testAccProviders,
 			Steps: []r.TestStep{
 				r.TestStep{


### PR DESCRIPTION
External network calls can fail, and shouldn't stop unit tests from
running.

#14271 Introduced a change that can cause `make test` to frequently fail. Though it's not currently failing, TestAccDnsCnameRecordSet_Basic should also be an acceptance test for consistency. 