### PR TITLE
provider/google: Update google_compute_target_pool's session_affinity default

### DIFF
--- a/builtin/providers/google/resource_compute_target_pool.go
+++ b/builtin/providers/google/resource_compute_target_pool.go
@@ -82,6 +82,7 @@ func resourceComputeTargetPool() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
+				Default:  "NONE",
 			},
 		},
 	}


### PR DESCRIPTION
Update the session_affinity field to have a default set, like our [documentation](https://www.terraform.io/docs/providers/google/r/compute_target_pool.html) suggests. The API also has this value - right now, Terraform recreates target pools on every apply.

This can be seen with this configuration:

```hcl
resource "google_compute_target_pool" "target-pool" {
  name = "tf-target-pool"
}
```
followed by:

```bash
terraform apply
terraform apply
```


This should stop the creation of a new resource in #14770.

@danawillow 