### PR TITLE
AWS Provider - Expose RDS instance and cluster resource id

### DIFF
--- a/builtin/providers/aws/resource_aws_db_instance.go
+++ b/builtin/providers/aws/resource_aws_db_instance.go
@@ -340,6 +340,11 @@ func resourceAwsDbInstance() *schema.Resource {
 				Optional: true,
 			},
 
+			"resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -701,6 +706,7 @@ func resourceAwsDbInstanceRead(d *schema.ResourceData, meta interface{}) error {
 
 	d.Set("name", v.DBName)
 	d.Set("identifier", v.DBInstanceIdentifier)
+	d.Set("resource_id", v.DbiResourceId)
 	d.Set("username", v.MasterUsername)
 	d.Set("engine", v.Engine)
 	d.Set("engine_version", v.EngineVersion)

--- a/builtin/providers/aws/resource_aws_db_instance_test.go
+++ b/builtin/providers/aws/resource_aws_db_instance_test.go
@@ -47,6 +47,8 @@ func TestAccAWSDBInstance_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(
 						"aws_db_instance.bar", "parameter_group_name", "default.mysql5.6"),
 					resource.TestCheckResourceAttrSet("aws_db_instance.bar", "hosted_zone_id"),
+					resource.TestCheckResourceAttrSet(
+						"aws_db_instance.bar", "resource_id"),
 				),
 			},
 		},

--- a/builtin/providers/aws/resource_aws_rds_cluster.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster.go
@@ -227,6 +227,11 @@ func resourceAwsRDSCluster() *schema.Resource {
 				Optional: true,
 			},
 
+			"cluster_resource_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+
 			"tags": tagsSchema(),
 		},
 	}
@@ -523,6 +528,7 @@ func resourceAwsRDSClusterRead(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.Set("cluster_identifier", dbc.DBClusterIdentifier)
+	d.Set("cluster_resource_id", dbc.DbClusterResourceId)
 	d.Set("db_subnet_group_name", dbc.DBSubnetGroup)
 	d.Set("db_cluster_parameter_group_name", dbc.DBClusterParameterGroup)
 	d.Set("endpoint", dbc.Endpoint)

--- a/builtin/providers/aws/resource_aws_rds_cluster_test.go
+++ b/builtin/providers/aws/resource_aws_rds_cluster_test.go
@@ -34,6 +34,8 @@ func TestAccAWSRDSCluster_basic(t *testing.T) {
 						"aws_rds_cluster.default", "db_cluster_parameter_group_name", "default.aurora5.6"),
 					resource.TestCheckResourceAttrSet(
 						"aws_rds_cluster.default", "reader_endpoint"),
+					resource.TestCheckResourceAttrSet(
+						"aws_rds_cluster.default", "cluster_resource_id"),
 				),
 			},
 		},

--- a/website/source/docs/providers/aws/r/db_instance.html.markdown
+++ b/website/source/docs/providers/aws/r/db_instance.html.markdown
@@ -126,6 +126,7 @@ standalone database.
 The following attributes are exported:
 
 * `id` - The RDS instance ID.
+* `resource_id` - The RDS Resource ID of this instance.
 * `address` - The address of the RDS instance.
 * `arn` - The ARN of the RDS instance.
 * `allocated_storage` - The amount of allocated storage

--- a/website/source/docs/providers/aws/r/rds_cluster.html.markdown
+++ b/website/source/docs/providers/aws/r/rds_cluster.html.markdown
@@ -91,6 +91,7 @@ The following attributes are exported:
 
 * `id` - The RDS Cluster Identifier
 * `cluster_identifier` - The RDS Cluster Identifier
+* `cluster_resource_id` - The RDS Cluster Resource ID
 * `cluster_members` – List of RDS Instances that are a part of this cluster
 * `allocated_storage` - The amount of allocated storage
 * `availability_zones` - The availability zone of the instance


### PR DESCRIPTION
Add support for exposing RDS Instance and Cluster Resource IDs which is required for setting up IAM policies for IAM DB Authentication (http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html).

Acceptance Tests Pass:

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSDBInstance_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/27 16:07:36 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSDBInstance_basic -timeout 120m
=== RUN   TestAccAWSDBInstance_basic
--- PASS: TestAccAWSDBInstance_basic (547.71s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    `547.816s`
```

```
make testacc TEST=./builtin/providers/aws TESTARGS='-run=TestAccAWSRDSCluster_basic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/27 16:18:13 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSRDSCluster_basic -timeout 120m
=== RUN   TestAccAWSRDSCluster_basic
--- PASS: TestAccAWSRDSCluster_basic (128.64s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    128.685s
```