### PR TITLE
Missing short name in the service scope (Google compute instance)

### DIFF
--- a/builtin/providers/google/service_scope.go
+++ b/builtin/providers/google/service_scope.go
@@ -24,6 +24,7 @@ func canonicalizeServiceScope(scope string) string {
 		"storage-rw":            "https://www.googleapis.com/auth/devstorage.read_write",
 		"taskqueue":             "https://www.googleapis.com/auth/taskqueue",
 		"trace-append":          "https://www.googleapis.com/auth/trace.append",
+		"trace-ro":              "https://www.googleapis.com/auth/trace.readonly",
 		"useraccounts-ro":       "https://www.googleapis.com/auth/cloud.useraccounts.readonly",
 		"useraccounts-rw":       "https://www.googleapis.com/auth/cloud.useraccounts",
 		"userinfo-email":        "https://www.googleapis.com/auth/userinfo.email",

--- a/builtin/providers/google/service_scope.go
+++ b/builtin/providers/google/service_scope.go
@@ -23,6 +23,7 @@ func canonicalizeServiceScope(scope string) string {
 		"storage-ro":            "https://www.googleapis.com/auth/devstorage.read_only",
 		"storage-rw":            "https://www.googleapis.com/auth/devstorage.read_write",
 		"taskqueue":             "https://www.googleapis.com/auth/taskqueue",
+		"trace-append":          "https://www.googleapis.com/auth/trace.append",
 		"useraccounts-ro":       "https://www.googleapis.com/auth/cloud.useraccounts.readonly",
 		"useraccounts-rw":       "https://www.googleapis.com/auth/cloud.useraccounts",
 		"userinfo-email":        "https://www.googleapis.com/auth/userinfo.email",


### PR DESCRIPTION
The missing short name is for Stackdriver Trace append.