### PR TITLE
[docs] add parameter used to disable locking in the S3 backend

### DIFF
--- a/website/source/docs/backends/types/s3.html.md
+++ b/website/source/docs/backends/types/s3.html.md
@@ -92,6 +92,7 @@ The following configuration options or environment variables are supported:
  * `secret_key` / `AWS_SECRET_ACCESS_KEY` - (Optional) AWS secret access key.
  * `kms_key_id` - (Optional) The ARN of a KMS Key to use for encrypting
    the state.
+ * `lock` - (Optional) `false` to disable locking. This defaults to true, but will require permissions with DynamoDB to perform locking.
  * `lock_table` - (Optional) The name of a DynamoDB table to use for state
    locking. The table must have a primary key named LockID.
  * `profile` - (Optional) This is the AWS profile name as set in the


### PR DESCRIPTION
The 0.9 upgrading doc specifies that you can use `lock = false` to disable locking in the S3 and consul backends. The consul backend includes this parameter but the S3 docs do not.

This change adds the `lock` parameter to the list of valid backend parameters for the S3 backend.