### PR TITLE
Document correct names for available Datadog timeboard graph request types

### DIFF
--- a/website/source/docs/providers/datadog/r/timeboard.html.markdown
+++ b/website/source/docs/providers/datadog/r/timeboard.html.markdown
@@ -115,7 +115,7 @@ Nested `graph` `request` blocks have the following structure:
 * `q` - (Required) The query of the request. Pro tip: Use the JSON tab inside the Datadog UI to help build you query strings.
 * `aggregator` - (Optional) The aggregation method used when the number of data points outnumbers the max that can be shown.
 * `stacked` - (Optional) Boolean value to determine if this is this a stacked area graph. Default: false (line chart).
-* `type` - (Optional) Choose how to draw the graph. For example: "lines", "bars" or "areas". Default: "lines".
+* `type` - (Optional) Choose how to draw the graph. For example: "line", "bar" or "area". Default: "line".
 * `style` - (Optional) Nested block to customize the graph style.
 
 ### Nested `graph` `style` block


### PR DESCRIPTION
Datadog does not explicitly document which graph types are available, but when you use the GUI to generate the graph and select the JSON tab to inspect said graph, you will see that the available timeboard graph type names are singular, not plural.