### PR TITLE
command init: show suggested constraints for unconstrained providers

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,11 +8,11 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/blang/semver"
 	"github.com/hashicorp/go-multierror"
 	"github.com/hashicorp/hil"
 	"github.com/hashicorp/hil/ast"
 	"github.com/hashicorp/terraform/helper/hilmapstructure"
+	"github.com/hashicorp/terraform/plugin/discovery"
 	"github.com/mitchellh/reflectwalk"
 )
 
@@ -391,7 +391,7 @@ func (c *Config) Validate() error {
 		}
 
 		if p.Version != "" {
-			_, err := semver.ParseRange(p.Version)
+			_, err := discovery.ConstraintStr(p.Version).Parse()
 			if err != nil {
 				errs = append(errs, fmt.Errorf(
 					"provider.%s: invalid version constraint %q: %s",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -626,6 +626,13 @@ func TestConfigValidate_varModuleInvalid(t *testing.T) {
 	}
 }
 
+func TestConfigValidate_varProviderVersionInvalid(t *testing.T) {
+	c := testConfig(t, "validate-provider-version-invalid")
+	if err := c.Validate(); err == nil {
+		t.Fatal("should not be valid")
+	}
+}
+
 func TestNameRegexp(t *testing.T) {
 	cases := []struct {
 		Input string

--- a/config/test-fixtures/validate-provider-version-invalid/main.tf
+++ b/config/test-fixtures/validate-provider-version-invalid/main.tf
@@ -1,0 +1,3 @@
+provider "test" {
+    version = "bananas!"
+}

--- a/plugin/discovery/version.go
+++ b/plugin/discovery/version.go
@@ -1,6 +1,7 @@
 package discovery
 
 import (
+	"fmt"
 	"sort"
 
 	version "github.com/hashicorp/go-version"
@@ -46,6 +47,13 @@ func (v Version) String() string {
 
 func (v Version) NewerThan(other Version) bool {
 	return v.raw.GreaterThan(other.raw)
+}
+
+// MinorUpgradeConstraintStr returns a ConstraintStr that would permit
+// minor upgrades relative to the receiving version.
+func (v Version) MinorUpgradeConstraintStr() ConstraintStr {
+	segments := v.raw.Segments()
+	return ConstraintStr(fmt.Sprintf("~> %d.%d", segments[0], segments[1]))
 }
 
 type Versions []Version

--- a/plugin/discovery/version_set.go
+++ b/plugin/discovery/version_set.go
@@ -69,3 +69,9 @@ func (s Constraints) Append(other Constraints) Constraints {
 func (s Constraints) String() string {
 	return s.raw.String()
 }
+
+// Unconstrained returns true if and only if the receiver is an empty
+// constraint set.
+func (s Constraints) Unconstrained() bool {
+	return len(s.raw) == 0
+}


### PR DESCRIPTION
When running `terraform init` with providers that are unconstrained, we will now produce information to help the user update configuration to constrain for the particular providers that were chosen, to prevent inadvertently drifting onto a newer major release that might contain breaking changes.
    
 A `~>` constraint is used here because pinning to a single specific version is expected to create dependency hell when using child modules. By using this constraint mode, which allows minor version upgrades, we avoid the need for users to constantly adjust version constraints across many modules, but make major version upgrades still be opt-in.
    
Any constraint at all in the configuration will prevent the display of these suggestions, so users are free to use stronger or weaker constraints if desired, ignoring the recommendation.

Here's how it looks:

```
$ terraform init
Downloading modules (if any)...
Initializing the backend...
Initializing provider plugins...

The following providers do not have any version constraints in configuration,
so the latest version was installed.

To prevent automatic upgrades to new major versions that may contain breaking
changes, it is recommended to add version = "..." constraints to the
corresponding provider blocks in configuration, with the constraint strings
suggested below.

* provider.null: version = "~> 0.0"
* provider.test: version = "~> 1.0"

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your environment. If you forget, other
commands will detect it and remind you to do so if necessary.
```

For now this new output is not highlighted in any particular severity color, since it's intended as an optional suggestion rather than as a warning. The success message (starting with `Terraform has been successfully...`) therefore remains prominent in practice due to it being shown in green.

---

This PR also includes a separate bonus commit that fixes an orthogonal bug I found while testing this, caused by a case I missed when we were switching from `semver` to `go-version`.
