### PR TITLE
core: allow overriding environment name via env var

### DIFF
--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform/backend"
@@ -390,23 +389,4 @@ func (b *Local) stateEnvDir() string {
 	}
 
 	return DefaultEnvDir
-}
-
-// currentStateName returns the name of the current named state as set in the
-// configuration files.
-// If there are no configured environments, currentStateName returns "default"
-func (b *Local) currentStateName() (string, error) {
-	contents, err := ioutil.ReadFile(filepath.Join(DefaultDataDir, DefaultEnvFile))
-	if os.IsNotExist(err) {
-		return backend.DefaultStateName, nil
-	}
-	if err != nil {
-		return "", err
-	}
-
-	if fromFile := strings.TrimSpace(string(contents)); fromFile != "" {
-		return fromFile, nil
-	}
-
-	return backend.DefaultStateName, nil
 }

--- a/command/env_command.go
+++ b/command/env_command.go
@@ -97,4 +97,27 @@ to another environment and try again.
 The environment name %q is not allowed. The name must contain only URL safe
 characters, and no path separators.
 `
+
+	envIsOverriddenNote = `
+
+The active environment is being overridden using the TF_ENVIRONMENT environment
+variable.
+`
+
+	envIsOverriddenSelectError = `
+The environment is currently overridden using the TF_ENVIRONMENT environment
+variable.
+
+To select a new environment, either update this environment variable or unset
+it and then run this command again.
+`
+
+	envIsOverriddenNewError = `
+The environment is currently overridden using the TF_ENVIRONMENT environment
+variable.  You cannot create a different environment when using this setting.
+
+To create a new environment, either unset this environment variable or update it
+to match the environment name you are trying to create, and then run this command
+again.
+`
 )

--- a/command/env_list.go
+++ b/command/env_list.go
@@ -39,7 +39,7 @@ func (c *EnvListCommand) Run(args []string) int {
 		return 1
 	}
 
-	env := c.Env()
+	env, isOverridden := c.EnvOverridden()
 
 	var out bytes.Buffer
 	for _, s := range states {
@@ -52,6 +52,11 @@ func (c *EnvListCommand) Run(args []string) int {
 	}
 
 	c.Ui.Output(out.String())
+
+	if isOverridden {
+		c.Ui.Output(envIsOverriddenNote)
+	}
+
 	return 0
 }
 

--- a/command/env_new.go
+++ b/command/env_new.go
@@ -40,6 +40,13 @@ func (c *EnvNewCommand) Run(args []string) int {
 		return 1
 	}
 
+	// You can't ask to create an environment when you're overriding the
+	// environment name to be something different.
+	if current, isOverridden := c.EnvOverridden(); current != newEnv && isOverridden {
+		c.Ui.Error(envIsOverriddenNewError)
+		return 1
+	}
+
 	configPath, err := ModulePath(args[1:])
 	if err != nil {
 		c.Ui.Error(err.Error())

--- a/command/env_select.go
+++ b/command/env_select.go
@@ -31,6 +31,12 @@ func (c *EnvSelectCommand) Run(args []string) int {
 		return 1
 	}
 
+	current, isOverridden := c.EnvOverridden()
+	if isOverridden {
+		c.Ui.Error(envIsOverriddenSelectError)
+		return 1
+	}
+
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{ConfigPath: configPath})
 	if err != nil {
@@ -50,7 +56,7 @@ func (c *EnvSelectCommand) Run(args []string) int {
 		return 1
 	}
 
-	if name == c.Env() {
+	if name == current {
 		// already using this env
 		return 0
 	}


### PR DESCRIPTION
This allows you to run multiple concurrent terraform operations against
different environments from the same source directory.

Fixes #14447.

Also removes some dead code which appears to do the same thing as the function I
modified.