### PR TITLE
Docs: Fix vpc_id argument in AWS route_table resource

### DIFF
--- a/website/source/docs/providers/aws/r/route_table.html.markdown
+++ b/website/source/docs/providers/aws/r/route_table.html.markdown
@@ -48,7 +48,7 @@ resource "aws_route_table" "r" {
 
 The following arguments are supported:
 
-* `vpc_id` - (Required) The ID of the routing table.
+* `vpc_id` - (Required) The VPC ID.
 * `route` - (Optional) A list of route objects. Their keys are documented below.
 * `tags` - (Optional) A mapping of tags to assign to the resource.
 * `propagating_vgws` - (Optional) A list of virtual gateways for propagation.


### PR DESCRIPTION
## Documentation Update

**Reasoning for docs update**: The `vpc_id` argument for the AWS route_table resource is incorrect.
**Relevant terraform version**: 0.9.6