### PR TITLE
provider/aws: Run Configure as part of testAccPreCheck

### DIFF
--- a/builtin/providers/aws/provider_test.go
+++ b/builtin/providers/aws/provider_test.go
@@ -46,4 +46,8 @@ func testAccPreCheck(t *testing.T) {
 		log.Println("[INFO] Test: Using us-west-2 as test region")
 		os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
 	}
+	err := testAccProvider.Configure(terraform.NewResourceConfig(nil))
+	if err != nil {
+		t.Fatal(err)
+	}
 }


### PR DESCRIPTION
This is to avoid crash caused by casting `nil` to `*AWSClient` when running test with wrong `AWS_PROFILE` which doesn't exist.

The crash is probably harmless as it appears at the very beginning before any API call is made, but still something worth fixing, IMO.