### PR TITLE
google container_cluster master_auth should be optional

### DIFF
--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -25,7 +25,7 @@ func resourceContainerCluster() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			"master_auth": &schema.Schema{
 				Type:     schema.TypeList,
-				Required: true,
+				Optional: true,
 				ForceNew: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
@@ -342,19 +342,21 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 	zoneName := d.Get("zone").(string)
 	clusterName := d.Get("name").(string)
 
-	masterAuths := d.Get("master_auth").([]interface{})
-	if len(masterAuths) > 1 {
-		return fmt.Errorf("Cannot specify more than one master_auth.")
-	}
-	masterAuth := masterAuths[0].(map[string]interface{})
-
 	cluster := &container.Cluster{
-		MasterAuth: &container.MasterAuth{
-			Password: masterAuth["password"].(string),
-			Username: masterAuth["username"].(string),
-		},
 		Name:             clusterName,
 		InitialNodeCount: int64(d.Get("initial_node_count").(int)),
+	}
+
+	if v, ok := d.GetOk("master_auth"); ok {
+		masterAuths := v.([]interface{})
+		if len(masterAuths) > 1 {
+			return fmt.Errorf("Cannot specify more than one master_auth.")
+		}
+		masterAuth := masterAuths[0].(map[string]interface{})
+		cluster.MasterAuth = &container.MasterAuth{
+			Password: masterAuth["password"].(string),
+			Username: masterAuth["username"].(string),
+		}
 	}
 
 	if v, ok := d.GetOk("node_version"); ok {

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -28,6 +28,7 @@ func resourceContainerCluster() *schema.Resource {
 				Optional: true,
 				ForceNew: true,
 				MaxItems: 1,
+				Computed: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"client_certificate": &schema.Schema{

--- a/builtin/providers/google/resource_container_cluster.go
+++ b/builtin/providers/google/resource_container_cluster.go
@@ -27,6 +27,7 @@ func resourceContainerCluster() *schema.Resource {
 				Type:     schema.TypeList,
 				Optional: true,
 				ForceNew: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"client_certificate": &schema.Schema{
@@ -349,9 +350,6 @@ func resourceContainerClusterCreate(d *schema.ResourceData, meta interface{}) er
 
 	if v, ok := d.GetOk("master_auth"); ok {
 		masterAuths := v.([]interface{})
-		if len(masterAuths) > 1 {
-			return fmt.Errorf("Cannot specify more than one master_auth.")
-		}
 		masterAuth := masterAuths[0].(map[string]interface{})
 		cluster.MasterAuth = &container.MasterAuth{
 			Password: masterAuth["password"].(string),

--- a/builtin/providers/google/resource_container_cluster_test.go
+++ b/builtin/providers/google/resource_container_cluster_test.go
@@ -28,6 +28,23 @@ func TestAccContainerCluster_basic(t *testing.T) {
 	})
 }
 
+func TestAccContainerCluster_withMasterAuth(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckContainerClusterDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccContainerCluster_withMasterAuth,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckContainerCluster(
+						"google_container_cluster.with_master_auth"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccContainerCluster_withAdditionalZones(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -372,6 +389,13 @@ func matchError(attr, tf string, gcp interface{}) string {
 
 var testAccContainerCluster_basic = fmt.Sprintf(`
 resource "google_container_cluster" "primary" {
+	name = "cluster-test-%s"
+	zone = "us-central1-a"
+	initial_node_count = 3
+}`, acctest.RandString(10))
+
+var testAccContainerCluster_withMasterAuth = fmt.Sprintf(`
+resource "google_container_cluster" "with_master_auth" {
 	name = "cluster-test-%s"
 	zone = "us-central1-a"
 	initial_node_count = 3

--- a/website/source/docs/providers/google/r/container_cluster.html.markdown
+++ b/website/source/docs/providers/google/r/container_cluster.html.markdown
@@ -49,9 +49,6 @@ resource "google_container_cluster" "primary" {
 * `initial_node_count` - (Required) The number of nodes to create in this
     cluster (not including the Kubernetes master).
 
-* `master_auth` - (Required) The authentication information for accessing the
-    Kubernetes master.
-
 * `name` - (Required) The name of the cluster, unique within the project and
     zone.
 
@@ -59,6 +56,9 @@ resource "google_container_cluster" "primary" {
     in `initial_node_count` should be created in.
 
 - - -
+* `master_auth` - (Optional) The authentication information for accessing the
+    Kubernetes master.
+
 * `additional_zones` - (Optional) If additional zones are configured, the number
     of nodes specified in `initial_node_count` is created in all specified zones.
 


### PR DESCRIPTION
I'm not sure why master_auth is required; it's not even an option when you create a cluster via the console today.
This should make it optional.