### PR TITLE
provider/aws: Provider ability to enable snapshotting on ElastiCache RG

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticache_replication_group.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group.go
@@ -370,6 +370,12 @@ func resourceAwsElasticacheReplicationGroupUpdate(d *schema.ResourceData, meta i
 	}
 
 	if d.HasChange("snapshot_retention_limit") {
+		// This is a real hack to set the Snapshotting Cluster ID to be the first Cluster in the RG
+		o, _ := d.GetChange("snapshot_retention_limit")
+		if o.(int) == 0 {
+			params.SnapshottingClusterId = aws.String(fmt.Sprintf("%s-001", d.Id()))
+		}
+
 		params.SnapshotRetentionLimit = aws.Int64(int64(d.Get("snapshot_retention_limit").(int)))
 		requestUpdate = true
 	}

--- a/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
+++ b/builtin/providers/aws/resource_aws_elasticache_replication_group_test.go
@@ -288,6 +288,36 @@ func TestAccAWSElasticacheReplicationGroup_clusteringAndCacheNodesCausesError(t 
 	})
 }
 
+func TestAccAWSElasticacheReplicationGroup_enableSnapshotting(t *testing.T) {
+	var rg elasticache.ReplicationGroup
+	rName := acctest.RandString(10)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSElasticacheReplicationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "0"),
+				),
+			},
+
+			{
+				Config: testAccAWSElasticacheReplicationGroupConfigEnableSnapshotting(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSElasticacheReplicationGroupExists("aws_elasticache_replication_group.bar", &rg),
+					resource.TestCheckResourceAttr(
+						"aws_elasticache_replication_group.bar", "snapshot_retention_limit", "2"),
+				),
+			},
+		},
+	})
+}
+
 func TestResourceAWSElastiCacheReplicationGroupIdValidation(t *testing.T) {
 	cases := []struct {
 		Value    string
@@ -443,6 +473,44 @@ resource "aws_elasticache_replication_group" "bar" {
     auto_minor_version_upgrade = false
     maintenance_window = "tue:06:30-tue:07:30"
     snapshot_window = "01:00-02:00"
+}`, rName, rName, rName)
+}
+
+func testAccAWSElasticacheReplicationGroupConfigEnableSnapshotting(rName string) string {
+	return fmt.Sprintf(`
+provider "aws" {
+  region = "us-east-1"
+}
+resource "aws_security_group" "bar" {
+    name = "tf-test-security-group-%s"
+    description = "tf-test-security-group-descr"
+    ingress {
+        from_port = -1
+        to_port = -1
+        protocol = "icmp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+}
+
+resource "aws_elasticache_security_group" "bar" {
+    name = "tf-test-security-group-%s"
+    description = "tf-test-security-group-descr"
+    security_group_names = ["${aws_security_group.bar.name}"]
+}
+
+resource "aws_elasticache_replication_group" "bar" {
+    replication_group_id = "tf-%s"
+    replication_group_description = "test description"
+    node_type = "cache.m1.small"
+    number_cache_clusters = 2
+    port = 6379
+    parameter_group_name = "default.redis3.2"
+    security_group_names = ["${aws_elasticache_security_group.bar.name}"]
+    apply_immediately = true
+    auto_minor_version_upgrade = false
+    maintenance_window = "tue:06:30-tue:07:30"
+    snapshot_window = "01:00-02:00"
+    snapshot_retention_limit = 2
 }`, rName, rName, rName)
 }
 


### PR DESCRIPTION
Fixes: #10581

When a cluster was originally created, you could not enable snapshotting
on it. An error message like this was found:

```
* aws_elasticache_replication_group.bar: Error updating Elasticache replication group: InvalidParameterCombination: Must specify both SnapshotRetentionLimit and SnapshottingClusterId to turn on snapshots
    status code: 400, request id: 98d2ea4e-3fb1-11e7-b077-5967719aeab4
```

There is no guidance from AWS on which is the preferred Cluster in the RG to use for snapshotting. Therefore, I decided to set it to be the first cluster. We can now enable snapshotting

```
% make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSElasticacheReplicationGroup_enableSnapshotting'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/23 15:02:21 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSElasticacheReplicationGroup_enableSnapshotting -timeout 120m
=== RUN   TestAccAWSElasticacheReplicationGroup_enableSnapshotting
--- PASS: TestAccAWSElasticacheReplicationGroup_enableSnapshotting (1261.47s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1261.496s
```

<img width="639" alt="screen shot 2017-05-23 at 16 03 08" src="https://cloud.githubusercontent.com/assets/227823/26360940/6074a540-3fd1-11e7-942c-dd796b34a2a0.png">
