### PR TITLE
provider/google : Added creation of a new disk from a snapshot made in another project

### DIFF
--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -3,6 +3,7 @@ package google
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"google.golang.org/api/compute/v1"
@@ -129,17 +130,21 @@ func resourceComputeDiskCreate(d *schema.ResourceData, meta interface{}) error {
 
 	if v, ok := d.GetOk("snapshot"); ok {
 		snapshotName := v.(string)
-		log.Printf("[DEBUG] Loading snapshot: %s", snapshotName)
-		snapshotData, err := config.clientCompute.Snapshots.Get(
-			project, snapshotName).Do()
+		match, _ := regexp.MatchString("^https://www.googleapis.com/compute", snapshotName)
+		if match {
+			disk.SourceSnapshot = snapshotName
+		} else {
+			log.Printf("[DEBUG] Loading snapshot: %s", snapshotName)
+			snapshotData, err := config.clientCompute.Snapshots.Get(
+				project, snapshotName).Do()
 
-		if err != nil {
-			return fmt.Errorf(
-				"Error loading snapshot '%s': %s",
-				snapshotName, err)
+			if err != nil {
+				return fmt.Errorf(
+					"Error loading snapshot '%s': %s",
+					snapshotName, err)
+			}
+			disk.SourceSnapshot = snapshotData.SelfLink
 		}
-
-		disk.SourceSnapshot = snapshotData.SelfLink
 	}
 
 	if v, ok := d.GetOk("disk_encryption_key_raw"); ok {

--- a/builtin/providers/google/resource_compute_disk_test.go
+++ b/builtin/providers/google/resource_compute_disk_test.go
@@ -2,6 +2,7 @@ package google
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/acctest"
@@ -24,6 +25,29 @@ func TestAccComputeDisk_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckComputeDiskExists(
 						"google_compute_disk.foobar", &disk),
+				),
+			},
+		},
+	})
+}
+
+func TestAccComputeDisk_from_snapshot_uri(t *testing.T) {
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	firstDiskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	snapshotName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var xpn_host = os.Getenv("GOOGLE_XPN_HOST_PROJECT")
+	var disk compute.Disk
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckComputeDiskDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccComputeDisk_from_snapshot_uri(firstDiskName, snapshotName, diskName, xpn_host),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeDiskExists(
+						"google_compute_disk.seconddisk", &disk),
 				),
 			},
 		},
@@ -128,6 +152,32 @@ resource "google_compute_disk" "foobar" {
 	type = "pd-ssd"
 	zone = "us-central1-a"
 }`, diskName)
+}
+
+func testAccComputeDisk_from_snapshot_uri(firstDiskName string, snapshotName string, diskName string, xpn_host string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "foobar" {
+  name = "%s"
+  image = "debian-8-jessie-v20160803"
+  size = 50
+  type = "pd-ssd"
+  zone = "us-central1-a"
+  project = "%s"
+}
+
+resource "google_compute_snapshot" "snapdisk" {
+  name = "%s"
+  source_disk = "${google_compute_disk.foobar.name}"
+  zone = "us-central1-a"
+	project = "%s"
+}
+
+resource "google_compute_disk" "seconddisk" {
+	name = "%s"
+	snapshot = "${google_compute_snapshot.snapdisk.self_link}"
+	type = "pd-ssd"
+	zone = "us-central1-a"
+}`, firstDiskName, xpn_host, snapshotName, xpn_host, diskName)
 }
 
 func testAccComputeDisk_encryption(diskName string) string {


### PR DESCRIPTION
Hi @paddycarver 

I re-made a brand new PR (supercedes #12278).

Sorry for the big mess ...

I ran the test TestAccComputeDisk_from_snapshot_uri : 

```
$ make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccComputeDisk_from_snapshot_uri'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/24 00:23:54 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeDisk_from_snapshot_uri -timeout 120m
=== RUN   TestAccComputeDisk_from_snapshot_uri
--- PASS: TestAccComputeDisk_from_snapshot_uri (131.71s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	131.730s
```

Thanks in advance.

Thomas
