### PR TITLE
DOCS: The resource name should be consistent.

### DIFF
--- a/website/source/docs/backends/types/s3.html.md
+++ b/website/source/docs/backends/types/s3.html.md
@@ -44,7 +44,7 @@ To make use of the S3 remote state we can use the
 source](/docs/providers/terraform/d/remote_state.html).
 
 ```hcl
-data "terraform_remote_state" "foo" {
+data "terraform_remote_state" "network" {
   backend = "s3"
   config {
     bucket = "terraform-state-prod"
@@ -58,7 +58,7 @@ The `terraform_remote_state` data source will return all of the root outputs
 defined in the referenced remote state, an example output might look like:
 
 ```
-data.terraform_remote_state.foo:
+data.terraform_remote_state.network:
   id = 2016-10-29 01:57:59.780010914 +0000 UTC
   addresses.# = 2
   addresses.0 = 52.207.220.222

--- a/website/source/docs/backends/types/s3.html.md
+++ b/website/source/docs/backends/types/s3.html.md
@@ -58,7 +58,7 @@ The `terraform_remote_state` data source will return all of the root outputs
 defined in the referenced remote state, an example output might look like:
 
 ```
-data.terraform_remote_state.network:
+data.terraform_remote_state.foo:
   id = 2016-10-29 01:57:59.780010914 +0000 UTC
   addresses.# = 2
   addresses.0 = 52.207.220.222


### PR DESCRIPTION
The HCL declares the terraform_remote_state with a resource name of foo. But the example invocation uses network which is incorrect.