### PR TITLE
provider/google: Set instances to computed in compute_instance_group

### DIFF
--- a/builtin/providers/google/resource_compute_instance_group.go
+++ b/builtin/providers/google/resource_compute_instance_group.go
@@ -21,42 +21,43 @@ func resourceComputeInstanceGroup() *schema.Resource {
 		SchemaVersion: 1,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"zone": &schema.Schema{
+			"zone": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
 
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"instances": &schema.Schema{
+			"instances": {
 				Type:     schema.TypeSet,
 				Optional: true,
+				Computed: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
 
-			"named_port": &schema.Schema{
+			"named_port": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
 
-						"port": &schema.Schema{
+						"port": {
 							Type:     schema.TypeInt,
 							Required: true,
 						},
@@ -64,23 +65,23 @@ func resourceComputeInstanceGroup() *schema.Resource {
 				},
 			},
 
-			"network": &schema.Schema{
+			"network": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"project": &schema.Schema{
+			"project": {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 			},
 
-			"self_link": &schema.Schema{
+			"self_link": {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
 
-			"size": &schema.Schema{
+			"size": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},

--- a/builtin/providers/google/resource_compute_instance_group_test.go
+++ b/builtin/providers/google/resource_compute_instance_group_test.go
@@ -20,7 +20,7 @@ func TestAccComputeInstanceGroup_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccComputeInstanceGroup_destroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeInstanceGroup_basic(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeInstanceGroup_exists(
@@ -42,7 +42,7 @@ func TestAccComputeInstanceGroup_update(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccComputeInstanceGroup_destroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeInstanceGroup_update(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeInstanceGroup_exists(
@@ -53,7 +53,7 @@ func TestAccComputeInstanceGroup_update(t *testing.T) {
 						&instanceGroup),
 				),
 			},
-			resource.TestStep{
+			{
 				Config: testAccComputeInstanceGroup_update2(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeInstanceGroup_exists(
@@ -79,7 +79,7 @@ func TestAccComputeInstanceGroup_outOfOrderInstances(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccComputeInstanceGroup_destroy,
 		Steps: []resource.TestStep{
-			resource.TestStep{
+			{
 				Config: testAccComputeInstanceGroup_outOfOrderInstances(instanceName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccComputeInstanceGroup_exists(


### PR DESCRIPTION
Fixes: #15024

```
% make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccComputeInstanceGroup_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/06/02 20:48:54 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeInstanceGroup_ -timeout 120m
=== RUN   TestAccComputeInstanceGroup_basic
--- PASS: TestAccComputeInstanceGroup_basic (123.64s)
=== RUN   TestAccComputeInstanceGroup_update
--- PASS: TestAccComputeInstanceGroup_update (150.37s)
=== RUN   TestAccComputeInstanceGroup_outOfOrderInstances
--- PASS: TestAccComputeInstanceGroup_outOfOrderInstances (103.71s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	377.737s
```