### PR TITLE
provider/google: enable use of URI as snapshot name when creating a disk

### DIFF
--- a/builtin/providers/google/provider_test.go
+++ b/builtin/providers/google/provider_test.go
@@ -78,10 +78,6 @@ func testAccPreCheck(t *testing.T) {
 	if v := os.Getenv("GOOGLE_XPN_HOST_PROJECT"); v == "" {
 		t.Fatal("GOOGLE_XPN_HOST_PROJECT must be set for acceptance tests")
 	}
-
-	if v := os.Getenv("GOOGLE_COMPUTE_DISK_SNAPSHOT_URI"); v == "" {
-		t.Fatal("GOOGLE_COMPUTE_DISK_SNAPSHOT_URI must be set for acceptance tests")
-	}
 }
 
 func TestProvider_getRegionFromZone(t *testing.T) {

--- a/builtin/providers/google/resource_compute_disk_test.go
+++ b/builtin/providers/google/resource_compute_disk_test.go
@@ -31,7 +31,7 @@ func TestAccComputeDisk_basic(t *testing.T) {
 	})
 }
 
-func TestAccComputeDisk_from_snapshot_uri(t *testing.T) {
+func TestAccComputeDisk_fromSnapshotURI(t *testing.T) {
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	firstDiskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	snapshotName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -45,7 +45,7 @@ func TestAccComputeDisk_from_snapshot_uri(t *testing.T) {
 		CheckDestroy: testAccCheckComputeDiskDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccComputeDisk_from_snapshot_uri(firstDiskName, snapshotName, diskName, xpn_host),
+				Config: testAccComputeDisk_fromSnapshotURI(firstDiskName, snapshotName, diskName, xpn_host),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeDiskExists(
 						"google_compute_disk.seconddisk", &disk),
@@ -155,7 +155,7 @@ resource "google_compute_disk" "foobar" {
 }`, diskName)
 }
 
-func testAccComputeDisk_from_snapshot_uri(firstDiskName string, snapshotName string, diskName string, xpn_host string) string {
+func testAccComputeDisk_fromSnapshotURI(firstDiskName, snapshotName, diskName, xpn_host string) string {
 	return fmt.Sprintf(`
 		resource "google_compute_disk" "foobar" {
 			name = "%s"


### PR DESCRIPTION
Hi

It's possible to create a disk in a Google project A from a snapshot made in project B. But to do this, you need to use URI of the snapshot in project B.

This PR enable this usage.

I tested it :

* I made a snapshot of a disk in project A (named "snapshot-1")
* I used terraform to create a disk in project B, using the snapshot.

```hcl
resource "google_compute_disk" "default" {
  name  = "test-disk-gbook"
  type  = "pd-ssd"
  zone  = "europe-west1-d"
  snapshot = "https://www.googleapis.com/compute/v1/projects/sk5-formations-thomas-build/global/snapshots/snapshot-1"
}
```

Thanks.

Thomas

<hr>

This PR was originally #12278, but due to some git shenanigans, that PR became unusable, so it has been moved here. It was originally opened by @tpoindessous, who remains the shepherd and author of it, no matter what GitHub says. :)