### PR TITLE
provider/aws: Increase timeout for retrying creation of CW log subs

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -57,7 +57,7 @@ func resourceAwsCloudwatchLogSubscriptionFilterCreate(d *schema.ResourceData, me
 	params := getAwsCloudWatchLogsSubscriptionFilterInput(d)
 	log.Printf("[DEBUG] Creating SubscriptionFilter %#v", params)
 
-	return resource.Retry(3*time.Minute, func() *resource.RetryError {
+	return resource.Retry(5*time.Minute, func() *resource.RetryError {
 		_, err := conn.PutSubscriptionFilter(&params)
 
 		if err == nil {


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_basic
--- FAIL: TestAccAWSCloudwatchLogSubscriptionFilter_basic (21.29s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: 1 error(s) occurred:
        
        * aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: InvalidParameterException: Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function.
            status code: 400, request id: df554472-3eb1-11e7-a06d-195b209438c3
```