### PR TITLE
provider/aws: Randomize SNS topic names in acceptance tests

### DIFF
--- a/builtin/providers/aws/import_aws_sns_topic_test.go
+++ b/builtin/providers/aws/import_aws_sns_topic_test.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"testing"
 
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
 func TestAccAWSSNSTopic_importBasic(t *testing.T) {
 	resourceName := "aws_sns_topic.test_topic"
+	rName := acctest.RandString(10)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -15,7 +17,7 @@ func TestAccAWSSNSTopic_importBasic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSSNSTopicConfig,
+				Config: testAccAWSSNSTopicConfig(rName),
 			},
 
 			resource.TestStep{

--- a/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
+++ b/builtin/providers/aws/resource_aws_s3_bucket_notification_test.go
@@ -344,7 +344,7 @@ func testAccCheckAWSS3BucketLambdaFunctionConfiguration(n, i, t string, events [
 func testAccAWSS3BucketConfigWithTopicNotification(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "topic" {
-    name = "terraform-test-topic"
+    name = "terraform-test-topic-%d"
 	policy = <<POLICY
 {
 	"Version":"2012-10-17",
@@ -353,7 +353,7 @@ resource "aws_sns_topic" "topic" {
 		"Effect": "Allow",
 		"Principal": {"AWS":"*"},
 		"Action": "SNS:Publish",
-		"Resource": "arn:aws:sns:*:*:terraform-test-topic",
+		"Resource": "arn:aws:sns:*:*:terraform-test-topic-%d",
 		"Condition":{
 			"ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
 		}
@@ -389,7 +389,7 @@ resource "aws_s3_bucket_notification" "notification" {
 		filter_suffix = ".log"
 	}
 }
-`, randInt, randInt)
+`, randInt, randInt, randInt, randInt)
 }
 
 func testAccAWSS3BucketConfigWithQueueNotification(randInt int) string {
@@ -482,7 +482,7 @@ resource "aws_s3_bucket_notification" "notification" {
 func testAccAWSS3BucketConfigWithTopicNotificationWithoutFilter(randInt int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "topic" {
-    name = "terraform-test-topic"
+    name = "terraform-test-topic-%d"
 	policy = <<POLICY
 {
 	"Version":"2012-10-17",
@@ -491,7 +491,7 @@ resource "aws_sns_topic" "topic" {
 		"Effect": "Allow",
 		"Principal": {"AWS":"*"},
 		"Action": "SNS:Publish",
-		"Resource": "arn:aws:sns:*:*:terraform-test-topic",
+		"Resource": "arn:aws:sns:*:*:terraform-test-topic-%d",
 		"Condition":{
 			"ArnLike":{"aws:SourceArn":"${aws_s3_bucket.bucket.arn}"}
 		}
@@ -516,5 +516,5 @@ resource "aws_s3_bucket_notification" "notification" {
 		]
 	}
 }
-`, randInt)
+`, randInt, randInt, randInt)
 }

--- a/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_subscription_test.go
@@ -108,7 +108,7 @@ func testAccCheckAWSSNSTopicSubscriptionExists(n string) resource.TestCheckFunc 
 func testAccAWSSNSTopicSubscriptionConfig(i int) string {
 	return fmt.Sprintf(`
 resource "aws_sns_topic" "test_topic" {
-    name = "terraform-test-topic"
+    name = "terraform-test-topic-%d"
 }
 
 resource "aws_sqs_queue" "test_queue" {
@@ -120,7 +120,7 @@ resource "aws_sns_topic_subscription" "test_subscription" {
     protocol = "sqs"
     endpoint = "${aws_sqs_queue.test_queue.arn}"
 }
-`, i)
+`, i, i)
 }
 
 func testAccAWSSNSTopicSubscriptionConfig_autoConfirmingEndpoint(i int) string {

--- a/builtin/providers/aws/resource_aws_sns_topic_test.go
+++ b/builtin/providers/aws/resource_aws_sns_topic_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestAccAWSSNSTopic_basic(t *testing.T) {
+	rName := acctest.RandString(10)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_sns_topic.test_topic",
@@ -21,7 +23,7 @@ func TestAccAWSSNSTopic_basic(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSSNSTopicConfig,
+				Config: testAccAWSSNSTopicConfig(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),
 				),
@@ -51,6 +53,7 @@ func TestAccAWSSNSTopic_policy(t *testing.T) {
 }
 
 func TestAccAWSSNSTopic_withIAMRole(t *testing.T) {
+	rName := acctest.RandString(10)
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
 		IDRefreshName: "aws_sns_topic.test_topic",
@@ -58,7 +61,7 @@ func TestAccAWSSNSTopic_withIAMRole(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSSNSTopicConfig_withIAMRole,
+				Config: testAccAWSSNSTopicConfig_withIAMRole(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),
 				),
@@ -68,6 +71,7 @@ func TestAccAWSSNSTopic_withIAMRole(t *testing.T) {
 }
 
 func TestAccAWSSNSTopic_withDeliveryPolicy(t *testing.T) {
+	rName := acctest.RandString(10)
 	expectedPolicy := `{"http":{"defaultHealthyRetryPolicy": {"minDelayTarget": 20,"maxDelayTarget": 20,"numMaxDelayRetries": 0,"numRetries": 3,"numNoDelayRetries": 0,"numMinDelayRetries": 0,"backoffFunction": "linear"},"disableSubscriptionOverrides": false}}`
 	resource.Test(t, resource.TestCase{
 		PreCheck:      func() { testAccPreCheck(t) },
@@ -76,7 +80,7 @@ func TestAccAWSSNSTopic_withDeliveryPolicy(t *testing.T) {
 		CheckDestroy:  testAccCheckAWSSNSTopicDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAWSSNSTopicConfig_withDeliveryPolicy,
+				Config: testAccAWSSNSTopicConfig_withDeliveryPolicy(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSSNSTopicExists("aws_sns_topic.test_topic"),
 					testAccCheckAWSNSTopicHasDeliveryPolicy("aws_sns_topic.test_topic", expectedPolicy),
@@ -229,11 +233,13 @@ func testAccCheckAWSSNSTopicExists(n string) resource.TestCheckFunc {
 	}
 }
 
-const testAccAWSSNSTopicConfig = `
+func testAccAWSSNSTopicConfig(r string) string {
+	return fmt.Sprintf(`
 resource "aws_sns_topic" "test_topic" {
-    name = "terraform-test-topic"
+    name = "terraform-test-topic-%s"
 }
-`
+`, r)
+}
 
 func testAccAWSSNSTopicWithPolicy(r string) string {
 	return fmt.Sprintf(`
@@ -261,9 +267,10 @@ EOF
 }
 
 // Test for https://github.com/hashicorp/terraform/issues/3660
-const testAccAWSSNSTopicConfig_withIAMRole = `
+func testAccAWSSNSTopicConfig_withIAMRole(r string) string {
+	return fmt.Sprintf(`
 resource "aws_iam_role" "example" {
-  name = "terraform_bug"
+  name = "tf_acc_test_%s"
   path = "/test/"
   assume_role_policy = <<EOF
 {
@@ -283,7 +290,7 @@ EOF
 }
 
 resource "aws_sns_topic" "test_topic" {
-  name = "example"
+  name = "tf-acc-test-with-iam-role-%s"
   policy = <<EOF
 {
   "Statement": [
@@ -302,12 +309,14 @@ resource "aws_sns_topic" "test_topic" {
 }
 EOF
 }
-`
+`, r, r)
+}
 
 // Test for https://github.com/hashicorp/terraform/issues/14024
-const testAccAWSSNSTopicConfig_withDeliveryPolicy = `
+func testAccAWSSNSTopicConfig_withDeliveryPolicy(r string) string {
+	return fmt.Sprintf(`
 resource "aws_sns_topic" "test_topic" {
-  name = "test_delivery_policy"
+  name = "tf_acc_test_delivery_policy_%s"
   delivery_policy = <<EOF
 {
   "http": {
@@ -325,4 +334,5 @@ resource "aws_sns_topic" "test_topic" {
 }
 EOF
 }
-`
+`, r)
+}


### PR DESCRIPTION
### Test plan

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run="(TestAccAWSS3Bucket_Notification|TestAccAWSSNSTopicSubscription_|TestAccAWSSNSTopic_)"'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/18 11:09:28 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run="(TestAccAWSS3Bucket_Notification|TestAccAWSSNSTopicSubscription_|TestAccAWSSNSTopic_)" -timeout 120m
=== RUN   TestAccAWSSNSTopicSubscription_importBasic
--- PASS: TestAccAWSSNSTopicSubscription_importBasic (44.36s)
=== RUN   TestAccAWSSNSTopic_importBasic
--- PASS: TestAccAWSSNSTopic_importBasic (33.93s)
=== RUN   TestAccAWSS3Bucket_Notification
--- PASS: TestAccAWSS3Bucket_Notification (220.49s)
=== RUN   TestAccAWSS3Bucket_NotificationWithoutFilter
--- PASS: TestAccAWSS3Bucket_NotificationWithoutFilter (88.00s)
=== RUN   TestAccAWSSNSTopicSubscription_basic
--- PASS: TestAccAWSSNSTopicSubscription_basic (43.21s)
=== RUN   TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint
--- PASS: TestAccAWSSNSTopicSubscription_autoConfirmingEndpoint (91.69s)
=== RUN   TestAccAWSSNSTopic_basic
--- PASS: TestAccAWSSNSTopic_basic (31.37s)
=== RUN   TestAccAWSSNSTopic_policy
--- PASS: TestAccAWSSNSTopic_policy (33.55s)
=== RUN   TestAccAWSSNSTopic_withIAMRole
--- PASS: TestAccAWSSNSTopic_withIAMRole (47.51s)
=== RUN   TestAccAWSSNSTopic_withDeliveryPolicy
--- PASS: TestAccAWSSNSTopic_withDeliveryPolicy (32.77s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	666.913s
```