### PR TITLE
provider/aws: Add Sweeper setup, Sweepers for DB Option Group, Key Pair

### DIFF
--- a/builtin/providers/aws/aws_sweeper_test.go
+++ b/builtin/providers/aws/aws_sweeper_test.go
@@ -1,0 +1,11 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}

--- a/builtin/providers/aws/aws_sweeper_test.go
+++ b/builtin/providers/aws/aws_sweeper_test.go
@@ -12,7 +12,7 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-// sharedCredsForRegion returns a common config setup needed for the sweeper
+// sharedClientForRegion returns a common AWSClient setup needed for the sweeper
 // functions for a given region
 func sharedClientForRegion(region string) (interface{}, error) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
@@ -27,6 +27,7 @@ func sharedClientForRegion(region string) (interface{}, error) {
 		Region: region,
 	}
 
+	// configures a default client for the region, using the above env vars
 	client, err := conf.Client()
 	if err != nil {
 		return nil, fmt.Errorf("error getting AWS client")

--- a/builtin/providers/aws/aws_sweeper_test.go
+++ b/builtin/providers/aws/aws_sweeper_test.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -8,4 +10,27 @@ import (
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
+}
+
+// sharedCredsForRegion returns a common config setup needed for the sweeper
+// functions for a given region
+func sharedClientForRegion(region string) (interface{}, error) {
+	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
+		return nil, fmt.Errorf("empty AWS_ACCESS_KEY_ID")
+	}
+
+	if os.Getenv("AWS_SECRET_ACCESS_KEY") == "" {
+		return nil, fmt.Errorf("empty AWS_SECRET_ACCESS_KEY")
+	}
+
+	conf := &Config{
+		Region: region,
+	}
+
+	client, err := conf.Client()
+	if err != nil {
+		return nil, fmt.Errorf("error getting AWS client")
+	}
+
+	return client, nil
 }

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -3,11 +3,13 @@ package aws
 import (
 	"errors"
 	"fmt"
+	"log"
 	"reflect"
 	"regexp"
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -17,6 +19,74 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_autoscaling_group", &resource.Sweeper{
+		Name: "aws_autoscaling_group",
+		F:    testSweepAutoscalingGroups,
+	})
+}
+
+func testSweepAutoscalingGroups(c interface{}) error {
+	region := c.(string)
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	autoscalingconn := client.(*AWSClient).autoscalingconn
+
+	resp, err := autoscalingconn.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving launch configuration: %s", err)
+	}
+
+	if len(resp.AutoScalingGroups) == 0 {
+		log.Print("[DEBUG] No aws autoscaling groups to sweep")
+		return nil
+	}
+
+	for _, asg := range resp.AutoScalingGroups {
+		var testOptGroup bool
+		for _, testName := range []string{"foobar", "terraform-"} {
+			if strings.HasPrefix(*asg.AutoScalingGroupName, testName) {
+				testOptGroup = true
+			}
+		}
+
+		if !testOptGroup {
+			continue
+		}
+
+		deleteopts := autoscaling.DeleteAutoScalingGroupInput{
+			AutoScalingGroupName: asg.AutoScalingGroupName,
+			ForceDelete:          aws.Bool(true),
+		}
+
+		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
+			if _, err := autoscalingconn.DeleteAutoScalingGroup(&deleteopts); err != nil {
+				if awserr, ok := err.(awserr.Error); ok {
+					switch awserr.Code() {
+					case "InvalidGroup.NotFound":
+						// Already gone? Sure!
+						return nil
+					case "ResourceInUse", "ScalingActivityInProgress":
+						// These are retryable
+						return resource.RetryableError(awserr)
+					}
+				}
+				// Didn't recognize the error, so shouldn't retry.
+				return resource.NonRetryableError(err)
+			}
+			// Successful delete
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSAutoScalingGroup_basic(t *testing.T) {
 	var group autoscaling.Group

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -33,9 +33,9 @@ func testSweepAutoscalingGroups(c interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	autoscalingconn := client.(*AWSClient).autoscalingconn
+	conn := client.(*AWSClient).autoscalingconn
 
-	resp, err := autoscalingconn.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
+	resp, err := conn.DescribeAutoScalingGroups(&autoscaling.DescribeAutoScalingGroupsInput{})
 	if err != nil {
 		return fmt.Errorf("Error retrieving launch configuration: %s", err)
 	}
@@ -63,17 +63,16 @@ func testSweepAutoscalingGroups(c interface{}) error {
 		}
 
 		err = resource.Retry(5*time.Minute, func() *resource.RetryError {
-			if _, err := autoscalingconn.DeleteAutoScalingGroup(&deleteopts); err != nil {
+			if _, err := conn.DeleteAutoScalingGroup(&deleteopts); err != nil {
 				if awserr, ok := err.(awserr.Error); ok {
 					switch awserr.Code() {
 					case "InvalidGroup.NotFound":
-						// Already gone? Sure!
 						return nil
 					case "ResourceInUse", "ScalingActivityInProgress":
-						// These are retryable
 						return resource.RetryableError(awserr)
 					}
 				}
+
 				// Didn't recognize the error, so shouldn't retry.
 				return resource.NonRetryableError(err)
 			}

--- a/builtin/providers/aws/resource_aws_autoscaling_group_test.go
+++ b/builtin/providers/aws/resource_aws_autoscaling_group_test.go
@@ -27,8 +27,7 @@ func init() {
 	})
 }
 
-func testSweepAutoscalingGroups(c interface{}) error {
-	region := c.(string)
+func testSweepAutoscalingGroups(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -23,8 +23,7 @@ func init() {
 	})
 }
 
-func testSweepDbOptionGroups(c interface{}) error {
-	region := c.(string)
+func testSweepDbOptionGroups(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -18,21 +18,29 @@ import (
 
 func init() {
 	// add sweepers for each region
-	for _, r := range []string{"us-east-1", "us-west-2"} {
-		name := fmt.Sprintf("aws-db-option-group-%s", r)
-		resource.AddTestSweepers(name,
-			&resource.Sweeper{
-				Name: name,
-				Config: &Config{
-					Region: r,
-				},
-				F: testSweepDbOptionGroups,
-			})
-	}
+	// for _, r := range []string{"us-east-1", "us-west-2"} {
+	// 	name := fmt.Sprintf("aws-db-option-group-%s", r)
+	// 	resource.AddTestSweepers(name,
+	// 		&resource.Sweeper{
+	// 			Name: name,
+	// 			Config: &Config{
+	// 				Region: r,
+	// 			},
+	// 			F: testSweepDbOptionGroups,
+	// 		})
+	// }
+	resource.AddTestSweepers("aws_db_option_group", &resource.Sweeper{
+		Name: "aws_db_option_group",
+		F:    testSweepDbOptionGroups,
+	})
 }
 
 func testSweepDbOptionGroups(c interface{}) error {
-	client, err := c.(*Config).Client()
+	region := c.(string)
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
 	conn := client.(*AWSClient).rdsconn
 
 	log.Printf("Destroying the DB Options Groups in (%s)", client.(*AWSClient).region)

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -17,18 +17,6 @@ import (
 )
 
 func init() {
-	// add sweepers for each region
-	// for _, r := range []string{"us-east-1", "us-west-2"} {
-	// 	name := fmt.Sprintf("aws-db-option-group-%s", r)
-	// 	resource.AddTestSweepers(name,
-	// 		&resource.Sweeper{
-	// 			Name: name,
-	// 			Config: &Config{
-	// 				Region: r,
-	// 			},
-	// 			F: testSweepDbOptionGroups,
-	// 		})
-	// }
 	resource.AddTestSweepers("aws_db_option_group", &resource.Sweeper{
 		Name: "aws_db_option_group",
 		F:    testSweepDbOptionGroups,
@@ -41,14 +29,13 @@ func testSweepDbOptionGroups(c interface{}) error {
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)
 	}
-	conn := client.(*AWSClient).rdsconn
 
-	log.Printf("Destroying the DB Options Groups in (%s)", client.(*AWSClient).region)
+	conn := client.(*AWSClient).rdsconn
 
 	opts := rds.DescribeOptionGroupsInput{}
 	resp, err := conn.DescribeOptionGroups(&opts)
 	if err != nil {
-		return fmt.Errorf("Error describing DB Option Groups in Sweeper: %s", err)
+		return fmt.Errorf("error describing DB Option Groups in Sweeper: %s", err)
 	}
 
 	for _, og := range resp.OptionGroupsList {
@@ -67,7 +54,6 @@ func testSweepDbOptionGroups(c interface{}) error {
 			OptionGroupName: og.OptionGroupName,
 		}
 
-		log.Printf("[DEBUG] Delete DB Option Group: %s", *og.OptionGroupName)
 		ret := resource.Retry(1*time.Minute, func() *resource.RetryError {
 			_, err := conn.DeleteOptionGroup(deleteOpts)
 			if err != nil {

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -18,17 +18,17 @@ import (
 
 func init() {
 	// add sweepers for each region
-	var fs []*resource.Sweeper
 	for _, r := range []string{"us-east-1", "us-west-2"} {
-		fs = append(fs, &resource.Sweeper{
-			Config: &Config{
-				Region: r,
-			},
-			F: testSweepDbOptionGroups,
-		})
+		name := fmt.Sprintf("aws-db-option-group-%s", r)
+		resource.AddTestSweepers(name,
+			&resource.Sweeper{
+				Name: name,
+				Config: &Config{
+					Region: r,
+				},
+				F: testSweepDbOptionGroups,
+			})
 	}
-
-	resource.AddTestSweepers("aws_db_option_group", fs)
 }
 
 func testSweepDbOptionGroups(c interface{}) error {

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -74,7 +74,7 @@ func testSweepDbOptionGroups(c interface{}) error {
 			return nil
 		})
 		if ret != nil {
-			return fmt.Errorf("Error Deleting DB Option Group (%s) in Sweeper: %s", ret)
+			return fmt.Errorf("Error Deleting DB Option Group (%s) in Sweeper: %s", *og.OptionGroupName, ret)
 		}
 	}
 

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -35,7 +35,7 @@ func testSweepDbOptionGroups(c interface{}) error {
 	client, err := c.(*Config).Client()
 	conn := client.(*AWSClient).rdsconn
 
-	log.Printf("Destroying the DB Options Groups in (%s)\n\n", client.(*AWSClient).region)
+	log.Printf("Destroying the DB Options Groups in (%s)", client.(*AWSClient).region)
 
 	opts := rds.DescribeOptionGroupsInput{}
 	resp, err := conn.DescribeOptionGroups(&opts)

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -32,7 +32,7 @@ func testSweepKeyPairs(c interface{}) error {
 	client, err := c.(*Config).Client()
 	ec2conn := client.(*AWSClient).ec2conn
 
-	log.Printf("Destroying the tmp keys in (%s)\n\n", client.(*AWSClient).region)
+	log.Printf("Destroying the tmp keys in (%s)", client.(*AWSClient).region)
 
 	resp, err := ec2conn.DescribeKeyPairs(&ec2.DescribeKeyPairsInput{
 		Filters: []*ec2.Filter{

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -20,8 +20,7 @@ func init() {
 	})
 }
 
-func testSweepKeyPairs(c interface{}) error {
-	region := c.(string)
+func testSweepKeyPairs(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -38,9 +38,7 @@ func testSweepKeyPairs(region string) error {
 		},
 	})
 	if err != nil {
-		if resp != nil {
-			return fmt.Errorf("Error describing key pairs in Sweeper: %s", err)
-		}
+		return fmt.Errorf("Error describing key pairs in Sweeper: %s", err)
 	}
 
 	keyPairs := resp.KeyPairs

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -14,22 +14,18 @@ import (
 )
 
 func init() {
-	// add sweepers for each region
-	for _, r := range []string{"us-east-1", "us-west-2", "us-east-2"} {
-		name := fmt.Sprintf("aws_key_pair-%s", r)
-		resource.AddTestSweepers(name,
-			&resource.Sweeper{
-				Name: name,
-				Config: &Config{
-					Region: r,
-				},
-				F: testSweepKeyPairs,
-			})
-	}
+	resource.AddTestSweepers("aws_key_pair", &resource.Sweeper{
+		Name: "aws_key_pair",
+		F:    testSweepKeyPairs,
+	})
 }
 
 func testSweepKeyPairs(c interface{}) error {
-	client, err := c.(*Config).Client()
+	region := c.(string)
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
 	ec2conn := client.(*AWSClient).ec2conn
 
 	log.Printf("Destroying the tmp keys in (%s)", client.(*AWSClient).region)

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -55,7 +55,7 @@ func testSweepKeyPairs(c interface{}) error {
 		})
 
 		if err != nil {
-			fmt.Errorf("Error deleting key pairs in Sweeper: %s", err)
+			return fmt.Errorf("Error deleting key pairs in Sweeper: %s", err)
 		}
 	}
 	return nil

--- a/builtin/providers/aws/resource_aws_key_pair_test.go
+++ b/builtin/providers/aws/resource_aws_key_pair_test.go
@@ -15,17 +15,17 @@ import (
 
 func init() {
 	// add sweepers for each region
-	var fs []*resource.Sweeper
 	for _, r := range []string{"us-east-1", "us-west-2", "us-east-2"} {
-		fs = append(fs, &resource.Sweeper{
-			Config: &Config{
-				Region: r,
-			},
-			F: testSweepKeyPairs,
-		})
+		name := fmt.Sprintf("aws_key_pair-%s", r)
+		resource.AddTestSweepers(name,
+			&resource.Sweeper{
+				Name: name,
+				Config: &Config{
+					Region: r,
+				},
+				F: testSweepKeyPairs,
+			})
 	}
-
-	resource.AddTestSweepers("aws_key_pair", fs)
 }
 
 func testSweepKeyPairs(c interface{}) error {

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -19,8 +19,9 @@ import (
 
 func init() {
 	resource.AddTestSweepers("aws_launch_configuration", &resource.Sweeper{
-		Name: "aws_launch_configuration",
-		F:    testSweepLaunchConfigurations,
+		Name:         "aws_launch_configuration",
+		Dependencies: []string{"aws_autoscaling_group"},
+		F:            testSweepLaunchConfigurations,
 	})
 }
 

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"log"
 	"math/rand"
 	"strings"
 	"testing"
@@ -15,6 +16,61 @@ import (
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
+
+func init() {
+	resource.AddTestSweepers("aws_launch_configuration", &resource.Sweeper{
+		Name: "aws_launch_configuration",
+		F:    testSweepLaunchConfigurations,
+	})
+}
+
+func testSweepLaunchConfigurations(c interface{}) error {
+	region := c.(string)
+	client, err := sharedClientForRegion(region)
+	if err != nil {
+		return fmt.Errorf("error getting client: %s", err)
+	}
+	autoscalingconn := client.(*AWSClient).autoscalingconn
+
+	resp, err := autoscalingconn.DescribeLaunchConfigurations(&autoscaling.DescribeLaunchConfigurationsInput{})
+	if err != nil {
+		return fmt.Errorf("Error retrieving launch configuration: %s", err)
+	}
+
+	if len(resp.LaunchConfigurations) == 0 {
+		log.Print("[DEBUG] No aws launch configurations to sweep")
+		return nil
+	}
+
+	for _, lc := range resp.LaunchConfigurations {
+		var testOptGroup bool
+		for _, testName := range []string{"terraform-", "foobar"} {
+			if strings.HasPrefix(*lc.LaunchConfigurationName, testName) {
+				testOptGroup = true
+			}
+		}
+
+		if !testOptGroup {
+			continue
+		}
+
+		_, err := autoscalingconn.DeleteLaunchConfiguration(
+			&autoscaling.DeleteLaunchConfigurationInput{
+				LaunchConfigurationName: lc.LaunchConfigurationName,
+			})
+		if err != nil {
+			autoscalingerr, ok := err.(awserr.Error)
+			if ok && (autoscalingerr.Code() == "InvalidConfiguration.NotFound" || autoscalingerr.Code() == "ValidationError") {
+				log.Printf("[DEBUG] Launch configuration (%s) not found", *lc.LaunchConfigurationName)
+				return nil
+			}
+
+			return err
+		}
+	}
+
+	return nil
+}
 
 func TestAccAWSLaunchConfiguration_basic(t *testing.T) {
 	var conf autoscaling.LaunchConfiguration

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -25,8 +25,7 @@ func init() {
 	})
 }
 
-func testSweepLaunchConfigurations(c interface{}) error {
-	region := c.(string)
+func testSweepLaunchConfigurations(region string) error {
 	client, err := sharedClientForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting client: %s", err)

--- a/builtin/providers/google/gcp_sweeper_test.go
+++ b/builtin/providers/google/gcp_sweeper_test.go
@@ -12,9 +12,9 @@ func TestMain(m *testing.M) {
 	resource.TestMain(m)
 }
 
-// sharedCredsForRegion returns a common config setup needed for the sweeper
+// sharedConfigForRegion returns a common config setup needed for the sweeper
 // functions for a given region
-func sharedCredsForRegion(region string) (*Config, error) {
+func sharedConfigForRegion(region string) (*Config, error) {
 	project := os.Getenv("GOOGLE_PROJECT")
 	if project == "" {
 		return nil, fmt.Errorf("empty GOOGLE_PROJECT")

--- a/builtin/providers/google/gcp_sweeper_test.go
+++ b/builtin/providers/google/gcp_sweeper_test.go
@@ -1,6 +1,8 @@
 package google
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -8,4 +10,26 @@ import (
 
 func TestMain(m *testing.M) {
 	resource.TestMain(m)
+}
+
+// sharedCredsForRegion returns a common config setup needed for the sweeper
+// functions for a given region
+func sharedCredsForRegion(region string) (*Config, error) {
+	project := os.Getenv("GOOGLE_PROJECT")
+	if project == "" {
+		return nil, fmt.Errorf("empty GOOGLE_PROJECT")
+	}
+
+	creds := os.Getenv("GOOGLE_CREDENTIALS")
+	if project == "" {
+		return nil, fmt.Errorf("empty GOOGLE_CREDENTIALS")
+	}
+
+	conf := &Config{
+		Credentials: creds,
+		Region:      region,
+		Project:     project,
+	}
+
+	return conf, nil
 }

--- a/builtin/providers/google/gcp_sweeper_test.go
+++ b/builtin/providers/google/gcp_sweeper_test.go
@@ -21,7 +21,7 @@ func sharedCredsForRegion(region string) (*Config, error) {
 	}
 
 	creds := os.Getenv("GOOGLE_CREDENTIALS")
-	if project == "" {
+	if creds == "" {
 		return nil, fmt.Errorf("empty GOOGLE_CREDENTIALS")
 	}
 

--- a/builtin/providers/google/gcp_sweeper_test.go
+++ b/builtin/providers/google/gcp_sweeper_test.go
@@ -1,0 +1,11 @@
+package google
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestMain(m *testing.M) {
+	resource.TestMain(m)
+}

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -22,21 +22,20 @@ import (
 )
 
 func init() {
-	var fs []*resource.Sweeper
-	// add sweepers for each region
 	for _, r := range []string{"us-central1"} {
 		c, err := sharedCredsForRegion(r)
 		if err != nil {
 			log.Printf("[ERR] error getting shared config for region: %s", err)
 			continue
 		}
-		fs = append(fs, &resource.Sweeper{
-			Config: c,
-			F:      sweepDatabases,
-		})
+		name := fmt.Sprintf("gcp-sql-db-instance-%s", r)
+		resource.AddTestSweepers(name,
+			&resource.Sweeper{
+				Name:   name,
+				Config: c,
+				F:      sweepDatabases,
+			})
 	}
-
-	resource.AddTestSweepers("google_sql_database_instance", fs)
 }
 
 func sweepDatabases(c interface{}) error {

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -28,8 +28,8 @@ func init() {
 	})
 }
 
-func testSweepDatabases(c interface{}) error {
-	config, err := sharedConfigForRegion(c.(string))
+func testSweepDatabases(region string) error {
+	config, err := sharedConfigForRegion(region)
 	if err != nil {
 		return fmt.Errorf("error getting shared config for region: %s", err)
 	}

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -22,20 +22,6 @@ import (
 )
 
 func init() {
-	// for _, r := range []string{"us-central1"} {
-	// 	c, err := sharedCredsForRegion(r)
-	// 	if err != nil {
-	// 		log.Printf("[ERR] error getting shared config for region: %s", err)
-	// 		continue
-	// 	}
-	// 	name := fmt.Sprintf("gcp-sql-db-instance-%s", r)
-	// 	resource.AddTestSweepers(name,
-	// 		&resource.Sweeper{
-	// 			Name:   name,
-	// 			Config: c,
-	// 			F:      sweepDatabases,
-	// 		})
-	// }
 	resource.AddTestSweepers("gcp_sql_db_instance", &resource.Sweeper{
 		Name: "gcp_sql_db_instance",
 		F:    testSweepDatabases,
@@ -43,9 +29,9 @@ func init() {
 }
 
 func testSweepDatabases(c interface{}) error {
-	config, err := sharedCredsForRegion(c.(string))
+	config, err := sharedConfigForRegion(c.(string))
 	if err != nil {
-		return fmt.Errorf("[ERR] error getting shared config for region: %s", err)
+		return fmt.Errorf("error getting shared config for region: %s", err)
 	}
 
 	err = config.loadAndValidate()
@@ -87,7 +73,7 @@ func testSweepDatabases(c interface{}) error {
 			op, err := config.clientSqlAdmin.Instances.StopReplica(config.Project, replicaName).Do()
 
 			if err != nil {
-				return fmt.Errorf("Error, failed to stop replica instance (%s) for instance (%s): %s", replicaName, d.Name, err)
+				return fmt.Errorf("error, failed to stop replica instance (%s) for instance (%s): %s", replicaName, d.Name, err)
 			}
 
 			err = sqladminOperationWait(config, op, "Stop Replica")

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -22,25 +22,33 @@ import (
 )
 
 func init() {
-	for _, r := range []string{"us-central1"} {
-		c, err := sharedCredsForRegion(r)
-		if err != nil {
-			log.Printf("[ERR] error getting shared config for region: %s", err)
-			continue
-		}
-		name := fmt.Sprintf("gcp-sql-db-instance-%s", r)
-		resource.AddTestSweepers(name,
-			&resource.Sweeper{
-				Name:   name,
-				Config: c,
-				F:      sweepDatabases,
-			})
-	}
+	// for _, r := range []string{"us-central1"} {
+	// 	c, err := sharedCredsForRegion(r)
+	// 	if err != nil {
+	// 		log.Printf("[ERR] error getting shared config for region: %s", err)
+	// 		continue
+	// 	}
+	// 	name := fmt.Sprintf("gcp-sql-db-instance-%s", r)
+	// 	resource.AddTestSweepers(name,
+	// 		&resource.Sweeper{
+	// 			Name:   name,
+	// 			Config: c,
+	// 			F:      sweepDatabases,
+	// 		})
+	// }
+	resource.AddTestSweepers("gcp_sql_db_instance", &resource.Sweeper{
+		Name: "gcp_sql_db_instance",
+		F:    testSweepDatabases,
+	})
 }
 
-func sweepDatabases(c interface{}) error {
-	config := c.(*Config)
-	err := config.loadAndValidate()
+func testSweepDatabases(c interface{}) error {
+	config, err := sharedCredsForRegion(c.(string))
+	if err != nil {
+		return fmt.Errorf("[ERR] error getting shared config for region: %s", err)
+	}
+
+	err = config.loadAndValidate()
 	if err != nil {
 		log.Fatalf("error loading: %s", err)
 	}

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -10,7 +10,6 @@ package google
 import (
 	"fmt"
 	"log"
-	"os"
 	"strconv"
 	"strings"
 	"testing"
@@ -23,25 +22,17 @@ import (
 )
 
 func init() {
-	// add sweepers for each region
-	project := os.Getenv("GOOGLE_PROJECT")
-	if project == "" {
-		log.Fatalf("empty GOOGLE_PROJECT")
-	}
-
-	creds := os.Getenv("GOOGLE_CREDENTIALS")
-	if project == "" {
-		log.Fatalf("empty GOOGLE_CREDENTIALS")
-	}
 	var fs []*resource.Sweeper
+	// add sweepers for each region
 	for _, r := range []string{"us-central1"} {
+		c, err := sharedCredsForRegion(r)
+		if err != nil {
+			log.Printf("[ERR] error getting shared config for region: %s", err)
+			continue
+		}
 		fs = append(fs, &resource.Sweeper{
-			Config: &Config{
-				Credentials: creds,
-				Region:      r,
-				Project:     project,
-			},
-			F: sweepDatabases,
+			Config: c,
+			F:      sweepDatabases,
 		})
 	}
 

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -75,7 +75,7 @@ func sweepDatabases(c interface{}) error {
 		// instance. The ordering slice tracks replica databases for a given master
 		// and we call destroy on them before destroying the master
 		var ordering []string
-		for i, replicaName := range d.ReplicaNames {
+		for _, replicaName := range d.ReplicaNames {
 			// need to stop replication before being able to destroy a database
 			op, err := config.clientSqlAdmin.Instances.StopReplica(config.Project, replicaName).Do()
 
@@ -98,7 +98,7 @@ func sweepDatabases(c interface{}) error {
 		// ordering has a list of replicas (or none), now add the primary to the end
 		ordering = append(ordering, d.Name)
 
-		for i, db := range ordering {
+		for _, db := range ordering {
 			// destroy instances, replicas first
 			op, err := config.clientSqlAdmin.Instances.Delete(config.Project, db).Do()
 

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -42,7 +42,7 @@ import (
 // destroyed.
 
 var flagSweep = flag.String("sweep", "", "List of Regions to run available Sweepers")
-var flagSweepRun = flag.String("sweep-run", "", "Comman seperated list of Sweeper Tests to run")
+var flagSweepRun = flag.String("sweep-run", "", "Comma seperated list of Sweeper Tests to run")
 var sweeperFuncs map[string]*Sweeper
 
 // map of sweepers that have ran, and the success/fail status based on any error
@@ -128,10 +128,9 @@ func TestMain(m *testing.M) {
 				fmt.Printf("\t- %s\n", s)
 			}
 		}
-		os.Exit(0)
+	} else {
+		os.Exit(m.Run())
 	}
-
-	os.Exit(m.Run())
 }
 
 func runSweeperWithRegion(region string, s *Sweeper) error {

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -97,14 +97,14 @@ func TestMain(m *testing.M) {
 			// reset sweeperRunList for each region
 			sweeperRunList = map[string]bool{}
 
-			fmt.Printf("[DEBUG] Running Sweepers for region (%s):\n", region)
+			log.Printf("[DEBUG] Running Sweepers for region (%s):\n", region)
 			for _, sweeper := range sweepers {
 				if err := runSweeperWithRegion(region, sweeper); err != nil {
 					log.Fatalf("[ERR] error running (%s): %s", sweeper.Name, err)
 				}
 			}
 
-			fmt.Printf("Sweeper Tests ran:\n")
+			log.Printf("Sweeper Tests ran:\n")
 			for s, _ := range sweeperRunList {
 				fmt.Printf("\t- %s\n", s)
 			}

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -94,6 +94,7 @@ func TestMain(m *testing.M) {
 		// get filtered list of sweepers to run based on sweep-run flag
 		sweepers := filterSweepers(*flagSweepRun, sweeperFuncs)
 		for _, region := range regions {
+			region = strings.TrimSpace(region)
 			// reset sweeperRunList for each region
 			sweeperRunList = map[string]bool{}
 

--- a/helper/resource/testing.go
+++ b/helper/resource/testing.go
@@ -91,7 +91,7 @@ func TestMain(m *testing.M) {
 		// parse flagSweep contents for regions to run
 		regions := strings.Split(*flagSweep, ",")
 
-		// get list of filtered sweepers to run
+		// get filtered list of sweepers to run based on sweep-run flag
 		sweepers := filterSweepers(*flagSweepRun, sweeperFuncs)
 		for _, region := range regions {
 			// reset sweeperRunList for each region
@@ -114,7 +114,7 @@ func TestMain(m *testing.M) {
 	}
 }
 
-// filterSweepers takes a comma seperated strings listing the names of sweepers
+// filterSweepers takes a comma seperated string listing the names of sweepers
 // to be ran, and returns a filtered set from the list of all of sweepers to
 // run based on the names given.
 func filterSweepers(f string, source map[string]*Sweeper) map[string]*Sweeper {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -707,6 +707,25 @@ func TestTest_Main(t *testing.T) {
 			ExpectedRunList: []string{"aws_top", "aws_sub"},
 			SweepRun:        "aws_top",
 		},
+		{
+			Name: "filter and none",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			SweepRun: "none",
+		},
 	}
 
 	for _, tc := range cases {

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -5,7 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"reflect"
 	"regexp"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -119,17 +121,6 @@ func TestTest(t *testing.T) {
 	if !mp.TestResetCalled {
 		t.Fatal("didn't call TestReset")
 	}
-}
-
-func TestTest_Main(t *testing.T) {
-	flag.Parse()
-	if *flagSweep == "" {
-		// Tests for the TestMain method used for Sweepers will panic without the -sweep
-		// flag specified. Mock the value for now
-		*flagSweep = "us-east-1"
-	}
-	TestMain(&testing.M{})
-	t.Fatalf("fall")
 }
 
 func TestTest_plan_only(t *testing.T) {
@@ -631,3 +622,120 @@ func testProvider() *terraform.MockResourceProvider {
 const testConfigStr = `
 resource "test_instance" "foo" {}
 `
+
+func TestTest_Main(t *testing.T) {
+	flag.Parse()
+	if *flagSweep == "" {
+		// Tests for the TestMain method used for Sweepers will panic without the -sweep
+		// flag specified. Mock the value for now
+		*flagSweep = "us-east-1"
+	}
+
+	cases := []struct {
+		Name            string
+		ShouldErr       bool
+		Sweepers        map[string]*Sweeper
+		ExpectedRunList []string
+		SweepRun        string
+	}{
+		{
+			Name: "normal",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_dummy"},
+		},
+		{
+			Name: "with dep",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_dummy", "aws_sub", "aws_top"},
+		},
+		{
+			Name: "with filter",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_dummy"},
+			SweepRun:        "aws_dummy",
+		},
+		{
+			Name: "with dep and filter",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_top", "aws_sub"},
+			SweepRun:        "aws_top",
+		},
+	}
+
+	for _, tc := range cases {
+		// reset sweepers
+		sweeperFuncs = map[string]*Sweeper{}
+
+		t.Run(tc.Name, func(t *testing.T) {
+			for n, s := range tc.Sweepers {
+				AddTestSweepers(n, s)
+			}
+			*flagSweepRun = tc.SweepRun
+
+			TestMain(&testing.M{})
+
+			// get list of tests ran from sweeperRan keys
+			var keys []string
+			for k, _ := range sweeperRan {
+				keys = append(keys, k)
+			}
+
+			sort.Strings(keys)
+			sort.Strings(tc.ExpectedRunList)
+			if !reflect.DeepEqual(keys, tc.ExpectedRunList) {
+				t.Fatalf("Expected keys mismatch, expected:\n%#v\ngot:\n%#v\n", tc.ExpectedRunList, keys)
+			}
+		})
+	}
+}
+
+func mockSweeperFunc(s string) error {
+	return nil
+}

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -633,7 +633,6 @@ func TestTest_Main(t *testing.T) {
 
 	cases := []struct {
 		Name            string
-		ShouldErr       bool
 		Sweepers        map[string]*Sweeper
 		ExpectedRunList []string
 		SweepRun        string
@@ -740,9 +739,9 @@ func TestTest_Main(t *testing.T) {
 
 			TestMain(&testing.M{})
 
-			// get list of tests ran from sweeperRan keys
+			// get list of tests ran from sweeperRunList keys
 			var keys []string
-			for k, _ := range sweeperRan {
+			for k, _ := range sweeperRunList {
 				keys = append(keys, k)
 			}
 

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -687,6 +687,26 @@ func TestTest_Main(t *testing.T) {
 			SweepRun:        "aws_dummy",
 		},
 		{
+			Name: "with two filters",
+			Sweepers: map[string]*Sweeper{
+				"aws_dummy": &Sweeper{
+					Name: "aws_dummy",
+					F:    mockSweeperFunc,
+				},
+				"aws_top": &Sweeper{
+					Name:         "aws_top",
+					Dependencies: []string{"aws_sub"},
+					F:            mockSweeperFunc,
+				},
+				"aws_sub": &Sweeper{
+					Name: "aws_sub",
+					F:    mockSweeperFunc,
+				},
+			},
+			ExpectedRunList: []string{"aws_dummy", "aws_sub"},
+			SweepRun:        "aws_dummy,aws_sub",
+		},
+		{
 			Name: "with dep and filter",
 			Sweepers: map[string]*Sweeper{
 				"aws_dummy": &Sweeper{

--- a/helper/resource/testing_test.go
+++ b/helper/resource/testing_test.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"os"
 	"regexp"
@@ -118,6 +119,17 @@ func TestTest(t *testing.T) {
 	if !mp.TestResetCalled {
 		t.Fatal("didn't call TestReset")
 	}
+}
+
+func TestTest_Main(t *testing.T) {
+	flag.Parse()
+	if *flagSweep == "" {
+		// Tests for the TestMain method used for Sweepers will panic without the -sweep
+		// flag specified. Mock the value for now
+		*flagSweep = "us-east-1"
+	}
+	TestMain(&testing.M{})
+	t.Fatalf("fall")
 }
 
 func TestTest_plan_only(t *testing.T) {


### PR DESCRIPTION
Terraform's acceptance testing framework is responsible for creating the infrastructure in the configuration, and then destroying all resources created. While by itself it is largely successful in destroying all resources created, configurations can be constructed that prevent successful teardown. Additionally, any test that panics or hits the Test Runner timeout can result in dangling, leaked resources.

Here we introduce "Sweepers" into helper/resource and adds example implementations for:

- `aws_db_option_group`
- `aws_key_pair`
- `aws_launch_configurations`
- `aws_autoscaling_group`
- `google_sql_database_instances`

We use the CLI flag `sweep` to provide a list of regions to run the Sweepers in. This flag will intercept the normal test flow, and instead run the Sweepers that have been registered. Provider authors are responsible for writing the Sweeper methods and the criteria they use to determine what to destroy. For example, the included `aws_key_pair` sweeper func `testSweepKeyPairs` will destroy any EC2 key pair that match the name pattern of tmp-key*. 

A Sweeper may list another Sweeper as a dependency, via the Sweepers name. For example, the `aws_launch_configuration` depends on the `aws_autoscaling_group` Sweeper to be ran first. The `sweep-run` flag is an optional argument allowing users to specifically run that sweeper. **NOTE** there is no way at time of writing to target run a given Sweeper **and not** also run it's dependencies. 

Sweepers are meant to be ran periodically, especially in a Continuous Integration environment, and should not be used anywhere outside of a test environment, where everything should be considered disposable. The majority of Terraform users should not use sweepers at all. Sweepers have no purpose other than to destroy leaked resources. 


------

Invocation examples:

    $ go test ./builtin/providers/aws -sweep=us-east-1,us-west-2
    $ go test ./builtin/providers/aws -sweep=us-east-1 -sweep-run=launch_configuration

The `-v` option to `go test` will show a list of tests ran per region:

```
$ go test ./builtin/providers/aws -v -sweep=us-east-1 -sweep-run=launch_configuration
[DEBUG] Running Sweepers for region (us-east-1):
[...]
Sweeper Tests ran:
        - aws_launch_configuration
        - aws_autoscaling_group
ok      github.com/hashicorp/terraform/builtin/providers/aws    3.443s
```

```
$ go test ./builtin/providers/aws -v -sweep=us-west-2
[DEBUG] Running Sweepers for region (us-west-2):
[...]
Sweeper Tests ran:
        - aws_key_pair
        - aws_autoscaling_group
        - aws_launch_configuration
        - aws_db_option_group
ok      github.com/hashicorp/terraform/builtin/providers/aws    5.593s
```

Included test:

```
$ go test ./helper/resource -v -run=TestTest_Main
[debug output omitted]
--- PASS: TestTest_Main (0.00s)
    --- PASS: TestTest_Main/normal (0.00s)
    --- PASS: TestTest_Main/with_dep (0.00s)
    --- PASS: TestTest_Main/with_filter (0.00s)
    --- PASS: TestTest_Main/with_two_filters (0.00s)
    --- PASS: TestTest_Main/with_dep_and_filter (0.00s)
    --- PASS: TestTest_Main/filter_and_none (0.00s)
PASS
ok      github.com/hashicorp/terraform/helper/resource  0.012s
```