### PR TITLE
provider/aws: Expect exception on deletion of APIG Usage Plan Key

### DIFF
--- a/builtin/providers/aws/resource_aws_api_gateway_usage_plan_key.go
+++ b/builtin/providers/aws/resource_aws_api_gateway_usage_plan_key.go
@@ -102,8 +102,10 @@ func resourceAwsApiGatewayUsagePlanKeyDelete(d *schema.ResourceData, meta interf
 			UsagePlanId: aws.String(d.Get("usage_plan_id").(string)),
 			KeyId:       aws.String(d.Get("key_id").(string)),
 		})
-
 		if err == nil {
+			return nil
+		}
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == "NotFoundException" {
 			return nil
 		}
 


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSAPIGatewayUsagePlanKey_basic
--- FAIL: TestAccAWSAPIGatewayUsagePlanKey_basic (26.11s)
    testing.go:280: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_api_gateway_usage_plan_key.main (destroy): 1 error(s) occurred:
        
        * aws_api_gateway_usage_plan_key.main: NotFoundException: Invalid Usage Plan ID specified
            status code: 404, request id: f4b3accd-45c1-11e7-8092-e564314c0a39
```