### PR TITLE
rancher_host: error on nil or removed host

### DIFF
--- a/builtin/providers/rancher/resource_rancher_host.go
+++ b/builtin/providers/rancher/resource_rancher_host.go
@@ -97,6 +97,18 @@ func resourceRancherHostRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
+	if host == nil {
+		log.Printf("[INFO] Host %s not found", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	if removed(host.State) {
+		log.Printf("[INFO] Host %s was removed on %v", d.Id(), host.Removed)
+		d.SetId("")
+		return nil
+	}
+
 	log.Printf("[INFO] Host Name: %s", host.Name)
 
 	d.Set("description", host.Description)


### PR DESCRIPTION
Deactivated/removed hosts should not be used.