### PR TITLE
provider/vsphere Set different hostname of a VM than name

### DIFF
--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -2055,7 +2055,7 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 			}
 
 			customIdentification := types.CustomizationIdentification{}
-			
+
 			if len(vm.hostname) == 0 {
 				vm.hostname = vm.name
 			}

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine.go
@@ -78,6 +78,7 @@ type memoryAllocation struct {
 
 type virtualMachine struct {
 	name                  string
+	hostname              string
 	folder                string
 	datacenter            string
 	cluster               string
@@ -128,6 +129,12 @@ func resourceVSphereVirtualMachine() *schema.Resource {
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
+			},
+
+			"hostname": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
 				ForceNew: true,
 			},
 
@@ -664,6 +671,10 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		memoryAllocation: memoryAllocation{
 			reservation: int64(d.Get("memory_reservation").(int)),
 		},
+	}
+
+	if v, ok := d.GetOk("hostname"); ok {
+		vm.hostname = v.(string)
 	}
 
 	if v, ok := d.GetOk("folder"); ok {
@@ -2044,10 +2055,14 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 			}
 
 			customIdentification := types.CustomizationIdentification{}
+			
+			if len(vm.hostname) == 0 {
+				vm.hostname = vm.name
+			}
 
 			userData := types.CustomizationUserData{
 				ComputerName: &types.CustomizationFixedName{
-					Name: strings.Split(vm.name, ".")[0],
+					Name: strings.Split(vm.hostname, ".")[0],
 				},
 				ProductId: vm.windowsOptionalConfig.productKey,
 				FullName:  "terraform",
@@ -2076,9 +2091,12 @@ func (vm *virtualMachine) setupVirtualMachine(c *govmomi.Client) error {
 				UserData:       userData,
 			}
 		} else {
+			if len(vm.hostname) == 0 {
+				vm.hostname = vm.name
+			}
 			identity_options = &types.CustomizationLinuxPrep{
 				HostName: &types.CustomizationFixedName{
-					Name: strings.Split(vm.name, ".")[0],
+					Name: strings.Split(vm.hostname, ".")[0],
 				},
 				Domain:     vm.domain,
 				TimeZone:   vm.timeZone,

--- a/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
+++ b/builtin/providers/vsphere/resource_vsphere_virtual_machine_test.go
@@ -294,6 +294,35 @@ func TestAccVSphereVirtualMachine_basic(t *testing.T) {
 	})
 }
 
+const testAccCheckVSphereVirtualMachineConfig_hostname = `
+resource "vsphere_virtual_machine" "foo" {
+    name = "terraform-test"
+    hostname = "testterraform"
+` + testAccTemplateBasicBodyWithEnd
+
+func TestAccVSphereVirtualMachine_hostname(t *testing.T) {
+	var vm virtualMachine
+	basic_vars := setupTemplateBasicBodyVars()
+	config := basic_vars.testSprintfTemplateBody(testAccCheckVSphereVirtualMachineConfig_hostname)
+
+	log.Printf("[DEBUG] template= %s", testAccCheckVSphereVirtualMachineConfig_hostname)
+	log.Printf("[DEBUG] template config= %s", config)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testBasicPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckVSphereVirtualMachineDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					TestFuncData{vm: vm, label: basic_vars.label}.testCheckFuncBasic(),
+				),
+			},
+		},
+	})
+}
+
 const testAccCheckVSphereVirtualMachineConfig_debug = `
 provider "vsphere" {
   client_debug = true

--- a/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
+++ b/website/source/docs/providers/vsphere/r/virtual_machine.html.markdown
@@ -34,6 +34,7 @@ resource "vsphere_virtual_machine" "web" {
 ```hcl
 resource "vsphere_virtual_machine" "lb" {
   name          = "lb01"
+  hostname      = "lbalancer01"
   folder        = "Loadbalancers"
   vcpu          = 2
   memory        = 4096
@@ -42,10 +43,9 @@ resource "vsphere_virtual_machine" "lb" {
   cluster       = "Production Cluster"
   resource_pool = "Production Cluster/Resources/Production Servers"
 
-  gateway = "10.20.30.254"
-
   network_interface {
     label              = "10_20_30_VMNet"
+    ipv4_gateway       = "10.20.30.254"
     ipv4_address       = "10.20.30.40"
     ipv4_prefix_length = "24"
   }
@@ -64,6 +64,7 @@ The following arguments are supported:
 * `name` - (Required) The virtual machine name (cannot contain underscores and must be less than 15 characters)
 * `vcpu` - (Required) The number of virtual CPUs to allocate to the virtual machine
 * `memory` - (Required) The amount of RAM (in MB) to allocate to the virtual machine
+* `hostname` - (Optional) The virtual machine hostname used during the OS customization - if not specified then `name` will be a hostname
 * `memory_reservation` - (Optional) The amount of RAM (in MB) to reserve physical memory resource; defaults to 0 (means not to reserve)
 * `datacenter` - (Optional) The name of a Datacenter in which to launch the virtual machine
 * `cluster` - (Optional) Name of a Cluster in which to launch the virtual machine


### PR DESCRIPTION
Fixes: #14659

With this version, one can set different hostname (during the OS customization) than a VM name. If "hostname" variable isn't set, the "name" will be used in the customization process. "Hostname" is optional.

Tested on my vSphere Lab (both scenarios), everything works as expected. Of course, there is another acc test created. Output:

```
$ make testacc TEST=./builtin/providers/vsphere/ TESTARGS='-run=TestAccVSphereVirtualMachine_hostname'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/23 20:31:14 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/vsphere/ -v -run=TestAccVSphereVirtualMachine_hostname -timeout 120m
=== RUN   TestAccVSphereVirtualMachine_hostname
2017/05/23 20:31:25 [DEBUG] template=
resource "vsphere_virtual_machine" "foo" {
    name = "terraform-test"
    hostname = "testterraform"

%s
    vcpu = 2
    memory = 1024
    network_interface {
        label = "%s"
        ipv4_address = "%s"
        ipv4_prefix_length = %s
        ipv4_gateway = "%s"
    }
     disk {
%s
        template = "%s"
        iops = 500
    }

}
--- PASS: TestAccVSphereVirtualMachine_hostname (376.23s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/vsphere        376.254s

```

Please review and tell me if it's anything more I should do. 