### PR TITLE
Docs: Update atlas_artifact resource to use data

### DIFF
--- a/builtin/providers/atlas/resource_artifact.go
+++ b/builtin/providers/atlas/resource_artifact.go
@@ -25,7 +25,7 @@ func resourceArtifact() *schema.Resource {
 				Type:       schema.TypeString,
 				Required:   true,
 				ForceNew:   true,
-				Deprecated: `atlas_artifact is now deprecated. Use the Atlas Artifact Data Source instead. See https://terraform.io/docs/providers/atlas/d/artifact.html`,
+				Deprecated: `atlas_artifact is now deprecated. Use the Atlas Artifact Data Source instead. See https://www.terraform.io/docs/providers/terraform-enterprise/d/artifact.html`,
 			},
 
 			"type": &schema.Schema{

--- a/website/source/docs/enterprise/artifacts/artifact-provider.html.md
+++ b/website/source/docs/enterprise/artifacts/artifact-provider.html.md
@@ -26,7 +26,7 @@ provider "atlas" {
   token = "${var.atlas_token}"
 }
 
-resource "atlas_artifact" "web-worker" {
+data "atlas_artifact" "web-worker" {
   name    = "my-username/web-worker"
   type    = "amazon.image"
   version = "latest"

--- a/website/source/docs/enterprise/artifacts/managing-versions.html.md
+++ b/website/source/docs/enterprise/artifacts/managing-versions.html.md
@@ -44,9 +44,9 @@ You can pin artifacts to a specific version. This allows for a targeted
 deploy.
 
 ```hcl
-resource "atlas_artifact" "web-worker" {
-  name    = "my-username/web-worker"
-  type    = "amazon.image"
+data "atlas_artifact" "web-worker" {
+  name  = "my-username/web-worker"
+  type  = "amazon.image"
   version = 7
 }
 ```
@@ -59,7 +59,7 @@ Artifacts can also be pinned to an Terraform build number. This is only
 possible if Terraform Enterprise was used to build the artifact with Packer.
 
 ```hcl
-resource "atlas_artifact" "web-worker" {
+data "atlas_artifact" "web-worker" {
   name  = "my-username/web-worker"
   type  = "amazon.image"
   build = 5

--- a/website/source/docs/enterprise/faq/rolling-deployments.html.md
+++ b/website/source/docs/enterprise/faq/rolling-deployments.html.md
@@ -26,7 +26,7 @@ variable "atlas_username" {}
 variable "pinned_name"    {}
 variable "pinned_version" { default = "latest" }
 
-resource "atlas_artifact" "pinned" {
+data "atlas_artifact" "pinned" {
   name     = "${var.atlas_username}/${var.pinned_name}"
   type     = "${var.type}"
   version  = "${var.pinned_version}"
@@ -57,7 +57,7 @@ variable "atlas_username"   {}
 variable "artifact_name"    {}
 variable "artifact_version" { default = "latest" }
 
-resource "atlas_artifact" "artifact" {
+data "atlas_artifact" "artifact" {
   name    = "${var.atlas_username}/${var.artifact_name}"
   type    = "${var.type}"
   count   = "${length(split(",", var.artifact_version))}"


### PR DESCRIPTION
A while back `atlas_artifact` was switched from being a `resource` to a `data` provider. When you use the examples suggested in the Terraform Enterprise docs, the Terraform cli shows a deprecation warning and provides an old url to the new data provider docs.

There are some complimentary doc updates in the Terraform Enterprise/Atlas repo.