### PR TITLE
provider/aws: Increase timeout for deleting IGW

### DIFF
--- a/builtin/providers/aws/resource_aws_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_internet_gateway.go
@@ -134,7 +134,7 @@ func resourceAwsInternetGatewayDelete(d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("[INFO] Deleting Internet Gateway: %s", d.Id())
 
-	return resource.Retry(5*time.Minute, func() *resource.RetryError {
+	return resource.Retry(10*time.Minute, func() *resource.RetryError {
 		_, err := conn.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
 			InternetGatewayId: aws.String(d.Id()),
 		})


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSRoute_ipv6ToInternetGateway
--- FAIL: TestAccAWSRoute_ipv6ToInternetGateway (386.54s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_internet_gateway.foo: 1 error(s) occurred:
        
        * aws_internet_gateway.foo: timeout while waiting for state to become 'success' (timeout: 5m0s)
```