### PR TITLE
Fixed export to be master_username from username

### DIFF
--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -106,7 +106,7 @@ load-balanced across replicas
 * `database_name` - The database name
 * `port` - The database port
 * `status` - The RDS instance status
-* `username` - The master username for the database
+* `master_username` - The master username for the database
 * `storage_encrypted` - Specifies whether the DB cluster is encrypted
 * `preferred_backup_window` - The daily time range during which the backups happen
 * `replication_source_identifier` - ARN  of the source DB cluster if this DB cluster is created as a Read Replica.


### PR DESCRIPTION
rds cluster exports the variable for "username" as master_username, not username.