### PR TITLE
helper/schema: fix validating nested objects

### DIFF
--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -1373,7 +1373,7 @@ func (m schemaMap) validateObject(
 	k string,
 	schema map[string]*Schema,
 	c *terraform.ResourceConfig) ([]string, []error) {
-	raw, _ := c.GetRaw(k)
+	raw, _ := c.Get(k)
 	if _, ok := raw.(map[string]interface{}); !ok {
 		return nil, []error{fmt.Errorf(
 			"%s: expected object, got %s",

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -3947,6 +3947,33 @@ func TestSchemaMap_Validate(t *testing.T) {
 			Err: false,
 		},
 
+		"Good sub-resource, interpolated value": {
+			Schema: map[string]*Schema{
+				"ingress": &Schema{
+					Type:     TypeList,
+					Optional: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"from": &Schema{
+								Type:     TypeInt,
+								Required: true,
+							},
+						},
+					},
+				},
+			},
+
+			Config: map[string]interface{}{
+				"ingress": []interface{}{
+					`${map("from", "80")}`,
+				},
+			},
+
+			Vars: map[string]string{},
+
+			Err: false,
+		},
+
 		"Invalid/unknown field": {
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{


### PR DESCRIPTION
When interpreting a nested object, we were validating against the "raw"
value, and not the interpolated value, causing incorrect errors.

This affects structures such as:

```tf
tags = "${list(map("foo", "bar"))}"
```

Prior to this, a complaint about "expected object, got string" since the
raw value is obviously a string, when the interpolated value is the
correct shape.