### PR TITLE
core: nested types support in jsonencode

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -1406,8 +1406,6 @@ func TestInterpolateFuncJSONEncode(t *testing.T) {
 				Type:  ast.TypeString,
 			},
 			"list": interfaceToVariableSwallowError([]string{"foo", "bar\tbaz"}),
-			// XXX can't use InterfaceToVariable as it converts empty slice into empty
-			// map.
 			"emptylist": ast.Variable{
 				Value: []ast.Variable{},
 				Type:  ast.TypeList,
@@ -1416,9 +1414,7 @@ func TestInterpolateFuncJSONEncode(t *testing.T) {
 				"foo":     "bar",
 				"ba \n z": "q\\x",
 			}),
-			"emptymap": interfaceToVariableSwallowError(map[string]string{}),
-
-			// Not yet supported (but it would be nice)
+			"emptymap":   interfaceToVariableSwallowError(map[string]string{}),
 			"nestedlist": interfaceToVariableSwallowError([][]string{{"foo"}}),
 			"nestedmap":  interfaceToVariableSwallowError(map[string][]string{"foo": {"bar"}}),
 		},
@@ -1470,13 +1466,13 @@ func TestInterpolateFuncJSONEncode(t *testing.T) {
 			},
 			{
 				`${jsonencode(nestedlist)}`,
-				nil,
-				true,
+				`[["foo"]]`,
+				false,
 			},
 			{
 				`${jsonencode(nestedmap)}`,
-				nil,
-				true,
+				`{"foo":["bar"]}`,
+				false,
 			},
 		},
 	})

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -262,10 +262,9 @@ The supported built-in functions are:
       * `join(",", aws_instance.foo.*.id)`
       * `join(",", var.ami_list)`
 
-  * `jsonencode(item)` - Returns a JSON-encoded representation of the given
-    item, which may be a string, list of strings, or map from string to string.
-    Note that if the item is a string, the return value includes the double
-    quotes.
+  * `jsonencode(value)` - Returns a JSON-encoded representation of the given
+      value, which can contain arbitrarily-nested lists and maps. Note that if
+      the value is a string then its value will be placed in quotes.
 
   * `keys(map)` - Returns a lexically sorted list of the map keys.
 


### PR DESCRIPTION
Regarding issue #9112, support in nested types in jsonencode would be beneficial for ECS task management. For example: instead of template with multiple variables (strings) for ECS task environment variables (which is list of maps in json), now it can be defined and passed as a single variable. Same story with ports or other ECS properties. 