### PR TITLE
provider/docker network alias

### DIFF
--- a/builtin/providers/docker/resource_docker_container.go
+++ b/builtin/providers/docker/resource_docker_container.go
@@ -376,6 +376,14 @@ func resourceDockerContainer() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"network_alias": &schema.Schema{
+				Type:     schema.TypeSet,
+				Optional: true,
+				ForceNew: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+
 			"network_mode": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -188,7 +188,15 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 	d.SetId(retContainer.ID)
 
 	if v, ok := d.GetOk("networks"); ok {
-		connectionOpts := dc.NetworkConnectionOptions{Container: retContainer.ID}
+		var connectionOpts dc.NetworkConnectionOptions
+
+		if v, ok := d.GetOk("network_alias"); ok {
+			endpointConfig := &dc.EndpointConfig{}
+			endpointConfig.Aliases = stringSetToStringSlice(v.(*schema.Set))
+			connectionOpts = dc.NetworkConnectionOptions{Container: retContainer.ID, EndpointConfig: endpointConfig}
+		} else {
+			connectionOpts = dc.NetworkConnectionOptions{Container: retContainer.ID}
+		}
 
 		for _, rawNetwork := range v.(*schema.Set).List() {
 			network := rawNetwork.(string)

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -187,8 +187,6 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(retContainer.ID)
 
-	var endpointConfig *dc.EndpointConfig
-
 	if v, ok := d.GetOk("networks"); ok {
 		var connectionOpts dc.NetworkConnectionOptions
 		if v, ok := d.GetOk("network_alias"); ok {

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -194,7 +194,7 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		endpointConfig.Aliases = stringSetToStringSlice(v.(*schema.Set))
 		connectionOpts := dc.NetworkConnectionOptions{Container: retContainer.ID, EndpointConfig: endpointConfig}
 		if err := client.ConnectNetwork("bridge", connectionOpts); err != nil {
-			return fmt.Errorf("Unable to connect to network '%s': %s", network, err)
+			return fmt.Errorf("Unable to connect to network 'bridge': %s", err)
 		}
 	}
 

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -187,12 +187,15 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 
 	d.SetId(retContainer.ID)
 
-	if v, ok := d.GetOk("networks"); ok {
-		var connectionOpts dc.NetworkConnectionOptions
+	var endpointConfig *dc.EndpointConfig
+	if v, ok := d.GetOk("network_alias"); ok {
+		endpointConfig = &dc.EndpointConfig{}
+		endpointConfig.Aliases = stringSetToStringSlice(v.(*schema.Set))
+	}
 
-		if v, ok := d.GetOk("network_alias"); ok {
-			endpointConfig := &dc.EndpointConfig{}
-			endpointConfig.Aliases = stringSetToStringSlice(v.(*schema.Set))
+	var connectionOpts dc.NetworkConnectionOptions
+	if v, ok := d.GetOk("networks"); ok {
+		if endpointConfig != nil {
 			connectionOpts = dc.NetworkConnectionOptions{Container: retContainer.ID, EndpointConfig: endpointConfig}
 		} else {
 			connectionOpts = dc.NetworkConnectionOptions{Container: retContainer.ID}
@@ -201,6 +204,13 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 		for _, rawNetwork := range v.(*schema.Set).List() {
 			network := rawNetwork.(string)
 			if err := client.ConnectNetwork(network, connectionOpts); err != nil {
+				return fmt.Errorf("Unable to connect to network '%s': %s", network, err)
+			}
+		}
+	} else {
+		if endpointConfig != nil {
+			connectionOpts = dc.NetworkConnectionOptions{Container: retContainer.ID, EndpointConfig: endpointConfig}
+			if err := client.ConnectNetwork("bridge", connectionOpts); err != nil {
 				return fmt.Errorf("Unable to connect to network '%s': %s", network, err)
 			}
 		}

--- a/builtin/providers/docker/resource_docker_container_funcs.go
+++ b/builtin/providers/docker/resource_docker_container_funcs.go
@@ -189,18 +189,11 @@ func resourceDockerContainerCreate(d *schema.ResourceData, meta interface{}) err
 
 	var endpointConfig *dc.EndpointConfig
 
-	if v, ok := d.GetOk("network_alias"); ok {
-		endpointConfig = &dc.EndpointConfig{}
-		endpointConfig.Aliases = stringSetToStringSlice(v.(*schema.Set))
-		connectionOpts := dc.NetworkConnectionOptions{Container: retContainer.ID, EndpointConfig: endpointConfig}
-		if err := client.ConnectNetwork("bridge", connectionOpts); err != nil {
-			return fmt.Errorf("Unable to connect to network 'bridge': %s", err)
-		}
-	}
-
 	if v, ok := d.GetOk("networks"); ok {
 		var connectionOpts dc.NetworkConnectionOptions
-		if endpointConfig != nil {
+		if v, ok := d.GetOk("network_alias"); ok {
+			endpointConfig := &dc.EndpointConfig{}
+			endpointConfig.Aliases = stringSetToStringSlice(v.(*schema.Set))
 			connectionOpts = dc.NetworkConnectionOptions{Container: retContainer.ID, EndpointConfig: endpointConfig}
 		} else {
 			connectionOpts = dc.NetworkConnectionOptions{Container: retContainer.ID}

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -203,6 +203,10 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has incorrect extra host string: %q", c.HostConfig.ExtraHosts[1])
 		}
 
+		if val, ok := c.NetworkSettings.Networks["test"]; !ok {
+			return fmt.Errorf("Container is not connected to the right user defined network: test")
+		}
+
 		return nil
 	}
 
@@ -370,6 +374,9 @@ resource "docker_container" "foo" {
 	}
 	network_mode = "bridge"
 
+	networks = ["${docker_network.test_network.name}"]
+	network_alias = ["tftest"]
+
 	host {
 		host = "testhost"
 		ip = "10.0.1.0"
@@ -379,6 +386,10 @@ resource "docker_container" "foo" {
 		host = "testhost2"
 		ip = "10.0.2.0"
 	}
+}
+
+resource "docker_network" "test_network" {
+  name = "test"
 }
 `
 

--- a/builtin/providers/docker/resource_docker_container_test.go
+++ b/builtin/providers/docker/resource_docker_container_test.go
@@ -203,7 +203,7 @@ func TestAccDockerContainer_customized(t *testing.T) {
 			return fmt.Errorf("Container has incorrect extra host string: %q", c.HostConfig.ExtraHosts[1])
 		}
 
-		if val, ok := c.NetworkSettings.Networks["test"]; !ok {
+		if _, ok := c.NetworkSettings.Networks["test"]; !ok {
 			return fmt.Errorf("Container is not connected to the right user defined network: test")
 		}
 

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
   Defaults to "json-file".
 * `log_opts` - (Optional, map of strings) Key/value pairs to use as options for
   the logging driver.
-* `network_alias` - (Optional, set of string) Network aliases of the container for user-defined networks only.
+* `network_alias` - (Optional, set of strings) Network aliases of the container for user-defined networks only.
 * `network_mode` - (Optional, string) Network mode of the container.
 * `networks` - (Optional, set of strings) Id of the networks in which the
   container is.

--- a/website/source/docs/providers/docker/r/container.html.markdown
+++ b/website/source/docs/providers/docker/r/container.html.markdown
@@ -77,6 +77,7 @@ The following arguments are supported:
   Defaults to "json-file".
 * `log_opts` - (Optional, map of strings) Key/value pairs to use as options for
   the logging driver.
+* `network_alias` - (Optional, set of string) Network aliases of the container for user-defined networks only.
 * `network_mode` - (Optional, string) Network mode of the container.
 * `networks` - (Optional, set of strings) Id of the networks in which the
   container is.


### PR DESCRIPTION
This is addressing #10452 - basically an implementation where configuration can specify `network_alias` set of strings in a user-defined `network`. This is similar to `--network-alias` command from docker run. 

For example you can do something like:
```
resource "docker_container" "web01" {
  image = "${docker_image.nginx.latest}"
  name  = "${var.environment}_web01"
  networks = ["${docker_network.private_network.name}"]
  network_alias = ["web01", "anotherweb01"]
}
```

And this will create Aliases of `web01` and `anotherweb01`