### PR TITLE
provider/alicloud: Fix allocating public ip bug

### DIFF
--- a/builtin/providers/alicloud/resource_alicloud_instance.go
+++ b/builtin/providers/alicloud/resource_alicloud_instance.go
@@ -195,7 +195,7 @@ func resourceAliyunInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 
 	// after instance created, its status is pending,
 	// so we need to wait it become to stopped and then start it
-	if err := conn.WaitForInstance(d.Id(), ecs.Stopped, defaultTimeout); err != nil {
+	if err := conn.WaitForInstanceAsyn(d.Id(), ecs.Stopped, defaultTimeout); err != nil {
 		return fmt.Errorf("[DEBUG] WaitForInstance %s got error: %#v", ecs.Stopped, err)
 	}
 
@@ -207,7 +207,7 @@ func resourceAliyunInstanceCreate(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("Start instance got error: %#v", err)
 	}
 
-	if err := conn.WaitForInstance(d.Id(), ecs.Running, defaultTimeout); err != nil {
+	if err := conn.WaitForInstanceAsyn(d.Id(), ecs.Running, defaultTimeout); err != nil {
 		return fmt.Errorf("[DEBUG] WaitForInstance %s got error: %#v", ecs.Running, err)
 	}
 


### PR DESCRIPTION
This PR fixed the bug that ensure ecs instance is already existed before allocating its public ip.

In addition, return error when some one operation failed. 