### PR TITLE
fix incorrect Lambda GovCloud regexes

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_permission.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-var LambdaFunctionRegexp = `^(arn:[\w-]+:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
+var LambdaFunctionRegexp = `^(arn:[\w-]+:lambda:)?([a-z]{2}-(?:[a-z]+-){1,2}\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
 
 func resourceAwsLambdaPermission() *schema.Resource {
 	return &schema.Resource{

--- a/builtin/providers/aws/resource_aws_lambda_permission_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_permission_test.go
@@ -62,9 +62,8 @@ func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_alias(t *testin
 		t.Fatalf("Expected qualifier to match (%q != %q)", qualifier, expectedQualifier)
 	}
 }
-
 func TestLambdaPermissionGetQualifierFromLambdaAliasOrVersionArn_govcloud(t *testing.T) {
-	arnWithAlias := "arn:aws-us-gov:lambda:us-west-2:187636751137:function:lambda_function_name:testalias"
+	arnWithAlias := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name:testalias"
 	expectedQualifier := "testalias"
 	qualifier, err := getQualifierFromLambdaAliasOrVersionArn(arnWithAlias)
 	if err != nil {
@@ -138,6 +137,19 @@ func TestLambdaPermissionGetFunctionNameFromLambdaArn_valid(t *testing.T) {
 		t.Fatalf("Expected no error (%q): %q", validArn, err)
 	}
 	expectedFunctionname = "lambda_function_name"
+	if fn != expectedFunctionname {
+		t.Fatalf("Expected Lambda function name to match (%q != %q)",
+			validArn, expectedFunctionname)
+	}
+}
+
+func TestLambdaPermissionGetFunctionNameFromGovCloudLambdaArn(t *testing.T) {
+	validArn := "arn:aws-us-gov:lambda:us-gov-west-1:187636751137:function:lambda_function_name"
+	fn, err := getFunctionNameFromLambdaArn(validArn)
+	if err != nil {
+		t.Fatalf("Expected no error (%q): %q", validArn, err)
+	}
+	expectedFunctionname := "lambda_function_name"
 	if fn != expectedFunctionname {
 		t.Fatalf("Expected Lambda function name to match (%q != %q)",
 			validArn, expectedFunctionname)

--- a/builtin/providers/aws/validators.go
+++ b/builtin/providers/aws/validators.go
@@ -293,7 +293,7 @@ func validateLambdaFunctionName(v interface{}, k string) (ws []string, errors []
 			"%q cannot be longer than 140 characters: %q", k, value))
 	}
 	// http://docs.aws.amazon.com/lambda/latest/dg/API_AddPermission.html
-	pattern := `^(arn:[\w-]+:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
+	pattern := `^(arn:[\w-]+:lambda:)?([a-z]{2}-(?:[a-z]+-){1,2}\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?$`
 	if !regexp.MustCompile(pattern).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
 			"%q doesn't comply with restrictions (%q): %q",

--- a/builtin/providers/aws/validators_test.go
+++ b/builtin/providers/aws/validators_test.go
@@ -78,7 +78,7 @@ func TestValidateCloudWatchEventRuleName(t *testing.T) {
 func TestValidateLambdaFunctionName(t *testing.T) {
 	validNames := []string{
 		"arn:aws:lambda:us-west-2:123456789012:function:ThumbNail",
-		"arn:aws-us-gov:lambda:us-west-2:123456789012:function:ThumbNail",
+		"arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:ThumbNail",
 		"FunctionName",
 		"function-name",
 	}


### PR DESCRIPTION
I'm putting this up for comment on the approach.

    This updates two regexes that are used to validate and parse ARNs for
    aws_lambda_permission.  The ARNs were not accurate when using GovCloud
    Lambdas.  This resulted in failures during the read call after applying
    a resource.

Without this fix:
```
2017/05/25 17:01:25 [ERROR] root.module_name: eval: *terraform.EvalRefresh, err: aws_lambda_permission.allow_cloudwatch: Invalid ARN or otherwise unable to get qualifier from ARN ("arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:function_name")
...
Error refreshing state: 1 error(s) occurred:

* module.module-name.aws_lambda_permission.allow_cloudwatch: aws_lambda_permission.allow_cloudwatch: Invalid ARN or otherwise unable to get qualifier from ARN ("arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:function_name")
```

This occurs because the region name for GovCloud contains an additional section.

Considering the duplication of the regex and the fact that validateLambdaFunctionName is only used in aws_lambda_permission, I'm thinking some cleanup is in order as well, but this patch should work on its own.  I'm open to suggestions to improve this, but wasn't sure where I should put the Regex if it needs to be reused.  Note that it's tightly coupled to this code as well:
https://github.com/jeremy-asher/terraform/blob/28a2ec1b9fa83549a2b5c45ab75f5928ce848893/builtin/providers/aws/resource_aws_lambda_permission.go#L346-L363