### PR TITLE
[docs] clarify S3 locking in 0.9 upgrade guide and S3 backend

### DIFF
--- a/website/source/docs/backends/types/s3.html.md
+++ b/website/source/docs/backends/types/s3.html.md
@@ -13,7 +13,8 @@ description: |-
 Stores the state as a given key in a given bucket on
 [Amazon S3](https://aws.amazon.com/s3/).
 This backend also supports state locking via
-[Dynamo DB](https://aws.amazon.com/dynamodb/).
+[Dynamo DB](https://aws.amazon.com/dynamodb/). Enable locking by setting the
+`lock_table` key to a Dynamo DB table to use for the locks.
 
 ~> **Warning!** It is highly recommended that you enable
 [Bucket Versioning](http://docs.aws.amazon.com/AmazonS3/latest/UG/enable-bucket-versioning.html)
@@ -93,7 +94,8 @@ The following configuration options or environment variables are supported:
  * `kms_key_id` - (Optional) The ARN of a KMS Key to use for encrypting
    the state.
  * `lock_table` - (Optional) The name of a DynamoDB table to use for state
-   locking. The table must have a primary key named LockID.
+   locking. The table must have a primary key named LockID. If not present,
+   locking will be disabled.
  * `profile` - (Optional) This is the AWS profile name as set in the
    shared credentials file.
  * `shared_credentials_file`  - (Optional) This is the path to the

--- a/website/source/upgrade-guides/0-9.html.markdown
+++ b/website/source/upgrade-guides/0-9.html.markdown
@@ -62,12 +62,12 @@ use these backends, you can ignore this section.
 Specific notes for each affected backend:
 
   * **Amazon S3**: DynamoDB is used for locking. The AWS access keys
-    must have access to Dynamo. You may disable locking by specifying
-	`lock = false` in your backend configuration.
+    must have access to Dynamo. You may disable locking by omitting the
+    `lock_table` key in your backend configuration.
 
   * **HashiCorp Consul**: Sessions are used for locking. If an auth token
     is used it must have permissions to create and destroy sessions. You
-	may disable locking by specifying `lock = false` in your backend
-	configuration.
+    may disable locking by specifying `lock = false` in your backend
+    configuration.
 
 **Action:** Update your credentials or configuration if necessary.


### PR DESCRIPTION
The upgrade guide instructs us to use `lock = false` in the S3 backend config to disable locking. The [S3 schema](https://github.com/hashicorp/terraform/blob/master/backend/remote-state/s3/backend.go#L17-L134) does not have a `lock` key but if the `lock_table` key is missing (or the default empty string) [locking will be disabled](https://github.com/hashicorp/terraform/blob/master/backend/remote-state/s3/client.go#L185-L188).

Thanks @radeksimko and @oskarpearson for helping me find the right answer after PR #14896 and my attempts to add `lock` to my S3 backend failed.

This change updates the 0.9 upgrade guide that initially led me astray and adds a little more detail to the S3 backend page talking about locking.