### PR TITLE
core: Use environment variables to set VersionPrerelease at compile time

### DIFF
--- a/builtin/providers/circonus/provider.go
+++ b/builtin/providers/circonus/provider.go
@@ -1,7 +1,6 @@
 package circonus
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/circonus-labs/circonus-gometrics/api"
@@ -123,13 +122,5 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 func tfAppName() string {
-	const VersionPrerelease = terraform.VersionPrerelease
-	var versionString bytes.Buffer
-
-	fmt.Fprintf(&versionString, "Terraform v%s", terraform.Version)
-	if VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", VersionPrerelease)
-	}
-
-	return versionString.String()
+	return fmt.Sprintf("Terraform v%s", terraform.VersionString())
 }

--- a/builtin/providers/postgresql/provider.go
+++ b/builtin/providers/postgresql/provider.go
@@ -1,7 +1,6 @@
 package postgresql
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/hashicorp/errwrap"
@@ -109,13 +108,5 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 }
 
 func tfAppName() string {
-	const VersionPrerelease = terraform.VersionPrerelease
-	var versionString bytes.Buffer
-
-	fmt.Fprintf(&versionString, "Terraform v%s", terraform.Version)
-	if terraform.VersionPrerelease != "" {
-		fmt.Fprintf(&versionString, "-%s", terraform.VersionPrerelease)
-	}
-
-	return versionString.String()
+	return fmt.Sprintf("Terraform v%s", terraform.VersionString())
 }

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,8 +40,9 @@ fi
 export CGO_ENABLED=0
 
 # Allow LD_FLAGS to be appended during development compilations
-LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} $LD_FLAGS"
-# In relase mode we don't want debug information in the binary
+LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X github.com/hashicorp/terraform/terraform.VersionPrerelease=dev $LD_FLAGS"
+
+# In release mode we don't want debug information in the binary
 if [[ -n "${TF_RELEASE}" ]]; then
     LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -s -w"
 fi

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -40,11 +40,11 @@ fi
 export CGO_ENABLED=0
 
 # Allow LD_FLAGS to be appended during development compilations
-LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X github.com/hashicorp/terraform/terraform.VersionPrerelease=dev $LD_FLAGS"
+LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} $LD_FLAGS"
 
 # In release mode we don't want debug information in the binary
 if [[ -n "${TF_RELEASE}" ]]; then
-    LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -s -w"
+    LD_FLAGS="-X main.GitCommit=${GIT_COMMIT}${GIT_DIRTY} -X github.com/hashicorp/terraform/terraform.VersionPrerelease= -s -w"
 fi
 
 # Build!

--- a/terraform/version.go
+++ b/terraform/version.go
@@ -12,7 +12,7 @@ const Version = "0.9.6"
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-var VersionPrerelease string
+var VersionPrerelease = "dev"
 
 // SemVersion is an instance of version.Version. This has the secondary
 // benefit of verifying during tests and init time that our version is a

--- a/terraform/version.go
+++ b/terraform/version.go
@@ -12,7 +12,7 @@ const Version = "0.9.6"
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-const VersionPrerelease = "dev"
+var VersionPrerelease string
 
 // SemVersion is an instance of version.Version. This has the secondary
 // benefit of verifying during tests and init time that our version is a

--- a/version.go
+++ b/version.go
@@ -6,4 +6,5 @@ import "github.com/hashicorp/terraform/terraform"
 var GitCommit string
 
 const Version = terraform.Version
-const VersionPrerelease = terraform.VersionPrerelease
+
+var VersionPrerelease = terraform.VersionPrerelease


### PR DESCRIPTION
Instead of using a hardcoded version prerelease string, which makes release automation difficult, set the version prerelease string from an environment variable via the go linker tool during compile time.

The environment variable `TF_RELEASE` should only be set via the `make bin` target, and thus leaves the version prerelease string unset. Otherwise, when running a local compile of terraform via the `make dev` makefile target, the version prerelease string is set to `"dev"`, as usual.

This also requires some changes to both the circonus and postgresql providers, as they directly used the `VersionPrerelease` constant. We now simply call the `VersionString()` function, which returns the proper interpolated version string with the prerelease string populated correctly.

`TF_RELEASE` is unset:

```sh
$ make dev
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/22 10:38:19 Generated command/internal_plugin_list.go
==> Removing old directory...
==> Building...
Number of parallel builds: 3

-->     linux/amd64: github.com/hashicorp/terraform

==> Results:
total 209M
-rwxr-xr-x 1 jake jake 209M May 22 10:39 terraform

$ terraform version
Terraform v0.9.6-dev (fd472e4a86500606b03c314f70d11f2bc4bc84e5+CHANGES)
```

`TF_RELEASE` is set (mimicking the `make bin` target):

```sh
$ TF_RELEASE=1 make dev
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/22 10:40:39 Generated command/internal_plugin_list.go
==> Removing old directory...
==> Building...
Number of parallel builds: 3

-->     linux/amd64: github.com/hashicorp/terraform

==> Results:
total 121M
-rwxr-xr-x 1 jake jake 121M May 22 10:42 terraform

$ terraform version
Terraform v0.9.6
```