### PR TITLE
provider/datadog: make datadog_user verified a computed attribute

### DIFF
--- a/builtin/providers/datadog/resource_datadog_user.go
+++ b/builtin/providers/datadog/resource_datadog_user.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/schema"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 )
@@ -49,7 +50,7 @@ func resourceDatadogUser() *schema.Resource {
 			},
 			"verified": {
 				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
 			},
 		},
 	}
@@ -96,7 +97,7 @@ func resourceDatadogUserCreate(d *schema.ResourceData, meta interface{}) error {
 
 	d.SetId(u.GetHandle())
 
-	return nil
+	return resourceDatadogUserRead(d, meta)
 }
 
 func resourceDatadogUserRead(d *schema.ResourceData, meta interface{}) error {
@@ -107,7 +108,7 @@ func resourceDatadogUserRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] user: %v", u)
+	log.Printf("[DEBUG] user: %s", spew.Sdump(u))
 	d.Set("disabled", u.GetDisabled())
 	d.Set("email", u.GetEmail())
 	d.Set("handle", u.GetHandle())

--- a/builtin/providers/datadog/resource_datadog_user.go
+++ b/builtin/providers/datadog/resource_datadog_user.go
@@ -5,7 +5,6 @@ import (
 	"log"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/hashicorp/terraform/helper/schema"
 	"gopkg.in/zorkian/go-datadog-api.v2"
 )
@@ -108,7 +107,6 @@ func resourceDatadogUserRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	log.Printf("[DEBUG] user: %s", spew.Sdump(u))
 	d.Set("disabled", u.GetDisabled())
 	d.Set("email", u.GetEmail())
 	d.Set("handle", u.GetHandle())

--- a/builtin/providers/datadog/resource_datadog_user_test.go
+++ b/builtin/providers/datadog/resource_datadog_user_test.go
@@ -26,6 +26,8 @@ func TestAccDatadogUser_Updated(t *testing.T) {
 						"datadog_user.foo", "handle", "test@example.com"),
 					resource.TestCheckResourceAttr(
 						"datadog_user.foo", "name", "Test User"),
+					resource.TestCheckResourceAttr(
+						"datadog_user.foo", "verified", "false"),
 				),
 			},
 			resource.TestStep{
@@ -42,6 +44,8 @@ func TestAccDatadogUser_Updated(t *testing.T) {
 						"datadog_user.foo", "is_admin", "true"),
 					resource.TestCheckResourceAttr(
 						"datadog_user.foo", "name", "Updated User"),
+					resource.TestCheckResourceAttr(
+						"datadog_user.foo", "verified", "false"),
 				),
 			},
 		},


### PR DESCRIPTION
It's read-only and generates supurious diffs for verified users.