### PR TITLE
provider/aws: Do not dereference source_Dest_check in aws_instance

### DIFF
--- a/builtin/providers/aws/resource_aws_instance.go
+++ b/builtin/providers/aws/resource_aws_instance.go
@@ -654,7 +654,7 @@ func resourceAwsInstanceRead(d *schema.ResourceData, meta interface{}) error {
 		d.Set("primary_network_interface_id", primaryNetworkInterface.NetworkInterfaceId)
 		d.Set("associate_public_ip_address", primaryNetworkInterface.Association != nil)
 		d.Set("ipv6_address_count", len(primaryNetworkInterface.Ipv6Addresses))
-		d.Set("source_dest_check", *primaryNetworkInterface.SourceDestCheck)
+		d.Set("source_dest_check", primaryNetworkInterface.SourceDestCheck)
 
 		for _, address := range primaryNetworkInterface.Ipv6Addresses {
 			ipv6Addresses = append(ipv6Addresses, *address.Ipv6Address)


### PR DESCRIPTION
Fixes: #14718

source_dest_check may not be set so we should pass the pointer to d.Set
func and allow it to dereference it safely