### PR TITLE
github_team data source: fix wrong set

### DIFF
--- a/builtin/providers/github/data_source_github_team.go
+++ b/builtin/providers/github/data_source_github_team.go
@@ -55,8 +55,6 @@ func dataSourceGithubTeamRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("description", *team.Description)
 	d.Set("privacy", *team.Privacy)
 	d.Set("permission", *team.Permission)
-	d.Set("members_count", *team.MembersCount)
-	d.Set("repos_count", *team.ReposCount)
 
 	return nil
 }


### PR DESCRIPTION
Do not set `members_count` and `repos_count`, which are not declared.

The current code crashes on apply.