### PR TITLE
provider/openstack: Allow numerical protocols in security group rules

### DIFF
--- a/builtin/providers/openstack/resource_openstack_networking_secgroup_rule_v2.go
+++ b/builtin/providers/openstack/resource_openstack_networking_secgroup_rule_v2.go
@@ -3,6 +3,7 @@ package openstack
 import (
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 	"time"
 
@@ -229,6 +230,8 @@ func resourceNetworkingSecGroupRuleV2DetermineEtherType(v string) rules.RuleEthe
 
 func resourceNetworkingSecGroupRuleV2DetermineProtocol(v string) rules.RuleProtocol {
 	var protocol rules.RuleProtocol
+
+	// Check and see if the requested protocol matched a list of known protocol names.
 	switch v {
 	case "tcp":
 		protocol = rules.ProtocolTCP
@@ -272,6 +275,14 @@ func resourceNetworkingSecGroupRuleV2DetermineProtocol(v string) rules.RuleProto
 		protocol = rules.ProtocolUDPLite
 	case "vrrp":
 		protocol = rules.ProtocolVRRP
+	}
+
+	// If the protocol wasn't matched above, see if it's an integer.
+	if protocol == "" {
+		_, err := strconv.Atoi(v)
+		if err == nil {
+			protocol = rules.RuleProtocol(v)
+		}
 	}
 
 	return protocol

--- a/builtin/providers/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
+++ b/builtin/providers/openstack/resource_openstack_networking_secgroup_rule_v2_test.go
@@ -194,6 +194,30 @@ func TestAccNetworkingV2SecGroupRule_protocols(t *testing.T) {
 	})
 }
 
+func TestAccNetworkingV2SecGroupRule_numericProtocol(t *testing.T) {
+	var secgroup_1 groups.SecGroup
+	var secgroup_rule_1 rules.SecGroupRule
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckNetworkingV2SecGroupRuleDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccNetworkingV2SecGroupRule_numericProtocol,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckNetworkingV2SecGroupExists(
+						"openstack_networking_secgroup_v2.secgroup_1", &secgroup_1),
+					testAccCheckNetworkingV2SecGroupRuleExists(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_1", &secgroup_rule_1),
+					resource.TestCheckResourceAttr(
+						"openstack_networking_secgroup_rule_v2.secgroup_rule_1", "protocol", "115"),
+				),
+			},
+		},
+	})
+}
+
 func testAccCheckNetworkingV2SecGroupRuleDestroy(s *terraform.State) error {
 	config := testAccProvider.Meta().(*Config)
 	networkingClient, err := config.networkingV2Client(OS_REGION_NAME)
@@ -482,6 +506,23 @@ resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_vrrp" {
   direction = "ingress"
   ethertype = "IPv4"
   protocol = "vrrp"
+  remote_ip_prefix = "0.0.0.0/0"
+  security_group_id = "${openstack_networking_secgroup_v2.secgroup_1.id}"
+}
+`
+
+const testAccNetworkingV2SecGroupRule_numericProtocol = `
+resource "openstack_networking_secgroup_v2" "secgroup_1" {
+  name = "secgroup_1"
+  description = "terraform security group rule acceptance test"
+}
+
+resource "openstack_networking_secgroup_rule_v2" "secgroup_rule_1" {
+  direction = "ingress"
+  ethertype = "IPv4"
+  port_range_max = 22
+  port_range_min = 22
+  protocol = "115"
   remote_ip_prefix = "0.0.0.0/0"
   security_group_id = "${openstack_networking_secgroup_v2.secgroup_1.id}"
 }


### PR DESCRIPTION
This commit enables a user to specify protocols in numerical form
when creating security group rules.

Based on the comment here: https://github.com/hashicorp/terraform/pull/14307#issuecomment-304747731

cc @jaydub
