### PR TITLE
provider/aws: Allow updating tuples in WAF SQLInjectionMatchSet + no tuples

### DIFF
--- a/builtin/providers/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/builtin/providers/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -149,6 +149,29 @@ func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
 	})
 }
 
+func TestAccAWSWafSqlInjectionMatchSet_noTuples(t *testing.T) {
+	var ipset waf.SqlInjectionMatchSet
+	setName := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafSqlInjectionMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafSqlInjectionMatchSetConfig_noTuples(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &ipset),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "0"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckAWSWafSqlInjectionMatchSetDisappears(v *waf.SqlInjectionMatchSet) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		conn := testAccProvider.Meta().(*AWSClient).wafconn
@@ -287,5 +310,12 @@ resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
       data = "GET"
     }
   }
+}`, name)
+}
+
+func testAccAWSWafSqlInjectionMatchSetConfig_noTuples(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
+  name = "%s"
 }`, name)
 }

--- a/builtin/providers/aws/resource_aws_waf_sql_injection_match_set_test.go
+++ b/builtin/providers/aws/resource_aws_waf_sql_injection_match_set_test.go
@@ -31,6 +31,14 @@ func TestAccAWSWafSqlInjectionMatchSet_basic(t *testing.T) {
 						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", sqlInjectionMatchSet),
 					resource.TestCheckResourceAttr(
 						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.data", ""),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.text_transformation", "URL_DECODE"),
 				),
 			},
 		},
@@ -87,6 +95,55 @@ func TestAccAWSWafSqlInjectionMatchSet_disappears(t *testing.T) {
 					testAccCheckAWSWafSqlInjectionMatchSetDisappears(&v),
 				),
 				ExpectNonEmptyPlan: true,
+			},
+		},
+	})
+}
+
+func TestAccAWSWafSqlInjectionMatchSet_changeTuples(t *testing.T) {
+	var before, after waf.SqlInjectionMatchSet
+	setName := fmt.Sprintf("sqlInjectionMatchSet-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSWafSqlInjectionMatchSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSWafSqlInjectionMatchSetConfig(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &before),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.data", ""),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.field_to_match.2316364334.type", "QUERY_STRING"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3367958210.text_transformation", "URL_DECODE"),
+				),
+			},
+			{
+				Config: testAccAWSWafSqlInjectionMatchSetConfig_changeTuples(setName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSWafSqlInjectionMatchSetExists("aws_waf_sql_injection_match_set.sql_injection_match_set", &after),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "name", setName),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.field_to_match.#", "1"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.field_to_match.4253810390.data", "GET"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.field_to_match.4253810390.type", "METHOD"),
+					resource.TestCheckResourceAttr(
+						"aws_waf_sql_injection_match_set.sql_injection_match_set", "sql_injection_match_tuples.3333510133.text_transformation", "NONE"),
+				),
 			},
 		},
 	})
@@ -214,6 +271,20 @@ resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
     text_transformation = "URL_DECODE"
     field_to_match {
       type = "QUERY_STRING"
+    }
+  }
+}`, name)
+}
+
+func testAccAWSWafSqlInjectionMatchSetConfig_changeTuples(name string) string {
+	return fmt.Sprintf(`
+resource "aws_waf_sql_injection_match_set" "sql_injection_match_set" {
+  name = "%s"
+  sql_injection_match_tuples {
+    text_transformation = "NONE"
+    field_to_match {
+      type = "METHOD"
+      data = "GET"
     }
   }
 }`, name)


### PR DESCRIPTION
This is to fix a bug very similar to #10403 and #11959

TL;DR We were not deleting any tuples except when deleting the whole Set.

### Test plan

```
make testacc TEST=./
builtin/providers/aws TESTARGS='-run=TestAccAWSWafSqlInjectionMatchSet_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 16:07:49 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSWafSqlInjectionMatchSet_ -timeout 120m
=== RUN   TestAccAWSWafSqlInjectionMatchSet_basic
--- PASS: TestAccAWSWafSqlInjectionMatchSet_basic (27.47s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeNameForceNew (54.99s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_disappears
--- PASS: TestAccAWSWafSqlInjectionMatchSet_disappears (25.67s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_changeTuples
--- PASS: TestAccAWSWafSqlInjectionMatchSet_changeTuples (48.09s)
=== RUN   TestAccAWSWafSqlInjectionMatchSet_noTuples
--- PASS: TestAccAWSWafSqlInjectionMatchSet_noTuples (24.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	181.207s
```

cc @yusukegoto