### PR TITLE
provider/aws: Work around IAM eventual consistency in CW Log Subs

### DIFF
--- a/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter.go
+++ b/builtin/providers/aws/resource_aws_cloudwatch_log_subscription_filter.go
@@ -75,6 +75,9 @@ func resourceAwsCloudwatchLogSubscriptionFilterCreate(d *schema.ResourceData, me
 			if strings.Contains(awsErr.Message(), "Could not deliver test message to specified") {
 				return resource.RetryableError(err)
 			}
+			if strings.Contains(awsErr.Message(), "Could not execute the lambda function") {
+				return resource.RetryableError(err)
+			}
 			resource.NonRetryableError(err)
 		}
 


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSCloudwatchLogSubscriptionFilter_basic
--- FAIL: TestAccAWSCloudwatchLogSubscriptionFilter_basic (22.19s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: 1 error(s) occurred:
        
        * aws_cloudwatch_log_subscription_filter.test_lambdafunction_logfilter: InvalidParameterException: Could not execute the lambda function. Make sure you have given CloudWatch Logs permission to execute your function.
            status code: 400, request id: e0a09920-45c3-11e7-990c-8b94632d80c0
```