### PR TITLE
provider/aws: Fix Service Directory acc tests

### DIFF
--- a/builtin/providers/aws/resource_aws_directory_service_directory.go
+++ b/builtin/providers/aws/resource_aws_directory_service_directory.go
@@ -41,6 +41,7 @@ func resourceAwsDirectoryServiceDirectory() *schema.Resource {
 			"size": &schema.Schema{
 				Type:     schema.TypeString,
 				Optional: true,
+				Default:  "Large",
 				ForceNew: true,
 			},
 			"alias": &schema.Schema{


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSDirectoryServiceDirectory_microsoft
--- FAIL: TestAccAWSDirectoryServiceDirectory_microsoft (1622.47s)
    testing.go:280: Step 0 error: After applying this step, the plan was not empty:
        
        DIFF:
        
        DESTROY/CREATE: aws_directory_service_directory.bar
          access_url:                           "d-926722f797.awsapps.com" => "<computed>"
          alias:                                "d-926722f797" => "<computed>"
          dns_ip_addresses.#:                   "2" => "<computed>"
          enable_sso:                           "false" => "false"
          name:                                 "corp.notexample.com" => "corp.notexample.com"
          password:                             "<sensitive>" => "<sensitive>" (attribute changed)
          short_name:                           "corp" => "<computed>"
          size:                                 "Large" => "" (forces new resource)
          type:                                 "MicrosoftAD" => "MicrosoftAD"
          vpc_settings.#:                       "1" => "1"
          vpc_settings.0.subnet_ids.#:          "2" => "2"
          vpc_settings.0.subnet_ids.3038726517: "subnet-ca773883" => "subnet-ca773883"
          vpc_settings.0.subnet_ids.914094928:  "subnet-4ea19529" => "subnet-4ea19529"
          vpc_settings.0.vpc_id:                "vpc-fe312a99" => "vpc-fe312a99"
        
```

Apparently AWS has changed the Read API method in a way that it returns size even when it's not explicitly defined.