### PR TITLE
provider/aws: Add aws_ssm_path_* to aws.erb

### DIFF
--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1313,6 +1313,14 @@
                             <a href="/docs/providers/aws/r/ssm_maintenance_window_task.html">aws_ssm_maintenance_window_task</a>
                         </li>
 
+                        <li<%= sidebar_current("docs-aws-resource-ssm-patch-baseline") %>>
+                            <a href="/docs/providers/aws/r/ssm_patch_baseline.html">aws_ssm_patch_baseline</a>
+                        </li>
+
+                        <li<%= sidebar_current("docs-aws-resource-ssm-patch-group") %>>
+                            <a href="/docs/providers/aws/r/ssm_patch_group.html">aws_ssm_patch_group</a>
+                        </li>
+
                     </ul>
                 </li>
 


### PR DESCRIPTION
Original PR didn't add the docs to the aws.erb - so this is a follow up of that