### PR TITLE
[docs] update terraform configuration page to include backends

### DIFF
--- a/website/source/docs/configuration/terraform.html.md
+++ b/website/source/docs/configuration/terraform.html.md
@@ -29,11 +29,16 @@ terraform {
 
 The `terraform` block configures the behavior of Terraform itself.
 
-The currently only allowed configuration within this block is
-`required_version`. This setting specifies a set of version constraints
+The currently only allowed configurations within this block are
+`required_version` and `backend`.
+
+`required_version` specifies a set of version constraints
 that must be met to perform operations on this configuration. If the
 running Terraform version doesn't meet these constraints, an error
 is shown. See the section below dedicated to this option.
+
+See [backends](/docs/backends/index.html) for more detail on the `backend`
+configuration.
 
 **No value within the `terraform` block can use interpolations.** The
 `terraform` block is loaded very early in the execution of Terraform


### PR DESCRIPTION
Looking at the release notes for 0.9 it describes using a `backend` section in the `terraform` section of the terraform config.  The docs for the `terraform` section still assert that the only valid configuration element for that section is the `required_version`.

This change updates the `terraform` config section of the docs to remove the misleading comment and include a link over to the backends section of the config.