### PR TITLE
[WIP] Allow specification of name for the initial add-on attachment

### DIFF
--- a/builtin/providers/heroku/resource_heroku_addon.go
+++ b/builtin/providers/heroku/resource_heroku_addon.go
@@ -115,7 +115,8 @@ func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if len(d.Get("attach_as").(string)) > 0 {
-		updateAttachment := heroku.AddOnAttachmentCreateOpts{Addon: d.Id(), App: app, Force: &true, Name: &d.Get("attach_as").(string)}
+		attachmentName := d.Get("attach_as").(string)
+		updateAttachment := heroku.AddOnAttachmentCreateOpts{Addon: d.Id(), App: app, Name: &attachmentName}
 
 		_, err = client.AddOnAttachmentCreate(context.TODO(), updateAttachment)
 		if err != nil {

--- a/builtin/providers/heroku/resource_heroku_addon.go
+++ b/builtin/providers/heroku/resource_heroku_addon.go
@@ -41,6 +41,12 @@ func resourceHerokuAddon() *schema.Resource {
 				Required: true,
 			},
 
+			"attach_as": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+
 			"config": {
 				Type:     schema.TypeList,
 				Optional: true,
@@ -84,6 +90,10 @@ func resourceHerokuAddonCreate(d *schema.ResourceData, meta interface{}) error {
 		}
 
 		opts.Config = &config
+	}
+
+	if d.Get("attach_as").(string) != nil {
+		opts.Name = d.Get("attach_as").(string)
 	}
 
 	log.Printf("[DEBUG] Addon create configuration: %#v, %#v", app, opts)


### PR DESCRIPTION
Currently with the Heroku CLI you can specify `--as` when creating an addon:
```
$ heroku addons:create -h
Usage: heroku addons:create SERVICE:PLAN

create an add-on resource

 -a, --app APP       # app to run command against
 -r, --remote REMOTE # git remote of app to run command against
 --as AS             # name for the initial add-on attachment
 --confirm CONFIRM   # overwrite existing config vars or existing add-on attachments
 --name NAME         # name for the add-on resource
 --wait              # watch add-on creation status and exit when complete
```

This PR adds the ability to specify this