### PR TITLE
Use `helpers.shema.Provisoner` in Chef provisioner V2

### DIFF
--- a/builtin/bins/provisioner-chef/main.go
+++ b/builtin/bins/provisioner-chef/main.go
@@ -3,13 +3,10 @@ package main
 import (
 	"github.com/hashicorp/terraform/builtin/provisioners/chef"
 	"github.com/hashicorp/terraform/plugin"
-	"github.com/hashicorp/terraform/terraform"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
-		ProvisionerFunc: func() terraform.ResourceProvisioner {
-			return new(chef.ResourceProvisioner)
-		},
+		ProvisionerFunc: chef.Provisioner,
 	})
 }

--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -14,7 +14,7 @@ const (
 	installURL = "https://www.chef.io/chef/install.sh"
 )
 
-func (p *Provisioner) linuxInstallChefClient(
+func (p *ProvisionerS) linuxInstallChefClient(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 
@@ -26,7 +26,7 @@ func (p *Provisioner) linuxInstallChefClient(
 	if p.HTTPSProxy != "" {
 		prefix += fmt.Sprintf("https_proxy='%s' ", p.HTTPSProxy)
 	}
-	if p.NOProxy != nil {
+	if p.NOProxy != nil && len(p.NOProxy) > 0 {
 		prefix += fmt.Sprintf("no_proxy='%s' ", strings.Join(p.NOProxy, ","))
 	}
 
@@ -46,7 +46,7 @@ func (p *Provisioner) linuxInstallChefClient(
 	return p.runCommand(o, comm, fmt.Sprintf("%srm -f install.sh", prefix))
 }
 
-func (p *Provisioner) linuxCreateConfigFiles(
+func (p *ProvisionerS) linuxCreateConfigFiles(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 	// Make sure the config directory exists

--- a/builtin/provisioners/chef/linux_provisioner.go
+++ b/builtin/provisioners/chef/linux_provisioner.go
@@ -14,10 +14,7 @@ const (
 	installURL = "https://www.chef.io/chef/install.sh"
 )
 
-func (p *ProvisionerS) linuxInstallChefClient(
-	o terraform.UIOutput,
-	comm communicator.Communicator) error {
-
+func (p *provisioner) linuxInstallChefClient(o terraform.UIOutput, comm communicator.Communicator) error {
 	// Build up the command prefix
 	prefix := ""
 	if p.HTTPProxy != "" {
@@ -26,7 +23,7 @@ func (p *ProvisionerS) linuxInstallChefClient(
 	if p.HTTPSProxy != "" {
 		prefix += fmt.Sprintf("https_proxy='%s' ", p.HTTPSProxy)
 	}
-	if p.NOProxy != nil && len(p.NOProxy) > 0 {
+	if len(p.NOProxy) > 0 {
 		prefix += fmt.Sprintf("no_proxy='%s' ", strings.Join(p.NOProxy, ","))
 	}
 
@@ -46,9 +43,7 @@ func (p *ProvisionerS) linuxInstallChefClient(
 	return p.runCommand(o, comm, fmt.Sprintf("%srm -f install.sh", prefix))
 }
 
-func (p *ProvisionerS) linuxCreateConfigFiles(
-	o terraform.UIOutput,
-	comm communicator.Communicator) error {
+func (p *provisioner) linuxCreateConfigFiles(o terraform.UIOutput, comm communicator.Communicator) error {
 	// Make sure the config directory exists
 	if err := p.runCommand(o, comm, "mkdir -p "+linuxConfDir); err != nil {
 		return err

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -125,14 +125,13 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -264,7 +263,6 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
@@ -272,7 +270,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/chef/linux_provisioner_test.go
+++ b/builtin/provisioners/chef/linux_provisioner_test.go
@@ -6,22 +6,23 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 	cases := map[string]struct {
-		Config   *terraform.ResourceConfig
+		Config   map[string]interface{}
 		Commands map[string]bool
 	}{
 		"Sudo": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"node_name":  "nodename1",
 				"run_list":   []interface{}{"cookbook::recipe"},
 				"server_url": "https://chef.local",
 				"user_name":  "bob",
 				"user_key":   "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"sudo curl -LO https://www.chef.io/chef/install.sh": true,
@@ -31,7 +32,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 		},
 
 		"NoSudo": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"node_name":    "nodename1",
 				"prevent_sudo": true,
 				"run_list":     []interface{}{"cookbook::recipe"},
@@ -39,7 +40,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 				"server_url":   "https://chef.local",
 				"user_name":    "bob",
 				"user_key":     "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"curl -LO https://www.chef.io/chef/install.sh": true,
@@ -49,7 +50,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 		},
 
 		"HTTPProxy": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"http_proxy":   "http://proxy.local",
 				"node_name":    "nodename1",
 				"prevent_sudo": true,
@@ -57,7 +58,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 				"server_url":   "https://chef.local",
 				"user_name":    "bob",
 				"user_key":     "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"http_proxy='http://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
@@ -67,7 +68,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 		},
 
 		"HTTPSProxy": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"https_proxy":  "https://proxy.local",
 				"node_name":    "nodename1",
 				"prevent_sudo": true,
@@ -75,7 +76,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 				"server_url":   "https://chef.local",
 				"user_name":    "bob",
 				"user_key":     "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"https_proxy='https://proxy.local' curl -LO https://www.chef.io/chef/install.sh": true,
@@ -85,7 +86,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 		},
 
 		"NoProxy": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"http_proxy":   "http://proxy.local",
 				"no_proxy":     []interface{}{"http://local.local", "http://local.org"},
 				"node_name":    "nodename1",
@@ -94,7 +95,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 				"server_url":   "https://chef.local",
 				"user_name":    "bob",
 				"user_key":     "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"http_proxy='http://proxy.local' no_proxy='http://local.local,http://local.org' " +
@@ -107,7 +108,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 		},
 
 		"Version": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"node_name":    "nodename1",
 				"prevent_sudo": true,
 				"run_list":     []interface{}{"cookbook::recipe"},
@@ -115,7 +116,7 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 				"user_name":    "bob",
 				"user_key":     "USER-KEY",
 				"version":      "11.18.6",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"curl -LO https://www.chef.io/chef/install.sh": true,
@@ -131,7 +132,9 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 	for k, tc := range cases {
 		c.Commands = tc.Commands
 
-		p, err := decodeConfig(getTestResourceData(tc.Config))
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -147,12 +150,12 @@ func TestResourceProvider_linuxInstallChefClient(t *testing.T) {
 
 func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 	cases := map[string]struct {
-		Config   *terraform.ResourceConfig
+		Config   map[string]interface{}
 		Commands map[string]bool
 		Uploads  map[string]string
 	}{
 		"Sudo": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"ohai_hints": []interface{}{"test-fixtures/ohaihint.json"},
 				"node_name":  "nodename1",
 				"run_list":   []interface{}{"cookbook::recipe"},
@@ -160,7 +163,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 				"server_url": "https://chef.local",
 				"user_name":  "bob",
 				"user_key":   "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"sudo mkdir -p " + linuxConfDir:                                          true,
@@ -187,7 +190,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		},
 
 		"NoSudo": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"node_name":    "nodename1",
 				"prevent_sudo": true,
 				"run_list":     []interface{}{"cookbook::recipe"},
@@ -195,7 +198,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 				"server_url":   "https://chef.local",
 				"user_name":    "bob",
 				"user_key":     "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"mkdir -p " + linuxConfDir: true,
@@ -210,7 +213,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		},
 
 		"Proxy": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"http_proxy":      "http://proxy.local",
 				"https_proxy":     "https://proxy.local",
 				"no_proxy":        []interface{}{"http://local.local", "https://local.local"},
@@ -222,7 +225,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 				"ssl_verify_mode": "verify_none",
 				"user_name":       "bob",
 				"user_key":        "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"mkdir -p " + linuxConfDir: true,
@@ -237,7 +240,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		},
 
 		"Attributes JSON": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"attributes_json": `{"key1":{"subkey1":{"subkey2a":["val1","val2","val3"],` +
 					`"subkey2b":{"subkey3":"value3"}}},"key2":"value2"}`,
 				"node_name":    "nodename1",
@@ -247,7 +250,7 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 				"server_url":   "https://chef.local",
 				"user_name":    "bob",
 				"user_key":     "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"mkdir -p " + linuxConfDir: true,
@@ -270,7 +273,9 @@ func TestResourceProvider_linuxCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := decodeConfig(getTestResourceData(tc.Config))
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -15,12 +15,13 @@ import (
 	"text/template"
 	"time"
 
+	"context"
 	"github.com/hashicorp/terraform/communicator"
 	"github.com/hashicorp/terraform/communicator/remote"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/mitchellh/go-homedir"
 	"github.com/mitchellh/go-linereader"
-	"github.com/mitchellh/mapstructure"
 )
 
 const (
@@ -81,36 +82,36 @@ enable_reporting false
 {{ end }}
 `
 
-// Provisioner represents a Chef provisioner
-type Provisioner struct {
-	AttributesJSON        string   `mapstructure:"attributes_json"`
-	ClientOptions         []string `mapstructure:"client_options"`
-	DisableReporting      bool     `mapstructure:"disable_reporting"`
-	Environment           string   `mapstructure:"environment"`
-	FetchChefCertificates bool     `mapstructure:"fetch_chef_certificates"`
-	LogToFile             bool     `mapstructure:"log_to_file"`
-	UsePolicyfile         bool     `mapstructure:"use_policyfile"`
-	PolicyGroup           string   `mapstructure:"policy_group"`
-	PolicyName            string   `mapstructure:"policy_name"`
-	HTTPProxy             string   `mapstructure:"http_proxy"`
-	HTTPSProxy            string   `mapstructure:"https_proxy"`
-	NamedRunList          string   `mapstructure:"named_run_list"`
-	NOProxy               []string `mapstructure:"no_proxy"`
-	NodeName              string   `mapstructure:"node_name"`
-	OhaiHints             []string `mapstructure:"ohai_hints"`
-	OSType                string   `mapstructure:"os_type"`
-	RecreateClient        bool     `mapstructure:"recreate_client"`
-	PreventSudo           bool     `mapstructure:"prevent_sudo"`
-	RunList               []string `mapstructure:"run_list"`
-	SecretKey             string   `mapstructure:"secret_key"`
-	ServerURL             string   `mapstructure:"server_url"`
-	SkipInstall           bool     `mapstructure:"skip_install"`
-	SkipRegister          bool     `mapstructure:"skip_register"`
-	SSLVerifyMode         string   `mapstructure:"ssl_verify_mode"`
-	UserName              string   `mapstructure:"user_name"`
-	UserKey               string   `mapstructure:"user_key"`
-	VaultJSON             string   `mapstructure:"vault_json"`
-	Version               string   `mapstructure:"version"`
+// ProvisionerS represents a Chef provisioner
+type ProvisionerS struct {
+	AttributesJSON        string
+	ClientOptions         []string
+	DisableReporting      bool
+	Environment           string
+	FetchChefCertificates bool
+	LogToFile             bool
+	UsePolicyfile         bool
+	PolicyGroup           string
+	PolicyName            string
+	HTTPProxy             string
+	HTTPSProxy            string
+	NamedRunList          string
+	NOProxy               []string
+	NodeName              string
+	OhaiHints             []string
+	OSType                string
+	RecreateClient        bool
+	PreventSudo           bool
+	RunList               []string
+	SecretKey             string
+	ServerURL             string
+	SkipInstall           bool
+	SkipRegister          bool
+	SSLVerifyMode         string
+	UserName              string
+	UserKey               string
+	VaultJSON             string
+	Version               string
 
 	attributes map[string]interface{}
 	vaults     map[string][]string
@@ -125,37 +126,179 @@ type Provisioner struct {
 	useSudo               bool
 
 	// Deprecated Fields
-	ValidationClientName string `mapstructure:"validation_client_name"`
-	ValidationKey        string `mapstructure:"validation_key"`
+	ValidationClientName string
+	ValidationKey        string
 }
 
-// ResourceProvisioner represents a generic chef provisioner
-type ResourceProvisioner struct{}
+func Provisioner() terraform.ResourceProvisioner {
+	return &schema.Provisioner{
+		Schema: map[string]*schema.Schema{
+			"attributes_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"client_options": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+			},
+			"disable_reporting": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"environment": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"fetch_chef_certificates": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"log_to_file": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"use_policyfile": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"policy_group": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"policy_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"http_proxy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"https_proxy": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"no_proxy": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				Optional: true,
+			},
+			"named_run_list": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"node_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ohai_hints": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				Optional: true,
+			},
+			"os_type": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"recreate_client": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"prevent_sudo": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"run_list": {
+				Type: schema.TypeList,
+				Elem: schema.Schema{
+					Type:     schema.TypeString,
+					Optional: true,
+				},
+				Optional: true,
+			},
+			"secret_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"server_url": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"skip_install": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"skip_register": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"ssl_verify_mode": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"user_key": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"vault_json": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"version": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 
-func (r *ResourceProvisioner) Stop() error {
-	// Noop for now. TODO in the future.
-	return nil
+			// Deprecated
+			"validation_client_name": {
+				Type:       schema.TypeString,
+				Deprecated: "Please use user_name instead",
+				Optional:   true,
+			},
+
+			"validation_key": {
+				Type:       schema.TypeString,
+				Deprecated: "Please use user_key instead",
+				Optional:   true,
+			},
+		},
+		ApplyFunc:    Apply,
+		ValidateFunc: Validate,
+	}
 }
 
+// TODO: Support context cancelling (Provisioner Stop)
 // Apply executes the file provisioner
-func (r *ResourceProvisioner) Apply(
-	o terraform.UIOutput,
-	s *terraform.InstanceState,
-	c *terraform.ResourceConfig) error {
+func Apply(ctx context.Context) error {
+	o := ctx.Value(schema.ProvOutputKey).(terraform.UIOutput)
+	d := ctx.Value(schema.ProvConfigDataKey).(*schema.ResourceData)
 	// Decode the raw config for this provisioner
-	p, err := r.decodeConfig(c)
+	p, err := decodeConfig(d)
 	if err != nil {
 		return err
 	}
 
 	if p.OSType == "" {
-		switch s.Ephemeral.ConnInfo["type"] {
+		t := d.State().Ephemeral.ConnInfo["type"]
+		switch t {
 		case "ssh", "": // The default connection type is ssh, so if the type is empty assume ssh
 			p.OSType = "linux"
 		case "winrm":
 			p.OSType = "windows"
 		default:
-			return fmt.Errorf("Unsupported connection type: %s", s.Ephemeral.ConnInfo["type"])
+			return fmt.Errorf("Unsupported connection type: %s", t)
 		}
 	}
 
@@ -169,7 +312,7 @@ func (r *ResourceProvisioner) Apply(
 		p.generateClientKey = p.generateClientKeyFunc(linuxKnifeCmd, linuxConfDir, linuxNoOutput)
 		p.configureVaults = p.configureVaultsFunc(linuxGemCmd, linuxKnifeCmd, linuxConfDir)
 		p.runChefClient = p.runChefClientFunc(linuxChefCmd, linuxConfDir)
-		p.useSudo = !p.PreventSudo && s.Ephemeral.ConnInfo["user"] != "root"
+		p.useSudo = !p.PreventSudo && d.State().Ephemeral.ConnInfo["user"] != "root"
 	case "windows":
 		p.cleanupUserKeyCmd = fmt.Sprintf("cd %s && del /F /Q %s", windowsConfDir, p.UserName+".pem")
 		p.createConfigFiles = p.windowsCreateConfigFiles
@@ -184,7 +327,7 @@ func (r *ResourceProvisioner) Apply(
 	}
 
 	// Get a new communicator
-	comm, err := communicator.New(s)
+	comm, err := communicator.New(d.State())
 	if err != nil {
 		return err
 	}
@@ -254,21 +397,15 @@ func (r *ResourceProvisioner) Apply(
 }
 
 // Validate checks if the required arguments are configured
-func (r *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string, es []error) {
-	p, err := r.decodeConfig(c)
+func Validate(d *schema.ResourceData) (ws []string, es []error) {
+	p, err := decodeConfig(d)
 	if err != nil {
 		es = append(es, err)
 		return ws, es
 	}
 
-	if p.NodeName == "" {
-		es = append(es, errors.New("Key not found: node_name"))
-	}
 	if !p.UsePolicyfile && p.RunList == nil {
 		es = append(es, errors.New("Key not found: run_list"))
-	}
-	if p.ServerURL == "" {
-		es = append(es, errors.New("Key not found: server_url"))
 	}
 	if p.UsePolicyfile && p.PolicyName == "" {
 		es = append(es, errors.New("Policyfile enabled but key not found: policy_name"))
@@ -284,12 +421,7 @@ func (r *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string
 		es = append(es, errors.New(
 			"One of user_key or the deprecated validation_key must be provided"))
 	}
-	if p.ValidationClientName != "" {
-		ws = append(ws, "validation_client_name is deprecated, please use user_name instead")
-	}
 	if p.ValidationKey != "" {
-		ws = append(ws, "validation_key is deprecated, please use user_key instead")
-
 		if p.RecreateClient {
 			es = append(es, errors.New(
 				"Cannot use recreate_client=true with the deprecated validation_key, please provide a user_key"))
@@ -303,38 +435,8 @@ func (r *ResourceProvisioner) Validate(c *terraform.ResourceConfig) (ws []string
 	return ws, es
 }
 
-func (r *ResourceProvisioner) decodeConfig(c *terraform.ResourceConfig) (*Provisioner, error) {
-	p := new(Provisioner)
-
-	decConf := &mapstructure.DecoderConfig{
-		ErrorUnused:      true,
-		WeaklyTypedInput: true,
-		Result:           p,
-	}
-	dec, err := mapstructure.NewDecoder(decConf)
-	if err != nil {
-		return nil, err
-	}
-
-	// We need to merge both configs into a single map first. Order is
-	// important as we need to make sure interpolated values are used
-	// over raw values. This makes sure that all values are there even
-	// if some still need to be interpolated later on. Without this
-	// the validation will fail when using a variable for a required
-	// parameter (the node_name for example).
-	m := make(map[string]interface{})
-
-	for k, v := range c.Raw {
-		m[k] = v
-	}
-
-	for k, v := range c.Config {
-		m[k] = v
-	}
-
-	if err := dec.Decode(m); err != nil {
-		return nil, err
-	}
+func decodeConfig(d *schema.ResourceData) (*ProvisionerS, error) {
+	p := decodeDataToProvisioner(d)
 
 	// Make sure the supplied URL has a trailing slash
 	p.ServerURL = strings.TrimSuffix(p.ServerURL, "/") + "/"
@@ -359,17 +461,17 @@ func (r *ResourceProvisioner) decodeConfig(c *terraform.ResourceConfig) (*Provis
 		p.UserKey = p.ValidationKey
 	}
 
-	if attrs, ok := c.Config["attributes_json"].(string); ok && !c.IsComputed("attributes_json") {
+	if attrs, ok := d.GetOk("attributes_json"); ok {
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(attrs), &m); err != nil {
+		if err := json.Unmarshal([]byte(attrs.(string)), &m); err != nil {
 			return nil, fmt.Errorf("Error parsing attributes_json: %v", err)
 		}
 		p.attributes = m
 	}
 
-	if vaults, ok := c.Config["vault_json"].(string); ok && !c.IsComputed("vault_json") {
+	if vaults, ok := d.GetOk("vault_json"); ok {
 		var m map[string]interface{}
-		if err := json.Unmarshal([]byte(vaults), &m); err != nil {
+		if err := json.Unmarshal([]byte(vaults.(string)), &m); err != nil {
 			return nil, fmt.Errorf("Error parsing vault_json: %v", err)
 		}
 
@@ -395,7 +497,7 @@ func (r *ResourceProvisioner) decodeConfig(c *terraform.ResourceConfig) (*Provis
 	return p, nil
 }
 
-func (p *Provisioner) deployConfigFiles(
+func (p *ProvisionerS) deployConfigFiles(
 	o terraform.UIOutput,
 	comm communicator.Communicator,
 	confDir string) error {
@@ -469,7 +571,7 @@ func (p *Provisioner) deployConfigFiles(
 	return nil
 }
 
-func (p *Provisioner) deployOhaiHints(
+func (p *ProvisionerS) deployOhaiHints(
 	o terraform.UIOutput,
 	comm communicator.Communicator,
 	hintDir string) error {
@@ -490,7 +592,7 @@ func (p *Provisioner) deployOhaiHints(
 	return nil
 }
 
-func (p *Provisioner) fetchChefCertificatesFunc(
+func (p *ProvisionerS) fetchChefCertificatesFunc(
 	knifeCmd string,
 	confDir string) func(terraform.UIOutput, communicator.Communicator) error {
 	return func(o terraform.UIOutput, comm communicator.Communicator) error {
@@ -501,7 +603,7 @@ func (p *Provisioner) fetchChefCertificatesFunc(
 	}
 }
 
-func (p *Provisioner) generateClientKeyFunc(
+func (p *ProvisionerS) generateClientKeyFunc(
 	knifeCmd string,
 	confDir string,
 	noOutput string) func(terraform.UIOutput, communicator.Communicator) error {
@@ -562,7 +664,7 @@ func (p *Provisioner) generateClientKeyFunc(
 	}
 }
 
-func (p *Provisioner) configureVaultsFunc(
+func (p *ProvisionerS) configureVaultsFunc(
 	gemCmd string,
 	knifeCmd string,
 	confDir string) func(terraform.UIOutput, communicator.Communicator) error {
@@ -596,7 +698,7 @@ func (p *Provisioner) configureVaultsFunc(
 	}
 }
 
-func (p *Provisioner) runChefClientFunc(
+func (p *ProvisionerS) runChefClientFunc(
 	chefCmd string,
 	confDir string) func(terraform.UIOutput, communicator.Communicator) error {
 	return func(o terraform.UIOutput, comm communicator.Communicator) error {
@@ -634,7 +736,7 @@ func (p *Provisioner) runChefClientFunc(
 }
 
 // Output implementation of terraform.UIOutput interface
-func (p *Provisioner) Output(output string) {
+func (p *ProvisionerS) Output(output string) {
 	logFile := path.Join(logfileDir, p.NodeName)
 	f, err := os.OpenFile(logFile, os.O_APPEND|os.O_WRONLY, 0666)
 	if err != nil {
@@ -660,7 +762,7 @@ func (p *Provisioner) Output(output string) {
 }
 
 // runCommand is used to run already prepared commands
-func (p *Provisioner) runCommand(
+func (p *ProvisionerS) runCommand(
 	o terraform.UIOutput,
 	comm communicator.Communicator,
 	command string) error {
@@ -702,7 +804,7 @@ func (p *Provisioner) runCommand(
 	return err
 }
 
-func (p *Provisioner) copyOutput(o terraform.UIOutput, r io.Reader, doneCh chan<- struct{}) {
+func (p *ProvisionerS) copyOutput(o terraform.UIOutput, r io.Reader, doneCh chan<- struct{}) {
 	defer close(doneCh)
 	lr := linereader.New(r)
 	for line := range lr.Ch {
@@ -725,5 +827,60 @@ func retryFunc(timeout time.Duration, f func() error) error {
 			return err
 		case <-time.After(3 * time.Second):
 		}
+	}
+}
+
+func decodeDataToProvisioner(d *schema.ResourceData) *ProvisionerS {
+	return &ProvisionerS{
+		AttributesJSON:        d.Get("attributes_json").(string),
+		ClientOptions:         getStringList(d.Get("client_options")),
+		DisableReporting:      d.Get("disable_reporting").(bool),
+		Environment:           d.Get("environment").(string),
+		FetchChefCertificates: d.Get("fetch_chef_certificates").(bool),
+		LogToFile:             d.Get("log_to_file").(bool),
+		UsePolicyfile:         d.Get("use_policyfile").(bool),
+		PolicyGroup:           d.Get("policy_group").(string),
+		PolicyName:            d.Get("policy_name").(string),
+		HTTPProxy:             d.Get("http_proxy").(string),
+		HTTPSProxy:            d.Get("https_proxy").(string),
+		NOProxy:               getStringList(d.Get("no_proxy")),
+		NamedRunList:          d.Get("named_run_list").(string),
+		NodeName:              d.Get("node_name").(string),
+		OhaiHints:             getStringList(d.Get("ohai_hints")),
+		OSType:                d.Get("os_type").(string),
+		RecreateClient:        d.Get("recreate_client").(bool),
+		PreventSudo:           d.Get("prevent_sudo").(bool),
+		RunList:               getStringList(d.Get("run_list")),
+		SecretKey:             d.Get("secret_key").(string),
+		ServerURL:             d.Get("server_url").(string),
+		SkipInstall:           d.Get("skip_install").(bool),
+		SkipRegister:          d.Get("skip_register").(bool),
+		SSLVerifyMode:         d.Get("ssl_verify_mode").(string),
+		UserName:              d.Get("user_name").(string),
+		UserKey:               d.Get("user_key").(string),
+		VaultJSON:             d.Get("vault_json").(string),
+		Version:               d.Get("version").(string),
+
+		// Deprecated
+		ValidationClientName: d.Get("validation_client_name").(string),
+		ValidationKey:        d.Get("validation_key").(string),
+	}
+}
+
+func getStringList(v interface{}) []string {
+	if v == nil {
+		return nil
+	}
+	switch l := v.(type) {
+	case []string:
+		return l
+	case []interface{}:
+		arr := make([]string, len(l))
+		for i, x := range l {
+			arr[i] = x.(string)
+		}
+		return arr
+	default:
+		panic(fmt.Sprintf("Unsupported type: %T", v))
 	}
 }

--- a/builtin/provisioners/chef/windows_provisioner.go
+++ b/builtin/provisioners/chef/windows_provisioner.go
@@ -46,7 +46,7 @@ Write-Host 'Installing Chef Client...'
 Start-Process -FilePath msiexec -ArgumentList /qn, /i, $dest -Wait
 `
 
-func (p *Provisioner) windowsInstallChefClient(
+func (p *ProvisionerS) windowsInstallChefClient(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 	script := path.Join(path.Dir(comm.ScriptPath()), "ChefClient.ps1")
@@ -62,7 +62,7 @@ func (p *Provisioner) windowsInstallChefClient(
 	return p.runCommand(o, comm, installCmd)
 }
 
-func (p *Provisioner) windowsCreateConfigFiles(
+func (p *ProvisionerS) windowsCreateConfigFiles(
 	o terraform.UIOutput,
 	comm communicator.Communicator) error {
 	// Make sure the config directory exists

--- a/builtin/provisioners/chef/windows_provisioner.go
+++ b/builtin/provisioners/chef/windows_provisioner.go
@@ -46,9 +46,7 @@ Write-Host 'Installing Chef Client...'
 Start-Process -FilePath msiexec -ArgumentList /qn, /i, $dest -Wait
 `
 
-func (p *ProvisionerS) windowsInstallChefClient(
-	o terraform.UIOutput,
-	comm communicator.Communicator) error {
+func (p *provisioner) windowsInstallChefClient(o terraform.UIOutput, comm communicator.Communicator) error {
 	script := path.Join(path.Dir(comm.ScriptPath()), "ChefClient.ps1")
 	content := fmt.Sprintf(installScript, p.Version, p.HTTPProxy, strings.Join(p.NOProxy, ","))
 
@@ -62,9 +60,7 @@ func (p *ProvisionerS) windowsInstallChefClient(
 	return p.runCommand(o, comm, installCmd)
 }
 
-func (p *ProvisionerS) windowsCreateConfigFiles(
-	o terraform.UIOutput,
-	comm communicator.Communicator) error {
+func (p *provisioner) windowsCreateConfigFiles(o terraform.UIOutput, comm communicator.Communicator) error {
 	// Make sure the config directory exists
 	cmd := fmt.Sprintf("cmd /c if not exist %q mkdir %q", windowsConfDir, windowsConfDir)
 	if err := p.runCommand(o, comm, cmd); err != nil {

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -73,7 +73,6 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
@@ -81,7 +80,7 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		c.Commands = tc.Commands
 		c.UploadScripts = tc.UploadScripts
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -180,7 +179,6 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		},
 	}
 
-	r := new(ResourceProvisioner)
 	o := new(terraform.MockUIOutput)
 	c := new(communicator.MockCommunicator)
 
@@ -188,7 +186,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := r.decodeConfig(tc.Config)
+		p, err := decodeConfig(getTestResourceData(tc.Config))
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/chef/windows_provisioner_test.go
+++ b/builtin/provisioners/chef/windows_provisioner_test.go
@@ -6,23 +6,24 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/communicator"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
 
 func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 	cases := map[string]struct {
-		Config        *terraform.ResourceConfig
+		Config        map[string]interface{}
 		Commands      map[string]bool
 		UploadScripts map[string]string
 	}{
 		"Default": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"node_name":  "nodename1",
 				"run_list":   []interface{}{"cookbook::recipe"},
 				"server_url": "https://chef.local",
 				"user_name":  "bob",
 				"user_key":   "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"powershell -NoProfile -ExecutionPolicy Bypass -File ChefClient.ps1": true,
@@ -34,7 +35,7 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		},
 
 		"Proxy": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"http_proxy": "http://proxy.local",
 				"no_proxy":   []interface{}{"http://local.local", "http://local.org"},
 				"node_name":  "nodename1",
@@ -42,7 +43,7 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 				"server_url": "https://chef.local",
 				"user_name":  "bob",
 				"user_key":   "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"powershell -NoProfile -ExecutionPolicy Bypass -File ChefClient.ps1": true,
@@ -54,14 +55,14 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		},
 
 		"Version": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"node_name":  "nodename1",
 				"run_list":   []interface{}{"cookbook::recipe"},
 				"server_url": "https://chef.local",
 				"user_name":  "bob",
 				"user_key":   "USER-KEY",
 				"version":    "11.18.6",
-			}),
+			},
 
 			Commands: map[string]bool{
 				"powershell -NoProfile -ExecutionPolicy Bypass -File ChefClient.ps1": true,
@@ -80,7 +81,9 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 		c.Commands = tc.Commands
 		c.UploadScripts = tc.UploadScripts
 
-		p, err := decodeConfig(getTestResourceData(tc.Config))
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}
@@ -96,12 +99,12 @@ func TestResourceProvider_windowsInstallChefClient(t *testing.T) {
 
 func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 	cases := map[string]struct {
-		Config   *terraform.ResourceConfig
+		Config   map[string]interface{}
 		Commands map[string]bool
 		Uploads  map[string]string
 	}{
 		"Default": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"ohai_hints": []interface{}{"test-fixtures/ohaihint.json"},
 				"node_name":  "nodename1",
 				"run_list":   []interface{}{"cookbook::recipe"},
@@ -109,7 +112,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 				"server_url": "https://chef.local",
 				"user_name":  "bob",
 				"user_key":   "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				fmt.Sprintf("cmd /c if not exist %q mkdir %q", windowsConfDir, windowsConfDir): true,
@@ -128,7 +131,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		},
 
 		"Proxy": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"http_proxy":      "http://proxy.local",
 				"https_proxy":     "https://proxy.local",
 				"no_proxy":        []interface{}{"http://local.local", "https://local.local"},
@@ -139,7 +142,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 				"ssl_verify_mode": "verify_none",
 				"user_name":       "bob",
 				"user_key":        "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				fmt.Sprintf("cmd /c if not exist %q mkdir %q", windowsConfDir, windowsConfDir): true,
@@ -154,7 +157,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		},
 
 		"Attributes JSON": {
-			Config: testConfig(t, map[string]interface{}{
+			Config: map[string]interface{}{
 				"attributes_json": `{"key1":{"subkey1":{"subkey2a":["val1","val2","val3"],` +
 					`"subkey2b":{"subkey3":"value3"}}},"key2":"value2"}`,
 				"node_name":  "nodename1",
@@ -163,7 +166,7 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 				"server_url": "https://chef.local",
 				"user_name":  "bob",
 				"user_key":   "USER-KEY",
-			}),
+			},
 
 			Commands: map[string]bool{
 				fmt.Sprintf("cmd /c if not exist %q mkdir %q", windowsConfDir, windowsConfDir): true,
@@ -186,7 +189,9 @@ func TestResourceProvider_windowsCreateConfigFiles(t *testing.T) {
 		c.Commands = tc.Commands
 		c.Uploads = tc.Uploads
 
-		p, err := decodeConfig(getTestResourceData(tc.Config))
+		p, err := decodeConfig(
+			schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, tc.Config),
+		)
 		if err != nil {
 			t.Fatalf("Error: %v", err)
 		}

--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -35,7 +35,8 @@ func Provisioner() terraform.ResourceProvisioner {
 			},
 		},
 
-		ApplyFunc: applyFn,
+		ApplyFunc:    applyFn,
+		ValidateFunc: Validate,
 	}
 }
 
@@ -75,6 +76,21 @@ func applyFn(ctx context.Context) error {
 	case <-ctx.Done():
 		return fmt.Errorf("file transfer interrupted")
 	}
+}
+
+// Validate checks if the required arguments are configured
+func Validate(d *schema.ResourceData) (ws []string, es []error) {
+	numSrc := 0
+	if _, ok := d.GetOk("source"); ok == true {
+		numSrc++
+	}
+	if _, ok := d.GetOk("content"); ok == true {
+		numSrc++
+	}
+	if numSrc != 1 {
+		es = append(es, fmt.Errorf("Must provide one of 'content' or 'source'"))
+	}
+	return
 }
 
 // getSrc returns the file to use as source

--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -36,7 +36,7 @@ func Provisioner() terraform.ResourceProvisioner {
 		},
 
 		ApplyFunc:    applyFn,
-		ValidateFunc: Validate,
+		ValidateFunc: validateFn,
 	}
 }
 
@@ -78,8 +78,7 @@ func applyFn(ctx context.Context) error {
 	}
 }
 
-// Validate checks if the required arguments are configured
-func Validate(d *schema.ResourceData) (ws []string, es []error) {
+func validateFn(d *schema.ResourceData) (ws []string, es []error) {
 	numSrc := 0
 	if _, ok := d.GetOk("source"); ok == true {
 		numSrc++

--- a/builtin/provisioners/file/resource_provisioner_test.go
+++ b/builtin/provisioners/file/resource_provisioner_test.go
@@ -4,8 +4,19 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func TestResourceProvisioner_impl(t *testing.T) {
+	var _ terraform.ResourceProvisioner = Provisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := Provisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
 
 func TestResourceProvider_Validate_good_source(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
@@ -40,6 +51,20 @@ func TestResourceProvider_Validate_good_content(t *testing.T) {
 func TestResourceProvider_Validate_bad_not_destination(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source": "nope",
+	})
+	p := Provisioner()
+	warn, errs := p.Validate(c)
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) == 0 {
+		t.Fatalf("Should have errors")
+	}
+}
+
+func TestResourceProvider_Validate_bad_no_source(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"destination": "/tmp/bar",
 	})
 	p := Provisioner()
 	warn, errs := p.Validate(c)

--- a/builtin/provisioners/file/resource_provisioner_test.go
+++ b/builtin/provisioners/file/resource_provisioner_test.go
@@ -23,8 +23,8 @@ func TestResourceProvider_Validate_good_source(t *testing.T) {
 		"source":      "/tmp/foo",
 		"destination": "/tmp/bar",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -38,8 +38,8 @@ func TestResourceProvider_Validate_good_content(t *testing.T) {
 		"content":     "value to copy",
 		"destination": "/tmp/bar",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -52,8 +52,8 @@ func TestResourceProvider_Validate_bad_not_destination(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source": "nope",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -66,8 +66,8 @@ func TestResourceProvider_Validate_bad_no_source(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"destination": "/tmp/bar",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -82,8 +82,8 @@ func TestResourceProvider_Validate_bad_to_many_src(t *testing.T) {
 		"content":     "value to copy",
 		"destination": "/tmp/bar",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -92,12 +92,11 @@ func TestResourceProvider_Validate_bad_to_many_src(t *testing.T) {
 	}
 }
 
-func testConfig(
-	t *testing.T,
-	c map[string]interface{}) *terraform.ResourceConfig {
+func testConfig(t *testing.T, c map[string]interface{}) *terraform.ResourceConfig {
 	r, err := config.NewRawConfig(c)
 	if err != nil {
 		t.Fatalf("bad: %s", err)
 	}
+
 	return terraform.NewResourceConfig(r)
 }

--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -8,8 +8,19 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform/config"
+	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func TestResourceProvisioner_impl(t *testing.T) {
+	var _ terraform.ResourceProvisioner = Provisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := Provisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
 
 func TestResourceProvider_Apply(t *testing.T) {
 	defer os.Remove("test_out")

--- a/builtin/provisioners/local-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/local-exec/resource_provisioner_test.go
@@ -30,6 +30,7 @@ func TestResourceProvider_Apply(t *testing.T) {
 
 	output := new(terraform.MockUIOutput)
 	p := Provisioner()
+
 	if err := p.Apply(output, nil, c); err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -84,8 +85,8 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"command": "echo foo",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -96,8 +97,8 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 
 func TestResourceProvider_Validate_missing(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -106,9 +107,7 @@ func TestResourceProvider_Validate_missing(t *testing.T) {
 	}
 }
 
-func testConfig(
-	t *testing.T,
-	c map[string]interface{}) *terraform.ResourceConfig {
+func testConfig(t *testing.T, c map[string]interface{}) *terraform.ResourceConfig {
 	r, err := config.NewRawConfig(c)
 	if err != nil {
 		t.Fatalf("bad: %s", err)

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -16,6 +16,16 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
+func TestResourceProvisioner_impl(t *testing.T) {
+	var _ terraform.ResourceProvisioner = Provisioner()
+}
+
+func TestProvisioner(t *testing.T) {
+	if err := Provisioner().(*schema.Provisioner).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
 func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"inline": "echo foo",

--- a/builtin/provisioners/remote-exec/resource_provisioner_test.go
+++ b/builtin/provisioners/remote-exec/resource_provisioner_test.go
@@ -30,8 +30,8 @@ func TestResourceProvider_Validate_good(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"inline": "echo foo",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -44,8 +44,8 @@ func TestResourceProvider_Validate_bad(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"invalid": "nope",
 	})
-	p := Provisioner()
-	warn, errs := p.Validate(c)
+
+	warn, errs := Provisioner().Validate(c)
 	if len(warn) > 0 {
 		t.Fatalf("Warnings: %v", warn)
 	}
@@ -60,7 +60,6 @@ exit 0
 `
 
 func TestResourceProvider_generateScript(t *testing.T) {
-	p := Provisioner().(*schema.Provisioner)
 	conf := map[string]interface{}{
 		"inline": []interface{}{
 			"cd /tmp",
@@ -68,8 +67,10 @@ func TestResourceProvider_generateScript(t *testing.T) {
 			"exit 0",
 		},
 	}
-	out, err := generateScripts(schema.TestResourceDataRaw(
-		t, p.Schema, conf))
+
+	out, err := generateScripts(
+		schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, conf),
+	)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -101,7 +102,6 @@ func TestResourceProvider_generateScriptEmptyInline(t *testing.T) {
 }
 
 func TestResourceProvider_CollectScripts_inline(t *testing.T) {
-	p := Provisioner().(*schema.Provisioner)
 	conf := map[string]interface{}{
 		"inline": []interface{}{
 			"cd /tmp",
@@ -110,8 +110,9 @@ func TestResourceProvider_CollectScripts_inline(t *testing.T) {
 		},
 	}
 
-	scripts, err := collectScripts(schema.TestResourceDataRaw(
-		t, p.Schema, conf))
+	scripts, err := collectScripts(
+		schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, conf),
+	)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -132,13 +133,13 @@ func TestResourceProvider_CollectScripts_inline(t *testing.T) {
 }
 
 func TestResourceProvider_CollectScripts_script(t *testing.T) {
-	p := Provisioner().(*schema.Provisioner)
 	conf := map[string]interface{}{
 		"script": "test-fixtures/script1.sh",
 	}
 
-	scripts, err := collectScripts(schema.TestResourceDataRaw(
-		t, p.Schema, conf))
+	scripts, err := collectScripts(
+		schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, conf),
+	)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -159,7 +160,6 @@ func TestResourceProvider_CollectScripts_script(t *testing.T) {
 }
 
 func TestResourceProvider_CollectScripts_scripts(t *testing.T) {
-	p := Provisioner().(*schema.Provisioner)
 	conf := map[string]interface{}{
 		"scripts": []interface{}{
 			"test-fixtures/script1.sh",
@@ -168,8 +168,9 @@ func TestResourceProvider_CollectScripts_scripts(t *testing.T) {
 		},
 	}
 
-	scripts, err := collectScripts(schema.TestResourceDataRaw(
-		t, p.Schema, conf))
+	scripts, err := collectScripts(
+		schema.TestResourceDataRaw(t, Provisioner().(*schema.Provisioner).Schema, conf),
+	)
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
@@ -234,9 +235,7 @@ func TestRetryFunc(t *testing.T) {
 	}
 }
 
-func testConfig(
-	t *testing.T,
-	c map[string]interface{}) *terraform.ResourceConfig {
+func testConfig(t *testing.T, c map[string]interface{}) *terraform.ResourceConfig {
 	r, err := config.NewRawConfig(c)
 	if err != nil {
 		t.Fatalf("bad: %s", err)

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -75,6 +75,7 @@ import (
 	vaultprovider "github.com/hashicorp/terraform/builtin/providers/vault"
 	vcdprovider "github.com/hashicorp/terraform/builtin/providers/vcd"
 	vsphereprovider "github.com/hashicorp/terraform/builtin/providers/vsphere"
+	chefprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef"
 	fileprovisioner "github.com/hashicorp/terraform/builtin/provisioners/file"
 	localexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/local-exec"
 	remoteexecprovisioner "github.com/hashicorp/terraform/builtin/provisioners/remote-exec"
@@ -84,9 +85,6 @@ import (
 
 	//New Provider Builds
 	opcprovider "github.com/hashicorp/terraform-provider-opc/opc"
-
-	// Legacy, will remove once it conforms with new structure
-	chefprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef"
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
@@ -162,16 +160,13 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 }
 
 var InternalProvisioners = map[string]plugin.ProvisionerFunc{
+	"chef":        chefprovisioner.Provisioner,
 	"file":        fileprovisioner.Provisioner,
 	"local-exec":  localexecprovisioner.Provisioner,
 	"remote-exec": remoteexecprovisioner.Provisioner,
 }
 
 func init() {
-	// Legacy provisioners that don't match our heuristics for auto-finding
-	// built-in provisioners.
-	InternalProvisioners["chef"] = func() terraform.ResourceProvisioner { return new(chefprovisioner.ResourceProvisioner) }
-
 	// New Provider Layouts
 	InternalProviders["opc"] = func() terraform.ResourceProvider { return opcprovider.Provider() }
 }

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -41,6 +41,11 @@ type Provisioner struct {
 	// information.
 	ApplyFunc func(ctx context.Context) error
 
+	// ValidateFunc is the function for extended validation. This is optional.
+	// It is given a resource data.
+	// Should be provided when Scheme is not enough.
+	ValidateFunc func(*ResourceData) ([]string, []error)
+
 	stopCtx       context.Context
 	stopCtxCancel context.CancelFunc
 	stopOnce      sync.Once
@@ -117,8 +122,30 @@ func (p *Provisioner) Stop() error {
 	return nil
 }
 
-func (p *Provisioner) Validate(c *terraform.ResourceConfig) ([]string, []error) {
-	return schemaMap(p.Schema).Validate(c)
+func (p *Provisioner) Validate(config *terraform.ResourceConfig) ([]string, []error) {
+	if err := p.InternalValidate(); err != nil {
+		return nil, []error{fmt.Errorf(
+			"Internal validation of the provisioner failed! This is always a bug\n"+
+				"with the provisioner itself, and not a user issue. Please report\n"+
+				"this bug:\n\n%s", err)}
+	}
+	w := []string{}
+	e := []error{}
+	if p.Schema != nil {
+		w2, e2 := schemaMap(p.Schema).Validate(config)
+		w = append(w, w2...)
+		e = append(e, e2...)
+	}
+	if p.ValidateFunc != nil {
+		data := &ResourceData{
+			schema: p.Schema,
+			config: config,
+		}
+		w2, e2 := p.ValidateFunc(data)
+		w = append(w, w2...)
+		e = append(e, e2...)
+	}
+	return w, e
 }
 
 // Apply implementation of terraform.ResourceProvisioner interface.

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -41,9 +41,8 @@ type Provisioner struct {
 	// information.
 	ApplyFunc func(ctx context.Context) error
 
-	// ValidateFunc is the function for extended validation. This is optional.
-	// It is given a resource data.
-	// Should be provided when Scheme is not enough.
+	// ValidateFunc is a function for extended validation. This is optional
+	// and should be used when individual field validation is not enough.
 	ValidateFunc func(*ResourceData) ([]string, []error)
 
 	stopCtx       context.Context

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -28,3 +28,10 @@ func TestResourceDataRaw(
 
 	return result
 }
+
+func TestResourceDataConfig(schema map[string]*Schema, config *terraform.ResourceConfig) *ResourceData {
+	return &ResourceData{
+		schema: schema,
+		config: config,
+	}
+}

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -28,10 +28,3 @@ func TestResourceDataRaw(
 
 	return result
 }
-
-func TestResourceDataConfig(schema map[string]*Schema, config *terraform.ResourceConfig) *ResourceData {
-	return &ResourceData{
-		schema: schema,
-		config: config,
-	}
-}

--- a/scripts/generate-plugins.go
+++ b/scripts/generate-plugins.go
@@ -82,12 +82,11 @@ func makeProviderMap(items []plugin) string {
 
 // makeProvisionerMap creates a map of provisioners like this:
 //
-//	"file":        func() terraform.ResourceProvisioner { return new(file.ResourceProvisioner) },
-//	"local-exec":  func() terraform.ResourceProvisioner { return new(localexec.ResourceProvisioner) },
-//	"remote-exec": func() terraform.ResourceProvisioner { return new(remoteexec.ResourceProvisioner) },
+//	"chef":        chefprovisioner.Provisioner,
+//	"file":        fileprovisioner.Provisioner,
+//	"local-exec":  localexecprovisioner.Provisioner,
+//	"remote-exec": remoteexecprovisioner.Provisioner,
 //
-// This is more verbose than the Provider case because there is no corresponding
-// Provisioner function.
 func makeProvisionerMap(items []plugin) string {
 	output := ""
 	for _, item := range items {
@@ -273,9 +272,6 @@ IMPORTS
 
 	//New Provider Builds
 	opcprovider "github.com/hashicorp/terraform-provider-opc/opc"
-
-	// Legacy, will remove once it conforms with new structure
-	chefprovisioner "github.com/hashicorp/terraform/builtin/provisioners/chef"
 )
 
 var InternalProviders = map[string]plugin.ProviderFunc{
@@ -287,12 +283,7 @@ PROVISIONERS
 }
 
 func init() {
-	// Legacy provisioners that don't match our heuristics for auto-finding
-	// built-in provisioners.
-	InternalProvisioners["chef"] = func() terraform.ResourceProvisioner { return new(chefprovisioner.ResourceProvisioner) }
-
 	// New Provider Layouts
 	InternalProviders["opc"] = func() terraform.ResourceProvider { return opcprovider.Provider() }
 }
-
 `

--- a/website/source/docs/provisioners/chef.html.markdown
+++ b/website/source/docs/provisioners/chef.html.markdown
@@ -157,9 +157,3 @@ The following arguments are supported:
 
 * `version (string)` - (Optional) The Chef Client version to install on the remote machine.
   If not set, the latest available version will be installed.
-
-These options are supported for backwards compatibility and may be removed in a
-future version:
-
-* `validation_client_name (string)` - __Deprecated: please use `user_name` instead__.
-* `validation_key (string)` - __Deprecated: please use `user_key` instead__.


### PR DESCRIPTION
Done by @VladRassokhin:
1. Migrate `chef` provisioner to `schema.Provisioner`:

 * `chef.Provisioner` structure was renamed to `ProvisionerS`and  now it's decoded from `schema.ResourceData` instead of `terraform.ResourceConfig` using simple copy-paste-based solution;
 * Added simple schema without any validation yet.

2. Support `ValidateFunc` validate function : implemented in `file` and `chef` provisioners.

Done by @svanharmelen:
1. The tests did pass, but that was because they only tested part of the changes. By using the `schema.TestResourceDataRaw` function the schema and config are better tested and so they pointed out a problem with the schema of the Chef provisioner. 

2. So fixed the `Elem` fields that did not have a `*schema.Schema` but a `schema.Schema` and in an `Elem` schema only the `Type` field may (and must) be set. Any other fields like `Optional` are not allowed here.

3. Next to fixing that problem I also did a little refactoring and cleaning up. Mainly making the `ProvisionerS` private (`provisioner`) and removing the deprecated fields.