### PR TITLE
provider/google: Refactor google_storage_bucket tests

### DIFF
--- a/builtin/providers/google/import_storage_bucket_test.go
+++ b/builtin/providers/google/import_storage_bucket_test.go
@@ -1,0 +1,30 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccStorageBucket_import(t *testing.T) {
+	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccStorageBucketDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccStorageBucket_basic(bucketName),
+			},
+			resource.TestStep{
+				ResourceName:            "google_storage_bucket.bucket",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"force_destroy"},
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_storage_bucket_test.go
+++ b/builtin/providers/google/resource_storage_bucket_test.go
@@ -13,19 +13,20 @@ import (
 	storage "google.golang.org/api/storage/v1"
 )
 
-func TestAccStorage_basic(t *testing.T) {
+func TestAccStorageBucket_basic(t *testing.T) {
+	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDestroy,
+		CheckDestroy: testAccStorageBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderDefaults(bucketName),
+				Config: testAccStorageBucket_basic(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "location", "US"),
 					resource.TestCheckResourceAttr(
@@ -36,19 +37,20 @@ func TestAccStorage_basic(t *testing.T) {
 	})
 }
 
-func TestAccStorageCustomAttributes(t *testing.T) {
+func TestAccStorageBucket_customAttributes(t *testing.T) {
+	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDestroy,
+		CheckDestroy: testAccStorageBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderCustomAttributes(bucketName),
+				Config: testAccStorageBucket_customAttributes(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "location", "EU"),
 					resource.TestCheckResourceAttr(
@@ -59,37 +61,38 @@ func TestAccStorageCustomAttributes(t *testing.T) {
 	})
 }
 
-func TestAccStorageStorageClass(t *testing.T) {
+func TestAccStorageBucket_storageClass(t *testing.T) {
+	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acc-bucket-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDestroy,
+		CheckDestroy: testAccStorageBucketDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "MULTI_REGIONAL", ""),
+				Config: testAccStorageBucket_storageClass(bucketName, "MULTI_REGIONAL", ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "storage_class", "MULTI_REGIONAL"),
 				),
 			},
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "NEARLINE", ""),
+				Config: testAccStorageBucket_storageClass(bucketName, "NEARLINE", ""),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "storage_class", "NEARLINE"),
 				),
 			},
 			{
-				Config: testGoogleStorageBucketsReaderStorageClass(bucketName, "REGIONAL", "US-CENTRAL1"),
+				Config: testAccStorageBucket_storageClass(bucketName, "REGIONAL", "US-CENTRAL1"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "storage_class", "REGIONAL"),
 					resource.TestCheckResourceAttr(
@@ -100,19 +103,20 @@ func TestAccStorageStorageClass(t *testing.T) {
 	})
 }
 
-func TestAccStorageBucketUpdate(t *testing.T) {
+func TestAccStorageBucket_update(t *testing.T) {
+	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDestroy,
+		CheckDestroy: testAccStorageBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderDefaults(bucketName),
+				Config: testAccStorageBucket_basic(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "location", "US"),
 					resource.TestCheckResourceAttr(
@@ -120,10 +124,10 @@ func TestAccStorageBucketUpdate(t *testing.T) {
 				),
 			},
 			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderCustomAttributes(bucketName),
+				Config: testAccStorageBucket_customAttributes(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 					resource.TestCheckResourceAttr(
 						"google_storage_bucket.bucket", "predefined_acl", "publicReadWrite"),
 					resource.TestCheckResourceAttr(
@@ -136,59 +140,39 @@ func TestAccStorageBucketUpdate(t *testing.T) {
 	})
 }
 
-func TestAccStorageBucketImport(t *testing.T) {
+func TestAccStorageBucket_forceDestroy(t *testing.T) {
+	var bucket storage.Bucket
 	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDestroy,
+		CheckDestroy: testAccStorageBucketDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderDefaults(bucketName),
-			},
-			resource.TestStep{
-				ResourceName:            "google_storage_bucket.bucket",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"force_destroy"},
-			},
-		},
-	})
-}
-
-func TestAccStorageForceDestroy(t *testing.T) {
-	bucketName := fmt.Sprintf("tf-test-acl-bucket-%d", acctest.RandInt())
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccGoogleStorageDestroy,
-		Steps: []resource.TestStep{
-			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderCustomAttributes(bucketName),
+				Config: testAccStorageBucket_customAttributes(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketExists(
-						"google_storage_bucket.bucket", bucketName),
+					testAccCheckStorageBucketExists(
+						"google_storage_bucket.bucket", bucketName, &bucket),
 				),
 			},
 			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderCustomAttributes(bucketName),
+				Config: testAccStorageBucket_customAttributes(bucketName),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketPutItem(bucketName),
+					testAccCheckStorageBucketPutItem(bucketName),
 				),
 			},
 			resource.TestStep{
-				Config: testGoogleStorageBucketsReaderCustomAttributes("idontexist"),
+				Config: testAccStorageBucket_customAttributes("idontexist"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckCloudStorageBucketMissing(bucketName),
+					testAccCheckStorageBucketMissing(bucketName),
 				),
 			},
 		},
 	})
 }
 
-func testAccCheckCloudStorageBucketExists(n string, bucketName string) resource.TestCheckFunc {
+func testAccCheckStorageBucketExists(n string, bucketName string, bucket *storage.Bucket) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -213,11 +197,13 @@ func testAccCheckCloudStorageBucketExists(n string, bucketName string) resource.
 		if found.Name != bucketName {
 			return fmt.Errorf("expected name %s, got %s", bucketName, found.Name)
 		}
+
+		*bucket = *found
 		return nil
 	}
 }
 
-func testAccCheckCloudStorageBucketPutItem(bucketName string) resource.TestCheckFunc {
+func testAccCheckStorageBucketPutItem(bucketName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 
@@ -236,7 +222,7 @@ func testAccCheckCloudStorageBucketPutItem(bucketName string) resource.TestCheck
 	}
 }
 
-func testAccCheckCloudStorageBucketMissing(bucketName string) resource.TestCheckFunc {
+func testAccCheckStorageBucketMissing(bucketName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		config := testAccProvider.Meta().(*Config)
 
@@ -253,7 +239,7 @@ func testAccCheckCloudStorageBucketMissing(bucketName string) resource.TestCheck
 	}
 }
 
-func testAccGoogleStorageDestroy(s *terraform.State) error {
+func testAccStorageBucketDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 
 	for _, rs := range s.RootModule().Resources {
@@ -270,7 +256,7 @@ func testAccGoogleStorageDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testGoogleStorageBucketsReaderDefaults(bucketName string) string {
+func testAccStorageBucket_basic(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
@@ -278,7 +264,7 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName)
 }
 
-func testGoogleStorageBucketsReaderCustomAttributes(bucketName string) string {
+func testAccStorageBucket_customAttributes(bucketName string) string {
 	return fmt.Sprintf(`
 resource "google_storage_bucket" "bucket" {
 	name = "%s"
@@ -289,7 +275,7 @@ resource "google_storage_bucket" "bucket" {
 `, bucketName)
 }
 
-func testGoogleStorageBucketsReaderStorageClass(bucketName, storageClass, location string) string {
+func testAccStorageBucket_storageClass(bucketName, storageClass, location string) string {
 	var locationBlock string
 	if location != "" {
 		locationBlock = fmt.Sprintf(`

--- a/builtin/providers/google/resource_storage_bucket_test.go
+++ b/builtin/providers/google/resource_storage_bucket_test.go
@@ -3,6 +3,7 @@ package google
 import (
 	"bytes"
 	"fmt"
+	"log"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -213,7 +214,7 @@ func testAccCheckStorageBucketPutItem(bucketName string) resource.TestCheckFunc 
 
 		// This needs to use Media(io.Reader) call, otherwise it does not go to /upload API and fails
 		if res, err := config.clientStorage.Objects.Insert(bucketName, object).Media(dataReader).Do(); err == nil {
-			fmt.Printf("Created object %v at location %v\n\n", res.Name, res.SelfLink)
+			log.Printf("[INFO] Created object %v at location %v\n\n", res.Name, res.SelfLink)
 		} else {
 			return fmt.Errorf("Objects.Insert failed: %v", err)
 		}


### PR DESCRIPTION
Refactor google_storage_bucket tests to look more like compute_instance.

- Pull import test to a separate file
- Change test names to match resource file name
- Expose a copy of the storage bucket from the exists method

```
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/19 17:38:29 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccStorageBucket -timeout 120m
=== RUN   TestAccStorageBucket_import
--- PASS: TestAccStorageBucket_import (5.73s)
=== RUN   TestAccStorageBucket_basic
--- PASS: TestAccStorageBucket_basic (4.91s)
=== RUN   TestAccStorageBucket_customAttributes
--- PASS: TestAccStorageBucket_customAttributes (6.49s)
=== RUN   TestAccStorageBucket_storageClass
--- PASS: TestAccStorageBucket_storageClass (13.15s)
=== RUN   TestAccStorageBucket_update
--- PASS: TestAccStorageBucket_update (11.12s)
=== RUN   TestAccStorageBucket_forceDestroy
Created object bucketDestroyTestFile at location https://www.googleapis.com/storage/v1/b/tf-test-acl-bucket-3480018121074495283/o/bucketDestroyTestFile

--- PASS: TestAccStorageBucket_forceDestroy (15.27s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	56.857s
```

@danawillow 