### PR TITLE
Url to aws-two-tier example changed.

### DIFF
--- a/website/source/intro/examples/index.html.markdown
+++ b/website/source/intro/examples/index.html.markdown
@@ -42,7 +42,7 @@ Once installed, you can use two steps to view and run the examples.
 To clone any examples, run `terraform init` with the URL to the example:
 
 ```
-$ terraform init github.com/hashicorp/terraform/examples/aws-two-tier
+$ terraform init github.com/hashicorp/terraform/tree/master/examples/aws-two-tier
 ...
 ```
 


### PR DESCRIPTION
Provided what I believe to the the new correct address for the example url.