### PR TITLE
provider/aws: Randomize CloudFormation acceptance tests

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
+++ b/builtin/providers/aws/resource_aws_cloudformation_stack_test.go
@@ -2,18 +2,18 @@ package aws
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestAccAWSCloudFormation_basic(t *testing.T) {
 	var stack cloudformation.Stack
+	stackName := fmt.Sprintf("tf-acc-test-basic-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,7 +21,7 @@ func TestAccAWSCloudFormation_basic(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig,
+				Config: testAccAWSCloudFormationConfig(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.network", &stack),
 				),
@@ -32,6 +32,7 @@ func TestAccAWSCloudFormation_basic(t *testing.T) {
 
 func TestAccAWSCloudFormation_yaml(t *testing.T) {
 	var stack cloudformation.Stack
+	stackName := fmt.Sprintf("tf-acc-test-yaml-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -39,7 +40,7 @@ func TestAccAWSCloudFormation_yaml(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_yaml,
+				Config: testAccAWSCloudFormationConfig_yaml(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.yaml", &stack),
 				),
@@ -50,6 +51,7 @@ func TestAccAWSCloudFormation_yaml(t *testing.T) {
 
 func TestAccAWSCloudFormation_defaultParams(t *testing.T) {
 	var stack cloudformation.Stack
+	stackName := fmt.Sprintf("tf-acc-test-default-params-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -57,7 +59,7 @@ func TestAccAWSCloudFormation_defaultParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_defaultParams,
+				Config: testAccAWSCloudFormationConfig_defaultParams(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.asg-demo", &stack),
 				),
@@ -68,6 +70,7 @@ func TestAccAWSCloudFormation_defaultParams(t *testing.T) {
 
 func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 	var stack cloudformation.Stack
+	stackName := fmt.Sprintf("tf-acc-test-all-attributes-%s", acctest.RandString(10))
 
 	expectedPolicyBody := "{\"Statement\":[{\"Action\":\"Update:*\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Resource\":\"LogicalResourceId/StaticVPC\"},{\"Action\":\"Update:*\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Resource\":\"*\"}]}"
 	resource.Test(t, resource.TestCase{
@@ -76,10 +79,10 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies,
+				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", "tf-full-stack"),
+					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", stackName),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.#", "1"),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.1328347040", "CAPABILITY_IAM"),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "disable_rollback", "false"),
@@ -94,10 +97,10 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies_modified,
+				Config: testAccAWSCloudFormationConfig_allAttributesWithBodies_modified(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.full", &stack),
-					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", "tf-full-stack"),
+					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "name", stackName),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.#", "1"),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "capabilities.1328347040", "CAPABILITY_IAM"),
 					resource.TestCheckResourceAttr("aws_cloudformation_stack.full", "disable_rollback", "false"),
@@ -118,6 +121,7 @@ func TestAccAWSCloudFormation_allAttributes(t *testing.T) {
 // Regression for https://github.com/hashicorp/terraform/issues/4332
 func TestAccAWSCloudFormation_withParams(t *testing.T) {
 	var stack cloudformation.Stack
+	stackName := fmt.Sprintf("tf-acc-test-with-params-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -125,13 +129,13 @@ func TestAccAWSCloudFormation_withParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_withParams,
+				Config: testAccAWSCloudFormationConfig_withParams(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_withParams_modified,
+				Config: testAccAWSCloudFormationConfig_withParams_modified(stackName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with_params", &stack),
 				),
@@ -143,8 +147,7 @@ func TestAccAWSCloudFormation_withParams(t *testing.T) {
 // Regression for https://github.com/hashicorp/terraform/issues/4534
 func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
 	var stack cloudformation.Stack
-	cfRandInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	cfBucketName := fmt.Sprintf("tf-stack-with-url-and-params-%d", cfRandInt)
+	rName := fmt.Sprintf("tf-acc-test-with-url-and-params-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -152,13 +155,13 @@ func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(cfBucketName, "tf-cf-stack.json", "11.0.0.0/16"),
+				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(cfBucketName, "tf-cf-stack.json", "13.0.0.0/16"),
+				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack.json", "13.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
@@ -169,8 +172,7 @@ func TestAccAWSCloudFormation_withUrl_withParams(t *testing.T) {
 
 func TestAccAWSCloudFormation_withUrl_withParams_withYaml(t *testing.T) {
 	var stack cloudformation.Stack
-	cfRandInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	cfBucketName := fmt.Sprintf("tf-stack-with-url-and-params-%d", cfRandInt)
+	rName := fmt.Sprintf("tf-acc-test-with-params-and-yaml-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -178,7 +180,7 @@ func TestAccAWSCloudFormation_withUrl_withParams_withYaml(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams_withYaml(cfBucketName, "tf-cf-stack.yaml", "13.0.0.0/16"),
+				Config: testAccAWSCloudFormationConfig_templateUrl_withParams_withYaml(rName, "tf-cf-stack.yaml", "13.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params-and-yaml", &stack),
 				),
@@ -190,8 +192,7 @@ func TestAccAWSCloudFormation_withUrl_withParams_withYaml(t *testing.T) {
 // Test for https://github.com/hashicorp/terraform/issues/5653
 func TestAccAWSCloudFormation_withUrl_withParams_noUpdate(t *testing.T) {
 	var stack cloudformation.Stack
-	cfRandInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
-	cfBucketName := fmt.Sprintf("tf-stack-with-url-and-params-%d", cfRandInt)
+	rName := fmt.Sprintf("tf-acc-test-with-params-no-update-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -199,13 +200,13 @@ func TestAccAWSCloudFormation_withUrl_withParams_noUpdate(t *testing.T) {
 		CheckDestroy: testAccCheckAWSCloudFormationDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(cfBucketName, "tf-cf-stack-1.json", "11.0.0.0/16"),
+				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack-1.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
 			},
 			{
-				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(cfBucketName, "tf-cf-stack-2.json", "11.0.0.0/16"),
+				Config: testAccAWSCloudFormationConfig_templateUrl_withParams(rName, "tf-cf-stack-2.json", "11.0.0.0/16"),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckCloudFormationStackExists("aws_cloudformation_stack.with-url-and-params", &stack),
 				),
@@ -265,9 +266,10 @@ func testAccCheckAWSCloudFormationDestroy(s *terraform.State) error {
 	return nil
 }
 
-var testAccAWSCloudFormationConfig = `
+func testAccAWSCloudFormationConfig(stackName string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "network" {
-  name = "tf-networking-stack"
+  name = "%s"
   template_body = <<STACK
 {
   "Resources" : {
@@ -293,11 +295,13 @@ resource "aws_cloudformation_stack" "network" {
   }
 }
 STACK
-}`
+}`, stackName)
+}
 
-var testAccAWSCloudFormationConfig_yaml = `
+func testAccAWSCloudFormationConfig_yaml(stackName string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "yaml" {
-  name = "tf-yaml-stack"
+  name = "%s"
   template_body = <<STACK
 Resources:
   MyVPC:
@@ -317,11 +321,13 @@ Outputs:
     Description: The VPC ID
     Value: !Ref MyVPC
 STACK
-}`
+}`, stackName)
+}
 
-var testAccAWSCloudFormationConfig_defaultParams = `
+func testAccAWSCloudFormationConfig_defaultParams(stackName string) string {
+	return fmt.Sprintf(`
 resource "aws_cloudformation_stack" "asg-demo" {
-  name = "tf-asg-demo-stack"
+  name = "%s"
   template_body = <<BODY
 {
     "Parameters": {
@@ -371,11 +377,12 @@ BODY
     TopicName = "ExampleTopic"
   }
 }
-`
+`, stackName)
+}
 
 var testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl = `
 resource "aws_cloudformation_stack" "full" {
-  name = "tf-full-stack"
+  name = "%s"
   template_body = <<STACK
 {
   "Parameters" : {
@@ -472,18 +479,25 @@ var policyBody = `
 }
 `
 
-var testAccAWSCloudFormationConfig_allAttributesWithBodies = fmt.Sprintf(
-	testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl,
-	"Primary_CF_VPC",
-	policyBody)
-var testAccAWSCloudFormationConfig_allAttributesWithBodies_modified = fmt.Sprintf(
-	testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl,
-	"Primary_CloudFormation_VPC",
-	policyBody)
+func testAccAWSCloudFormationConfig_allAttributesWithBodies(stackName string) string {
+	return fmt.Sprintf(
+		testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl,
+		stackName,
+		"Primary_CF_VPC",
+		policyBody)
+}
+
+func testAccAWSCloudFormationConfig_allAttributesWithBodies_modified(stackName string) string {
+	return fmt.Sprintf(
+		testAccAWSCloudFormationConfig_allAttributesWithBodies_tpl,
+		stackName,
+		"Primary_CloudFormation_VPC",
+		policyBody)
+}
 
 var tpl_testAccAWSCloudFormationConfig_withParams = `
 resource "aws_cloudformation_stack" "with_params" {
-  name = "tf-stack-with-params"
+  name = "%s"
   parameters {
     VpcCIDR = "%s"
   }
@@ -514,14 +528,21 @@ STACK
 }
 `
 
-var testAccAWSCloudFormationConfig_withParams = fmt.Sprintf(
-	tpl_testAccAWSCloudFormationConfig_withParams,
-	"10.0.0.0/16")
-var testAccAWSCloudFormationConfig_withParams_modified = fmt.Sprintf(
-	tpl_testAccAWSCloudFormationConfig_withParams,
-	"12.0.0.0/16")
+func testAccAWSCloudFormationConfig_withParams(stackName string) string {
+	return fmt.Sprintf(
+		tpl_testAccAWSCloudFormationConfig_withParams,
+		stackName,
+		"10.0.0.0/16")
+}
 
-func testAccAWSCloudFormationConfig_templateUrl_withParams(bucketName, bucketKey, vpcCidr string) string {
+func testAccAWSCloudFormationConfig_withParams_modified(stackName string) string {
+	return fmt.Sprintf(
+		tpl_testAccAWSCloudFormationConfig_withParams,
+		stackName,
+		"12.0.0.0/16")
+}
+
+func testAccAWSCloudFormationConfig_templateUrl_withParams(rName, bucketKey, vpcCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "b" {
   bucket = "%s"
@@ -556,7 +577,7 @@ resource "aws_s3_bucket_object" "object" {
 }
 
 resource "aws_cloudformation_stack" "with-url-and-params" {
-  name = "tf-stack-template-url-with-params"
+  name = "%s"
   parameters {
     VpcCIDR = "%s"
   }
@@ -564,10 +585,10 @@ resource "aws_cloudformation_stack" "with-url-and-params" {
   on_failure = "DELETE"
   timeout_in_minutes = 1
 }
-`, bucketName, bucketName, bucketKey, vpcCidr)
+`, rName, rName, bucketKey, rName, vpcCidr)
 }
 
-func testAccAWSCloudFormationConfig_templateUrl_withParams_withYaml(bucketName, bucketKey, vpcCidr string) string {
+func testAccAWSCloudFormationConfig_templateUrl_withParams_withYaml(rName, bucketKey, vpcCidr string) string {
 	return fmt.Sprintf(`
 resource "aws_s3_bucket" "b" {
   bucket = "%s"
@@ -602,7 +623,7 @@ resource "aws_s3_bucket_object" "object" {
 }
 
 resource "aws_cloudformation_stack" "with-url-and-params-and-yaml" {
-  name = "tf-stack-template-url-with-params-and-yaml"
+  name = "%s"
   parameters {
     VpcCIDR = "%s"
   }
@@ -610,5 +631,5 @@ resource "aws_cloudformation_stack" "with-url-and-params-and-yaml" {
   on_failure = "DELETE"
   timeout_in_minutes = 1
 }
-`, bucketName, bucketName, bucketKey, vpcCidr)
+`, rName, rName, bucketKey, rName, vpcCidr)
 }


### PR DESCRIPTION
### Test plan
```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSCloudFormation_'
```
```
=== RUN   TestAccAWSCloudFormation_yaml
--- PASS: TestAccAWSCloudFormation_yaml (51.64s)
=== RUN   TestAccAWSCloudFormation_basic
--- PASS: TestAccAWSCloudFormation_basic (60.43s)
=== RUN   TestAccAWSCloudFormation_withUrl_withParams_noUpdate
--- PASS: TestAccAWSCloudFormation_withUrl_withParams_noUpdate (73.15s)
=== RUN   TestAccAWSCloudFormation_defaultParams
--- PASS: TestAccAWSCloudFormation_defaultParams (74.89s)
=== RUN   TestAccAWSCloudFormation_withUrl_withParams_withYaml
--- PASS: TestAccAWSCloudFormation_withUrl_withParams_withYaml (81.29s)
=== RUN   TestAccAWSCloudFormation_allAttributes
--- PASS: TestAccAWSCloudFormation_allAttributes (84.63s)
=== RUN   TestAccAWSCloudFormation_withParams
--- PASS: TestAccAWSCloudFormation_withParams (113.88s)
=== RUN   TestAccAWSCloudFormation_withUrl_withParams
--- PASS: TestAccAWSCloudFormation_withUrl_withParams (117.05s)
```