### PR TITLE
docs: Fix inline comment in AWS instance resource

### DIFF
--- a/website/source/docs/providers/aws/r/instance.html.markdown
+++ b/website/source/docs/providers/aws/r/instance.html.markdown
@@ -202,7 +202,7 @@ resource "aws_network_interface" "foo" {
 }
 
 resource "aws_instance" "foo" {
-	ami = "ami-22b9a343" // us-west-2
+	ami = "ami-22b9a343" # us-west-2
 	instance_type = "t2.micro"
 	network_interface {
 	 network_interface_id = "${aws_network_interface.foo.id}"


### PR DESCRIPTION
`//` appears to be a valid inline comment, but it affects the formatting
in the documentation.

![image](https://cloud.githubusercontent.com/assets/714287/26506090/e388463a-4210-11e7-9fb0-d4a73880c1b9.png)

Octothorps are formatted properly when used at the end of a line:

![image](https://cloud.githubusercontent.com/assets/714287/26506131/07b132e2-4211-11e7-9f0f-f0594b4e5375.png)
