### PR TITLE
provider/aws: Allow lightsail resources to work in other regions

### DIFF
--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -368,7 +368,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.kinesisconn = kinesis.New(awsKinesisSess)
 	client.kmsconn = kms.New(awsKmsSess)
 	client.lambdaconn = lambda.New(sess)
-	client.lightsailconn = lightsail.New(usEast1Sess)
+	client.lightsailconn = lightsail.New(sess)
 	client.opsworksconn = opsworks.New(sess)
 	client.r53conn = route53.New(usEast1Sess)
 	client.rdsconn = rds.New(awsRdsSess)

--- a/builtin/providers/aws/config.go
+++ b/builtin/providers/aws/config.go
@@ -269,12 +269,11 @@ func (c *Config) Client() (interface{}, error) {
 		sess.Handlers.UnmarshalError.PushFrontNamed(debugAuthFailure)
 	}
 
-	// Some services exist only in us-east-1, e.g. because they manage
-	// resources that can span across multiple regions, or because
-	// signature format v4 requires region to be us-east-1 for global
-	// endpoints:
-	// http://docs.aws.amazon.com/general/latest/gr/sigv4_changes.html
-	usEast1Sess := sess.Copy(&aws.Config{Region: aws.String("us-east-1")})
+	// This restriction should only be used for Route53 sessions.
+	// Other resources that have restrictions should allow the API to fail, rather
+	// than Terraform abstracting the region for the user. This can lead to breaking
+	// changes if that resource is ever opened up to more regions.
+	r53Sess := sess.Copy(&aws.Config{Region: aws.String("us-east-1")})
 
 	// Some services have user-configurable endpoints
 	awsCfSess := sess.Copy(&aws.Config{Endpoint: aws.String(c.CloudFormationEndpoint)})
@@ -370,7 +369,7 @@ func (c *Config) Client() (interface{}, error) {
 	client.lambdaconn = lambda.New(sess)
 	client.lightsailconn = lightsail.New(sess)
 	client.opsworksconn = opsworks.New(sess)
-	client.r53conn = route53.New(usEast1Sess)
+	client.r53conn = route53.New(r53Sess)
 	client.rdsconn = rds.New(awsRdsSess)
 	client.redshiftconn = redshift.New(sess)
 	client.simpledbconn = simpledb.New(sess)

--- a/builtin/providers/aws/resource_aws_lightsail_instance_test.go
+++ b/builtin/providers/aws/resource_aws_lightsail_instance_test.go
@@ -38,6 +38,30 @@ func TestAccAWSLightsailInstance_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLightsailInstance_euRegion(t *testing.T) {
+	var conf lightsail.Instance
+	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_lightsail_instance.lightsail_instance_test",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSLightsailInstanceDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLightsailInstanceConfig_euRegion(lightsailName),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckAWSLightsailInstanceExists("aws_lightsail_instance.lightsail_instance_test", &conf),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "availability_zone"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "blueprint_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "bundle_id"),
+					resource.TestCheckResourceAttrSet("aws_lightsail_instance.lightsail_instance_test", "key_pair_name"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSLightsailInstance_disapear(t *testing.T) {
 	var conf lightsail.Instance
 	lightsailName := fmt.Sprintf("tf-test-lightsail-%d", acctest.RandInt())
@@ -145,6 +169,20 @@ resource "aws_lightsail_instance" "lightsail_instance_test" {
   name              = "%s"
   availability_zone = "us-east-1b"
   blueprint_id      = "gitlab_8_12_6"
+  bundle_id         = "nano_1_0"
+}
+`, lightsailName)
+}
+
+func testAccAWSLightsailInstanceConfig_euRegion(lightsailName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "eu-west-1"
+}
+resource "aws_lightsail_instance" "lightsail_instance_test" {
+  name              = "%s"
+  availability_zone = "eu-west-1a"
+  blueprint_id = "joomla_3_6_5"
   bundle_id         = "nano_1_0"
 }
 `, lightsailName)


### PR DESCRIPTION
Previously lightsail was limited to `us-east-1` only. This restriction has now been lifted to new regions.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSLightsailInstance_euRegion'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 16:40:48 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLightsailInstance_euRegion -timeout 120m
=== RUN   TestAccAWSLightsailInstance_euRegion
--- PASS: TestAccAWSLightsailInstance_euRegion (45.31s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    45.319s
```

Fixes: #14668