### PR TITLE
Use CAS to Put consul state, and reacquire locks when necessary

### DIFF
--- a/backend/remote-state/consul/backend_state.go
+++ b/backend/remote-state/consul/backend_state.go
@@ -91,9 +91,10 @@ func (b *Backend) State(name string) (state.State, error) {
 	// Build the state client
 	var stateMgr state.State = &remote.State{
 		Client: &RemoteClient{
-			Client: client,
-			Path:   path,
-			GZip:   gzip,
+			Client:    client,
+			Path:      path,
+			GZip:      gzip,
+			lockState: b.lock,
 		},
 	}
 


### PR DESCRIPTION
Consul locks favor liveness, and when a client can't maintain it's session the lock is automatically released. 

Since it isn't possible for Terraform to ensure that a lock is not lost at any point during execution, the only option is to attempt to reacquire the lock. When a consul lock is taken, start a goroutine to monitor the lock status channel and attempt to reacquire the lock immediately if it is lost. 

This also converts the state Put operation to a CAS, which ensures that the state is always consistent, regardless of the state of the lock.

fixes #14312
