### PR TITLE
[WIP] Icanhazip data source

### DIFF
--- a/builtin/bins/provider-icanhazip/main.go
+++ b/builtin/bins/provider-icanhazip/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"github.com/hashicorp/terraform/builtin/providers/icanhazip"
+	"github.com/hashicorp/terraform/plugin"
+)
+
+func main() {
+	plugin.Serve(&plugin.ServeOpts{
+		ProviderFunc: icanhazip.Provider,
+	})
+}

--- a/builtin/providers/icanhazip/data_source_ip_address.go
+++ b/builtin/providers/icanhazip/data_source_ip_address.go
@@ -5,11 +5,13 @@ import (
 	"io/ioutil"
 	"log"
 	"strconv"
+	"strings"
 
-	"github.com/hashicorp/go-cleanhttp"
 	"github.com/hashicorp/terraform/helper/hashcode"
 	"github.com/hashicorp/terraform/helper/schema"
-	"strings"
+	"github.com/hashicorp/terraform/helper/validation"
+
+	cleanhttp "github.com/hashicorp/go-cleanhttp"
 )
 
 func dataSourceIcanhazipIPAddress() *schema.Resource {
@@ -20,6 +22,12 @@ func dataSourceIcanhazipIPAddress() *schema.Resource {
 			"ip_address": &schema.Schema{
 				Type:     schema.TypeString,
 				Computed: true,
+			},
+			"version": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				Default:      "ipv4",
+				ValidateFunc: validation.StringInSlice([]string{"ipv4", "ipv6"}, true),
 			},
 		},
 	}

--- a/builtin/providers/icanhazip/data_source_ip_address.go
+++ b/builtin/providers/icanhazip/data_source_ip_address.go
@@ -1,0 +1,59 @@
+package icanhazip
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
+)
+
+func dataSourceIcanhazipIPAddress() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceIcanhazipIPAddressRead,
+
+		Schema: map[string]*schema.Schema{
+			"ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceIcanhazipIPAddressRead(d *schema.ResourceData, meta interface{}) error {
+
+	conn := cleanhttp.DefaultClient()
+
+	version := d.Get("version").(string)
+
+	log.Printf("[DEBUG] Fetching %s IP address", version)
+
+	res, err := conn.Get(fmt.Sprintf("https://%s.icanhazip.com/", version))
+
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve %s IP address: %s", version, err)
+	}
+
+	defer res.Body.Close()
+
+	data, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return fmt.Errorf("Error reading response body: %s", err)
+	}
+
+	d.SetId(strconv.Itoa(hashcode.String(string(data))))
+
+	result := strings.Trim(string(data), "\n")
+
+	if err := d.Set("ip_address", result); err != nil {
+		return fmt.Errorf("Error setting ip address: %s", err)
+	}
+
+	return nil
+}

--- a/builtin/providers/icanhazip/data_source_ip_address_test.go
+++ b/builtin/providers/icanhazip/data_source_ip_address_test.go
@@ -3,6 +3,7 @@ package icanhazip
 import (
 	"fmt"
 	"net"
+	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform/helper/resource"
@@ -19,6 +20,19 @@ func TestAccIcanhazipIPAddress_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccIcanhazipIPAddress("data.icanhazip_ipaddress.localip"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccIcanhazipIPAddress_invalidversion(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      testAccIcanhazipIPAddressConfigInvalidVersion,
+				ExpectError: regexp.MustCompile("got invalid"),
 			},
 		},
 	})
@@ -42,4 +56,8 @@ func testAccIcanhazipIPAddress(n string) resource.TestCheckFunc {
 
 const testAccIcanhazipIPAddressConfig = `
 data "icanhazip_ipaddress" "localip" { }
+`
+
+const testAccIcanhazipIPAddressConfigInvalidVersion = `
+data "icanhazip_ipaddress" "bogus_version" { version = "invalid" }
 `

--- a/builtin/providers/icanhazip/data_source_ip_address_test.go
+++ b/builtin/providers/icanhazip/data_source_ip_address_test.go
@@ -1,0 +1,45 @@
+package icanhazip
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccIcanhazipIPAddress_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccIcanhazipIPAddressConfig,
+				Check: resource.ComposeTestCheckFunc(
+					testAccIcanhazipIPAddress("data.icanhazip_ipaddress.localip"),
+				),
+			},
+		},
+	})
+}
+
+func testAccIcanhazipIPAddress(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		r := s.RootModule().Resources[n]
+		a := r.Primary.Attributes
+
+		ipaddress := a["ip_address"]
+
+		if ip := net.ParseIP(ipaddress); ip == nil {
+			return fmt.Errorf("Not a valid IP address: %s", ipaddress)
+		}
+
+		return nil
+	}
+}
+
+const testAccIcanhazipIPAddressConfig = `
+data "icanhazip_ipaddress" "localip" { }
+`

--- a/builtin/providers/icanhazip/data_source_ip_address_test.go
+++ b/builtin/providers/icanhazip/data_source_ip_address_test.go
@@ -14,7 +14,7 @@ func TestAccIcanhazipIPAddress_basic(t *testing.T) {
 		PreCheck:  func() { testAccPreCheck(t) },
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccIcanhazipIPAddressConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccIcanhazipIPAddress("data.icanhazip_ipaddress.localip"),

--- a/builtin/providers/icanhazip/provider.go
+++ b/builtin/providers/icanhazip/provider.go
@@ -1,0 +1,15 @@
+package icanhazip
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+// Provider returns a terraform.ResourceProvider.
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		DataSourcesMap: map[string]*schema.Resource{
+			"icanhazip_ipaddress": dataSourceIcanhazipIPAddress(),
+		},
+	}
+}

--- a/builtin/providers/icanhazip/provider_test.go
+++ b/builtin/providers/icanhazip/provider_test.go
@@ -1,0 +1,30 @@
+package icanhazip
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"icanhazip": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func TestProvider_impl(t *testing.T) {
+	var _ terraform.ResourceProvider = Provider()
+}
+
+func testAccPreCheck(t *testing.T) {}

--- a/command/internal_plugin_list.go
+++ b/command/internal_plugin_list.go
@@ -36,6 +36,7 @@ import (
 	grafanaprovider "github.com/hashicorp/terraform/builtin/providers/grafana"
 	herokuprovider "github.com/hashicorp/terraform/builtin/providers/heroku"
 	httpprovider "github.com/hashicorp/terraform/builtin/providers/http"
+	icanhazipprovider "github.com/hashicorp/terraform/builtin/providers/icanhazip"
 	icinga2provider "github.com/hashicorp/terraform/builtin/providers/icinga2"
 	ignitionprovider "github.com/hashicorp/terraform/builtin/providers/ignition"
 	influxdbprovider "github.com/hashicorp/terraform/builtin/providers/influxdb"
@@ -120,6 +121,7 @@ var InternalProviders = map[string]plugin.ProviderFunc{
 	"grafana":      grafanaprovider.Provider,
 	"heroku":       herokuprovider.Provider,
 	"http":         httpprovider.Provider,
+	"icanhazip":    icanhazipprovider.Provider,
 	"icinga2":      icinga2provider.Provider,
 	"ignition":     ignitionprovider.Provider,
 	"influxdb":     influxdbprovider.Provider,

--- a/website/source/docs/providers/icanhazip/ip_address.html.markdown
+++ b/website/source/docs/providers/icanhazip/ip_address.html.markdown
@@ -1,0 +1,38 @@
+---
+layout: "icanhazip"
+page_title: "icanhazip: icanhazip_ip_address"
+sidebar_current: "docs-icanhazip-datasource-ip_address"
+description: |-
+  Get your external IP IPv4 or IPv6 Address.
+---
+
+# icanhazip\_ip_address
+
+Use this data source to get the IP address you appear as on the internet.
+
+## Example Usage
+
+```hcl
+data "icanhazip_ipaddress" "localip" { }
+
+resource "aws_security_group" "from_office" {
+  name = "from_office"
+
+  ingress {
+    from_port   = "22"
+    to_port     = "22"
+    protocol    = "tcp"
+    cidr_blocks = ["${data.icanhazip_ipaddress.localip.ip_address}/32"]
+  }
+}
+```
+
+## Argument Reference
+
+* `version` - (Optional) The version of the IP protocol to fetch your IP address
+  for. Valid versions are `ipv4`, the default, and `ipv6`.
+
+## Attributes Reference
+
+* `ip_address` - The IP address you present to the internet.
+

--- a/website/source/layouts/icanhazip.erb
+++ b/website/source/layouts/icanhazip.erb
@@ -1,0 +1,23 @@
+<% wrap_layout :inner do %>
+    <% content_for :sidebar do %>
+        <div class="docs-sidebar hidden-print affix-top" role="complementary">
+            <ul class="nav docs-sidenav">
+                <li<%= sidebar_current("docs-home") %>>
+                    <a href="/docs/providers/index.html">All Providers</a>
+                </li>
+
+                <li<%= sidebar_current("docs-icanhazip-datasource") %>>
+                <a href="#">Data Sources</a>
+                    <ul class="nav nav-visible">
+                        <li<%= sidebar_current("docs-icanhazip-datasource-ip_address") %>>
+                            <a href="/docs/providers/icanhazip/d/ip_address.html">icanhazip_ip_address</a>
+                        </li>
+                    </ul>
+                </li>
+
+            </ul>
+        </div>
+    <% end %>
+
+    <%= yield %>
+<% end %>


### PR DESCRIPTION
I often need to have my AWS security groups update their "from" lines to suit the IP my ISP has assigned me. While this can be done out of bounds, or via a local exec, I'd rather have Terraform manage this via a data source.

Any feedback would be greatly welcomed.