### PR TITLE
helper/schema: Custom diff logic support for providers

### DIFF
--- a/builtin/providers/test/provider.go
+++ b/builtin/providers/test/provider.go
@@ -17,8 +17,9 @@ func Provider() terraform.ResourceProvider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"test_resource":         testResource(),
-			"test_resource_gh12183": testResourceGH12183(),
+			"test_resource":                  testResource(),
+			"test_resource_gh12183":          testResourceGH12183(),
+			"test_resource_with_custom_diff": testResourceCustomDiff(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"test_data_source":    testDataSource(),

--- a/builtin/providers/test/resource_with_custom_diff.go
+++ b/builtin/providers/test/resource_with_custom_diff.go
@@ -8,11 +8,11 @@ import (
 
 func testResourceCustomDiff() *schema.Resource {
 	return &schema.Resource{
-		Create:        testResourceCustomDiffCreate,
-		Read:          testResourceCustomDiffRead,
-		CustomizeDiff: testResourceCustomDiffCustomizeDiff,
-		Update:        testResourceCustomDiffUpdate,
-		Delete:        testResourceCustomDiffDelete,
+		Create: testResourceCustomDiffCreate,
+		Read:   testResourceCustomDiffRead,
+		Review: testResourceCustomDiffReview,
+		Update: testResourceCustomDiffUpdate,
+		Delete: testResourceCustomDiffDelete,
 		Schema: map[string]*schema.Schema{
 			"required": {
 				Type:     schema.TypeString,
@@ -57,7 +57,7 @@ func testResourceCustomDiffRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func testResourceCustomDiffCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
+func testResourceCustomDiffReview(d *schema.ResourceDiff, meta interface{}) error {
 	if d.Get("veto").(bool) == true {
 		return fmt.Errorf("veto is true, diff vetoed")
 	}

--- a/builtin/providers/test/resource_with_custom_diff.go
+++ b/builtin/providers/test/resource_with_custom_diff.go
@@ -8,11 +8,11 @@ import (
 
 func testResourceCustomDiff() *schema.Resource {
 	return &schema.Resource{
-		Create: testResourceCustomDiffCreate,
-		Read:   testResourceCustomDiffRead,
-		Review: testResourceCustomDiffReview,
-		Update: testResourceCustomDiffUpdate,
-		Delete: testResourceCustomDiffDelete,
+		Create:        testResourceCustomDiffCreate,
+		Read:          testResourceCustomDiffRead,
+		CustomizeDiff: testResourceCustomDiffCustomizeDiff,
+		Update:        testResourceCustomDiffUpdate,
+		Delete:        testResourceCustomDiffDelete,
 		Schema: map[string]*schema.Schema{
 			"required": {
 				Type:     schema.TypeString,
@@ -57,7 +57,7 @@ func testResourceCustomDiffRead(d *schema.ResourceData, meta interface{}) error 
 	return nil
 }
 
-func testResourceCustomDiffReview(d *schema.ResourceDiff, meta interface{}) error {
+func testResourceCustomDiffCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
 	if d.Get("veto").(bool) == true {
 		return fmt.Errorf("veto is true, diff vetoed")
 	}

--- a/builtin/providers/test/resource_with_custom_diff.go
+++ b/builtin/providers/test/resource_with_custom_diff.go
@@ -1,0 +1,84 @@
+package test
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func testResourceCustomDiff() *schema.Resource {
+	return &schema.Resource{
+		Create:        testResourceCustomDiffCreate,
+		Read:          testResourceCustomDiffRead,
+		CustomizeDiff: testResourceCustomDiffCustomizeDiff,
+		Update:        testResourceCustomDiffUpdate,
+		Delete:        testResourceCustomDiffDelete,
+		Schema: map[string]*schema.Schema{
+			"required": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"computed": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"index": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"veto": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func testResourceCustomDiffCreate(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("testId")
+
+	// Required must make it through to Create
+	if _, ok := d.GetOk("required"); !ok {
+		return fmt.Errorf("missing attribute 'required', but it's required")
+	}
+
+	_, new := d.GetChange("computed")
+	expected := new.(int) - 1
+	actual := d.Get("index").(int)
+	if expected != actual {
+		return fmt.Errorf("expected computed to be 1 ahead of index, got computed: %d, index: %d", expected, actual)
+	}
+	d.Set("index", new)
+
+	return testResourceCustomDiffRead(d, meta)
+}
+
+func testResourceCustomDiffRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func testResourceCustomDiffCustomizeDiff(d *schema.ResourceDiff, meta interface{}) error {
+	if d.Get("veto").(bool) == true {
+		return fmt.Errorf("veto is true, diff vetoed")
+	}
+	// Note that this gets put into state after the update, regardless of whether
+	// or not anything is acted upon in the diff.
+	d.SetNew("computed", d.Get("computed").(int)+1)
+	return nil
+}
+
+func testResourceCustomDiffUpdate(d *schema.ResourceData, meta interface{}) error {
+	_, new := d.GetChange("computed")
+	expected := new.(int) - 1
+	actual := d.Get("index").(int)
+	if expected != actual {
+		return fmt.Errorf("expected computed to be 1 ahead of index, got computed: %d, index: %d", expected, actual)
+	}
+	d.Set("index", new)
+	return nil
+}
+
+func testResourceCustomDiffDelete(d *schema.ResourceData, meta interface{}) error {
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/test/resource_with_custom_diff_test.go
+++ b/builtin/providers/test/resource_with_custom_diff_test.go
@@ -1,0 +1,47 @@
+package test
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// TestResourceWithCustomDiff test custom diff behaviour.
+func TestResourceWithCustomDiff(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: resourceWithCustomDiffConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "computed", "1"),
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "index", "1"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config: resourceWithCustomDiffConfig(false),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "computed", "2"),
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "index", "2"),
+				),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				Config:      resourceWithCustomDiffConfig(true),
+				ExpectError: regexp.MustCompile("veto is true, diff vetoed"),
+			},
+		},
+	})
+}
+
+func resourceWithCustomDiffConfig(veto bool) string {
+	return fmt.Sprintf(`
+resource "test_resource_with_custom_diff" "foo" {
+	required = "yep"
+	veto = %t
+}
+`, veto)
+}

--- a/builtin/providers/test/resource_with_custom_diff_test.go
+++ b/builtin/providers/test/resource_with_custom_diff_test.go
@@ -18,6 +18,8 @@ func TestResourceWithCustomDiff(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "computed", "1"),
 					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "index", "1"),
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "list.#", "1"),
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "list.0", "dc1"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
@@ -26,6 +28,10 @@ func TestResourceWithCustomDiff(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "computed", "2"),
 					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "index", "2"),
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "list.#", "2"),
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "list.0", "dc2"),
+					resource.TestCheckResourceAttr("test_resource_with_custom_diff.foo", "list.1", "dc3"),
+					resource.TestCheckNoResourceAttr("test_resource_with_custom_diff.foo", "list.2"),
 				),
 				ExpectNonEmptyPlan: true,
 			},

--- a/helper/schema/backend.go
+++ b/helper/schema/backend.go
@@ -65,7 +65,7 @@ func (b *Backend) Configure(c *terraform.ResourceConfig) error {
 
 	// Get a ResourceData for this configuration. To do this, we actually
 	// generate an intermediary "diff" although that is never exposed.
-	diff, err := sm.Diff(nil, c)
+	diff, err := sm.Diff(nil, c, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/helper/schema/provider.go
+++ b/helper/schema/provider.go
@@ -251,7 +251,7 @@ func (p *Provider) Configure(c *terraform.ResourceConfig) error {
 
 	// Get a ResourceData for this configuration. To do this, we actually
 	// generate an intermediary "diff" although that is never exposed.
-	diff, err := sm.Diff(nil, c)
+	diff, err := sm.Diff(nil, c, nil, p.meta)
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (p *Provider) Diff(
 		return nil, fmt.Errorf("unknown resource type: %s", info.Type)
 	}
 
-	return r.Diff(s, c)
+	return r.Diff(s, c, p.meta)
 }
 
 // Refresh implementation of terraform.ResourceProvider interface.
@@ -410,7 +410,7 @@ func (p *Provider) ReadDataDiff(
 		return nil, fmt.Errorf("unknown data source: %s", info.Type)
 	}
 
-	return r.Diff(nil, c)
+	return r.Diff(nil, c, p.meta)
 }
 
 // RefreshData implementation of terraform.ResourceProvider interface.

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -146,7 +146,7 @@ func (p *Provisioner) Apply(
 		}
 
 		sm := schemaMap(p.ConnSchema)
-		diff, err := sm.Diff(nil, terraform.NewResourceConfig(c))
+		diff, err := sm.Diff(nil, terraform.NewResourceConfig(c), nil, nil)
 		if err != nil {
 			return err
 		}
@@ -160,7 +160,7 @@ func (p *Provisioner) Apply(
 		// Build the configuration data. Doing this requires making a "diff"
 		// even though that's never used. We use that just to get the correct types.
 		configMap := schemaMap(p.Schema)
-		diff, err := configMap.Diff(nil, c)
+		diff, err := configMap.Diff(nil, c, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -112,6 +112,8 @@ type Resource struct {
 	//
 	// For the most part, only computed fields can be customized by this
 	// function.
+	//
+	// This function is only allowed on regular resources (not data sources).
 	CustomizeDiff CustomizeDiffFunc
 
 	// Importer is the ResourceImporter implementation for this resource.
@@ -377,6 +379,11 @@ func (r *Resource) InternalValidate(topSchemaMap schemaMap, writable bool) error
 	if !writable {
 		if r.Create != nil || r.Update != nil || r.Delete != nil {
 			return fmt.Errorf("must not implement Create, Update or Delete")
+		}
+
+		// CustomizeDiff cannot be defined for read-only resources
+		if r.CustomizeDiff != nil {
+			return fmt.Errorf("cannot implement CustomizeDiff")
 		}
 	}
 

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -85,6 +85,16 @@ type Resource struct {
 	Delete DeleteFunc
 	Exists ExistsFunc
 
+	// CustomizeDiff is a custom function for controlling diff logic after the
+	// initial diff is performed - it can be used to veto particular changes in
+	// the diff, customize the diff that has been created, or diff values not
+	// controlled by config. It is passed a *ResourceDiff, a structure similar to
+	// ResourceData but lacking most write functions, allowing the provider to
+	// customize the diff only.
+	//
+	// Only computed fields can be customized by this function.
+	CustomizeDiff CustomizeDiffFunc
+
 	// Importer is the ResourceImporter implementation for this resource.
 	// If this is nil, then this resource does not support importing. If
 	// this is non-nil, then it supports importing and ResourceImporter
@@ -125,6 +135,9 @@ type ExistsFunc func(*ResourceData, interface{}) (bool, error)
 // See Resource documentation.
 type StateMigrateFunc func(
 	int, *terraform.InstanceState, interface{}) (*terraform.InstanceState, error)
+
+// See Resource documentation.
+type CustomizeDiffFunc func(*ResourceDiff, interface{}) error
 
 // Apply creates, updates, and/or deletes a resource.
 func (r *Resource) Apply(

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -85,15 +85,16 @@ type Resource struct {
 	Delete DeleteFunc
 	Exists ExistsFunc
 
-	// CustomizeDiff is a custom function for controlling diff logic after the
-	// initial diff is performed - it can be used to veto particular changes in
-	// the diff, customize the diff that has been created, or diff values not
-	// controlled by config. It is passed a *ResourceDiff, a structure similar to
-	// ResourceData but lacking most write functions, allowing the provider to
-	// customize the diff only.
+	// Review is a custom function for "reviewing" the diff that Terraform has
+	// created for this resource - it can be used to customize the diff that has
+	// been created, diff values not controlled by configuration, or even veto
+	// the diff altogether and abort the plan. It is passed a *ResourceDiff, a
+	// structure similar to ResourceData but lacking most write functions,
+	// allowing the provider to customize the diff only.
 	//
-	// Only computed fields can be customized by this function.
-	CustomizeDiff CustomizeDiffFunc
+	// For the most part, only computed fields can be customized by this
+	// function.
+	Review ReviewFunc
 
 	// Importer is the ResourceImporter implementation for this resource.
 	// If this is nil, then this resource does not support importing. If
@@ -137,7 +138,7 @@ type StateMigrateFunc func(
 	int, *terraform.InstanceState, interface{}) (*terraform.InstanceState, error)
 
 // See Resource documentation.
-type CustomizeDiffFunc func(*ResourceDiff, interface{}) error
+type ReviewFunc func(*ResourceDiff, interface{}) error
 
 // Apply creates, updates, and/or deletes a resource.
 func (r *Resource) Apply(
@@ -229,7 +230,7 @@ func (r *Resource) Diff(
 		return nil, fmt.Errorf("[ERR] Error decoding timeout: %s", err)
 	}
 
-	instanceDiff, err := schemaMap(r.Schema).Diff(s, c, r.CustomizeDiff, meta)
+	instanceDiff, err := schemaMap(r.Schema).Diff(s, c, r.Review, meta)
 	if err != nil {
 		return instanceDiff, err
 	}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -219,7 +219,8 @@ func (r *Resource) Apply(
 // ResourceProvider interface.
 func (r *Resource) Diff(
 	s *terraform.InstanceState,
-	c *terraform.ResourceConfig) (*terraform.InstanceDiff, error) {
+	c *terraform.ResourceConfig,
+	meta interface{}) (*terraform.InstanceDiff, error) {
 
 	t := &ResourceTimeout{}
 	err := t.ConfigDecode(r, c)
@@ -228,7 +229,7 @@ func (r *Resource) Diff(
 		return nil, fmt.Errorf("[ERR] Error decoding timeout: %s", err)
 	}
 
-	instanceDiff, err := schemaMap(r.Schema).Diff(s, c)
+	instanceDiff, err := schemaMap(r.Schema).Diff(s, c, r.CustomizeDiff, meta)
 	if err != nil {
 		return instanceDiff, err
 	}

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -90,7 +90,25 @@ type Resource struct {
 	// diff that has been created, diff values not controlled by configuration,
 	// or even veto the diff altogether and abort the plan. It is passed a
 	// *ResourceDiff, a structure similar to ResourceData but lacking most write
-	// functions, allowing the provider to customize the diff only.
+	// functions like Set, while introducing new functions that work with the
+	// diff such as SetNew, SetNewComputed, and ForceNew.
+	//
+	// The phases Terraform runs this in, and the state available via functions
+	// like Get and GetChange, are as follows:
+	//
+	//  * New resource: One run with no state
+	//  * Existing resource: One run with state
+	//   * Existing resource, forced new: One run with state (before ForceNew),
+	//     then one run without state (as if new resource)
+	//  * Tainted resource: No runs (custom diff logic is skipped)
+	//  * Destroy: No runs (standard diff logic is skipped on destroy diffs)
+	//
+	// This function needs to be resilient to support all scenarios.
+	//
+	// If this function needs to access external API resources, remember to flag
+	// the RequiresRefresh attribute mentioned below to ensure that
+	// -refresh=false is blocked when running plan or apply, as this means that
+	// this resource requires refresh-like behaviour to work effectively.
 	//
 	// For the most part, only computed fields can be customized by this
 	// function.

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -216,8 +216,7 @@ func (r *Resource) Apply(
 	return r.recordCurrentSchemaVersion(data.State()), err
 }
 
-// Diff returns a diff of this resource and is API compatible with the
-// ResourceProvider interface.
+// Diff returns a diff of this resource.
 func (r *Resource) Diff(
 	s *terraform.InstanceState,
 	c *terraform.ResourceConfig,

--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -85,16 +85,16 @@ type Resource struct {
 	Delete DeleteFunc
 	Exists ExistsFunc
 
-	// Review is a custom function for "reviewing" the diff that Terraform has
-	// created for this resource - it can be used to customize the diff that has
-	// been created, diff values not controlled by configuration, or even veto
-	// the diff altogether and abort the plan. It is passed a *ResourceDiff, a
-	// structure similar to ResourceData but lacking most write functions,
-	// allowing the provider to customize the diff only.
+	// CustomizeDiff is a custom function for working with the diff that
+	// Terraform has created for this resource - it can be used to customize the
+	// diff that has been created, diff values not controlled by configuration,
+	// or even veto the diff altogether and abort the plan. It is passed a
+	// *ResourceDiff, a structure similar to ResourceData but lacking most write
+	// functions, allowing the provider to customize the diff only.
 	//
 	// For the most part, only computed fields can be customized by this
 	// function.
-	Review ReviewFunc
+	CustomizeDiff CustomizeDiffFunc
 
 	// Importer is the ResourceImporter implementation for this resource.
 	// If this is nil, then this resource does not support importing. If
@@ -138,7 +138,7 @@ type StateMigrateFunc func(
 	int, *terraform.InstanceState, interface{}) (*terraform.InstanceState, error)
 
 // See Resource documentation.
-type ReviewFunc func(*ResourceDiff, interface{}) error
+type CustomizeDiffFunc func(*ResourceDiff, interface{}) error
 
 // Apply creates, updates, and/or deletes a resource.
 func (r *Resource) Apply(
@@ -229,7 +229,7 @@ func (r *Resource) Diff(
 		return nil, fmt.Errorf("[ERR] Error decoding timeout: %s", err)
 	}
 
-	instanceDiff, err := schemaMap(r.Schema).Diff(s, c, r.Review, meta)
+	instanceDiff, err := schemaMap(r.Schema).Diff(s, c, r.CustomizeDiff, meta)
 	if err != nil {
 		return instanceDiff, err
 	}

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -260,10 +260,6 @@ func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, b
 // sets). The original value from the state is used as the old value.
 //
 // This function is only allowed on computed attributes.
-//
-// It is an unsupported operation to set invalid values with this function -
-// doing so will taint any existing diff for this key and will remove it from
-// the catalog.
 func (d *ResourceDiff) SetNew(key string, value interface{}) error {
 	return d.SetDiff(key, d.get(strings.Split(key, "."), "state").Value, value, false)
 }
@@ -271,7 +267,7 @@ func (d *ResourceDiff) SetNew(key string, value interface{}) error {
 // SetNewComputed functions like SetNew, except that it blanks out a new value
 // and marks it as computed.
 //
-// This function is only allowed on computed keys.
+// This function is only allowed on computed attributes.
 func (d *ResourceDiff) SetNewComputed(key string) error {
 	return d.SetDiff(key, d.get(strings.Split(key, "."), "state").Value, nil, true)
 }
@@ -282,7 +278,7 @@ func (d *ResourceDiff) SetNewComputed(key string) error {
 // ClearAll to construct a compleletely new diff based off of provider logic
 // alone.
 //
-// This function is only allowed on computed keys.
+// This function is only allowed on computed attributes.
 func (d *ResourceDiff) SetDiff(key string, old, new interface{}, computed bool) error {
 	if !d.schema[key].Computed {
 		return fmt.Errorf("SetNew, SetNewComputed, and SetDiff are allowed on computed attributes only - %s is not one", key)

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -206,15 +206,6 @@ func (d *ResourceDiff) UpdatedKeys() []string {
 	return s
 }
 
-// ClearAll wipes the current diff. This cannot be undone - use only if you
-// need to create a whole new diff from scatch, such as when you are leaning on
-// the provider completely to create the diff.
-//
-// Note that this does not wipe overrides.
-func (d *ResourceDiff) ClearAll() {
-	d.diff = new(terraform.InstanceDiff)
-}
-
 // Clear wipes the diff for a particular key. It is called by SetDiff to remove
 // any possibility of conflicts, but can be called on its own to just remove a
 // specific key from the diff completely.

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -78,7 +78,7 @@ func (r *newValueReader) ReadField(address []string) (FieldReadResult, error) {
 		return FieldReadResult{}, err
 	}
 	for computedKey := range r.computedKeys {
-		if strings.HasPrefix(addrKey, computedKey) {
+		if childAddrOf(addrKey, computedKey) {
 			if strings.HasSuffix(addrKey, ".#") {
 				// This is a count value for a list or set that has been marked as
 				// computed, or a sub-list/sub-set of a complex resource that has

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -4,128 +4,196 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 
 	"github.com/hashicorp/terraform/terraform"
 )
+
+// newValueWriter is a minor re-implementation of MapFieldWriter to include
+// keys that should be marked as computed, to represent the new part of a
+// pseudo-diff.
+type newValueWriter struct {
+	*MapFieldWriter
+
+	// A list of keys that should be marked as computed.
+	computedKeys map[string]bool
+
+	// A lock to prevent races on writes. The underlying writer will have one as
+	// well - this is for computed keys.
+	lock sync.Mutex
+}
+
+// WriteField overrides MapValueWriter's WriteField, adding the ability to flag
+// the address as computed.
+func (w *newValueWriter) WriteField(address []string, value interface{}, computed bool) error {
+	if err := w.MapFieldWriter.WriteField(address, value); err != nil {
+		return err
+	}
+
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if w.result == nil {
+		w.computedKeys = make(map[string]bool)
+	}
+
+	if computed {
+		w.computedKeys[strings.Join(address, ".")] = true
+	}
+	return nil
+}
+
+// ComputedKeysMap returns the underlying computed keys map.
+func (w *newValueWriter) ComputedKeysMap() map[string]bool {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	if w.result == nil {
+		w.computedKeys = make(map[string]bool)
+	}
+	return w.computedKeys
+}
+
+// newValueReader is a minor re-implementation of MapFieldReader and is the
+// read counterpart to MapValueWriter, allowing the read of keys flagged as
+// computed to accommodate the diff override logic in ResourceDiff.
+type newValueReader struct {
+	*MapFieldReader
+
+	// The list of computed keys from a newValueWriter.
+	computedKeys map[string]bool
+}
+
+// ReadField reads the values from the underlying writer, returning the
+// computed value if it is found as well.
+func (r *newValueReader) ReadField(address []string) (FieldReadResult, error) {
+	v, err := r.MapFieldReader.ReadField(address)
+	if err != nil {
+		return FieldReadResult{}, err
+	}
+	if _, ok := r.computedKeys[strings.Join(address, ".")]; ok {
+		v.Computed = true
+	}
+
+	return v, nil
+}
 
 // ResourceDiff is used to query and make custom changes to an in-flight diff.
 // It can be used to veto particular changes in the diff, customize the diff
 // that has been created, or diff values not controlled by config.
 //
 // The object functions similar to ResourceData, however most notably lacks
-// Set, SetPartial, and Partial, as it should only be used to change diff
-// values only. Most other frist-class ResourceData functions exist, namely
-// Get, GetOk, HasChange, and GetChange exist.
+// Set, SetPartial, and Partial, as it should be used to change diff values
+// only.  Most other frist-class ResourceData functions exist, namely Get,
+// GetOk, HasChange, and GetChange exist.
 //
 // All functions in ResourceDiff, save for ForceNew, can only be used on
 // computed fields.
 type ResourceDiff struct {
-	// The underlying ResourceData object used as a refrence and diff storage.
-	data *ResourceData
+	// The schema for the resource being worked on.
+	schema map[string]*Schema
 
-	// A source "copy" of the ResourceData object, designed to preserve the
-	// original diff, schema, and state to allow for rollbacks.
-	originalData *ResourceData
+	// The current config for this resource.
+	config *terraform.ResourceConfig
 
-	// A writer that holds overridden old fields.
+	// The state for this resource as it exists post-refresh, after the initial
+	// diff.
+	state *terraform.InstanceState
+
+	// The diff created by Terraform. This diff is used, along with state,
+	// config, and custom-set diff data, to provide a multi-level reader
+	// experience similar to ResourceData.
+	diff *terraform.InstanceDiff
+
+	// The internal reader structure that contains the state, config, the default
+	// diff, and the new diff.
+	multiReader *MultiLevelFieldReader
+
+	// A writer that writes overridden old fields.
 	oldWriter *MapFieldWriter
 
-	// A reader that is tied to oldWriter's map.
-	oldReader *MapFieldReader
-
-	// A writer that holds overridden new fields.
-	newWriter *MapFieldWriter
-
-	// A reader that is tied to newWriter's map.
-	newReader *MapFieldReader
-
-	// A map of keys that will be force-flagged as computed.
-	computedKeys map[string]bool
-
-	// A catalog of top-level keys that are safely diffable. diffChange will
-	// panic if the key is not found here to guard against bugs and edge cases
-	// when processing diffs.
-	catalog map[string]bool
+	// A writer that writes overridden new fields.
+	newWriter *newValueWriter
 }
 
 // newResourceDiff creates a new ResourceDiff instance.
-func newResourceDiff(diff *terraform.InstanceDiff, data *ResourceData) *ResourceDiff {
-	d := new(ResourceDiff)
-	d.originalData = &ResourceData{
-		schema: data.schema,
-		state:  data.state,
-		config: data.config,
+func newResourceDiff(schema map[string]*Schema, config *terraform.ResourceConfig, state *terraform.InstanceState, diff *terraform.InstanceDiff) *ResourceDiff {
+	d := &ResourceDiff{
+		config: config,
+		state:  state,
 		diff:   diff,
 	}
-	d.data = new(ResourceData)
-	d.data.config = data.config
-	d.data.state = d.originalData.state.DeepCopy()
-	d.data.diff = d.originalData.diff.DeepCopy()
-	for k, v := range d.originalData.schema {
+	// Duplicate the passed in schema to ensure that any changes we make with
+	// functions like ForceNew don't affect the referenced schema.
+	for k, v := range schema {
 		newSchema := *v
-		d.data.schema[k] = &newSchema
+		d.schema[k] = &newSchema
 	}
 
-	d.data.once.Do(d.data.init)
-
-	d.oldWriter = &MapFieldWriter{Schema: data.schema}
-	d.oldReader = &MapFieldReader{
-		Schema: data.schema,
+	d.oldWriter = &MapFieldWriter{Schema: d.schema}
+	d.newWriter = &newValueWriter{
+		MapFieldWriter: &MapFieldWriter{Schema: d.schema},
+	}
+	readers := make(map[string]FieldReader)
+	var stateAttributes map[string]string
+	if d.state != nil {
+		stateAttributes = d.state.Attributes
+		readers["state"] = &MapFieldReader{
+			Schema: d.schema,
+			Map:    BasicMapReader(stateAttributes),
+		}
+	}
+	if d.config != nil {
+		readers["config"] = &ConfigFieldReader{
+			Schema: d.schema,
+			Config: d.config,
+		}
+	}
+	if d.diff != nil {
+		readers["diff"] = &DiffFieldReader{
+			Schema: d.schema,
+			Diff:   d.diff,
+			Source: &MultiLevelFieldReader{
+				Levels:  []string{"state", "config"},
+				Readers: readers,
+			},
+		}
+	}
+	readers["newDiffOld"] = &MapFieldReader{
+		Schema: d.schema,
 		Map:    BasicMapReader(d.oldWriter.Map()),
 	}
+	readers["newDiffNew"] = &newValueReader{
+		MapFieldReader: &MapFieldReader{
+			Schema: d.schema,
+			Map:    BasicMapReader(d.newWriter.Map()),
+		},
+		computedKeys: d.newWriter.ComputedKeysMap(),
+	}
+	d.multiReader = &MultiLevelFieldReader{
+		Levels: []string{
+			"state",
+			"config",
+			"diff",
+			"newDiffOld",
+			"newDiffNew",
+		},
 
-	d.newWriter = &MapFieldWriter{Schema: data.schema}
-	d.newReader = &MapFieldReader{
-		Schema: data.schema,
-		Map:    BasicMapReader(d.newWriter.Map()),
+		Readers: readers,
 	}
 
 	return d
 }
 
-// ClearAll re-creates the ResourceDiff instance and drops the old one on the
-// floor. The new instance starts off without a diff.
+// ClearAll wipes the current diff. This cannot be undone - use only if you
+// need to create a whole new diff from scatch, such as when you are leaning on
+// the provider completely to create the diff.
 func (d *ResourceDiff) ClearAll() {
-	nd := newResourceDiff(d.originalData.diff, d.originalData)
-	nd.data.diff = new(terraform.InstanceDiff)
-	d = nd
-}
-
-// Reset re-creates the ResourceDiff instance, similar to ClearAll, but with
-// the original diff preserved.
-func (d *ResourceDiff) Reset() {
-	nd := newResourceDiff(d.originalData.diff, d.originalData)
-	d = nd
-}
-
-// getDiff returns the current diff as it is in the underlying ResourceData
-// object.
-func (d *ResourceDiff) getDiff() *terraform.InstanceDiff {
-	return d.data.diff
+	d.diff = new(terraform.InstanceDiff)
 }
 
 // diffChange helps to implement resourceDiffer and derives its change values
-// from ResourceDiff's own change data.
-//
-// Note that it's a currently unsupported operation to diff a field (and hence
-// use this function) on a field that has not been explicitly operated on with
-// SetNew, SetNewComputed, or SetDiff. The function will panic if you do.
+// from ResourceDiff's own change data, in addition to existing diff, config, and state.
 func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, bool) {
-	// Panic if key was never set by any of our diff functions. It's not a legit
-	// use case of this function to be used outside of very specific functions in
-	// ResourceDiff.
-	if _, ok := d.catalog[key]; !ok {
-		panic(fmt.Errorf("ResourceDiff.diffChange: %s was not found as a valid set key", key))
-	}
-
-	old, err := d.oldReader.ReadField(strings.Split(key, "."))
-	if err != nil {
-		panic(fmt.Errorf("ResourceDiff.diffChange: Reading old value for %s failed: %s", key, err))
-	}
-	new, err := d.newReader.ReadField(strings.Split(key, "."))
-	if err != nil {
-		panic(fmt.Errorf("ResourceDiff.diffChange: Reading new value for %s failed: %s", key, err))
-	}
+	old, new := d.getChange(key)
 
 	if !old.Exists {
 		old.Value = nil
@@ -134,12 +202,7 @@ func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, b
 		new.Value = nil
 	}
 
-	var computed bool
-	if v, ok := d.computedKeys[strings.Split(key, ".")[0]]; ok {
-		computed = v
-	}
-
-	return old.Value, new.Value, !reflect.DeepEqual(old.Value, new.Value), computed
+	return old.Value, new.Value, !reflect.DeepEqual(old.Value, new.Value), new.Computed
 }
 
 // SetNew is used to set a new diff value for the mentioned key. The value must
@@ -160,7 +223,7 @@ func (d *ResourceDiff) SetNew(key string, value interface{}) error {
 //
 // This function is only allowed on computed keys.
 func (d *ResourceDiff) SetNewComputed(key string) error {
-	return d.SetDiff(key, d.Get(key), d.data.schema[key].ZeroValue(), true)
+	return d.SetDiff(key, d.Get(key), d.schema[key].ZeroValue(), true)
 }
 
 // SetDiff allows the setting of both old and new values for the diff
@@ -171,24 +234,19 @@ func (d *ResourceDiff) SetNewComputed(key string) error {
 //
 // This function is only allowed on computed keys.
 func (d *ResourceDiff) SetDiff(key string, old, new interface{}, computed bool) error {
-	if !d.data.schema[key].Computed {
+	if !d.schema[key].Computed {
 		return fmt.Errorf("SetNew, SetNewComputed, and SetDiff are allowed on computed attributes only - %s is not one", key)
 	}
 
 	if err := d.oldWriter.WriteField(strings.Split(key, "."), old); err != nil {
-		delete(d.catalog, key)
 		return fmt.Errorf("Cannot set old diff value for key %s: %s", key, err)
 	}
 
-	if err := d.newWriter.WriteField(strings.Split(key, "."), new); err != nil {
-		delete(d.catalog, key)
+	if err := d.newWriter.WriteField(strings.Split(key, "."), new, computed); err != nil {
 		return fmt.Errorf("Cannot set new diff value for key %s: %s", key, err)
 	}
 
-	d.computedKeys[key] = computed
-	d.catalog[key] = true
-
-	return schemaMap(d.data.schema).diff(key, d.data.schema[key], d.data.diff, d, false)
+	return nil
 }
 
 // ForceNew force-flags ForceNew in the schema for a specific key, and
@@ -203,31 +261,140 @@ func (d *ResourceDiff) ForceNew(key string) error {
 	}
 
 	old, new := d.GetChange(key)
-	d.data.schema[key].ForceNew = true
+	d.schema[key].ForceNew = true
 	return d.SetDiff(key, old, new, false)
 }
 
 // Get hands off to ResourceData.Get.
 func (d *ResourceDiff) Get(key string) interface{} {
-	return d.data.Get(key)
+	r, _ := d.GetOk(key)
+	return r
 }
 
-// GetChange hands off to ResourceData.GetChange.
+// GetChange gets the change between the state and diff, checking first to see
+// if a overridden diff exists.
+//
+// This implementation differs from ResourceData's in the way that we first get
+// results from the exact levels for the new diff, then from state and diff as
+// per normal.
 func (d *ResourceDiff) GetChange(key string) (interface{}, interface{}) {
-	return d.data.getChange(key, getSourceState, getSourceDiff)
+	old, new := d.getChange(key)
+	return old.Value, new.Value
 }
 
-// GetOk hands off to ResourceData.GetOk.
+// GetOk functions the same way as ResourceData.GetOk, but it also checks the
+// new diff levels to provide data consistent with the current state of the
+// customized diff.
 func (d *ResourceDiff) GetOk(key string) (interface{}, bool) {
-	return d.data.GetOk(key)
+	r := d.get(strings.Split(key, "."), "newDiffNew")
+	exists := r.Exists && !r.Computed
+	if exists {
+		// If it exists, we also want to verify it is not the zero-value.
+		value := r.Value
+		zero := r.Schema.Type.Zero()
+
+		if eq, ok := value.(Equal); ok {
+			exists = !eq.Equal(zero)
+		} else {
+			exists = !reflect.DeepEqual(value, zero)
+		}
+	}
+
+	return r.Value, exists
 }
 
-// HasChange hands off to ResourceData.HasChange.
+// HasChange checks to see if there is a change between state and the diff, or
+// in the overridden diff.
 func (d *ResourceDiff) HasChange(key string) bool {
-	return d.data.HasChange(key)
+	old, new := d.GetChange(key)
+
+	// If the type implements the Equal interface, then call that
+	// instead of just doing a reflect.DeepEqual. An example where this is
+	// needed is *Set
+	if eq, ok := old.(Equal); ok {
+		return !eq.Equal(new)
+	}
+
+	return !reflect.DeepEqual(old, new)
 }
 
-// Id hands off to ResourceData.Id.
+// Id returns the ID of this resource.
+//
+// Note that technically, ID does not change during diffs (it either has
+// already changed in the refresh, or will change on update), hence we do not
+// support updating the ID or fetching it from anything else other than state.
 func (d *ResourceDiff) Id() string {
-	return d.data.Id()
+	var result string
+
+	if d.state != nil {
+		result = d.state.ID
+	}
+	return result
+}
+
+// getChange gets values from two different levels, designed for use in
+// diffChange, HasChange, and GetChange.
+//
+// This implementation differs from ResourceData's in the way that we first get
+// results from the exact levels for the new diff, then from state and diff as
+// per normal.
+func (d *ResourceDiff) getChange(key string) (getResult, getResult) {
+	old := d.getExact(strings.Split(key, "."), "newDiffOld")
+	new := d.getExact(strings.Split(key, "."), "newDiffNew")
+
+	if old.Exists && new.Exists {
+		// Both values should exist if SetDiff operated on this key.
+		// TODO: Maybe verify this. Zero values might be an issue here.
+		return old, new
+	}
+
+	// If we haven't set this in the new diff, then we want to get the default
+	// levels as if we were using ResourceData normally.
+	old = d.get(strings.Split(key, "."), "state")
+	new = d.get(strings.Split(key, "."), "diff")
+	return old, new
+}
+
+// get performs the appropriate multi-level reader logic for ResourceDiff,
+// starting at source. Refer to newResourceDiff for the level order.
+func (d *ResourceDiff) get(addr []string, source string) getResult {
+	result, err := d.multiReader.ReadFieldMerge(addr, source)
+	if err != nil {
+		panic(err)
+	}
+
+	return d.finalizeResult(addr, result)
+}
+
+// getExact gets an attribute from the exact level referenced by source.
+func (d *ResourceDiff) getExact(addr []string, source string) getResult {
+	result, err := d.multiReader.ReadFieldExact(addr, source)
+	if err != nil {
+		panic(err)
+	}
+
+	return d.finalizeResult(addr, result)
+}
+
+// finalizeResult does some post-processing of the result produced by get and getExact.
+func (d *ResourceDiff) finalizeResult(addr []string, result FieldReadResult) getResult {
+	// If the result doesn't exist, then we set the value to the zero value
+	var schema *Schema
+	if schemaL := addrToSchema(addr, d.schema); len(schemaL) > 0 {
+		schema = schemaL[len(schemaL)-1]
+	}
+
+	if result.Value == nil && schema != nil {
+		result.Value = result.ValueOrZero(schema)
+	}
+
+	// Transform the FieldReadResult into a getResult. It might be worth
+	// merging these two structures one day.
+	return getResult{
+		Value:          result.Value,
+		ValueProcessed: result.ValueProcessed,
+		Computed:       result.Computed,
+		Exists:         result.Exists,
+		Schema:         schema,
+	}
 }

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -237,7 +237,6 @@ func (d *ResourceDiff) clear(key string) error {
 // from ResourceDiff's own change data, in addition to existing diff, config, and state.
 func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, bool) {
 	old, new := d.getChange(key)
-	// log.Printf("\nkey:%s\n\nold:%s\n\nnew:%s\n", key, spew.Sdump(old), spew.Sdump(new))
 
 	if !old.Exists {
 		old.Value = nil

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -259,7 +259,7 @@ func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, b
 // doing so will taint any existing diff for this key and will remove it from
 // the catalog.
 func (d *ResourceDiff) SetNew(key string, value interface{}) error {
-	return d.SetDiff(key, d.getExact(strings.Split(key, "."), "state").Value, value, false)
+	return d.SetDiff(key, d.get(strings.Split(key, "."), "state").Value, value, false)
 }
 
 // SetNewComputed functions like SetNew, except that it sets the new value to
@@ -267,7 +267,7 @@ func (d *ResourceDiff) SetNew(key string, value interface{}) error {
 //
 // This function is only allowed on computed keys.
 func (d *ResourceDiff) SetNewComputed(key string) error {
-	return d.SetDiff(key, d.getExact(strings.Split(key, "."), "state").Value, d.schema[key].ZeroValue(), true)
+	return d.SetDiff(key, d.get(strings.Split(key, "."), "state").Value, d.schema[key].ZeroValue(), true)
 }
 
 // SetDiff allows the setting of both old and new values for the diff

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -197,7 +197,7 @@ func newResourceDiff(schema map[string]*Schema, config *terraform.ResourceConfig
 // UpdatedKeys returns the keys that were updated by SetNew, SetNewComputed, or
 // SetDiff. These are the only keys that a diff should be re-calculated for.
 func (d *ResourceDiff) UpdatedKeys() []string {
-	s := make([]string, 0)
+	var s []string
 	for k := range d.updatedKeys {
 		s = append(s, k)
 	}
@@ -435,5 +435,8 @@ func (d *ResourceDiff) finalizeResult(addr []string, result FieldReadResult) get
 func childAddrOf(child, parent string) bool {
 	cs := strings.Split(child, ".")
 	ps := strings.Split(parent, ".")
+	if len(ps) > len(cs) {
+		return false
+	}
 	return reflect.DeepEqual(ps, cs[:len(ps)])
 }

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -99,7 +99,7 @@ func (r *newValueReader) ReadField(address []string) (FieldReadResult, error) {
 //
 // The object functions similar to ResourceData, however most notably lacks
 // Set, SetPartial, and Partial, as it should be used to change diff values
-// only.  Most other frist-class ResourceData functions exist, namely Get,
+// only.  Most other first-class ResourceData functions exist, namely Get,
 // GetOk, HasChange, and GetChange exist.
 //
 // All functions in ResourceDiff, save for ForceNew, can only be used on

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -290,7 +290,17 @@ func (d *ResourceDiff) setDiff(key string, new interface{}, computed bool) error
 }
 
 // ForceNew force-flags ForceNew in the schema for a specific key, and
-// re-calculates its diff. This function is a no-op/error if there is no diff.
+// re-calculates its diff, effectively causing this attribute to force a new
+// resource.
+//
+// Keep in mind that forcing a new resource will force a second run of the
+// resource's CustomizeDiff function (with a new ResourceDiff) once the current
+// one has completed. This second run is performed without state. This behavior
+// will be the same as if a new resource is being created and is performed to
+// ensure that the diff looks like the diff for a new resource as much as
+// possible. CustomizeDiff should expect such a scenario and act correctly.
+//
+// This function is a no-op/error if there is no diff.
 //
 // Note that the change to schema is permanent for the lifecycle of this
 // specific ResourceDiff instance.

--- a/helper/schema/resource_diff.go
+++ b/helper/schema/resource_diff.go
@@ -1,0 +1,233 @@
+package schema
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// ResourceDiff is used to query and make custom changes to an in-flight diff.
+// It can be used to veto particular changes in the diff, customize the diff
+// that has been created, or diff values not controlled by config.
+//
+// The object functions similar to ResourceData, however most notably lacks
+// Set, SetPartial, and Partial, as it should only be used to change diff
+// values only. Most other frist-class ResourceData functions exist, namely
+// Get, GetOk, HasChange, and GetChange exist.
+//
+// All functions in ResourceDiff, save for ForceNew, can only be used on
+// computed fields.
+type ResourceDiff struct {
+	// The underlying ResourceData object used as a refrence and diff storage.
+	data *ResourceData
+
+	// A source "copy" of the ResourceData object, designed to preserve the
+	// original diff, schema, and state to allow for rollbacks.
+	originalData *ResourceData
+
+	// A writer that holds overridden old fields.
+	oldWriter *MapFieldWriter
+
+	// A reader that is tied to oldWriter's map.
+	oldReader *MapFieldReader
+
+	// A writer that holds overridden new fields.
+	newWriter *MapFieldWriter
+
+	// A reader that is tied to newWriter's map.
+	newReader *MapFieldReader
+
+	// A map of keys that will be force-flagged as computed.
+	computedKeys map[string]bool
+
+	// A catalog of top-level keys that are safely diffable. diffChange will
+	// panic if the key is not found here to guard against bugs and edge cases
+	// when processing diffs.
+	catalog map[string]bool
+}
+
+// newResourceDiff creates a new ResourceDiff instance.
+func newResourceDiff(diff *terraform.InstanceDiff, data *ResourceData) *ResourceDiff {
+	d := new(ResourceDiff)
+	d.originalData = &ResourceData{
+		schema: data.schema,
+		state:  data.state,
+		config: data.config,
+		diff:   diff,
+	}
+	d.data = new(ResourceData)
+	d.data.config = data.config
+	d.data.state = d.originalData.state.DeepCopy()
+	d.data.diff = d.originalData.diff.DeepCopy()
+	for k, v := range d.originalData.schema {
+		newSchema := *v
+		d.data.schema[k] = &newSchema
+	}
+
+	d.data.once.Do(d.data.init)
+
+	d.oldWriter = &MapFieldWriter{Schema: data.schema}
+	d.oldReader = &MapFieldReader{
+		Schema: data.schema,
+		Map:    BasicMapReader(d.oldWriter.Map()),
+	}
+
+	d.newWriter = &MapFieldWriter{Schema: data.schema}
+	d.newReader = &MapFieldReader{
+		Schema: data.schema,
+		Map:    BasicMapReader(d.newWriter.Map()),
+	}
+
+	return d
+}
+
+// ClearAll re-creates the ResourceDiff instance and drops the old one on the
+// floor. The new instance starts off without a diff.
+func (d *ResourceDiff) ClearAll() {
+	nd := newResourceDiff(d.originalData.diff, d.originalData)
+	nd.data.diff = new(terraform.InstanceDiff)
+	d = nd
+}
+
+// Reset re-creates the ResourceDiff instance, similar to ClearAll, but with
+// the original diff preserved.
+func (d *ResourceDiff) Reset() {
+	nd := newResourceDiff(d.originalData.diff, d.originalData)
+	d = nd
+}
+
+// getDiff returns the current diff as it is in the underlying ResourceData
+// object.
+func (d *ResourceDiff) getDiff() *terraform.InstanceDiff {
+	return d.data.diff
+}
+
+// diffChange helps to implement resourceDiffer and derives its change values
+// from ResourceDiff's own change data.
+//
+// Note that it's a currently unsupported operation to diff a field (and hence
+// use this function) on a field that has not been explicitly operated on with
+// SetNew, SetNewComputed, or SetDiff. The function will panic if you do.
+func (d *ResourceDiff) diffChange(key string) (interface{}, interface{}, bool, bool) {
+	// Panic if key was never set by any of our diff functions. It's not a legit
+	// use case of this function to be used outside of very specific functions in
+	// ResourceDiff.
+	if _, ok := d.catalog[key]; !ok {
+		panic(fmt.Errorf("ResourceDiff.diffChange: %s was not found as a valid set key", key))
+	}
+
+	old, err := d.oldReader.ReadField(strings.Split(key, "."))
+	if err != nil {
+		panic(fmt.Errorf("ResourceDiff.diffChange: Reading old value for %s failed: %s", key, err))
+	}
+	new, err := d.newReader.ReadField(strings.Split(key, "."))
+	if err != nil {
+		panic(fmt.Errorf("ResourceDiff.diffChange: Reading new value for %s failed: %s", key, err))
+	}
+
+	if !old.Exists {
+		old.Value = nil
+	}
+	if !new.Exists {
+		new.Value = nil
+	}
+
+	var computed bool
+	if v, ok := d.computedKeys[strings.Split(key, ".")[0]]; ok {
+		computed = v
+	}
+
+	return old.Value, new.Value, !reflect.DeepEqual(old.Value, new.Value), computed
+}
+
+// SetNew is used to set a new diff value for the mentioned key. The value must
+// be correct for the attribute's schema (mostly relevant for maps, lists, and
+// sets). The original value from the state is used as the old value.
+//
+// This function is only allowed on computed attributes.
+//
+// It is an unsupported operation to set invalid values with this function -
+// doing so will taint any existing diff for this key and will remove it from
+// the catalog.
+func (d *ResourceDiff) SetNew(key string, value interface{}) error {
+	return d.SetDiff(key, d.Get(key), value, false)
+}
+
+// SetNewComputed functions like SetNew, except that it sets the new value to
+// the zero value and flags the attribute's diff as computed.
+//
+// This function is only allowed on computed keys.
+func (d *ResourceDiff) SetNewComputed(key string) error {
+	return d.SetDiff(key, d.Get(key), d.data.schema[key].ZeroValue(), true)
+}
+
+// SetDiff allows the setting of both old and new values for the diff
+// referenced by a given key. This can be used to completely override
+// Terraform's own diff behaviour, and can be used in conjunction with Clear or
+// ClearAll to construct a compleletely new diff based off of provider logic
+// alone.
+//
+// This function is only allowed on computed keys.
+func (d *ResourceDiff) SetDiff(key string, old, new interface{}, computed bool) error {
+	if !d.data.schema[key].Computed {
+		return fmt.Errorf("SetNew, SetNewComputed, and SetDiff are allowed on computed attributes only - %s is not one", key)
+	}
+
+	if err := d.oldWriter.WriteField(strings.Split(key, "."), old); err != nil {
+		delete(d.catalog, key)
+		return fmt.Errorf("Cannot set old diff value for key %s: %s", key, err)
+	}
+
+	if err := d.newWriter.WriteField(strings.Split(key, "."), new); err != nil {
+		delete(d.catalog, key)
+		return fmt.Errorf("Cannot set new diff value for key %s: %s", key, err)
+	}
+
+	d.computedKeys[key] = computed
+	d.catalog[key] = true
+
+	return schemaMap(d.data.schema).diff(key, d.data.schema[key], d.data.diff, d, false)
+}
+
+// ForceNew force-flags ForceNew in the schema for a specific key, and
+// re-calculates its diff. This function is a no-op/error if there is no diff.
+//
+// Note that the change to schema is permanent for the lifecycle of this
+// specific ResourceDiff instance, until ClearAll or Reset is called to start
+// anew.
+func (d *ResourceDiff) ForceNew(key string) error {
+	if !d.HasChange(key) {
+		return fmt.Errorf("ResourceDiff.ForceNew: No changes for %s", key)
+	}
+
+	old, new := d.GetChange(key)
+	d.data.schema[key].ForceNew = true
+	return d.SetDiff(key, old, new, false)
+}
+
+// Get hands off to ResourceData.Get.
+func (d *ResourceDiff) Get(key string) interface{} {
+	return d.data.Get(key)
+}
+
+// GetChange hands off to ResourceData.GetChange.
+func (d *ResourceDiff) GetChange(key string) (interface{}, interface{}) {
+	return d.data.getChange(key, getSourceState, getSourceDiff)
+}
+
+// GetOk hands off to ResourceData.GetOk.
+func (d *ResourceDiff) GetOk(key string) (interface{}, bool) {
+	return d.data.GetOk(key)
+}
+
+// HasChange hands off to ResourceData.HasChange.
+func (d *ResourceDiff) HasChange(key string) bool {
+	return d.data.HasChange(key)
+}
+
+// Id hands off to ResourceData.Id.
+func (d *ResourceDiff) Id() string {
+	return d.data.Id()
+}

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -547,7 +547,7 @@ func TestSetNew(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := schemaMap(tc.Schema)
-			d := newResourceDiff(tc.Schema, nil, tc.State, tc.Diff)
+			d := newResourceDiff(tc.Schema, tc.Config, tc.State, tc.Diff)
 			err := d.SetNew(tc.Key, tc.NewValue)
 			switch {
 			case err != nil && !tc.ExpectedError:
@@ -574,7 +574,7 @@ func TestSetNewComputed(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := schemaMap(tc.Schema)
-			d := newResourceDiff(tc.Schema, nil, tc.State, tc.Diff)
+			d := newResourceDiff(tc.Schema, tc.Config, tc.State, tc.Diff)
 			err := d.SetNewComputed(tc.Key)
 			switch {
 			case err != nil && !tc.ExpectedError:
@@ -601,7 +601,7 @@ func TestSetDiff(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := schemaMap(tc.Schema)
-			d := newResourceDiff(tc.Schema, nil, tc.State, tc.Diff)
+			d := newResourceDiff(tc.Schema, tc.Config, tc.State, tc.Diff)
 			err := d.SetDiff(tc.Key, tc.OldValue, tc.NewValue, false)
 			switch {
 			case err != nil && !tc.ExpectedError:
@@ -719,7 +719,7 @@ func TestForceNew(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := schemaMap(tc.Schema)
-			d := newResourceDiff(m, nil, tc.State, tc.Diff)
+			d := newResourceDiff(m, tc.Config, tc.State, tc.Diff)
 			err := d.ForceNew(tc.Key)
 			switch {
 			case err != nil && !tc.ExpectedError:
@@ -848,7 +848,7 @@ func TestClear(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			m := schemaMap(tc.Schema)
-			d := newResourceDiff(m, nil, tc.State, tc.Diff)
+			d := newResourceDiff(m, tc.Config, tc.State, tc.Diff)
 			err := d.Clear(tc.Key)
 			switch {
 			case err != nil && !tc.ExpectedError:

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1,0 +1,420 @@
+package schema
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// testSetFunc is a very simple function we use to test a foo/bar complex set.
+// Both "foo" and "bar" are int values.
+//
+// This is not foolproof as since it performs sums, you can run into
+// collisions. Spec tests accordingly. :P
+func testSetFunc(v interface{}) int {
+	m := v.(map[string]interface{})
+	return m["foo"].(int) + m["bar"].(int)
+}
+
+func TestSetNew(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Schema        map[string]*Schema
+		State         *terraform.InstanceState
+		Config        *terraform.ResourceConfig
+		Diff          *terraform.InstanceDiff
+		Key           string
+		NewValue      interface{}
+		Expected      *terraform.InstanceDiff
+		ExpectedError bool
+	}{
+		{
+			Name: "basic primitive diff",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": "baz",
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "baz",
+					},
+				},
+			},
+			Key:      "foo",
+			NewValue: "qux",
+			Expected: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "qux",
+					},
+				},
+			},
+		},
+		{
+			Name: "basic set diff",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &Schema{Type: TypeString},
+					Set:      HashString,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo.#":          "1",
+					"foo.1996459178": "bar",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": []interface{}{"baz"},
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo.1996459178": &terraform.ResourceAttrDiff{
+						Old:        "bar",
+						New:        "",
+						NewRemoved: true,
+					},
+					"foo.2015626392": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "baz",
+					},
+				},
+			},
+			Key:      "foo",
+			NewValue: []interface{}{"qux"},
+			Expected: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo.1996459178": &terraform.ResourceAttrDiff{
+						Old:        "bar",
+						New:        "",
+						NewRemoved: true,
+					},
+					"foo.2800005064": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "qux",
+					},
+				},
+			},
+		},
+		{
+			Name: "basic list diff",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeList,
+					Optional: true,
+					Computed: true,
+					Elem:     &Schema{Type: TypeString},
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo.#": "1",
+					"foo.0": "bar",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": []interface{}{"baz"},
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo.0": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "baz",
+					},
+				},
+			},
+			Key:      "foo",
+			NewValue: []interface{}{"qux"},
+			Expected: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo.0": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "qux",
+					},
+				},
+			},
+		},
+		{
+			Name: "basic map diff",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeMap,
+					Optional: true,
+					Computed: true,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo.%":   "1",
+					"foo.bar": "baz",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": map[string]interface{}{"bar": "qux"},
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo.bar": &terraform.ResourceAttrDiff{
+						Old: "baz",
+						New: "qux",
+					},
+				},
+			},
+			Key:      "foo",
+			NewValue: map[string]interface{}{"bar": "quux"},
+			Expected: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo.bar": &terraform.ResourceAttrDiff{
+						Old: "baz",
+						New: "quux",
+					},
+				},
+			},
+		},
+		{
+			Name: "additional diff with primitive",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeString,
+					Optional: true,
+				},
+				"one": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": "baz",
+				"one": "three",
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "baz",
+					},
+					"one": &terraform.ResourceAttrDiff{
+						Old: "two",
+						New: "three",
+					},
+				},
+			},
+			Key:      "one",
+			NewValue: "four",
+			Expected: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "baz",
+					},
+					"one": &terraform.ResourceAttrDiff{
+						Old: "two",
+						New: "four",
+					},
+				},
+			},
+		},
+		{
+			Name: "additional diff with primitive computed only",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeString,
+					Optional: true,
+				},
+				"one": &Schema{
+					Type:     TypeString,
+					Computed: true,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo": "bar",
+					"one": "two",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": "baz",
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "baz",
+					},
+				},
+			},
+			Key:      "one",
+			NewValue: "three",
+			Expected: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "baz",
+					},
+					"one": &terraform.ResourceAttrDiff{
+						Old: "two",
+						New: "three",
+					},
+				},
+			},
+		},
+		{
+			Name: "complex-ish set diff",
+			Schema: map[string]*Schema{
+				"top": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem: &Resource{
+						Schema: map[string]*Schema{
+							"foo": &Schema{
+								Type:     TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+							"bar": &Schema{
+								Type:     TypeInt,
+								Optional: true,
+								Computed: true,
+							},
+						},
+					},
+					Set: testSetFunc,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"top.#":      "2",
+					"top.3.foo":  "1",
+					"top.3.bar":  "2",
+					"top.23.foo": "11",
+					"top.23.bar": "12",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"top": []interface{}{
+					map[string]interface{}{
+						"foo": 1,
+						"bar": 3,
+					},
+					map[string]interface{}{
+						"foo": 12,
+						"bar": 12,
+					},
+				},
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"top.4.foo": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "1",
+					},
+					"top.4.bar": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "3",
+					},
+					"top.24.foo": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "12",
+					},
+					"top.24.bar": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "12",
+					},
+				},
+			},
+			Key: "top",
+			NewValue: NewSet(testSetFunc, []interface{}{
+				map[string]interface{}{
+					"foo": 1,
+					"bar": 4,
+				},
+				map[string]interface{}{
+					"foo": 13,
+					"bar": 12,
+				},
+				map[string]interface{}{
+					"foo": 21,
+					"bar": 22,
+				},
+			}),
+			Expected: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"top.#": &terraform.ResourceAttrDiff{
+						Old: "2",
+						New: "3",
+					},
+					"top.5.foo": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "1",
+					},
+					"top.5.bar": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "4",
+					},
+					"top.25.foo": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "13",
+					},
+					"top.25.bar": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "12",
+					},
+					"top.43.foo": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "21",
+					},
+					"top.43.bar": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "22",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("%s", tc.Name), func(t *testing.T) {
+			m := schemaMap(tc.Schema)
+			d := newResourceDiff(tc.Schema, nil, tc.State, tc.Diff)
+			if err := d.SetNew(tc.Key, tc.NewValue); err != nil {
+				t.Fatalf("bad: %s", err)
+			}
+			for _, k := range d.UpdatedKeys() {
+				if err := m.diff(k, m[k], tc.Diff, d, false); err != nil {
+					t.Fatalf("bad: %s", err)
+				}
+			}
+			if !reflect.DeepEqual(tc.Expected, tc.Diff) {
+				t.Fatalf("Expected %s, got %s", spew.Sdump(tc.Expected), spew.Sdump(tc.Diff))
+			}
+		})
+	}
+}

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -1,7 +1,6 @@
 package schema
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 
@@ -62,12 +61,11 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key:      "foo",
-			OldValue: fmt.Sprintf("%sbar", oldPrefix),
 			NewValue: "qux",
 			Expected: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
 					"foo": &terraform.ResourceAttrDiff{
-						Old: fmt.Sprintf("%sbar", oldPrefix),
+						Old: "bar",
 						New: func() string {
 							if computed {
 								return ""
@@ -113,7 +111,6 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key:      "foo",
-			OldValue: []interface{}{fmt.Sprintf("%sbar", oldPrefix)},
 			NewValue: []interface{}{"qux"},
 			Expected: &terraform.InstanceDiff{
 				Attributes: func() map[string]*terraform.ResourceAttrDiff {
@@ -129,8 +126,8 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 							Old: "",
 							New: "qux",
 						}
-						result[fmt.Sprintf("foo.%d", HashString(fmt.Sprintf("%sbar", oldPrefix)))] = &terraform.ResourceAttrDiff{
-							Old:        fmt.Sprintf("%sbar", oldPrefix),
+						result["foo.1996459178"] = &terraform.ResourceAttrDiff{
+							Old:        "bar",
 							New:        "",
 							NewRemoved: true,
 						}
@@ -167,7 +164,6 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key:      "foo",
-			OldValue: []interface{}{fmt.Sprintf("%sbar", oldPrefix)},
 			NewValue: []interface{}{"qux"},
 			Expected: &terraform.InstanceDiff{
 				Attributes: func() map[string]*terraform.ResourceAttrDiff {
@@ -180,7 +176,7 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 						}
 					} else {
 						result["foo.0"] = &terraform.ResourceAttrDiff{
-							Old: fmt.Sprintf("%sbar", oldPrefix),
+							Old: "bar",
 							New: "qux",
 						}
 					}
@@ -215,7 +211,6 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key:      "foo",
-			OldValue: map[string]interface{}{"bar": fmt.Sprintf("%sbaz", oldPrefix)},
 			NewValue: map[string]interface{}{"bar": "quux"},
 			Expected: &terraform.InstanceDiff{
 				Attributes: func() map[string]*terraform.ResourceAttrDiff {
@@ -233,7 +228,7 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 						}
 					} else {
 						result["foo.bar"] = &terraform.ResourceAttrDiff{
-							Old: fmt.Sprintf("%sbaz", oldPrefix),
+							Old: "baz",
 							New: "quux",
 						}
 					}
@@ -272,7 +267,6 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key:      "one",
-			OldValue: fmt.Sprintf("%stwo", oldPrefix),
 			NewValue: "four",
 			Expected: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
@@ -281,7 +275,7 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 						New: "baz",
 					},
 					"one": &terraform.ResourceAttrDiff{
-						Old: fmt.Sprintf("%stwo", oldPrefix),
+						Old: "two",
 						New: func() string {
 							if computed {
 								return ""
@@ -323,7 +317,6 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key:      "one",
-			OldValue: fmt.Sprintf("%stwo", oldPrefix),
 			NewValue: "three",
 			Expected: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
@@ -332,7 +325,7 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 						New: "baz",
 					},
 					"one": &terraform.ResourceAttrDiff{
-						Old: fmt.Sprintf("%stwo", oldPrefix),
+						Old: "two",
 						New: func() string {
 							if computed {
 								return ""
@@ -410,30 +403,6 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key: "top",
-			OldValue: NewSet(testSetFunc, []interface{}{
-				map[string]interface{}{
-					"foo": 1,
-					"bar": 4 + oldOffset,
-				},
-				map[string]interface{}{
-					"foo": 13 + oldOffset,
-					"bar": 12,
-				},
-			}),
-			NewValue: NewSet(testSetFunc, []interface{}{
-				map[string]interface{}{
-					"foo": 1,
-					"bar": 4,
-				},
-				map[string]interface{}{
-					"foo": 13,
-					"bar": 12,
-				},
-				map[string]interface{}{
-					"foo": 21,
-					"bar": 22,
-				},
-			}),
 			Expected: &terraform.InstanceDiff{
 				Attributes: func() map[string]*terraform.ResourceAttrDiff {
 					result := make(map[string]*terraform.ResourceAttrDiff)
@@ -493,12 +462,11 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 			Config:   testConfig(t, map[string]interface{}{}),
 			Diff:     &terraform.InstanceDiff{Attributes: map[string]*terraform.ResourceAttrDiff{}},
 			Key:      "foo",
-			OldValue: fmt.Sprintf("%sbar", oldPrefix),
 			NewValue: "baz",
 			Expected: &terraform.InstanceDiff{
 				Attributes: map[string]*terraform.ResourceAttrDiff{
 					"foo": &terraform.ResourceAttrDiff{
-						Old: fmt.Sprintf("%sbar", oldPrefix),
+						Old: "bar",
 						New: func() string {
 							if computed {
 								return ""
@@ -535,7 +503,6 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key:           "foo",
-			OldValue:      fmt.Sprintf("%sbar", oldPrefix),
 			NewValue:      "qux",
 			ExpectedError: true,
 		},
@@ -576,33 +543,6 @@ func TestSetNewComputed(t *testing.T) {
 			m := schemaMap(tc.Schema)
 			d := newResourceDiff(tc.Schema, tc.Config, tc.State, tc.Diff)
 			err := d.SetNewComputed(tc.Key)
-			switch {
-			case err != nil && !tc.ExpectedError:
-				t.Fatalf("bad: %s", err)
-			case err == nil && tc.ExpectedError:
-				t.Fatalf("Expected error, got none")
-			case err != nil && tc.ExpectedError:
-				return
-			}
-			for _, k := range d.UpdatedKeys() {
-				if err := m.diff(k, m[k], tc.Diff, d, false); err != nil {
-					t.Fatalf("bad: %s", err)
-				}
-			}
-			if !reflect.DeepEqual(tc.Expected, tc.Diff) {
-				t.Fatalf("Expected %s, got %s", spew.Sdump(tc.Expected), spew.Sdump(tc.Diff))
-			}
-		})
-	}
-}
-
-func TestSetDiff(t *testing.T) {
-	testCases := testDiffCases(t, "testSetDiff", 1, false)
-	for _, tc := range testCases {
-		t.Run(tc.Name, func(t *testing.T) {
-			m := schemaMap(tc.Schema)
-			d := newResourceDiff(tc.Schema, tc.Config, tc.State, tc.Diff)
-			err := d.SetDiff(tc.Key, tc.OldValue, tc.NewValue, false)
 			switch {
 			case err != nil && !tc.ExpectedError:
 				t.Fatalf("bad: %s", err)

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -403,6 +403,20 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 				},
 			},
 			Key: "top",
+			NewValue: NewSet(testSetFunc, []interface{}{
+				map[string]interface{}{
+					"foo": 1,
+					"bar": 4,
+				},
+				map[string]interface{}{
+					"foo": 13,
+					"bar": 12,
+				},
+				map[string]interface{}{
+					"foo": 21,
+					"bar": 22,
+				},
+			}),
 			Expected: &terraform.InstanceDiff{
 				Attributes: func() map[string]*terraform.ResourceAttrDiff {
 					result := make(map[string]*terraform.ResourceAttrDiff)

--- a/helper/schema/resource_diff_test.go
+++ b/helper/schema/resource_diff_test.go
@@ -520,6 +520,34 @@ func testDiffCases(t *testing.T, oldPrefix string, oldOffset int, computed bool)
 			NewValue:      "qux",
 			ExpectedError: true,
 		},
+		resourceDiffTestCase{
+			Name: "bad key, should error",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeString,
+					Required: true,
+				},
+			},
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo": "bar",
+				},
+			},
+			Config: testConfig(t, map[string]interface{}{
+				"foo": "baz",
+			}),
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"foo": &terraform.ResourceAttrDiff{
+						Old: "bar",
+						New: "baz",
+					},
+				},
+			},
+			Key:           "bad",
+			NewValue:      "qux",
+			ExpectedError: true,
+		},
 	}
 }
 

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -254,6 +254,44 @@ func TestResourceDiff_Timeout_diff(t *testing.T) {
 	}
 }
 
+func TestResourceDiff_CustomizeFunc(t *testing.T) {
+	r := &Resource{
+		Schema: map[string]*Schema{
+			"foo": &Schema{
+				Type:     TypeInt,
+				Optional: true,
+			},
+		},
+	}
+
+	var called bool
+
+	r.CustomizeDiff = func(d *ResourceDiff, m interface{}) error {
+		called = true
+		return nil
+	}
+
+	raw, err := config.NewRawConfig(
+		map[string]interface{}{
+			"foo": 42,
+		})
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	var s *terraform.InstanceState
+	conf := terraform.NewResourceConfig(raw)
+
+	_, err = r.Diff(s, conf, nil)
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if !called {
+		t.Fatalf("diff customization not called")
+	}
+}
+
 func TestResourceApply_destroy(t *testing.T) {
 	r := &Resource{
 		Schema: map[string]*Schema{

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -835,6 +835,21 @@ func TestResourceInternalValidate(t *testing.T) {
 			true,
 			false,
 		},
+
+		13: { // non-writable must not define CustomizeDiff
+			&Resource{
+				Read: func(d *ResourceData, meta interface{}) error { return nil },
+				Schema: map[string]*Schema{
+					"goo": &Schema{
+						Type:     TypeInt,
+						Optional: true,
+					},
+				},
+				CustomizeDiff: func(*ResourceDiff, interface{}) error { return nil },
+			},
+			false,
+			true,
+		},
 	}
 
 	for i, tc := range cases {

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -266,7 +266,7 @@ func TestResourceDiff_CustomizeFunc(t *testing.T) {
 
 	var called bool
 
-	r.CustomizeDiff = func(d *ResourceDiff, m interface{}) error {
+	r.Review = func(d *ResourceDiff, m interface{}) error {
 		called = true
 		return nil
 	}

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -266,7 +266,7 @@ func TestResourceDiff_CustomizeFunc(t *testing.T) {
 
 	var called bool
 
-	r.Review = func(d *ResourceDiff, m interface{}) error {
+	r.CustomizeDiff = func(d *ResourceDiff, m interface{}) error {
 		called = true
 		return nil
 	}

--- a/helper/schema/resource_test.go
+++ b/helper/schema/resource_test.go
@@ -226,7 +226,7 @@ func TestResourceDiff_Timeout_diff(t *testing.T) {
 	var s *terraform.InstanceState = nil
 	conf := terraform.NewResourceConfig(raw)
 
-	actual, err := r.Diff(s, conf)
+	actual, err := r.Diff(s, conf, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -333,7 +333,7 @@ func (s *Schema) finalizeDiff(
 		return d
 	}
 
-	if s.Computed {
+	if s.Computed && !d.NewComputed {
 		if d.Old != "" && d.New == "" {
 			// This is a computed value with an old value set already,
 			// just let it go.
@@ -1107,7 +1107,7 @@ func (m schemaMap) diffString(
 	}
 
 	removed := false
-	if o != nil && n == nil {
+	if o != nil && n == nil && !computed {
 		removed = true
 	}
 	if removed && schema.Computed {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -451,7 +451,7 @@ func (m schemaMap) Diff(
 		}
 
 		// Re-run customization
-		if customizeFunc != nil {
+		if !result2.Destroy && !result2.DestroyTainted && customizeFunc != nil {
 			mc := m.DeepCopy()
 			rd := newResourceDiff(mc, c, d.state, result2)
 			if err := customizeFunc(rd, meta); err != nil {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/mitchellh/copystructure"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -368,6 +369,16 @@ func (m schemaMap) Data(
 		state:  s,
 		diff:   d,
 	}, nil
+}
+
+// DeepCopy returns a copy of this schemaMap. The copy can be safely modified
+// without affecting the original.
+func (m *schemaMap) DeepCopy() schemaMap {
+	copy, err := copystructure.Config{Lock: true}.Copy(m)
+	if err != nil {
+		panic(err)
+	}
+	return copy.(schemaMap)
 }
 
 // Diff returns the diff for a resource given the schema map,

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -386,7 +386,7 @@ func (m *schemaMap) DeepCopy() schemaMap {
 func (m schemaMap) Diff(
 	s *terraform.InstanceState,
 	c *terraform.ResourceConfig,
-	customizeFunc CustomizeDiffFunc,
+	review ReviewFunc,
 	meta interface{}) (*terraform.InstanceDiff, error) {
 	result := new(terraform.InstanceDiff)
 	result.Attributes = make(map[string]*terraform.ResourceAttrDiff)
@@ -411,10 +411,10 @@ func (m schemaMap) Diff(
 
 	// If this is a non-destroy diff, call any custom diff logic that has been
 	// defined.
-	if !result.DestroyTainted && customizeFunc != nil {
+	if !result.DestroyTainted && review != nil {
 		mc := m.DeepCopy()
 		rd := newResourceDiff(mc, c, s, result)
-		if err := customizeFunc(rd, meta); err != nil {
+		if err := review(rd, meta); err != nil {
 			return nil, err
 		}
 		for _, k := range rd.UpdatedKeys() {
@@ -451,10 +451,10 @@ func (m schemaMap) Diff(
 		}
 
 		// Re-run customization
-		if !result2.DestroyTainted && customizeFunc != nil {
+		if !result2.DestroyTainted && review != nil {
 			mc := m.DeepCopy()
 			rd := newResourceDiff(mc, c, d.state, result2)
-			if err := customizeFunc(rd, meta); err != nil {
+			if err := review(rd, meta); err != nil {
 				return nil, err
 			}
 			for _, k := range rd.UpdatedKeys() {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -411,7 +411,7 @@ func (m schemaMap) Diff(
 
 	// If this is a non-destroy diff, call any custom diff logic that has been
 	// defined.
-	if !result.Destroy && !result.DestroyTainted && customizeFunc != nil {
+	if !result.DestroyTainted && customizeFunc != nil {
 		mc := m.DeepCopy()
 		rd := newResourceDiff(mc, c, s, result)
 		if err := customizeFunc(rd, meta); err != nil {
@@ -451,7 +451,7 @@ func (m schemaMap) Diff(
 		}
 
 		// Re-run customization
-		if !result2.Destroy && !result2.DestroyTainted && customizeFunc != nil {
+		if !result2.DestroyTainted && customizeFunc != nil {
 			mc := m.DeepCopy()
 			rd := newResourceDiff(mc, c, d.state, result2)
 			if err := customizeFunc(rd, meta); err != nil {

--- a/helper/schema/schema.go
+++ b/helper/schema/schema.go
@@ -386,7 +386,7 @@ func (m *schemaMap) DeepCopy() schemaMap {
 func (m schemaMap) Diff(
 	s *terraform.InstanceState,
 	c *terraform.ResourceConfig,
-	review ReviewFunc,
+	customizeDiff CustomizeDiffFunc,
 	meta interface{}) (*terraform.InstanceDiff, error) {
 	result := new(terraform.InstanceDiff)
 	result.Attributes = make(map[string]*terraform.ResourceAttrDiff)
@@ -411,10 +411,10 @@ func (m schemaMap) Diff(
 
 	// If this is a non-destroy diff, call any custom diff logic that has been
 	// defined.
-	if !result.DestroyTainted && review != nil {
+	if !result.DestroyTainted && customizeDiff != nil {
 		mc := m.DeepCopy()
 		rd := newResourceDiff(mc, c, s, result)
-		if err := review(rd, meta); err != nil {
+		if err := customizeDiff(rd, meta); err != nil {
 			return nil, err
 		}
 		for _, k := range rd.UpdatedKeys() {
@@ -451,10 +451,10 @@ func (m schemaMap) Diff(
 		}
 
 		// Re-run customization
-		if !result2.DestroyTainted && review != nil {
+		if !result2.DestroyTainted && customizeDiff != nil {
 			mc := m.DeepCopy()
 			rd := newResourceDiff(mc, c, d.state, result2)
-			if err := review(rd, meta); err != nil {
+			if err := customizeDiff(rd, meta); err != nil {
 				return nil, err
 			}
 			for _, k := range rd.UpdatedKeys() {

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -2826,7 +2827,46 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "overridden diff with a CustomizeDiff function",
+			Name: "overridden diff with a CustomizeDiff function, ForceNew not in schema",
+			Schema: map[string]*Schema{
+				"availability_zone": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"availability_zone": "foo",
+			},
+
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+				if err := d.SetNew("availability_zone", "bar"); err != nil {
+					return err
+				}
+				if err := d.ForceNew("availability_zone"); err != nil {
+					return err
+				}
+				return nil
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"availability_zone": &terraform.ResourceAttrDiff{
+						Old:         "",
+						New:         "bar",
+						RequiresNew: true,
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
+			Name: "overridden diff with a CustomizeDiff function, ForceNew in schema",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2860,6 +2900,215 @@ func TestSchemaMap_Diff(t *testing.T) {
 			},
 
 			Err: false,
+		},
+
+		{
+			Name: "required field with computed diff added with CustomizeDiff function",
+			Schema: map[string]*Schema{
+				"ami_id": &Schema{
+					Type:     TypeString,
+					Required: true,
+				},
+				"instance_id": &Schema{
+					Type:     TypeString,
+					Computed: true,
+				},
+			},
+
+			State: nil,
+
+			Config: map[string]interface{}{
+				"ami_id": "foo",
+			},
+
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+				if err := d.SetNew("instance_id", "bar"); err != nil {
+					return err
+				}
+				return nil
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"ami_id": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "foo",
+					},
+					"instance_id": &terraform.ResourceAttrDiff{
+						Old: "",
+						New: "bar",
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
+			Name: "Set ForceNew only marks the changing element as ForceNew - CustomizeDiffFunc edition",
+			Schema: map[string]*Schema{
+				"ports": &Schema{
+					Type:     TypeSet,
+					Optional: true,
+					Computed: true,
+					Elem:     &Schema{Type: TypeInt},
+					Set: func(a interface{}) int {
+						return a.(int)
+					},
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"ports.#": "3",
+					"ports.1": "1",
+					"ports.2": "2",
+					"ports.4": "4",
+				},
+			},
+
+			Config: map[string]interface{}{
+				"ports": []interface{}{5, 2, 6},
+			},
+
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+				if err := d.SetNew("ports", []interface{}{5, 2, 1}); err != nil {
+					return err
+				}
+				if err := d.ForceNew("ports"); err != nil {
+					return err
+				}
+				return nil
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"ports.#": &terraform.ResourceAttrDiff{
+						Old: "3",
+						New: "3",
+					},
+					"ports.1": &terraform.ResourceAttrDiff{
+						Old: "1",
+						New: "1",
+					},
+					"ports.2": &terraform.ResourceAttrDiff{
+						Old: "2",
+						New: "2",
+					},
+					"ports.5": &terraform.ResourceAttrDiff{
+						Old:         "",
+						New:         "5",
+						RequiresNew: true,
+					},
+					"ports.4": &terraform.ResourceAttrDiff{
+						Old:         "4",
+						New:         "0",
+						NewRemoved:  true,
+						RequiresNew: true,
+					},
+				},
+			},
+		},
+
+		{
+			Name:   "tainted resource does not run CustomizeDiffFunc",
+			Schema: map[string]*Schema{},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"id": "someid",
+				},
+				Tainted: true,
+			},
+
+			Config: map[string]interface{}{},
+
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+				return errors.New("diff customization should not have run")
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes:     map[string]*terraform.ResourceAttrDiff{},
+				DestroyTainted: true,
+			},
+
+			Err: false,
+		},
+
+		{
+			Name: "NewComputed based on a conditional with CustomizeDiffFunc",
+			Schema: map[string]*Schema{
+				"etag": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+				"version_id": &Schema{
+					Type:     TypeString,
+					Computed: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"etag":       "foo",
+					"version_id": "1",
+				},
+			},
+
+			Config: map[string]interface{}{
+				"etag": "bar",
+			},
+
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+				if d.HasChange("etag") {
+					d.SetNewComputed("version_id")
+				}
+				return nil
+			},
+
+			Diff: &terraform.InstanceDiff{
+				Attributes: map[string]*terraform.ResourceAttrDiff{
+					"etag": &terraform.ResourceAttrDiff{
+						Old: "foo",
+						New: "bar",
+					},
+					"version_id": &terraform.ResourceAttrDiff{
+						Old:         "1",
+						New:         "",
+						NewComputed: true,
+					},
+				},
+			},
+
+			Err: false,
+		},
+
+		{
+			Name: "vetoing a diff",
+			Schema: map[string]*Schema{
+				"foo": &Schema{
+					Type:     TypeString,
+					Optional: true,
+					Computed: true,
+				},
+			},
+
+			State: &terraform.InstanceState{
+				Attributes: map[string]string{
+					"foo": "bar",
+				},
+			},
+
+			Config: map[string]interface{}{
+				"foo": "baz",
+			},
+
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+				return fmt.Errorf("diff vetoed")
+			},
+
+			Err: true,
 		},
 	}
 

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -139,7 +139,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		State           *terraform.InstanceState
 		Config          map[string]interface{}
 		ConfigVariables map[string]ast.Variable
-		Review          ReviewFunc
+		CustomizeDiff   CustomizeDiffFunc
 		Diff            *terraform.InstanceDiff
 		Err             bool
 	}{
@@ -2827,7 +2827,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "overridden diff with a Review function, ForceNew not in schema",
+			Name: "overridden diff with a CustomizeDiff function, ForceNew not in schema",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2842,7 +2842,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"availability_zone": "foo",
 			},
 
-			Review: func(d *ResourceDiff, meta interface{}) error {
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("availability_zone", "bar"); err != nil {
 					return err
 				}
@@ -2866,7 +2866,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "overridden diff with a Review function, ForceNew in schema",
+			Name: "overridden diff with a CustomizeDiff function, ForceNew in schema",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2882,7 +2882,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"availability_zone": "foo",
 			},
 
-			Review: func(d *ResourceDiff, meta interface{}) error {
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("availability_zone", "bar"); err != nil {
 					return err
 				}
@@ -2903,7 +2903,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "required field with computed diff added with Review function",
+			Name: "required field with computed diff added with CustomizeDiff function",
 			Schema: map[string]*Schema{
 				"ami_id": &Schema{
 					Type:     TypeString,
@@ -2921,7 +2921,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"ami_id": "foo",
 			},
 
-			Review: func(d *ResourceDiff, meta interface{}) error {
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("instance_id", "bar"); err != nil {
 					return err
 				}
@@ -2945,7 +2945,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "Set ForceNew only marks the changing element as ForceNew - ReviewFunc edition",
+			Name: "Set ForceNew only marks the changing element as ForceNew - CustomizeDiffFunc edition",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -2971,7 +2971,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"ports": []interface{}{5, 2, 6},
 			},
 
-			Review: func(d *ResourceDiff, meta interface{}) error {
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("ports", []interface{}{5, 2, 1}); err != nil {
 					return err
 				}
@@ -3011,7 +3011,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name:   "tainted resource does not run ReviewFunc",
+			Name:   "tainted resource does not run CustomizeDiffFunc",
 			Schema: map[string]*Schema{},
 
 			State: &terraform.InstanceState{
@@ -3023,7 +3023,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			Config: map[string]interface{}{},
 
-			Review: func(d *ResourceDiff, meta interface{}) error {
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
 				return errors.New("diff customization should not have run")
 			},
 
@@ -3036,7 +3036,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "NewComputed based on a conditional with ReviewFunc",
+			Name: "NewComputed based on a conditional with CustomizeDiffFunc",
 			Schema: map[string]*Schema{
 				"etag": &Schema{
 					Type:     TypeString,
@@ -3060,7 +3060,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"etag": "bar",
 			},
 
-			Review: func(d *ResourceDiff, meta interface{}) error {
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
 				if d.HasChange("etag") {
 					d.SetNewComputed("version_id")
 				}
@@ -3104,7 +3104,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"foo": "baz",
 			},
 
-			Review: func(d *ResourceDiff, meta interface{}) error {
+			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
 				return fmt.Errorf("diff vetoed")
 			},
 
@@ -3125,7 +3125,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				}
 			}
 
-			d, err := schemaMap(tc.Schema).Diff(tc.State, terraform.NewResourceConfig(c), tc.Review, nil)
+			d, err := schemaMap(tc.Schema).Diff(tc.State, terraform.NewResourceConfig(c), tc.CustomizeDiff, nil)
 			if err != nil != tc.Err {
 				t.Fatalf("err: %s", err)
 			}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -5022,3 +5022,17 @@ func (e errorSort) Swap(i, j int) { e[i], e[j] = e[j], e[i] }
 func (e errorSort) Less(i, j int) bool {
 	return e[i].Error() < e[j].Error()
 }
+
+func TestSchemaMapDeepCopy(t *testing.T) {
+	schema := map[string]*Schema{
+		"foo": &Schema{
+			Type: TypeString,
+		},
+	}
+	source := schemaMap(schema)
+	dest := source.DeepCopy()
+	dest["foo"].ForceNew = true
+	if reflect.DeepEqual(source, dest) {
+		t.Fatalf("source and dest should not match")
+	}
+}

--- a/helper/schema/schema_test.go
+++ b/helper/schema/schema_test.go
@@ -139,7 +139,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		State           *terraform.InstanceState
 		Config          map[string]interface{}
 		ConfigVariables map[string]ast.Variable
-		CustomizeDiff   CustomizeDiffFunc
+		Review          ReviewFunc
 		Diff            *terraform.InstanceDiff
 		Err             bool
 	}{
@@ -2827,7 +2827,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "overridden diff with a CustomizeDiff function, ForceNew not in schema",
+			Name: "overridden diff with a Review function, ForceNew not in schema",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2842,7 +2842,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"availability_zone": "foo",
 			},
 
-			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+			Review: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("availability_zone", "bar"); err != nil {
 					return err
 				}
@@ -2866,7 +2866,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "overridden diff with a CustomizeDiff function, ForceNew in schema",
+			Name: "overridden diff with a Review function, ForceNew in schema",
 			Schema: map[string]*Schema{
 				"availability_zone": &Schema{
 					Type:     TypeString,
@@ -2882,7 +2882,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"availability_zone": "foo",
 			},
 
-			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+			Review: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("availability_zone", "bar"); err != nil {
 					return err
 				}
@@ -2903,7 +2903,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "required field with computed diff added with CustomizeDiff function",
+			Name: "required field with computed diff added with Review function",
 			Schema: map[string]*Schema{
 				"ami_id": &Schema{
 					Type:     TypeString,
@@ -2921,7 +2921,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"ami_id": "foo",
 			},
 
-			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+			Review: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("instance_id", "bar"); err != nil {
 					return err
 				}
@@ -2945,7 +2945,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "Set ForceNew only marks the changing element as ForceNew - CustomizeDiffFunc edition",
+			Name: "Set ForceNew only marks the changing element as ForceNew - ReviewFunc edition",
 			Schema: map[string]*Schema{
 				"ports": &Schema{
 					Type:     TypeSet,
@@ -2971,7 +2971,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"ports": []interface{}{5, 2, 6},
 			},
 
-			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+			Review: func(d *ResourceDiff, meta interface{}) error {
 				if err := d.SetNew("ports", []interface{}{5, 2, 1}); err != nil {
 					return err
 				}
@@ -3011,7 +3011,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name:   "tainted resource does not run CustomizeDiffFunc",
+			Name:   "tainted resource does not run ReviewFunc",
 			Schema: map[string]*Schema{},
 
 			State: &terraform.InstanceState{
@@ -3023,7 +3023,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 
 			Config: map[string]interface{}{},
 
-			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+			Review: func(d *ResourceDiff, meta interface{}) error {
 				return errors.New("diff customization should not have run")
 			},
 
@@ -3036,7 +3036,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 		},
 
 		{
-			Name: "NewComputed based on a conditional with CustomizeDiffFunc",
+			Name: "NewComputed based on a conditional with ReviewFunc",
 			Schema: map[string]*Schema{
 				"etag": &Schema{
 					Type:     TypeString,
@@ -3060,7 +3060,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"etag": "bar",
 			},
 
-			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+			Review: func(d *ResourceDiff, meta interface{}) error {
 				if d.HasChange("etag") {
 					d.SetNewComputed("version_id")
 				}
@@ -3104,7 +3104,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				"foo": "baz",
 			},
 
-			CustomizeDiff: func(d *ResourceDiff, meta interface{}) error {
+			Review: func(d *ResourceDiff, meta interface{}) error {
 				return fmt.Errorf("diff vetoed")
 			},
 
@@ -3125,7 +3125,7 @@ func TestSchemaMap_Diff(t *testing.T) {
 				}
 			}
 
-			d, err := schemaMap(tc.Schema).Diff(tc.State, terraform.NewResourceConfig(c), tc.CustomizeDiff, nil)
+			d, err := schemaMap(tc.Schema).Diff(tc.State, terraform.NewResourceConfig(c), tc.Review, nil)
 			if err != nil != tc.Err {
 				t.Fatalf("err: %s", err)
 			}

--- a/helper/schema/testing.go
+++ b/helper/schema/testing.go
@@ -18,7 +18,7 @@ func TestResourceDataRaw(
 	}
 
 	sm := schemaMap(schema)
-	diff, err := sm.Diff(nil, terraform.NewResourceConfig(c))
+	diff, err := sm.Diff(nil, terraform.NewResourceConfig(c), nil, nil)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -1151,6 +1151,62 @@ func TestInstanceDiffSame(t *testing.T) {
 			false,
 			"value mismatch: foo",
 		},
+
+		// Make sure that DestroyTainted diffs pass as well, especially when diff
+		// two works off of no state.
+		{
+			&InstanceDiff{
+				DestroyTainted: true,
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{
+						Old: "foo",
+						New: "foo",
+					},
+				},
+			},
+			&InstanceDiff{
+				DestroyTainted: true,
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{
+						Old: "",
+						New: "foo",
+					},
+				},
+			},
+			true,
+			"",
+		},
+		// RequiresNew in different attribute
+		{
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{
+						Old: "foo",
+						New: "foo",
+					},
+					"bar": &ResourceAttrDiff{
+						Old:         "bar",
+						New:         "baz",
+						RequiresNew: true,
+					},
+				},
+			},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{
+						Old: "",
+						New: "foo",
+					},
+					"bar": &ResourceAttrDiff{
+						Old:         "",
+						New:         "baz",
+						RequiresNew: true,
+					},
+				},
+			},
+			true,
+			"",
+		},
 	}
 
 	for i, tc := range cases {

--- a/terraform/diff_test.go
+++ b/terraform/diff_test.go
@@ -1131,6 +1131,26 @@ func TestInstanceDiffSame(t *testing.T) {
 			true,
 			"",
 		},
+		{
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{
+						Old: "1",
+						New: "2",
+					},
+				},
+			},
+			&InstanceDiff{
+				Attributes: map[string]*ResourceAttrDiff{
+					"foo": &ResourceAttrDiff{
+						Old: "1",
+						New: "3",
+					},
+				},
+			},
+			false,
+			"value mismatch: foo",
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This is far along enough now that I think putting in a PR is warranted :)

See #8769 for more details!

---

This adds a new object, `ResourceDiff`, to the schema package. This object, in conjunction with a function defined in `CustomizeDiff` in the resource schema, allows for the in-flight customization of a Terraform
diff after the initial diff has been performed.

Use cases for this functionality include:

 * Creating diffs off of computed values alone, for when a state transition requires action on a field that cannot be reasonably controlled via config
 * Leaning on the provider's API as much as possible when said provider has diff logic of its own (ie: Nomad)
 * Vetoing changes to the diff that could not be reasonably carried out (ie: illegal AWS RDS operations) by kicking back an error to the `CustomizeDiff` function, much like the other CRUD functions.

As part of this work, many internal diff functions have been moved to use a special `resourceDiffer` interface, to allow for shared functionality between `ResourceDiff` and `ResourceData`. This may be extended to the `DiffSuppressFunc` as well which would restrict use of `ResourceData` in `DiffSuppressFunc` to generally read-only fields.