### PR TITLE
provider/aws: Increase timeout for creating security group

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -253,7 +253,7 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 		Pending: []string{""},
 		Target:  []string{"exists"},
 		Refresh: SGStateRefreshFunc(conn, d.Id()),
-		Timeout: 3 * time.Minute,
+		Timeout: 5 * time.Minute,
 	}
 
 	resp, err := stateConf.WaitForState()


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSSecurityGroup_ingressWithCidrAndSGs
--- FAIL: TestAccAWSSecurityGroup_ingressWithCidrAndSGs (249.23s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_security_group.other_web: 1 error(s) occurred:
        
        * aws_security_group.other_web: Error waiting for Security Group (sg-d4a7ebaf) to become available: timeout while waiting for state to become 'exists' (timeout: 3m0s)
FAIL
```