### PR TITLE
provider/aws: Fix RDS DB snapshot data source acc test

### DIFF
--- a/builtin/providers/aws/data_source_aws_db_snapshot_test.go
+++ b/builtin/providers/aws/data_source_aws_db_snapshot_test.go
@@ -49,7 +49,7 @@ resource "aws_db_instance" "bar" {
 	name = "baz"
 	password = "barbarbarbar"
 	username = "foo"
-
+	skip_final_snapshot = true
 
 	# Maintenance Window is stored in lower case in the API, though not strictly
 	# documented. Terraform will downcase this to match (as opposed to throw a


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSDbSnapshotDataSource_basic
--- FAIL: TestAccAWSDbSnapshotDataSource_basic (715.86s)
    testing.go:344: Error destroying resource! WARNING: Dangling resources
        may exist. The full state and error is shown below.
        
        Error: Error applying: 1 error(s) occurred:
        
        * aws_db_instance.bar (destroy): 1 error(s) occurred:
        
        * aws_db_instance.bar: DB Instance FinalSnapshotIdentifier is required when a final snapshot is required
        
```

```
=== RUN   TestAccAWSDbSnapshotDataSource_basic
--- PASS: TestAccAWSDbSnapshotDataSource_basic (799.64s)
PASS
```