### PR TITLE
provider/librato: Update based on Librato API changes

### DIFF
--- a/builtin/providers/librato/resource_librato_alert.go
+++ b/builtin/providers/librato/resource_librato_alert.go
@@ -23,61 +23,61 @@ func resourceLibratoAlert() *schema.Resource {
 		Delete: resourceLibratoAlertDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 			},
-			"description": &schema.Schema{
+			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"active": &schema.Schema{
+			"active": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
 			},
-			"rearm_seconds": &schema.Schema{
+			"rearm_seconds": {
 				Type:     schema.TypeInt,
 				Optional: true,
 				Default:  600,
 			},
-			"services": &schema.Schema{
+			"services": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Set:      schema.HashString,
 			},
-			"condition": &schema.Schema{
+			"condition": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"type": &schema.Schema{
+						"type": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"metric_name": &schema.Schema{
+						"metric_name": {
 							Type:     schema.TypeString,
 							Required: true,
 						},
-						"source": &schema.Schema{
+						"source": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"detect_reset": &schema.Schema{
+						"detect_reset": {
 							Type:     schema.TypeBool,
 							Optional: true,
 						},
-						"duration": &schema.Schema{
+						"duration": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
-						"threshold": &schema.Schema{
+						"threshold": {
 							Type:     schema.TypeFloat,
 							Optional: true,
 						},
-						"summary_function": &schema.Schema{
+						"summary_function": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -85,12 +85,12 @@ func resourceLibratoAlert() *schema.Resource {
 				},
 				Set: resourceLibratoAlertConditionsHash,
 			},
-			"attributes": &schema.Schema{
+			"attributes": {
 				Type:     schema.TypeList,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"runbook_url": &schema.Schema{
+						"runbook_url": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
@@ -112,9 +112,9 @@ func resourceLibratoAlertConditionsHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%s-", source.(string)))
 	}
 
-	detect_reset, present := m["detect_reset"]
+	detectReset, present := m["detect_reset"]
 	if present {
-		buf.WriteString(fmt.Sprintf("%t-", detect_reset.(bool)))
+		buf.WriteString(fmt.Sprintf("%t-", detectReset.(bool)))
 	}
 
 	duration, present := m["duration"]
@@ -127,9 +127,9 @@ func resourceLibratoAlertConditionsHash(v interface{}) int {
 		buf.WriteString(fmt.Sprintf("%f-", threshold.(float64)))
 	}
 
-	summary_function, present := m["summary_function"]
+	summaryFunction, present := m["summary_function"]
 	if present {
-		buf.WriteString(fmt.Sprintf("%s-", summary_function.(string)))
+		buf.WriteString(fmt.Sprintf("%s-", summaryFunction.(string)))
 	}
 
 	return hashcode.String(buf.String())
@@ -413,9 +413,9 @@ func resourceLibratoAlertUpdate(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	log.Printf("[INFO] Updating Librato alert: %s", alert)
-	_, err = client.Alerts.Edit(uint(alertID), alert)
-	if err != nil {
-		return fmt.Errorf("Error updating Librato alert: %s", err)
+	_, updErr := client.Alerts.Update(uint(alertID), alert)
+	if updErr != nil {
+		return fmt.Errorf("Error updating Librato alert: %s", updErr)
 	}
 
 	log.Printf("[INFO] Updated Librato alert %d", alertID)
@@ -429,9 +429,9 @@ func resourceLibratoAlertUpdate(d *schema.ResourceData, meta interface{}) error 
 		ContinuousTargetOccurence: 5,
 		Refresh: func() (interface{}, string, error) {
 			log.Printf("[DEBUG] Checking if Librato Alert %d was updated yet", alertID)
-			changedAlert, _, err := client.Alerts.Get(uint(alertID))
-			if err != nil {
-				return changedAlert, "", err
+			changedAlert, _, getErr := client.Alerts.Get(uint(alertID))
+			if getErr != nil {
+				return changedAlert, "", getErr
 			}
 			isEqual := reflect.DeepEqual(*fullAlert, *changedAlert)
 			log.Printf("[DEBUG] Updated Librato Alert %d match: %t", alertID, isEqual)

--- a/builtin/providers/librato/resource_librato_metric.go
+++ b/builtin/providers/librato/resource_librato_metric.go
@@ -151,7 +151,7 @@ func resourceLibratoMetricCreate(d *schema.ResourceData, meta interface{}) error
 		metric.Attributes = attributes
 	}
 
-	_, err := client.Metrics.Edit(&metric)
+	_, err := client.Metrics.Update(&metric)
 	if err != nil {
 		log.Printf("[INFO] ERROR creating Metric: %s", err)
 		return fmt.Errorf("Error creating Librato metric: %s", err)
@@ -280,7 +280,7 @@ func resourceLibratoMetricUpdate(d *schema.ResourceData, meta interface{}) error
 
 	log.Printf("[INFO] Updating Librato metric: %v", structToString(metric))
 
-	_, err := client.Metrics.Edit(metric)
+	_, err := client.Metrics.Update(metric)
 	if err != nil {
 		return fmt.Errorf("Error updating Librato metric: %s", err)
 	}

--- a/builtin/providers/librato/resource_librato_space.go
+++ b/builtin/providers/librato/resource_librato_space.go
@@ -19,12 +19,12 @@ func resourceLibratoSpace() *schema.Resource {
 		Delete: resourceLibratoSpaceDelete,
 
 		Schema: map[string]*schema.Schema{
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: false,
 			},
-			"id": &schema.Schema{
+			"id": {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
@@ -97,7 +97,7 @@ func resourceLibratoSpaceUpdate(d *schema.ResourceData, meta interface{}) error 
 	if d.HasChange("name") {
 		newName := d.Get("name").(string)
 		log.Printf("[INFO] Modifying name space attribute for %d: %#v", id, newName)
-		if _, err = client.Spaces.Edit(uint(id), &librato.Space{Name: &newName}); err != nil {
+		if _, err = client.Spaces.Update(uint(id), &librato.Space{Name: &newName}); err != nil {
 			return err
 		}
 	}

--- a/builtin/providers/librato/resource_librato_space_chart.go
+++ b/builtin/providers/librato/resource_librato_space_chart.go
@@ -23,98 +23,98 @@ func resourceLibratoSpaceChart() *schema.Resource {
 		Delete: resourceLibratoSpaceChartDelete,
 
 		Schema: map[string]*schema.Schema{
-			"space_id": &schema.Schema{
+			"space_id": {
 				Type:     schema.TypeInt,
 				Required: true,
 				ForceNew: true,
 			},
-			"name": &schema.Schema{
+			"name": {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"type": &schema.Schema{
+			"type": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
 			},
-			"min": &schema.Schema{
+			"min": {
 				Type:     schema.TypeFloat,
 				Default:  math.NaN(),
 				Optional: true,
 			},
-			"max": &schema.Schema{
+			"max": {
 				Type:     schema.TypeFloat,
 				Default:  math.NaN(),
 				Optional: true,
 			},
-			"label": &schema.Schema{
+			"label": {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
-			"related_space": &schema.Schema{
+			"related_space": {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
-			"stream": &schema.Schema{
+			"stream": {
 				Type:     schema.TypeSet,
 				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
-						"metric": &schema.Schema{
+						"metric": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							ConflictsWith: []string{"stream.composite"},
 						},
-						"source": &schema.Schema{
+						"source": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							ConflictsWith: []string{"stream.composite"},
 						},
-						"group_function": &schema.Schema{
+						"group_function": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							ConflictsWith: []string{"stream.composite"},
 						},
-						"composite": &schema.Schema{
+						"composite": {
 							Type:          schema.TypeString,
 							Optional:      true,
 							ConflictsWith: []string{"stream.metric", "stream.source", "stream.group_function"},
 						},
-						"summary_function": &schema.Schema{
+						"summary_function": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"name": &schema.Schema{
+						"name": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"color": &schema.Schema{
+						"color": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"units_short": &schema.Schema{
+						"units_short": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"units_long": &schema.Schema{
+						"units_long": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"min": &schema.Schema{
+						"min": {
 							Type:     schema.TypeFloat,
 							Default:  math.NaN(),
 							Optional: true,
 						},
-						"max": &schema.Schema{
+						"max": {
 							Type:     schema.TypeFloat,
 							Default:  math.NaN(),
 							Optional: true,
 						},
-						"transform_function": &schema.Schema{
+						"transform_function": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
-						"period": &schema.Schema{
+						"period": {
 							Type:     schema.TypeInt,
 							Optional: true,
 						},
@@ -420,7 +420,7 @@ func resourceLibratoSpaceChartUpdate(d *schema.ResourceData, meta interface{}) e
 		fullChart.Streams = streams
 	}
 
-	_, err = client.Spaces.EditChart(spaceID, uint(chartID), spaceChart)
+	_, err = client.Spaces.UpdateChart(spaceID, uint(chartID), spaceChart)
 	if err != nil {
 		return fmt.Errorf("Error updating Librato space chart %s: %s", *spaceChart.Name, err)
 	}
@@ -434,9 +434,9 @@ func resourceLibratoSpaceChartUpdate(d *schema.ResourceData, meta interface{}) e
 		ContinuousTargetOccurence: 5,
 		Refresh: func() (interface{}, string, error) {
 			log.Printf("[DEBUG] Checking if Librato Space Chart %d was updated yet", chartID)
-			changedChart, _, err := client.Spaces.GetChart(spaceID, uint(chartID))
-			if err != nil {
-				return changedChart, "", err
+			changedChart, _, getErr := client.Spaces.GetChart(spaceID, uint(chartID))
+			if getErr != nil {
+				return changedChart, "", getErr
 			}
 			isEqual := reflect.DeepEqual(*fullChart, *changedChart)
 			log.Printf("[DEBUG] Updated Librato Space Chart %d match: %t", chartID, isEqual)

--- a/vendor/github.com/henrikhodne/go-librato/librato/alerts.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/alerts.go
@@ -83,10 +83,10 @@ func (a *AlertsService) Create(alert *Alert) (*Alert, *http.Response, error) {
 	return al, resp, err
 }
 
-// Edit an alert.
+// Update an alert.
 //
 // Librato API docs: https://www.librato.com/docs/api/?shell#update-alert
-func (a *AlertsService) Edit(alertID uint, alert *Alert) (*http.Response, error) {
+func (a *AlertsService) Update(alertID uint, alert *Alert) (*http.Response, error) {
 	u := fmt.Sprintf("alerts/%d", alertID)
 	req, err := a.client.NewRequest("PUT", u, alert)
 	if err != nil {

--- a/vendor/github.com/henrikhodne/go-librato/librato/client.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/client.go
@@ -100,9 +100,9 @@ func (c *Client) NewRequest(method, urlStr string, body interface{}) (*http.Requ
 	var buf io.ReadWriter
 	if body != nil {
 		buf = new(bytes.Buffer)
-		err := json.NewEncoder(buf).Encode(body)
-		if err != nil {
-			return nil, err
+		encodeErr := json.NewEncoder(buf).Encode(body)
+		if encodeErr != nil {
+			return nil, encodeErr
 		}
 	}
 

--- a/vendor/github.com/henrikhodne/go-librato/librato/metrics.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/metrics.go
@@ -32,7 +32,6 @@ type MetricAttributes struct {
 	DisplayUnitsLong  string      `json:"display_units_long"`
 	DisplayUnitsShort string      `json:"display_units_short"`
 	DisplayStacked    bool        `json:"display_stacked"`
-	DisplayTransform  string      `json:"display_transform"`
 	CreatedByUA       string      `json:"created_by_ua,omitempty"`
 	GapDetection      bool        `json:"gap_detection,omitempty"`
 	Aggregate         bool        `json:"aggregate,omitempty"`
@@ -136,10 +135,10 @@ type GaugeMeasurement struct {
 	SumSquares *float64 `json:"sum_squares,omitempty"`
 }
 
-// Submit metrics
+// Create metrics
 //
 // Librato API docs: https://www.librato.com/docs/api/#create-a-measurement
-func (m *MetricsService) Submit(measurements *MeasurementSubmission) (*http.Response, error) {
+func (m *MetricsService) Create(measurements *MeasurementSubmission) (*http.Response, error) {
 	req, err := m.client.NewRequest("POST", "/metrics", measurements)
 	if err != nil {
 		return nil, err
@@ -148,10 +147,10 @@ func (m *MetricsService) Submit(measurements *MeasurementSubmission) (*http.Resp
 	return m.client.Do(req, nil)
 }
 
-// Edit a metric.
+// Update a metric.
 //
 // Librato API docs: https://www.librato.com/docs/api/#update-a-metric-by-name
-func (m *MetricsService) Edit(metric *Metric) (*http.Response, error) {
+func (m *MetricsService) Update(metric *Metric) (*http.Response, error) {
 	u := fmt.Sprintf("metrics/%s", *metric.Name)
 
 	req, err := m.client.NewRequest("PUT", u, metric)

--- a/vendor/github.com/henrikhodne/go-librato/librato/services.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/services.go
@@ -63,10 +63,10 @@ func (s *ServicesService) Create(service *Service) (*Service, *http.Response, er
 	return sv, resp, err
 }
 
-// Edit a service.
+// Update a service.
 //
 // Librato API docs: https://www.librato.com/docs/api/#update-a-service
-func (s *ServicesService) Edit(serviceID uint, service *Service) (*http.Response, error) {
+func (s *ServicesService) Update(serviceID uint, service *Service) (*http.Response, error) {
 	u := fmt.Sprintf("services/%d", serviceID)
 	req, err := s.client.NewRequest("PUT", u, service)
 	if err != nil {

--- a/vendor/github.com/henrikhodne/go-librato/librato/spaces.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/spaces.go
@@ -96,10 +96,10 @@ func (s *SpacesService) Create(space *Space) (*Space, *http.Response, error) {
 	return sp, resp, err
 }
 
-// Edit a space.
+// Update a space.
 //
 // Librato API docs: http://dev.librato.com/v1/put/spaces/:id
-func (s *SpacesService) Edit(spaceID uint, space *Space) (*http.Response, error) {
+func (s *SpacesService) Update(spaceID uint, space *Space) (*http.Response, error) {
 	u := fmt.Sprintf("spaces/%d", spaceID)
 	req, err := s.client.NewRequest("PUT", u, space)
 	if err != nil {

--- a/vendor/github.com/henrikhodne/go-librato/librato/spaces_charts.go
+++ b/vendor/github.com/henrikhodne/go-librato/librato/spaces_charts.go
@@ -91,10 +91,10 @@ func (s *SpacesService) GetChart(spaceID, chartID uint) (*SpaceChart, *http.Resp
 	return c, resp, err
 }
 
-// EditChart edits a chart.
+// UpdateChart updates a chart.
 //
 // Librato API docs: http://dev.librato.com/v1/put/spaces/:id/charts/:id
-func (s *SpacesService) EditChart(spaceID, chartID uint, chart *SpaceChart) (*http.Response, error) {
+func (s *SpacesService) UpdateChart(spaceID, chartID uint, chart *SpaceChart) (*http.Response, error) {
 	u := fmt.Sprintf("spaces/%d/charts/%d", spaceID, chartID)
 	req, err := s.client.NewRequest("PUT", u, chart)
 	if err != nil {

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2287,10 +2287,10 @@
 			"revisionTime": "2016-07-20T23:31:40Z"
 		},
 		{
-			"checksumSHA1": "HtxHX0u0oN+aiTN1Pd67Y4ilMdI=",
+			"checksumSHA1": "era7cPiPrCcdoEeHB+kNNYLODfg=",
 			"path": "github.com/henrikhodne/go-librato/librato",
-			"revision": "1bca649ee479cdfcf2e19f30ecb74b6f23345e5a",
-			"revisionTime": "2017-05-13T14:06:44Z"
+			"revision": "f82d1c74e11de20191cc53b762a2217d582b0596",
+			"revisionTime": "2017-06-05T03:23:04Z"
 		},
 		{
 			"checksumSHA1": "K6exl2ouL7d8cR2i378EzZOdRVI=",


### PR DESCRIPTION
Recently, the underlying Librato client API was updated; this PR brings these changes into the Librato provider.

Also cleaned up a few lint errors and refactored a few items to remove extraneous "&schema.Schema" items.