### PR TITLE
provider/github Check for potentially nil response from GitHub API client

### DIFF
--- a/builtin/providers/github/resource_github_issue_label.go
+++ b/builtin/providers/github/resource_github_issue_label.go
@@ -84,7 +84,9 @@ func resourceGithubIssueLabelCreateOrUpdate(d *schema.ResourceData, meta interfa
 	} else {
 		log.Printf("[DEBUG] Creating label: %s/%s (%s: %s)", o, r, n, c)
 		_, resp, err := client.Issues.CreateLabel(context.TODO(), o, r, label)
-		log.Printf("[DEBUG] Response from creating label: %s", *resp)
+		if resp != nil {
+			log.Printf("[DEBUG] Response from creating label: %s", *resp)
+		}
 		if err != nil {
 			return err
 		}

--- a/builtin/providers/github/resource_github_organization_webhook.go
+++ b/builtin/providers/github/resource_github_organization_webhook.go
@@ -94,7 +94,7 @@ func resourceGithubOrganizationWebhookRead(d *schema.ResourceData, meta interfac
 
 	hook, resp, err := client.Organizations.GetHook(context.TODO(), meta.(*Organization).name, hookID)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}

--- a/builtin/providers/github/resource_github_repository.go
+++ b/builtin/providers/github/resource_github_repository.go
@@ -127,7 +127,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	log.Printf("[DEBUG] read github repository %s/%s", meta.(*Organization).name, repoName)
 	repo, resp, err := client.Repositories.Get(context.TODO(), meta.(*Organization).name, repoName)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			log.Printf(
 				"[WARN] removing %s/%s from state because it no longer exists in github",
 				meta.(*Organization).name,

--- a/builtin/providers/github/resource_github_repository_webhook.go
+++ b/builtin/providers/github/resource_github_repository_webhook.go
@@ -89,7 +89,7 @@ func resourceGithubRepositoryWebhookRead(d *schema.ResourceData, meta interface{
 
 	hook, resp, err := client.Repositories.GetHook(context.TODO(), meta.(*Organization).name, d.Get("repository").(string), hookID)
 	if err != nil {
-		if resp.StatusCode == 404 {
+		if resp != nil && resp.StatusCode == 404 {
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
The GitHub API client methods usually return 3 values - object, resp, err.
If a non-`nil` _err_ is returned, _object_ will be `nil` but _resp_ may or may not be `nil`.
In a few places in the GitHub provider there were assumptions that when `err != nil`, `resp != nil` and I hit this when I had an invalid GitHub token at one point and got a nil-pointer dereference panic.

Acceptance tests:
```
make testacc TEST=./builtin/providers/github/ TESTARGS='-run=TestAccGithubIssueLabel_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 15:30:58 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/github/ -v -run=TestAccGithubIssueLabel_ -timeout 120m
=== RUN   TestAccGithubIssueLabel_basic
--- PASS: TestAccGithubIssueLabel_basic (2.32s)
=== RUN   TestAccGithubIssueLabel_existingLabel
--- PASS: TestAccGithubIssueLabel_existingLabel (1.61s)
=== RUN   TestAccGithubIssueLabel_importBasic
--- PASS: TestAccGithubIssueLabel_importBasic (1.37s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/github	5.313s

make testacc TEST=./builtin/providers/github/ TESTARGS='-run=TestAccGithubOrganizationWebhook_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 15:13:50 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/github/ -v -run=TestAccGithubOrganizationWebhook_ -timeout 120m
=== RUN   TestAccGithubOrganizationWebhook_basic
--- PASS: TestAccGithubOrganizationWebhook_basic (0.87s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/github	0.878s

make testacc TEST=./builtin/providers/github/ TESTARGS='-run=TestAccGithubRepository_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 15:16:26 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/github/ -v -run=TestAccGithubRepository_ -timeout 120m
=== RUN   TestAccGithubRepository_basic
--- PASS: TestAccGithubRepository_basic (1.67s)
=== RUN   TestAccGithubRepository_importBasic
--- PASS: TestAccGithubRepository_importBasic (1.12s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/github	2.798s

make testacc TEST=./builtin/providers/github/ TESTARGS='-run=TestAccGithubRepositoryWebhook_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 15:34:01 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/github/ -v -run=TestAccGithubRepositoryWebhook_ -timeout 120m
=== RUN   TestAccGithubRepositoryWebhook_basic
--- PASS: TestAccGithubRepositoryWebhook_basic (2.61s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/github	2.614s
```