### PR TITLE
provider/google: Updated debug message in compute_firewall_migrate.

### DIFF
--- a/builtin/providers/google/resource_compute_firewall_migrate.go
+++ b/builtin/providers/google/resource_compute_firewall_migrate.go
@@ -13,7 +13,7 @@ import (
 func resourceComputeFirewallMigrateState(
 	v int, is *terraform.InstanceState, meta interface{}) (*terraform.InstanceState, error) {
 	if is.Empty() {
-		log.Println("[DEBUG] Empty FirewallState; nothing to migrate.")
+		log.Println("[DEBUG] Empty InstanceState; nothing to migrate.")
 		return is, nil
 	}
 


### PR DESCRIPTION
Update the compute_firewall_migrate debug message so other people writing migrate functions don't also use the wrong debug message format.

@danawillow 