### PR TITLE
provider/aws: Add ability to define timeouts for DMS replication instance

### DIFF
--- a/builtin/providers/aws/resource_aws_dms_replication_instance.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_instance.go
@@ -19,6 +19,12 @@ func resourceAwsDmsReplicationInstance() *schema.Resource {
 		Update: resourceAwsDmsReplicationInstanceUpdate,
 		Delete: resourceAwsDmsReplicationInstanceDelete,
 
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
+		},
+
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -304,7 +310,7 @@ func resourceAwsDmsReplicationInstanceUpdate(d *schema.ResourceData, meta interf
 			Pending:    []string{"modifying"},
 			Target:     []string{"available"},
 			Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(d, meta),
-			Timeout:    d.Timeout(schema.TimeoutCreate),
+			Timeout:    d.Timeout(schema.TimeoutUpdate),
 			MinTimeout: 10 * time.Second,
 			Delay:      30 * time.Second, // Wait 30 secs before starting
 		}
@@ -339,7 +345,7 @@ func resourceAwsDmsReplicationInstanceDelete(d *schema.ResourceData, meta interf
 		Pending:    []string{"deleting"},
 		Target:     []string{},
 		Refresh:    resourceAwsDmsReplicationInstanceStateRefreshFunc(d, meta),
-		Timeout:    d.Timeout(schema.TimeoutCreate),
+		Timeout:    d.Timeout(schema.TimeoutDelete),
 		MinTimeout: 10 * time.Second,
 		Delay:      30 * time.Second, // Wait 30 secs before starting
 	}

--- a/builtin/providers/aws/resource_aws_dms_replication_instance_test.go
+++ b/builtin/providers/aws/resource_aws_dms_replication_instance_test.go
@@ -139,6 +139,10 @@ resource "aws_dms_replication_instance" "dms_replication_instance" {
 		Update = "to-update"
 		Remove = "to-remove"
 	}
+
+	timeouts {
+		create = "40m"
+	}
 }
 `, randId)
 }

--- a/website/source/docs/providers/aws/r/dms_replication_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/dms_replication_instance.html.markdown
@@ -77,6 +77,16 @@ The following attributes are exported:
 * `replication_instance_private_ips` -  A list of the private IP addresses of the replication instance.
 * `replication_instance_public_ips` - A list of the public IP addresses of the replication instance.
 
+<a id="timeouts"></a>
+## Timeouts
+
+`aws_dms_replication_instance` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `create` - (Default `30 minutes`) Used for Creating Instances
+- `update` - (Default `30 minutes`) Used for Database modifications
+- `delete` - (Default `30 minutes`) Used for destroying databases.
+
 ## Import
 
 Replication instances can be imported using the `replication_instance_id`, e.g.


### PR DESCRIPTION
Fixes: #13996

<img width="561" alt="screen shot 2017-05-22 at 15 18 56" src="https://cloud.githubusercontent.com/assets/227823/26310696/0c2eee84-3f02-11e7-9180-127f51e969aa.png">
