### PR TITLE
docs/kubernetes: Fix import docs (missing namespace)

### DIFF
--- a/website/source/docs/providers/kubernetes/r/config_map.html.markdown
+++ b/website/source/docs/providers/kubernetes/r/config_map.html.markdown
@@ -54,8 +54,8 @@ The following arguments are supported:
 
 ## Import
 
-Config Map can be imported using its name, e.g.
+Config Map can be imported using its namespace and name, e.g.
 
 ```
-$ terraform import kubernetes_config_map.example my-config
+$ terraform import kubernetes_config_map.example default/my-config
 ```

--- a/website/source/docs/providers/kubernetes/r/limit_range.html.markdown
+++ b/website/source/docs/providers/kubernetes/r/limit_range.html.markdown
@@ -90,8 +90,8 @@ The following arguments are supported:
 
 ## Import
 
-Limit Range can be imported using its name, e.g.
+Limit Range can be imported using its namespace and name, e.g.
 
 ```
-$ terraform import kubernetes_limit_range.example terraform-example
+$ terraform import kubernetes_limit_range.example default/terraform-example
 ```

--- a/website/source/docs/providers/kubernetes/r/persistent_volume_claim.html.markdown
+++ b/website/source/docs/providers/kubernetes/r/persistent_volume_claim.html.markdown
@@ -107,8 +107,8 @@ The following arguments are supported:
 
 ## Import
 
-Persistent Volume Claim can be imported using its name, e.g.
+Persistent Volume Claim can be imported using its namespace and name, e.g.
 
 ```
-$ terraform import kubernetes_persistent_volume_claim.example example-name
+$ terraform import kubernetes_persistent_volume_claim.example default/example-name
 ```

--- a/website/source/docs/providers/kubernetes/r/resource_quota.html.markdown
+++ b/website/source/docs/providers/kubernetes/r/resource_quota.html.markdown
@@ -62,8 +62,8 @@ The following arguments are supported:
 
 ## Import
 
-Resource Quota can be imported using its name, e.g.
+Resource Quota can be imported using its namespace and name, e.g.
 
 ```
-$ terraform import kubernetes_resource_quota.example terraform-example
+$ terraform import kubernetes_resource_quota.example default/terraform-example
 ```

--- a/website/source/docs/providers/kubernetes/r/secret.html.markdown
+++ b/website/source/docs/providers/kubernetes/r/secret.html.markdown
@@ -78,8 +78,8 @@ The following arguments are supported:
 
 ## Import
 
-Secret can be imported using its name, e.g.
+Secret can be imported using its namespace and name, e.g.
 
 ```
-$ terraform import kubernetes_secret.example my-secret
+$ terraform import kubernetes_secret.example default/my-secret
 ```


### PR DESCRIPTION
I somehow missed this out when writing the docs.