### PR TITLE
Kubernetes persistent volume should be namespace aware

### DIFF
--- a/builtin/providers/kubernetes/resource_kubernetes_persistent_volume.go
+++ b/builtin/providers/kubernetes/resource_kubernetes_persistent_volume.go
@@ -25,7 +25,7 @@ func resourceKubernetesPersistentVolume() *schema.Resource {
 		},
 
 		Schema: map[string]*schema.Schema{
-			"metadata": metadataSchema("persistent volume", false),
+			"metadata": namespacedMetadataSchema("persistent volume", false),
 			"spec": {
 				Type:        schema.TypeList,
 				Description: "Spec of the persistent volume owned by the cluster",


### PR DESCRIPTION
kubernetes_persistent_volume_claim allows namespace, but not kubernetes_persistent_volume.

Changed to use namespaceMetadataSchema instead