### PR TITLE
provider/aws: Add support for a configurable timeout in db_option_group

### DIFF
--- a/builtin/providers/aws/resource_aws_db_option_group.go
+++ b/builtin/providers/aws/resource_aws_db_option_group.go
@@ -25,12 +25,16 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
+		Timeouts: &schema.ResourceTimeout{
+			Delete: schema.DefaultTimeout(15 * time.Minute),
+		},
+
 		Schema: map[string]*schema.Schema{
-			"arn": &schema.Schema{
+			"arn": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:          schema.TypeString,
 				Optional:      true,
 				Computed:      true,
@@ -38,66 +42,66 @@ func resourceAwsDbOptionGroup() *schema.Resource {
 				ConflictsWith: []string{"name_prefix"},
 				ValidateFunc:  validateDbOptionGroupName,
 			},
-			"name_prefix": &schema.Schema{
+			"name_prefix": {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
 				ForceNew:     true,
 				ValidateFunc: validateDbOptionGroupNamePrefix,
 			},
-			"engine_name": &schema.Schema{
+			"engine_name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"major_engine_version": &schema.Schema{
+			"major_engine_version": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"option_group_description": &schema.Schema{
+			"option_group_description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Default:  "Managed by Terraform",
 			},
 
-			"option": &schema.Schema{
+			"option": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"option_name": &schema.Schema{
+						"option_name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"option_settings": &schema.Schema{
+						"option_settings": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
-									"name": &schema.Schema{
+									"name": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
-									"value": &schema.Schema{
+									"value": {
 										Type:     schema.TypeString,
 										Required: true,
 									},
 								},
 							},
 						},
-						"port": &schema.Schema{
+						"port": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-						"db_security_group_memberships": &schema.Schema{
+						"db_security_group_memberships": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
 							Set:      schema.HashString,
 						},
-						"vpc_security_group_memberships": &schema.Schema{
+						"vpc_security_group_memberships": {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     &schema.Schema{Type: schema.TypeString},
@@ -299,7 +303,7 @@ func resourceAwsDbOptionGroupDelete(d *schema.ResourceData, meta interface{}) er
 	}
 
 	log.Printf("[DEBUG] Delete DB Option Group: %#v", deleteOpts)
-	ret := resource.Retry(5*time.Minute, func() *resource.RetryError {
+	ret := resource.Retry(d.Timeout(schema.TimeoutDelete), func() *resource.RetryError {
 		_, err := rdsconn.DeleteOptionGroup(deleteOpts)
 		if err != nil {
 			if awsErr, ok := err.(awserr.Error); ok {

--- a/builtin/providers/aws/resource_aws_db_option_group_test.go
+++ b/builtin/providers/aws/resource_aws_db_option_group_test.go
@@ -22,8 +22,30 @@ func TestAccAWSDBOptionGroup_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroupBasicConfig(rName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
+					testAccCheckAWSDBOptionGroupAttributes(&v),
+					resource.TestCheckResourceAttr(
+						"aws_db_option_group.bar", "name", rName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccAWSDBOptionGroup_timeoutBlock(t *testing.T) {
+	var v rds.OptionGroup
+	rName := fmt.Sprintf("option-group-test-terraform-%s", acctest.RandString(5))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccAWSDBOptionGroupBasicConfigTimeoutBlock(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
 					testAccCheckAWSDBOptionGroupAttributes(&v),
@@ -43,7 +65,7 @@ func TestAccAWSDBOptionGroup_namePrefix(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroup_namePrefix,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.test", &v),
@@ -64,7 +86,7 @@ func TestAccAWSDBOptionGroup_generatedName(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroup_generatedName,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.test", &v),
@@ -83,7 +105,7 @@ func TestAccAWSDBOptionGroup_defaultDescription(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroup_defaultDescription(acctest.RandInt()),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.test", &v),
@@ -103,7 +125,7 @@ func TestAccAWSDBOptionGroup_basicDestroyWithInstance(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroupBasicDestroyConfig(rName),
 			},
 		},
@@ -119,7 +141,7 @@ func TestAccAWSDBOptionGroup_OptionSettings(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroupOptionSettings(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
@@ -131,7 +153,7 @@ func TestAccAWSDBOptionGroup_OptionSettings(t *testing.T) {
 						"aws_db_option_group.bar", "option.961211605.option_settings.129825347.value", "UTC"),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroupOptionSettings_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
@@ -156,7 +178,7 @@ func TestAccAWSDBOptionGroup_sqlServerOptionsUpdate(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroupSqlServerEEOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
@@ -165,7 +187,7 @@ func TestAccAWSDBOptionGroup_sqlServerOptionsUpdate(t *testing.T) {
 				),
 			},
 
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroupSqlServerEEOptions_update(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
@@ -188,7 +210,7 @@ func TestAccAWSDBOptionGroup_multipleOptions(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckAWSDBOptionGroupDestroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccAWSDBOptionGroupMultipleOptions(rName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckAWSDBOptionGroupExists("aws_db_option_group.bar", &v),
@@ -286,6 +308,21 @@ func testAccCheckAWSDBOptionGroupDestroy(s *terraform.State) error {
 	}
 
 	return nil
+}
+
+func testAccAWSDBOptionGroupBasicConfigTimeoutBlock(r string) string {
+	return fmt.Sprintf(`
+resource "aws_db_option_group" "bar" {
+  name                     = "%s"
+  option_group_description = "Test option group for terraform"
+  engine_name              = "mysql"
+  major_engine_version     = "5.6"
+
+  timeouts {
+  	delete = "10m"
+  }
+}
+`, r)
 }
 
 func testAccAWSDBOptionGroupBasicConfig(r string) string {

--- a/website/source/docs/providers/aws/r/db_option_group.html.markdown
+++ b/website/source/docs/providers/aws/r/db_option_group.html.markdown
@@ -65,6 +65,14 @@ The following attributes are exported:
 
 * `arn` - The ARN of the db option group.
 
+<a id="timeouts"></a>
+## Timeouts
+
+`aws_db_option_group` provides the following
+[Timeouts](/docs/configuration/resources.html#timeouts) configuration options:
+
+- `delete` - (Default `15 minutes`)
+
 ## Import
 
 DB Option groups can be imported using the `name`, e.g.


### PR DESCRIPTION
Fixes: #14995

Adds a timeout block to configure deletes

```
% make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSDBOptionGroup'                                                      
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/06/02 19:54:18 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSDBOptionGroup -timeout 120m
=== RUN   TestAccAWSDBOptionGroup_importBasic
--- PASS: TestAccAWSDBOptionGroup_importBasic (57.03s)
=== RUN   TestAccAWSDBOptionGroup_basic
--- PASS: TestAccAWSDBOptionGroup_basic (32.69s)
=== RUN   TestAccAWSDBOptionGroup_timeoutBlock
--- PASS: TestAccAWSDBOptionGroup_timeoutBlock (31.59s)
=== RUN   TestAccAWSDBOptionGroup_namePrefix
--- PASS: TestAccAWSDBOptionGroup_namePrefix (28.24s)
=== RUN   TestAccAWSDBOptionGroup_generatedName
--- PASS: TestAccAWSDBOptionGroup_generatedName (30.91s)
=== RUN   TestAccAWSDBOptionGroup_defaultDescription
--- PASS: TestAccAWSDBOptionGroup_defaultDescription (54.13s)
=== RUN   TestAccAWSDBOptionGroup_basicDestroyWithInstance
--- PASS: TestAccAWSDBOptionGroup_basicDestroyWithInstance (612.01s)
=== RUN   TestAccAWSDBOptionGroup_OptionSettings
--- PASS: TestAccAWSDBOptionGroup_OptionSettings (54.34s)
=== RUN   TestAccAWSDBOptionGroup_sqlServerOptionsUpdate
--- PASS: TestAccAWSDBOptionGroup_sqlServerOptionsUpdate (53.86s)
=== RUN   TestAccAWSDBOptionGroup_multipleOptions
--- PASS: TestAccAWSDBOptionGroup_multipleOptions (33.72s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	956.958s
```