### PR TITLE
fix simple spelling mistake

### DIFF
--- a/builtin/providers/pagerduty/structure.go
+++ b/builtin/providers/pagerduty/structure.go
@@ -277,11 +277,11 @@ func flattenIncidentUrgencyRule(service *pagerduty.Service) ([]interface{}, bool
 }
 
 func flattenIncidentUrgencyType(iut *pagerduty.IncidentUrgencyType) []interface{} {
-	incidenUrgencyType := map[string]interface{}{
+	incidentUrgencyType := map[string]interface{}{
 		"type":    iut.Type,
 		"urgency": iut.Urgency,
 	}
-	return []interface{}{incidenUrgencyType}
+	return []interface{}{incidentUrgencyType}
 }
 
 // Expands attribute to support hours


### PR DESCRIPTION
There was a spelling mistake in the name of a map. The fix will not affect functionality and all tests pass.