### PR TITLE
provider/aws: Avoid crash when EgressOnly IGW disappears

### DIFF
--- a/builtin/providers/aws/resource_aws_egress_only_internet_gateway.go
+++ b/builtin/providers/aws/resource_aws_egress_only_internet_gateway.go
@@ -74,6 +74,9 @@ func EIGWStateRefreshFunc(conn *ec2.EC2, id string) resource.StateRefreshFunc {
 				return nil, "", err
 			}
 		}
+		if len(resp.EgressOnlyInternetGateways) < 1 {
+			resp = nil
+		}
 
 		if resp == nil {
 			// Sometimes AWS just has consistency issues and doesn't see


### PR DESCRIPTION
This is to avoid the following intermittent test failure:

```
=== RUN   TestAccAWSRoute_ipv6Support

------- Stderr: -------
panic: runtime error: index out of range

goroutine 499 [running]:
github.com/hashicorp/terraform/builtin/providers/aws.EIGWStateRefreshFunc.func1(0xc42000e0c0, 0xc4204b4680, 0x16, 0xc4204b4a00, 0x24b5c40, 0xc4203c5c70)
    /opt/teamcity-agent/work/aed1168611c3040/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_egress_only_internet_gateway.go:84 +0x1a2
github.com/hashicorp/terraform/builtin/providers/aws.resourceAwsEgressOnlyInternetGatewayCreate.func1(0x2)
    /opt/teamcity-agent/work/aed1168611c3040/src/github.com/hashicorp/terraform/builtin/providers/aws/resource_aws_egress_only_internet_gateway.go:45 +0x6e
github.com/hashicorp/terraform/helper/resource.Retry.func1(0x0, 0x0, 0x0, 0x0, 0x0, 0x0)
    /opt/teamcity-agent/work/aed1168611c3040/src/github.com/hashicorp/terraform/helper/resource/wait.go:22 +0x78
github.com/hashicorp/terraform/helper/resource.(*StateChangeConf).WaitForState.func1(0xc4206c6720, 0xc4207821c0, 0xc4206e0880, 0xc4206c6780, 0xc420366718, 0xc420366710)
    /opt/teamcity-agent/work/aed1168611c3040/src/github.com/hashicorp/terraform/helper/resource/state.go:103 +0x1c8
created by github.com/hashicorp/terraform/helper/resource.(*StateChangeConf).WaitForState
    /opt/teamcity-agent/work/aed1168611c3040/src/github.com/hashicorp/terraform/helper/resource/state.go:195 +0x249
```