### PR TITLE
provider/alicloud: Fix access_key NOT FOUND bug and nat_gateway diff bug

### DIFF
--- a/builtin/providers/alicloud/provider.go
+++ b/builtin/providers/alicloud/provider.go
@@ -5,6 +5,7 @@ import (
 	"github.com/hashicorp/terraform/helper/mutexkv"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"os"
 )
 
 // Provider returns a schema.Provider for alicloud
@@ -67,10 +68,26 @@ func Provider() terraform.ResourceProvider {
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
+	accesskey, ok := d.GetOk("access_key")
+	if !ok {
+		accesskey = os.Getenv("ALICLOUD_ACCESS_KEY")
+	}
+	secretkey, ok := d.GetOk("secret_key")
+	if !ok {
+		secretkey = os.Getenv("ALICLOUD_SECRET_KEY")
+	}
+	region, ok := d.GetOk("region")
+	if !ok {
+		region = os.Getenv("ALICLOUD_REGION")
+		if region == "" {
+			region = DEFAULT_REGION
+		}
+	}
+
 	config := Config{
-		AccessKey: d.Get("access_key").(string),
-		SecretKey: d.Get("secret_key").(string),
-		Region:    common.Region(d.Get("region").(string)),
+		AccessKey: accesskey.(string),
+		SecretKey: secretkey.(string),
+		Region:    common.Region(region.(string)),
 	}
 
 	client, err := config.Client()

--- a/builtin/providers/alicloud/resource_alicloud_nat_gateway.go
+++ b/builtin/providers/alicloud/resource_alicloud_nat_gateway.go
@@ -70,6 +70,7 @@ func resourceAliyunNatGateway() *schema.Resource {
 						"zone": &schema.Schema{
 							Type:     schema.TypeString,
 							Optional: true,
+							Computed: true,
 						},
 						"public_ip_addresses": &schema.Schema{
 							Type:     schema.TypeString,


### PR DESCRIPTION
This PR fix the following bugs:
1. When setting access_key to "", running 'terraform apply' will raise ACCESS KEY NOT FOUND error.  And the PR fix the bug by using ENV ALICLOUD_ACCESS_KEY and ALICLOUD_SECRET_KEY.
2. When creating nat gateway, if set "zone" is nil, diff resource will appear error. Now, the PR set "zone" Compute is true.

The running result of nat gateway testcase as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudNatGateway -timeout 120m
=== RUN   TestAccAlicloudNatGateway_basic
--- PASS: TestAccAlicloudNatGateway_basic (76.65s)
=== RUN   TestAccAlicloudNatGateway_spec
--- PASS: TestAccAlicloudNatGateway_spec (69.36s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  146.017s