### PR TITLE
provider/librato: Fixup the Librato Docs (metrics)

### DIFF
--- a/website/source/layouts/librato.erb
+++ b/website/source/layouts/librato.erb
@@ -16,6 +16,9 @@
                     <li<%= sidebar_current("docs-librato-resource-alert") %>>
           <a href="/docs/providers/librato/r/alert.html">librato_alert</a>
                     </li>
+                    <li<%= sidebar_current("docs-librato-resource-metric") %>>
+          <a href="/docs/providers/librato/r/metric.html">librato_metric</a>
+                    </li>
                     <li<%= sidebar_current("docs-librato-resource-service") %>>
           <a href="/docs/providers/librato/r/service.html">librato_service</a>
                     </li>


### PR DESCRIPTION
In my latest PR against the Librato provider, I just realized I neglected to add the new metric resource to the sidebar so it would show up in the docs. This fixes that up.