### PR TITLE
Fix winrm provisioner cacert option

### DIFF
--- a/communicator/winrm/communicator.go
+++ b/communicator/winrm/communicator.go
@@ -40,9 +40,8 @@ func New(s *terraform.InstanceState) (*Communicator, error) {
 		HTTPS:    connInfo.HTTPS,
 		Insecure: connInfo.Insecure,
 	}
-
-	if connInfo.CACert != nil {
-		endpoint.CACert = *connInfo.CACert
+	if len(connInfo.CACert) > 0 {
+		endpoint.CACert = []byte(connInfo.CACert)
 	}
 
 	comm := &Communicator{
@@ -86,7 +85,7 @@ func (c *Communicator) Connect(o terraform.UIOutput) error {
 			c.connInfo.Password != "",
 			c.connInfo.HTTPS,
 			c.connInfo.Insecure,
-			c.connInfo.CACert != nil,
+			c.connInfo.CACert != "",
 		))
 	}
 
@@ -211,8 +210,8 @@ func (c *Communicator) newCopyClient() (*winrmcp.Winrmcp, error) {
 		MaxOperationsPerShell: 15, // lowest common denominator
 	}
 
-	if c.connInfo.CACert != nil {
-		config.CACertBytes = *c.connInfo.CACert
+	if c.connInfo.CACert != "" {
+		config.CACertBytes = []byte(c.connInfo.CACert)
 	}
 
 	return winrmcp.New(addr, &config)

--- a/communicator/winrm/provisioner.go
+++ b/communicator/winrm/provisioner.go
@@ -37,7 +37,7 @@ type connectionInfo struct {
 	Port       int
 	HTTPS      bool
 	Insecure   bool
-	CACert     *[]byte `mapstructure:"ca_cert"`
+	CACert     string `mapstructure:"cacert"`
 	Timeout    string
 	ScriptPath string        `mapstructure:"script_path"`
 	TimeoutVal time.Duration `mapstructure:"-"`

--- a/communicator/winrm/provisioner_test.go
+++ b/communicator/winrm/provisioner_test.go
@@ -49,6 +49,75 @@ func TestProvisioner_connInfo(t *testing.T) {
 	}
 }
 
+func TestProvisioner_connInfoCACert(t *testing.T) {
+	caCert := `
+-----BEGIN CERTIFICATE-----
+MIIDBjCCAe4CCQCGWwBmOiHQdTANBgkqhkiG9w0BAQUFADBFMQswCQYDVQQGEwJB
+VTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0
+cyBQdHkgTHRkMB4XDTE2MDYyMTE2MzM0MVoXDTE3MDYyMTE2MzM0MVowRTELMAkG
+A1UEBhMCQVUxEzARBgNVBAgTClNvbWUtU3RhdGUxITAfBgNVBAoTGEludGVybmV0
+IFdpZGdpdHMgUHR5IEx0ZDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEB
+AL+LFlsCJG5txZp4yuu+lQnuUrgBXRG+irQqcTXlV91Bp5hpmRIyhnGCtWxxDBUL
+xrh4WN3VV/0jDzKT976oLgOy3hj56Cdqf+JlZ1qgMN5bHB3mm3aVWnrnsLbBsfwZ
+SEbk3Kht/cE1nK2toNVW+rznS3m+eoV3Zn/DUNwGlZr42hGNs6ETn2jURY78ETqR
+mW47xvjf86eIo7vULHJaY6xyarPqkL8DZazOmvY06hUGvGwGBny7gugfXqDG+I8n
+cPBsGJGSAmHmVV8o0RCB9UjY+TvSMQRpEDoVlvyrGuglsD8to/4+7UcsuDGlRYN6
+jmIOC37mOi/jwRfWL1YUa4MCAwEAATANBgkqhkiG9w0BAQUFAAOCAQEAPDxTH0oQ
+JjKXoJgkmQxurB81RfnK/NrswJVzWbOv6ejcbhwh+/ZgJTMc15BrYcxU6vUW1V/i
+Z7APU0qJ0icECACML+a2fRI7YdLCTiPIOmY66HY8MZHAn3dGjU5TeiUflC0n0zkP
+mxKJe43kcYLNDItbfvUDo/GoxTXrC3EFVZyU0RhFzoVJdODlTHXMVFCzcbQEBrBJ
+xKdShCEc8nFMneZcGFeEU488ntZoWzzms8/QpYrKa5S0Sd7umEU2Kwu4HTkvUFg/
+CqDUFjhydXxYRsxXBBrEiLOE5BdtJR1sH/QHxIJe23C9iHI2nS1NbLziNEApLwC4
+GnSud83VUo9G9w==
+-----END CERTIFICATE-----
+`
+
+	r := &terraform.InstanceState{
+		Ephemeral: terraform.EphemeralState{
+			ConnInfo: map[string]string{
+				"type":     "winrm",
+				"user":     "Administrator",
+				"password": "supersecret",
+				"host":     "127.0.0.1",
+				"port":     "5985",
+				"https":    "true",
+				"timeout":  "30s",
+				"cacert":   caCert,
+			},
+		},
+	}
+
+	conf, err := parseConnectionInfo(r)
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+
+	if conf.User != "Administrator" {
+		t.Fatalf("expected: %v: got: %v", "Administrator", conf)
+	}
+	if conf.Password != "supersecret" {
+		t.Fatalf("expected: %v: got: %v", "supersecret", conf)
+	}
+	if conf.Host != "127.0.0.1" {
+		t.Fatalf("expected: %v: got: %v", "127.0.0.1", conf)
+	}
+	if conf.Port != 5985 {
+		t.Fatalf("expected: %v: got: %v", 5985, conf)
+	}
+	if conf.HTTPS != true {
+		t.Fatalf("expected: %v: got: %v", true, conf)
+	}
+	if conf.Timeout != "30s" {
+		t.Fatalf("expected: %v: got: %v", "30s", conf)
+	}
+	if conf.ScriptPath != DefaultScriptPath {
+		t.Fatalf("expected: %v: got: %v", DefaultScriptPath, conf)
+	}
+	if conf.CACert != caCert {
+		t.Fatalf("expected: %v: got: %v", caCert, conf.CACert)
+	}
+}
+
 func TestProvisioner_connInfoIpv6(t *testing.T) {
 	r := &terraform.InstanceState{
 		Ephemeral: terraform.EphemeralState{


### PR DESCRIPTION
It appears that the cacert option for the winrm provisioner was
not getting passed correctly to the winrm package. Log output
showed that CACert was false regardless of configuration.

While the validation of the connector looked for cacert, the winrm
communicator looked for ca_cert.