### PR TITLE
Fixes #14765 Handle migration when restoring db cluster from snapshot

### DIFF
--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -308,7 +308,7 @@ func resourceAwsRDSClusterCreate(d *schema.ResourceData, meta interface{}) error
 			log.Println("[INFO] Waiting for RDS Cluster to be available")
 
 			stateConf := &resource.StateChangeConf{
-				Pending:    []string{"creating", "backing-up", "modifying", "preparing-data-migration"},
+				Pending:    []string{"creating", "backing-up", "modifying", "preparing-data-migration", "migrating"},
 				Target:     []string{"available"},
 				Refresh:    resourceAwsRDSClusterStateRefreshFunc(d, meta),
 				Timeout:    d.Timeout(schema.TimeoutCreate),


### PR DESCRIPTION
Add `migrating` to the list of pending statuses when creating a cluster from a snapshot using a different engine.