### PR TITLE
core: fix bad Sprintf in backend migration message

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1746,7 +1746,7 @@ process.
 
 const successBackendLegacyUnset = `
 Terraform has successfully migrated from legacy remote state to your
-configured remote state.
+configured backend (%q).
 `
 
 const successBackendReconfigureWithLegacy = `


### PR DESCRIPTION
Before this, invoking this codepath would print

    Terraform has successfully migrated from legacy remote state to your
    configured remote state.%!(EXTRA string=s3)