### PR TITLE
Replace lock_table with dynamodb_table in S3 backend config

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -81,6 +81,14 @@ func New() backend.Backend {
 				Optional:    true,
 				Description: "DynamoDB table for state locking",
 				Default:     "",
+				Deprecated:  "please use the dynamodb_table attribute",
+			},
+
+			"dynamodb_table": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "DynamoDB table for state locking and consistency",
+				Default:     "",
 			},
 
 			"profile": {
@@ -151,7 +159,7 @@ type Backend struct {
 	serverSideEncryption bool
 	acl                  string
 	kmsKeyID             string
-	lockTable            string
+	ddbTable             string
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -167,7 +175,12 @@ func (b *Backend) configure(ctx context.Context) error {
 	b.serverSideEncryption = data.Get("encrypt").(bool)
 	b.acl = data.Get("acl").(string)
 	b.kmsKeyID = data.Get("kms_key_id").(string)
-	b.lockTable = data.Get("lock_table").(string)
+
+	b.ddbTable = data.Get("dynamodb_table").(string)
+	if b.ddbTable == "" {
+		// try the depracted field
+		b.ddbTable = data.Get("lock_table").(string)
+	}
 
 	cfg := &terraformAWS.Config{
 		AccessKey:             data.Get("access_key").(string),

--- a/backend/remote-state/s3/backend_state.go
+++ b/backend/remote-state/s3/backend_state.go
@@ -96,7 +96,7 @@ func (b *Backend) State(name string) (state.State, error) {
 		serverSideEncryption: b.serverSideEncryption,
 		acl:                  b.acl,
 		kmsKeyID:             b.kmsKeyID,
-		lockTable:            b.lockTable,
+		ddbTable:             b.ddbTable,
 	}
 
 	stateMgr := &remote.State{Client: client}

--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -34,11 +34,11 @@ func TestBackend_impl(t *testing.T) {
 func TestBackendConfig(t *testing.T) {
 	testACC(t)
 	config := map[string]interface{}{
-		"region":     "us-west-1",
-		"bucket":     "tf-test",
-		"key":        "state",
-		"encrypt":    true,
-		"lock_table": "dynamoTable",
+		"region":         "us-west-1",
+		"bucket":         "tf-test",
+		"key":            "state",
+		"encrypt":        true,
+		"dynamodb_table": "dynamoTable",
 	}
 
 	b := backend.TestBackendConfig(t, New(), config).(*Backend)
@@ -90,17 +90,17 @@ func TestBackendLocked(t *testing.T) {
 	keyName := "test/state"
 
 	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"encrypt":    true,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"encrypt":        true,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"encrypt":    true,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"encrypt":        true,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
@@ -139,7 +139,7 @@ func TestBackendExtraPaths(t *testing.T) {
 		serverSideEncryption: b.serverSideEncryption,
 		acl:                  b.acl,
 		kmsKeyID:             b.kmsKeyID,
-		lockTable:            b.lockTable,
+		ddbTable:             b.ddbTable,
 	}
 
 	stateMgr := &remote.State{Client: client}

--- a/backend/remote-state/s3/client_test.go
+++ b/backend/remote-state/s3/client_test.go
@@ -47,17 +47,17 @@ func TestRemoteClientLocks(t *testing.T) {
 	keyName := "testState"
 
 	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"encrypt":    true,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"encrypt":        true,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"encrypt":    true,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"encrypt":        true,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
@@ -85,17 +85,17 @@ func TestForceUnlock(t *testing.T) {
 	keyName := "testState"
 
 	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"encrypt":    true,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"encrypt":        true,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"encrypt":    true,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"encrypt":        true,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
@@ -162,9 +162,9 @@ func TestRemoteClient_clientMD5(t *testing.T) {
 	keyName := "testState"
 
 	b := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	createS3Bucket(t, b.s3Client, bucketName)
@@ -210,9 +210,9 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 	keyName := "testState"
 
 	b1 := backend.TestBackendConfig(t, New(), map[string]interface{}{
-		"bucket":     bucketName,
-		"key":        keyName,
-		"lock_table": bucketName,
+		"bucket":         bucketName,
+		"key":            keyName,
+		"dynamodb_table": bucketName,
 	}).(*Backend)
 
 	createS3Bucket(t, b1.s3Client, bucketName)
@@ -238,7 +238,7 @@ func TestRemoteClient_stateChecksum(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Use b2 without a lock_table to bypass the lock table to write the state directly.
+	// Use b2 without a dynamodb_table to bypass the lock table to write the state directly.
 	// client2 will write the "incorrect" state, simulating s3 eventually consistency delays
 	b2 := backend.TestBackendConfig(t, New(), map[string]interface{}{
 		"bucket": bucketName,

--- a/website/source/docs/backends/types/s3.html.md
+++ b/website/source/docs/backends/types/s3.html.md
@@ -93,9 +93,10 @@ The following configuration options or environment variables are supported:
  * `secret_key` / `AWS_SECRET_ACCESS_KEY` - (Optional) AWS secret access key.
  * `kms_key_id` - (Optional) The ARN of a KMS Key to use for encrypting
    the state.
- * `lock_table` - (Optional) The name of a DynamoDB table to use for state
-   locking. The table must have a primary key named LockID. If not present,
-   locking will be disabled.
+ * `lock_table` - (Optional, Deprecated) Use `dynamodb_table` instead.
+ * `dynamodb_table` - (Optional) The name of a DynamoDB table to use for state
+   locking and consistency. The table must have a primary key named LockID. If
+   not present, locking will be disabled.
  * `profile` - (Optional) This is the AWS profile name as set in the
    shared credentials file.
  * `shared_credentials_file`  - (Optional) This is the path to the
@@ -103,4 +104,7 @@ The following configuration options or environment variables are supported:
    `~/.aws/credentials` will be used.
  * `token` - (Optional) Use this to set an MFA token. It can also be
    sourced from the `AWS_SESSION_TOKEN` environment variable.
- * `role_arn` - (Optional) The role to be assumed
+ * `role_arn` - (Optional) The role to be assumed.
+ * `assume_role_policy` - (Optional) The permissions applied when assuming a role.
+ * `external_id` - (Optional) The external ID to use when assuming the role.
+ * `session_name` - (Optional) The session name to use when assuming the role.


### PR DESCRIPTION
Since the DynamoDB table used by the S3 backend is no longer only used
for locks, rename it in the config to remove any confusion about it
being lock-specific.

Update the docs and add missing `assume_role_policy`, `external_id`, and `session_name` parameters too.