### PR TITLE
provider/scaleway: clarify scaleway_server volume attribute

### DIFF
--- a/website/source/docs/providers/scaleway/r/server.html.markdown
+++ b/website/source/docs/providers/scaleway/r/server.html.markdown
@@ -46,6 +46,9 @@ Field `name`, `type`, `tags`, `dynamic_ip_required`, `security_group` are editab
 You can attach additional volumes to your instance, which will share the lifetime
 of your `scaleway_server` resource.
 
+**Warning:** Using the `volume` attribute does not modify the System Volume provided default with every `scaleway_server` instance.
+Instead it adds additional volumes to the server instance.
+
 The `volume` mapping supports the following:
 
 * `type` - (Required) The type of volume. Can be `"l_ssd"`


### PR DESCRIPTION
This PR aims to improve the docs so misunderstandings like #14699 don't occur more often.

**background**
 
System volumes on Scaleway can't easily be modified - instead one has to create
a new image with the desired system volume size. This is way out of scope of
terraform - see https://community.online.net/t/expanding-lssd/907/2 for steps on
how to build a new image.

the `scaleway_server` `volume` attribute should only be used if you want to
attach additional volumes to a server which will share the lifetime of the
server, e.g. they will be destroyed once the server is shut down.

To have volumes which outlive the attached server one should use
`scaleway_volume` and `scaleway_volume_attachement` instead.