### PR TITLE
Fixes #14620 Handle migration of data when restoring db cluster from …

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -308,7 +308,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			log.Println("[INFO] Waiting for RDS Cluster to be available")
 
 			stateConf := &resource.StateChangeConf{
-				Pending:    []string{"creating", "backing-up", "modifying"},
+				Pending:    []string{"creating", "backing-up", "modifying", "preparing-data-migration"},
 				Target:     []string{"available"},
 				Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
 				Timeout:    d.Timeout(schema.TimeoutCreate),


### PR DESCRIPTION
…snapshot

Add `preparing-data-migration` to the list of pending statuses when creating a cluster from a snapshot using a different engine.