### PR TITLE
docs/google: Add "list" to tags description

### DIFF
--- a/website/source/docs/providers/google/r/compute_instance.html.markdown
+++ b/website/source/docs/providers/google/r/compute_instance.html.markdown
@@ -100,7 +100,7 @@ The following arguments are supported:
 * `service_account` - (Optional) Service account to attach to the instance.
     Structure is documented below.
 
-* `tags` - (Optional) Tags to attach to the instance.
+* `tags` - (Optional) A list of tags to attach to the instance.
 
 * `create_timeout` - (Optional) Configurable timeout in minutes for creating instances. Default is 4 minutes.
     Changing this forces a new resource to be created.


### PR DESCRIPTION
The tags argument requires a list in order to work.