### PR TITLE
[docs] Updated import command provider to specify syntax

### DIFF
--- a/website/source/docs/commands/import.html.md
+++ b/website/source/docs/commands/import.html.md
@@ -48,8 +48,8 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-no-color` - If specified, output won't contain any color.
 
-* `-provider=provider` - Specified provider to use for import. This is used for
-  specifying provider aliases, such as "aws.eu". This defaults to the normal
+* `-provider=provider` - Specified provider to use for import. The value should be a provider
+  alias in the form `TYPE.ALIAS`, such as "aws.eu". This defaults to the normal
   provider based on the prefix of the resource being imported. You usually
   don't need to specify this.
 


### PR DESCRIPTION
Updated import command provider flag documentation to explicitly specify syntax.

The [providers documentation](https://www.terraform.io/docs/configuration/providers.html#multiple-provider-instances) explicitly specifies the format of the value for the `provider` field in a resource, but the [import provider flag](https://www.terraform.io/docs/commands/import.html#provider-provider) documentation does not.

It was unclear to me when first looking at the page that `aws.eu` meant an `aws` provider with the alias `eu`, and not an alias of `aws.eu`. This way, the formatting of the expected value should be more clear for readers in the future.

Related to #14998 