### PR TITLE
provider/google: remove deleted services field.

### DIFF
--- a/website/source/docs/providers/google/r/google_project.html.markdown
+++ b/website/source/docs/providers/google/r/google_project.html.markdown
@@ -8,8 +8,7 @@ description: |-
 
 # google\_project
 
-Allows creation and management of a Google Cloud Platform project and its
-associated enabled services/APIs.
+Allows creation and management of a Google Cloud Platform project.
 
 Projects created with this resource must be associated with an Organization.
 See the [Organization documentation](https://cloud.google.com/resource-manager/docs/quickstarts) for more details.
@@ -43,7 +42,6 @@ Terraform. Only newly added projects are affected.
 resource "google_project" "my_project" {
   project_id = "your-project-id"
   org_id     = "1234567"
-  services   = ["compute_component", "storage-component-json.googleapis.com", "iam.googleapis.com"]
 }
 ```
 


### PR DESCRIPTION
We removed the services field from the `google_project` resource, but it
lingered in the docs. This removes those out of date references to it.

Fixes #14452.