### PR TITLE
providers/heroku: upgrade vendored cyberdelia/heroku-go client

### DIFF
--- a/builtin/providers/heroku/import_heroku_pipeline_coupling_test.go
+++ b/builtin/providers/heroku/import_heroku_pipeline_coupling_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccHerokuPipelineCoupling_importBasic(t *testing.T) {
-	var coupling heroku.PipelineCouplingInfoResult
+	var coupling heroku.PipelineCoupling
 
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))

--- a/builtin/providers/heroku/resource_heroku_addon_test.go
+++ b/builtin/providers/heroku/resource_heroku_addon_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccHerokuAddon_Basic(t *testing.T) {
-	var addon heroku.AddOnInfoResult
+	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -39,7 +39,7 @@ func TestAccHerokuAddon_Basic(t *testing.T) {
 
 // GH-198
 func TestAccHerokuAddon_noPlan(t *testing.T) {
-	var addon heroku.AddOnInfoResult
+	var addon heroku.AddOn
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -81,7 +81,7 @@ func testAccCheckHerokuAddonDestroy(s *terraform.State) error {
 			continue
 		}
 
-		_, err := client.AddOnInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
+		_, err := client.AddOnInfoByApp(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err == nil {
 			return fmt.Errorf("Addon still exists")
@@ -91,7 +91,7 @@ func testAccCheckHerokuAddonDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuAddonAttributes(addon *heroku.AddOnInfoResult, n string) resource.TestCheckFunc {
+func testAccCheckHerokuAddonAttributes(addon *heroku.AddOn, n string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if addon.Plan.Name != n {
@@ -102,7 +102,7 @@ func testAccCheckHerokuAddonAttributes(addon *heroku.AddOnInfoResult, n string) 
 	}
 }
 
-func testAccCheckHerokuAddonExists(n string, addon *heroku.AddOnInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuAddonExists(n string, addon *heroku.AddOn) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -116,7 +116,7 @@ func testAccCheckHerokuAddonExists(n string, addon *heroku.AddOnInfoResult) reso
 
 		client := testAccProvider.Meta().(*heroku.Service)
 
-		foundAddon, err := client.AddOnInfo(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
+		foundAddon, err := client.AddOnInfoByApp(context.TODO(), rs.Primary.Attributes["app"], rs.Primary.ID)
 
 		if err != nil {
 			return err

--- a/builtin/providers/heroku/resource_heroku_app_feature_test.go
+++ b/builtin/providers/heroku/resource_heroku_app_feature_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccHerokuAppFeature(t *testing.T) {
-	var feature heroku.AppFeatureInfoResult
+	var feature heroku.AppFeature
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -62,7 +62,7 @@ func testAccCheckHerokuFeatureDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuFeatureExists(n string, feature *heroku.AppFeatureInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuFeatureExists(n string, feature *heroku.AppFeature) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -95,7 +95,7 @@ func testAccCheckHerokuFeatureExists(n string, feature *heroku.AppFeatureInfoRes
 	}
 }
 
-func testAccCheckHerokuFeatureEnabled(feature *heroku.AppFeatureInfoResult, enabled bool) resource.TestCheckFunc {
+func testAccCheckHerokuFeatureEnabled(feature *heroku.AppFeature, enabled bool) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if feature.Enabled != enabled {
 			return fmt.Errorf("Bad enabled: %v", feature.Enabled)

--- a/builtin/providers/heroku/resource_heroku_app_test.go
+++ b/builtin/providers/heroku/resource_heroku_app_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccHerokuApp_Basic(t *testing.T) {
-	var app heroku.AppInfoResult
+	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -37,7 +37,7 @@ func TestAccHerokuApp_Basic(t *testing.T) {
 }
 
 func TestAccHerokuApp_NameChange(t *testing.T) {
-	var app heroku.AppInfoResult
+	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	appName2 := fmt.Sprintf("%s-v2", appName)
 
@@ -75,7 +75,7 @@ func TestAccHerokuApp_NameChange(t *testing.T) {
 }
 
 func TestAccHerokuApp_NukeVars(t *testing.T) {
-	var app heroku.AppInfoResult
+	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -110,7 +110,7 @@ func TestAccHerokuApp_NukeVars(t *testing.T) {
 }
 
 func TestAccHerokuApp_Buildpacks(t *testing.T) {
-	var app heroku.AppInfoResult
+	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -149,7 +149,7 @@ func TestAccHerokuApp_Buildpacks(t *testing.T) {
 }
 
 func TestAccHerokuApp_ExternallySetBuildpacks(t *testing.T) {
-	var app heroku.AppInfoResult
+	var app heroku.App
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -252,7 +252,7 @@ func testAccCheckHerokuAppDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuAppAttributes(app *heroku.AppInfoResult, appName string) resource.TestCheckFunc {
+func testAccCheckHerokuAppAttributes(app *heroku.App, appName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
 
@@ -281,7 +281,7 @@ func testAccCheckHerokuAppAttributes(app *heroku.AppInfoResult, appName string) 
 	}
 }
 
-func testAccCheckHerokuAppAttributesUpdated(app *heroku.AppInfoResult, appName string) resource.TestCheckFunc {
+func testAccCheckHerokuAppAttributesUpdated(app *heroku.App, appName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
 
@@ -308,7 +308,7 @@ func testAccCheckHerokuAppAttributesUpdated(app *heroku.AppInfoResult, appName s
 	}
 }
 
-func testAccCheckHerokuAppAttributesNoVars(app *heroku.AppInfoResult, appName string) resource.TestCheckFunc {
+func testAccCheckHerokuAppAttributesNoVars(app *heroku.App, appName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		client := testAccProvider.Meta().(*heroku.Service)
 
@@ -424,7 +424,7 @@ func testAccCheckHerokuAppAttributesOrg(app *heroku.OrganizationApp, appName, sp
 	}
 }
 
-func testAccCheckHerokuAppExists(n string, app *heroku.AppInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuAppExists(n string, app *heroku.App) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 

--- a/builtin/providers/heroku/resource_heroku_cert.go
+++ b/builtin/providers/heroku/resource_heroku_cert.go
@@ -122,7 +122,7 @@ func resourceHerokuCertDelete(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func resourceHerokuSSLCertRetrieve(app string, id string, client *heroku.Service) (*heroku.SSLEndpointInfoResult, error) {
+func resourceHerokuSSLCertRetrieve(app string, id string, client *heroku.Service) (*heroku.SSLEndpoint, error) {
 	addon, err := client.SSLEndpointInfo(context.TODO(), app, id)
 
 	if err != nil {

--- a/builtin/providers/heroku/resource_heroku_cert_test.go
+++ b/builtin/providers/heroku/resource_heroku_cert_test.go
@@ -29,7 +29,7 @@ import (
 // on update seems to allow the test to run smoothly; in real life, this test
 // case is definitely an extreme edge case.
 func TestAccHerokuCert_EU(t *testing.T) {
-	var endpoint heroku.SSLEndpointInfoResult
+	var endpoint heroku.SSLEndpoint
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	wd, _ := os.Getwd()
@@ -74,7 +74,7 @@ func TestAccHerokuCert_EU(t *testing.T) {
 }
 
 func TestAccHerokuCert_US(t *testing.T) {
-	var endpoint heroku.SSLEndpointInfoResult
+	var endpoint heroku.SSLEndpoint
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	wd, _ := os.Getwd()
@@ -182,7 +182,7 @@ func testAccCheckHerokuCertDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuCertificateChain(endpoint *heroku.SSLEndpointInfoResult, chain string) resource.TestCheckFunc {
+func testAccCheckHerokuCertificateChain(endpoint *heroku.SSLEndpoint, chain string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if endpoint.CertificateChain != chain {
@@ -193,7 +193,7 @@ func testAccCheckHerokuCertificateChain(endpoint *heroku.SSLEndpointInfoResult, 
 	}
 }
 
-func testAccCheckHerokuCertExists(n string, endpoint *heroku.SSLEndpointInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuCertExists(n string, endpoint *heroku.SSLEndpoint) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 

--- a/builtin/providers/heroku/resource_heroku_domain_test.go
+++ b/builtin/providers/heroku/resource_heroku_domain_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccHerokuDomain_Basic(t *testing.T) {
-	var domain heroku.DomainInfoResult
+	var domain heroku.Domain
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -55,7 +55,7 @@ func testAccCheckHerokuDomainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuDomainAttributes(Domain *heroku.DomainInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuDomainAttributes(Domain *heroku.Domain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if Domain.Hostname != "terraform.example.com" {
@@ -66,7 +66,7 @@ func testAccCheckHerokuDomainAttributes(Domain *heroku.DomainInfoResult) resourc
 	}
 }
 
-func testAccCheckHerokuDomainExists(n string, Domain *heroku.DomainInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuDomainExists(n string, Domain *heroku.Domain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 

--- a/builtin/providers/heroku/resource_heroku_drain.go
+++ b/builtin/providers/heroku/resource_heroku_drain.go
@@ -49,7 +49,7 @@ func resourceHerokuDrainCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] Drain create configuration: %#v, %#v", app, url)
 
-	var dr *heroku.LogDrainCreateResult
+	var dr *heroku.LogDrain
 	err := resource.Retry(2*time.Minute, func() *resource.RetryError {
 		d, err := client.LogDrainCreate(context.TODO(), app, heroku.LogDrainCreateOpts{URL: url})
 		if err != nil {

--- a/builtin/providers/heroku/resource_heroku_drain_test.go
+++ b/builtin/providers/heroku/resource_heroku_drain_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccHerokuDrain_Basic(t *testing.T) {
-	var drain heroku.LogDrainInfoResult
+	var drain heroku.LogDrain
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
@@ -53,7 +53,7 @@ func testAccCheckHerokuDrainDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckHerokuDrainAttributes(Drain *heroku.LogDrainInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuDrainAttributes(Drain *heroku.LogDrain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
 		if Drain.URL != "syslog://terraform.example.com:1234" {
@@ -68,7 +68,7 @@ func testAccCheckHerokuDrainAttributes(Drain *heroku.LogDrainInfoResult) resourc
 	}
 }
 
-func testAccCheckHerokuDrainExists(n string, Drain *heroku.LogDrainInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuDrainExists(n string, Drain *heroku.LogDrain) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 

--- a/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_coupling_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccHerokuPipelineCoupling_Basic(t *testing.T) {
-	var coupling heroku.PipelineCouplingInfoResult
+	var coupling heroku.PipelineCoupling
 
 	appName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
@@ -57,7 +57,7 @@ resource "heroku_pipeline_coupling" "default" {
 `, appName, pipelineName, stageName)
 }
 
-func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.PipelineCouplingInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.PipelineCoupling) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -86,7 +86,7 @@ func testAccCheckHerokuPipelineCouplingExists(n string, pipeline *heroku.Pipelin
 	}
 }
 
-func testAccCheckHerokuPipelineCouplingAttributes(coupling *heroku.PipelineCouplingInfoResult, pipelineResource, stageName string) resource.TestCheckFunc {
+func testAccCheckHerokuPipelineCouplingAttributes(coupling *heroku.PipelineCoupling, pipelineResource, stageName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		pipeline, ok := s.RootModule().Resources[pipelineResource]
 		if !ok {

--- a/builtin/providers/heroku/resource_heroku_pipeline_test.go
+++ b/builtin/providers/heroku/resource_heroku_pipeline_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestAccHerokuPipeline_Basic(t *testing.T) {
-	var pipeline heroku.PipelineInfoResult
+	var pipeline heroku.Pipeline
 	pipelineName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	pipelineName2 := fmt.Sprintf("%s-2", pipelineName)
 
@@ -48,7 +48,7 @@ resource "heroku_pipeline" "foobar" {
 `, pipelineName)
 }
 
-func testAccCheckHerokuPipelineExists(n string, pipeline *heroku.PipelineInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuPipelineExists(n string, pipeline *heroku.Pipeline) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 

--- a/builtin/providers/heroku/resource_heroku_space_test.go
+++ b/builtin/providers/heroku/resource_heroku_space_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestAccHerokuSpace_Basic(t *testing.T) {
-	var space heroku.SpaceInfoResult
+	var space heroku.Space
 	spaceName := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	spaceName2 := fmt.Sprintf("tftest-%s", acctest.RandString(10))
 	org := os.Getenv("HEROKU_ORGANIZATION")
@@ -56,7 +56,7 @@ resource "heroku_space" "foobar" {
 `, spaceName, orgName)
 }
 
-func testAccCheckHerokuSpaceExists(n string, space *heroku.SpaceInfoResult) resource.TestCheckFunc {
+func testAccCheckHerokuSpaceExists(n string, space *heroku.Space) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 
@@ -85,7 +85,7 @@ func testAccCheckHerokuSpaceExists(n string, space *heroku.SpaceInfoResult) reso
 	}
 }
 
-func testAccCheckHerokuSpaceAttributes(space *heroku.SpaceInfoResult, spaceName string) resource.TestCheckFunc {
+func testAccCheckHerokuSpaceAttributes(space *heroku.Space, spaceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		if space.Name != spaceName {
 			return fmt.Errorf("Bad name: %s", space.Name)

--- a/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/heroku.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"reflect"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/google/go-querystring/query"
@@ -165,14 +166,15 @@ func (lr *ListRange) SetHeader(req *http.Request) {
 		hdrval += lr.Field + " "
 	}
 	hdrval += lr.FirstID + ".." + lr.LastID
+	params := make([]string, 0, 2)
 	if lr.Max != 0 {
-		hdrval += fmt.Sprintf("; max=%d", lr.Max)
-		if lr.Descending {
-			hdrval += "; "
-		}
+		params = append(params, fmt.Sprintf("max=%d", lr.Max))
 	}
 	if lr.Descending {
-		hdrval += "order=desc"
+		params = append(params, "order=desc")
+	}
+	if len(params) > 0 {
+		hdrval += fmt.Sprintf("; %s", strings.Join(params, ","))
 	}
 	req.Header.Set("Range", hdrval)
 	return
@@ -234,36 +236,10 @@ type Account struct {
 	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
 	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
 }
-type AccountInfoResult struct {
-	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
-	Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
-	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
-	DefaultOrganization *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"default_organization" url:"default_organization,key"` // organization selected by default
-	DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
-	Email            string     `json:"email" url:"email,key"`                 // unique email address of account
-	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
-	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
-	IdentityProvider *struct {
-		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
-		Organization struct {
-			Name string `json:"name" url:"name,key"` // unique name of organization
-		} `json:"organization" url:"organization,key"`
-	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
-	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
-	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
-	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
-	SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
-	TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
-	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
-	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
-}
 
 // Info for account.
-func (s *Service) AccountInfo(ctx context.Context) (*AccountInfoResult, error) {
-	var account AccountInfoResult
+func (s *Service) AccountInfo(ctx context.Context) (*Account, error) {
+	var account Account
 	return &account, s.Get(ctx, &account, fmt.Sprintf("/account"), nil, nil)
 }
 
@@ -272,111 +248,65 @@ type AccountUpdateOpts struct {
 	Beta          *bool   `json:"beta,omitempty" url:"beta,omitempty,key"`                     // whether allowed to utilize beta Heroku features
 	Name          *string `json:"name,omitempty" url:"name,omitempty,key"`                     // full name of the account owner
 }
-type AccountUpdateResult struct {
-	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
-	Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
-	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
-	DefaultOrganization *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"default_organization" url:"default_organization,key"` // organization selected by default
-	DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
-	Email            string     `json:"email" url:"email,key"`                 // unique email address of account
-	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
-	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
-	IdentityProvider *struct {
-		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
-		Organization struct {
-			Name string `json:"name" url:"name,key"` // unique name of organization
-		} `json:"organization" url:"organization,key"`
-	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
-	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
-	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
-	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
-	SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
-	TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
-	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
-	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
-}
 
 // Update account.
-func (s *Service) AccountUpdate(ctx context.Context, o AccountUpdateOpts) (*AccountUpdateResult, error) {
-	var account AccountUpdateResult
+func (s *Service) AccountUpdate(ctx context.Context, o AccountUpdateOpts) (*Account, error) {
+	var account Account
 	return &account, s.Patch(ctx, &account, fmt.Sprintf("/account"), o)
 }
 
-type AccountDeleteResult struct {
-	AllowTracking       bool      `json:"allow_tracking" url:"allow_tracking,key"` // whether to allow third party web activity tracking
-	Beta                bool      `json:"beta" url:"beta,key"`                     // whether allowed to utilize beta Heroku features
-	CreatedAt           time.Time `json:"created_at" url:"created_at,key"`         // when account was created
-	DefaultOrganization *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"default_organization" url:"default_organization,key"` // organization selected by default
-	DelinquentAt     *time.Time `json:"delinquent_at" url:"delinquent_at,key"` // when account became delinquent
-	Email            string     `json:"email" url:"email,key"`                 // unique email address of account
-	Federated        bool       `json:"federated" url:"federated,key"`         // whether the user is federated and belongs to an Identity Provider
-	ID               string     `json:"id" url:"id,key"`                       // unique identifier of an account
-	IdentityProvider *struct {
-		ID           string `json:"id" url:"id,key"` // unique identifier of this identity provider
-		Organization struct {
-			Name string `json:"name" url:"name,key"` // unique name of organization
-		} `json:"organization" url:"organization,key"`
-	} `json:"identity_provider" url:"identity_provider,key"` // Identity Provider details for federated users.
-	LastLogin               *time.Time `json:"last_login" url:"last_login,key"`                               // when account last authorized with Heroku
-	Name                    *string    `json:"name" url:"name,key"`                                           // full name of the account owner
-	SmsNumber               *string    `json:"sms_number" url:"sms_number,key"`                               // SMS number of account
-	SuspendedAt             *time.Time `json:"suspended_at" url:"suspended_at,key"`                           // when account was suspended
-	TwoFactorAuthentication bool       `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether two-factor auth is enabled on the account
-	UpdatedAt               time.Time  `json:"updated_at" url:"updated_at,key"`                               // when account was updated
-	Verified                bool       `json:"verified" url:"verified,key"`                                   // whether account has been verified with billing information
+// Delete account. Note that this action cannot be undone.
+func (s *Service) AccountDelete(ctx context.Context) (*Account, error) {
+	var account Account
+	return &account, s.Delete(ctx, &account, fmt.Sprintf("/account"))
+}
+
+// Info for account.
+func (s *Service) AccountInfoByUser(ctx context.Context, accountIdentity string) (*Account, error) {
+	var account Account
+	return &account, s.Get(ctx, &account, fmt.Sprintf("/users/%v", accountIdentity), nil, nil)
+}
+
+type AccountUpdateByUserOpts struct {
+	AllowTracking *bool   `json:"allow_tracking,omitempty" url:"allow_tracking,omitempty,key"` // whether to allow third party web activity tracking
+	Beta          *bool   `json:"beta,omitempty" url:"beta,omitempty,key"`                     // whether allowed to utilize beta Heroku features
+	Name          *string `json:"name,omitempty" url:"name,omitempty,key"`                     // full name of the account owner
+}
+
+// Update account.
+func (s *Service) AccountUpdateByUser(ctx context.Context, accountIdentity string, o AccountUpdateByUserOpts) (*Account, error) {
+	var account Account
+	return &account, s.Patch(ctx, &account, fmt.Sprintf("/users/%v", accountIdentity), o)
 }
 
 // Delete account. Note that this action cannot be undone.
-func (s *Service) AccountDelete(ctx context.Context) (*AccountDeleteResult, error) {
-	var account AccountDeleteResult
-	return &account, s.Delete(ctx, &account, fmt.Sprintf("/account"))
+func (s *Service) AccountDeleteByUser(ctx context.Context, accountIdentity string) (*Account, error) {
+	var account Account
+	return &account, s.Delete(ctx, &account, fmt.Sprintf("/users/%v", accountIdentity))
 }
 
 // An account feature represents a Heroku labs capability that can be
 // enabled or disabled for an account on Heroku.
 type AccountFeature struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
-}
-type AccountFeatureInfoResult struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when account feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of account feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of account feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not account feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of account feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of account feature
+	State         string    `json:"state" url:"state,key"`                   // state of account feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when account feature was updated
 }
 
 // Info for an existing account feature.
-func (s *Service) AccountFeatureInfo(ctx context.Context, accountFeatureIdentity string) (*AccountFeatureInfoResult, error) {
-	var accountFeature AccountFeatureInfoResult
+func (s *Service) AccountFeatureInfo(ctx context.Context, accountFeatureIdentity string) (*AccountFeature, error) {
+	var accountFeature AccountFeature
 	return &accountFeature, s.Get(ctx, &accountFeature, fmt.Sprintf("/account/features/%v", accountFeatureIdentity), nil, nil)
 }
 
-type AccountFeatureListResult []struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
-}
+type AccountFeatureListResult []AccountFeature
 
 // List existing account features.
 func (s *Service) AccountFeatureList(ctx context.Context, lr *ListRange) (AccountFeatureListResult, error) {
@@ -387,20 +317,10 @@ func (s *Service) AccountFeatureList(ctx context.Context, lr *ListRange) (Accoun
 type AccountFeatureUpdateOpts struct {
 	Enabled bool `json:"enabled" url:"enabled,key"` // whether or not account feature has been enabled
 }
-type AccountFeatureUpdateResult struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
-}
 
 // Update an existing account feature.
-func (s *Service) AccountFeatureUpdate(ctx context.Context, accountFeatureIdentity string, o AccountFeatureUpdateOpts) (*AccountFeatureUpdateResult, error) {
-	var accountFeature AccountFeatureUpdateResult
+func (s *Service) AccountFeatureUpdate(ctx context.Context, accountFeatureIdentity string, o AccountFeatureUpdateOpts) (*AccountFeature, error) {
+	var accountFeature AccountFeature
 	return &accountFeature, s.Patch(ctx, &accountFeature, fmt.Sprintf("/account/features/%v", accountFeatureIdentity), o)
 }
 
@@ -429,124 +349,7 @@ type AddOn struct {
 	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
 	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
 }
-type AddOnCreateOpts struct {
-	Attachment *struct{}          `json:"attachment,omitempty" url:"attachment,omitempty,key"` // name for add-on's initial attachment
-	Config     *map[string]string `json:"config,omitempty" url:"config,omitempty,key"`         // custom add-on provisioning options
-	Plan       string             `json:"plan" url:"plan,key"`                                 // unique identifier of this plan
-}
-type AddOnCreateResult struct {
-	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // billing application associated with this add-on
-	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-	Plan       struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-		Name string `json:"name" url:"name,key"` // unique name of this plan
-	} `json:"plan" url:"plan,key"` // identity of add-on plan
-	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
-}
-
-// Create a new add-on.
-func (s *Service) AddOnCreate(ctx context.Context, appIdentity string, o AddOnCreateOpts) (*AddOnCreateResult, error) {
-	var addOn AddOnCreateResult
-	return &addOn, s.Post(ctx, &addOn, fmt.Sprintf("/apps/%v/addons", appIdentity), o)
-}
-
-type AddOnDeleteResult struct {
-	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // billing application associated with this add-on
-	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-	Plan       struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-		Name string `json:"name" url:"name,key"` // unique name of this plan
-	} `json:"plan" url:"plan,key"` // identity of add-on plan
-	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
-}
-
-// Delete an existing add-on.
-func (s *Service) AddOnDelete(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOnDeleteResult, error) {
-	var addOn AddOnDeleteResult
-	return &addOn, s.Delete(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity))
-}
-
-type AddOnInfoResult struct {
-	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // billing application associated with this add-on
-	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-	Plan       struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-		Name string `json:"name" url:"name,key"` // unique name of this plan
-	} `json:"plan" url:"plan,key"` // identity of add-on plan
-	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
-}
-
-// Info for an existing add-on.
-func (s *Service) AddOnInfo(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOnInfoResult, error) {
-	var addOn AddOnInfoResult
-	return &addOn, s.Get(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity), nil, nil)
-}
-
-type AddOnListResult []struct {
-	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // billing application associated with this add-on
-	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-	Plan       struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-		Name string `json:"name" url:"name,key"` // unique name of this plan
-	} `json:"plan" url:"plan,key"` // identity of add-on plan
-	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
-}
+type AddOnListResult []AddOn
 
 // List all existing add-ons.
 func (s *Service) AddOnList(ctx context.Context, lr *ListRange) (AddOnListResult, error) {
@@ -554,59 +357,37 @@ func (s *Service) AddOnList(ctx context.Context, lr *ListRange) (AddOnListResult
 	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/addons"), nil, lr)
 }
 
-type AddOnListByUserResult []struct {
-	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // billing application associated with this add-on
-	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-	Plan       struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-		Name string `json:"name" url:"name,key"` // unique name of this plan
-	} `json:"plan" url:"plan,key"` // identity of add-on plan
-	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+// Info for an existing add-on.
+func (s *Service) AddOnInfo(ctx context.Context, addOnIdentity string) (*AddOn, error) {
+	var addOn AddOn
+	return &addOn, s.Get(ctx, &addOn, fmt.Sprintf("/addons/%v", addOnIdentity), nil, nil)
 }
 
-// List all existing add-ons a user has access to
-func (s *Service) AddOnListByUser(ctx context.Context, accountIdentity string, lr *ListRange) (AddOnListByUserResult, error) {
-	var addOn AddOnListByUserResult
-	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/users/%v/addons", accountIdentity), nil, lr)
+type AddOnCreateOpts struct {
+	Attachment *struct{}          `json:"attachment,omitempty" url:"attachment,omitempty,key"` // name for add-on's initial attachment
+	Config     *map[string]string `json:"config,omitempty" url:"config,omitempty,key"`         // custom add-on provisioning options
+	Plan       string             `json:"plan" url:"plan,key"`                                 // unique identifier of this plan
 }
 
-type AddOnListByAppResult []struct {
-	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // billing application associated with this add-on
-	ConfigVars []string  `json:"config_vars" url:"config_vars,key"` // config vars exposed to the owning app by this add-on
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when add-on was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of add-on
-	Name       string    `json:"name" url:"name,key"`               // globally unique name of the add-on
-	Plan       struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-		Name string `json:"name" url:"name,key"` // unique name of this plan
-	} `json:"plan" url:"plan,key"` // identity of add-on plan
-	ProviderID string    `json:"provider_id" url:"provider_id,key"` // id of this add-on with its provider
-	State      string    `json:"state" url:"state,key"`             // state in the add-on's lifecycle
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when add-on was updated
-	WebURL     *string   `json:"web_url" url:"web_url,key"`         // URL for logging into web interface of add-on (e.g. a dashboard)
+// Create a new add-on.
+func (s *Service) AddOnCreate(ctx context.Context, appIdentity string, o AddOnCreateOpts) (*AddOn, error) {
+	var addOn AddOn
+	return &addOn, s.Post(ctx, &addOn, fmt.Sprintf("/apps/%v/addons", appIdentity), o)
 }
+
+// Delete an existing add-on.
+func (s *Service) AddOnDelete(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOn, error) {
+	var addOn AddOn
+	return &addOn, s.Delete(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity))
+}
+
+// Info for an existing add-on.
+func (s *Service) AddOnInfoByApp(ctx context.Context, appIdentity string, addOnIdentity string) (*AddOn, error) {
+	var addOn AddOn
+	return &addOn, s.Get(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity), nil, nil)
+}
+
+type AddOnListByAppResult []AddOn
 
 // List existing add-ons for an app.
 func (s *Service) AddOnListByApp(ctx context.Context, appIdentity string, lr *ListRange) (AddOnListByAppResult, error) {
@@ -625,12 +406,28 @@ func (s *Service) AddOnUpdate(ctx context.Context, appIdentity string, addOnIden
 	return &addOn, s.Patch(ctx, &addOn, fmt.Sprintf("/apps/%v/addons/%v", appIdentity, addOnIdentity), o)
 }
 
+type AddOnListByUserResult []AddOn
+
+// List all existing add-ons a user has access to
+func (s *Service) AddOnListByUser(ctx context.Context, accountIdentity string, lr *ListRange) (AddOnListByUserResult, error) {
+	var addOn AddOnListByUserResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/users/%v/addons", accountIdentity), nil, lr)
+}
+
+type AddOnListByTeamResult []AddOn
+
+// List add-ons used across all Team apps
+func (s *Service) AddOnListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (AddOnListByTeamResult, error) {
+	var addOn AddOnListByTeamResult
+	return addOn, s.Get(ctx, &addOn, fmt.Sprintf("/teams/%v/addons", teamIdentity), nil, lr)
+}
+
 // Add-on Actions are lifecycle operations for add-on provisioning and
 // deprovisioning. They allow whitelisted add-on providers to
 // (de)provision add-ons in the background and then report back when
 // (de)provisioning is complete.
 type AddOnAction struct{}
-type AddOnActionCreateProvisionResult struct {
+type AddOnActionProvisionResult struct {
 	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
 	AddonService struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
@@ -655,12 +452,12 @@ type AddOnActionCreateProvisionResult struct {
 }
 
 // Mark an add-on as provisioned for use.
-func (s *Service) AddOnActionCreateProvision(ctx context.Context, addOnIdentity string) (*AddOnActionCreateProvisionResult, error) {
-	var addOnAction AddOnActionCreateProvisionResult
+func (s *Service) AddOnActionProvision(ctx context.Context, addOnIdentity string) (*AddOnActionProvisionResult, error) {
+	var addOnAction AddOnActionProvisionResult
 	return &addOnAction, s.Post(ctx, &addOnAction, fmt.Sprintf("/addons/%v/actions/provision", addOnIdentity), nil)
 }
 
-type AddOnActionCreateDeprovisionResult struct {
+type AddOnActionDeprovisionResult struct {
 	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
 	AddonService struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
@@ -685,8 +482,8 @@ type AddOnActionCreateDeprovisionResult struct {
 }
 
 // Mark an add-on as deprovisioned.
-func (s *Service) AddOnActionCreateDeprovision(ctx context.Context, addOnIdentity string) (*AddOnActionCreateDeprovisionResult, error) {
-	var addOnAction AddOnActionCreateDeprovisionResult
+func (s *Service) AddOnActionDeprovision(ctx context.Context, addOnIdentity string) (*AddOnActionDeprovisionResult, error) {
+	var addOnAction AddOnActionDeprovisionResult
 	return &addOnAction, s.Post(ctx, &addOnAction, fmt.Sprintf("/addons/%v/actions/deprovision", addOnIdentity), nil)
 }
 
@@ -712,6 +509,7 @@ type AddOnAttachment struct {
 	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
 	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
 	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
+	Namespace *string   `json:"namespace" url:"namespace,key"`   // attachment namespace
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
 	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
 }
@@ -720,121 +518,29 @@ type AddOnAttachmentCreateOpts struct {
 	App   string `json:"app" url:"app,key"`                         // unique identifier of app
 	Force *bool  `json:"force,omitempty" url:"force,omitempty,key"` // whether or not to allow existing attachment with same name to be
 	// replaced
-	Name *string `json:"name,omitempty" url:"name,omitempty,key"` // unique name for this add-on attachment to this app
-}
-type AddOnAttachmentCreateResult struct {
-	Addon struct {
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-		Plan struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-	} `json:"addon" url:"addon,key"` // identity of add-on
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application that is attached to add-on
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
-	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
-	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
+	Name      *string `json:"name,omitempty" url:"name,omitempty,key"`           // unique name for this add-on attachment to this app
+	Namespace *string `json:"namespace,omitempty" url:"namespace,omitempty,key"` // attachment namespace
 }
 
 // Create a new add-on attachment.
-func (s *Service) AddOnAttachmentCreate(ctx context.Context, o AddOnAttachmentCreateOpts) (*AddOnAttachmentCreateResult, error) {
-	var addOnAttachment AddOnAttachmentCreateResult
+func (s *Service) AddOnAttachmentCreate(ctx context.Context, o AddOnAttachmentCreateOpts) (*AddOnAttachment, error) {
+	var addOnAttachment AddOnAttachment
 	return &addOnAttachment, s.Post(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments"), o)
 }
 
-type AddOnAttachmentDeleteResult struct {
-	Addon struct {
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-		Plan struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-	} `json:"addon" url:"addon,key"` // identity of add-on
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application that is attached to add-on
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
-	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
-	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
-}
-
 // Delete an existing add-on attachment.
-func (s *Service) AddOnAttachmentDelete(ctx context.Context, addOnAttachmentIdentity string) (*AddOnAttachmentDeleteResult, error) {
-	var addOnAttachment AddOnAttachmentDeleteResult
+func (s *Service) AddOnAttachmentDelete(ctx context.Context, addOnAttachmentIdentity string) (*AddOnAttachment, error) {
+	var addOnAttachment AddOnAttachment
 	return &addOnAttachment, s.Delete(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments/%v", addOnAttachmentIdentity))
 }
 
-type AddOnAttachmentInfoResult struct {
-	Addon struct {
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-		Plan struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-	} `json:"addon" url:"addon,key"` // identity of add-on
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application that is attached to add-on
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
-	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
-	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
-}
-
 // Info for existing add-on attachment.
-func (s *Service) AddOnAttachmentInfo(ctx context.Context, addOnAttachmentIdentity string) (*AddOnAttachmentInfoResult, error) {
-	var addOnAttachment AddOnAttachmentInfoResult
+func (s *Service) AddOnAttachmentInfo(ctx context.Context, addOnAttachmentIdentity string) (*AddOnAttachment, error) {
+	var addOnAttachment AddOnAttachment
 	return &addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments/%v", addOnAttachmentIdentity), nil, nil)
 }
 
-type AddOnAttachmentListResult []struct {
-	Addon struct {
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-		Plan struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-	} `json:"addon" url:"addon,key"` // identity of add-on
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application that is attached to add-on
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
-	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
-	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
-}
+type AddOnAttachmentListResult []AddOnAttachment
 
 // List existing add-on attachments.
 func (s *Service) AddOnAttachmentList(ctx context.Context, lr *ListRange) (AddOnAttachmentListResult, error) {
@@ -842,29 +548,7 @@ func (s *Service) AddOnAttachmentList(ctx context.Context, lr *ListRange) (AddOn
 	return addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/addon-attachments"), nil, lr)
 }
 
-type AddOnAttachmentListByAddOnResult []struct {
-	Addon struct {
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-		Plan struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-	} `json:"addon" url:"addon,key"` // identity of add-on
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application that is attached to add-on
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
-	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
-	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
-}
+type AddOnAttachmentListByAddOnResult []AddOnAttachment
 
 // List existing add-on attachments for an add-on.
 func (s *Service) AddOnAttachmentListByAddOn(ctx context.Context, addOnIdentity string, lr *ListRange) (AddOnAttachmentListByAddOnResult, error) {
@@ -872,29 +556,7 @@ func (s *Service) AddOnAttachmentListByAddOn(ctx context.Context, addOnIdentity 
 	return addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/addons/%v/addon-attachments", addOnIdentity), nil, lr)
 }
 
-type AddOnAttachmentListByAppResult []struct {
-	Addon struct {
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-		Plan struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-	} `json:"addon" url:"addon,key"` // identity of add-on
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application that is attached to add-on
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
-	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
-	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
-}
+type AddOnAttachmentListByAppResult []AddOnAttachment
 
 // List existing add-on attachments for an app.
 func (s *Service) AddOnAttachmentListByApp(ctx context.Context, appIdentity string, lr *ListRange) (AddOnAttachmentListByAppResult, error) {
@@ -902,33 +564,9 @@ func (s *Service) AddOnAttachmentListByApp(ctx context.Context, appIdentity stri
 	return addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/apps/%v/addon-attachments", appIdentity), nil, lr)
 }
 
-type AddOnAttachmentInfoByAppResult struct {
-	Addon struct {
-		App struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of app
-			Name string `json:"name" url:"name,key"` // unique name of app
-		} `json:"app" url:"app,key"` // billing application associated with this add-on
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-		Plan struct {
-			ID   string `json:"id" url:"id,key"`     // unique identifier of this plan
-			Name string `json:"name" url:"name,key"` // unique name of this plan
-		} `json:"plan" url:"plan,key"` // identity of add-on plan
-	} `json:"addon" url:"addon,key"` // identity of add-on
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application that is attached to add-on
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when add-on attachment was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this add-on attachment
-	Name      string    `json:"name" url:"name,key"`             // unique name for this add-on attachment to this app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on attachment was updated
-	WebURL    *string   `json:"web_url" url:"web_url,key"`       // URL for logging into web interface of add-on in attached app context
-}
-
 // Info for existing add-on attachment for an app.
-func (s *Service) AddOnAttachmentInfoByApp(ctx context.Context, appIdentity string, addOnAttachmentScopedIdentity string) (*AddOnAttachmentInfoByAppResult, error) {
-	var addOnAttachment AddOnAttachmentInfoByAppResult
+func (s *Service) AddOnAttachmentInfoByApp(ctx context.Context, appIdentity string, addOnAttachmentScopedIdentity string) (*AddOnAttachment, error) {
+	var addOnAttachment AddOnAttachment
 	return &addOnAttachment, s.Get(ctx, &addOnAttachment, fmt.Sprintf("/apps/%v/addon-attachments/%v", appIdentity, addOnAttachmentScopedIdentity), nil, nil)
 }
 
@@ -937,10 +575,7 @@ type AddOnConfig struct {
 	Name  string  `json:"name" url:"name,key"`   // unique name of the config
 	Value *string `json:"value" url:"value,key"` // value of the config
 }
-type AddOnConfigListResult []struct {
-	Name  string  `json:"name" url:"name,key"`   // unique name of the config
-	Value *string `json:"value" url:"value,key"` // value of the config
-}
+type AddOnConfigListResult []AddOnConfig
 
 // Get an add-on's config. Accessible by customers with access and by
 // the add-on partner providing this add-on.
@@ -955,10 +590,7 @@ type AddOnConfigUpdateOpts struct {
 		Value *string `json:"value,omitempty" url:"value,omitempty,key"` // value of the config
 	} `json:"config,omitempty" url:"config,omitempty,key"`
 }
-type AddOnConfigUpdateResult []struct {
-	Name  string  `json:"name" url:"name,key"`   // unique name of the config
-	Value *string `json:"value" url:"value,key"` // value of the config
-}
+type AddOnConfigUpdateResult []AddOnConfig
 
 // Update an add-on's config. Can only be accessed by the add-on partner
 // providing this add-on.
@@ -1014,40 +646,7 @@ type AddOnRegionCapability struct {
 	// may run.
 	SupportsPrivateNetworking bool `json:"supports_private_networking" url:"supports_private_networking,key"` // whether the add-on can be installed to a Space
 }
-type AddOnRegionCapabilityListResult []struct {
-	AddonService struct {
-		CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
-		CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
-		HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
-		ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
-		Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
-		State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
-		SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
-		// add-on at the same time
-		SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
-		// app
-		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
-	} `json:"addon_service" url:"addon_service,key"` // Add-on services represent add-ons that may be provisioned for apps.
-	// Endpoints under add-on services can be accessed without
-	// authentication.
-	ID     string `json:"id" url:"id,key"` // unique identifier of this add-on-region-capability
-	Region struct {
-		Country        string    `json:"country" url:"country,key"`                 // country where the region exists
-		CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
-		Description    string    `json:"description" url:"description,key"`         // description of region
-		ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
-		Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
-		Name           string    `json:"name" url:"name,key"`                       // unique name of region
-		PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
-		Provider       struct {
-			Name   string `json:"name" url:"name,key"`     // name of provider
-			Region string `json:"region" url:"region,key"` // region name used by provider
-		} `json:"provider" url:"provider,key"` // provider of underlying substrate
-		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
-	} `json:"region" url:"region,key"` // A region represents a geographic location in which your application
-	// may run.
-	SupportsPrivateNetworking bool `json:"supports_private_networking" url:"supports_private_networking,key"` // whether the add-on can be installed to a Space
-}
+type AddOnRegionCapabilityListResult []AddOnRegionCapability
 
 // List all existing add-on region capabilities.
 func (s *Service) AddOnRegionCapabilityList(ctx context.Context, lr *ListRange) (AddOnRegionCapabilityListResult, error) {
@@ -1055,45 +654,20 @@ func (s *Service) AddOnRegionCapabilityList(ctx context.Context, lr *ListRange) 
 	return addOnRegionCapability, s.Get(ctx, &addOnRegionCapability, fmt.Sprintf("/addon-region-capabilities"), nil, lr)
 }
 
-type AddOnRegionCapabilityListByAddOnServiceResult []struct {
-	AddonService struct {
-		CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
-		CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
-		HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
-		ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
-		Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
-		State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
-		SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
-		// add-on at the same time
-		SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
-		// app
-		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
-	} `json:"addon_service" url:"addon_service,key"` // Add-on services represent add-ons that may be provisioned for apps.
-	// Endpoints under add-on services can be accessed without
-	// authentication.
-	ID     string `json:"id" url:"id,key"` // unique identifier of this add-on-region-capability
-	Region struct {
-		Country        string    `json:"country" url:"country,key"`                 // country where the region exists
-		CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
-		Description    string    `json:"description" url:"description,key"`         // description of region
-		ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
-		Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
-		Name           string    `json:"name" url:"name,key"`                       // unique name of region
-		PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
-		Provider       struct {
-			Name   string `json:"name" url:"name,key"`     // name of provider
-			Region string `json:"region" url:"region,key"` // region name used by provider
-		} `json:"provider" url:"provider,key"` // provider of underlying substrate
-		UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
-	} `json:"region" url:"region,key"` // A region represents a geographic location in which your application
-	// may run.
-	SupportsPrivateNetworking bool `json:"supports_private_networking" url:"supports_private_networking,key"` // whether the add-on can be installed to a Space
-}
+type AddOnRegionCapabilityListByAddOnServiceResult []AddOnRegionCapability
 
 // List existing add-on region capabilities for an add-on-service
 func (s *Service) AddOnRegionCapabilityListByAddOnService(ctx context.Context, addOnServiceIdentity string, lr *ListRange) (AddOnRegionCapabilityListByAddOnServiceResult, error) {
 	var addOnRegionCapability AddOnRegionCapabilityListByAddOnServiceResult
 	return addOnRegionCapability, s.Get(ctx, &addOnRegionCapability, fmt.Sprintf("/addon-services/%v/region-capabilities", addOnServiceIdentity), nil, lr)
+}
+
+type AddOnRegionCapabilityListByRegionResult []AddOnRegionCapability
+
+// List existing add-on region capabilities for a region.
+func (s *Service) AddOnRegionCapabilityListByRegion(ctx context.Context, regionIdentity string, lr *ListRange) (AddOnRegionCapabilityListByRegionResult, error) {
+	var addOnRegionCapability AddOnRegionCapabilityListByRegionResult
+	return addOnRegionCapability, s.Get(ctx, &addOnRegionCapability, fmt.Sprintf("/regions/%v/addon-region-capabilities", regionIdentity), nil, lr)
 }
 
 // Add-on services represent add-ons that may be provisioned for apps.
@@ -1112,39 +686,14 @@ type AddOnService struct {
 	// app
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
 }
-type AddOnServiceInfoResult struct {
-	CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
-	CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
-	HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
-	ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
-	Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
-	State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
-	SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
-	// add-on at the same time
-	SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
-	// app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
-}
 
 // Info for existing add-on-service.
-func (s *Service) AddOnServiceInfo(ctx context.Context, addOnServiceIdentity string) (*AddOnServiceInfoResult, error) {
-	var addOnService AddOnServiceInfoResult
+func (s *Service) AddOnServiceInfo(ctx context.Context, addOnServiceIdentity string) (*AddOnService, error) {
+	var addOnService AddOnService
 	return &addOnService, s.Get(ctx, &addOnService, fmt.Sprintf("/addon-services/%v", addOnServiceIdentity), nil, nil)
 }
 
-type AddOnServiceListResult []struct {
-	CliPluginName                 *string   `json:"cli_plugin_name" url:"cli_plugin_name,key"`                                 // npm package name of the add-on service's Heroku CLI plugin
-	CreatedAt                     time.Time `json:"created_at" url:"created_at,key"`                                           // when add-on-service was created
-	HumanName                     string    `json:"human_name" url:"human_name,key"`                                           // human-readable name of the add-on service provider
-	ID                            string    `json:"id" url:"id,key"`                                                           // unique identifier of this add-on-service
-	Name                          string    `json:"name" url:"name,key"`                                                       // unique name of this add-on-service
-	State                         string    `json:"state" url:"state,key"`                                                     // release status for add-on service
-	SupportsMultipleInstallations bool      `json:"supports_multiple_installations" url:"supports_multiple_installations,key"` // whether or not apps can have access to more than one instance of this
-	// add-on at the same time
-	SupportsSharing bool `json:"supports_sharing" url:"supports_sharing,key"` // whether or not apps can have access to add-ons billed to a different
-	// app
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when add-on-service was updated
-}
+type AddOnServiceListResult []AddOnService
 
 // List existing add-on-services.
 func (s *Service) AddOnServiceList(ctx context.Context, lr *ListRange) (AddOnServiceListResult, error) {
@@ -1190,6 +739,10 @@ type App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
 		Name string `json:"name" url:"name,key"` // unique name of stack
 	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of team
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // identity of team
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
@@ -1198,183 +751,26 @@ type AppCreateOpts struct {
 	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
 	Stack  *string `json:"stack,omitempty" url:"stack,omitempty,key"`   // unique name of stack
 }
-type AppCreateResult struct {
-	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
-	BuildStack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
-	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // identity of organization
-	Owner struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID     string `json:"id" url:"id,key"`         // unique identifier of space
-		Name   string `json:"name" url:"name,key"`     // unique name of space
-		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
 
 // Create a new app.
-func (s *Service) AppCreate(ctx context.Context, o AppCreateOpts) (*AppCreateResult, error) {
-	var app AppCreateResult
+func (s *Service) AppCreate(ctx context.Context, o AppCreateOpts) (*App, error) {
+	var app App
 	return &app, s.Post(ctx, &app, fmt.Sprintf("/apps"), o)
 }
 
-type AppDeleteResult struct {
-	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
-	BuildStack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
-	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // identity of organization
-	Owner struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID     string `json:"id" url:"id,key"`         // unique identifier of space
-		Name   string `json:"name" url:"name,key"`     // unique name of space
-		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
-
 // Delete an existing app.
-func (s *Service) AppDelete(ctx context.Context, appIdentity string) (*AppDeleteResult, error) {
-	var app AppDeleteResult
+func (s *Service) AppDelete(ctx context.Context, appIdentity string) (*App, error) {
+	var app App
 	return &app, s.Delete(ctx, &app, fmt.Sprintf("/apps/%v", appIdentity))
 }
 
-type AppInfoResult struct {
-	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
-	BuildStack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
-	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // identity of organization
-	Owner struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID     string `json:"id" url:"id,key"`         // unique identifier of space
-		Name   string `json:"name" url:"name,key"`     // unique name of space
-		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
-
 // Info for existing app.
-func (s *Service) AppInfo(ctx context.Context, appIdentity string) (*AppInfoResult, error) {
-	var app AppInfoResult
+func (s *Service) AppInfo(ctx context.Context, appIdentity string) (*App, error) {
+	var app App
 	return &app, s.Get(ctx, &app, fmt.Sprintf("/apps/%v", appIdentity), nil, nil)
 }
 
-type AppListResult []struct {
-	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
-	BuildStack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
-	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // identity of organization
-	Owner struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID     string `json:"id" url:"id,key"`         // unique identifier of space
-		Name   string `json:"name" url:"name,key"`     // unique name of space
-		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
+type AppListResult []App
 
 // List existing apps.
 func (s *Service) AppList(ctx context.Context, lr *ListRange) (AppListResult, error) {
@@ -1382,47 +778,9 @@ func (s *Service) AppList(ctx context.Context, lr *ListRange) (AppListResult, er
 	return app, s.Get(ctx, &app, fmt.Sprintf("/apps"), nil, lr)
 }
 
-type AppListOwnedAndCollaboratedResult []struct {
-	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
-	BuildStack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
-	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // identity of organization
-	Owner struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID     string `json:"id" url:"id,key"`         // unique identifier of space
-		Name   string `json:"name" url:"name,key"`     // unique name of space
-		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
+type AppListOwnedAndCollaboratedResult []App
 
-// List owned and collaborated apps (excludes organization apps).
+// List owned and collaborated apps (excludes team apps).
 func (s *Service) AppListOwnedAndCollaborated(ctx context.Context, accountIdentity string, lr *ListRange) (AppListOwnedAndCollaboratedResult, error) {
 	var app AppListOwnedAndCollaboratedResult
 	return app, s.Get(ctx, &app, fmt.Sprintf("/users/%v/apps", accountIdentity), nil, lr)
@@ -1433,91 +791,35 @@ type AppUpdateOpts struct {
 	Maintenance *bool   `json:"maintenance,omitempty" url:"maintenance,omitempty,key"` // maintenance status of app
 	Name        *string `json:"name,omitempty" url:"name,omitempty,key"`               // unique name of app
 }
-type AppUpdateResult struct {
-	ArchivedAt *time.Time `json:"archived_at" url:"archived_at,key"` // when app was archived
-	BuildStack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"build_stack" url:"build_stack,key"` // identity of the stack that will be used for new builds
-	BuildpackProvidedDescription *string   `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string    `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string    `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Maintenance                  bool      `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string    `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // identity of organization
-	Owner struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID     string `json:"id" url:"id,key"`         // unique identifier of space
-		Name   string `json:"name" url:"name,key"`     // unique name of space
-		Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
 
 // Update an existing app.
-func (s *Service) AppUpdate(ctx context.Context, appIdentity string, o AppUpdateOpts) (*AppUpdateResult, error) {
-	var app AppUpdateResult
+func (s *Service) AppUpdate(ctx context.Context, appIdentity string, o AppUpdateOpts) (*App, error) {
+	var app App
 	return &app, s.Patch(ctx, &app, fmt.Sprintf("/apps/%v", appIdentity), o)
 }
 
 // An app feature represents a Heroku labs capability that can be
 // enabled or disabled for an app on Heroku.
 type AppFeature struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
-	Description string    `json:"description" url:"description,key"` // description of app feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
-	State       string    `json:"state" url:"state,key"`             // state of app feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
-}
-type AppFeatureInfoResult struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
-	Description string    `json:"description" url:"description,key"` // description of app feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
-	State       string    `json:"state" url:"state,key"`             // state of app feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when app feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of app feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of app feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not app feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of app feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of app feature
+	State         string    `json:"state" url:"state,key"`                   // state of app feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when app feature was updated
 }
 
 // Info for an existing app feature.
-func (s *Service) AppFeatureInfo(ctx context.Context, appIdentity string, appFeatureIdentity string) (*AppFeatureInfoResult, error) {
-	var appFeature AppFeatureInfoResult
+func (s *Service) AppFeatureInfo(ctx context.Context, appIdentity string, appFeatureIdentity string) (*AppFeature, error) {
+	var appFeature AppFeature
 	return &appFeature, s.Get(ctx, &appFeature, fmt.Sprintf("/apps/%v/features/%v", appIdentity, appFeatureIdentity), nil, nil)
 }
 
-type AppFeatureListResult []struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
-	Description string    `json:"description" url:"description,key"` // description of app feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
-	State       string    `json:"state" url:"state,key"`             // state of app feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
-}
+type AppFeatureListResult []AppFeature
 
 // List existing app features.
 func (s *Service) AppFeatureList(ctx context.Context, appIdentity string, lr *ListRange) (AppFeatureListResult, error) {
@@ -1528,20 +830,10 @@ func (s *Service) AppFeatureList(ctx context.Context, appIdentity string, lr *Li
 type AppFeatureUpdateOpts struct {
 	Enabled bool `json:"enabled" url:"enabled,key"` // whether or not app feature has been enabled
 }
-type AppFeatureUpdateResult struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when app feature was created
-	Description string    `json:"description" url:"description,key"` // description of app feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of app feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not app feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of app feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of app feature
-	State       string    `json:"state" url:"state,key"`             // state of app feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when app feature was updated
-}
 
 // Update an existing app feature.
-func (s *Service) AppFeatureUpdate(ctx context.Context, appIdentity string, appFeatureIdentity string, o AppFeatureUpdateOpts) (*AppFeatureUpdateResult, error) {
-	var appFeature AppFeatureUpdateResult
+func (s *Service) AppFeatureUpdate(ctx context.Context, appIdentity string, appFeatureIdentity string, o AppFeatureUpdateOpts) (*AppFeature, error) {
+	var appFeature AppFeature
 	return &appFeature, s.Patch(ctx, &appFeature, fmt.Sprintf("/apps/%v/features/%v", appIdentity, appFeatureIdentity), o)
 }
 
@@ -1611,70 +903,17 @@ type AppSetupCreateOpts struct {
 		Version *string `json:"version,omitempty" url:"version,omitempty,key"` // Version of the gzipped tarball.
 	} `json:"source_blob" url:"source_blob,key"` // gzipped tarball of source code containing app.json manifest file
 }
-type AppSetupCreateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // identity of app
-	Build *struct {
-		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
-		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
-		// stream is available as either `text/plain` or `text/event-stream`.
-		// Clients should be prepared to handle disconnects and can resume the
-		// stream by sending a `Range` header (for `text/plain`) or a
-		// `Last-Event-Id` header (for `text/event-stream`).
-		Status string `json:"status" url:"status,key"` // status of build
-	} `json:"build" url:"build,key"` // identity and status of build
-	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when app setup was created
-	FailureMessage *string   `json:"failure_message" url:"failure_message,key"` // reason that app setup has failed
-	ID             string    `json:"id" url:"id,key"`                           // unique identifier of app setup
-	ManifestErrors []string  `json:"manifest_errors" url:"manifest_errors,key"` // errors associated with invalid app.json manifest file
-	Postdeploy     *struct {
-		ExitCode int    `json:"exit_code" url:"exit_code,key"` // The exit code of the postdeploy script
-		Output   string `json:"output" url:"output,key"`       // output of the postdeploy script
-	} `json:"postdeploy" url:"postdeploy,key"` // result of postdeploy script
-	ResolvedSuccessURL *string   `json:"resolved_success_url" url:"resolved_success_url,key"` // fully qualified success url
-	Status             string    `json:"status" url:"status,key"`                             // the overall status of app setup
-	UpdatedAt          time.Time `json:"updated_at" url:"updated_at,key"`                     // when app setup was updated
-}
 
 // Create a new app setup from a gzipped tar archive containing an
 // app.json manifest file.
-func (s *Service) AppSetupCreate(ctx context.Context, o AppSetupCreateOpts) (*AppSetupCreateResult, error) {
-	var appSetup AppSetupCreateResult
+func (s *Service) AppSetupCreate(ctx context.Context, o AppSetupCreateOpts) (*AppSetup, error) {
+	var appSetup AppSetup
 	return &appSetup, s.Post(ctx, &appSetup, fmt.Sprintf("/app-setups"), o)
 }
 
-type AppSetupInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // identity of app
-	Build *struct {
-		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
-		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
-		// stream is available as either `text/plain` or `text/event-stream`.
-		// Clients should be prepared to handle disconnects and can resume the
-		// stream by sending a `Range` header (for `text/plain`) or a
-		// `Last-Event-Id` header (for `text/event-stream`).
-		Status string `json:"status" url:"status,key"` // status of build
-	} `json:"build" url:"build,key"` // identity and status of build
-	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when app setup was created
-	FailureMessage *string   `json:"failure_message" url:"failure_message,key"` // reason that app setup has failed
-	ID             string    `json:"id" url:"id,key"`                           // unique identifier of app setup
-	ManifestErrors []string  `json:"manifest_errors" url:"manifest_errors,key"` // errors associated with invalid app.json manifest file
-	Postdeploy     *struct {
-		ExitCode int    `json:"exit_code" url:"exit_code,key"` // The exit code of the postdeploy script
-		Output   string `json:"output" url:"output,key"`       // output of the postdeploy script
-	} `json:"postdeploy" url:"postdeploy,key"` // result of postdeploy script
-	ResolvedSuccessURL *string   `json:"resolved_success_url" url:"resolved_success_url,key"` // fully qualified success url
-	Status             string    `json:"status" url:"status,key"`                             // the overall status of app setup
-	UpdatedAt          time.Time `json:"updated_at" url:"updated_at,key"`                     // when app setup was updated
-}
-
 // Get the status of an app setup.
-func (s *Service) AppSetupInfo(ctx context.Context, appSetupIdentity string) (*AppSetupInfoResult, error) {
-	var appSetup AppSetupInfoResult
+func (s *Service) AppSetupInfo(ctx context.Context, appSetupIdentity string) (*AppSetup, error) {
+	var appSetup AppSetup
 	return &appSetup, s.Get(ctx, &appSetup, fmt.Sprintf("/app-setups/%v", appSetupIdentity), nil, nil)
 }
 
@@ -1703,99 +942,26 @@ type AppTransferCreateOpts struct {
 	Recipient string `json:"recipient" url:"recipient,key"`               // unique email address of account
 	Silent    *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email notification when transferring apps
 }
-type AppTransferCreateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the transfer
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
-	Owner     struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
-	Recipient struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
-	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
-}
 
 // Create a new app transfer.
-func (s *Service) AppTransferCreate(ctx context.Context, o AppTransferCreateOpts) (*AppTransferCreateResult, error) {
-	var appTransfer AppTransferCreateResult
+func (s *Service) AppTransferCreate(ctx context.Context, o AppTransferCreateOpts) (*AppTransfer, error) {
+	var appTransfer AppTransfer
 	return &appTransfer, s.Post(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers"), o)
 }
 
-type AppTransferDeleteResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the transfer
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
-	Owner     struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
-	Recipient struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
-	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
-}
-
 // Delete an existing app transfer
-func (s *Service) AppTransferDelete(ctx context.Context, appTransferIdentity string) (*AppTransferDeleteResult, error) {
-	var appTransfer AppTransferDeleteResult
+func (s *Service) AppTransferDelete(ctx context.Context, appTransferIdentity string) (*AppTransfer, error) {
+	var appTransfer AppTransfer
 	return &appTransfer, s.Delete(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity))
 }
 
-type AppTransferInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the transfer
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
-	Owner     struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
-	Recipient struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
-	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
-}
-
 // Info for existing app transfer.
-func (s *Service) AppTransferInfo(ctx context.Context, appTransferIdentity string) (*AppTransferInfoResult, error) {
-	var appTransfer AppTransferInfoResult
+func (s *Service) AppTransferInfo(ctx context.Context, appTransferIdentity string) (*AppTransfer, error) {
+	var appTransfer AppTransfer
 	return &appTransfer, s.Get(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity), nil, nil)
 }
 
-type AppTransferListResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the transfer
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
-	Owner     struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
-	Recipient struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
-	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
-}
+type AppTransferListResult []AppTransfer
 
 // List existing apps transfers.
 func (s *Service) AppTransferList(ctx context.Context, lr *ListRange) (AppTransferListResult, error) {
@@ -1806,28 +972,10 @@ func (s *Service) AppTransferList(ctx context.Context, lr *ListRange) (AppTransf
 type AppTransferUpdateOpts struct {
 	State string `json:"state" url:"state,key"` // the current state of an app transfer
 }
-type AppTransferUpdateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the transfer
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when app transfer was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of app transfer
-	Owner     struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of the owner of the transfer
-	Recipient struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"recipient" url:"recipient,key"` // identity of the recipient of the transfer
-	State     string    `json:"state" url:"state,key"`           // the current state of an app transfer
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app transfer was updated
-}
 
 // Update an existing app transfer.
-func (s *Service) AppTransferUpdate(ctx context.Context, appTransferIdentity string, o AppTransferUpdateOpts) (*AppTransferUpdateResult, error) {
-	var appTransfer AppTransferUpdateResult
+func (s *Service) AppTransferUpdate(ctx context.Context, appTransferIdentity string, o AppTransferUpdateOpts) (*AppTransfer, error) {
+	var appTransfer AppTransfer
 	return &appTransfer, s.Patch(ctx, &appTransfer, fmt.Sprintf("/account/app-transfers/%v", appTransferIdentity), o)
 }
 
@@ -1881,125 +1029,20 @@ type BuildCreateOpts struct {
 		Version *string `json:"version,omitempty" url:"version,omitempty,key"` // Version of the gzipped tarball.
 	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
 }
-type BuildCreateResult struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app that the build belongs to
-	Buildpacks *[]struct {
-		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
-		// buildpacks) or an internal urn (heroku official buildpacks).
-	} `json:"buildpacks" url:"buildpacks,key"` // buildpacks executed for this build, in order
-	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when build was created
-	ID              string    `json:"id" url:"id,key"`                               // unique identifier of build
-	OutputStreamURL string    `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
-	// stream is available as either `text/plain` or `text/event-stream`.
-	// Clients should be prepared to handle disconnects and can resume the
-	// stream by sending a `Range` header (for `text/plain`) or a
-	// `Last-Event-Id` header (for `text/event-stream`).
-	Release *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of release
-	} `json:"release" url:"release,key"` // release resulting from the build
-	Slug *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of slug
-	} `json:"slug" url:"slug,key"` // slug created by this build
-	SourceBlob struct {
-		Checksum *string `json:"checksum" url:"checksum,key"` // an optional checksum of the gzipped tarball for verifying its
-		// integrity
-		URL string `json:"url" url:"url,key"` // URL where gzipped tar archive of source code for build was
-		// downloaded.
-		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
-	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
-	Status    string    `json:"status" url:"status,key"`         // status of build
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // user that started the build
-}
 
 // Create a new build.
-func (s *Service) BuildCreate(ctx context.Context, appIdentity string, o BuildCreateOpts) (*BuildCreateResult, error) {
-	var build BuildCreateResult
+func (s *Service) BuildCreate(ctx context.Context, appIdentity string, o BuildCreateOpts) (*Build, error) {
+	var build Build
 	return &build, s.Post(ctx, &build, fmt.Sprintf("/apps/%v/builds", appIdentity), o)
 }
 
-type BuildInfoResult struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app that the build belongs to
-	Buildpacks *[]struct {
-		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
-		// buildpacks) or an internal urn (heroku official buildpacks).
-	} `json:"buildpacks" url:"buildpacks,key"` // buildpacks executed for this build, in order
-	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when build was created
-	ID              string    `json:"id" url:"id,key"`                               // unique identifier of build
-	OutputStreamURL string    `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
-	// stream is available as either `text/plain` or `text/event-stream`.
-	// Clients should be prepared to handle disconnects and can resume the
-	// stream by sending a `Range` header (for `text/plain`) or a
-	// `Last-Event-Id` header (for `text/event-stream`).
-	Release *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of release
-	} `json:"release" url:"release,key"` // release resulting from the build
-	Slug *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of slug
-	} `json:"slug" url:"slug,key"` // slug created by this build
-	SourceBlob struct {
-		Checksum *string `json:"checksum" url:"checksum,key"` // an optional checksum of the gzipped tarball for verifying its
-		// integrity
-		URL string `json:"url" url:"url,key"` // URL where gzipped tar archive of source code for build was
-		// downloaded.
-		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
-	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
-	Status    string    `json:"status" url:"status,key"`         // status of build
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // user that started the build
-}
-
 // Info for existing build.
-func (s *Service) BuildInfo(ctx context.Context, appIdentity string, buildIdentity string) (*BuildInfoResult, error) {
-	var build BuildInfoResult
+func (s *Service) BuildInfo(ctx context.Context, appIdentity string, buildIdentity string) (*Build, error) {
+	var build Build
 	return &build, s.Get(ctx, &build, fmt.Sprintf("/apps/%v/builds/%v", appIdentity, buildIdentity), nil, nil)
 }
 
-type BuildListResult []struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app that the build belongs to
-	Buildpacks *[]struct {
-		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
-		// buildpacks) or an internal urn (heroku official buildpacks).
-	} `json:"buildpacks" url:"buildpacks,key"` // buildpacks executed for this build, in order
-	CreatedAt       time.Time `json:"created_at" url:"created_at,key"`               // when build was created
-	ID              string    `json:"id" url:"id,key"`                               // unique identifier of build
-	OutputStreamURL string    `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
-	// stream is available as either `text/plain` or `text/event-stream`.
-	// Clients should be prepared to handle disconnects and can resume the
-	// stream by sending a `Range` header (for `text/plain`) or a
-	// `Last-Event-Id` header (for `text/event-stream`).
-	Release *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of release
-	} `json:"release" url:"release,key"` // release resulting from the build
-	Slug *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of slug
-	} `json:"slug" url:"slug,key"` // slug created by this build
-	SourceBlob struct {
-		Checksum *string `json:"checksum" url:"checksum,key"` // an optional checksum of the gzipped tarball for verifying its
-		// integrity
-		URL string `json:"url" url:"url,key"` // URL where gzipped tar archive of source code for build was
-		// downloaded.
-		Version *string `json:"version" url:"version,key"` // Version of the gzipped tarball.
-	} `json:"source_blob" url:"source_blob,key"` // location of gzipped tarball of source code used to create build
-	Status    string    `json:"status" url:"status,key"`         // status of build
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when build was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // user that started the build
-}
+type BuildListResult []Build
 
 // List existing build.
 func (s *Service) BuildList(ctx context.Context, appIdentity string, lr *ListRange) (BuildListResult, error) {
@@ -2025,27 +1068,10 @@ type BuildResult struct {
 	} `json:"lines" url:"lines,key"` // A list of all the lines of a build's output. This has been replaced
 	// by the `output_stream_url` attribute on the build resource.
 }
-type BuildResultInfoResult struct {
-	Build struct {
-		ID              string `json:"id" url:"id,key"`                               // unique identifier of build
-		OutputStreamURL string `json:"output_stream_url" url:"output_stream_url,key"` // Build process output will be available from this URL as a stream. The
-		// stream is available as either `text/plain` or `text/event-stream`.
-		// Clients should be prepared to handle disconnects and can resume the
-		// stream by sending a `Range` header (for `text/plain`) or a
-		// `Last-Event-Id` header (for `text/event-stream`).
-		Status string `json:"status" url:"status,key"` // status of build
-	} `json:"build" url:"build,key"` // identity of build
-	ExitCode float64 `json:"exit_code" url:"exit_code,key"` // status from the build
-	Lines    []struct {
-		Line   string `json:"line" url:"line,key"`     // A line of output from the build.
-		Stream string `json:"stream" url:"stream,key"` // The output stream where the line was sent.
-	} `json:"lines" url:"lines,key"` // A list of all the lines of a build's output. This has been replaced
-	// by the `output_stream_url` attribute on the build resource.
-}
 
 // Info for existing result.
-func (s *Service) BuildResultInfo(ctx context.Context, appIdentity string, buildIdentity string) (*BuildResultInfoResult, error) {
-	var buildResult BuildResultInfoResult
+func (s *Service) BuildResultInfo(ctx context.Context, appIdentity string, buildIdentity string) (*BuildResult, error) {
+	var buildResult BuildResult
 	return &buildResult, s.Get(ctx, &buildResult, fmt.Sprintf("/apps/%v/builds/%v/result", appIdentity, buildIdentity), nil, nil)
 }
 
@@ -2066,15 +1092,7 @@ type BuildpackInstallationUpdateOpts struct {
 		// buildpacks) or an internal urn (heroku official buildpacks).
 	} `json:"updates" url:"updates,key"` // The buildpack attribute can accept a name, a url, or a urn.
 }
-type BuildpackInstallationUpdateResult []struct {
-	Buildpack struct {
-		Name string `json:"name" url:"name,key"` // either the shorthand name (heroku official buildpacks) or url
-		// (unofficial buildpacks) of the buildpack for the app
-		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
-		// buildpacks) or an internal urn (heroku official buildpacks).
-	} `json:"buildpack" url:"buildpack,key"` // buildpack
-	Ordinal int `json:"ordinal" url:"ordinal,key"` // determines the order in which the buildpacks will execute
-}
+type BuildpackInstallationUpdateResult []BuildpackInstallation
 
 // Update an app's buildpack installations.
 func (s *Service) BuildpackInstallationUpdate(ctx context.Context, appIdentity string, o BuildpackInstallationUpdateOpts) (BuildpackInstallationUpdateResult, error) {
@@ -2082,15 +1100,7 @@ func (s *Service) BuildpackInstallationUpdate(ctx context.Context, appIdentity s
 	return buildpackInstallation, s.Put(ctx, &buildpackInstallation, fmt.Sprintf("/apps/%v/buildpack-installations", appIdentity), o)
 }
 
-type BuildpackInstallationListResult []struct {
-	Buildpack struct {
-		Name string `json:"name" url:"name,key"` // either the shorthand name (heroku official buildpacks) or url
-		// (unofficial buildpacks) of the buildpack for the app
-		URL string `json:"url" url:"url,key"` // location of the buildpack for the app. Either a url (unofficial
-		// buildpacks) or an internal urn (heroku official buildpacks).
-	} `json:"buildpack" url:"buildpack,key"` // buildpack
-	Ordinal int `json:"ordinal" url:"ordinal,key"` // determines the order in which the buildpacks will execute
-}
+type BuildpackInstallationListResult []BuildpackInstallation
 
 // List an app's existing buildpack installations.
 func (s *Service) BuildpackInstallationList(ctx context.Context, appIdentity string, lr *ListRange) (BuildpackInstallationListResult, error) {
@@ -2111,7 +1121,7 @@ type Collaborator struct {
 		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
 		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
 	} `json:"permissions" url:"permissions,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
+	Role      *string   `json:"role" url:"role,key"`             // role in the team
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
 	User      struct {
 		Email     string `json:"email" url:"email,key"`         // unique email address of account
@@ -2123,103 +1133,26 @@ type CollaboratorCreateOpts struct {
 	Silent *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email invitation when creating collaborator
 	User   string `json:"user" url:"user,key"`                         // unique email address of account
 }
-type CollaboratorCreateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Permissions []struct {
-		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
-		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
-	} `json:"permissions" url:"permissions,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
-}
 
 // Create a new collaborator.
-func (s *Service) CollaboratorCreate(ctx context.Context, appIdentity string, o CollaboratorCreateOpts) (*CollaboratorCreateResult, error) {
-	var collaborator CollaboratorCreateResult
+func (s *Service) CollaboratorCreate(ctx context.Context, appIdentity string, o CollaboratorCreateOpts) (*Collaborator, error) {
+	var collaborator Collaborator
 	return &collaborator, s.Post(ctx, &collaborator, fmt.Sprintf("/apps/%v/collaborators", appIdentity), o)
 }
 
-type CollaboratorDeleteResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Permissions []struct {
-		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
-		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
-	} `json:"permissions" url:"permissions,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
-}
-
 // Delete an existing collaborator.
-func (s *Service) CollaboratorDelete(ctx context.Context, appIdentity string, collaboratorIdentity string) (*CollaboratorDeleteResult, error) {
-	var collaborator CollaboratorDeleteResult
+func (s *Service) CollaboratorDelete(ctx context.Context, appIdentity string, collaboratorIdentity string) (*Collaborator, error) {
+	var collaborator Collaborator
 	return &collaborator, s.Delete(ctx, &collaborator, fmt.Sprintf("/apps/%v/collaborators/%v", appIdentity, collaboratorIdentity))
 }
 
-type CollaboratorInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Permissions []struct {
-		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
-		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
-	} `json:"permissions" url:"permissions,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
-}
-
 // Info for existing collaborator.
-func (s *Service) CollaboratorInfo(ctx context.Context, appIdentity string, collaboratorIdentity string) (*CollaboratorInfoResult, error) {
-	var collaborator CollaboratorInfoResult
+func (s *Service) CollaboratorInfo(ctx context.Context, appIdentity string, collaboratorIdentity string) (*Collaborator, error) {
+	var collaborator Collaborator
 	return &collaborator, s.Get(ctx, &collaborator, fmt.Sprintf("/apps/%v/collaborators/%v", appIdentity, collaboratorIdentity), nil, nil)
 }
 
-type CollaboratorListResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID          string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Permissions []struct {
-		Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
-		Name        string `json:"name" url:"name,key"`               // The name of the app permission.
-	} `json:"permissions" url:"permissions,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
-}
+type CollaboratorListResult []Collaborator
 
 // List existing collaborators.
 func (s *Service) CollaboratorList(ctx context.Context, appIdentity string, lr *ListRange) (CollaboratorListResult, error) {
@@ -2270,47 +1203,20 @@ type CreditCreateOpts struct {
 	Code1 *string `json:"code1,omitempty" url:"code1,omitempty,key"` // first code from a discount card
 	Code2 *string `json:"code2,omitempty" url:"code2,omitempty,key"` // second code from a discount card
 }
-type CreditCreateResult struct {
-	Amount    float64   `json:"amount" url:"amount,key"`         // total value of credit in cents
-	Balance   float64   `json:"balance" url:"balance,key"`       // remaining value of credit in cents
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when credit was created
-	ExpiresAt time.Time `json:"expires_at" url:"expires_at,key"` // when credit will expire
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of credit
-	Title     string    `json:"title" url:"title,key"`           // a name for credit
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
-}
 
 // Create a new credit.
-func (s *Service) CreditCreate(ctx context.Context, o CreditCreateOpts) (*CreditCreateResult, error) {
-	var credit CreditCreateResult
+func (s *Service) CreditCreate(ctx context.Context, o CreditCreateOpts) (*Credit, error) {
+	var credit Credit
 	return &credit, s.Post(ctx, &credit, fmt.Sprintf("/account/credits"), o)
 }
 
-type CreditInfoResult struct {
-	Amount    float64   `json:"amount" url:"amount,key"`         // total value of credit in cents
-	Balance   float64   `json:"balance" url:"balance,key"`       // remaining value of credit in cents
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when credit was created
-	ExpiresAt time.Time `json:"expires_at" url:"expires_at,key"` // when credit will expire
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of credit
-	Title     string    `json:"title" url:"title,key"`           // a name for credit
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
-}
-
 // Info for existing credit.
-func (s *Service) CreditInfo(ctx context.Context, creditIdentity string) (*CreditInfoResult, error) {
-	var credit CreditInfoResult
+func (s *Service) CreditInfo(ctx context.Context, creditIdentity string) (*Credit, error) {
+	var credit Credit
 	return &credit, s.Get(ctx, &credit, fmt.Sprintf("/account/credits/%v", creditIdentity), nil, nil)
 }
 
-type CreditListResult []struct {
-	Amount    float64   `json:"amount" url:"amount,key"`         // total value of credit in cents
-	Balance   float64   `json:"balance" url:"balance,key"`       // remaining value of credit in cents
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when credit was created
-	ExpiresAt time.Time `json:"expires_at" url:"expires_at,key"` // when credit will expire
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of credit
-	Title     string    `json:"title" url:"title,key"`           // a name for credit
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when credit was updated
-}
+type CreditListResult []Credit
 
 // List existing credits.
 func (s *Service) CreditList(ctx context.Context, lr *ListRange) (CreditListResult, error) {
@@ -2335,79 +1241,26 @@ type Domain struct {
 type DomainCreateOpts struct {
 	Hostname string `json:"hostname" url:"hostname,key"` // full hostname
 }
-type DomainCreateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app that owns the domain
-	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
-	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
-	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
-	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
-}
 
 // Create a new domain.
-func (s *Service) DomainCreate(ctx context.Context, appIdentity string, o DomainCreateOpts) (*DomainCreateResult, error) {
-	var domain DomainCreateResult
+func (s *Service) DomainCreate(ctx context.Context, appIdentity string, o DomainCreateOpts) (*Domain, error) {
+	var domain Domain
 	return &domain, s.Post(ctx, &domain, fmt.Sprintf("/apps/%v/domains", appIdentity), o)
 }
 
-type DomainDeleteResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app that owns the domain
-	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
-	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
-	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
-	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
-}
-
 // Delete an existing domain
-func (s *Service) DomainDelete(ctx context.Context, appIdentity string, domainIdentity string) (*DomainDeleteResult, error) {
-	var domain DomainDeleteResult
+func (s *Service) DomainDelete(ctx context.Context, appIdentity string, domainIdentity string) (*Domain, error) {
+	var domain Domain
 	return &domain, s.Delete(ctx, &domain, fmt.Sprintf("/apps/%v/domains/%v", appIdentity, domainIdentity))
 }
 
-type DomainInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app that owns the domain
-	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
-	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
-	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
-	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
-}
-
 // Info for existing domain.
-func (s *Service) DomainInfo(ctx context.Context, appIdentity string, domainIdentity string) (*DomainInfoResult, error) {
-	var domain DomainInfoResult
+func (s *Service) DomainInfo(ctx context.Context, appIdentity string, domainIdentity string) (*Domain, error) {
+	var domain Domain
 	return &domain, s.Get(ctx, &domain, fmt.Sprintf("/apps/%v/domains/%v", appIdentity, domainIdentity), nil, nil)
 }
 
-type DomainListResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app that owns the domain
-	CName     *string   `json:"cname" url:"cname,key"`           // canonical name record, the address to point a domain at
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when domain was created
-	Hostname  string    `json:"hostname" url:"hostname,key"`     // full hostname
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this domain
-	Kind      string    `json:"kind" url:"kind,key"`             // type of domain name
-	Status    string    `json:"status" url:"status,key"`         // status of this record's cname
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when domain was updated
-}
+type DomainListResult []Domain
 
 // List existing domains.
 func (s *Service) DomainList(ctx context.Context, appIdentity string, lr *ListRange) (DomainListResult, error) {
@@ -2449,31 +1302,10 @@ type DynoCreateOpts struct {
 	TimeToLive *int               `json:"time_to_live,omitempty" url:"time_to_live,omitempty,key"` // seconds until dyno expires, after which it will soon be killed
 	Type       *string            `json:"type,omitempty" url:"type,omitempty,key"`                 // type of process
 }
-type DynoCreateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app formation belongs to
-	AttachURL *string `json:"attach_url" url:"attach_url,key"` // a URL to stream output from for attached processes or null for
-	// non-attached processes
-	Command   string    `json:"command" url:"command,key"`       // command used to start this process
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when dyno was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this dyno
-	Name      string    `json:"name" url:"name,key"`             // the name of this process on this dyno
-	Release   struct {
-		ID      string `json:"id" url:"id,key"`           // unique identifier of release
-		Version int    `json:"version" url:"version,key"` // unique version assigned to the release
-	} `json:"release" url:"release,key"` // app release of the dyno
-	Size  string `json:"size" url:"size,key"`   // dyno size (default: "standard-1X")
-	State string `json:"state" url:"state,key"` // current status of process (either: crashed, down, idle, starting, or
-	// up)
-	Type      string    `json:"type" url:"type,key"`             // type of process
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
-}
 
 // Create a new dyno.
-func (s *Service) DynoCreate(ctx context.Context, appIdentity string, o DynoCreateOpts) (*DynoCreateResult, error) {
-	var dyno DynoCreateResult
+func (s *Service) DynoCreate(ctx context.Context, appIdentity string, o DynoCreateOpts) (*Dyno, error) {
+	var dyno Dyno
 	return &dyno, s.Post(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos", appIdentity), o)
 }
 
@@ -2501,55 +1333,13 @@ func (s *Service) DynoStop(ctx context.Context, appIdentity string, dynoIdentity
 	return dyno, s.Post(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos/%v/actions/stop", appIdentity, dynoIdentity), nil)
 }
 
-type DynoInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app formation belongs to
-	AttachURL *string `json:"attach_url" url:"attach_url,key"` // a URL to stream output from for attached processes or null for
-	// non-attached processes
-	Command   string    `json:"command" url:"command,key"`       // command used to start this process
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when dyno was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this dyno
-	Name      string    `json:"name" url:"name,key"`             // the name of this process on this dyno
-	Release   struct {
-		ID      string `json:"id" url:"id,key"`           // unique identifier of release
-		Version int    `json:"version" url:"version,key"` // unique version assigned to the release
-	} `json:"release" url:"release,key"` // app release of the dyno
-	Size  string `json:"size" url:"size,key"`   // dyno size (default: "standard-1X")
-	State string `json:"state" url:"state,key"` // current status of process (either: crashed, down, idle, starting, or
-	// up)
-	Type      string    `json:"type" url:"type,key"`             // type of process
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
-}
-
 // Info for existing dyno.
-func (s *Service) DynoInfo(ctx context.Context, appIdentity string, dynoIdentity string) (*DynoInfoResult, error) {
-	var dyno DynoInfoResult
+func (s *Service) DynoInfo(ctx context.Context, appIdentity string, dynoIdentity string) (*Dyno, error) {
+	var dyno Dyno
 	return &dyno, s.Get(ctx, &dyno, fmt.Sprintf("/apps/%v/dynos/%v", appIdentity, dynoIdentity), nil, nil)
 }
 
-type DynoListResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app formation belongs to
-	AttachURL *string `json:"attach_url" url:"attach_url,key"` // a URL to stream output from for attached processes or null for
-	// non-attached processes
-	Command   string    `json:"command" url:"command,key"`       // command used to start this process
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when dyno was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this dyno
-	Name      string    `json:"name" url:"name,key"`             // the name of this process on this dyno
-	Release   struct {
-		ID      string `json:"id" url:"id,key"`           // unique identifier of release
-		Version int    `json:"version" url:"version,key"` // unique version assigned to the release
-	} `json:"release" url:"release,key"` // app release of the dyno
-	Size  string `json:"size" url:"size,key"`   // dyno size (default: "standard-1X")
-	State string `json:"state" url:"state,key"` // current status of process (either: crashed, down, idle, starting, or
-	// up)
-	Type      string    `json:"type" url:"type,key"`             // type of process
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when process last changed state
-}
+type DynoListResult []Dyno
 
 // List existing dynos.
 func (s *Service) DynoList(ctx context.Context, appIdentity string, lr *ListRange) (DynoListResult, error) {
@@ -2571,33 +1361,14 @@ type DynoSize struct {
 	Name             string    `json:"name" url:"name,key"`                             // the name of this dyno-size
 	PrivateSpaceOnly bool      `json:"private_space_only" url:"private_space_only,key"` // whether this dyno can only be provisioned in a private space
 }
-type DynoSizeInfoResult struct {
-	Compute          int       `json:"compute" url:"compute,key"`                       // minimum vCPUs, non-dedicated may get more depending on load
-	Cost             *struct{} `json:"cost" url:"cost,key"`                             // price information for this dyno size
-	Dedicated        bool      `json:"dedicated" url:"dedicated,key"`                   // whether this dyno will be dedicated to one user
-	DynoUnits        int       `json:"dyno_units" url:"dyno_units,key"`                 // unit of consumption for Heroku Enterprise customers
-	ID               string    `json:"id" url:"id,key"`                                 // unique identifier of this dyno size
-	Memory           float64   `json:"memory" url:"memory,key"`                         // amount of RAM in GB
-	Name             string    `json:"name" url:"name,key"`                             // the name of this dyno-size
-	PrivateSpaceOnly bool      `json:"private_space_only" url:"private_space_only,key"` // whether this dyno can only be provisioned in a private space
-}
 
 // Info for existing dyno size.
-func (s *Service) DynoSizeInfo(ctx context.Context, dynoSizeIdentity string) (*DynoSizeInfoResult, error) {
-	var dynoSize DynoSizeInfoResult
+func (s *Service) DynoSizeInfo(ctx context.Context, dynoSizeIdentity string) (*DynoSize, error) {
+	var dynoSize DynoSize
 	return &dynoSize, s.Get(ctx, &dynoSize, fmt.Sprintf("/dyno-sizes/%v", dynoSizeIdentity), nil, nil)
 }
 
-type DynoSizeListResult []struct {
-	Compute          int       `json:"compute" url:"compute,key"`                       // minimum vCPUs, non-dedicated may get more depending on load
-	Cost             *struct{} `json:"cost" url:"cost,key"`                             // price information for this dyno size
-	Dedicated        bool      `json:"dedicated" url:"dedicated,key"`                   // whether this dyno will be dedicated to one user
-	DynoUnits        int       `json:"dyno_units" url:"dyno_units,key"`                 // unit of consumption for Heroku Enterprise customers
-	ID               string    `json:"id" url:"id,key"`                                 // unique identifier of this dyno size
-	Memory           float64   `json:"memory" url:"memory,key"`                         // amount of RAM in GB
-	Name             string    `json:"name" url:"name,key"`                             // the name of this dyno-size
-	PrivateSpaceOnly bool      `json:"private_space_only" url:"private_space_only,key"` // whether this dyno can only be provisioned in a private space
-}
+type DynoSizeListResult []DynoSize
 
 // List existing dyno sizes.
 func (s *Service) DynoSizeList(ctx context.Context, lr *ListRange) (DynoSizeListResult, error) {
@@ -2684,13 +1455,10 @@ type FilterAppsAppsResult []struct {
 	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
 	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
 	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
 	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
 	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this app
-	Owner *struct {
+	Owner                        *struct {
 		Email string `json:"email" url:"email,key"` // unique email address of account
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
 	} `json:"owner" url:"owner,key"` // identity of app owner
@@ -2709,6 +1477,9 @@ type FilterAppsAppsResult []struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
 		Name string `json:"name" url:"name,key"` // unique name of stack
 	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this app
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
 	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
@@ -2737,39 +1508,14 @@ type Formation struct {
 	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
 }
-type FormationInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app formation belongs to
-	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
-	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
-	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
-	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
-}
 
 // Info for a process type
-func (s *Service) FormationInfo(ctx context.Context, appIdentity string, formationIdentity string) (*FormationInfoResult, error) {
-	var formation FormationInfoResult
+func (s *Service) FormationInfo(ctx context.Context, appIdentity string, formationIdentity string) (*Formation, error) {
+	var formation Formation
 	return &formation, s.Get(ctx, &formation, fmt.Sprintf("/apps/%v/formation/%v", appIdentity, formationIdentity), nil, nil)
 }
 
-type FormationListResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app formation belongs to
-	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
-	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
-	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
-	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
-}
+type FormationListResult []Formation
 
 // List process type formation
 func (s *Service) FormationList(ctx context.Context, appIdentity string, lr *ListRange) (FormationListResult, error) {
@@ -2786,19 +1532,7 @@ type FormationBatchUpdateOpts struct {
 	// or name of the process type to be updated, and can optionally update
 	// its "quantity" or "size".
 }
-type FormationBatchUpdateResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app formation belongs to
-	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
-	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
-	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
-	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
-}
+type FormationBatchUpdateResult []Formation
 
 // Batch update process types
 func (s *Service) FormationBatchUpdate(ctx context.Context, appIdentity string, o FormationBatchUpdateOpts) (FormationBatchUpdateResult, error) {
@@ -2810,23 +1544,10 @@ type FormationUpdateOpts struct {
 	Quantity *int    `json:"quantity,omitempty" url:"quantity,omitempty,key"` // number of processes to maintain
 	Size     *string `json:"size,omitempty" url:"size,omitempty,key"`         // dyno size (default: "standard-1X")
 }
-type FormationUpdateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app formation belongs to
-	Command   string    `json:"command" url:"command,key"`       // command to use to launch this process
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when process type was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this process type
-	Quantity  int       `json:"quantity" url:"quantity,key"`     // number of processes to maintain
-	Size      string    `json:"size" url:"size,key"`             // dyno size (default: "standard-1X")
-	Type      string    `json:"type" url:"type,key"`             // type of process to maintain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when dyno type was updated
-}
 
 // Update process type
-func (s *Service) FormationUpdate(ctx context.Context, appIdentity string, formationIdentity string, o FormationUpdateOpts) (*FormationUpdateResult, error) {
-	var formation FormationUpdateResult
+func (s *Service) FormationUpdate(ctx context.Context, appIdentity string, formationIdentity string, o FormationUpdateOpts) (*Formation, error) {
+	var formation Formation
 	return &formation, s.Patch(ctx, &formation, fmt.Sprintf("/apps/%v/formation/%v", appIdentity, formationIdentity), o)
 }
 
@@ -2844,92 +1565,84 @@ type IdentityProvider struct {
 	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
 	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
 }
-type IdentityProviderListResult []struct {
-	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
-	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
-	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
-	Organization *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
-	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
-	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
-}
+type IdentityProviderListByOrganizationResult []IdentityProvider
 
 // Get a list of an organization's Identity Providers
-func (s *Service) IdentityProviderList(ctx context.Context, organizationName string, lr *ListRange) (IdentityProviderListResult, error) {
-	var identityProvider IdentityProviderListResult
+func (s *Service) IdentityProviderListByOrganization(ctx context.Context, organizationName string, lr *ListRange) (IdentityProviderListByOrganizationResult, error) {
+	var identityProvider IdentityProviderListByOrganizationResult
 	return identityProvider, s.Get(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers", organizationName), nil, lr)
 }
 
-type IdentityProviderCreateOpts struct {
+type IdentityProviderCreateByOrganizationOpts struct {
 	Certificate  string  `json:"certificate" url:"certificate,key"`                           // raw contents of the public certificate (eg: .crt or .pem file)
 	EntityID     string  `json:"entity_id" url:"entity_id,key"`                               // URL identifier provided by the identity provider
 	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
 	SsoTargetURL string  `json:"sso_target_url" url:"sso_target_url,key"`                     // single sign on URL for this identity provider
 }
-type IdentityProviderCreateResult struct {
-	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
-	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
-	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
-	Organization *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
-	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
-	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
-}
 
 // Create an Identity Provider for an organization
-func (s *Service) IdentityProviderCreate(ctx context.Context, organizationName string, o IdentityProviderCreateOpts) (*IdentityProviderCreateResult, error) {
-	var identityProvider IdentityProviderCreateResult
+func (s *Service) IdentityProviderCreateByOrganization(ctx context.Context, organizationName string, o IdentityProviderCreateByOrganizationOpts) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
 	return &identityProvider, s.Post(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers", organizationName), o)
 }
 
-type IdentityProviderUpdateOpts struct {
+type IdentityProviderUpdateByOrganizationOpts struct {
 	Certificate  *string `json:"certificate,omitempty" url:"certificate,omitempty,key"`       // raw contents of the public certificate (eg: .crt or .pem file)
 	EntityID     *string `json:"entity_id,omitempty" url:"entity_id,omitempty,key"`           // URL identifier provided by the identity provider
 	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
 	SsoTargetURL *string `json:"sso_target_url,omitempty" url:"sso_target_url,omitempty,key"` // single sign on URL for this identity provider
 }
-type IdentityProviderUpdateResult struct {
-	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
-	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
-	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
-	Organization *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
-	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
-	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
-}
 
 // Update an organization's Identity Provider
-func (s *Service) IdentityProviderUpdate(ctx context.Context, organizationName string, identityProviderID string, o IdentityProviderUpdateOpts) (*IdentityProviderUpdateResult, error) {
-	var identityProvider IdentityProviderUpdateResult
+func (s *Service) IdentityProviderUpdateByOrganization(ctx context.Context, organizationName string, identityProviderID string, o IdentityProviderUpdateByOrganizationOpts) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
 	return &identityProvider, s.Patch(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers/%v", organizationName, identityProviderID), o)
 }
 
-type IdentityProviderDeleteResult struct {
-	Certificate  string    `json:"certificate" url:"certificate,key"` // raw contents of the public certificate (eg: .crt or .pem file)
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`   // when provider record was created
-	EntityID     string    `json:"entity_id" url:"entity_id,key"`     // URL identifier provided by the identity provider
-	ID           string    `json:"id" url:"id,key"`                   // unique identifier of this identity provider
-	Organization *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization associated with this identity provider
-	SloTargetURL string    `json:"slo_target_url" url:"slo_target_url,key"` // single log out URL for this identity provider
-	SsoTargetURL string    `json:"sso_target_url" url:"sso_target_url,key"` // single sign on URL for this identity provider
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`         // when the identity provider record was updated
+// Delete an organization's Identity Provider
+func (s *Service) IdentityProviderDeleteByOrganization(ctx context.Context, organizationName string, identityProviderID string) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
+	return &identityProvider, s.Delete(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers/%v", organizationName, identityProviderID))
 }
 
-// Delete an organization's Identity Provider
-func (s *Service) IdentityProviderDelete(ctx context.Context, organizationName string, identityProviderID string) (*IdentityProviderDeleteResult, error) {
-	var identityProvider IdentityProviderDeleteResult
-	return &identityProvider, s.Delete(ctx, &identityProvider, fmt.Sprintf("/organizations/%v/identity-providers/%v", organizationName, identityProviderID))
+type IdentityProviderListByTeamResult []IdentityProvider
+
+// Get a list of a team's Identity Providers
+func (s *Service) IdentityProviderListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (IdentityProviderListByTeamResult, error) {
+	var identityProvider IdentityProviderListByTeamResult
+	return identityProvider, s.Get(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers", teamIdentity), nil, lr)
+}
+
+type IdentityProviderCreateByTeamOpts struct {
+	Certificate  string  `json:"certificate" url:"certificate,key"`                           // raw contents of the public certificate (eg: .crt or .pem file)
+	EntityID     string  `json:"entity_id" url:"entity_id,key"`                               // URL identifier provided by the identity provider
+	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
+	SsoTargetURL string  `json:"sso_target_url" url:"sso_target_url,key"`                     // single sign on URL for this identity provider
+}
+
+// Create an Identity Provider for a team
+func (s *Service) IdentityProviderCreateByTeam(ctx context.Context, teamIdentity string, o IdentityProviderCreateByTeamOpts) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
+	return &identityProvider, s.Post(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers", teamIdentity), o)
+}
+
+type IdentityProviderUpdateByTeamOpts struct {
+	Certificate  *string `json:"certificate,omitempty" url:"certificate,omitempty,key"`       // raw contents of the public certificate (eg: .crt or .pem file)
+	EntityID     *string `json:"entity_id,omitempty" url:"entity_id,omitempty,key"`           // URL identifier provided by the identity provider
+	SloTargetURL *string `json:"slo_target_url,omitempty" url:"slo_target_url,omitempty,key"` // single log out URL for this identity provider
+	SsoTargetURL *string `json:"sso_target_url,omitempty" url:"sso_target_url,omitempty,key"` // single sign on URL for this identity provider
+}
+
+// Update a team's Identity Provider
+func (s *Service) IdentityProviderUpdateByTeam(ctx context.Context, teamIdentity string, identityProviderID string, o IdentityProviderUpdateByTeamOpts) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
+	return &identityProvider, s.Patch(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers/%v", teamIdentity, identityProviderID), o)
+}
+
+// Delete a team's Identity Provider
+func (s *Service) IdentityProviderDeleteByTeam(ctx context.Context, teamName string, identityProviderID string) (*IdentityProvider, error) {
+	var identityProvider IdentityProvider
+	return &identityProvider, s.Delete(ctx, &identityProvider, fmt.Sprintf("/teams/%v/identity-providers/%v", teamName, identityProviderID))
 }
 
 // An inbound-ruleset is a collection of rules that specify what hosts
@@ -2943,31 +1656,20 @@ type InboundRuleset struct {
 		Source string `json:"source" url:"source,key"` // is the request’s source in CIDR notation
 	} `json:"rules" url:"rules,key"`
 }
-type InboundRulesetInfoResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when inbound-ruleset was created
-	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an inbound-ruleset
-	Rules     []struct {
-		Action string `json:"action" url:"action,key"` // states whether the connection is allowed or denied
-		Source string `json:"source" url:"source,key"` // is the request’s source in CIDR notation
-	} `json:"rules" url:"rules,key"`
-}
 
 // Current inbound ruleset for a space
-func (s *Service) InboundRulesetInfo(ctx context.Context, spaceIdentity string) (*InboundRulesetInfoResult, error) {
-	var inboundRuleset InboundRulesetInfoResult
+func (s *Service) InboundRulesetCurrent(ctx context.Context, spaceIdentity string) (*InboundRuleset, error) {
+	var inboundRuleset InboundRuleset
 	return &inboundRuleset, s.Get(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-ruleset", spaceIdentity), nil, nil)
 }
 
-type InboundRulesetListResult []struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when inbound-ruleset was created
-	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an inbound-ruleset
-	Rules     []struct {
-		Action string `json:"action" url:"action,key"` // states whether the connection is allowed or denied
-		Source string `json:"source" url:"source,key"` // is the request’s source in CIDR notation
-	} `json:"rules" url:"rules,key"`
+// Info on an existing Inbound Ruleset
+func (s *Service) InboundRulesetInfo(ctx context.Context, spaceIdentity string, inboundRulesetIdentity string) (*InboundRuleset, error) {
+	var inboundRuleset InboundRuleset
+	return &inboundRuleset, s.Get(ctx, &inboundRuleset, fmt.Sprintf("/spaces/%v/inbound-rulesets/%v", spaceIdentity, inboundRulesetIdentity), nil, nil)
 }
+
+type InboundRulesetListResult []InboundRuleset
 
 // List all inbound rulesets for a space
 func (s *Service) InboundRulesetList(ctx context.Context, spaceIdentity string, lr *ListRange) (InboundRulesetListResult, error) {
@@ -3063,37 +1765,14 @@ type Invoice struct {
 	Total        float64   `json:"total" url:"total,key"`                 // combined total of charges and credits on this invoice
 	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when invoice was updated
 }
-type InvoiceInfoResult struct {
-	ChargesTotal float64   `json:"charges_total" url:"charges_total,key"` // total charges on this invoice
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`       // when invoice was created
-	CreditsTotal float64   `json:"credits_total" url:"credits_total,key"` // total credits on this invoice
-	ID           string    `json:"id" url:"id,key"`                       // unique identifier of this invoice
-	Number       int       `json:"number" url:"number,key"`               // human readable invoice number
-	PeriodEnd    string    `json:"period_end" url:"period_end,key"`       // the ending date that the invoice covers
-	PeriodStart  string    `json:"period_start" url:"period_start,key"`   // the starting date that this invoice covers
-	State        int       `json:"state" url:"state,key"`                 // payment status for this invoice (pending, successful, failed)
-	Total        float64   `json:"total" url:"total,key"`                 // combined total of charges and credits on this invoice
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when invoice was updated
-}
 
 // Info for existing invoice.
-func (s *Service) InvoiceInfo(ctx context.Context, invoiceIdentity int) (*InvoiceInfoResult, error) {
-	var invoice InvoiceInfoResult
+func (s *Service) InvoiceInfo(ctx context.Context, invoiceIdentity int) (*Invoice, error) {
+	var invoice Invoice
 	return &invoice, s.Get(ctx, &invoice, fmt.Sprintf("/account/invoices/%v", invoiceIdentity), nil, nil)
 }
 
-type InvoiceListResult []struct {
-	ChargesTotal float64   `json:"charges_total" url:"charges_total,key"` // total charges on this invoice
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"`       // when invoice was created
-	CreditsTotal float64   `json:"credits_total" url:"credits_total,key"` // total credits on this invoice
-	ID           string    `json:"id" url:"id,key"`                       // unique identifier of this invoice
-	Number       int       `json:"number" url:"number,key"`               // human readable invoice number
-	PeriodEnd    string    `json:"period_end" url:"period_end,key"`       // the ending date that the invoice covers
-	PeriodStart  string    `json:"period_start" url:"period_start,key"`   // the starting date that this invoice covers
-	State        int       `json:"state" url:"state,key"`                 // payment status for this invoice (pending, successful, failed)
-	Total        float64   `json:"total" url:"total,key"`                 // combined total of charges and credits on this invoice
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when invoice was updated
-}
+type InvoiceListResult []Invoice
 
 // List existing invoices.
 func (s *Service) InvoiceList(ctx context.Context, lr *ListRange) (InvoiceListResult, error) {
@@ -3149,31 +1828,14 @@ type Key struct {
 	PublicKey   string    `json:"public_key" url:"public_key,key"`   // full public_key as uploaded
 	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when key was updated
 }
-type KeyInfoResult struct {
-	Comment     string    `json:"comment" url:"comment,key"`         // comment on the key
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when key was created
-	Email       string    `json:"email" url:"email,key"`             // deprecated. Please refer to 'comment' instead
-	Fingerprint string    `json:"fingerprint" url:"fingerprint,key"` // a unique identifying string based on contents
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of this key
-	PublicKey   string    `json:"public_key" url:"public_key,key"`   // full public_key as uploaded
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when key was updated
-}
 
 // Info for existing key.
-func (s *Service) KeyInfo(ctx context.Context, keyIdentity string) (*KeyInfoResult, error) {
-	var key KeyInfoResult
+func (s *Service) KeyInfo(ctx context.Context, keyIdentity string) (*Key, error) {
+	var key Key
 	return &key, s.Get(ctx, &key, fmt.Sprintf("/account/keys/%v", keyIdentity), nil, nil)
 }
 
-type KeyListResult []struct {
-	Comment     string    `json:"comment" url:"comment,key"`         // comment on the key
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when key was created
-	Email       string    `json:"email" url:"email,key"`             // deprecated. Please refer to 'comment' instead
-	Fingerprint string    `json:"fingerprint" url:"fingerprint,key"` // a unique identifying string based on contents
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of this key
-	PublicKey   string    `json:"public_key" url:"public_key,key"`   // full public_key as uploaded
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when key was updated
-}
+type KeyListResult []Key
 
 // List existing keys.
 func (s *Service) KeyList(ctx context.Context, lr *ListRange) (KeyListResult, error) {
@@ -3202,72 +1864,27 @@ type LogDrain struct {
 type LogDrainCreateOpts struct {
 	URL string `json:"url" url:"url,key"` // url associated with the log drain
 }
-type LogDrainCreateResult struct {
-	Addon *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-	} `json:"addon" url:"addon,key"` // add-on that created the drain
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
-	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
-	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
-}
 
 // Create a new log drain.
-func (s *Service) LogDrainCreate(ctx context.Context, appIdentity string, o LogDrainCreateOpts) (*LogDrainCreateResult, error) {
-	var logDrain LogDrainCreateResult
+func (s *Service) LogDrainCreate(ctx context.Context, appIdentity string, o LogDrainCreateOpts) (*LogDrain, error) {
+	var logDrain LogDrain
 	return &logDrain, s.Post(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains", appIdentity), o)
-}
-
-type LogDrainDeleteResult struct {
-	Addon *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-	} `json:"addon" url:"addon,key"` // add-on that created the drain
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
-	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
-	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
 }
 
 // Delete an existing log drain. Log drains added by add-ons can only be
 // removed by removing the add-on.
-func (s *Service) LogDrainDelete(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrainDeleteResult, error) {
-	var logDrain LogDrainDeleteResult
+func (s *Service) LogDrainDelete(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrain, error) {
+	var logDrain LogDrain
 	return &logDrain, s.Delete(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains/%v", appIdentity, logDrainQueryIdentity))
 }
 
-type LogDrainInfoResult struct {
-	Addon *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-	} `json:"addon" url:"addon,key"` // add-on that created the drain
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
-	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
-	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
-}
-
 // Info for existing log drain.
-func (s *Service) LogDrainInfo(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrainInfoResult, error) {
-	var logDrain LogDrainInfoResult
+func (s *Service) LogDrainInfo(ctx context.Context, appIdentity string, logDrainQueryIdentity string) (*LogDrain, error) {
+	var logDrain LogDrain
 	return &logDrain, s.Get(ctx, &logDrain, fmt.Sprintf("/apps/%v/log-drains/%v", appIdentity, logDrainQueryIdentity), nil, nil)
 }
 
-type LogDrainListResult []struct {
-	Addon *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of add-on
-		Name string `json:"name" url:"name,key"` // globally unique name of the add-on
-	} `json:"addon" url:"addon,key"` // add-on that created the drain
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when log drain was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this log drain
-	Token     string    `json:"token" url:"token,key"`           // token associated with the log drain
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when log drain was updated
-	URL       string    `json:"url" url:"url,key"`               // url associated with the log drain
-}
+type LogDrainListResult []LogDrain
 
 // List existing log drains.
 func (s *Service) LogDrainList(ctx context.Context, appIdentity string, lr *ListRange) (LogDrainListResult, error) {
@@ -3288,16 +1905,10 @@ type LogSessionCreateOpts struct {
 	Source *string `json:"source,omitempty" url:"source,omitempty,key"` // log source to limit results to
 	Tail   *bool   `json:"tail,omitempty" url:"tail,omitempty,key"`     // whether to stream ongoing logs
 }
-type LogSessionCreateResult struct {
-	CreatedAt  time.Time `json:"created_at" url:"created_at,key"`   // when log connection was created
-	ID         string    `json:"id" url:"id,key"`                   // unique identifier of this log session
-	LogplexURL string    `json:"logplex_url" url:"logplex_url,key"` // URL for log streaming session
-	UpdatedAt  time.Time `json:"updated_at" url:"updated_at,key"`   // when log session was updated
-}
 
 // Create a new log session.
-func (s *Service) LogSessionCreate(ctx context.Context, appIdentity string, o LogSessionCreateOpts) (*LogSessionCreateResult, error) {
-	var logSession LogSessionCreateResult
+func (s *Service) LogSessionCreate(ctx context.Context, appIdentity string, o LogSessionCreateOpts) (*LogSession, error) {
+	var logSession LogSession
 	return &logSession, s.Post(ctx, &logSession, fmt.Sprintf("/apps/%v/log-sessions", appIdentity), o)
 }
 
@@ -3345,159 +1956,26 @@ type OAuthAuthorizationCreateOpts struct {
 	// indefinite lifetime
 	Scope []string `json:"scope" url:"scope,key"` // The scope of access OAuth authorization allows
 }
-type OAuthAuthorizationCreateResult struct {
-	AccessToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"access_token" url:"access_token,key"` // access token for this authorization
-	Client *struct {
-		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
-		Name        string `json:"name" url:"name,key"`                 // OAuth client name
-		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
-	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
-	Grant     *struct {
-		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
-		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
-	} `json:"grant" url:"grant,key"` // this authorization's grant
-	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
-	RefreshToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
-	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
-	User      struct {
-		Email    string  `json:"email" url:"email,key"`         // unique email address of account
-		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
-		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
-}
 
 // Create a new OAuth authorization.
-func (s *Service) OAuthAuthorizationCreate(ctx context.Context, o OAuthAuthorizationCreateOpts) (*OAuthAuthorizationCreateResult, error) {
-	var oauthAuthorization OAuthAuthorizationCreateResult
+func (s *Service) OAuthAuthorizationCreate(ctx context.Context, o OAuthAuthorizationCreateOpts) (*OAuthAuthorization, error) {
+	var oauthAuthorization OAuthAuthorization
 	return &oauthAuthorization, s.Post(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations"), o)
 }
 
-type OAuthAuthorizationDeleteResult struct {
-	AccessToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"access_token" url:"access_token,key"` // access token for this authorization
-	Client *struct {
-		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
-		Name        string `json:"name" url:"name,key"`                 // OAuth client name
-		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
-	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
-	Grant     *struct {
-		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
-		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
-	} `json:"grant" url:"grant,key"` // this authorization's grant
-	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
-	RefreshToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
-	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
-	User      struct {
-		Email    string  `json:"email" url:"email,key"`         // unique email address of account
-		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
-		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
-}
-
 // Delete OAuth authorization.
-func (s *Service) OAuthAuthorizationDelete(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorizationDeleteResult, error) {
-	var oauthAuthorization OAuthAuthorizationDeleteResult
+func (s *Service) OAuthAuthorizationDelete(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorization, error) {
+	var oauthAuthorization OAuthAuthorization
 	return &oauthAuthorization, s.Delete(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations/%v", oauthAuthorizationIdentity))
 }
 
-type OAuthAuthorizationInfoResult struct {
-	AccessToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"access_token" url:"access_token,key"` // access token for this authorization
-	Client *struct {
-		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
-		Name        string `json:"name" url:"name,key"`                 // OAuth client name
-		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
-	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
-	Grant     *struct {
-		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
-		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
-	} `json:"grant" url:"grant,key"` // this authorization's grant
-	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
-	RefreshToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
-	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
-	User      struct {
-		Email    string  `json:"email" url:"email,key"`         // unique email address of account
-		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
-		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
-}
-
 // Info for an OAuth authorization.
-func (s *Service) OAuthAuthorizationInfo(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorizationInfoResult, error) {
-	var oauthAuthorization OAuthAuthorizationInfoResult
+func (s *Service) OAuthAuthorizationInfo(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorization, error) {
+	var oauthAuthorization OAuthAuthorization
 	return &oauthAuthorization, s.Get(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations/%v", oauthAuthorizationIdentity), nil, nil)
 }
 
-type OAuthAuthorizationListResult []struct {
-	AccessToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"access_token" url:"access_token,key"` // access token for this authorization
-	Client *struct {
-		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
-		Name        string `json:"name" url:"name,key"`                 // OAuth client name
-		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
-	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
-	Grant     *struct {
-		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
-		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
-	} `json:"grant" url:"grant,key"` // this authorization's grant
-	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
-	RefreshToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
-	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
-	User      struct {
-		Email    string  `json:"email" url:"email,key"`         // unique email address of account
-		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
-		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
-}
+type OAuthAuthorizationListResult []OAuthAuthorization
 
 // List OAuth authorizations.
 func (s *Service) OAuthAuthorizationList(ctx context.Context, lr *ListRange) (OAuthAuthorizationListResult, error) {
@@ -3505,44 +1983,10 @@ func (s *Service) OAuthAuthorizationList(ctx context.Context, lr *ListRange) (OA
 	return oauthAuthorization, s.Get(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations"), nil, lr)
 }
 
-type OAuthAuthorizationRegenerateResult struct {
-	AccessToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"access_token" url:"access_token,key"` // access token for this authorization
-	Client *struct {
-		ID          string `json:"id" url:"id,key"`                     // unique identifier of this OAuth client
-		Name        string `json:"name" url:"name,key"`                 // OAuth client name
-		RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
-	} `json:"client" url:"client,key"` // identifier of the client that obtained this authorization, if any
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth authorization was created
-	Grant     *struct {
-		Code      string `json:"code" url:"code,key"`             // grant code received from OAuth web application authorization
-		ExpiresIn int    `json:"expires_in" url:"expires_in,key"` // seconds until OAuth grant expires
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of OAuth grant
-	} `json:"grant" url:"grant,key"` // this authorization's grant
-	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
-	RefreshToken *struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
-	Scope     []string  `json:"scope" url:"scope,key"`           // The scope of access OAuth authorization allows
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth authorization was updated
-	User      struct {
-		Email    string  `json:"email" url:"email,key"`         // unique email address of account
-		FullName *string `json:"full_name" url:"full_name,key"` // full name of the account owner
-		ID       string  `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // authenticated user associated with this authorization
-}
-
 // Regenerate OAuth tokens. This endpoint is only available to direct
 // authorizations or privileged OAuth clients.
-func (s *Service) OAuthAuthorizationRegenerate(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorizationRegenerateResult, error) {
-	var oauthAuthorization OAuthAuthorizationRegenerateResult
+func (s *Service) OAuthAuthorizationRegenerate(ctx context.Context, oauthAuthorizationIdentity string) (*OAuthAuthorization, error) {
+	var oauthAuthorization OAuthAuthorization
 	return &oauthAuthorization, s.Post(ctx, &oauthAuthorization, fmt.Sprintf("/oauth/authorizations/%v/actions/regenerate-tokens", oauthAuthorizationIdentity), nil)
 }
 
@@ -3563,35 +2007,16 @@ type OAuthClientCreateOpts struct {
 	Name        string `json:"name" url:"name,key"`                 // OAuth client name
 	RedirectURI string `json:"redirect_uri" url:"redirect_uri,key"` // endpoint for redirection after authorization with OAuth client
 }
-type OAuthClientCreateResult struct {
-	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
-	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
-	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
-	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
-	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
-	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
-	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
-}
 
 // Create a new OAuth client.
-func (s *Service) OAuthClientCreate(ctx context.Context, o OAuthClientCreateOpts) (*OAuthClientCreateResult, error) {
-	var oauthClient OAuthClientCreateResult
+func (s *Service) OAuthClientCreate(ctx context.Context, o OAuthClientCreateOpts) (*OAuthClient, error) {
+	var oauthClient OAuthClient
 	return &oauthClient, s.Post(ctx, &oauthClient, fmt.Sprintf("/oauth/clients"), o)
 }
 
-type OAuthClientDeleteResult struct {
-	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
-	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
-	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
-	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
-	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
-	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
-	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
-}
-
 // Delete OAuth client.
-func (s *Service) OAuthClientDelete(ctx context.Context, oauthClientIdentity string) (*OAuthClientDeleteResult, error) {
-	var oauthClient OAuthClientDeleteResult
+func (s *Service) OAuthClientDelete(ctx context.Context, oauthClientIdentity string) (*OAuthClient, error) {
+	var oauthClient OAuthClient
 	return &oauthClient, s.Delete(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity))
 }
 
@@ -3601,15 +2026,7 @@ func (s *Service) OAuthClientInfo(ctx context.Context, oauthClientIdentity strin
 	return &oauthClient, s.Get(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity), nil, nil)
 }
 
-type OAuthClientListResult []struct {
-	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
-	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
-	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
-	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
-	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
-	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
-	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
-}
+type OAuthClientListResult []OAuthClient
 
 // List OAuth clients
 func (s *Service) OAuthClientList(ctx context.Context, lr *ListRange) (OAuthClientListResult, error) {
@@ -3621,35 +2038,16 @@ type OAuthClientUpdateOpts struct {
 	Name        *string `json:"name,omitempty" url:"name,omitempty,key"`                 // OAuth client name
 	RedirectURI *string `json:"redirect_uri,omitempty" url:"redirect_uri,omitempty,key"` // endpoint for redirection after authorization with OAuth client
 }
-type OAuthClientUpdateResult struct {
-	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
-	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
-	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
-	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
-	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
-	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
-	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
-}
 
 // Update OAuth client
-func (s *Service) OAuthClientUpdate(ctx context.Context, oauthClientIdentity string, o OAuthClientUpdateOpts) (*OAuthClientUpdateResult, error) {
-	var oauthClient OAuthClientUpdateResult
+func (s *Service) OAuthClientUpdate(ctx context.Context, oauthClientIdentity string, o OAuthClientUpdateOpts) (*OAuthClient, error) {
+	var oauthClient OAuthClient
 	return &oauthClient, s.Patch(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v", oauthClientIdentity), o)
 }
 
-type OAuthClientRotateCredentialsResult struct {
-	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                 // when OAuth client was created
-	ID                string    `json:"id" url:"id,key"`                                 // unique identifier of this OAuth client
-	IgnoresDelinquent *bool     `json:"ignores_delinquent" url:"ignores_delinquent,key"` // whether the client is still operable given a delinquent account
-	Name              string    `json:"name" url:"name,key"`                             // OAuth client name
-	RedirectURI       string    `json:"redirect_uri" url:"redirect_uri,key"`             // endpoint for redirection after authorization with OAuth client
-	Secret            string    `json:"secret" url:"secret,key"`                         // secret used to obtain OAuth authorizations under this client
-	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                 // when OAuth client was updated
-}
-
 // Rotate credentials for an OAuth client
-func (s *Service) OAuthClientRotateCredentials(ctx context.Context, oauthClientIdentity string) (*OAuthClientRotateCredentialsResult, error) {
-	var oauthClient OAuthClientRotateCredentialsResult
+func (s *Service) OAuthClientRotateCredentials(ctx context.Context, oauthClientIdentity string) (*OAuthClient, error) {
+	var oauthClient OAuthClient
 	return &oauthClient, s.Post(ctx, &oauthClient, fmt.Sprintf("/oauth/clients/%v/actions/rotate-credentials", oauthClientIdentity), nil)
 }
 
@@ -3709,90 +2107,21 @@ type OAuthTokenCreateOpts struct {
 		Token *string `json:"token,omitempty" url:"token,omitempty,key"` // contents of the token to be used for authorization
 	} `json:"refresh_token" url:"refresh_token,key"`
 }
-type OAuthTokenCreateResult struct {
-	AccessToken struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"access_token" url:"access_token,key"` // current access token
-	Authorization struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
-	} `json:"authorization" url:"authorization,key"` // authorization for this set of tokens
-	Client *struct {
-		Secret string `json:"secret" url:"secret,key"` // secret used to obtain OAuth authorizations under this client
-	} `json:"client" url:"client,key"` // OAuth client secret used to obtain token
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth token was created
-	Grant     struct {
-		Code string `json:"code" url:"code,key"` // grant code received from OAuth web application authorization
-		Type string `json:"type" url:"type,key"` // type of grant requested, one of `authorization_code` or
-		// `refresh_token`
-	} `json:"grant" url:"grant,key"` // grant used on the underlying authorization
-	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth token
-	RefreshToken struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
-	Session struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of OAuth token
-	} `json:"session" url:"session,key"` // OAuth session using this token
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth token was updated
-	User      struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of an account
-	} `json:"user" url:"user,key"` // Reference to the user associated with this token
-}
 
 // Create a new OAuth token.
-func (s *Service) OAuthTokenCreate(ctx context.Context, o OAuthTokenCreateOpts) (*OAuthTokenCreateResult, error) {
-	var oauthToken OAuthTokenCreateResult
+func (s *Service) OAuthTokenCreate(ctx context.Context, o OAuthTokenCreateOpts) (*OAuthToken, error) {
+	var oauthToken OAuthToken
 	return &oauthToken, s.Post(ctx, &oauthToken, fmt.Sprintf("/oauth/tokens"), o)
 }
 
-type OAuthTokenDeleteResult struct {
-	AccessToken struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"access_token" url:"access_token,key"` // current access token
-	Authorization struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of OAuth authorization
-	} `json:"authorization" url:"authorization,key"` // authorization for this set of tokens
-	Client *struct {
-		Secret string `json:"secret" url:"secret,key"` // secret used to obtain OAuth authorizations under this client
-	} `json:"client" url:"client,key"` // OAuth client secret used to obtain token
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when OAuth token was created
-	Grant     struct {
-		Code string `json:"code" url:"code,key"` // grant code received from OAuth web application authorization
-		Type string `json:"type" url:"type,key"` // type of grant requested, one of `authorization_code` or
-		// `refresh_token`
-	} `json:"grant" url:"grant,key"` // grant used on the underlying authorization
-	ID           string `json:"id" url:"id,key"` // unique identifier of OAuth token
-	RefreshToken struct {
-		ExpiresIn *int `json:"expires_in" url:"expires_in,key"` // seconds until OAuth token expires; may be `null` for tokens with
-		// indefinite lifetime
-		ID    string `json:"id" url:"id,key"`       // unique identifier of OAuth token
-		Token string `json:"token" url:"token,key"` // contents of the token to be used for authorization
-	} `json:"refresh_token" url:"refresh_token,key"` // refresh token for this authorization
-	Session struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of OAuth token
-	} `json:"session" url:"session,key"` // OAuth session using this token
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when OAuth token was updated
-	User      struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of an account
-	} `json:"user" url:"user,key"` // Reference to the user associated with this token
-}
-
 // Revoke OAuth access token.
-func (s *Service) OAuthTokenDelete(ctx context.Context, oauthTokenIdentity string) (*OAuthTokenDeleteResult, error) {
-	var oauthToken OAuthTokenDeleteResult
+func (s *Service) OAuthTokenDelete(ctx context.Context, oauthTokenIdentity string) (*OAuthToken, error) {
+	var oauthToken OAuthToken
 	return &oauthToken, s.Delete(ctx, &oauthToken, fmt.Sprintf("/oauth/tokens/%v", oauthTokenIdentity))
 }
 
-// Organizations allow you to manage access to a shared group of
-// applications across your development team.
+// Deprecated: Organizations allow you to manage access to a shared
+// group of applications across your development team.
 type Organization struct {
 	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
 	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
@@ -3805,18 +2134,7 @@ type Organization struct {
 	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
 	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
 }
-type OrganizationListResult []struct {
-	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
-	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
-	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
-	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
-	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
-	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
-	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
-	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
-	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
-	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
-}
+type OrganizationListResult []Organization
 
 // List organizations in which you are a member.
 func (s *Service) OrganizationList(ctx context.Context, lr *ListRange) (OrganizationListResult, error) {
@@ -3834,22 +2152,10 @@ type OrganizationUpdateOpts struct {
 	Default *bool   `json:"default,omitempty" url:"default,omitempty,key"` // whether to use this organization when none is specified
 	Name    *string `json:"name,omitempty" url:"name,omitempty,key"`       // unique name of organization
 }
-type OrganizationUpdateResult struct {
-	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
-	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
-	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
-	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
-	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
-	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
-	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
-	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
-	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
-	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
-}
 
 // Update organization properties.
-func (s *Service) OrganizationUpdate(ctx context.Context, organizationIdentity string, o OrganizationUpdateOpts) (*OrganizationUpdateResult, error) {
-	var organization OrganizationUpdateResult
+func (s *Service) OrganizationUpdate(ctx context.Context, organizationIdentity string, o OrganizationUpdateOpts) (*Organization, error) {
+	var organization Organization
 	return &organization, s.Patch(ctx, &organization, fmt.Sprintf("/organizations/%v", organizationIdentity), o)
 }
 
@@ -3869,45 +2175,20 @@ type OrganizationCreateOpts struct {
 	PostalCode      *string `json:"postal_code,omitempty" url:"postal_code,omitempty,key"`           // postal code
 	State           *string `json:"state,omitempty" url:"state,omitempty,key"`                       // state
 }
-type OrganizationCreateResult struct {
-	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
-	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
-	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
-	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
-	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
-	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
-	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
-	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
-	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
-	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
-}
 
 // Create a new organization.
-func (s *Service) OrganizationCreate(ctx context.Context, o OrganizationCreateOpts) (*OrganizationCreateResult, error) {
-	var organization OrganizationCreateResult
+func (s *Service) OrganizationCreate(ctx context.Context, o OrganizationCreateOpts) (*Organization, error) {
+	var organization Organization
 	return &organization, s.Post(ctx, &organization, fmt.Sprintf("/organizations"), o)
 }
 
-type OrganizationDeleteResult struct {
-	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the organization was created
-	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the org are paid by credit card.
-	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this organization when none is specified
-	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of organization
-	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in an organization.
-	Name                  string    `json:"name" url:"name,key"`                                       // unique name of organization
-	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the org is provisioned licenses by salesforce.
-	Role                  *string   `json:"role" url:"role,key"`                                       // role in the organization
-	Type                  string    `json:"type" url:"type,key"`                                       // type of organization.
-	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the organization was updated
-}
-
 // Delete an existing organization.
-func (s *Service) OrganizationDelete(ctx context.Context, organizationIdentity string) (*OrganizationDeleteResult, error) {
-	var organization OrganizationDeleteResult
+func (s *Service) OrganizationDelete(ctx context.Context, organizationIdentity string) (*Organization, error) {
+	var organization Organization
 	return &organization, s.Delete(ctx, &organization, fmt.Sprintf("/organizations/%v", organizationIdentity))
 }
 
-// A list of add-ons the Organization uses across all apps
+// Deprecated: A list of add-ons the Organization uses across all apps
 type OrganizationAddOn struct{}
 type OrganizationAddOnListForOrganizationResult []struct {
 	Actions      []struct{} `json:"actions" url:"actions,key"` // provider actions for this specific add-on
@@ -3939,8 +2220,8 @@ func (s *Service) OrganizationAddOnListForOrganization(ctx context.Context, orga
 	return organizationAddOn, s.Get(ctx, &organizationAddOn, fmt.Sprintf("/organizations/%v/addons", organizationIdentity), nil, lr)
 }
 
-// An organization app encapsulates the organization specific
-// functionality of Heroku apps.
+// Deprecated: An organization app encapsulates the organization
+// specific functionality of Heroku apps.
 type OrganizationApp struct {
 	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
 	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
@@ -3995,41 +2276,7 @@ func (s *Service) OrganizationAppCreate(ctx context.Context, o OrganizationAppCr
 	return &organizationApp, s.Post(ctx, &organizationApp, fmt.Sprintf("/organizations/apps"), o)
 }
 
-type OrganizationAppListResult []struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this app
-	Owner *struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of space
-		Name string `json:"name" url:"name,key"` // unique name of space
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
+type OrganizationAppListResult []OrganizationApp
 
 // List apps in the default organization, or in personal account, if
 // default organization is not set.
@@ -4038,41 +2285,7 @@ func (s *Service) OrganizationAppList(ctx context.Context, lr *ListRange) (Organ
 	return organizationApp, s.Get(ctx, &organizationApp, fmt.Sprintf("/organizations/apps"), nil, lr)
 }
 
-type OrganizationAppListForOrganizationResult []struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this app
-	Owner *struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of space
-		Name string `json:"name" url:"name,key"` // unique name of space
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
+type OrganizationAppListForOrganizationResult []OrganizationApp
 
 // List organization apps.
 func (s *Service) OrganizationAppListForOrganization(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationAppListForOrganizationResult, error) {
@@ -4089,45 +2302,10 @@ func (s *Service) OrganizationAppInfo(ctx context.Context, organizationAppIdenti
 type OrganizationAppUpdateLockedOpts struct {
 	Locked bool `json:"locked" url:"locked,key"` // are other organization members forbidden from joining this app.
 }
-type OrganizationAppUpdateLockedResult struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this app
-	Owner *struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of space
-		Name string `json:"name" url:"name,key"` // unique name of space
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
 
 // Lock or unlock an organization app.
-func (s *Service) OrganizationAppUpdateLocked(ctx context.Context, organizationAppIdentity string, o OrganizationAppUpdateLockedOpts) (*OrganizationAppUpdateLockedResult, error) {
-	var organizationApp OrganizationAppUpdateLockedResult
+func (s *Service) OrganizationAppUpdateLocked(ctx context.Context, organizationAppIdentity string, o OrganizationAppUpdateLockedOpts) (*OrganizationApp, error) {
+	var organizationApp OrganizationApp
 	return &organizationApp, s.Patch(ctx, &organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
 }
 
@@ -4144,50 +2322,15 @@ func (s *Service) OrganizationAppTransferToAccount(ctx context.Context, organiza
 type OrganizationAppTransferToOrganizationOpts struct {
 	Owner string `json:"owner" url:"owner,key"` // unique name of organization
 }
-type OrganizationAppTransferToOrganizationResult struct {
-	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
-	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
-	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
-	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
-	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
-	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
-	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
-	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
-	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
-	Organization                 *struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this app
-	Owner *struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"owner" url:"owner,key"` // identity of app owner
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of app region
-	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
-	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
-	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
-	Space      *struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of space
-		Name string `json:"name" url:"name,key"` // unique name of space
-	} `json:"space" url:"space,key"` // identity of space
-	Stack struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of app stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
-	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
-}
 
 // Transfer an existing organization app to another organization.
-func (s *Service) OrganizationAppTransferToOrganization(ctx context.Context, organizationAppIdentity string, o OrganizationAppTransferToOrganizationOpts) (*OrganizationAppTransferToOrganizationResult, error) {
-	var organizationApp OrganizationAppTransferToOrganizationResult
+func (s *Service) OrganizationAppTransferToOrganization(ctx context.Context, organizationAppIdentity string, o OrganizationAppTransferToOrganizationOpts) (*OrganizationApp, error) {
+	var organizationApp OrganizationApp
 	return &organizationApp, s.Patch(ctx, &organizationApp, fmt.Sprintf("/organizations/apps/%v", organizationAppIdentity), o)
 }
 
-// An organization collaborator represents an account that has been
-// given access to an organization app on Heroku.
+// Deprecated: An organization collaborator represents an account that
+// has been given access to an organization app on Heroku.
 type OrganizationAppCollaborator struct {
 	App struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of app
@@ -4204,23 +2347,9 @@ type OrganizationAppCollaborator struct {
 	} `json:"user" url:"user,key"` // identity of collaborated account
 }
 type OrganizationAppCollaboratorCreateOpts struct {
-	Silent *bool  `json:"silent,omitempty" url:"silent,omitempty,key"` // whether to suppress email invitation when creating collaborator
-	User   string `json:"user" url:"user,key"`                         // unique email address of account
-}
-type OrganizationAppCollaboratorCreateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
+	Permissions *[]*string `json:"permissions,omitempty" url:"permissions,omitempty,key"` // An array of permissions to give to the collaborator.
+	Silent      *bool      `json:"silent,omitempty" url:"silent,omitempty,key"`           // whether to suppress email invitation when creating collaborator
+	User        string     `json:"user" url:"user,key"`                                   // unique email address of account
 }
 
 // Create a new collaborator on an organization app. Use this endpoint
@@ -4228,92 +2357,34 @@ type OrganizationAppCollaboratorCreateResult struct {
 // you want the collaborator to be granted [permissions]
 // (https://devcenter.heroku.com/articles/org-users-access#roles-and-app-
 // permissions) according to their role in the organization.
-func (s *Service) OrganizationAppCollaboratorCreate(ctx context.Context, appIdentity string, o OrganizationAppCollaboratorCreateOpts) (*OrganizationAppCollaboratorCreateResult, error) {
-	var organizationAppCollaborator OrganizationAppCollaboratorCreateResult
+func (s *Service) OrganizationAppCollaboratorCreate(ctx context.Context, appIdentity string, o OrganizationAppCollaboratorCreateOpts) (*OrganizationAppCollaborator, error) {
+	var organizationAppCollaborator OrganizationAppCollaborator
 	return &organizationAppCollaborator, s.Post(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators", appIdentity), o)
 }
 
-type OrganizationAppCollaboratorDeleteResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
-}
-
 // Delete an existing collaborator from an organization app.
-func (s *Service) OrganizationAppCollaboratorDelete(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaboratorDeleteResult, error) {
-	var organizationAppCollaborator OrganizationAppCollaboratorDeleteResult
+func (s *Service) OrganizationAppCollaboratorDelete(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaborator, error) {
+	var organizationAppCollaborator OrganizationAppCollaborator
 	return &organizationAppCollaborator, s.Delete(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity))
 }
 
-type OrganizationAppCollaboratorInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
-}
-
 // Info for a collaborator on an organization app.
-func (s *Service) OrganizationAppCollaboratorInfo(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaboratorInfoResult, error) {
-	var organizationAppCollaborator OrganizationAppCollaboratorInfoResult
+func (s *Service) OrganizationAppCollaboratorInfo(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaborator, error) {
+	var organizationAppCollaborator OrganizationAppCollaborator
 	return &organizationAppCollaborator, s.Get(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity), nil, nil)
 }
 
-type OrganizationAppCollaboratorUpdateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
+type OrganizationAppCollaboratorUpdateOpts struct {
+	Permissions []string `json:"permissions" url:"permissions,key"` // An array of permissions to give to the collaborator.
 }
 
 // Update an existing collaborator from an organization app.
-func (s *Service) OrganizationAppCollaboratorUpdate(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string) (*OrganizationAppCollaboratorUpdateResult, error) {
-	var organizationAppCollaborator OrganizationAppCollaboratorUpdateResult
-	return &organizationAppCollaborator, s.Patch(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity), nil)
+func (s *Service) OrganizationAppCollaboratorUpdate(ctx context.Context, organizationAppIdentity string, organizationAppCollaboratorIdentity string, o OrganizationAppCollaboratorUpdateOpts) (*OrganizationAppCollaborator, error) {
+	var organizationAppCollaborator OrganizationAppCollaborator
+	return &organizationAppCollaborator, s.Patch(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators/%v", organizationAppIdentity, organizationAppCollaboratorIdentity), o)
 }
 
-type OrganizationAppCollaboratorListResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app collaborator belongs to
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
-	User      struct {
-		Email     string `json:"email" url:"email,key"`         // unique email address of account
-		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
-		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of collaborated account
-}
+type OrganizationAppCollaboratorListResult []OrganizationAppCollaborator
 
 // List collaborators on an organization app.
 func (s *Service) OrganizationAppCollaboratorList(ctx context.Context, organizationAppIdentity string, lr *ListRange) (OrganizationAppCollaboratorListResult, error) {
@@ -4321,16 +2392,13 @@ func (s *Service) OrganizationAppCollaboratorList(ctx context.Context, organizat
 	return organizationAppCollaborator, s.Get(ctx, &organizationAppCollaborator, fmt.Sprintf("/organizations/apps/%v/collaborators", organizationAppIdentity), nil, lr)
 }
 
-// An organization app permission is a behavior that is assigned to a
-// user in an organization app.
+// Deprecated: An organization app permission is a behavior that is
+// assigned to a user in an organization app.
 type OrganizationAppPermission struct {
 	Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
 	Name        string `json:"name" url:"name,key"`               // The name of the app permission.
 }
-type OrganizationAppPermissionListResult []struct {
-	Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
-	Name        string `json:"name" url:"name,key"`               // The name of the app permission.
-}
+type OrganizationAppPermissionListResult []OrganizationAppPermission
 
 // Lists permissions available to organizations.
 func (s *Service) OrganizationAppPermissionList(ctx context.Context, lr *ListRange) (OrganizationAppPermissionListResult, error) {
@@ -4338,45 +2406,28 @@ func (s *Service) OrganizationAppPermissionList(ctx context.Context, lr *ListRan
 	return organizationAppPermission, s.Get(ctx, &organizationAppPermission, fmt.Sprintf("/organizations/permissions"), nil, lr)
 }
 
-// An organization feature represents a feature enabled on an
-// organization account.
+// Deprecated: An organization feature represents a feature enabled on
+// an organization account.
 type OrganizationFeature struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
-}
-type OrganizationFeatureInfoResult struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when organization feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of organization feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of organization feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not organization feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of organization feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of organization feature
+	State         string    `json:"state" url:"state,key"`                   // state of organization feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when organization feature was updated
 }
 
-// Info for an existing account feature.
-func (s *Service) OrganizationFeatureInfo(ctx context.Context, organizationIdentity string, organizationFeatureIdentity string) (*OrganizationFeatureInfoResult, error) {
-	var organizationFeature OrganizationFeatureInfoResult
+// Info for an existing organization feature.
+func (s *Service) OrganizationFeatureInfo(ctx context.Context, organizationIdentity string, organizationFeatureIdentity string) (*OrganizationFeature, error) {
+	var organizationFeature OrganizationFeature
 	return &organizationFeature, s.Get(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features/%v", organizationIdentity, organizationFeatureIdentity), nil, nil)
 }
 
-type OrganizationFeatureListResult []struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when account feature was created
-	Description string    `json:"description" url:"description,key"` // description of account feature
-	DocURL      string    `json:"doc_url" url:"doc_url,key"`         // documentation URL of account feature
-	Enabled     bool      `json:"enabled" url:"enabled,key"`         // whether or not account feature has been enabled
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of account feature
-	Name        string    `json:"name" url:"name,key"`               // unique name of account feature
-	State       string    `json:"state" url:"state,key"`             // state of account feature
-	UpdatedAt   time.Time `json:"updated_at" url:"updated_at,key"`   // when account feature was updated
-}
+type OrganizationFeatureListResult []OrganizationFeature
 
 // List existing organization features.
 func (s *Service) OrganizationFeatureList(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationFeatureListResult, error) {
@@ -4384,7 +2435,18 @@ func (s *Service) OrganizationFeatureList(ctx context.Context, organizationIdent
 	return organizationFeature, s.Get(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features", organizationIdentity), nil, lr)
 }
 
-// An organization invitation represents an invite to an organization.
+type OrganizationFeatureUpdateOpts struct {
+	Enabled bool `json:"enabled" url:"enabled,key"` // whether or not organization feature has been enabled
+}
+
+// Update an existing organization feature.
+func (s *Service) OrganizationFeatureUpdate(ctx context.Context, organizationIdentity string, organizationFeatureIdentity string, o OrganizationFeatureUpdateOpts) (*OrganizationFeature, error) {
+	var organizationFeature OrganizationFeature
+	return &organizationFeature, s.Patch(ctx, &organizationFeature, fmt.Sprintf("/organizations/%v/features/%v", organizationIdentity, organizationFeatureIdentity), o)
+}
+
+// Deprecated: An organization invitation represents an invite to an
+// organization.
 type OrganizationInvitation struct {
 	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
 	ID        string    `json:"id" url:"id,key"`                 // Unique identifier of an invitation
@@ -4405,26 +2467,7 @@ type OrganizationInvitation struct {
 		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
 	} `json:"user" url:"user,key"`
 }
-type OrganizationInvitationListResult []struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
-	ID        string    `json:"id" url:"id,key"`                 // Unique identifier of an invitation
-	InvitedBy struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"invited_by" url:"invited_by,key"`
-	Organization struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when invitation was updated
-	User      struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"user" url:"user,key"`
-}
+type OrganizationInvitationListResult []OrganizationInvitation
 
 // Get a list of an organization's Identity Providers
 func (s *Service) OrganizationInvitationList(ctx context.Context, organizationName string, lr *ListRange) (OrganizationInvitationListResult, error) {
@@ -4449,30 +2492,9 @@ func (s *Service) OrganizationInvitationRevoke(ctx context.Context, organization
 	return &organizationInvitation, s.Delete(ctx, &organizationInvitation, fmt.Sprintf("/organizations/%v/invitations/%v", organizationIdentity, organizationInvitationIdentity))
 }
 
-type OrganizationInvitationGetResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
-	ID        string    `json:"id" url:"id,key"`                 // Unique identifier of an invitation
-	InvitedBy struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"invited_by" url:"invited_by,key"`
-	Organization struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of organization
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"`
-	Role      *string   `json:"role" url:"role,key"`             // role in the organization
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when invitation was updated
-	User      struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"user" url:"user,key"`
-}
-
 // Get an invitation by its token
-func (s *Service) OrganizationInvitationGet(ctx context.Context, organizationInvitationToken string, lr *ListRange) (*OrganizationInvitationGetResult, error) {
-	var organizationInvitation OrganizationInvitationGetResult
+func (s *Service) OrganizationInvitationGet(ctx context.Context, organizationInvitationToken string, lr *ListRange) (*OrganizationInvitation, error) {
+	var organizationInvitation OrganizationInvitation
 	return &organizationInvitation, s.Get(ctx, &organizationInvitation, fmt.Sprintf("/organizations/invitations/%v", organizationInvitationToken), nil, lr)
 }
 
@@ -4498,27 +2520,9 @@ func (s *Service) OrganizationInvitationAccept(ctx context.Context, organization
 	return &organizationInvitation, s.Post(ctx, &organizationInvitation, fmt.Sprintf("/organizations/invitations/%v/accept", organizationInvitationToken), nil)
 }
 
-// An organization invoice is an itemized bill of goods for an
-// organization which includes pricing and charges.
+// Deprecated: An organization invoice is an itemized bill of goods for
+// an organization which includes pricing and charges.
 type OrganizationInvoice struct {
-	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
-	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
-	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
-	CreditsTotal      int       `json:"credits_total" url:"credits_total,key"`             // total credits on this invoice
-	DatabaseTotal     int       `json:"database_total" url:"database_total,key"`           // total database charges on this invoice
-	DynoUnits         float64   `json:"dyno_units" url:"dyno_units,key"`                   // The total amount of dyno units consumed across dyno types.
-	ID                string    `json:"id" url:"id,key"`                                   // unique identifier of this invoice
-	Number            int       `json:"number" url:"number,key"`                           // human readable invoice number
-	PaymentStatus     string    `json:"payment_status" url:"payment_status,key"`           // Status of the invoice payment.
-	PeriodEnd         string    `json:"period_end" url:"period_end,key"`                   // the ending date that the invoice covers
-	PeriodStart       string    `json:"period_start" url:"period_start,key"`               // the starting date that this invoice covers
-	PlatformTotal     int       `json:"platform_total" url:"platform_total,key"`           // total platform charges on this invoice
-	State             int       `json:"state" url:"state,key"`                             // payment status for this invoice (pending, successful, failed)
-	Total             int       `json:"total" url:"total,key"`                             // combined total of charges and credits on this invoice
-	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                   // when invoice was updated
-	WeightedDynoHours float64   `json:"weighted_dyno_hours" url:"weighted_dyno_hours,key"` // The total amount of hours consumed across dyno types.
-}
-type OrganizationInvoiceInfoResult struct {
 	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
 	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
 	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
@@ -4538,29 +2542,12 @@ type OrganizationInvoiceInfoResult struct {
 }
 
 // Info for existing invoice.
-func (s *Service) OrganizationInvoiceInfo(ctx context.Context, organizationIdentity string, organizationInvoiceIdentity int) (*OrganizationInvoiceInfoResult, error) {
-	var organizationInvoice OrganizationInvoiceInfoResult
+func (s *Service) OrganizationInvoiceInfo(ctx context.Context, organizationIdentity string, organizationInvoiceIdentity int) (*OrganizationInvoice, error) {
+	var organizationInvoice OrganizationInvoice
 	return &organizationInvoice, s.Get(ctx, &organizationInvoice, fmt.Sprintf("/organizations/%v/invoices/%v", organizationIdentity, organizationInvoiceIdentity), nil, nil)
 }
 
-type OrganizationInvoiceListResult []struct {
-	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
-	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
-	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
-	CreditsTotal      int       `json:"credits_total" url:"credits_total,key"`             // total credits on this invoice
-	DatabaseTotal     int       `json:"database_total" url:"database_total,key"`           // total database charges on this invoice
-	DynoUnits         float64   `json:"dyno_units" url:"dyno_units,key"`                   // The total amount of dyno units consumed across dyno types.
-	ID                string    `json:"id" url:"id,key"`                                   // unique identifier of this invoice
-	Number            int       `json:"number" url:"number,key"`                           // human readable invoice number
-	PaymentStatus     string    `json:"payment_status" url:"payment_status,key"`           // Status of the invoice payment.
-	PeriodEnd         string    `json:"period_end" url:"period_end,key"`                   // the ending date that the invoice covers
-	PeriodStart       string    `json:"period_start" url:"period_start,key"`               // the starting date that this invoice covers
-	PlatformTotal     int       `json:"platform_total" url:"platform_total,key"`           // total platform charges on this invoice
-	State             int       `json:"state" url:"state,key"`                             // payment status for this invoice (pending, successful, failed)
-	Total             int       `json:"total" url:"total,key"`                             // combined total of charges and credits on this invoice
-	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                   // when invoice was updated
-	WeightedDynoHours float64   `json:"weighted_dyno_hours" url:"weighted_dyno_hours,key"` // The total amount of hours consumed across dyno types.
-}
+type OrganizationInvoiceListResult []OrganizationInvoice
 
 // List existing invoices.
 func (s *Service) OrganizationInvoiceList(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationInvoiceListResult, error) {
@@ -4568,7 +2555,7 @@ func (s *Service) OrganizationInvoiceList(ctx context.Context, organizationIdent
 	return organizationInvoice, s.Get(ctx, &organizationInvoice, fmt.Sprintf("/organizations/%v/invoices", organizationIdentity), nil, lr)
 }
 
-// An organization member is an individual with access to an
+// Deprecated: An organization member is an individual with access to an
 // organization.
 type OrganizationMember struct {
 	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
@@ -4590,25 +2577,10 @@ type OrganizationMemberCreateOrUpdateOpts struct {
 	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
 	Role      *string `json:"role" url:"role,key"`                               // role in the organization
 }
-type OrganizationMemberCreateOrUpdateResult struct {
-	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
-	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
-	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
-	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
-	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
-	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
-	// authentication enabled
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
-	User      struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"user" url:"user,key"` // user information for the membership
-}
 
 // Create a new organization member, or update their role.
-func (s *Service) OrganizationMemberCreateOrUpdate(ctx context.Context, organizationIdentity string, o OrganizationMemberCreateOrUpdateOpts) (*OrganizationMemberCreateOrUpdateResult, error) {
-	var organizationMember OrganizationMemberCreateOrUpdateResult
+func (s *Service) OrganizationMemberCreateOrUpdate(ctx context.Context, organizationIdentity string, o OrganizationMemberCreateOrUpdateOpts) (*OrganizationMember, error) {
+	var organizationMember OrganizationMember
 	return &organizationMember, s.Put(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), o)
 }
 
@@ -4617,25 +2589,10 @@ type OrganizationMemberCreateOpts struct {
 	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
 	Role      *string `json:"role" url:"role,key"`                               // role in the organization
 }
-type OrganizationMemberCreateResult struct {
-	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
-	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
-	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
-	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
-	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
-	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
-	// authentication enabled
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
-	User      struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"user" url:"user,key"` // user information for the membership
-}
 
 // Create a new organization member.
-func (s *Service) OrganizationMemberCreate(ctx context.Context, organizationIdentity string, o OrganizationMemberCreateOpts) (*OrganizationMemberCreateResult, error) {
-	var organizationMember OrganizationMemberCreateResult
+func (s *Service) OrganizationMemberCreate(ctx context.Context, organizationIdentity string, o OrganizationMemberCreateOpts) (*OrganizationMember, error) {
+	var organizationMember OrganizationMember
 	return &organizationMember, s.Post(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), o)
 }
 
@@ -4644,65 +2601,20 @@ type OrganizationMemberUpdateOpts struct {
 	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
 	Role      *string `json:"role" url:"role,key"`                               // role in the organization
 }
-type OrganizationMemberUpdateResult struct {
-	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
-	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
-	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
-	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
-	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
-	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
-	// authentication enabled
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
-	User      struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"user" url:"user,key"` // user information for the membership
-}
 
 // Update an organization member.
-func (s *Service) OrganizationMemberUpdate(ctx context.Context, organizationIdentity string, o OrganizationMemberUpdateOpts) (*OrganizationMemberUpdateResult, error) {
-	var organizationMember OrganizationMemberUpdateResult
+func (s *Service) OrganizationMemberUpdate(ctx context.Context, organizationIdentity string, o OrganizationMemberUpdateOpts) (*OrganizationMember, error) {
+	var organizationMember OrganizationMember
 	return &organizationMember, s.Patch(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), o)
 }
 
-type OrganizationMemberDeleteResult struct {
-	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
-	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
-	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
-	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
-	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
-	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
-	// authentication enabled
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
-	User      struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"user" url:"user,key"` // user information for the membership
-}
-
 // Remove a member from the organization.
-func (s *Service) OrganizationMemberDelete(ctx context.Context, organizationIdentity string, organizationMemberIdentity string) (*OrganizationMemberDeleteResult, error) {
-	var organizationMember OrganizationMemberDeleteResult
+func (s *Service) OrganizationMemberDelete(ctx context.Context, organizationIdentity string, organizationMemberIdentity string) (*OrganizationMember, error) {
+	var organizationMember OrganizationMember
 	return &organizationMember, s.Delete(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members/%v", organizationIdentity, organizationMemberIdentity))
 }
 
-type OrganizationMemberListResult []struct {
-	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
-	Email                   string    `json:"email" url:"email,key"`                                         // email address of the organization member
-	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
-	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of organization member
-	Role                    *string   `json:"role" url:"role,key"`                                           // role in the organization
-	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise organization member has two factor
-	// authentication enabled
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
-	User      struct {
-		Email string  `json:"email" url:"email,key"` // unique email address of account
-		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
-		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
-	} `json:"user" url:"user,key"` // user information for the membership
-}
+type OrganizationMemberListResult []OrganizationMember
 
 // List members of the organization.
 func (s *Service) OrganizationMemberList(ctx context.Context, organizationIdentity string, lr *ListRange) (OrganizationMemberListResult, error) {
@@ -4710,36 +2622,68 @@ func (s *Service) OrganizationMemberList(ctx context.Context, organizationIdenti
 	return organizationMember, s.Get(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members", organizationIdentity), nil, lr)
 }
 
-// Tracks an organization's preferences
-type OrganizationPreferences struct {
-	DefaultPermission *string `json:"default-permission" url:"default-permission,key"` // The default permission used when adding new members to the
-	// organization
-	WhitelistingEnabled *bool `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
+type OrganizationMemberAppListResult []struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other organization members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Organization                 *struct {
+		Name string `json:"name" url:"name,key"` // unique name of organization
+	} `json:"organization" url:"organization,key"` // organization that owns this app
+	Owner *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
 }
-type OrganizationPreferencesListResult struct {
+
+// List the apps of a member.
+func (s *Service) OrganizationMemberAppList(ctx context.Context, organizationIdentity string, organizationMemberIdentity string, lr *ListRange) (OrganizationMemberAppListResult, error) {
+	var organizationMember OrganizationMemberAppListResult
+	return organizationMember, s.Get(ctx, &organizationMember, fmt.Sprintf("/organizations/%v/members/%v/apps", organizationIdentity, organizationMemberIdentity), nil, lr)
+}
+
+// Deprecated: Tracks an organization's preferences
+type OrganizationPreferences struct {
 	DefaultPermission *string `json:"default-permission" url:"default-permission,key"` // The default permission used when adding new members to the
 	// organization
 	WhitelistingEnabled *bool `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
 }
 
 // Retrieve Organization Preferences
-func (s *Service) OrganizationPreferencesList(ctx context.Context, organizationPreferencesIdentity string) (*OrganizationPreferencesListResult, error) {
-	var organizationPreferences OrganizationPreferencesListResult
+func (s *Service) OrganizationPreferencesList(ctx context.Context, organizationPreferencesIdentity string) (*OrganizationPreferences, error) {
+	var organizationPreferences OrganizationPreferences
 	return &organizationPreferences, s.Get(ctx, &organizationPreferences, fmt.Sprintf("/organizations/%v/preferences", organizationPreferencesIdentity), nil, nil)
 }
 
 type OrganizationPreferencesUpdateOpts struct {
 	WhitelistingEnabled *bool `json:"whitelisting-enabled,omitempty" url:"whitelisting-enabled,omitempty,key"` // Whether whitelisting rules should be applied to add-on installations
 }
-type OrganizationPreferencesUpdateResult struct {
-	DefaultPermission *string `json:"default-permission" url:"default-permission,key"` // The default permission used when adding new members to the
-	// organization
-	WhitelistingEnabled *bool `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
-}
 
 // Update Organization Preferences
-func (s *Service) OrganizationPreferencesUpdate(ctx context.Context, organizationPreferencesIdentity string, o OrganizationPreferencesUpdateOpts) (*OrganizationPreferencesUpdateResult, error) {
-	var organizationPreferences OrganizationPreferencesUpdateResult
+func (s *Service) OrganizationPreferencesUpdate(ctx context.Context, organizationPreferencesIdentity string, o OrganizationPreferencesUpdateOpts) (*OrganizationPreferences, error) {
+	var organizationPreferences OrganizationPreferences
 	return &organizationPreferences, s.Patch(ctx, &organizationPreferences, fmt.Sprintf("/organizations/%v/preferences", organizationPreferencesIdentity), o)
 }
 
@@ -4758,39 +2702,20 @@ type OutboundRuleset struct {
 		ToPort int    `json:"to_port" url:"to_port,key"` // an endpoint of communication in an operating system.
 	} `json:"rules" url:"rules,key"`
 }
-type OutboundRulesetInfoResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when outbound-ruleset was created
-	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an outbound-ruleset
-	Rules     []struct {
-		FromPort int    `json:"from_port" url:"from_port,key"` // an endpoint of communication in an operating system.
-		Protocol string `json:"protocol" url:"protocol,key"`   // formal standards and policies comprised of rules, procedures and
-		// formats that define communication between two or more devices over a
-		// network
-		Target string `json:"target" url:"target,key"`   // is the target destination in CIDR notation
-		ToPort int    `json:"to_port" url:"to_port,key"` // an endpoint of communication in an operating system.
-	} `json:"rules" url:"rules,key"`
-}
 
 // Current outbound ruleset for a space
-func (s *Service) OutboundRulesetInfo(ctx context.Context, spaceIdentity string) (*OutboundRulesetInfoResult, error) {
-	var outboundRuleset OutboundRulesetInfoResult
+func (s *Service) OutboundRulesetCurrent(ctx context.Context, spaceIdentity string) (*OutboundRuleset, error) {
+	var outboundRuleset OutboundRuleset
 	return &outboundRuleset, s.Get(ctx, &outboundRuleset, fmt.Sprintf("/spaces/%v/outbound-ruleset", spaceIdentity), nil, nil)
 }
 
-type OutboundRulesetListResult []struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when outbound-ruleset was created
-	CreatedBy string    `json:"created_by" url:"created_by,key"` // unique email address of account
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an outbound-ruleset
-	Rules     []struct {
-		FromPort int    `json:"from_port" url:"from_port,key"` // an endpoint of communication in an operating system.
-		Protocol string `json:"protocol" url:"protocol,key"`   // formal standards and policies comprised of rules, procedures and
-		// formats that define communication between two or more devices over a
-		// network
-		Target string `json:"target" url:"target,key"`   // is the target destination in CIDR notation
-		ToPort int    `json:"to_port" url:"to_port,key"` // an endpoint of communication in an operating system.
-	} `json:"rules" url:"rules,key"`
+// Info on an existing Outbound Ruleset
+func (s *Service) OutboundRulesetInfo(ctx context.Context, spaceIdentity string, outboundRulesetIdentity string) (*OutboundRuleset, error) {
+	var outboundRuleset OutboundRuleset
+	return &outboundRuleset, s.Get(ctx, &outboundRuleset, fmt.Sprintf("/spaces/%v/outbound-rulesets/%v", spaceIdentity, outboundRulesetIdentity), nil, nil)
 }
+
+type OutboundRulesetListResult []OutboundRuleset
 
 // List all Outbound Rulesets for a space
 func (s *Service) OutboundRulesetList(ctx context.Context, spaceIdentity string, lr *ListRange) (OutboundRulesetListResult, error) {
@@ -4855,67 +2780,36 @@ type Pipeline struct {
 type PipelineCreateOpts struct {
 	Name string `json:"name" url:"name,key"` // name of pipeline
 }
-type PipelineCreateResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
-	Name      string    `json:"name" url:"name,key"`             // name of pipeline
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
-}
 
 // Create a new pipeline.
-func (s *Service) PipelineCreate(ctx context.Context, o PipelineCreateOpts) (*PipelineCreateResult, error) {
-	var pipeline PipelineCreateResult
+func (s *Service) PipelineCreate(ctx context.Context, o PipelineCreateOpts) (*Pipeline, error) {
+	var pipeline Pipeline
 	return &pipeline, s.Post(ctx, &pipeline, fmt.Sprintf("/pipelines"), o)
 }
 
-type PipelineInfoResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
-	Name      string    `json:"name" url:"name,key"`             // name of pipeline
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
-}
-
 // Info for existing pipeline.
-func (s *Service) PipelineInfo(ctx context.Context, pipelineIdentity string) (*PipelineInfoResult, error) {
-	var pipeline PipelineInfoResult
+func (s *Service) PipelineInfo(ctx context.Context, pipelineIdentity string) (*Pipeline, error) {
+	var pipeline Pipeline
 	return &pipeline, s.Get(ctx, &pipeline, fmt.Sprintf("/pipelines/%v", pipelineIdentity), nil, nil)
 }
 
-type PipelineDeleteResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
-	Name      string    `json:"name" url:"name,key"`             // name of pipeline
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
-}
-
 // Delete an existing pipeline.
-func (s *Service) PipelineDelete(ctx context.Context, pipelineID string) (*PipelineDeleteResult, error) {
-	var pipeline PipelineDeleteResult
+func (s *Service) PipelineDelete(ctx context.Context, pipelineID string) (*Pipeline, error) {
+	var pipeline Pipeline
 	return &pipeline, s.Delete(ctx, &pipeline, fmt.Sprintf("/pipelines/%v", pipelineID))
 }
 
 type PipelineUpdateOpts struct {
 	Name *string `json:"name,omitempty" url:"name,omitempty,key"` // name of pipeline
 }
-type PipelineUpdateResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
-	Name      string    `json:"name" url:"name,key"`             // name of pipeline
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
-}
 
 // Update an existing pipeline.
-func (s *Service) PipelineUpdate(ctx context.Context, pipelineID string, o PipelineUpdateOpts) (*PipelineUpdateResult, error) {
-	var pipeline PipelineUpdateResult
+func (s *Service) PipelineUpdate(ctx context.Context, pipelineID string, o PipelineUpdateOpts) (*Pipeline, error) {
+	var pipeline Pipeline
 	return &pipeline, s.Patch(ctx, &pipeline, fmt.Sprintf("/pipelines/%v", pipelineID), o)
 }
 
-type PipelineListResult []struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline
-	Name      string    `json:"name" url:"name,key"`             // name of pipeline
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline was updated
-}
+type PipelineListResult []Pipeline
 
 // List existing pipelines.
 func (s *Service) PipelineList(ctx context.Context, lr *ListRange) (PipelineListResult, error) {
@@ -4936,23 +2830,20 @@ type PipelineCoupling struct {
 	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
 }
-type PipelineCouplingListResult []struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
-	Pipeline  struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
-	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
-	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
-}
+type PipelineCouplingListByPipelineResult []PipelineCoupling
 
 // List couplings for a pipeline
-func (s *Service) PipelineCouplingList(ctx context.Context, pipelineID string, lr *ListRange) (PipelineCouplingListResult, error) {
-	var pipelineCoupling PipelineCouplingListResult
+func (s *Service) PipelineCouplingListByPipeline(ctx context.Context, pipelineID string, lr *ListRange) (PipelineCouplingListByPipelineResult, error) {
+	var pipelineCoupling PipelineCouplingListByPipelineResult
 	return pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/pipelines/%v/pipeline-couplings", pipelineID), nil, lr)
+}
+
+type PipelineCouplingListResult []PipelineCoupling
+
+// List pipeline couplings.
+func (s *Service) PipelineCouplingList(ctx context.Context, lr *ListRange) (PipelineCouplingListResult, error) {
+	var pipelineCoupling PipelineCouplingListResult
+	return pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings"), nil, lr)
 }
 
 type PipelineCouplingCreateOpts struct {
@@ -4960,83 +2851,39 @@ type PipelineCouplingCreateOpts struct {
 	Pipeline string `json:"pipeline" url:"pipeline,key"` // unique identifier of pipeline
 	Stage    string `json:"stage" url:"stage,key"`       // target pipeline stage
 }
-type PipelineCouplingCreateResult struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
-	Pipeline  struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
-	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
-	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
-}
 
 // Create a new pipeline coupling.
-func (s *Service) PipelineCouplingCreate(ctx context.Context, o PipelineCouplingCreateOpts) (*PipelineCouplingCreateResult, error) {
-	var pipelineCoupling PipelineCouplingCreateResult
+func (s *Service) PipelineCouplingCreate(ctx context.Context, o PipelineCouplingCreateOpts) (*PipelineCoupling, error) {
+	var pipelineCoupling PipelineCoupling
 	return &pipelineCoupling, s.Post(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings"), o)
 }
 
-type PipelineCouplingInfoResult struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
-	Pipeline  struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
-	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
-	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
-}
-
 // Info for an existing pipeline coupling.
-func (s *Service) PipelineCouplingInfo(ctx context.Context, pipelineCouplingIdentity string) (*PipelineCouplingInfoResult, error) {
-	var pipelineCoupling PipelineCouplingInfoResult
+func (s *Service) PipelineCouplingInfo(ctx context.Context, pipelineCouplingIdentity string) (*PipelineCoupling, error) {
+	var pipelineCoupling PipelineCoupling
 	return &pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings/%v", pipelineCouplingIdentity), nil, nil)
 }
 
-type PipelineCouplingDeleteResult struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
-	Pipeline  struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
-	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
-	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
-}
-
 // Delete an existing pipeline coupling.
-func (s *Service) PipelineCouplingDelete(ctx context.Context, pipelineCouplingIdentity string) (*PipelineCouplingDeleteResult, error) {
-	var pipelineCoupling PipelineCouplingDeleteResult
+func (s *Service) PipelineCouplingDelete(ctx context.Context, pipelineCouplingIdentity string) (*PipelineCoupling, error) {
+	var pipelineCoupling PipelineCoupling
 	return &pipelineCoupling, s.Delete(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings/%v", pipelineCouplingIdentity))
 }
 
 type PipelineCouplingUpdateOpts struct {
 	Stage *string `json:"stage,omitempty" url:"stage,omitempty,key"` // target pipeline stage
 }
-type PipelineCouplingUpdateResult struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // app involved in the pipeline coupling
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when pipeline coupling was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of pipeline coupling
-	Pipeline  struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
-	} `json:"pipeline" url:"pipeline,key"` // pipeline involved in the coupling
-	Stage     string    `json:"stage" url:"stage,key"`           // target pipeline stage
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when pipeline coupling was updated
-}
 
 // Update an existing pipeline coupling.
-func (s *Service) PipelineCouplingUpdate(ctx context.Context, pipelineCouplingIdentity string, o PipelineCouplingUpdateOpts) (*PipelineCouplingUpdateResult, error) {
-	var pipelineCoupling PipelineCouplingUpdateResult
+func (s *Service) PipelineCouplingUpdate(ctx context.Context, pipelineCouplingIdentity string, o PipelineCouplingUpdateOpts) (*PipelineCoupling, error) {
+	var pipelineCoupling PipelineCoupling
 	return &pipelineCoupling, s.Patch(ctx, &pipelineCoupling, fmt.Sprintf("/pipeline-couplings/%v", pipelineCouplingIdentity), o)
+}
+
+// Info for an existing app pipeline coupling.
+func (s *Service) PipelineCouplingInfoByApp(ctx context.Context, appIdentity string) (*PipelineCoupling, error) {
+	var pipelineCoupling PipelineCoupling
+	return &pipelineCoupling, s.Get(ctx, &pipelineCoupling, fmt.Sprintf("/apps/%v/pipeline-couplings", appIdentity), nil, nil)
 }
 
 // Promotions allow you to move code from an app in a pipeline to all
@@ -5080,27 +2927,9 @@ func (s *Service) PipelinePromotionCreate(ctx context.Context, o PipelinePromoti
 	return &pipelinePromotion, s.Post(ctx, &pipelinePromotion, fmt.Sprintf("/pipeline-promotions"), o)
 }
 
-type PipelinePromotionInfoResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when promotion was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of promotion
-	Pipeline  struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of pipeline
-	} `json:"pipeline" url:"pipeline,key"` // the pipeline which the promotion belongs to
-	Source struct {
-		App struct {
-			ID string `json:"id" url:"id,key"` // unique identifier of app
-		} `json:"app" url:"app,key"` // the app which was promoted from
-		Release struct {
-			ID string `json:"id" url:"id,key"` // unique identifier of release
-		} `json:"release" url:"release,key"` // the release used to promoted from
-	} `json:"source" url:"source,key"` // the app being promoted from
-	Status    string     `json:"status" url:"status,key"`         // status of promotion
-	UpdatedAt *time.Time `json:"updated_at" url:"updated_at,key"` // when promotion was updated
-}
-
 // Info for existing pipeline promotion.
-func (s *Service) PipelinePromotionInfo(ctx context.Context, pipelinePromotionIdentity string) (*PipelinePromotionInfoResult, error) {
-	var pipelinePromotion PipelinePromotionInfoResult
+func (s *Service) PipelinePromotionInfo(ctx context.Context, pipelinePromotionIdentity string) (*PipelinePromotion, error) {
+	var pipelinePromotion PipelinePromotion
 	return &pipelinePromotion, s.Get(ctx, &pipelinePromotion, fmt.Sprintf("/pipeline-promotions/%v", pipelinePromotionIdentity), nil, nil)
 }
 
@@ -5119,20 +2948,7 @@ type PipelinePromotionTarget struct {
 	} `json:"release" url:"release,key"` // the release which was created on the target app
 	Status string `json:"status" url:"status,key"` // status of promotion
 }
-type PipelinePromotionTargetListResult []struct {
-	App struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of app
-	} `json:"app" url:"app,key"` // the app which was promoted to
-	ErrorMessage      *string `json:"error_message" url:"error_message,key"` // an error message for why the promotion failed
-	ID                string  `json:"id" url:"id,key"`                       // unique identifier of promotion target
-	PipelinePromotion struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of promotion
-	} `json:"pipeline_promotion" url:"pipeline_promotion,key"` // the promotion which the target belongs to
-	Release *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of release
-	} `json:"release" url:"release,key"` // the release which was created on the target app
-	Status string `json:"status" url:"status,key"` // status of promotion
-}
+type PipelinePromotionTargetListResult []PipelinePromotionTarget
 
 // List promotion targets belonging to an existing promotion.
 func (s *Service) PipelinePromotionTargetList(ctx context.Context, pipelinePromotionID string, lr *ListRange) (PipelinePromotionTargetListResult, error) {
@@ -5166,63 +2982,24 @@ type Plan struct {
 	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when plan was updated
 	Visible      bool      `json:"visible" url:"visible,key"`             // whether this plan is publicly visible
 }
-type PlanInfoResult struct {
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	Compliance                       *[]string `json:"compliance" url:"compliance,key"`                                                   // the compliance regimes applied to an add-on plan
-	CreatedAt                        time.Time `json:"created_at" url:"created_at,key"`                                                   // when plan was created
-	Default                          bool      `json:"default" url:"default,key"`                                                         // whether this plan is the default for its add-on service
-	Description                      string    `json:"description" url:"description,key"`                                                 // description of plan
-	HumanName                        string    `json:"human_name" url:"human_name,key"`                                                   // human readable name of the add-on plan
-	ID                               string    `json:"id" url:"id,key"`                                                                   // unique identifier of this plan
-	InstallableInsidePrivateNetwork  bool      `json:"installable_inside_private_network" url:"installable_inside_private_network,key"`   // whether this plan is installable to a Private Spaces app
-	InstallableOutsidePrivateNetwork bool      `json:"installable_outside_private_network" url:"installable_outside_private_network,key"` // whether this plan is installable to a Common Runtime app
-	Name                             string    `json:"name" url:"name,key"`                                                               // unique name of this plan
-	Price                            struct {
-		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
-		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
-	} `json:"price" url:"price,key"` // price
-	SpaceDefault bool      `json:"space_default" url:"space_default,key"` // whether this plan is the default for apps in Private Spaces
-	State        string    `json:"state" url:"state,key"`                 // release status for plan
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when plan was updated
-	Visible      bool      `json:"visible" url:"visible,key"`             // whether this plan is publicly visible
-}
 
 // Info for existing plan.
-func (s *Service) PlanInfo(ctx context.Context, addOnServiceIdentity string, planIdentity string) (*PlanInfoResult, error) {
-	var plan PlanInfoResult
+func (s *Service) PlanInfo(ctx context.Context, planIdentity string) (*Plan, error) {
+	var plan Plan
+	return &plan, s.Get(ctx, &plan, fmt.Sprintf("/plans/%v", planIdentity), nil, nil)
+}
+
+// Info for existing plan by Add-on.
+func (s *Service) PlanInfoByAddOn(ctx context.Context, addOnServiceIdentity string, planIdentity string) (*Plan, error) {
+	var plan Plan
 	return &plan, s.Get(ctx, &plan, fmt.Sprintf("/addon-services/%v/plans/%v", addOnServiceIdentity, planIdentity), nil, nil)
 }
 
-type PlanListResult []struct {
-	AddonService struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of this add-on-service
-		Name string `json:"name" url:"name,key"` // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // identity of add-on service
-	Compliance                       *[]string `json:"compliance" url:"compliance,key"`                                                   // the compliance regimes applied to an add-on plan
-	CreatedAt                        time.Time `json:"created_at" url:"created_at,key"`                                                   // when plan was created
-	Default                          bool      `json:"default" url:"default,key"`                                                         // whether this plan is the default for its add-on service
-	Description                      string    `json:"description" url:"description,key"`                                                 // description of plan
-	HumanName                        string    `json:"human_name" url:"human_name,key"`                                                   // human readable name of the add-on plan
-	ID                               string    `json:"id" url:"id,key"`                                                                   // unique identifier of this plan
-	InstallableInsidePrivateNetwork  bool      `json:"installable_inside_private_network" url:"installable_inside_private_network,key"`   // whether this plan is installable to a Private Spaces app
-	InstallableOutsidePrivateNetwork bool      `json:"installable_outside_private_network" url:"installable_outside_private_network,key"` // whether this plan is installable to a Common Runtime app
-	Name                             string    `json:"name" url:"name,key"`                                                               // unique name of this plan
-	Price                            struct {
-		Cents int    `json:"cents" url:"cents,key"` // price in cents per unit of plan
-		Unit  string `json:"unit" url:"unit,key"`   // unit of price for plan
-	} `json:"price" url:"price,key"` // price
-	SpaceDefault bool      `json:"space_default" url:"space_default,key"` // whether this plan is the default for apps in Private Spaces
-	State        string    `json:"state" url:"state,key"`                 // release status for plan
-	UpdatedAt    time.Time `json:"updated_at" url:"updated_at,key"`       // when plan was updated
-	Visible      bool      `json:"visible" url:"visible,key"`             // whether this plan is publicly visible
-}
+type PlanListByAddOnResult []Plan
 
-// List existing plans.
-func (s *Service) PlanList(ctx context.Context, addOnServiceIdentity string, lr *ListRange) (PlanListResult, error) {
-	var plan PlanListResult
+// List existing plans by Add-on.
+func (s *Service) PlanListByAddOn(ctx context.Context, addOnServiceIdentity string, lr *ListRange) (PlanListByAddOnResult, error) {
+	var plan PlanListByAddOnResult
 	return plan, s.Get(ctx, &plan, fmt.Sprintf("/addon-services/%v/plans", addOnServiceIdentity), nil, lr)
 }
 
@@ -5231,13 +3008,10 @@ func (s *Service) PlanList(ctx context.Context, addOnServiceIdentity string, lr 
 type RateLimit struct {
 	Remaining int `json:"remaining" url:"remaining,key"` // allowed requests remaining in current interval
 }
-type RateLimitInfoResult struct {
-	Remaining int `json:"remaining" url:"remaining,key"` // allowed requests remaining in current interval
-}
 
 // Info for rate limits.
-func (s *Service) RateLimitInfo(ctx context.Context) (*RateLimitInfoResult, error) {
-	var rateLimit RateLimitInfoResult
+func (s *Service) RateLimitInfo(ctx context.Context) (*RateLimit, error) {
+	var rateLimit RateLimit
 	return &rateLimit, s.Get(ctx, &rateLimit, fmt.Sprintf("/account/rate-limits"), nil, nil)
 }
 
@@ -5257,41 +3031,14 @@ type Region struct {
 	} `json:"provider" url:"provider,key"` // provider of underlying substrate
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
 }
-type RegionInfoResult struct {
-	Country        string    `json:"country" url:"country,key"`                 // country where the region exists
-	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
-	Description    string    `json:"description" url:"description,key"`         // description of region
-	ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
-	Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
-	Name           string    `json:"name" url:"name,key"`                       // unique name of region
-	PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
-	Provider       struct {
-		Name   string `json:"name" url:"name,key"`     // name of provider
-		Region string `json:"region" url:"region,key"` // region name used by provider
-	} `json:"provider" url:"provider,key"` // provider of underlying substrate
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
-}
 
 // Info for existing region.
-func (s *Service) RegionInfo(ctx context.Context, regionIdentity string) (*RegionInfoResult, error) {
-	var region RegionInfoResult
+func (s *Service) RegionInfo(ctx context.Context, regionIdentity string) (*Region, error) {
+	var region Region
 	return &region, s.Get(ctx, &region, fmt.Sprintf("/regions/%v", regionIdentity), nil, nil)
 }
 
-type RegionListResult []struct {
-	Country        string    `json:"country" url:"country,key"`                 // country where the region exists
-	CreatedAt      time.Time `json:"created_at" url:"created_at,key"`           // when region was created
-	Description    string    `json:"description" url:"description,key"`         // description of region
-	ID             string    `json:"id" url:"id,key"`                           // unique identifier of region
-	Locale         string    `json:"locale" url:"locale,key"`                   // area in the country where the region exists
-	Name           string    `json:"name" url:"name,key"`                       // unique name of region
-	PrivateCapable bool      `json:"private_capable" url:"private_capable,key"` // whether or not region is available for creating a Private Space
-	Provider       struct {
-		Name   string `json:"name" url:"name,key"`     // name of provider
-		Region string `json:"region" url:"region,key"` // region name used by provider
-	} `json:"provider" url:"provider,key"` // provider of underlying substrate
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when region was updated
-}
+type RegionListResult []Region
 
 // List existing regions.
 func (s *Service) RegionList(ctx context.Context, lr *ListRange) (RegionListResult, error) {
@@ -5322,55 +3069,14 @@ type Release struct {
 	} `json:"user" url:"user,key"` // user that created the release
 	Version int `json:"version" url:"version,key"` // unique version assigned to the release
 }
-type ReleaseInfoResult struct {
-	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
-	App            struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the release
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
-	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
-	Description string    `json:"description" url:"description,key"` // description of changes in this release
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
-	Slug        *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of slug
-	} `json:"slug" url:"slug,key"` // slug running in this release
-	Status    string    `json:"status" url:"status,key"`         // current status of the release
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // user that created the release
-	Version int `json:"version" url:"version,key"` // unique version assigned to the release
-}
 
 // Info for existing release.
-func (s *Service) ReleaseInfo(ctx context.Context, appIdentity string, releaseIdentity string) (*ReleaseInfoResult, error) {
-	var release ReleaseInfoResult
+func (s *Service) ReleaseInfo(ctx context.Context, appIdentity string, releaseIdentity string) (*Release, error) {
+	var release Release
 	return &release, s.Get(ctx, &release, fmt.Sprintf("/apps/%v/releases/%v", appIdentity, releaseIdentity), nil, nil)
 }
 
-type ReleaseListResult []struct {
-	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
-	App            struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the release
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
-	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
-	Description string    `json:"description" url:"description,key"` // description of changes in this release
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
-	Slug        *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of slug
-	} `json:"slug" url:"slug,key"` // slug running in this release
-	Status    string    `json:"status" url:"status,key"`         // current status of the release
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // user that created the release
-	Version int `json:"version" url:"version,key"` // unique version assigned to the release
-}
+type ReleaseListResult []Release
 
 // List existing releases.
 func (s *Service) ReleaseList(ctx context.Context, appIdentity string, lr *ListRange) (ReleaseListResult, error) {
@@ -5382,62 +3088,20 @@ type ReleaseCreateOpts struct {
 	Description *string `json:"description,omitempty" url:"description,omitempty,key"` // description of changes in this release
 	Slug        string  `json:"slug" url:"slug,key"`                                   // unique identifier of slug
 }
-type ReleaseCreateResult struct {
-	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
-	App            struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the release
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
-	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
-	Description string    `json:"description" url:"description,key"` // description of changes in this release
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
-	Slug        *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of slug
-	} `json:"slug" url:"slug,key"` // slug running in this release
-	Status    string    `json:"status" url:"status,key"`         // current status of the release
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // user that created the release
-	Version int `json:"version" url:"version,key"` // unique version assigned to the release
-}
 
 // Create new release.
-func (s *Service) ReleaseCreate(ctx context.Context, appIdentity string, o ReleaseCreateOpts) (*ReleaseCreateResult, error) {
-	var release ReleaseCreateResult
+func (s *Service) ReleaseCreate(ctx context.Context, appIdentity string, o ReleaseCreateOpts) (*Release, error) {
+	var release Release
 	return &release, s.Post(ctx, &release, fmt.Sprintf("/apps/%v/releases", appIdentity), o)
 }
 
 type ReleaseRollbackOpts struct {
 	Release string `json:"release" url:"release,key"` // unique identifier of release
 }
-type ReleaseRollbackResult struct {
-	AddonPlanNames []string `json:"addon_plan_names" url:"addon_plan_names,key"` // add-on plans installed on the app for this release
-	App            struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // app involved in the release
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"`   // when release was created
-	Current     bool      `json:"current" url:"current,key"`         // indicates this release as being the current one for the app
-	Description string    `json:"description" url:"description,key"` // description of changes in this release
-	ID          string    `json:"id" url:"id,key"`                   // unique identifier of release
-	Slug        *struct {
-		ID string `json:"id" url:"id,key"` // unique identifier of slug
-	} `json:"slug" url:"slug,key"` // slug running in this release
-	Status    string    `json:"status" url:"status,key"`         // current status of the release
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when release was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // user that created the release
-	Version int `json:"version" url:"version,key"` // unique version assigned to the release
-}
 
 // Rollback to an existing release.
-func (s *Service) ReleaseRollback(ctx context.Context, appIdentity string, o ReleaseRollbackOpts) (*ReleaseRollbackResult, error) {
-	var release ReleaseRollbackResult
+func (s *Service) ReleaseRollback(ctx context.Context, appIdentity string, o ReleaseRollbackOpts) (*Release, error) {
+	var release Release
 	return &release, s.Post(ctx, &release, fmt.Sprintf("/apps/%v/releases", appIdentity), o)
 }
 
@@ -5464,31 +3128,10 @@ type Slug struct {
 	} `json:"stack" url:"stack,key"` // identity of slug stack
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when slug was updated
 }
-type SlugInfoResult struct {
-	Blob struct {
-		Method string `json:"method" url:"method,key"` // method to be used to interact with the slug blob
-		URL    string `json:"url" url:"url,key"`       // URL to interact with the slug blob
-	} `json:"blob" url:"blob,key"` // pointer to the url where clients can fetch or store the actual
-	// release binary
-	BuildpackProvidedDescription *string `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of slug
-	Checksum                     *string `json:"checksum" url:"checksum,key"`                                             // an optional checksum of the slug for verifying its integrity
-	Commit                       *string `json:"commit" url:"commit,key"`                                                 // identification of the code with your version control system (eg: SHA
-	// of the git HEAD)
-	CommitDescription *string           `json:"commit_description" url:"commit_description,key"` // an optional description of the provided commit
-	CreatedAt         time.Time         `json:"created_at" url:"created_at,key"`                 // when slug was created
-	ID                string            `json:"id" url:"id,key"`                                 // unique identifier of slug
-	ProcessTypes      map[string]string `json:"process_types" url:"process_types,key"`           // hash mapping process type names to their respective command
-	Size              *int              `json:"size" url:"size,key"`                             // size of slug, in bytes
-	Stack             struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of slug stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when slug was updated
-}
 
 // Info for existing slug.
-func (s *Service) SlugInfo(ctx context.Context, appIdentity string, slugIdentity string) (*SlugInfoResult, error) {
-	var slug SlugInfoResult
+func (s *Service) SlugInfo(ctx context.Context, appIdentity string, slugIdentity string) (*Slug, error) {
+	var slug Slug
 	return &slug, s.Get(ctx, &slug, fmt.Sprintf("/apps/%v/slugs/%v", appIdentity, slugIdentity), nil, nil)
 }
 
@@ -5501,34 +3144,13 @@ type SlugCreateOpts struct {
 	ProcessTypes      map[string]string `json:"process_types" url:"process_types,key"`                               // hash mapping process type names to their respective command
 	Stack             *string           `json:"stack,omitempty" url:"stack,omitempty,key"`                           // unique name of stack
 }
-type SlugCreateResult struct {
-	Blob struct {
-		Method string `json:"method" url:"method,key"` // method to be used to interact with the slug blob
-		URL    string `json:"url" url:"url,key"`       // URL to interact with the slug blob
-	} `json:"blob" url:"blob,key"` // pointer to the url where clients can fetch or store the actual
-	// release binary
-	BuildpackProvidedDescription *string `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of slug
-	Checksum                     *string `json:"checksum" url:"checksum,key"`                                             // an optional checksum of the slug for verifying its integrity
-	Commit                       *string `json:"commit" url:"commit,key"`                                                 // identification of the code with your version control system (eg: SHA
-	// of the git HEAD)
-	CommitDescription *string           `json:"commit_description" url:"commit_description,key"` // an optional description of the provided commit
-	CreatedAt         time.Time         `json:"created_at" url:"created_at,key"`                 // when slug was created
-	ID                string            `json:"id" url:"id,key"`                                 // unique identifier of slug
-	ProcessTypes      map[string]string `json:"process_types" url:"process_types,key"`           // hash mapping process type names to their respective command
-	Size              *int              `json:"size" url:"size,key"`                             // size of slug, in bytes
-	Stack             struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
-		Name string `json:"name" url:"name,key"` // unique name of stack
-	} `json:"stack" url:"stack,key"` // identity of slug stack
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when slug was updated
-}
 
 // Create a new slug. For more information please refer to [Deploying
 // Slugs using the Platform
 // API](https://devcenter.heroku.com/articles/platform-api-deploying-slug
 // s).
-func (s *Service) SlugCreate(ctx context.Context, appIdentity string, o SlugCreateOpts) (*SlugCreateResult, error) {
-	var slug SlugCreateResult
+func (s *Service) SlugCreate(ctx context.Context, appIdentity string, o SlugCreateOpts) (*Slug, error) {
+	var slug Slug
 	return &slug, s.Post(ctx, &slug, fmt.Sprintf("/apps/%v/slugs", appIdentity), o)
 }
 
@@ -5537,33 +3159,22 @@ func (s *Service) SlugCreate(ctx context.Context, appIdentity string, o SlugCrea
 type SmsNumber struct {
 	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
 }
-type SmsNumberSMSNumberResult struct {
-	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
-}
 
 // Recover an account using an SMS recovery code
-func (s *Service) SmsNumberSMSNumber(ctx context.Context, accountIdentity string) (*SmsNumberSMSNumberResult, error) {
-	var smsNumber SmsNumberSMSNumberResult
+func (s *Service) SmsNumberSMSNumber(ctx context.Context, accountIdentity string) (*SmsNumber, error) {
+	var smsNumber SmsNumber
 	return &smsNumber, s.Get(ctx, &smsNumber, fmt.Sprintf("/users/%v/sms-number", accountIdentity), nil, nil)
 }
 
-type SmsNumberRecoverResult struct {
-	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
-}
-
 // Recover an account using an SMS recovery code
-func (s *Service) SmsNumberRecover(ctx context.Context, accountIdentity string) (*SmsNumberRecoverResult, error) {
-	var smsNumber SmsNumberRecoverResult
+func (s *Service) SmsNumberRecover(ctx context.Context, accountIdentity string) (*SmsNumber, error) {
+	var smsNumber SmsNumber
 	return &smsNumber, s.Post(ctx, &smsNumber, fmt.Sprintf("/users/%v/sms-number/actions/recover", accountIdentity), nil)
 }
 
-type SmsNumberConfirmResult struct {
-	SmsNumber *string `json:"sms_number" url:"sms_number,key"` // SMS number of account
-}
-
 // Confirm an SMS number change with a confirmation code
-func (s *Service) SmsNumberConfirm(ctx context.Context, accountIdentity string) (*SmsNumberConfirmResult, error) {
-	var smsNumber SmsNumberConfirmResult
+func (s *Service) SmsNumberConfirm(ctx context.Context, accountIdentity string) (*SmsNumber, error) {
+	var smsNumber SmsNumber
 	return &smsNumber, s.Post(ctx, &smsNumber, fmt.Sprintf("/users/%v/sms-number/actions/confirm", accountIdentity), nil)
 }
 
@@ -5582,63 +3193,26 @@ type SniEndpointCreateOpts struct {
 	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
 	PrivateKey       string `json:"private_key" url:"private_key,key"`             // contents of the private key (eg .key file)
 }
-type SniEndpointCreateResult struct {
-	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
-	// app
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
-	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
-}
 
 // Create a new SNI endpoint.
-func (s *Service) SniEndpointCreate(ctx context.Context, appIdentity string, o SniEndpointCreateOpts) (*SniEndpointCreateResult, error) {
-	var sniEndpoint SniEndpointCreateResult
+func (s *Service) SniEndpointCreate(ctx context.Context, appIdentity string, o SniEndpointCreateOpts) (*SniEndpoint, error) {
+	var sniEndpoint SniEndpoint
 	return &sniEndpoint, s.Post(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints", appIdentity), o)
 }
 
-type SniEndpointDeleteResult struct {
-	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
-	// app
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
-	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
-}
-
 // Delete existing SNI endpoint.
-func (s *Service) SniEndpointDelete(ctx context.Context, appIdentity string, sniEndpointIdentity string) (*SniEndpointDeleteResult, error) {
-	var sniEndpoint SniEndpointDeleteResult
+func (s *Service) SniEndpointDelete(ctx context.Context, appIdentity string, sniEndpointIdentity string) (*SniEndpoint, error) {
+	var sniEndpoint SniEndpoint
 	return &sniEndpoint, s.Delete(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints/%v", appIdentity, sniEndpointIdentity))
 }
 
-type SniEndpointInfoResult struct {
-	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
-	// app
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
-	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
-}
-
 // Info for existing SNI endpoint.
-func (s *Service) SniEndpointInfo(ctx context.Context, appIdentity string, sniEndpointIdentity string) (*SniEndpointInfoResult, error) {
-	var sniEndpoint SniEndpointInfoResult
+func (s *Service) SniEndpointInfo(ctx context.Context, appIdentity string, sniEndpointIdentity string) (*SniEndpoint, error) {
+	var sniEndpoint SniEndpoint
 	return &sniEndpoint, s.Get(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints/%v", appIdentity, sniEndpointIdentity), nil, nil)
 }
 
-type SniEndpointListResult []struct {
-	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
-	// app
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
-	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
-}
+type SniEndpointListResult []SniEndpoint
 
 // List existing SNI endpoints.
 func (s *Service) SniEndpointList(ctx context.Context, appIdentity string, lr *ListRange) (SniEndpointListResult, error) {
@@ -5650,19 +3224,10 @@ type SniEndpointUpdateOpts struct {
 	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
 	PrivateKey       string `json:"private_key" url:"private_key,key"`             // contents of the private key (eg .key file)
 }
-type SniEndpointUpdateResult struct {
-	CertificateChain string `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string `json:"cname" url:"cname,key"`                         // deprecated; refer to GET /apps/:id/domains for valid CNAMEs for this
-	// app
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when endpoint was created
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of this SNI endpoint
-	Name      string    `json:"name" url:"name,key"`             // unique name for SNI endpoint
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when SNI endpoint was updated
-}
 
 // Update an existing SNI endpoint.
-func (s *Service) SniEndpointUpdate(ctx context.Context, appIdentity string, sniEndpointIdentity string, o SniEndpointUpdateOpts) (*SniEndpointUpdateResult, error) {
-	var sniEndpoint SniEndpointUpdateResult
+func (s *Service) SniEndpointUpdate(ctx context.Context, appIdentity string, sniEndpointIdentity string, o SniEndpointUpdateOpts) (*SniEndpoint, error) {
+	var sniEndpoint SniEndpoint
 	return &sniEndpoint, s.Patch(ctx, &sniEndpoint, fmt.Sprintf("/apps/%v/sni-endpoints/%v", appIdentity, sniEndpointIdentity), o)
 }
 
@@ -5674,30 +3239,17 @@ type Source struct {
 		PutURL string `json:"put_url" url:"put_url,key"` // URL to upload the source
 	} `json:"source_blob" url:"source_blob,key"` // pointer to the URL where clients can fetch or store the source
 }
-type SourceCreateResult struct {
-	SourceBlob struct {
-		GetURL string `json:"get_url" url:"get_url,key"` // URL to download the source
-		PutURL string `json:"put_url" url:"put_url,key"` // URL to upload the source
-	} `json:"source_blob" url:"source_blob,key"` // pointer to the URL where clients can fetch or store the source
-}
 
 // Create URLs for uploading and downloading source.
-func (s *Service) SourceCreate(ctx context.Context) (*SourceCreateResult, error) {
-	var source SourceCreateResult
+func (s *Service) SourceCreate(ctx context.Context) (*Source, error) {
+	var source Source
 	return &source, s.Post(ctx, &source, fmt.Sprintf("/sources"), nil)
-}
-
-type SourceCreateDeprecatedResult struct {
-	SourceBlob struct {
-		GetURL string `json:"get_url" url:"get_url,key"` // URL to download the source
-		PutURL string `json:"put_url" url:"put_url,key"` // URL to upload the source
-	} `json:"source_blob" url:"source_blob,key"` // pointer to the URL where clients can fetch or store the source
 }
 
 // Create URLs for uploading and downloading source. Deprecated in favor
 // of `POST /sources`
-func (s *Service) SourceCreateDeprecated(ctx context.Context, appIdentity string) (*SourceCreateDeprecatedResult, error) {
-	var source SourceCreateDeprecatedResult
+func (s *Service) SourceCreateDeprecated(ctx context.Context, appIdentity string) (*Source, error) {
+	var source Source
 	return &source, s.Post(ctx, &source, fmt.Sprintf("/apps/%v/sources", appIdentity), nil)
 }
 
@@ -5714,25 +3266,15 @@ type Space struct {
 		ID   string `json:"id" url:"id,key"`     // unique identifier of region
 		Name string `json:"name" url:"name,key"` // unique name of region
 	} `json:"region" url:"region,key"` // identity of space region
-	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
-	State     string    `json:"state" url:"state,key"`           // availability of this space
+	Shield bool   `json:"shield" url:"shield,key"` // true if this space has shield enabled
+	State  string `json:"state" url:"state,key"`   // availability of this space
+	Team   struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of team
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this space
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
 }
-type SpaceListResult []struct {
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Name         string    `json:"name" url:"name,key"`             // unique name of space
-	Organization struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this space
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of space region
-	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
-	State     string    `json:"state" url:"state,key"`           // availability of this space
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-}
+type SpaceListResult []Space
 
 // List existing spaces.
 func (s *Service) SpaceList(ctx context.Context, lr *ListRange) (SpaceListResult, error) {
@@ -5740,72 +3282,25 @@ func (s *Service) SpaceList(ctx context.Context, lr *ListRange) (SpaceListResult
 	return space, s.Get(ctx, &space, fmt.Sprintf("/spaces"), nil, lr)
 }
 
-type SpaceInfoResult struct {
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Name         string    `json:"name" url:"name,key"`             // unique name of space
-	Organization struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this space
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of space region
-	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
-	State     string    `json:"state" url:"state,key"`           // availability of this space
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-}
-
 // Info for existing space.
-func (s *Service) SpaceInfo(ctx context.Context, spaceIdentity string) (*SpaceInfoResult, error) {
-	var space SpaceInfoResult
+func (s *Service) SpaceInfo(ctx context.Context, spaceIdentity string) (*Space, error) {
+	var space Space
 	return &space, s.Get(ctx, &space, fmt.Sprintf("/spaces/%v", spaceIdentity), nil, nil)
 }
 
 type SpaceUpdateOpts struct {
 	Name *string `json:"name,omitempty" url:"name,omitempty,key"` // unique name of space
 }
-type SpaceUpdateResult struct {
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Name         string    `json:"name" url:"name,key"`             // unique name of space
-	Organization struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this space
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of space region
-	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
-	State     string    `json:"state" url:"state,key"`           // availability of this space
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-}
 
 // Update an existing space.
-func (s *Service) SpaceUpdate(ctx context.Context, spaceIdentity string, o SpaceUpdateOpts) (*SpaceUpdateResult, error) {
-	var space SpaceUpdateResult
+func (s *Service) SpaceUpdate(ctx context.Context, spaceIdentity string, o SpaceUpdateOpts) (*Space, error) {
+	var space Space
 	return &space, s.Patch(ctx, &space, fmt.Sprintf("/spaces/%v", spaceIdentity), o)
 }
 
-type SpaceDeleteResult struct {
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Name         string    `json:"name" url:"name,key"`             // unique name of space
-	Organization struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this space
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of space region
-	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
-	State     string    `json:"state" url:"state,key"`           // availability of this space
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-}
-
 // Delete an existing space.
-func (s *Service) SpaceDelete(ctx context.Context, spaceIdentity string) (*SpaceDeleteResult, error) {
-	var space SpaceDeleteResult
+func (s *Service) SpaceDelete(ctx context.Context, spaceIdentity string) (*Space, error) {
+	var space Space
 	return &space, s.Delete(ctx, &space, fmt.Sprintf("/spaces/%v", spaceIdentity))
 }
 
@@ -5815,25 +3310,10 @@ type SpaceCreateOpts struct {
 	Region       *string `json:"region,omitempty" url:"region,omitempty,key"` // unique identifier of region
 	Shield       *bool   `json:"shield,omitempty" url:"shield,omitempty,key"` // true if this space has shield enabled
 }
-type SpaceCreateResult struct {
-	CreatedAt    time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID           string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Name         string    `json:"name" url:"name,key"`             // unique name of space
-	Organization struct {
-		Name string `json:"name" url:"name,key"` // unique name of organization
-	} `json:"organization" url:"organization,key"` // organization that owns this space
-	Region struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of region
-		Name string `json:"name" url:"name,key"` // unique name of region
-	} `json:"region" url:"region,key"` // identity of space region
-	Shield    bool      `json:"shield" url:"shield,key"`         // true if this space has shield enabled
-	State     string    `json:"state" url:"state,key"`           // availability of this space
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-}
 
 // Create a new space.
-func (s *Service) SpaceCreate(ctx context.Context, o SpaceCreateOpts) (*SpaceCreateResult, error) {
-	var space SpaceCreateResult
+func (s *Service) SpaceCreate(ctx context.Context, o SpaceCreateOpts) (*Space, error) {
+	var space Space
 	return &space, s.Post(ctx, &space, fmt.Sprintf("/spaces"), o)
 }
 
@@ -5856,27 +3336,10 @@ type SpaceAppAccess struct {
 		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
 	} `json:"user" url:"user,key"` // identity of user account
 }
-type SpaceAppAccessInfoResult struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID          string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Permissions []struct {
-		Description string `json:"description" url:"description,key"`
-		Name        string `json:"name" url:"name,key"`
-	} `json:"permissions" url:"permissions,key"` // user space permissions
-	Space struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"space" url:"space,key"` // space user belongs to
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of user account
-}
 
 // List permissions for a given user on a given space.
-func (s *Service) SpaceAppAccessInfo(ctx context.Context, spaceIdentity string, accountIdentity string) (*SpaceAppAccessInfoResult, error) {
-	var spaceAppAccess SpaceAppAccessInfoResult
+func (s *Service) SpaceAppAccessInfo(ctx context.Context, spaceIdentity string, accountIdentity string) (*SpaceAppAccess, error) {
+	var spaceAppAccess SpaceAppAccess
 	return &spaceAppAccess, s.Get(ctx, &spaceAppAccess, fmt.Sprintf("/spaces/%v/members/%v", spaceIdentity, accountIdentity), nil, nil)
 }
 
@@ -5885,47 +3348,14 @@ type SpaceAppAccessUpdateOpts struct {
 		Name *string `json:"name,omitempty" url:"name,omitempty,key"`
 	} `json:"permissions,omitempty" url:"permissions,omitempty,key"`
 }
-type SpaceAppAccessUpdateResult struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID          string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Permissions []struct {
-		Description string `json:"description" url:"description,key"`
-		Name        string `json:"name" url:"name,key"`
-	} `json:"permissions" url:"permissions,key"` // user space permissions
-	Space struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"space" url:"space,key"` // space user belongs to
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of user account
-}
 
 // Update an existing user's set of permissions on a space.
-func (s *Service) SpaceAppAccessUpdate(ctx context.Context, spaceIdentity string, accountIdentity string, o SpaceAppAccessUpdateOpts) (*SpaceAppAccessUpdateResult, error) {
-	var spaceAppAccess SpaceAppAccessUpdateResult
+func (s *Service) SpaceAppAccessUpdate(ctx context.Context, spaceIdentity string, accountIdentity string, o SpaceAppAccessUpdateOpts) (*SpaceAppAccess, error) {
+	var spaceAppAccess SpaceAppAccess
 	return &spaceAppAccess, s.Patch(ctx, &spaceAppAccess, fmt.Sprintf("/spaces/%v/members/%v", spaceIdentity, accountIdentity), o)
 }
 
-type SpaceAppAccessListResult []struct {
-	CreatedAt   time.Time `json:"created_at" url:"created_at,key"` // when space was created
-	ID          string    `json:"id" url:"id,key"`                 // unique identifier of space
-	Permissions []struct {
-		Description string `json:"description" url:"description,key"`
-		Name        string `json:"name" url:"name,key"`
-	} `json:"permissions" url:"permissions,key"` // user space permissions
-	Space struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"space" url:"space,key"` // space user belongs to
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when space was updated
-	User      struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"user" url:"user,key"` // identity of user account
-}
+type SpaceAppAccessListResult []SpaceAppAccess
 
 // List all users and their permissions on a space.
 func (s *Service) SpaceAppAccessList(ctx context.Context, spaceIdentity string, lr *ListRange) (SpaceAppAccessListResult, error) {
@@ -5941,16 +3371,10 @@ type SpaceNat struct {
 	State     string    `json:"state" url:"state,key"`           // availability of network address translation for a space
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when network address translation for a space was updated
 }
-type SpaceNatInfoResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when network address translation for a space was created
-	Sources   []string  `json:"sources" url:"sources,key"`       // potential IPs from which outbound network traffic will originate
-	State     string    `json:"state" url:"state,key"`           // availability of network address translation for a space
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when network address translation for a space was updated
-}
 
 // Current state of network address translation for a space.
-func (s *Service) SpaceNatInfo(ctx context.Context, spaceIdentity string) (*SpaceNatInfoResult, error) {
-	var spaceNat SpaceNatInfoResult
+func (s *Service) SpaceNatInfo(ctx context.Context, spaceIdentity string) (*SpaceNat, error) {
+	var spaceNat SpaceNat
 	return &spaceNat, s.Get(ctx, &spaceNat, fmt.Sprintf("/spaces/%v/nat", spaceIdentity), nil, nil)
 }
 
@@ -5977,75 +3401,26 @@ type SSLEndpointCreateOpts struct {
 	// ones, etc.
 	PrivateKey string `json:"private_key" url:"private_key,key"` // contents of the private key (eg .key file)
 }
-type SSLEndpointCreateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
-	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
-	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
-	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
-	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
-	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
-}
 
 // Create a new SSL endpoint.
-func (s *Service) SSLEndpointCreate(ctx context.Context, appIdentity string, o SSLEndpointCreateOpts) (*SSLEndpointCreateResult, error) {
-	var sslEndpoint SSLEndpointCreateResult
+func (s *Service) SSLEndpointCreate(ctx context.Context, appIdentity string, o SSLEndpointCreateOpts) (*SSLEndpoint, error) {
+	var sslEndpoint SSLEndpoint
 	return &sslEndpoint, s.Post(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints", appIdentity), o)
 }
 
-type SSLEndpointDeleteResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
-	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
-	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
-	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
-	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
-	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
-}
-
 // Delete existing SSL endpoint.
-func (s *Service) SSLEndpointDelete(ctx context.Context, appIdentity string, sslEndpointIdentity string) (*SSLEndpointDeleteResult, error) {
-	var sslEndpoint SSLEndpointDeleteResult
+func (s *Service) SSLEndpointDelete(ctx context.Context, appIdentity string, sslEndpointIdentity string) (*SSLEndpoint, error) {
+	var sslEndpoint SSLEndpoint
 	return &sslEndpoint, s.Delete(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity))
 }
 
-type SSLEndpointInfoResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
-	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
-	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
-	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
-	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
-	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
-}
-
 // Info for existing SSL endpoint.
-func (s *Service) SSLEndpointInfo(ctx context.Context, appIdentity string, sslEndpointIdentity string) (*SSLEndpointInfoResult, error) {
-	var sslEndpoint SSLEndpointInfoResult
+func (s *Service) SSLEndpointInfo(ctx context.Context, appIdentity string, sslEndpointIdentity string) (*SSLEndpoint, error) {
+	var sslEndpoint SSLEndpoint
 	return &sslEndpoint, s.Get(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity), nil, nil)
 }
 
-type SSLEndpointListResult []struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
-	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
-	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
-	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
-	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
-	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
-}
+type SSLEndpointListResult []SSLEndpoint
 
 // List existing SSL endpoints.
 func (s *Service) SSLEndpointList(ctx context.Context, appIdentity string, lr *ListRange) (SSLEndpointListResult, error) {
@@ -6061,22 +3436,10 @@ type SSLEndpointUpdateOpts struct {
 	PrivateKey *string `json:"private_key,omitempty" url:"private_key,omitempty,key"` // contents of the private key (eg .key file)
 	Rollback   *bool   `json:"rollback,omitempty" url:"rollback,omitempty,key"`       // indicates that a rollback should be performed
 }
-type SSLEndpointUpdateResult struct {
-	App struct {
-		ID   string `json:"id" url:"id,key"`     // unique identifier of app
-		Name string `json:"name" url:"name,key"` // unique name of app
-	} `json:"app" url:"app,key"` // application associated with this ssl-endpoint
-	CertificateChain string    `json:"certificate_chain" url:"certificate_chain,key"` // raw contents of the public certificate chain (eg: .crt or .pem file)
-	CName            string    `json:"cname" url:"cname,key"`                         // canonical name record, the address to point a domain at
-	CreatedAt        time.Time `json:"created_at" url:"created_at,key"`               // when endpoint was created
-	ID               string    `json:"id" url:"id,key"`                               // unique identifier of this SSL endpoint
-	Name             string    `json:"name" url:"name,key"`                           // unique name for SSL endpoint
-	UpdatedAt        time.Time `json:"updated_at" url:"updated_at,key"`               // when endpoint was updated
-}
 
 // Update an existing SSL endpoint.
-func (s *Service) SSLEndpointUpdate(ctx context.Context, appIdentity string, sslEndpointIdentity string, o SSLEndpointUpdateOpts) (*SSLEndpointUpdateResult, error) {
-	var sslEndpoint SSLEndpointUpdateResult
+func (s *Service) SSLEndpointUpdate(ctx context.Context, appIdentity string, sslEndpointIdentity string, o SSLEndpointUpdateOpts) (*SSLEndpoint, error) {
+	var sslEndpoint SSLEndpoint
 	return &sslEndpoint, s.Patch(ctx, &sslEndpoint, fmt.Sprintf("/apps/%v/ssl-endpoints/%v", appIdentity, sslEndpointIdentity), o)
 }
 
@@ -6089,32 +3452,539 @@ type Stack struct {
 	State     string    `json:"state" url:"state,key"`           // availability of this stack: beta, deprecated or public
 	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when stack was last modified
 }
-type StackInfoResult struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when stack was introduced
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of stack
-	Name      string    `json:"name" url:"name,key"`             // unique name of stack
-	State     string    `json:"state" url:"state,key"`           // availability of this stack: beta, deprecated or public
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when stack was last modified
-}
 
 // Stack info.
-func (s *Service) StackInfo(ctx context.Context, stackIdentity string) (*StackInfoResult, error) {
-	var stack StackInfoResult
+func (s *Service) StackInfo(ctx context.Context, stackIdentity string) (*Stack, error) {
+	var stack Stack
 	return &stack, s.Get(ctx, &stack, fmt.Sprintf("/stacks/%v", stackIdentity), nil, nil)
 }
 
-type StackListResult []struct {
-	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when stack was introduced
-	ID        string    `json:"id" url:"id,key"`                 // unique identifier of stack
-	Name      string    `json:"name" url:"name,key"`             // unique name of stack
-	State     string    `json:"state" url:"state,key"`           // availability of this stack: beta, deprecated or public
-	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when stack was last modified
-}
+type StackListResult []Stack
 
 // List available stacks.
 func (s *Service) StackList(ctx context.Context, lr *ListRange) (StackListResult, error) {
 	var stack StackListResult
 	return stack, s.Get(ctx, &stack, fmt.Sprintf("/stacks"), nil, lr)
+}
+
+// Teams allow you to manage access to a shared group of applications
+// and other resources.
+type Team struct {
+	CreatedAt             time.Time `json:"created_at" url:"created_at,key"`                           // when the team was created
+	CreditCardCollections bool      `json:"credit_card_collections" url:"credit_card_collections,key"` // whether charges incurred by the team are paid by credit card.
+	Default               bool      `json:"default" url:"default,key"`                                 // whether to use this team when none is specified
+	ID                    string    `json:"id" url:"id,key"`                                           // unique identifier of team
+	MembershipLimit       *float64  `json:"membership_limit" url:"membership_limit,key"`               // upper limit of members allowed in a team.
+	Name                  string    `json:"name" url:"name,key"`                                       // unique name of team
+	ProvisionedLicenses   bool      `json:"provisioned_licenses" url:"provisioned_licenses,key"`       // whether the team is provisioned licenses by salesforce.
+	Role                  *string   `json:"role" url:"role,key"`                                       // role in the team
+	Type                  string    `json:"type" url:"type,key"`                                       // type of team.
+	UpdatedAt             time.Time `json:"updated_at" url:"updated_at,key"`                           // when the team was updated
+}
+type TeamListResult []Team
+
+// List teams in which you are a member.
+func (s *Service) TeamList(ctx context.Context, lr *ListRange) (TeamListResult, error) {
+	var team TeamListResult
+	return team, s.Get(ctx, &team, fmt.Sprintf("/teams"), nil, lr)
+}
+
+// Info for a team.
+func (s *Service) TeamInfo(ctx context.Context, teamIdentity string) (*Team, error) {
+	var team Team
+	return &team, s.Get(ctx, &team, fmt.Sprintf("/teams/%v", teamIdentity), nil, nil)
+}
+
+type TeamUpdateOpts struct {
+	Default *bool   `json:"default,omitempty" url:"default,omitempty,key"` // whether to use this team when none is specified
+	Name    *string `json:"name,omitempty" url:"name,omitempty,key"`       // unique name of team
+}
+
+// Update team properties.
+func (s *Service) TeamUpdate(ctx context.Context, teamIdentity string, o TeamUpdateOpts) (*Team, error) {
+	var team Team
+	return &team, s.Patch(ctx, &team, fmt.Sprintf("/teams/%v", teamIdentity), o)
+}
+
+type TeamCreateOpts struct {
+	Address1        *string `json:"address_1,omitempty" url:"address_1,omitempty,key"`               // street address line 1
+	Address2        *string `json:"address_2,omitempty" url:"address_2,omitempty,key"`               // street address line 2
+	CardNumber      *string `json:"card_number,omitempty" url:"card_number,omitempty,key"`           // encrypted card number of payment method
+	City            *string `json:"city,omitempty" url:"city,omitempty,key"`                         // city
+	Country         *string `json:"country,omitempty" url:"country,omitempty,key"`                   // country
+	Cvv             *string `json:"cvv,omitempty" url:"cvv,omitempty,key"`                           // card verification value
+	ExpirationMonth *string `json:"expiration_month,omitempty" url:"expiration_month,omitempty,key"` // expiration month
+	ExpirationYear  *string `json:"expiration_year,omitempty" url:"expiration_year,omitempty,key"`   // expiration year
+	FirstName       *string `json:"first_name,omitempty" url:"first_name,omitempty,key"`             // the first name for payment method
+	LastName        *string `json:"last_name,omitempty" url:"last_name,omitempty,key"`               // the last name for payment method
+	Name            string  `json:"name" url:"name,key"`                                             // unique name of team
+	Other           *string `json:"other,omitempty" url:"other,omitempty,key"`                       // metadata
+	PostalCode      *string `json:"postal_code,omitempty" url:"postal_code,omitempty,key"`           // postal code
+	State           *string `json:"state,omitempty" url:"state,omitempty,key"`                       // state
+}
+
+// Create a new team.
+func (s *Service) TeamCreate(ctx context.Context, o TeamCreateOpts) (*Team, error) {
+	var team Team
+	return &team, s.Post(ctx, &team, fmt.Sprintf("/teams"), o)
+}
+
+// Delete an existing team.
+func (s *Service) TeamDelete(ctx context.Context, teamIdentity string) (*Team, error) {
+	var team Team
+	return &team, s.Delete(ctx, &team, fmt.Sprintf("/teams/%v", teamIdentity))
+}
+
+// An team app encapsulates the team specific functionality of Heroku
+// apps.
+type TeamApp struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Owner                        *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
+}
+type TeamAppCreateOpts struct {
+	Locked   *bool   `json:"locked,omitempty" url:"locked,omitempty,key"`     // are other team members forbidden from joining this app.
+	Name     *string `json:"name,omitempty" url:"name,omitempty,key"`         // unique name of app
+	Personal *bool   `json:"personal,omitempty" url:"personal,omitempty,key"` // force creation of the app in the user account even if a default team
+	// is set.
+	Region *string `json:"region,omitempty" url:"region,omitempty,key"` // unique name of region
+	Space  *string `json:"space,omitempty" url:"space,omitempty,key"`   // unique name of space
+	Stack  *string `json:"stack,omitempty" url:"stack,omitempty,key"`   // unique name of stack
+	Team   *string `json:"team,omitempty" url:"team,omitempty,key"`     // unique name of team
+}
+
+// Create a new app in the specified team, in the default team if
+// unspecified, or in personal account, if default team is not set.
+func (s *Service) TeamAppCreate(ctx context.Context, o TeamAppCreateOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Post(ctx, &teamApp, fmt.Sprintf("/teams/apps"), o)
+}
+
+type TeamAppListResult []TeamApp
+
+// List apps in the default team, or in personal account, if default
+// team is not set.
+func (s *Service) TeamAppList(ctx context.Context, lr *ListRange) (TeamAppListResult, error) {
+	var teamApp TeamAppListResult
+	return teamApp, s.Get(ctx, &teamApp, fmt.Sprintf("/teams/apps"), nil, lr)
+}
+
+// Info for a team app.
+func (s *Service) TeamAppInfo(ctx context.Context, teamAppIdentity string) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Get(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), nil, nil)
+}
+
+type TeamAppUpdateLockedOpts struct {
+	Locked bool `json:"locked" url:"locked,key"` // are other team members forbidden from joining this app.
+}
+
+// Lock or unlock a team app.
+func (s *Service) TeamAppUpdateLocked(ctx context.Context, teamAppIdentity string, o TeamAppUpdateLockedOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Patch(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), o)
+}
+
+type TeamAppTransferToAccountOpts struct {
+	Owner string `json:"owner" url:"owner,key"` // unique email address of account
+}
+
+// Transfer an existing team app to another Heroku account.
+func (s *Service) TeamAppTransferToAccount(ctx context.Context, teamAppIdentity string, o TeamAppTransferToAccountOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Patch(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), o)
+}
+
+type TeamAppTransferToTeamOpts struct {
+	Owner string `json:"owner" url:"owner,key"` // unique name of team
+}
+
+// Transfer an existing team app to another team.
+func (s *Service) TeamAppTransferToTeam(ctx context.Context, teamAppIdentity string, o TeamAppTransferToTeamOpts) (*TeamApp, error) {
+	var teamApp TeamApp
+	return &teamApp, s.Patch(ctx, &teamApp, fmt.Sprintf("/teams/apps/%v", teamAppIdentity), o)
+}
+
+type TeamAppListByTeamResult []TeamApp
+
+// List team apps.
+func (s *Service) TeamAppListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (TeamAppListByTeamResult, error) {
+	var teamApp TeamAppListByTeamResult
+	return teamApp, s.Get(ctx, &teamApp, fmt.Sprintf("/teams/%v/apps", teamIdentity), nil, lr)
+}
+
+// A team collaborator represents an account that has been given access
+// to a team app on Heroku.
+type TeamAppCollaborator struct {
+	App struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of app
+		Name string `json:"name" url:"name,key"` // unique name of app
+	} `json:"app" url:"app,key"` // app collaborator belongs to
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when collaborator was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of collaborator
+	Role      *string   `json:"role" url:"role,key"`             // role in the team
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when collaborator was updated
+	User      struct {
+		Email     string `json:"email" url:"email,key"`         // unique email address of account
+		Federated bool   `json:"federated" url:"federated,key"` // whether the user is federated and belongs to an Identity Provider
+		ID        string `json:"id" url:"id,key"`               // unique identifier of an account
+	} `json:"user" url:"user,key"` // identity of collaborated account
+}
+type TeamAppCollaboratorCreateOpts struct {
+	Permissions *[]*string `json:"permissions,omitempty" url:"permissions,omitempty,key"` // An array of permissions to give to the collaborator.
+	Silent      *bool      `json:"silent,omitempty" url:"silent,omitempty,key"`           // whether to suppress email invitation when creating collaborator
+	User        string     `json:"user" url:"user,key"`                                   // unique email address of account
+}
+
+// Create a new collaborator on a team app. Use this endpoint instead of
+// the `/apps/{app_id_or_name}/collaborator` endpoint when you want the
+// collaborator to be granted [permissions]
+// (https://devcenter.heroku.com/articles/org-users-access#roles-and-app-
+// permissions) according to their role in the team.
+func (s *Service) TeamAppCollaboratorCreate(ctx context.Context, appIdentity string, o TeamAppCollaboratorCreateOpts) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Post(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators", appIdentity), o)
+}
+
+// Delete an existing collaborator from a team app.
+func (s *Service) TeamAppCollaboratorDelete(ctx context.Context, teamAppIdentity string, teamAppCollaboratorIdentity string) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Delete(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators/%v", teamAppIdentity, teamAppCollaboratorIdentity))
+}
+
+// Info for a collaborator on a team app.
+func (s *Service) TeamAppCollaboratorInfo(ctx context.Context, teamAppIdentity string, teamAppCollaboratorIdentity string) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Get(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators/%v", teamAppIdentity, teamAppCollaboratorIdentity), nil, nil)
+}
+
+type TeamAppCollaboratorUpdateOpts struct {
+	Permissions []string `json:"permissions" url:"permissions,key"` // An array of permissions to give to the collaborator.
+}
+
+// Update an existing collaborator from a team app.
+func (s *Service) TeamAppCollaboratorUpdate(ctx context.Context, teamAppIdentity string, teamAppCollaboratorIdentity string, o TeamAppCollaboratorUpdateOpts) (*TeamAppCollaborator, error) {
+	var teamAppCollaborator TeamAppCollaborator
+	return &teamAppCollaborator, s.Patch(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators/%v", teamAppIdentity, teamAppCollaboratorIdentity), o)
+}
+
+type TeamAppCollaboratorListResult []TeamAppCollaborator
+
+// List collaborators on a team app.
+func (s *Service) TeamAppCollaboratorList(ctx context.Context, teamAppIdentity string, lr *ListRange) (TeamAppCollaboratorListResult, error) {
+	var teamAppCollaborator TeamAppCollaboratorListResult
+	return teamAppCollaborator, s.Get(ctx, &teamAppCollaborator, fmt.Sprintf("/teams/apps/%v/collaborators", teamAppIdentity), nil, lr)
+}
+
+// A team app permission is a behavior that is assigned to a user in a
+// team app.
+type TeamAppPermission struct {
+	Description string `json:"description" url:"description,key"` // A description of what the app permission allows.
+	Name        string `json:"name" url:"name,key"`               // The name of the app permission.
+}
+type TeamAppPermissionListResult []TeamAppPermission
+
+// Lists permissions available to teams.
+func (s *Service) TeamAppPermissionList(ctx context.Context, lr *ListRange) (TeamAppPermissionListResult, error) {
+	var teamAppPermission TeamAppPermissionListResult
+	return teamAppPermission, s.Get(ctx, &teamAppPermission, fmt.Sprintf("/teams/permissions"), nil, lr)
+}
+
+// A team feature represents a feature enabled on a team account.
+type TeamFeature struct {
+	CreatedAt     time.Time `json:"created_at" url:"created_at,key"`         // when team feature was created
+	Description   string    `json:"description" url:"description,key"`       // description of team feature
+	DisplayName   string    `json:"display_name" url:"display_name,key"`     // user readable feature name
+	DocURL        string    `json:"doc_url" url:"doc_url,key"`               // documentation URL of team feature
+	Enabled       bool      `json:"enabled" url:"enabled,key"`               // whether or not team feature has been enabled
+	FeedbackEmail string    `json:"feedback_email" url:"feedback_email,key"` // e-mail to send feedback about the feature
+	ID            string    `json:"id" url:"id,key"`                         // unique identifier of team feature
+	Name          string    `json:"name" url:"name,key"`                     // unique name of team feature
+	State         string    `json:"state" url:"state,key"`                   // state of team feature
+	UpdatedAt     time.Time `json:"updated_at" url:"updated_at,key"`         // when team feature was updated
+}
+
+// Info for an existing team feature.
+func (s *Service) TeamFeatureInfo(ctx context.Context, teamIdentity string, teamFeatureIdentity string) (*TeamFeature, error) {
+	var teamFeature TeamFeature
+	return &teamFeature, s.Get(ctx, &teamFeature, fmt.Sprintf("/teams/%v/features/%v", teamIdentity, teamFeatureIdentity), nil, nil)
+}
+
+type TeamFeatureListResult []TeamFeature
+
+// List existing team features.
+func (s *Service) TeamFeatureList(ctx context.Context, teamIdentity string, lr *ListRange) (TeamFeatureListResult, error) {
+	var teamFeature TeamFeatureListResult
+	return teamFeature, s.Get(ctx, &teamFeature, fmt.Sprintf("/teams/%v/features", teamIdentity), nil, lr)
+}
+
+// A team invitation represents an invite to a team.
+type TeamInvitation struct {
+	CreatedAt time.Time `json:"created_at" url:"created_at,key"` // when invitation was created
+	ID        string    `json:"id" url:"id,key"`                 // unique identifier of an invitation
+	InvitedBy struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"invited_by" url:"invited_by,key"`
+	Role *string `json:"role" url:"role,key"` // role in the team
+	Team struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of team
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"`
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when invitation was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"`
+}
+type TeamInvitationListResult []TeamInvitation
+
+// Get a list of a team's Identity Providers
+func (s *Service) TeamInvitationList(ctx context.Context, teamName string, lr *ListRange) (TeamInvitationListResult, error) {
+	var teamInvitation TeamInvitationListResult
+	return teamInvitation, s.Get(ctx, &teamInvitation, fmt.Sprintf("/teams/%v/invitations", teamName), nil, lr)
+}
+
+type TeamInvitationCreateOpts struct {
+	Email string  `json:"email" url:"email,key"` // unique email address of account
+	Role  *string `json:"role" url:"role,key"`   // role in the team
+}
+
+// Create Team Invitation
+func (s *Service) TeamInvitationCreate(ctx context.Context, teamIdentity string, o TeamInvitationCreateOpts) (*TeamInvitation, error) {
+	var teamInvitation TeamInvitation
+	return &teamInvitation, s.Put(ctx, &teamInvitation, fmt.Sprintf("/teams/%v/invitations", teamIdentity), o)
+}
+
+// Revoke a team invitation.
+func (s *Service) TeamInvitationRevoke(ctx context.Context, teamIdentity string, teamInvitationIdentity string) (*TeamInvitation, error) {
+	var teamInvitation TeamInvitation
+	return &teamInvitation, s.Delete(ctx, &teamInvitation, fmt.Sprintf("/teams/%v/invitations/%v", teamIdentity, teamInvitationIdentity))
+}
+
+// Get an invitation by its token
+func (s *Service) TeamInvitationGet(ctx context.Context, teamInvitationToken string, lr *ListRange) (*TeamInvitation, error) {
+	var teamInvitation TeamInvitation
+	return &teamInvitation, s.Get(ctx, &teamInvitation, fmt.Sprintf("/teams/invitations/%v", teamInvitationToken), nil, lr)
+}
+
+type TeamInvitationAcceptResult struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the team member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of the team member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the team
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise team member has two factor authentication
+	// enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
+}
+
+// Accept Team Invitation
+func (s *Service) TeamInvitationAccept(ctx context.Context, teamInvitationToken string) (*TeamInvitationAcceptResult, error) {
+	var teamInvitation TeamInvitationAcceptResult
+	return &teamInvitation, s.Post(ctx, &teamInvitation, fmt.Sprintf("/teams/invitations/%v/accept", teamInvitationToken), nil)
+}
+
+// A Team Invoice is an itemized bill of goods for a team which includes
+// pricing and charges.
+type TeamInvoice struct {
+	AddonsTotal       int       `json:"addons_total" url:"addons_total,key"`               // total add-ons charges in on this invoice
+	ChargesTotal      int       `json:"charges_total" url:"charges_total,key"`             // total charges on this invoice
+	CreatedAt         time.Time `json:"created_at" url:"created_at,key"`                   // when invoice was created
+	CreditsTotal      int       `json:"credits_total" url:"credits_total,key"`             // total credits on this invoice
+	DatabaseTotal     int       `json:"database_total" url:"database_total,key"`           // total database charges on this invoice
+	DynoUnits         float64   `json:"dyno_units" url:"dyno_units,key"`                   // total amount of dyno units consumed across dyno types.
+	ID                string    `json:"id" url:"id,key"`                                   // unique identifier of this invoice
+	Number            int       `json:"number" url:"number,key"`                           // human readable invoice number
+	PaymentStatus     string    `json:"payment_status" url:"payment_status,key"`           // status of the invoice payment
+	PeriodEnd         string    `json:"period_end" url:"period_end,key"`                   // the ending date that the invoice covers
+	PeriodStart       string    `json:"period_start" url:"period_start,key"`               // the starting date that this invoice covers
+	PlatformTotal     int       `json:"platform_total" url:"platform_total,key"`           // total platform charges on this invoice
+	State             int       `json:"state" url:"state,key"`                             // payment status for this invoice (pending, successful, failed)
+	Total             int       `json:"total" url:"total,key"`                             // combined total of charges and credits on this invoice
+	UpdatedAt         time.Time `json:"updated_at" url:"updated_at,key"`                   // when invoice was updated
+	WeightedDynoHours float64   `json:"weighted_dyno_hours" url:"weighted_dyno_hours,key"` // The total amount of hours consumed across dyno types.
+}
+
+// Info for existing invoice.
+func (s *Service) TeamInvoiceInfo(ctx context.Context, teamIdentity string, teamInvoiceIdentity int) (*TeamInvoice, error) {
+	var teamInvoice TeamInvoice
+	return &teamInvoice, s.Get(ctx, &teamInvoice, fmt.Sprintf("/teams/%v/invoices/%v", teamIdentity, teamInvoiceIdentity), nil, nil)
+}
+
+type TeamInvoiceListResult []TeamInvoice
+
+// List existing invoices.
+func (s *Service) TeamInvoiceList(ctx context.Context, teamIdentity string, lr *ListRange) (TeamInvoiceListResult, error) {
+	var teamInvoice TeamInvoiceListResult
+	return teamInvoice, s.Get(ctx, &teamInvoice, fmt.Sprintf("/teams/%v/invoices", teamIdentity), nil, lr)
+}
+
+// A team member is an individual with access to a team.
+type TeamMember struct {
+	CreatedAt               time.Time `json:"created_at" url:"created_at,key"`                               // when the membership record was created
+	Email                   string    `json:"email" url:"email,key"`                                         // email address of the team member
+	Federated               bool      `json:"federated" url:"federated,key"`                                 // whether the user is federated and belongs to an Identity Provider
+	ID                      string    `json:"id" url:"id,key"`                                               // unique identifier of the team member
+	Role                    *string   `json:"role" url:"role,key"`                                           // role in the team
+	TwoFactorAuthentication bool      `json:"two_factor_authentication" url:"two_factor_authentication,key"` // whether the Enterprise team member has two factor authentication
+	// enabled
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when the membership record was updated
+	User      struct {
+		Email string  `json:"email" url:"email,key"` // unique email address of account
+		ID    string  `json:"id" url:"id,key"`       // unique identifier of an account
+		Name  *string `json:"name" url:"name,key"`   // full name of the account owner
+	} `json:"user" url:"user,key"` // user information for the membership
+}
+type TeamMemberCreateOrUpdateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the team member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the team
+}
+
+// Create a new team member, or update their role.
+func (s *Service) TeamMemberCreateOrUpdate(ctx context.Context, teamIdentity string, o TeamMemberCreateOrUpdateOpts) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Put(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), o)
+}
+
+type TeamMemberCreateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the team member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the team
+}
+
+// Create a new team member.
+func (s *Service) TeamMemberCreate(ctx context.Context, teamIdentity string, o TeamMemberCreateOpts) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Post(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), o)
+}
+
+type TeamMemberUpdateOpts struct {
+	Email     string  `json:"email" url:"email,key"`                             // email address of the team member
+	Federated *bool   `json:"federated,omitempty" url:"federated,omitempty,key"` // whether the user is federated and belongs to an Identity Provider
+	Role      *string `json:"role" url:"role,key"`                               // role in the team
+}
+
+// Update a team member.
+func (s *Service) TeamMemberUpdate(ctx context.Context, teamIdentity string, o TeamMemberUpdateOpts) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Patch(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), o)
+}
+
+// Remove a member from the team.
+func (s *Service) TeamMemberDelete(ctx context.Context, teamIdentity string, teamMemberIdentity string) (*TeamMember, error) {
+	var teamMember TeamMember
+	return &teamMember, s.Delete(ctx, &teamMember, fmt.Sprintf("/teams/%v/members/%v", teamIdentity, teamMemberIdentity))
+}
+
+type TeamMemberListResult []TeamMember
+
+// List members of the team.
+func (s *Service) TeamMemberList(ctx context.Context, teamIdentity string, lr *ListRange) (TeamMemberListResult, error) {
+	var teamMember TeamMemberListResult
+	return teamMember, s.Get(ctx, &teamMember, fmt.Sprintf("/teams/%v/members", teamIdentity), nil, lr)
+}
+
+type TeamMemberListByMemberResult []struct {
+	ArchivedAt                   *time.Time `json:"archived_at" url:"archived_at,key"`                                       // when app was archived
+	BuildpackProvidedDescription *string    `json:"buildpack_provided_description" url:"buildpack_provided_description,key"` // description from buildpack of app
+	CreatedAt                    time.Time  `json:"created_at" url:"created_at,key"`                                         // when app was created
+	GitURL                       string     `json:"git_url" url:"git_url,key"`                                               // git repo URL of app
+	ID                           string     `json:"id" url:"id,key"`                                                         // unique identifier of app
+	Joined                       bool       `json:"joined" url:"joined,key"`                                                 // is the current member a collaborator on this app.
+	Locked                       bool       `json:"locked" url:"locked,key"`                                                 // are other team members forbidden from joining this app.
+	Maintenance                  bool       `json:"maintenance" url:"maintenance,key"`                                       // maintenance status of app
+	Name                         string     `json:"name" url:"name,key"`                                                     // unique name of app
+	Owner                        *struct {
+		Email string `json:"email" url:"email,key"` // unique email address of account
+		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
+	} `json:"owner" url:"owner,key"` // identity of app owner
+	Region struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of region
+		Name string `json:"name" url:"name,key"` // unique name of region
+	} `json:"region" url:"region,key"` // identity of app region
+	ReleasedAt *time.Time `json:"released_at" url:"released_at,key"` // when app was released
+	RepoSize   *int       `json:"repo_size" url:"repo_size,key"`     // git repo size in bytes of app
+	SlugSize   *int       `json:"slug_size" url:"slug_size,key"`     // slug size in bytes of app
+	Space      *struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of space
+		Name string `json:"name" url:"name,key"` // unique name of space
+	} `json:"space" url:"space,key"` // identity of space
+	Stack struct {
+		ID   string `json:"id" url:"id,key"`     // unique identifier of stack
+		Name string `json:"name" url:"name,key"` // unique name of stack
+	} `json:"stack" url:"stack,key"` // identity of app stack
+	Team *struct {
+		Name string `json:"name" url:"name,key"` // unique name of team
+	} `json:"team" url:"team,key"` // team that owns this app
+	UpdatedAt time.Time `json:"updated_at" url:"updated_at,key"` // when app was updated
+	WebURL    string    `json:"web_url" url:"web_url,key"`       // web URL of app
+}
+
+// List the apps of a team member.
+func (s *Service) TeamMemberListByMember(ctx context.Context, teamIdentity string, teamMemberIdentity string, lr *ListRange) (TeamMemberListByMemberResult, error) {
+	var teamMember TeamMemberListByMemberResult
+	return teamMember, s.Get(ctx, &teamMember, fmt.Sprintf("/teams/%v/members/%v/apps", teamIdentity, teamMemberIdentity), nil, lr)
+}
+
+// Tracks a Team's Preferences
+type TeamPreferences struct {
+	DefaultPermission   *string `json:"default-permission" url:"default-permission,key"`     // The default permission used when adding new members to the team
+	WhitelistingEnabled *bool   `json:"whitelisting-enabled" url:"whitelisting-enabled,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+
+// Retrieve Team Preferences
+func (s *Service) TeamPreferencesList(ctx context.Context, teamPreferencesIdentity string) (*TeamPreferences, error) {
+	var teamPreferences TeamPreferences
+	return &teamPreferences, s.Get(ctx, &teamPreferences, fmt.Sprintf("/teams/%v/preferences", teamPreferencesIdentity), nil, nil)
+}
+
+type TeamPreferencesUpdateOpts struct {
+	WhitelistingEnabled *bool `json:"whitelisting-enabled,omitempty" url:"whitelisting-enabled,omitempty,key"` // Whether whitelisting rules should be applied to add-on installations
+}
+
+// Update Team Preferences
+func (s *Service) TeamPreferencesUpdate(ctx context.Context, teamPreferencesIdentity string, o TeamPreferencesUpdateOpts) (*TeamPreferences, error) {
+	var teamPreferences TeamPreferences
+	return &teamPreferences, s.Patch(ctx, &teamPreferences, fmt.Sprintf("/teams/%v/preferences", teamPreferencesIdentity), o)
 }
 
 // Tracks a user's preferences and message dismissals
@@ -6132,24 +4002,10 @@ type UserPreferences struct {
 	DismissedSmsBanner              *bool     `json:"dismissed-sms-banner" url:"dismissed-sms-banner,key"`                             // Whether the user has dismissed the 2FA SMS banner
 	Timezone                        *string   `json:"timezone" url:"timezone,key"`                                                     // User's default timezone
 }
-type UserPreferencesListResult struct {
-	DefaultOrganization        *string `json:"default-organization" url:"default-organization,key"`                   // User's default organization
-	DismissedGettingStarted    *bool   `json:"dismissed-getting-started" url:"dismissed-getting-started,key"`         // Whether the user has dismissed the getting started banner
-	DismissedGithubBanner      *bool   `json:"dismissed-github-banner" url:"dismissed-github-banner,key"`             // Whether the user has dismissed the GitHub link banner
-	DismissedOrgAccessControls *bool   `json:"dismissed-org-access-controls" url:"dismissed-org-access-controls,key"` // Whether the user has dismissed the Organization Access Controls
-	// banner
-	DismissedOrgWizardNotification *bool `json:"dismissed-org-wizard-notification" url:"dismissed-org-wizard-notification,key"` // Whether the user has dismissed the Organization Wizard
-	DismissedPipelinesBanner       *bool `json:"dismissed-pipelines-banner" url:"dismissed-pipelines-banner,key"`               // Whether the user has dismissed the Pipelines banner
-	DismissedPipelinesGithubBanner *bool `json:"dismissed-pipelines-github-banner" url:"dismissed-pipelines-github-banner,key"` // Whether the user has dismissed the GitHub banner on a pipeline
-	// overview
-	DismissedPipelinesGithubBanners *[]string `json:"dismissed-pipelines-github-banners" url:"dismissed-pipelines-github-banners,key"` // Which pipeline uuids the user has dismissed the GitHub banner for
-	DismissedSmsBanner              *bool     `json:"dismissed-sms-banner" url:"dismissed-sms-banner,key"`                             // Whether the user has dismissed the 2FA SMS banner
-	Timezone                        *string   `json:"timezone" url:"timezone,key"`                                                     // User's default timezone
-}
 
 // Retrieve User Preferences
-func (s *Service) UserPreferencesList(ctx context.Context, userPreferencesIdentity string) (*UserPreferencesListResult, error) {
-	var userPreferences UserPreferencesListResult
+func (s *Service) UserPreferencesList(ctx context.Context, userPreferencesIdentity string) (*UserPreferences, error) {
+	var userPreferences UserPreferences
 	return &userPreferences, s.Get(ctx, &userPreferences, fmt.Sprintf("/users/%v/preferences", userPreferencesIdentity), nil, nil)
 }
 
@@ -6167,24 +4023,10 @@ type UserPreferencesUpdateOpts struct {
 	DismissedSmsBanner              *bool      `json:"dismissed-sms-banner,omitempty" url:"dismissed-sms-banner,omitempty,key"`                             // Whether the user has dismissed the 2FA SMS banner
 	Timezone                        *string    `json:"timezone,omitempty" url:"timezone,omitempty,key"`                                                     // User's default timezone
 }
-type UserPreferencesUpdateResult struct {
-	DefaultOrganization        *string `json:"default-organization" url:"default-organization,key"`                   // User's default organization
-	DismissedGettingStarted    *bool   `json:"dismissed-getting-started" url:"dismissed-getting-started,key"`         // Whether the user has dismissed the getting started banner
-	DismissedGithubBanner      *bool   `json:"dismissed-github-banner" url:"dismissed-github-banner,key"`             // Whether the user has dismissed the GitHub link banner
-	DismissedOrgAccessControls *bool   `json:"dismissed-org-access-controls" url:"dismissed-org-access-controls,key"` // Whether the user has dismissed the Organization Access Controls
-	// banner
-	DismissedOrgWizardNotification *bool `json:"dismissed-org-wizard-notification" url:"dismissed-org-wizard-notification,key"` // Whether the user has dismissed the Organization Wizard
-	DismissedPipelinesBanner       *bool `json:"dismissed-pipelines-banner" url:"dismissed-pipelines-banner,key"`               // Whether the user has dismissed the Pipelines banner
-	DismissedPipelinesGithubBanner *bool `json:"dismissed-pipelines-github-banner" url:"dismissed-pipelines-github-banner,key"` // Whether the user has dismissed the GitHub banner on a pipeline
-	// overview
-	DismissedPipelinesGithubBanners *[]string `json:"dismissed-pipelines-github-banners" url:"dismissed-pipelines-github-banners,key"` // Which pipeline uuids the user has dismissed the GitHub banner for
-	DismissedSmsBanner              *bool     `json:"dismissed-sms-banner" url:"dismissed-sms-banner,key"`                             // Whether the user has dismissed the 2FA SMS banner
-	Timezone                        *string   `json:"timezone" url:"timezone,key"`                                                     // User's default timezone
-}
 
 // Update User Preferences
-func (s *Service) UserPreferencesUpdate(ctx context.Context, userPreferencesIdentity string, o UserPreferencesUpdateOpts) (*UserPreferencesUpdateResult, error) {
-	var userPreferences UserPreferencesUpdateResult
+func (s *Service) UserPreferencesUpdate(ctx context.Context, userPreferencesIdentity string, o UserPreferencesUpdateOpts) (*UserPreferences, error) {
+	var userPreferences UserPreferences
 	return &userPreferences, s.Patch(ctx, &userPreferences, fmt.Sprintf("/users/%v/preferences", userPreferencesIdentity), o)
 }
 
@@ -6202,65 +4044,53 @@ type WhitelistedAddOnService struct {
 	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
 	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
 }
-type WhitelistedAddOnServiceListResult []struct {
-	AddedAt time.Time `json:"added_at" url:"added_at,key"` // when the add-on service was whitelisted
-	AddedBy struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"added_by" url:"added_by,key"` // the user which whitelisted the Add-on Service
-	AddonService struct {
-		HumanName string `json:"human_name" url:"human_name,key"` // human-readable name of the add-on service provider
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of this add-on-service
-		Name      string `json:"name" url:"name,key"`             // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
-	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
-}
+type WhitelistedAddOnServiceListByOrganizationResult []WhitelistedAddOnService
 
 // List all whitelisted Add-on Services for an Organization
-func (s *Service) WhitelistedAddOnServiceList(ctx context.Context, organizationIdentity string, lr *ListRange) (WhitelistedAddOnServiceListResult, error) {
-	var whitelistedAddOnService WhitelistedAddOnServiceListResult
+func (s *Service) WhitelistedAddOnServiceListByOrganization(ctx context.Context, organizationIdentity string, lr *ListRange) (WhitelistedAddOnServiceListByOrganizationResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceListByOrganizationResult
 	return whitelistedAddOnService, s.Get(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services", organizationIdentity), nil, lr)
 }
 
-type WhitelistedAddOnServiceCreateOpts struct {
+type WhitelistedAddOnServiceCreateByOrganizationOpts struct {
 	AddonService *string `json:"addon_service,omitempty" url:"addon_service,omitempty,key"` // name of the Add-on to whitelist
 }
-type WhitelistedAddOnServiceCreateResult []struct {
-	AddedAt time.Time `json:"added_at" url:"added_at,key"` // when the add-on service was whitelisted
-	AddedBy struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"added_by" url:"added_by,key"` // the user which whitelisted the Add-on Service
-	AddonService struct {
-		HumanName string `json:"human_name" url:"human_name,key"` // human-readable name of the add-on service provider
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of this add-on-service
-		Name      string `json:"name" url:"name,key"`             // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
-	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
-}
+type WhitelistedAddOnServiceCreateByOrganizationResult []WhitelistedAddOnService
 
 // Whitelist an Add-on Service
-func (s *Service) WhitelistedAddOnServiceCreate(ctx context.Context, organizationIdentity string, o WhitelistedAddOnServiceCreateOpts) (WhitelistedAddOnServiceCreateResult, error) {
-	var whitelistedAddOnService WhitelistedAddOnServiceCreateResult
+func (s *Service) WhitelistedAddOnServiceCreateByOrganization(ctx context.Context, organizationIdentity string, o WhitelistedAddOnServiceCreateByOrganizationOpts) (WhitelistedAddOnServiceCreateByOrganizationResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceCreateByOrganizationResult
 	return whitelistedAddOnService, s.Post(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services", organizationIdentity), o)
 }
 
-type WhitelistedAddOnServiceDeleteResult struct {
-	AddedAt time.Time `json:"added_at" url:"added_at,key"` // when the add-on service was whitelisted
-	AddedBy struct {
-		Email string `json:"email" url:"email,key"` // unique email address of account
-		ID    string `json:"id" url:"id,key"`       // unique identifier of an account
-	} `json:"added_by" url:"added_by,key"` // the user which whitelisted the Add-on Service
-	AddonService struct {
-		HumanName string `json:"human_name" url:"human_name,key"` // human-readable name of the add-on service provider
-		ID        string `json:"id" url:"id,key"`                 // unique identifier of this add-on-service
-		Name      string `json:"name" url:"name,key"`             // unique name of this add-on-service
-	} `json:"addon_service" url:"addon_service,key"` // the Add-on Service whitelisted for use
-	ID string `json:"id" url:"id,key"` // unique identifier for this whitelisting entity
+// Remove a whitelisted entity
+func (s *Service) WhitelistedAddOnServiceDeleteByOrganization(ctx context.Context, organizationIdentity string, whitelistedAddOnServiceIdentity string) (*WhitelistedAddOnService, error) {
+	var whitelistedAddOnService WhitelistedAddOnService
+	return &whitelistedAddOnService, s.Delete(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services/%v", organizationIdentity, whitelistedAddOnServiceIdentity))
+}
+
+type WhitelistedAddOnServiceListByTeamResult []WhitelistedAddOnService
+
+// List all whitelisted Add-on Services for a Team
+func (s *Service) WhitelistedAddOnServiceListByTeam(ctx context.Context, teamIdentity string, lr *ListRange) (WhitelistedAddOnServiceListByTeamResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceListByTeamResult
+	return whitelistedAddOnService, s.Get(ctx, &whitelistedAddOnService, fmt.Sprintf("/teams/%v/whitelisted-addon-services", teamIdentity), nil, lr)
+}
+
+type WhitelistedAddOnServiceCreateByTeamOpts struct {
+	AddonService *string `json:"addon_service,omitempty" url:"addon_service,omitempty,key"` // name of the Add-on to whitelist
+}
+type WhitelistedAddOnServiceCreateByTeamResult []WhitelistedAddOnService
+
+// Whitelist an Add-on Service
+func (s *Service) WhitelistedAddOnServiceCreateByTeam(ctx context.Context, teamIdentity string, o WhitelistedAddOnServiceCreateByTeamOpts) (WhitelistedAddOnServiceCreateByTeamResult, error) {
+	var whitelistedAddOnService WhitelistedAddOnServiceCreateByTeamResult
+	return whitelistedAddOnService, s.Post(ctx, &whitelistedAddOnService, fmt.Sprintf("/teams/%v/whitelisted-addon-services", teamIdentity), o)
 }
 
 // Remove a whitelisted entity
-func (s *Service) WhitelistedAddOnServiceDelete(ctx context.Context, organizationIdentity string, whitelistedAddOnServiceIdentity string) (*WhitelistedAddOnServiceDeleteResult, error) {
-	var whitelistedAddOnService WhitelistedAddOnServiceDeleteResult
-	return &whitelistedAddOnService, s.Delete(ctx, &whitelistedAddOnService, fmt.Sprintf("/organizations/%v/whitelisted-addon-services/%v", organizationIdentity, whitelistedAddOnServiceIdentity))
+func (s *Service) WhitelistedAddOnServiceDeleteByTeam(ctx context.Context, teamIdentity string, whitelistedAddOnServiceIdentity string) (*WhitelistedAddOnService, error) {
+	var whitelistedAddOnService WhitelistedAddOnService
+	return &whitelistedAddOnService, s.Delete(ctx, &whitelistedAddOnService, fmt.Sprintf("/teams/%v/whitelisted-addon-services/%v", teamIdentity, whitelistedAddOnServiceIdentity))
 }
+

--- a/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
+++ b/vendor/github.com/cyberdelia/heroku-go/v3/schema.json
@@ -90,6 +90,22 @@
           "type": [
             "string"
           ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
@@ -166,6 +182,12 @@
         },
         "updated_at": {
           "$ref": "#/definitions/account-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/account-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/account-feature/definitions/feedback_email"
         }
       }
     },
@@ -394,7 +416,7 @@
           "targetSchema": {
             "$ref": "#/definitions/account"
           },
-          "title": "Info"
+          "title": "Info By User"
         },
         {
           "description": "Update account.",
@@ -420,7 +442,7 @@
           "targetSchema": {
             "$ref": "#/definitions/account"
           },
-          "title": "Update"
+          "title": "Update By User"
         },
         {
           "description": "Delete account. Note that this action cannot be undone.",
@@ -430,7 +452,7 @@
           "targetSchema": {
             "$ref": "#/definitions/account"
           },
-          "title": "Delete"
+          "title": "Delete By User"
         }
       ],
       "properties": {
@@ -536,7 +558,7 @@
           "targetSchema": {
             "$ref": "#/definitions/add-on"
           },
-          "title": "Create - Provision"
+          "title": "Provision"
         },
         {
           "description": "Mark an add-on as deprovisioned.",
@@ -546,7 +568,7 @@
           "targetSchema": {
             "$ref": "#/definitions/add-on"
           },
-          "title": "Create - Deprovision"
+          "title": "Deprovision"
         }
       ],
       "properties": {
@@ -614,6 +636,15 @@
             "string"
           ]
         },
+        "namespace": {
+          "description": "attachment namespace",
+          "example": "role:analytics",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "updated_at": {
           "description": "when add-on attachment was updated",
           "example": "2012-01-01T12:00:00Z",
@@ -653,6 +684,9 @@
               },
               "name": {
                 "$ref": "#/definitions/add-on-attachment/definitions/name"
+              },
+              "namespace": {
+                "$ref": "#/definitions/add-on-attachment/definitions/namespace"
               }
             },
             "required": [
@@ -818,6 +852,9 @@
         },
         "name": {
           "$ref": "#/definitions/add-on-attachment/definitions/name"
+        },
+        "namespace": {
+          "$ref": "#/definitions/add-on-attachment/definitions/namespace"
         },
         "updated_at": {
           "$ref": "#/definitions/add-on-attachment/definitions/updated_at"
@@ -1063,7 +1100,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Region"
         }
       ],
       "properties": {
@@ -1378,6 +1415,31 @@
       },
       "links": [
         {
+          "description": "List all existing add-ons.",
+          "href": "/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for an existing add-on.",
+          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/add-on"
+          },
+          "title": "Info"
+        },
+        {
           "description": "Create a new add-on.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/addons",
           "method": "POST",
@@ -1447,47 +1509,7 @@
           "targetSchema": {
             "$ref": "#/definitions/add-on"
           },
-          "title": "Info"
-        },
-        {
-          "description": "List all existing add-ons.",
-          "href": "/addons",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/add-on"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List"
-        },
-        {
-          "description": "Info for an existing add-on.",
-          "href": "/addons/{(%23%2Fdefinitions%2Fadd-on%2Fdefinitions%2Fidentity)}",
-          "method": "GET",
-          "rel": "self",
-          "targetSchema": {
-            "$ref": "#/definitions/add-on"
-          },
-          "title": "Info"
-        },
-        {
-          "description": "List all existing add-ons a user has access to",
-          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/addons",
-          "method": "GET",
-          "rel": "instances",
-          "targetSchema": {
-            "items": {
-              "$ref": "#/definitions/add-on"
-            },
-            "type": [
-              "array"
-            ]
-          },
-          "title": "List by User"
+          "title": "Info By App"
         },
         {
           "description": "List existing add-ons for an app.",
@@ -1502,7 +1524,7 @@
               "array"
             ]
           },
-          "title": "List by App"
+          "title": "List By App"
         },
         {
           "description": "Change add-on plan. Some add-ons may not support changing plans. In that case, an error will be returned.",
@@ -1523,6 +1545,36 @@
             ]
           },
           "title": "Update"
+        },
+        {
+          "description": "List all existing add-ons a user has access to",
+          "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By User"
+        },
+        {
+          "description": "List add-ons used across all Team apps",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/addons",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/add-on"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
         }
       ],
       "properties": {
@@ -1686,6 +1738,22 @@
           "type": [
             "string"
           ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
@@ -1762,6 +1830,12 @@
         },
         "updated_at": {
           "$ref": "#/definitions/app-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/app-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/app-feature/definitions/feedback_email"
         }
       }
     },
@@ -2597,7 +2671,7 @@
           "title": "List"
         },
         {
-          "description": "List owned and collaborated apps (excludes organization apps).",
+          "description": "List owned and collaborated apps (excludes team apps).",
           "href": "/users/{(%23%2Fdefinitions%2Faccount%2Fdefinitions%2Fidentity)}/apps",
           "method": "GET",
           "ranges": [
@@ -2703,6 +2777,21 @@
             },
             "name": {
               "$ref": "#/definitions/organization/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "team": {
+          "description": "identity of team",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
             }
           },
           "type": [
@@ -3443,11 +3532,11 @@
             "array"
           ],
           "items": {
-            "$ref": "#/definitions/organization-app-permission"
+            "$ref": "#/definitions/team-app-permission"
           }
         },
         "role": {
-          "$ref": "#/definitions/organization/definitions/role"
+          "$ref": "#/definitions/team/definitions/role"
         },
         "updated_at": {
           "$ref": "#/definitions/collaborator/definitions/updated_at"
@@ -4455,6 +4544,9 @@
             },
             {
               "$ref": "#/definitions/space"
+            },
+            {
+              "$ref": "#/definitions/team"
             }
           ],
           "readOnly": true,
@@ -4507,6 +4599,7 @@
             "organization",
             "release",
             "space",
+            "team",
             "user"
           ],
           "example": "app",
@@ -4782,7 +4875,7 @@
           },
           "targetSchema": {
             "items": {
-              "$ref": "#/definitions/organization-app"
+              "$ref": "#/definitions/team-app"
             },
             "type": [
               "array"
@@ -4952,7 +5045,7 @@
               "array"
             ]
           },
-          "title": "Batch update"
+          "title": "Batch Update"
         },
         {
           "description": "Update process type",
@@ -5103,7 +5196,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Organization"
         },
         {
           "description": "Create an Identity Provider for an organization",
@@ -5137,7 +5230,7 @@
           "targetSchema": {
             "$ref": "#/definitions/identity-provider"
           },
-          "title": "Create"
+          "title": "Create By Organization"
         },
         {
           "description": "Update an organization's Identity Provider",
@@ -5166,7 +5259,7 @@
           "targetSchema": {
             "$ref": "#/definitions/identity-provider"
           },
-          "title": "Update"
+          "title": "Update By Organization"
         },
         {
           "description": "Delete an organization's Identity Provider",
@@ -5176,7 +5269,95 @@
           "targetSchema": {
             "$ref": "#/definitions/identity-provider"
           },
-          "title": "Delete"
+          "title": "Delete By Organization"
+        },
+        {
+          "description": "Get a list of a team's Identity Providers",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/identity-providers",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/identity-provider"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Create an Identity Provider for a team",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/identity-providers",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "required": [
+              "certificate",
+              "sso_target_url",
+              "entity_id"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Create By Team"
+        },
+        {
+          "description": "Update a team's Identity Provider",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "certificate": {
+                "$ref": "#/definitions/identity-provider/definitions/certificate"
+              },
+              "entity_id": {
+                "$ref": "#/definitions/identity-provider/definitions/entity_id"
+              },
+              "slo_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/slo_target_url"
+              },
+              "sso_target_url": {
+                "$ref": "#/definitions/identity-provider/definitions/sso_target_url"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Update By Team"
+        },
+        {
+          "description": "Delete a team's Identity Provider",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/identity-providers/{(%23%2Fdefinitions%2Fidentity-provider%2Fdefinitions%2Fid)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/identity-provider"
+          },
+          "title": "Delete By Team"
         }
       ],
       "properties": {
@@ -5299,7 +5480,7 @@
           "targetSchema": {
             "$ref": "#/definitions/inbound-ruleset"
           },
-          "title": "Info"
+          "title": "Current"
         },
         {
           "description": "Info on an existing Inbound Ruleset",
@@ -7080,8 +7261,9 @@
     },
     "organization-add-on": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "A list of add-ons the Organization uses across all apps",
+      "description": "Deprecated: A list of add-ons the Organization uses across all apps",
       "stability": "production",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization Add-on",
       "type": [
         "object"
@@ -7105,9 +7287,10 @@
       ]
     },
     "organization-app-collaborator": {
-      "description": "An organization collaborator represents an account that has been given access to an organization app on Heroku.",
+      "description": "Deprecated: An organization collaborator represents an account that has been given access to an organization app on Heroku.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization App Collaborator",
       "type": [
         "object"
@@ -7129,6 +7312,15 @@
           "rel": "create",
           "schema": {
             "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/organization-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              },
               "silent": {
                 "$ref": "#/definitions/collaborator/definitions/silent"
               },
@@ -7173,6 +7365,25 @@
           "href": "/organizations/apps/{(%23%2Fdefinitions%2Forganization-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Forganization-app-collaborator%2Fdefinitions%2Fidentity)}",
           "method": "PATCH",
           "rel": "update",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/organization-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              }
+            },
+            "required": [
+              "permissions"
+            ],
+            "type": [
+              "object"
+            ]
+          },
           "targetSchema": {
             "$ref": "#/definitions/organization-app-collaborator"
           },
@@ -7244,8 +7455,9 @@
     },
     "organization-app": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization app encapsulates the organization specific functionality of Heroku apps.",
+      "description": "Deprecated: An organization app encapsulates the organization specific functionality of Heroku apps.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization App",
       "type": [
         "object"
@@ -7539,9 +7751,10 @@
       }
     },
     "organization-feature": {
-      "description": "An organization feature represents a feature enabled on an organization account.",
+      "description": "Deprecated: An organization feature represents a feature enabled on an organization account.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Feature",
       "type": [
@@ -7574,7 +7787,7 @@
           ]
         },
         "enabled": {
-          "description": "whether or not account feature has been enabled",
+          "description": "whether or not organization feature has been enabled",
           "example": true,
           "readOnly": false,
           "type": [
@@ -7624,11 +7837,27 @@
           "type": [
             "string"
           ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
         }
       },
       "links": [
         {
-          "description": "Info for an existing account feature.",
+          "description": "Info for an existing organization feature.",
           "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Forganization-feature%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
@@ -7651,39 +7880,69 @@
             ]
           },
           "title": "List"
+        },
+        {
+          "description": "Update an existing organization feature.",
+          "href": "/organizations/{(%23%2Fdefinitions%2Forganization%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Forganization-feature%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "enabled": {
+                "$ref": "#/definitions/organization-feature/definitions/enabled"
+              }
+            },
+            "required": [
+              "enabled"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/organization-feature"
+          },
+          "title": "Update"
         }
       ],
       "properties": {
         "created_at": {
-          "$ref": "#/definitions/account-feature/definitions/created_at"
+          "$ref": "#/definitions/organization-feature/definitions/created_at"
         },
         "description": {
-          "$ref": "#/definitions/account-feature/definitions/description"
+          "$ref": "#/definitions/organization-feature/definitions/description"
         },
         "doc_url": {
-          "$ref": "#/definitions/account-feature/definitions/doc_url"
+          "$ref": "#/definitions/organization-feature/definitions/doc_url"
         },
         "enabled": {
-          "$ref": "#/definitions/account-feature/definitions/enabled"
+          "$ref": "#/definitions/organization-feature/definitions/enabled"
         },
         "id": {
-          "$ref": "#/definitions/account-feature/definitions/id"
+          "$ref": "#/definitions/organization-feature/definitions/id"
         },
         "name": {
-          "$ref": "#/definitions/account-feature/definitions/name"
+          "$ref": "#/definitions/organization-feature/definitions/name"
         },
         "state": {
-          "$ref": "#/definitions/account-feature/definitions/state"
+          "$ref": "#/definitions/organization-feature/definitions/state"
         },
         "updated_at": {
-          "$ref": "#/definitions/account-feature/definitions/updated_at"
+          "$ref": "#/definitions/organization-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/organization-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/organization-feature/definitions/feedback_email"
         }
       }
     },
     "organization-invitation": {
-      "description": "An organization invitation represents an invite to an organization.",
+      "description": "Deprecated: An organization invitation represents an invite to an organization.",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Invitation",
       "type": [
@@ -7866,8 +8125,9 @@
     },
     "organization-invoice": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.",
+      "description": "Deprecated: An organization invoice is an itemized bill of goods for an organization which includes pricing and charges.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Invoice",
       "type": [
@@ -8093,8 +8353,9 @@
     },
     "organization-member": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization member is an individual with access to an organization.",
+      "description": "Deprecated: An organization member is an individual with access to an organization.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "additionalProperties": false,
       "required": [
         "created_at",
@@ -8310,7 +8571,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "App List"
         }
       ],
       "properties": {
@@ -8356,9 +8617,10 @@
       }
     },
     "organization-preferences": {
-      "description": "Tracks an organization's preferences",
+      "description": "Deprecated: Tracks an organization's preferences",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization Preferences",
       "type": [
@@ -8436,8 +8698,9 @@
     },
     "organization": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "Organizations allow you to manage access to a shared group of applications across your development team.",
+      "description": "Deprecated: Organizations allow you to manage access to a shared group of applications across your development team.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "strictProperties": true,
       "title": "Heroku Platform API - Organization",
       "type": [
@@ -8890,7 +9153,7 @@
           "targetSchema": {
             "$ref": "#/definitions/outbound-ruleset"
           },
-          "title": "Info"
+          "title": "Current"
         },
         {
           "description": "Info on an existing Outbound Ruleset",
@@ -9065,8 +9328,9 @@
     },
     "organization-app-permission": {
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
-      "description": "An organization app permission is a behavior that is assigned to a user in an organization app.",
+      "description": "Deprecated: An organization app permission is a behavior that is assigned to a user in an organization app.",
       "stability": "prototype",
+      "deprecated_at": "2017-04-10",
       "title": "Heroku Platform API - Organization App Permission",
       "type": [
         "object"
@@ -9194,7 +9458,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Pipeline"
         },
         {
           "description": "List pipeline couplings.",
@@ -9283,14 +9547,14 @@
           "title": "Update"
         },
         {
-          "description": "Info for an existing pipeline coupling.",
+          "description": "Info for an existing app pipeline coupling.",
           "href": "/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/pipeline-couplings",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
             "$ref": "#/definitions/pipeline-coupling"
           },
-          "title": "Info"
+          "title": "Info By App"
         }
       ],
       "properties": {
@@ -9964,7 +10228,7 @@
       "links": [
         {
           "description": "Info for existing plan.",
-          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "href": "/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
           "method": "GET",
           "rel": "self",
           "targetSchema": {
@@ -9973,7 +10237,17 @@
           "title": "Info"
         },
         {
-          "description": "List existing plans.",
+          "description": "Info for existing plan by Add-on.",
+          "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans/{(%23%2Fdefinitions%2Fplan%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/plan"
+          },
+          "title": "Info By Add-on"
+        },
+        {
+          "description": "List existing plans by Add-on.",
           "href": "/addon-services/{(%23%2Fdefinitions%2Fadd-on-service%2Fdefinitions%2Fidentity)}/plans",
           "method": "GET",
           "rel": "instances",
@@ -9985,7 +10259,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Add-on"
         }
       ],
       "properties": {
@@ -11502,6 +11776,20 @@
             "object"
           ]
         },
+        "team": {
+          "description": "team that owns this space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
         "region": {
           "description": "identity of space region",
           "properties": {
@@ -11868,6 +12156,1805 @@
         }
       }
     },
+    "team-app-collaborator": {
+      "description": "A team collaborator represents an account that has been given access to a team app on Heroku.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "title": "Heroku Platform API - Team App Collaborator",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/collaborator/definitions/email"
+            }
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new collaborator on a team app. Use this endpoint instead of the `/apps/{app_id_or_name}/collaborator` endpoint when you want the collaborator to be granted [permissions] (https://devcenter.heroku.com/articles/org-users-access#roles-and-app-permissions) according to their role in the team.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fapp%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              },
+              "silent": {
+                "$ref": "#/definitions/collaborator/definitions/silent"
+              },
+              "user": {
+                "$ref": "#/definitions/account/definitions/identity"
+              }
+            },
+            "required": [
+              "user"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing collaborator from a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "Info for a collaborator on a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "Update an existing collaborator from a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators/{(%23%2Fdefinitions%2Fteam-app-collaborator%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "permissions": {
+                "type": [
+                  "array"
+                ],
+                "items": {
+                  "$ref": "#/definitions/team-app-permission/definitions/name"
+                },
+                "description": "An array of permissions to give to the collaborator."
+              }
+            },
+            "required": [
+              "permissions"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app-collaborator"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "List collaborators on a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}/collaborators",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app-collaborator"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "app": {
+          "description": "app collaborator belongs to",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/app/definitions/name"
+            },
+            "id": {
+              "$ref": "#/definitions/app/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "created_at": {
+          "$ref": "#/definitions/collaborator/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/collaborator/definitions/id"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/collaborator/definitions/updated_at"
+        },
+        "user": {
+          "description": "identity of collaborated account",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "federated": {
+              "$ref": "#/definitions/account/definitions/federated"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-app-permission": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A team app permission is a behavior that is assigned to a user in a team app.",
+      "stability": "prototype",
+      "title": "Heroku Platform API - Team App Permission",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-app-permission/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "The name of the app permission.",
+          "example": "view",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "A description of what the app permission allows.",
+          "example": "Can manage config, deploy, run commands and restart the app.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Lists permissions available to teams.",
+          "href": "/teams/permissions",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app-permission"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/team-app-permission/definitions/name"
+        },
+        "description": {
+          "$ref": "#/definitions/team-app-permission/definitions/description"
+        }
+      }
+    },
+    "team-app": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "An team app encapsulates the team specific functionality of Heroku apps.",
+      "stability": "development",
+      "title": "Heroku Platform API - Team App",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "locked": {
+          "default": false,
+          "description": "are other team members forbidden from joining this app.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/app/definitions/name"
+            }
+          ]
+        },
+        "joined": {
+          "default": false,
+          "description": "is the current member a collaborator on this app.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "personal": {
+          "default": false,
+          "description": "force creation of the app in the user account even if a default team is set.",
+          "example": false,
+          "type": [
+            "boolean"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new app in the specified team, in the default team if unspecified, or in personal account, if default team is not set.",
+          "href": "/teams/apps",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "locked": {
+                "$ref": "#/definitions/team-app/definitions/locked"
+              },
+              "name": {
+                "$ref": "#/definitions/app/definitions/name"
+              },
+              "team": {
+                "$ref": "#/definitions/team/definitions/name"
+              },
+              "personal": {
+                "$ref": "#/definitions/team-app/definitions/personal"
+              },
+              "region": {
+                "$ref": "#/definitions/region/definitions/name"
+              },
+              "space": {
+                "$ref": "#/definitions/space/definitions/name"
+              },
+              "stack": {
+                "$ref": "#/definitions/stack/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Create"
+        },
+        {
+          "description": "List apps in the default team, or in personal account, if default team is not set.",
+          "href": "/teams/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "Lock or unlock a team app.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "locked": {
+                "$ref": "#/definitions/team-app/definitions/locked"
+              }
+            },
+            "required": [
+              "locked"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Update Locked"
+        },
+        {
+          "description": "Transfer an existing team app to another Heroku account.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "owner": {
+                "$ref": "#/definitions/account/definitions/identity"
+              }
+            },
+            "required": [
+              "owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "title": "Transfer to Account"
+        },
+        {
+          "description": "Transfer an existing team app to another team.",
+          "href": "/teams/apps/{(%23%2Fdefinitions%2Fteam-app%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "owner": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "required": [
+              "owner"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-app"
+          },
+          "title": "Transfer to Team"
+        },
+        {
+          "description": "List team apps.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        }
+      ],
+      "properties": {
+        "archived_at": {
+          "$ref": "#/definitions/app/definitions/archived_at"
+        },
+        "buildpack_provided_description": {
+          "$ref": "#/definitions/app/definitions/buildpack_provided_description"
+        },
+        "created_at": {
+          "$ref": "#/definitions/app/definitions/created_at"
+        },
+        "git_url": {
+          "$ref": "#/definitions/app/definitions/git_url"
+        },
+        "id": {
+          "$ref": "#/definitions/app/definitions/id"
+        },
+        "joined": {
+          "$ref": "#/definitions/team-app/definitions/joined"
+        },
+        "locked": {
+          "$ref": "#/definitions/team-app/definitions/locked"
+        },
+        "maintenance": {
+          "$ref": "#/definitions/app/definitions/maintenance"
+        },
+        "name": {
+          "$ref": "#/definitions/app/definitions/name"
+        },
+        "team": {
+          "description": "team that owns this app",
+          "properties": {
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "owner": {
+          "description": "identity of app owner",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "region": {
+          "description": "identity of app region",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/region/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/region/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "released_at": {
+          "$ref": "#/definitions/app/definitions/released_at"
+        },
+        "repo_size": {
+          "$ref": "#/definitions/app/definitions/repo_size"
+        },
+        "slug_size": {
+          "$ref": "#/definitions/app/definitions/slug_size"
+        },
+        "space": {
+          "description": "identity of space",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/space/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/space/definitions/name"
+            }
+          },
+          "type": [
+            "null",
+            "object"
+          ]
+        },
+        "stack": {
+          "description": "identity of app stack",
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/stack/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/stack/definitions/name"
+            }
+          },
+          "type": [
+            "object"
+          ]
+        },
+        "updated_at": {
+          "$ref": "#/definitions/app/definitions/updated_at"
+        },
+        "web_url": {
+          "$ref": "#/definitions/app/definitions/web_url"
+        }
+      }
+    },
+    "team-feature": {
+      "description": "A team feature represents a feature enabled on a team account.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Feature",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when team feature was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "description": {
+          "description": "description of team feature",
+          "example": "Causes account to example.",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "doc_url": {
+          "description": "documentation URL of team feature",
+          "example": "http://devcenter.heroku.com/articles/example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "enabled": {
+          "description": "whether or not team feature has been enabled",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of team feature",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-feature/definitions/id"
+            },
+            {
+              "$ref": "#/definitions/team-feature/definitions/name"
+            }
+          ]
+        },
+        "name": {
+          "description": "unique name of team feature",
+          "example": "name",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "state of team feature",
+          "example": "public",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when team feature was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "display_name": {
+          "description": "user readable feature name",
+          "example": "My Feature",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "feedback_email": {
+          "description": "e-mail to send feedback about the feature",
+          "example": "feedback@heroku.com",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for an existing team feature.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/features/{(%23%2Fdefinitions%2Fteam-feature%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-feature"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing team features.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/features",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-feature"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-feature/definitions/created_at"
+        },
+        "description": {
+          "$ref": "#/definitions/team-feature/definitions/description"
+        },
+        "doc_url": {
+          "$ref": "#/definitions/team-feature/definitions/doc_url"
+        },
+        "enabled": {
+          "$ref": "#/definitions/team-feature/definitions/enabled"
+        },
+        "id": {
+          "$ref": "#/definitions/team-feature/definitions/id"
+        },
+        "name": {
+          "$ref": "#/definitions/team-feature/definitions/name"
+        },
+        "state": {
+          "$ref": "#/definitions/team-feature/definitions/state"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-feature/definitions/updated_at"
+        },
+        "display_name": {
+          "$ref": "#/definitions/team-feature/definitions/display_name"
+        },
+        "feedback_email": {
+          "$ref": "#/definitions/team-feature/definitions/feedback_email"
+        }
+      }
+    },
+    "team-invitation": {
+      "description": "A team invitation represents an invite to a team.",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Invitation",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when invitation was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-invitation/definitions/id"
+            }
+          ]
+        },
+        "id": {
+          "description": "unique identifier of an invitation",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "token": {
+          "description": "special token for invitation",
+          "example": "614ae25aa2d4802096cd7c18625b526c",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when invitation was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Get a list of a team's Identity Providers",
+          "title": "List",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fname)}/invitations",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-invitation"
+            },
+            "type": [
+              "array"
+            ]
+          }
+        },
+        {
+          "description": "Create Team Invitation",
+          "title": "Create",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invitations",
+          "method": "PUT",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/account/definitions/email"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          }
+        },
+        {
+          "description": "Revoke a team invitation.",
+          "title": "Revoke",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "self"
+        },
+        {
+          "description": "Get an invitation by its token",
+          "title": "Get",
+          "href": "/teams/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Ftoken)}",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "$ref": "#/definitions/team-invitation"
+          }
+        },
+        {
+          "description": "Accept Team Invitation",
+          "title": "Accept",
+          "href": "/teams/invitations/{(%23%2Fdefinitions%2Fteam-invitation%2Fdefinitions%2Ftoken)}/accept",
+          "method": "POST",
+          "rel": "create",
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          }
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-invitation/definitions/created_at"
+        },
+        "id": {
+          "$ref": "#/definitions/team-invitation/definitions/id"
+        },
+        "invited_by": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "team": {
+          "properties": {
+            "id": {
+              "$ref": "#/definitions/team/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/team/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-invitation/definitions/updated_at"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-invoice": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A Team Invoice is an itemized bill of goods for a team which includes pricing and charges.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Invoice",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "addons_total": {
+          "description": "total add-ons charges in on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "database_total": {
+          "description": "total database charges on this invoice",
+          "example": 25000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "charges_total": {
+          "description": "total charges on this invoice",
+          "example": 0,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "created_at": {
+          "description": "when invoice was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credits_total": {
+          "description": "total credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "dyno_units": {
+          "description": "total amount of dyno units consumed across dyno types.",
+          "example": 1.92,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of this invoice",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-invoice/definitions/number"
+            }
+          ]
+        },
+        "number": {
+          "description": "human readable invoice number",
+          "example": 9403943,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "payment_status": {
+          "description": "status of the invoice payment",
+          "example": "Paid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "platform_total": {
+          "description": "total platform charges on this invoice",
+          "example": 50000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "period_end": {
+          "description": "the ending date that the invoice covers",
+          "example": "01/31/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "period_start": {
+          "description": "the starting date that this invoice covers",
+          "example": "01/01/2014",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "state": {
+          "description": "payment status for this invoice (pending, successful, failed)",
+          "example": 1,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "total": {
+          "description": "combined total of charges and credits on this invoice",
+          "example": 100000,
+          "readOnly": true,
+          "type": [
+            "integer"
+          ]
+        },
+        "updated_at": {
+          "description": "when invoice was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "weighted_dyno_hours": {
+          "description": "The total amount of hours consumed across dyno types.",
+          "example": 1488,
+          "readOnly": true,
+          "type": [
+            "number"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Info for existing invoice.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invoices/{(%23%2Fdefinitions%2Fteam-invoice%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-invoice"
+          },
+          "title": "Info"
+        },
+        {
+          "description": "List existing invoices.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/invoices",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-invoice"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        }
+      ],
+      "properties": {
+        "addons_total": {
+          "$ref": "#/definitions/team-invoice/definitions/addons_total"
+        },
+        "database_total": {
+          "$ref": "#/definitions/team-invoice/definitions/database_total"
+        },
+        "charges_total": {
+          "$ref": "#/definitions/team-invoice/definitions/charges_total"
+        },
+        "created_at": {
+          "$ref": "#/definitions/team-invoice/definitions/created_at"
+        },
+        "credits_total": {
+          "$ref": "#/definitions/team-invoice/definitions/credits_total"
+        },
+        "dyno_units": {
+          "$ref": "#/definitions/team-invoice/definitions/dyno_units"
+        },
+        "id": {
+          "$ref": "#/definitions/team-invoice/definitions/id"
+        },
+        "number": {
+          "$ref": "#/definitions/team-invoice/definitions/number"
+        },
+        "payment_status": {
+          "$ref": "#/definitions/team-invoice/definitions/payment_status"
+        },
+        "period_end": {
+          "$ref": "#/definitions/team-invoice/definitions/period_end"
+        },
+        "period_start": {
+          "$ref": "#/definitions/team-invoice/definitions/period_start"
+        },
+        "platform_total": {
+          "$ref": "#/definitions/team-invoice/definitions/platform_total"
+        },
+        "state": {
+          "$ref": "#/definitions/team-invoice/definitions/state"
+        },
+        "total": {
+          "$ref": "#/definitions/team-invoice/definitions/total"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-invoice/definitions/updated_at"
+        },
+        "weighted_dyno_hours": {
+          "$ref": "#/definitions/team-invoice/definitions/weighted_dyno_hours"
+        }
+      }
+    },
+    "team-member": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "A team member is an individual with access to a team.",
+      "stability": "development",
+      "additionalProperties": false,
+      "required": [
+        "created_at",
+        "email",
+        "federated",
+        "updated_at"
+      ],
+      "title": "Heroku Platform API - Team Member",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the membership record was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "email": {
+          "description": "email address of the team member",
+          "example": "someone@example.org",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "federated": {
+          "description": "whether the user is federated and belongs to an Identity Provider",
+          "example": false,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of the team member",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team-member/definitions/email"
+            },
+            {
+              "$ref": "#/definitions/team-member/definitions/id"
+            }
+          ]
+        },
+        "name": {
+          "description": "full name of the team member",
+          "example": "Tina Edmonds",
+          "readOnly": true,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "two_factor_authentication": {
+          "description": "whether the Enterprise team member has two factor authentication enabled",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "updated_at": {
+          "description": "when the membership record was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Create a new team member, or update their role.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "PUT",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Create or Update"
+        },
+        {
+          "description": "Create a new team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Update a team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "email": {
+                "$ref": "#/definitions/team-member/definitions/email"
+              },
+              "federated": {
+                "$ref": "#/definitions/team-member/definitions/federated"
+              },
+              "role": {
+                "$ref": "#/definitions/team/definitions/role"
+              }
+            },
+            "required": [
+              "email",
+              "role"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Remove a member from the team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fteam-member%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team-member"
+          },
+          "title": "Delete"
+        },
+        {
+          "description": "List members of the team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members",
+          "method": "GET",
+          "ranges": [
+            "email"
+          ],
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-member"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "List the apps of a team member.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/members/{(%23%2Fdefinitions%2Fteam-member%2Fdefinitions%2Fidentity)}/apps",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team-app"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Member"
+        }
+      ],
+      "properties": {
+        "created_at": {
+          "$ref": "#/definitions/team-member/definitions/created_at"
+        },
+        "email": {
+          "$ref": "#/definitions/team-member/definitions/email"
+        },
+        "federated": {
+          "$ref": "#/definitions/team-member/definitions/federated"
+        },
+        "id": {
+          "$ref": "#/definitions/team-member/definitions/id"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "two_factor_authentication": {
+          "$ref": "#/definitions/team-member/definitions/two_factor_authentication"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team-member/definitions/updated_at"
+        },
+        "user": {
+          "description": "user information for the membership",
+          "properties": {
+            "email": {
+              "$ref": "#/definitions/account/definitions/email"
+            },
+            "id": {
+              "$ref": "#/definitions/account/definitions/id"
+            },
+            "name": {
+              "$ref": "#/definitions/account/definitions/name"
+            }
+          },
+          "strictProperties": true,
+          "type": [
+            "object"
+          ]
+        }
+      }
+    },
+    "team-preferences": {
+      "description": "Tracks a Team's Preferences",
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team Preferences",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "default-permission": {
+          "description": "The default permission used when adding new members to the team",
+          "example": "member",
+          "readOnly": false,
+          "enum": [
+            "admin",
+            "member",
+            "viewer",
+            null
+          ],
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "identity": {
+          "$ref": "#/definitions/team/definitions/identity"
+        },
+        "whitelisting-enabled": {
+          "description": "Whether whitelisting rules should be applied to add-on installations",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "Retrieve Team Preferences",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "GET",
+          "rel": "self",
+          "targetSchema": {
+            "$ref": "#/definitions/team-preferences"
+          },
+          "title": "List"
+        },
+        {
+          "description": "Update Team Preferences",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam-preferences%2Fdefinitions%2Fidentity)}/preferences",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "whitelisting-enabled": {
+                "$ref": "#/definitions/team-preferences/definitions/whitelisting-enabled"
+              }
+            }
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team-preferences"
+          },
+          "title": "Update"
+        }
+      ],
+      "properties": {
+        "default-permission": {
+          "$ref": "#/definitions/team-preferences/definitions/default-permission"
+        },
+        "whitelisting-enabled": {
+          "$ref": "#/definitions/team-preferences/definitions/whitelisting-enabled"
+        }
+      }
+    },
+    "team": {
+      "$schema": "http://json-schema.org/draft-04/hyper-schema",
+      "description": "Teams allow you to manage access to a shared group of applications and other resources.",
+      "stability": "development",
+      "strictProperties": true,
+      "title": "Heroku Platform API - Team",
+      "type": [
+        "object"
+      ],
+      "definitions": {
+        "created_at": {
+          "description": "when the team was created",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "credit_card_collections": {
+          "description": "whether charges incurred by the team are paid by credit card.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "default": {
+          "description": "whether to use this team when none is specified",
+          "example": true,
+          "readOnly": false,
+          "type": [
+            "boolean"
+          ]
+        },
+        "id": {
+          "description": "unique identifier of team",
+          "example": "01234567-89ab-cdef-0123-456789abcdef",
+          "format": "uuid",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "identity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/team/definitions/name"
+            },
+            {
+              "$ref": "#/definitions/team/definitions/id"
+            }
+          ]
+        },
+        "address_1": {
+          "type": [
+            "string"
+          ],
+          "description": "street address line 1",
+          "example": "40 Hickory Lane"
+        },
+        "address_2": {
+          "type": [
+            "string"
+          ],
+          "description": "street address line 2",
+          "example": "Suite 103"
+        },
+        "card_number": {
+          "type": [
+            "string"
+          ],
+          "description": "encrypted card number of payment method",
+          "example": "encrypted-card-number"
+        },
+        "city": {
+          "type": [
+            "string"
+          ],
+          "description": "city",
+          "example": "San Francisco"
+        },
+        "country": {
+          "type": [
+            "string"
+          ],
+          "description": "country",
+          "example": "US"
+        },
+        "cvv": {
+          "type": [
+            "string"
+          ],
+          "description": "card verification value",
+          "example": "123"
+        },
+        "expiration_month": {
+          "type": [
+            "string"
+          ],
+          "description": "expiration month",
+          "example": "11"
+        },
+        "expiration_year": {
+          "type": [
+            "string"
+          ],
+          "description": "expiration year",
+          "example": "2014"
+        },
+        "first_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the first name for payment method",
+          "example": "Jason"
+        },
+        "last_name": {
+          "type": [
+            "string"
+          ],
+          "description": "the last name for payment method",
+          "example": "Walker"
+        },
+        "other": {
+          "type": [
+            "string"
+          ],
+          "description": "metadata",
+          "example": "Additional information for payment method"
+        },
+        "postal_code": {
+          "type": [
+            "string"
+          ],
+          "description": "postal code",
+          "example": "90210"
+        },
+        "state": {
+          "type": [
+            "string"
+          ],
+          "description": "state",
+          "example": "CA"
+        },
+        "membership_limit": {
+          "description": "upper limit of members allowed in a team.",
+          "example": 25,
+          "readOnly": true,
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "unique name of team",
+          "example": "example",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "provisioned_licenses": {
+          "description": "whether the team is provisioned licenses by salesforce.",
+          "example": true,
+          "readOnly": true,
+          "type": [
+            "boolean"
+          ]
+        },
+        "role": {
+          "description": "role in the team",
+          "enum": [
+            "admin",
+            "collaborator",
+            "member",
+            "owner",
+            null
+          ],
+          "example": "admin",
+          "readOnly": true,
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "type": {
+          "description": "type of team.",
+          "example": "team",
+          "enum": [
+            "enterprise",
+            "team"
+          ],
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        },
+        "updated_at": {
+          "description": "when the team was updated",
+          "example": "2012-01-01T12:00:00Z",
+          "format": "date-time",
+          "readOnly": true,
+          "type": [
+            "string"
+          ]
+        }
+      },
+      "links": [
+        {
+          "description": "List teams in which you are a member.",
+          "href": "/teams",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/team"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List"
+        },
+        {
+          "description": "Info for a team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "GET",
+          "rel": "self",
+          "title": "Info"
+        },
+        {
+          "description": "Update team properties.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "PATCH",
+          "rel": "update",
+          "schema": {
+            "properties": {
+              "default": {
+                "$ref": "#/definitions/team/definitions/default"
+              },
+              "name": {
+                "$ref": "#/definitions/team/definitions/name"
+              }
+            },
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Update"
+        },
+        {
+          "description": "Create a new team.",
+          "href": "/teams",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "properties": {
+              "name": {
+                "$ref": "#/definitions/team/definitions/name"
+              },
+              "address_1": {
+                "$ref": "#/definitions/team/definitions/address_1"
+              },
+              "address_2": {
+                "$ref": "#/definitions/team/definitions/address_2"
+              },
+              "card_number": {
+                "$ref": "#/definitions/team/definitions/card_number"
+              },
+              "city": {
+                "$ref": "#/definitions/team/definitions/city"
+              },
+              "country": {
+                "$ref": "#/definitions/team/definitions/country"
+              },
+              "cvv": {
+                "$ref": "#/definitions/team/definitions/cvv"
+              },
+              "expiration_month": {
+                "$ref": "#/definitions/team/definitions/expiration_month"
+              },
+              "expiration_year": {
+                "$ref": "#/definitions/team/definitions/expiration_year"
+              },
+              "first_name": {
+                "$ref": "#/definitions/team/definitions/first_name"
+              },
+              "last_name": {
+                "$ref": "#/definitions/team/definitions/last_name"
+              },
+              "other": {
+                "$ref": "#/definitions/team/definitions/other"
+              },
+              "postal_code": {
+                "$ref": "#/definitions/team/definitions/postal_code"
+              },
+              "state": {
+                "$ref": "#/definitions/team/definitions/state"
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "type": [
+              "object"
+            ]
+          },
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Create"
+        },
+        {
+          "description": "Delete an existing team.",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/team"
+          },
+          "title": "Delete"
+        }
+      ],
+      "properties": {
+        "id": {
+          "$ref": "#/definitions/team/definitions/id"
+        },
+        "created_at": {
+          "$ref": "#/definitions/team/definitions/created_at"
+        },
+        "credit_card_collections": {
+          "$ref": "#/definitions/team/definitions/credit_card_collections"
+        },
+        "default": {
+          "$ref": "#/definitions/team/definitions/default"
+        },
+        "membership_limit": {
+          "$ref": "#/definitions/team/definitions/membership_limit"
+        },
+        "name": {
+          "$ref": "#/definitions/team/definitions/name"
+        },
+        "provisioned_licenses": {
+          "$ref": "#/definitions/team/definitions/provisioned_licenses"
+        },
+        "role": {
+          "$ref": "#/definitions/team/definitions/role"
+        },
+        "type": {
+          "$ref": "#/definitions/team/definitions/type"
+        },
+        "updated_at": {
+          "$ref": "#/definitions/team/definitions/updated_at"
+        }
+      }
+    },
     "user-preferences": {
       "description": "Tracks a user's preferences and message dismissals",
       "$schema": "http://json-schema.org/draft-04/hyper-schema",
@@ -12178,7 +14265,7 @@
               "array"
             ]
           },
-          "title": "List"
+          "title": "List By Organization"
         },
         {
           "description": "Whitelist an Add-on Service",
@@ -12207,7 +14294,7 @@
               "array"
             ]
           },
-          "title": "Create"
+          "title": "Create By Organization"
         },
         {
           "description": "Remove a whitelisted entity",
@@ -12217,7 +14304,61 @@
           "targetSchema": {
             "$ref": "#/definitions/whitelisted-add-on-service"
           },
-          "title": "Delete"
+          "title": "Delete By Organization"
+        },
+        {
+          "description": "List all whitelisted Add-on Services for a Team",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/whitelisted-addon-services",
+          "method": "GET",
+          "rel": "instances",
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/whitelisted-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "List By Team"
+        },
+        {
+          "description": "Whitelist an Add-on Service",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/whitelisted-addon-services",
+          "method": "POST",
+          "rel": "create",
+          "schema": {
+            "type": [
+              "object"
+            ],
+            "properties": {
+              "addon_service": {
+                "description": "name of the Add-on to whitelist",
+                "example": "heroku-postgresql",
+                "type": [
+                  "string"
+                ]
+              }
+            }
+          },
+          "targetSchema": {
+            "items": {
+              "$ref": "#/definitions/whitelisted-add-on-service"
+            },
+            "type": [
+              "array"
+            ]
+          },
+          "title": "Create By Team"
+        },
+        {
+          "description": "Remove a whitelisted entity",
+          "href": "/teams/{(%23%2Fdefinitions%2Fteam%2Fdefinitions%2Fidentity)}/whitelisted-addon-services/{(%23%2Fdefinitions%2Fwhitelisted-add-on-service%2Fdefinitions%2Fidentity)}",
+          "method": "DELETE",
+          "rel": "destroy",
+          "targetSchema": {
+            "$ref": "#/definitions/whitelisted-add-on-service"
+          },
+          "title": "Delete By Team"
         }
       ],
       "properties": {
@@ -12440,6 +14581,33 @@
     },
     "stack": {
       "$ref": "#/definitions/stack"
+    },
+    "team-app-collaborator": {
+      "$ref": "#/definitions/team-app-collaborator"
+    },
+    "team-app-permission": {
+      "$ref": "#/definitions/team-app-permission"
+    },
+    "team-app": {
+      "$ref": "#/definitions/team-app"
+    },
+    "team-feature": {
+      "$ref": "#/definitions/team-feature"
+    },
+    "team-invitation": {
+      "$ref": "#/definitions/team-invitation"
+    },
+    "team-invoice": {
+      "$ref": "#/definitions/team-invoice"
+    },
+    "team-member": {
+      "$ref": "#/definitions/team-member"
+    },
+    "team-preferences": {
+      "$ref": "#/definitions/team-preferences"
+    },
+    "team": {
+      "$ref": "#/definitions/team"
     },
     "user-preferences": {
       "$ref": "#/definitions/user-preferences"

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1319,10 +1319,10 @@
 			"revisionTime": "2016-07-14T17:28:59Z"
 		},
 		{
-			"checksumSHA1": "cSJrzeVJLa9x2xoVqrJLz2Y+l0Y=",
+			"checksumSHA1": "ySg+wxsWmk5AipJDFGGG2JhxIPU=",
 			"path": "github.com/cyberdelia/heroku-go/v3",
-			"revision": "58deda4c1fb0b4803387b29dc916c21887b81954",
-			"revisionTime": "2017-03-06T18:52:00Z"
+			"revision": "84e6d0171b96992458bcbc5609d28b35edf26f00",
+			"revisionTime": "2017-05-16T20:23:11Z"
 		},
 		{
 			"checksumSHA1": "/5cvgU+J4l7EhMXTK76KaCAfOuU=",


### PR DESCRIPTION
As explained both in PR #14508 and #14611, the last revision of the vendored `cyberdelia/heroku-go` was breaking some functionalities from the `heroku` provider due to major changes. 

This PR aims to upgraded the vendored client and then to update the code from the provider to make it work properly.

Resolves #14611
