### PR TITLE
provider/openstack: Catch error during instance network parsing

### DIFF
--- a/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
+++ b/builtin/providers/openstack/resource_openstack_compute_instance_v2.go
@@ -1056,19 +1056,26 @@ func getInstanceNetworks(computeClient *gophercloud.ServiceClient, d *schema.Res
 					log.Printf("[DEBUG] os-tenant-networks disabled.")
 					tenantNetworkExt = false
 				} else {
-					return nil, err
+					log.Printf("[DEBUG] unexpected os-tenant-networks error: %s", err)
+					tenantNetworkExt = false
 				}
+			}
+		}
+
+		// In some cases, a call to os-tenant-networks might work,
+		// but the response is invalid. Catch this during extraction.
+		networkList := []tenantnetworks.Network{}
+		if tenantNetworkExt {
+			networkList, err = tenantnetworks.ExtractNetworks(allPages)
+			if err != nil {
+				log.Printf("[DEBUG] error extracting os-tenant-networks results: %s", err)
+				tenantNetworkExt = false
 			}
 		}
 
 		networkID := ""
 		networkName := ""
 		if tenantNetworkExt {
-			networkList, err := tenantnetworks.ExtractNetworks(allPages)
-			if err != nil {
-				return nil, err
-			}
-
 			for _, network := range networkList {
 				if network.Name == rawMap["name"] {
 					tenantnet = network


### PR DESCRIPTION
This commit catches an error when the instance is parsing and building
its network list. This can happen when a cloud provider responds with
a non-JSON response for the list of networks.

For #14574