### PR TITLE
provider/aws: Add ability to 'terraform import' aws_kms_alias resources

### DIFF
--- a/builtin/providers/aws/import_aws_kms_alias_test.go
+++ b/builtin/providers/aws/import_aws_kms_alias_test.go
@@ -1,0 +1,32 @@
+package aws
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccAWSKmsAlias_importBasic(t *testing.T) {
+	resourceName := "aws_kms_alias.single"
+	rInt := acctest.RandInt()
+	kmsAliasTimestamp := time.Now().Format(time.RFC1123)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSKmsAliasDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSKmsSingleAlias(rInt, kmsAliasTimestamp),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/aws/resource_aws_kms_alias.go
+++ b/builtin/providers/aws/resource_aws_kms_alias.go
@@ -19,6 +19,10 @@ func resourceAwsKmsAlias() *schema.Resource {
 		Update: resourceAwsKmsAliasUpdate,
 		Delete: resourceAwsKmsAliasDelete,
 
+		Importer: &schema.ResourceImporter{
+			State: resourceAwsKmsAliasImport,
+		},
+
 		Schema: map[string]*schema.Schema{
 			"arn": &schema.Schema{
 				Type:     schema.TypeString,
@@ -172,4 +176,9 @@ func findKmsAliasByName(conn *kms.KMS, name string, marker *string) (*kms.AliasL
 	}
 
 	return nil, nil
+}
+
+func resourceAwsKmsAliasImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	d.Set("name", d.Id())
+	return []*schema.ResourceData{d}, nil
 }

--- a/website/source/docs/providers/aws/r/kms_alias.html.markdown
+++ b/website/source/docs/providers/aws/r/kms_alias.html.markdown
@@ -38,3 +38,11 @@ The name must start with the word "alias" followed by a forward slash (alias/). 
 The following attributes are exported:
 
 * `arn` - The Amazon Resource Name (ARN) of the key alias.
+
+## Import
+
+KMS aliases can be imported using the `name`, e.g.
+
+```
+$ terraform import aws_kms_alias.a alias/my-key-alias
+```


### PR DESCRIPTION
Enable `terraform import` of KMS aliases using the `name` attribute.
Acceptance tests:
```
make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSKmsAlias_import'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 14:32:25 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSKmsAlias_import -timeout 120m
=== RUN   TestAccAWSKmsAlias_importBasic
--- PASS: TestAccAWSKmsAlias_importBasic (44.72s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	44.735s
```