### PR TITLE
provider/aws: Increase timeout for creation of route_table

### DIFF
--- a/builtin/providers/aws/resource_aws_route_table.go
+++ b/builtin/providers/aws/resource_aws_route_table.go
@@ -120,7 +120,7 @@ func resourceAwsRouteTableCreate(d *schema.ResourceData, meta interface{}) error
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: resourceAwsRouteTableStateRefreshFunc(conn, d.Id()),
-		Timeout: 5 * time.Minute,
+		Timeout: 10 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSRouteTable_vgwRoutePropagation
--- FAIL: TestAccAWSRouteTable_vgwRoutePropagation (370.71s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_route_table.foo: 1 error(s) occurred:
        
        * aws_route_table.foo: Error waiting for route table (rtb-654aca03) to become available: timeout while waiting for state to become 'ready' (timeout: 5m0s)
```