### PR TITLE
website/ux: various docs and usage tweaks for 0.10

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -228,6 +228,7 @@ func (c *InitCommand) getProviders(path string, state *terraform.State) error {
 
 	dst := c.pluginDir()
 	for provider, reqd := range missing {
+		c.Ui.Output(fmt.Sprintf("- downloading plugin for provider %q...", provider))
 		err := c.getProvider(dst, provider, reqd.Versions, plugin.Handshake.ProtocolVersion)
 		// TODO: return all errors
 		if err != nil {

--- a/command/init.go
+++ b/command/init.go
@@ -311,7 +311,7 @@ func (c *InitCommand) Help() string {
 	helpText := `
 Usage: terraform init [options] [SOURCE] [PATH]
 
-  Initialize a new or existing Terraform environment by creating
+  Initialize a new or existing Terraform working directory by creating
   initial files, loading any remote state, downloading modules, etc.
 
   This is the first command that should be run for any new or existing
@@ -320,9 +320,9 @@ Usage: terraform init [options] [SOURCE] [PATH]
   control.
 
   This command is always safe to run multiple times. Though subsequent runs
-  may give errors, this command will never blow away your environment or state.
-  Even so, if you have important information, please back it up prior to
-  running this command just in case.
+  may give errors, this command will never delete your configuration or
+  state. Even so, if you have important information, please back it up prior
+  to running this command, just in case.
 
   If no arguments are given, the configuration in this working directory
   is initialized.
@@ -337,7 +337,7 @@ Usage: terraform init [options] [SOURCE] [PATH]
 
 Options:
 
-  -backend=true        Configure the backend for this environment.
+  -backend=true        Configure the backend for this configuration.
 
   -backend-config=path This can be either a path to an HCL file with key/value
                        assignments (same format as terraform.tfvars) or a
@@ -395,7 +395,7 @@ any changes that are required for your infrastructure. All Terraform commands
 should now work.
 
 If you ever set or change modules or backend configuration for Terraform,
-rerun this command to reinitialize your environment. If you forget, other
+rerun this command to reinitialize your working directory. If you forget, other
 commands will detect it and remind you to do so if necessary.
 `
 

--- a/website/source/docs/commands/init.html.markdown
+++ b/website/source/docs/commands/init.html.markdown
@@ -8,15 +8,16 @@ description: |-
 
 # Command: init
 
-The `terraform init` command is used to initialize a Terraform configuration.
-This is the first command that should be run for any new or existing
-Terraform configuration. It is safe to run this command multiple times.
+The `terraform init` command is used to initialize a working directory
+containing Terraform configuration files. This is the first command that should
+be run after writing a new Terraform configuration or cloning an existing one
+from version control. It is safe to run this command multiple times.
 
 ## Usage
 
 Usage: `terraform init [options] [SOURCE] [PATH]`
 
-Initialize a new or existing Terraform environment by creating
+Initialize a new or existing Terraform working directory by creating
 initial files, loading any remote state, downloading modules, etc.
 
 This is the first command that should be run for any new or existing
@@ -25,11 +26,11 @@ necessary to run Terraform that is typically not committed to version
 control.
 
 This command is always safe to run multiple times. Though subsequent runs
-may give errors, this command will never blow away your environment or state.
+may give errors, this command will never delete your configuration or state.
 Even so, if you have important information, please back it up prior to
 running this command just in case.
 
-If no arguments are given, the configuration in this working directory
+If no arguments are given, the configuration in the current working directory
 is initialized.
 
 If one or two arguments are given, the first is a SOURCE of a module to
@@ -42,7 +43,7 @@ Git history.
 
 The command-line flags are all optional. The list of available flags are:
 
-* `-backend=true` - Initialize the [backend](/docs/backends) for this environment.
+* `-backend=true` - Initialize the [backend](/docs/backends) for this configuration.
 
 * `-backend-config=value` - Value can be a path to an HCL file or a string
   in the format of 'key=value'. This specifies additional configuration to merge

--- a/website/source/docs/commands/providers.html.markdown
+++ b/website/source/docs/commands/providers.html.markdown
@@ -7,7 +7,7 @@ description: |-
   in the current configuration.
 ---
 
-# Command: show
+# Command: providers
 
 The `terraform providers` command prints information about the providers
 used in the current configuration.
@@ -30,7 +30,7 @@ to understanding why a particular provider is needed.
 
 ## Usage
 
-Usage: `terraform show [config-path]`
+Usage: `terraform providers [config-path]`
 
 Pass an explicit configuration path to override the default of using the
 current working directory.

--- a/website/source/docs/configuration/providers.html.md
+++ b/website/source/docs/configuration/providers.html.md
@@ -33,7 +33,7 @@ A provider configuration looks like the following:
 provider "aws" {
   access_key = "foo"
   secret_key = "bar"
-  region = "us-east-1"
+  region     = "us-east-1"
 }
 ```
 
@@ -54,6 +54,61 @@ Both criteria must be matched for a provider to manage a resource:
 Within the block (the `{ }`) is configuration for the resource.
 The configuration is dependent on the type, and is documented
 [for each provider](/docs/providers/index.html).
+
+## Initialization
+
+Each time a new provider is added to configuration -- either explicitly via
+a `provider` block or by adding a resource from that provider -- it's necessary
+to initialize that provider before use. Initialization downloads and installs
+the provider's plugin and prepares it to be used.
+
+Provider initialization is one of the actions of `terraform init`. Running
+this command will download and initialize any providers that are not already
+initialized.
+
+For more information, see
+[the `terraform init` command](/docs/commands/init.html).
+
+## Provider Versions
+
+Providers are released on a separate rhythm from Terraform itself, and thus
+have their own version numbers. For production use, it is recommended to
+constrain the acceptable provider versions via configuration, to ensure that
+new versions with breaking changes will not be automatically installed by
+`terraform init` in future.
+
+When `terraform init` is run _without_ provider version constraints, it
+prints a suggested version constraint string for each provider:
+
+```
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.aws: version = "~> 1.0"
+```
+
+To constrain the provider version as suggested, add a `version` argument to
+the provider configuration block:
+
+```hcl
+provider "aws" {
+  version = "~> 1.0"
+
+  access_key = "foo"
+  secret_key = "bar"
+  region     = "us-east-1"
+}
+```
+
+This special argument applies to _all_ providers.
+[`terraform providers`](/docs/commands/providers.html) can be used to
+view the specified version constraints for all providers used in the
+current configuration.
 
 ## Multiple Provider Instances
 

--- a/website/source/intro/examples/index.html.markdown
+++ b/website/source/intro/examples/index.html.markdown
@@ -39,23 +39,19 @@ To use these examples, Terraform must first be installed on your machine.
 You can install Terraform from the [downloads page](/downloads.html).
 Once installed, you can use two steps to view and run the examples.
 
-To clone any examples, run `terraform init` with the URL to the example:
+To try these examples, first clone them with git as usual:
 
 ```
-$ terraform init github.com/hashicorp/terraform/examples/aws-two-tier
+git clone https://github.com/hashicorp/terraform/examples/aws-two-tier
+cd aws-to-tier
+```
+
+You can then use your own editor to read and browse the configurations.
+To try out the example, initialize and then apply:
+
+```
+$ terraform init
 ...
-```
-
-This will put the example files within your working directory. You can then
-use your own editor to read and browse the configurations. This command will
-not _run_ any code.
-
-~> If you want to browse the files before downloading them, you can [view
-them on GitHub](https://github.com/hashicorp/terraform/tree/master/examples/aws-two-tier).
-
-If you want to run the example, just run `terraform apply`:
-
-```
 $ terraform apply
 ...
 ```

--- a/website/source/intro/getting-started/build.html.md
+++ b/website/source/intro/getting-started/build.html.md
@@ -112,6 +112,52 @@ is fully documented within our
 an AMI for Ubuntu, and request a "t2.micro" instance so we
 qualify under the free tier.
 
+## Initialization
+
+The first command to run for a new configuration -- or after checking out
+an existing configuration from version control -- is `terraform init`, which
+initializes various local settings and data that will be used by subsequent
+commands.
+
+In particular, this command will install the plugins for the providers in
+use within the configuration, which in this case is just the `aws` provider:
+
+```
+$ terraform init
+Initializing the backend...
+Initializing provider plugins...
+- downloading plugin for provider "aws"...
+
+The following providers do not have any version constraints in configuration,
+so the latest version was installed.
+
+To prevent automatic upgrades to new major versions that may contain breaking
+changes, it is recommended to add version = "..." constraints to the
+corresponding provider blocks in configuration, with the constraint strings
+suggested below.
+
+* provider.aws: version = "~> 1.0"
+
+Terraform has been successfully initialized!
+
+You may now begin working with Terraform. Try running "terraform plan" to see
+any changes that are required for your infrastructure. All Terraform commands
+should now work.
+
+If you ever set or change modules or backend configuration for Terraform,
+rerun this command to reinitialize your environment. If you forget, other
+commands will detect it and remind you to do so if necessary.
+```
+
+The `aws` provider plugin is downloaded and installed in a subdirectory of
+the current working directory, along with various other book-keeping files.
+
+The output specifies which version of the plugin was installed, and suggests
+specifying that version in configuration to ensure that running
+`terraform init` in future will install a compatible version. This step
+is not necessary for following the getting started guide, since this
+configuration will be discarded at the end.
+
 ## Execution Plan
 
 Next, let's see what Terraform would do if we asked it to

--- a/website/source/layouts/downloads.erb
+++ b/website/source/layouts/downloads.erb
@@ -8,6 +8,9 @@
       <li<%= sidebar_current("upgrade-guides") %>>
         <a href="/upgrade-guides/index.html">Upgrade Guides</a>
         <ul class="nav">
+          <li<%= sidebar_current("upgrade-guides-0-10") %>>
+            <a href="/upgrade-guides/0-10.html">Upgrading to v0.10</a>
+          </li>
           <li<%= sidebar_current("upgrade-guides-0-9") %>>
             <a href="/upgrade-guides/0-9.html">Upgrading to v0.9</a>
           </li>

--- a/website/source/upgrade-guides/0-10.html.markdown
+++ b/website/source/upgrade-guides/0-10.html.markdown
@@ -1,0 +1,146 @@
+---
+layout: "downloads"
+page_title: "Upgrading to Terraform 0.10"
+sidebar_current: "upgrade-guides-0-10"
+description: |-
+  Upgrading to Terraform v0.10
+---
+
+# Upgrading to Terraform v0.10
+
+Terraform v0.10 is a major release and thus includes some changes that
+you'll need to consider when upgrading. This guide is intended to help with
+that process.
+
+The goal of this guide is to cover the most common upgrade concerns and
+issues that would benefit from more explanation and background. The exhaustive
+list of changes will always be the
+[Terraform Changelog](https://github.com/hashicorp/terraform/blob/master/CHANGELOG.md).
+After reviewing this guide, we recommend reviewing the Changelog to check on
+specific notes about the resources and providers you use.
+
+This guide focuses on changes from v0.9 to v0.10. Each previous major release
+has its own upgrade guide, so please consult the other guides (available
+in the navigation) if you are upgrading directly from an earlier version.
+
+## Separated Provider Plugins
+
+As of v0.10, provider plugins are no longer included in the main Terraform
+distribution. Instead, they are distributed separately and installed
+automatically by
+[the `terraform init` command](/docs/commands/init.html).
+
+In the long run, this new approach should be beneficial to anyone who wishes
+to upgrade a specific provider to get new functionality without also
+upgrading another provider that may have introduced incompatible changes.
+In the short term, it just means a smaller distribution package and thus
+avoiding the need to download tens of providers that may never be used.
+
+Provider plugins are now also versioned separately from Terraform itself.
+[Version constraints](/docs/configuration/providers.html#provider-versions)
+can be specified in configuration to ensure that new major releases
+(which may have breaking changes) are not automatically installed.
+
+**Action:** After upgrading, run `terraform init` in each Terraform
+configuration working directory to install the necessary provider plugins.
+If running Terraform in automation, this command should be run as the first
+step after a Terraform configuration is cloned from version control, and
+will also install any necessary modules and configure any remote backend.
+
+**Action:** For "production" configurations, consider adding
+[provider version constraints](/docs/configuration/providers.html#provider-versions),
+as suggested by the `terraform init` output, to prevent new major versions
+of plugins from being automatically installed in future.
+
+### Third-party Provider Plugins
+
+This initial release of separated provider plugins applies only to the
+providers that are packaged and released by Hashicorp. The goal is to
+eventually support a similar approach for third-party plugins, but we wish
+to ensure the robustness of the installation and versioning mechanisms before
+generalizing this feature.
+
+In the mean time,
+[the prior mechanisms for installing third-party providers](/docs/plugins/basics.html#installing-a-plugin)
+are still supported. Maintainers of third-party providers may optionally
+make use of the new versioning mechanism by naming provider binaries
+using the scheme `terraform-provider-NAME-V0.0.1`, where "0.0.1" is an
+example version. Terraform expects providers to follow
+[semantic versioning](http://semver.org/) methodology.
+
+Although third-party providers with versions cannot currently be automatically
+installed, Terraform 0.10 _will_ verify that the installed version matches the
+constraints in configuration and produce an error if an acceptable version
+is unavailable.
+
+**Action:** No immediate action required, but third-party plugin maintainers
+may optionally begin using version numbers in their binary distributions to
+help users deal with changes over time.
+
+## Recursive Module Targeting with `-target`
+
+It is possible to target all of the resources in a particular module by passing
+a module address to the `-target` argument:
+
+```
+$ terraform plan -out=tfplan -target=module.example
+```
+
+Prior to 0.10, this command would target only the resources _directly_ in
+the given module. As of 0.10, this behavior has changed such that the above
+command also targets resources in _descendent_ modules.
+
+For example, if `module.example` contains a module itself, called
+`module.examplechild`, the above command will target resources in both
+`module.example` _and_ `module.example.module.examplechild`.
+
+This also applies to other Terraform features that use
+[resource addressing](/docs/internals/resource-addressing.html) syntax.
+This includes some of the subcommands of
+[`terraform state`](http://127.0.0.1:4567/docs/commands/state/index.html).
+
+**Action:** If running Terraform with `-target` in automation, review usage
+to ensure that selecting additional resources in child modules will not have
+ill effects. Be sure to review plan output when `-target` is used to verify
+that only the desired resources have been targeted for operations. Please
+note that it is not recommended to routinely use `-target`; it is provided for
+exceptional uses and manual intervention.
+
+## Interactive Approval in `terraform apply`
+
+Starting with Terraform 0.10 `terraform apply` has a new mode where it will
+present the plan, pause for interactive confirmation, and then apply the
+plan only if confirmed. This is intended to get similar benefits to separately
+running `terraform plan`, but to streamline the workflow for interactive
+command-line use.
+
+For 0.10 this feature is disabled by default, to avoid breaking any wrapper
+scripts that are expecting the old behavior. To opt-in to this behavior,
+pass `-auto-approve=false` when running `terraform apply` without an explicit
+plan file.
+
+It is planned that a future version of Terraform will make this behavior the
+default. Although no immediate action is required, we strongly recommend
+adjusting any Terraform automation or wrapper scripts to prepare for this
+upcoming change in behavior, in the following ways:
+
+* Non-interative automation around production systems should _always_
+  separately run `terraform plan -out=tfplan` and then (after approval)
+  `terraform apply tfplan`, to ensure operators have a chance to review
+  the plan before applying it.
+
+* If running `terraform apply` _without_ a plan file in automation for
+  a _non-production_ system, add `-auto-approve=true` to the command line
+  soon, to preserve the current 0.10 behavior once auto-approval is no longer
+  enabled by default.
+
+We are using a staged deprecation for this change because we are aware that
+many teams use Terraform in wrapper scripts and automation, and we wish to
+ensure that such teams have an opportunity to update those tools in preparation
+for the future change in behavior.
+
+**Action:** 0.10 preserves the previous behavior as the default, so no
+immediate action is required. However, maintainers of tools that wrap
+Terraform, either in automation or in alternative command-line UI, should
+consider which behavior is appropriate for their use-case and explicitly
+set the `-auto-approve=...` flag to ensure that behavior in future versions.


### PR DESCRIPTION
This PR has an assortment of updates to the docs for changes planned in 0.10, focusing primarily on the core/provider split.

Since the release plan is not final, this is likely to require further iteration as we get closer, but this is intended as a starting point.

Since this PR is a bit of a grab-bag of different updates, it may help to view it on a commit-by-commit basis.

---

Although most of this is documentation updates, in the process of trying out automatic plugin installation in order to write the docs for it (using a mock releases server, of course!) I found that the lack of progress information on provider installation can feel a little disconcerting, so there's a commit amongst all of this that adds an extra line of output for each plugin being downloaded, to give a stronger sense of progress even though we don't actually have a real progress bar.
