### PR TITLE
Add missing ID from ElasticBeanstalk docs

### DIFF
--- a/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
+++ b/website/source/docs/providers/aws/r/elastic_beanstalk_environment.html.markdown
@@ -108,6 +108,7 @@ resource "aws_elastic_beanstalk_environment" "tfenvtest" {
 
 The following attributes are exported:
 
+* `id` - ID of the Elastic Beanstalk Environment.
 * `name` - Name of the Elastic Beanstalk Environment.
 * `description` - Description of the Elastic Beanstalk Environment.
 * `tier` - The environment tier specified.


### PR DESCRIPTION
This fixes the missing `id` attribute on the documentation.  The attribute exists if called via `"${aws_elastic_beanstalk_environment.myapp-environment.id}"`, but is just not documented.