### PR TITLE
provider/aws: Export internal tunnel addresses + document

### DIFF
--- a/builtin/providers/aws/resource_aws_vpn_connection.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection.go
@@ -23,15 +23,21 @@ type XmlVpnConnectionConfig struct {
 }
 
 type XmlIpsecTunnel struct {
-	OutsideAddress string `xml:"vpn_gateway>tunnel_outside_address>ip_address"`
-	PreSharedKey   string `xml:"ike>pre_shared_key"`
+	OutsideAddress   string `xml:"vpn_gateway>tunnel_outside_address>ip_address"`
+	PreSharedKey     string `xml:"ike>pre_shared_key"`
+	CgwInsideAddress string `xml:"customer_gateway>tunnel_inside_address>ip_address"`
+	VgwInsideAddress string `xml:"vpn_gateway>tunnel_inside_address>ip_address"`
 }
 
 type TunnelInfo struct {
-	Tunnel1Address      string
-	Tunnel1PreSharedKey string
-	Tunnel2Address      string
-	Tunnel2PreSharedKey string
+	Tunnel1Address          string
+	Tunnel1CgwInsideAddress string
+	Tunnel1VgwInsideAddress string
+	Tunnel1PreSharedKey     string
+	Tunnel2Address          string
+	Tunnel2CgwInsideAddress string
+	Tunnel2VgwInsideAddress string
+	Tunnel2PreSharedKey     string
 }
 
 func (slice XmlVpnConnectionConfig) Len() int {
@@ -96,12 +102,32 @@ func resourceAwsVpnConnection() *schema.Resource {
 				Computed: true,
 			},
 
+			"tunnel1_cgw_inside_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tunnel1_vgw_inside_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tunnel1_preshared_key": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
 			"tunnel2_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tunnel2_cgw_inside_address": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
+			"tunnel2_vgw_inside_address": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -323,9 +349,13 @@ func resourceAwsVpnConnectionRead(d *schema.ResourceData, meta interface{}) erro
 			log.Printf("[ERR] Error unmarshaling XML configuration for (%s): %s", d.Id(), err)
 		} else {
 			d.Set("tunnel1_address", tunnelInfo.Tunnel1Address)
+			d.Set("tunnel1_cgw_inside_address", tunnelInfo.Tunnel1CgwInsideAddress)
+			d.Set("tunnel1_vgw_inside_address", tunnelInfo.Tunnel1VgwInsideAddress)
 			d.Set("tunnel1_preshared_key", tunnelInfo.Tunnel1PreSharedKey)
 			d.Set("tunnel2_address", tunnelInfo.Tunnel2Address)
 			d.Set("tunnel2_preshared_key", tunnelInfo.Tunnel2PreSharedKey)
+			d.Set("tunnel2_cgw_inside_address", tunnelInfo.Tunnel2CgwInsideAddress)
+			d.Set("tunnel2_vgw_inside_address", tunnelInfo.Tunnel2VgwInsideAddress)
 		}
 	}
 
@@ -439,11 +469,15 @@ func xmlConfigToTunnelInfo(xmlConfig string) (*TunnelInfo, error) {
 	sort.Sort(vpnConfig)
 
 	tunnelInfo := TunnelInfo{
-		Tunnel1Address:      vpnConfig.Tunnels[0].OutsideAddress,
-		Tunnel1PreSharedKey: vpnConfig.Tunnels[0].PreSharedKey,
+		Tunnel1Address:          vpnConfig.Tunnels[0].OutsideAddress,
+		Tunnel1PreSharedKey:     vpnConfig.Tunnels[0].PreSharedKey,
+		Tunnel1CgwInsideAddress: vpnConfig.Tunnels[0].CgwInsideAddress,
+		Tunnel1VgwInsideAddress: vpnConfig.Tunnels[0].VgwInsideAddress,
 
-		Tunnel2Address:      vpnConfig.Tunnels[1].OutsideAddress,
-		Tunnel2PreSharedKey: vpnConfig.Tunnels[1].PreSharedKey,
+		Tunnel2Address:          vpnConfig.Tunnels[1].OutsideAddress,
+		Tunnel2PreSharedKey:     vpnConfig.Tunnels[1].PreSharedKey,
+		Tunnel2CgwInsideAddress: vpnConfig.Tunnels[1].CgwInsideAddress,
+		Tunnel2VgwInsideAddress: vpnConfig.Tunnels[1].VgwInsideAddress,
 	}
 
 	return &tunnelInfo, nil

--- a/builtin/providers/aws/resource_aws_vpn_connection_test.go
+++ b/builtin/providers/aws/resource_aws_vpn_connection_test.go
@@ -233,11 +233,27 @@ func TestAWSVpnConnection_xmlconfig(t *testing.T) {
 	if tunnelInfo.Tunnel1Address != "FIRST_ADDRESS" {
 		t.Fatalf("First address from tunnel XML was incorrect.")
 	}
+	if tunnelInfo.Tunnel1CgwInsideAddress != "FIRST_CGW_INSIDE_ADDRESS" {
+		t.Fatalf("First Customer Gateway inside address from tunnel" +
+			" XML was incorrect.")
+	}
+	if tunnelInfo.Tunnel1VgwInsideAddress != "FIRST_VGW_INSIDE_ADDRESS" {
+		t.Fatalf("First VPN Gateway inside address from tunnel " +
+			" XML was incorrect.")
+	}
 	if tunnelInfo.Tunnel1PreSharedKey != "FIRST_KEY" {
 		t.Fatalf("First key from tunnel XML was incorrect.")
 	}
 	if tunnelInfo.Tunnel2Address != "SECOND_ADDRESS" {
 		t.Fatalf("Second address from tunnel XML was incorrect.")
+	}
+	if tunnelInfo.Tunnel2CgwInsideAddress != "SECOND_CGW_INSIDE_ADDRESS" {
+		t.Fatalf("Second Customer Gateway inside address from tunnel" +
+			" XML was incorrect.")
+	}
+	if tunnelInfo.Tunnel2VgwInsideAddress != "SECOND_VGW_INSIDE_ADDRESS" {
+		t.Fatalf("Second VPN Gateway inside address from tunnel " +
+			" XML was incorrect.")
 	}
 	if tunnelInfo.Tunnel2PreSharedKey != "SECOND_KEY" {
 		t.Fatalf("Second key from tunnel XML was incorrect.")
@@ -301,20 +317,50 @@ func testAccAwsVpnConnectionConfigUpdate(rInt, rBgpAsn int) string {
 const testAccAwsVpnTunnelInfoXML = `
 <vpn_connection id="vpn-abc123">
   <ipsec_tunnel>
+    <customer_gateway>
+      <tunnel_outside_address>
+        <ip_address>123.123.123.123</ip_address>
+      </tunnel_outside_address>
+      <tunnel_inside_address>
+        <ip_address>SECOND_CGW_INSIDE_ADDRESS</ip_address>
+        <network_mask>255.255.255.252</network_mask>
+        <network_cidr>30</network_cidr>
+      </tunnel_inside_address>
+    </customer_gateway>
     <vpn_gateway>
       <tunnel_outside_address>
         <ip_address>SECOND_ADDRESS</ip_address>
       </tunnel_outside_address>
+      <tunnel_inside_address>
+        <ip_address>SECOND_VGW_INSIDE_ADDRESS</ip_address>
+        <network_mask>255.255.255.252</network_mask>
+        <network_cidr>30</network_cidr>
+      </tunnel_inside_address>
     </vpn_gateway>
     <ike>
       <pre_shared_key>SECOND_KEY</pre_shared_key>
     </ike>
   </ipsec_tunnel>
   <ipsec_tunnel>
+    <customer_gateway>
+      <tunnel_outside_address>
+        <ip_address>123.123.123.123</ip_address>
+      </tunnel_outside_address>
+      <tunnel_inside_address>
+        <ip_address>FIRST_CGW_INSIDE_ADDRESS</ip_address>
+        <network_mask>255.255.255.252</network_mask>
+        <network_cidr>30</network_cidr>
+      </tunnel_inside_address>
+    </customer_gateway>
     <vpn_gateway>
       <tunnel_outside_address>
         <ip_address>FIRST_ADDRESS</ip_address>
       </tunnel_outside_address>
+      <tunnel_inside_address>
+        <ip_address>FIRST_VGW_INSIDE_ADDRESS</ip_address>
+        <network_mask>255.255.255.252</network_mask>
+        <network_cidr>30</network_cidr>
+      </tunnel_inside_address>
     </vpn_gateway>
     <ike>
       <pre_shared_key>FIRST_KEY</pre_shared_key>

--- a/website/source/docs/providers/aws/r/vpn_connection.html.markdown
+++ b/website/source/docs/providers/aws/r/vpn_connection.html.markdown
@@ -56,8 +56,12 @@ The following attributes are exported:
 * `static_routes_only` - Whether the VPN connection uses static routes exclusively.
 * `tags` - Tags applied to the connection.
 * `tunnel1_address` - The public IP address of the first VPN tunnel.
+* `tunnel1_cgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (Customer Gateway Side).
+* `tunnel1_vgw_inside_address` - The RFC 6890 link-local address of the first VPN tunnel (VPN Gateway Side).
 * `tunnel1_preshared_key` - The preshared key of the first VPN tunnel.
 * `tunnel2_address` - The public IP address of the second VPN tunnel.
+* `tunnel2_cgw_inside_address` - The RFC 6890 link-local address of the second VPN tunnel (Customer Gateway Side).
+* `tunnel2_vgw_inside_address` - The RFC 6890 link-local address of the second VPN tunnel (VPN Gateway Side).
 * `tunnel2_preshared_key` - The preshared key of the second VPN tunnel.
 * `type` - The type of VPN connection.
 * `vpn_gateway_id` - The ID of the virtual private gateway to which the connection is attached.


### PR DESCRIPTION
Use case: wanted to plug in a packer-based router configuration build pipeline.

These addresses are required in order to configure the tunnel