### PR TITLE
provider/aws: Filter acm certificates by type

### DIFF
--- a/builtin/providers/aws/data_source_aws_acm_certificate_test.go
+++ b/builtin/providers/aws/data_source_aws_acm_certificate_test.go
@@ -24,6 +24,10 @@ func TestAccAwsAcmCertificateDataSource_noMatchReturnsError(t *testing.T) {
 				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain),
 				ExpectError: regexp.MustCompile(`No certificate for domain`),
 			},
+			{
+				Config:      testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain),
+				ExpectError: regexp.MustCompile(`No certificate for domain`),
+			},
 		},
 	})
 }
@@ -41,6 +45,15 @@ func testAccCheckAwsAcmCertificateDataSourceConfigWithStatus(domain string) stri
 data "aws_acm_certificate" "test" {
 	domain = "%s"
 	statuses = ["ISSUED"]
+}
+`, domain)
+}
+
+func testAccCheckAwsAcmCertificateDataSourceConfigWithTypes(domain string) string {
+	return fmt.Sprintf(`
+data "aws_acm_certificate" "test" {
+	domain = "%s"
+	types = ["IMPORTED"]
 }
 `, domain)
 }


### PR DESCRIPTION
GH-15063 - In case there are multiple acm certificates with the same domain name, it must be possible to configure which one to use by specifying required certificate type.

### Example Terraform Configuration
```hcl
data "aws_acm_certificate" "test" {
  domain = "test.com"
  types = ["IMPORTED"]
}
```

### Related issues
- GH-12650 - in case there are multiple certificates with the same domain name...
- GH-12111 - more than one cert present with equal domain names...
