### PR TITLE
provider/aws: Fix panic on nil dead_letter_config

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -263,6 +263,10 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 	if v, ok := d.GetOk("dead_letter_config"); ok {
 		dlcMaps := v.([]interface{})
 		if len(dlcMaps) == 1 { // Schema guarantees either 0 or 1
+			// Prevent panic on nil dead_letter_config. See GH-14961
+			if dlcMaps[0] == nil {
+				return fmt.Errorf("Nil dead_letter_config supplied for function: %s", functionName)
+			}
 			dlcMap := dlcMaps[0].(map[string]interface{})
 			params.DeadLetterConfig = &lambda.DeadLetterConfig{
 				TargetArn: aws.String(dlcMap["target_arn"].(string)),

--- a/builtin/providers/aws/resource_aws_lambda_function_test.go
+++ b/builtin/providers/aws/resource_aws_lambda_function_test.go
@@ -232,6 +232,24 @@ func TestAccAWSLambdaFunction_DeadLetterConfig(t *testing.T) {
 	})
 }
 
+func TestAccAWSLambdaFunction_nilDeadLetterConfig(t *testing.T) {
+	rSt := acctest.RandString(5)
+	rName := fmt.Sprintf("tf_test_%s", rSt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckLambdaFunctionDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSLambdaConfigWithNilDeadLetterConfig(rName, rSt),
+				ExpectError: regexp.MustCompile(
+					fmt.Sprintf("Nil dead_letter_config supplied for function: %s", rName)),
+			},
+		},
+	})
+}
+
 func TestAccAWSLambdaFunction_tracingConfig(t *testing.T) {
 	var conf lambda.GetFunctionOutput
 
@@ -1133,6 +1151,22 @@ resource "aws_sns_topic" "lambda_function_test" {
 }
 
 `, rName, rName)
+}
+
+func testAccAWSLambdaConfigWithNilDeadLetterConfig(rName, rSt string) string {
+	return fmt.Sprintf(baseAccAWSLambdaConfig(rSt)+`
+resource "aws_lambda_function" "lambda_function_test" {
+    filename = "test-fixtures/lambdatest.zip"
+    function_name = "%s"
+    role = "${aws_iam_role.iam_for_lambda.arn}"
+    handler = "exports.example"
+    runtime = "nodejs4.3"
+
+    dead_letter_config {
+        target_arn = ""
+    }
+}
+`, rName)
 }
 
 func testAccAWSLambdaConfigWithVPC(rName, rSt string) string {


### PR DESCRIPTION
Fixes a panic where specifying a nil `target_arn` for a `dead_letter_config` inside the `aws_lambda_function` resource would throw a panic.
Now, we return a nice error to the user instead of throwing a panic and stacktrace.

```
$ make testacc TEST=./builtin/providers/aws TESTARGS="-run=TestAccAWSLambdaFunction_nilDeadLetterConfig"
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/05/31 10:22:26 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws -v -run=TestAccAWSLambdaFunction_nilDeadLetterConfig -timeout 120m
=== RUN   TestAccAWSLambdaFunction_nilDeadLetterConfig
--- PASS: TestAccAWSLambdaFunction_nilDeadLetterConfig (20.86s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/aws    20.884s
```
Fixes: #14961 