### PR TITLE
provider/aws: Updated awsconfig_config_rule documentation

### DIFF
--- a/website/source/docs/providers/aws/r/config_config_rule.html.markdown
+++ b/website/source/docs/providers/aws/r/config_config_rule.html.markdown
@@ -77,7 +77,7 @@ The following arguments are supported:
 
 * `name` - (Required) The name of the rule
 * `description` - (Optional) Description of the rule
-* `input_parameters` - (Optional) A string in JSON format that is passed to the AWS Config rule Lambda function (only valid if `source.owner` is `CUSTOM_LAMBDA`).
+* `input_parameters` - (Optional) A string in JSON format that is passed to the AWS Config rule Lambda function.
 * `maximum_execution_frequency` - (Optional) The maximum frequency with which AWS Config runs evaluations for a rule.
 * `scope` - (Optional) Scope defines which resources can trigger an evaluation for the rule as documented below.
 * `source` - (Required) Source specifies the rule owner, the rule identifier, and the notifications that cause


### PR DESCRIPTION
At the moment, it is stated that `input_parameters` is valid only when owner is `CUSTOM_LAMBDA`. 

However, as per [the documentation example](http://docs.aws.amazon.com/cli/latest/reference/configservice/put-config-rule.html#examples), this is also valid for `AWS` owner, so for reserved rules (parameters are passed to the Lambda function, i.e. the one from AWS OR the custom one, if using CUSTOM_LAMBDA).