### PR TITLE
provider/aws: Support import of aws_lambda_event_source_mapping

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_event_source_mapping.go
+++ b/builtin/providers/aws/resource_aws_lambda_event_source_mapping.go
@@ -19,53 +19,56 @@ func resourceAwsLambdaEventSourceMapping() *schema.Resource {
 		Read:   resourceAwsLambdaEventSourceMappingRead,
 		Update: resourceAwsLambdaEventSourceMappingUpdate,
 		Delete: resourceAwsLambdaEventSourceMappingDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 
 		Schema: map[string]*schema.Schema{
-			"event_source_arn": &schema.Schema{
+			"event_source_arn": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"function_name": &schema.Schema{
+			"function_name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"starting_position": &schema.Schema{
+			"starting_position": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"batch_size": &schema.Schema{
+			"batch_size": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  100,
 			},
-			"enabled": &schema.Schema{
+			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
-			"function_arn": &schema.Schema{
+			"function_arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"last_modified": &schema.Schema{
+			"last_modified": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"last_processing_result": &schema.Schema{
+			"last_processing_result": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"state": &schema.Schema{
+			"state": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"state_transition_reason": &schema.Schema{
+			"state_transition_reason": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"uuid": &schema.Schema{
+			"uuid": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
@@ -151,6 +154,7 @@ func resourceAwsLambdaEventSourceMappingRead(d *schema.ResourceData, meta interf
 	d.Set("state", eventSourceMappingConfiguration.State)
 	d.Set("state_transition_reason", eventSourceMappingConfiguration.StateTransitionReason)
 	d.Set("uuid", eventSourceMappingConfiguration.UUID)
+	d.Set("function_name", eventSourceMappingConfiguration.FunctionArn)
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_lambda_event_source_mapping_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_event_source_mapping_test.go
@@ -24,14 +24,14 @@ func TestAccAWSLambdaEventSourceMapping_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSLambdaEventSourceMappingConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
 					testAccCheckAWSLambdaEventSourceMappingAttributes(&conf),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSLambdaEventSourceMappingConfigUpdate(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),
@@ -52,6 +52,29 @@ func TestAccAWSLambdaEventSourceMapping_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaEventSourceMapping_importBasic(t *testing.T) {
+	resourceName := "aws_lambda_event_source_mapping.lambda_event_source_mapping_test"
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaEventSourceMappingConfig(rInt),
+			},
+
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled", "starting_position"},
+			},
+		},
+	})
+}
+
 func TestAccAWSLambdaEventSourceMapping_disappears(t *testing.T) {
 	var conf lambda.EventSourceMappingConfiguration
 
@@ -62,7 +85,7 @@ func TestAccAWSLambdaEventSourceMapping_disappears(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckLambdaEventSourceMappingDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSLambdaEventSourceMappingConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAwsLambdaEventSourceMappingExists("aws_lambda_event_source_mapping.lambda_event_source_mapping_test", &conf),

--- a/website/source/docs/providers/aws/r/lambda_event_source_mapping.html.markdown
+++ b/website/source/docs/providers/aws/r/lambda_event_source_mapping.html.markdown
@@ -45,3 +45,12 @@ resource "aws_lambda_event_source_mapping" "event_source_mapping" {
 
 [1]: http://docs.aws.amazon.com/lambda/latest/dg/welcome.html
 [2]: http://docs.aws.amazon.com/lambda/latest/dg/API_CreateEventSourceMapping.html
+
+
+## Import
+
+Lambda Event Source Mappings can be imported using the `UUID` (event source mapping identifier), e.g.
+
+```
+$ terraform import aws_lambda_event_source_mapping.event_source_mapping 12345kxodurf3443
+```


### PR DESCRIPTION
Fixes: #14017

```
% make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSLambdaEventSourceMapping_importBasic'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/29 00:36:31 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSLambdaEventSourceMapping_importBasic -timeout 120m
=== RUN   TestAccAWSLambdaEventSourceMapping_importBasic
--- PASS: TestAccAWSLambdaEventSourceMapping_importBasic (144.23s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	144.258s
```