### PR TITLE
provider/aws: ForceNew aws_launch_config on ebs_block_device change

### DIFF
--- a/builtin/providers/aws/resource_aws_launch_configuration.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration.go
@@ -211,13 +211,6 @@ func resourceAwsLaunchConfiguration() *schema.Resource {
 						},
 					},
 				},
-				Set: func(v interface{}) int {
-					var buf bytes.Buffer
-					m := v.(map[string]interface{})
-					buf.WriteString(fmt.Sprintf("%s-", m["device_name"].(string)))
-					buf.WriteString(fmt.Sprintf("%s-", m["snapshot_id"].(string)))
-					return hashcode.String(buf.String())
-				},
 			},
 
 			"ephemeral_block_device": {

--- a/builtin/providers/aws/resource_aws_launch_configuration_test.go
+++ b/builtin/providers/aws/resource_aws_launch_configuration_test.go
@@ -198,8 +198,35 @@ func TestAccAWSLaunchConfiguration_withEncryption(t *testing.T) {
 				Config: testAccAWSLaunchConfigurationWithEncryption,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
-
 					testAccCheckAWSLaunchConfigurationWithEncryption(&conf),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSLaunchConfiguration_updateEbsBlockDevices(t *testing.T) {
+	var conf autoscaling.LaunchConfiguration
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSLaunchConfigurationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLaunchConfigurationWithEncryption,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_launch_configuration.baz", "ebs_block_device.2764618555.volume_size", "9"),
+				),
+			},
+			{
+				Config: testAccAWSLaunchConfigurationWithEncryptionUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSLaunchConfigurationExists("aws_launch_configuration.baz", &conf),
+					resource.TestCheckResourceAttr(
+						"aws_launch_configuration.baz", "ebs_block_device.3859927736.volume_size", "10"),
 				),
 			},
 		},
@@ -444,6 +471,25 @@ resource "aws_launch_configuration" "baz" {
 	}
 }
 `
+
+const testAccAWSLaunchConfigurationWithEncryptionUpdated = `
+resource "aws_launch_configuration" "baz" {
+   image_id = "ami-5189a661"
+   instance_type = "t2.micro"
+   associate_public_ip_address = false
+
+   	root_block_device {
+   		volume_type = "gp2"
+		volume_size = 11
+	}
+	ebs_block_device {
+		device_name = "/dev/sdb"
+		volume_size = 10
+		encrypted = true
+	}
+}
+`
+
 const testAccAWSLaunchConfigurationConfig_withVpcClassicLink = `
 resource "aws_vpc" "foo" {
    cidr_block = "10.0.0.0/16"


### PR DESCRIPTION
Fixes: #14826

aws_launch_configuration ebs_block_device only had selected properties in the set hash. I removed these to allow any changes to the block device config to force a new resource

```
% make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSLaunchConfiguration_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/29 01:08:55 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSLaunchConfiguration_ -timeout 120m
=== RUN   TestAccAWSLaunchConfiguration_importBasic
--- PASS: TestAccAWSLaunchConfiguration_importBasic (32.89s)
=== RUN   TestAccAWSLaunchConfiguration_basic
--- PASS: TestAccAWSLaunchConfiguration_basic (44.34s)
=== RUN   TestAccAWSLaunchConfiguration_withBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_withBlockDevices (28.98s)
=== RUN   TestAccAWSLaunchConfiguration_updateRootBlockDevice
--- PASS: TestAccAWSLaunchConfiguration_updateRootBlockDevice (52.23s)
=== RUN   TestAccAWSLaunchConfiguration_withSpotPrice
--- PASS: TestAccAWSLaunchConfiguration_withSpotPrice (23.04s)
=== RUN   TestAccAWSLaunchConfiguration_withVpcClassicLink
--- PASS: TestAccAWSLaunchConfiguration_withVpcClassicLink (62.30s)
=== RUN   TestAccAWSLaunchConfiguration_withIAMProfile
--- PASS: TestAccAWSLaunchConfiguration_withIAMProfile (51.62s)
=== RUN   TestAccAWSLaunchConfiguration_withEncryption
--- PASS: TestAccAWSLaunchConfiguration_withEncryption (27.91s)
=== RUN   TestAccAWSLaunchConfiguration_updateEbsBlockDevices
--- PASS: TestAccAWSLaunchConfiguration_updateEbsBlockDevices (62.98s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	386.308s
```