### PR TITLE
core: save provider plugin hashes during init, and verify during context creation

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -221,7 +221,7 @@ func (c *InitCommand) getProviders(path string, state *terraform.State) error {
 
 	dst := c.pluginDir()
 	for provider, reqd := range missing {
-		err := c.getProvider(dst, provider, reqd)
+		err := c.getProvider(dst, provider, reqd.Versions)
 		// TODO: return all errors
 		if err != nil {
 			return err

--- a/command/meta.go
+++ b/command/meta.go
@@ -50,6 +50,11 @@ type Meta struct {
 	// Override certain behavior for tests within this package
 	testingOverrides *testingOverrides
 
+	// Override the set of provider plugin SHA256 digests we expect.
+	// If this is nil we will instead read from the provider lock file
+	// when setting up ContextOpts.
+	forceProviderSHA256s map[string][]byte
+
 	//----------------------------------------------------------
 	// Private: do not set these
 	//----------------------------------------------------------
@@ -242,6 +247,12 @@ func (m *Meta) contextOpts() *terraform.ContextOpts {
 	} else {
 		opts.ProviderResolver = m.providerResolver()
 		opts.Provisioners = m.provisionerFactories()
+	}
+
+	if m.forceProviderSHA256s != nil {
+		opts.ProviderSHA256s = m.forceProviderSHA256s
+	} else {
+		opts.ProviderSHA256s = m.providerPluginsLock().Read()
 	}
 
 	opts.Meta = &terraform.ContextMeta{

--- a/command/plugins_lock.go
+++ b/command/plugins_lock.go
@@ -1,0 +1,86 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func (m *Meta) providerPluginsLock() *pluginSHA256LockFile {
+	return &pluginSHA256LockFile{
+		Filename: filepath.Join(m.pluginDir(), "providers.json"),
+	}
+}
+
+type pluginSHA256LockFile struct {
+	Filename string
+}
+
+// Read loads the lock information from the file and returns it. If the file
+// cannot be read, an empty map is returned to indicate that _no_ providers
+// are acceptable, since the user must run "terraform init" to lock some
+// providers before a context can be created.
+func (pf *pluginSHA256LockFile) Read() map[string][]byte {
+	// Returning an empty map is different than nil because it causes
+	// us to reject all plugins as uninitialized, rather than applying no
+	// constraints at all.
+	//
+	// We don't surface any specific errors here because we want it to all
+	// roll up into our more-user-friendly error that appears when plugin
+	// constraint verification fails during context creation.
+	digests := make(map[string][]byte)
+
+	buf, err := ioutil.ReadFile(pf.Filename)
+	if err != nil {
+		// This is expected if the user runs any context-using command before
+		// running "terraform init".
+		log.Printf("[INFO] Failed to read plugin lock file %s: %s", pf.Filename, err)
+		return digests
+	}
+
+	var strDigests map[string]string
+	err = json.Unmarshal(buf, &strDigests)
+	if err != nil {
+		// This should never happen unless the user directly edits the file.
+		log.Printf("[WARNING] Plugin lock file %s failed to parse as JSON: %s", pf.Filename, err)
+		return digests
+	}
+
+	for name, strDigest := range strDigests {
+		var digest []byte
+		_, err := fmt.Sscanf(strDigest, "%x", &digest)
+		if err == nil {
+			digests[name] = digest
+		} else {
+			// This should never happen unless the user directly edits the file.
+			log.Printf("[WARNING] Plugin lock file %s has invalid digest for %q", pf.Filename, name)
+		}
+	}
+
+	return digests
+}
+
+// Write persists lock information to disk, where it will be retrieved by
+// future calls to Read. This entirely replaces any previous lock information,
+// so the given map must be comprehensive.
+func (pf *pluginSHA256LockFile) Write(digests map[string][]byte) error {
+	strDigests := map[string]string{}
+	for name, digest := range digests {
+		strDigests[name] = fmt.Sprintf("%x", digest)
+	}
+
+	buf, err := json.MarshalIndent(strDigests, "", "  ")
+	if err != nil {
+		// should never happen
+		return fmt.Errorf("failed to serialize plugin lock as JSON: %s", err)
+	}
+
+	os.MkdirAll(
+		filepath.Dir(pf.Filename), os.ModePerm,
+	) // ignore error since WriteFile below will generate a better one anyway
+
+	return ioutil.WriteFile(pf.Filename, buf, os.ModePerm)
+}

--- a/command/plugins_lock_test.go
+++ b/command/plugins_lock_test.go
@@ -1,0 +1,40 @@
+package command
+
+import (
+	"io/ioutil"
+	"reflect"
+	"testing"
+)
+
+func TestPluginSHA256LockFile(t *testing.T) {
+	f, err := ioutil.TempFile("", "tf-pluginsha1lockfile-test-")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %s", err)
+	}
+	f.Close()
+	//defer os.Remove(f.Name())
+	t.Logf("working in %s", f.Name())
+
+	plf := &pluginSHA256LockFile{
+		Filename: f.Name(),
+	}
+
+	// Initially the file is invalid, so we should get an empty map.
+	digests := plf.Read()
+	if !reflect.DeepEqual(digests, map[string][]byte{}) {
+		t.Errorf("wrong initial content %#v; want empty map", digests)
+	}
+
+	digests = map[string][]byte{
+		"test": []byte("hello world"),
+	}
+	err = plf.Write(digests)
+	if err != nil {
+		t.Fatalf("failed to write lock file: %s", err)
+	}
+
+	got := plf.Read()
+	if !reflect.DeepEqual(got, digests) {
+		t.Errorf("wrong content %#v after write; want %#v", got, digests)
+	}
+}

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -4,10 +4,12 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -121,6 +123,9 @@ func TestPush_goodBackendInit(t *testing.T) {
 		// Expected weird behavior, doesn't affect unpackaging
 		".terraform/",
 		".terraform/",
+		".terraform/plugins/",
+		fmt.Sprintf(".terraform/plugins/%s_%s/", runtime.GOOS, runtime.GOARCH),
+		fmt.Sprintf(".terraform/plugins/%s_%s/providers.json", runtime.GOOS, runtime.GOARCH),
 		".terraform/terraform.tfstate",
 		".terraform/terraform.tfstate",
 		"main.tf",

--- a/command/test-fixtures/init-provider-lock-file/main.tf
+++ b/command/test-fixtures/init-provider-lock-file/main.tf
@@ -1,0 +1,3 @@
+provider "test" {
+	version = "1.2.3"
+}

--- a/command/test-fixtures/init-providers-lock/main.tf
+++ b/command/test-fixtures/init-providers-lock/main.tf
@@ -1,0 +1,3 @@
+provider "test" {
+	version = "1.2.3"
+}

--- a/moduledeps/module_test.go
+++ b/moduledeps/module_test.go
@@ -207,10 +207,10 @@ func TestModulePluginRequirements(t *testing.T) {
 	if len(reqd) != 2 {
 		t.Errorf("wrong number of elements in %#v; want 2", reqd)
 	}
-	if got, want := reqd["foo"].String(), ">=1.0.0,>=2.0.0"; got != want {
+	if got, want := reqd["foo"].Versions.String(), ">=1.0.0,>=2.0.0"; got != want {
 		t.Errorf("wrong combination of versions for 'foo' %q; want %q", got, want)
 	}
-	if got, want := reqd["baz"].String(), ">=3.0.0"; got != want {
+	if got, want := reqd["baz"].Versions.String(), ">=3.0.0"; got != want {
 		t.Errorf("wrong combination of versions for 'baz' %q; want %q", got, want)
 	}
 }

--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -147,6 +147,12 @@ func ResolvePluginPaths(paths []string) PluginMetaSet {
 			version = parts[1]
 		}
 
+		// Auto-installed plugins contain an extra name portion representing
+		// the expected plugin version, which we must trim off.
+		if dashX := strings.Index(version, "-X"); dashX != -1 {
+			version = version[:dashX]
+		}
+
 		if _, ok := found[nameVersion{name, version}]; ok {
 			// Skip duplicate versions of the same plugin
 			// (We do this during this step because after this we will be

--- a/plugin/discovery/find_test.go
+++ b/plugin/discovery/find_test.go
@@ -53,6 +53,7 @@ func TestResolvePluginPaths(t *testing.T) {
 		"/example/mockos_mockarch/terraform-foo-bar-V0.0.1",
 		"/example/mockos_mockarch/terraform-foo-baz-V0.0.1",
 		"/example/mockos_mockarch/terraform-foo-baz-V1.0.0",
+		"/example/mockos_mockarch/terraform-foo-baz-V2.0.0-X4",
 		"/example/terraform-foo-bar",
 		"/example/mockos_mockarch/terraform-foo-bar-Vbananas",
 		"/example/mockos_mockarch/terraform-foo-bar-V",
@@ -76,6 +77,11 @@ func TestResolvePluginPaths(t *testing.T) {
 			Path:    "/example/mockos_mockarch/terraform-foo-baz-V1.0.0",
 		},
 		{
+			Name:    "baz",
+			Version: "2.0.0",
+			Path:    "/example/mockos_mockarch/terraform-foo-baz-V2.0.0-X4",
+		},
+		{
 			Name:    "bar",
 			Version: "0.0.0",
 			Path:    "/example/terraform-foo-bar",
@@ -91,6 +97,8 @@ func TestResolvePluginPaths(t *testing.T) {
 			Path:    "/example/mockos_mockarch/terraform-foo-bar-V",
 		},
 	}
+
+	t.Logf("got %#v", got)
 
 	if got, want := got.Count(), len(want); got != want {
 		t.Errorf("got %d items; want %d", got, want)

--- a/plugin/discovery/meta_set_test.go
+++ b/plugin/discovery/meta_set_test.go
@@ -310,10 +310,10 @@ func TestPluginMetaSetConstrainVersions(t *testing.T) {
 	}
 
 	byName := s.ConstrainVersions(PluginRequirements{
-		"foo": ConstraintStr(">=2.0.0").MustParse(),
-		"bar": ConstraintStr(">=0.0.0").MustParse(),
-		"baz": ConstraintStr(">=1.0.0").MustParse(),
-		"fun": ConstraintStr(">5.0.0").MustParse(),
+		"foo": &PluginConstraints{Versions: ConstraintStr(">=2.0.0").MustParse()},
+		"bar": &PluginConstraints{Versions: ConstraintStr(">=0.0.0").MustParse()},
+		"baz": &PluginConstraints{Versions: ConstraintStr(">=1.0.0").MustParse()},
+		"fun": &PluginConstraints{Versions: ConstraintStr(">5.0.0").MustParse()},
 	})
 	if got, want := len(byName), 3; got != want {
 		t.Errorf("%d keys in map; want %d", got, want)

--- a/plugin/discovery/requirements.go
+++ b/plugin/discovery/requirements.go
@@ -1,26 +1,105 @@
 package discovery
 
+import (
+	"bytes"
+)
+
 // PluginRequirements describes a set of plugins (assumed to be of a consistent
 // kind) that are required to exist and have versions within the given
 // corresponding sets.
-//
-// PluginRequirements is a map from plugin name to Constraints.
-type PluginRequirements map[string]Constraints
+type PluginRequirements map[string]*PluginConstraints
+
+// PluginConstraints represents an element of PluginRequirements describing
+// the constraints for a single plugin.
+type PluginConstraints struct {
+	// Specifies that the plugin's version must be within the given
+	// constraints.
+	Versions Constraints
+
+	// If non-nil, the hash of the on-disk plugin executable must exactly
+	// match the SHA256 hash given here.
+	SHA256 []byte
+}
+
+// Allows returns true if the given version is within the receiver's version
+// constraints.
+func (s *PluginConstraints) Allows(v Version) bool {
+	return s.Versions.Allows(v)
+}
+
+// AcceptsSHA256 returns true if the given executable SHA256 hash is acceptable,
+// either because it matches the constraint or because there is no such
+// constraint.
+func (s *PluginConstraints) AcceptsSHA256(digest []byte) bool {
+	if s.SHA256 == nil {
+		return true
+	}
+	return bytes.Equal(s.SHA256, digest)
+}
 
 // Merge takes the contents of the receiver and the other given requirements
 // object and merges them together into a single requirements structure
 // that satisfies both sets of requirements.
+//
+// Note that it doesn't make sense to merge two PluginRequirements with
+// differing required plugin SHA256 hashes, since the result will never
+// match any plugin.
 func (r PluginRequirements) Merge(other PluginRequirements) PluginRequirements {
 	ret := make(PluginRequirements)
-	for n, vs := range r {
-		ret[n] = vs
+	for n, c := range r {
+		ret[n] = &PluginConstraints{
+			Versions: Constraints{}.Append(c.Versions),
+			SHA256:   c.SHA256,
+		}
 	}
-	for n, vs := range other {
+	for n, c := range other {
 		if existing, exists := ret[n]; exists {
-			ret[n] = existing.Append(vs)
+			ret[n].Versions = ret[n].Versions.Append(c.Versions)
+
+			if existing.SHA256 != nil {
+				if c.SHA256 != nil && !bytes.Equal(c.SHA256, existing.SHA256) {
+					// If we've been asked to merge two constraints with
+					// different SHA256 hashes then we'll produce a dummy value
+					// that can never match anything. This is a silly edge case
+					// that no reasonable caller should hit.
+					ret[n].SHA256 = []byte(invalidProviderHash)
+				}
+			} else {
+				ret[n].SHA256 = c.SHA256 // might still be nil
+			}
 		} else {
-			ret[n] = vs
+			ret[n] = &PluginConstraints{
+				Versions: Constraints{}.Append(c.Versions),
+				SHA256:   c.SHA256,
+			}
 		}
 	}
 	return ret
 }
+
+// LockExecutables applies additional constraints to the receiver that
+// require plugin executables with specific SHA256 digests. This modifies
+// the receiver in-place, since it's intended to be applied after
+// version constraints have been resolved.
+//
+// The given map must include a key for every plugin that is already
+// required. If not, any missing keys will cause the corresponding plugin
+// to never match, though the direct caller doesn't necessarily need to
+// guarantee this as long as the downstream code _applying_ these constraints
+// is able to deal with the non-match in some way.
+func (r PluginRequirements) LockExecutables(sha256s map[string][]byte) {
+	for name, cons := range r {
+		digest := sha256s[name]
+
+		if digest == nil {
+			// Prevent any match, which will then presumably cause the
+			// downstream consumer of this requirements to report an error.
+			cons.SHA256 = []byte(invalidProviderHash)
+			continue
+		}
+
+		cons.SHA256 = digest
+	}
+}
+
+const invalidProviderHash = "<invalid>"

--- a/plugin/discovery/requirements_test.go
+++ b/plugin/discovery/requirements_test.go
@@ -1,0 +1,93 @@
+package discovery
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestPluginConstraintsAllows(t *testing.T) {
+	tests := []struct {
+		Constraints *PluginConstraints
+		Version     string
+		Want        bool
+	}{
+		{
+			&PluginConstraints{
+				Versions: AllVersions,
+			},
+			"1.0.0",
+			true,
+		},
+		{
+			&PluginConstraints{
+				Versions: ConstraintStr(">1.0.0").MustParse(),
+			},
+			"1.0.0",
+			false,
+		},
+		// This is not an exhaustive test because the callees
+		// already have plentiful tests of their own.
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			version := VersionStr(test.Version).MustParse()
+			got := test.Constraints.Allows(version)
+			if got != test.Want {
+				t.Logf("looking for %s in %#v", test.Version, test.Constraints)
+				t.Errorf("wrong result %#v; want %#v", got, test.Want)
+			}
+		})
+	}
+}
+
+func TestPluginConstraintsAcceptsSHA256(t *testing.T) {
+	mustUnhex := func(hex string) (ret []byte) {
+		_, err := fmt.Sscanf(hex, "%x", &ret)
+		if err != nil {
+			panic(err)
+		}
+		return ret
+	}
+
+	tests := []struct {
+		Constraints *PluginConstraints
+		Digest      []byte
+		Want        bool
+	}{
+		{
+			&PluginConstraints{
+				Versions: AllVersions,
+				SHA256:   mustUnhex("0123456789abcdef"),
+			},
+			mustUnhex("0123456789abcdef"),
+			true,
+		},
+		{
+			&PluginConstraints{
+				Versions: AllVersions,
+				SHA256:   mustUnhex("0123456789abcdef"),
+			},
+			mustUnhex("f00dface"),
+			false,
+		},
+		{
+			&PluginConstraints{
+				Versions: AllVersions,
+				SHA256:   nil,
+			},
+			mustUnhex("f00dface"),
+			true,
+		},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%02d", i), func(t *testing.T) {
+			got := test.Constraints.AcceptsSHA256(test.Digest)
+			if got != test.Want {
+				t.Logf("%#v.AcceptsSHA256(%#v)", test.Constraints, test.Digest)
+				t.Errorf("wrong result %#v; want %#v", got, test.Want)
+			}
+		})
+	}
+}

--- a/plugin/discovery/version.go
+++ b/plugin/discovery/version.go
@@ -19,6 +19,16 @@ func (s VersionStr) Parse() (Version, error) {
 	return Version{raw}, nil
 }
 
+// MustParse transforms a VersionStr into a Version if it is
+// syntactically valid. If it isn't then it panics.
+func (s VersionStr) MustParse() Version {
+	ret, err := s.Parse()
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
 // Version represents a version number that has been parsed from
 // a semver string and known to be valid.
 type Version struct {

--- a/plugin/discovery/version_set.go
+++ b/plugin/discovery/version_set.go
@@ -43,7 +43,8 @@ func init() {
 	}
 }
 
-// Allows returns true if the given version is in the receiving set.
+// Allows returns true if the given version permitted by the receiving
+// constraints set.
 func (s Constraints) Allows(v Version) bool {
 	return s.raw.Check(v.raw)
 }

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -63,6 +63,10 @@ type ContextOpts struct {
 	Targets            []string
 	Variables          map[string]interface{}
 
+	// If non-nil, will apply as additional constraints on the provider
+	// plugins that will be requested from the provider resolver.
+	ProviderSHA256s map[string][]byte
+
 	UIInput UIInput
 }
 
@@ -180,6 +184,9 @@ func NewContext(opts *ContextOpts) (*Context, error) {
 		var err error
 		deps := ModuleTreeDependencies(opts.Module, state)
 		reqd := deps.AllPluginRequirements()
+		if opts.ProviderSHA256s != nil {
+			reqd.LockExecutables(opts.ProviderSHA256s)
+		}
 		providers, err = resourceProviderFactories(opts.ProviderResolver, reqd)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Previously we would re-discover plugins for every command, potentially using different plugins from one command to the next if something changed on disk.

Now we read the hashes of the plugin executables as part of `terraform init` and commit that manifest to a file. For each command that creates a `terraform.Context` we will then fail if the on-disk executables have changed from what was recorded, producing the pre-existing error message that asks the user to run `terraform init`.

As usual this required some foundational work first, so this large patch may be easier to read on a commit-by-commit basis.

The foundational work is here to support recording plugin hashes as part of the plan file and using that encapsulated manifest on apply, but that's not actually wired up here because this changeset has grown big enough as it is.
