### PR TITLE
Add support for changing TTL on DigitalOcean domain records.

### DIFF
--- a/builtin/providers/digitalocean/resource_digitalocean_record.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record.go
@@ -57,6 +57,12 @@ func resourceDigitalOceanRecord() *schema.Resource {
 				ForceNew: true,
 			},
 
+			"ttl": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+
 			"value": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -92,6 +98,12 @@ func resourceDigitalOceanRecordCreate(d *schema.ResourceData, meta interface{}) 
 		newRecord.Port, err = strconv.Atoi(port)
 		if err != nil {
 			return fmt.Errorf("Failed to parse port as an integer: %v", err)
+		}
+	}
+	if ttl := d.Get("ttl").(string); ttl != "" {
+		newRecord.TTL, err = strconv.Atoi(ttl)
+		if err != nil {
+			return fmt.Errorf("Failed to parse ttl as an integer: %v", err)
 		}
 	}
 	if weight := d.Get("weight").(string); weight != "" {
@@ -146,6 +158,7 @@ func resourceDigitalOceanRecordRead(d *schema.ResourceData, meta interface{}) er
 	d.Set("weight", strconv.Itoa(rec.Weight))
 	d.Set("priority", strconv.Itoa(rec.Priority))
 	d.Set("port", strconv.Itoa(rec.Port))
+	d.Set("ttl", strconv.Itoa(rec.TTL))
 
 	en := constructFqdn(rec.Name, d.Get("domain").(string))
 	log.Printf("[DEBUG] Constructed FQDN: %s", en)
@@ -166,6 +179,14 @@ func resourceDigitalOceanRecordUpdate(d *schema.ResourceData, meta interface{}) 
 	var editRecord godo.DomainRecordEditRequest
 	if v, ok := d.GetOk("name"); ok {
 		editRecord.Name = v.(string)
+	}
+
+	if d.HasChange("ttl") {
+		newTTL := d.Get("ttl").(string)
+		editRecord.TTL, err = strconv.Atoi(newTTL)
+		if err != nil {
+			return fmt.Errorf("Failed to parse ttl as an integer: %v", err)
+		}
 	}
 
 	log.Printf("[DEBUG] record update configuration: %#v", editRecord)

--- a/builtin/providers/digitalocean/resource_digitalocean_record_test.go
+++ b/builtin/providers/digitalocean/resource_digitalocean_record_test.go
@@ -85,6 +85,8 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 						"digitalocean_record.foobar", "value", "192.168.0.10"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "ttl", "1800"),
 				),
 			},
 			{
@@ -101,6 +103,8 @@ func TestAccDigitalOceanRecord_Updated(t *testing.T) {
 						"digitalocean_record.foobar", "value", "192.168.0.11"),
 					resource.TestCheckResourceAttr(
 						"digitalocean_record.foobar", "type", "A"),
+					resource.TestCheckResourceAttr(
+						"digitalocean_record.foobar", "ttl", "90"),
 				),
 			},
 		},
@@ -341,6 +345,7 @@ resource "digitalocean_record" "foobar" {
   name  = "terraform"
   value = "192.168.0.11"
   type  = "A"
+  ttl   = 90
 }`
 
 const testAccCheckDigitalOceanRecordConfig_cname = `

--- a/website/source/docs/providers/do/r/record.html.markdown
+++ b/website/source/docs/providers/do/r/record.html.markdown
@@ -40,6 +40,7 @@ The following arguments are supported:
 * `port` - (Optional) The port of the record, for SRV records.
 * `priority` - (Optional) The priority of the record, for MX and SRV
    records.
+* `ttl` - (Optional) The time to live for the record, in seconds.
 
 ## Attributes Reference
 
@@ -47,4 +48,3 @@ The following attributes are exported:
 
 * `id` - The record ID
 * `fqdn` - The FQDN of the record
-


### PR DESCRIPTION
The DO API was extended to support configuring the TTL value for individual domain records. See: 

https://developers.digitalocean.com/documentation/changelog/api-v2/configurable-ttl-for-domain-records/

This PR adds support for that as well as updating the vendorized copy of godo. That required a few changes:

- The introduction of Context usage.
- The deprecation of tag renaming. See:
  https://developers.digitalocean.com/documentation/changelog/api-v2/deprecating-update-tag/

Fixes: #12631 