### PR TITLE
provider/aws: Raise timeout for attaching/detaching VPN GW

### DIFF
--- a/builtin/providers/aws/resource_aws_vpn_gateway.go
+++ b/builtin/providers/aws/resource_aws_vpn_gateway.go
@@ -205,7 +205,7 @@ func resourceAwsVpnGatewayAttach(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"detached", "attaching"},
 		Target:  []string{"attached"},
 		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "available"),
-		Timeout: 5 * time.Minute,
+		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(
@@ -266,7 +266,7 @@ func resourceAwsVpnGatewayDetach(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"attached", "detaching", "available"},
 		Target:  []string{"detached"},
 		Refresh: vpnGatewayAttachStateRefreshFunc(conn, d.Id(), "detached"),
-		Timeout: 5 * time.Minute,
+		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
Apparently [raising it to 5mins](https://github.com/hashicorp/terraform/pull/13457) wasn't sufficient as we keep seeing failures like this:

```
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
--- FAIL: TestAccAWSRouteTable_vgwRoutePropagation (702.17s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_vpn_gateway.foo: 1 error(s) occurred:
        
        * aws_vpn_gateway.foo: Error waiting for VPN gateway (vgw-a0c71cbe) to attach: timeout while waiting for state to become 'attached' (last state: 'detached', timeout: 5m0s)
FAIL
```