### PR TITLE
Documentation: Adding missing Gitlab resources to the sidebar

### DIFF
--- a/website/source/docs/providers/gitlab/r/project.html.markdown
+++ b/website/source/docs/providers/gitlab/r/project.html.markdown
@@ -1,7 +1,7 @@
 ---
 layout: "gitlab"
 page_title: "GitLab: gitlab_project"
-sidebar_current: "docs-gitlab-resource-project"
+sidebar_current: "docs-gitlab-resource-project-x"
 description: |-
   Creates and manages projects within Github organizations
 ---

--- a/website/source/layouts/gitlab.erb
+++ b/website/source/layouts/gitlab.erb
@@ -13,7 +13,16 @@
         <li<%= sidebar_current("docs-gitlab-resource") %>>
         <a href="#">Resources</a>
         <ul class="nav nav-visible">
-          <li<%= sidebar_current("docs-gitlab-resource-project") %>>
+          <li<%= sidebar_current("docs-gitlab-resource-deploy_key") %>>
+            <a href="/docs/providers/gitlab/r/deploy_key.html">gitlab_deploy_key</a>
+          </li>
+          <li<%= sidebar_current("docs-gitlab-resource-group") %>>
+            <a href="/docs/providers/gitlab/r/group.html">gitlab_group</a>
+          </li>
+          <li<%= sidebar_current("docs-gitlab-resource-project-hook") %>>
+            <a href="/docs/providers/gitlab/r/project_hook.html">gitlab_project_hook</a>
+          </li>
+          <li<%= sidebar_current("docs-gitlab-resource-project-x") %>>
             <a href="/docs/providers/gitlab/r/project.html">gitlab_project</a>
           </li>
         </ul>


### PR DESCRIPTION
Whilst tagging #14827 and #14824 - I noticed that some of the Gitlab resources were missing from the sidebar. This PR adds them to the sidebar and fixes an issue where `gitlab_project` would be highlighted when `gitlab_project_hook` was selected