### PR TITLE
provider/aws: Retry Lambda func creation on IAM error

### DIFF
--- a/builtin/providers/aws/resource_aws_lambda_function.go
+++ b/builtin/providers/aws/resource_aws_lambda_function.go
@@ -342,6 +342,10 @@ func resourceAwsLambdaFunctionCreate(d *schema.ResourceData, meta interface{}) e
 				log.Printf("[DEBUG] Received %s, retrying CreateFunction", err)
 				return resource.RetryableError(err)
 			}
+			if isAWSErr(err, "InvalidParameterValueException", "The provided execution role does not have permissions") {
+				log.Printf("[DEBUG] Received %s, retrying CreateFunction", err)
+				return resource.RetryableError(err)
+			}
 
 			return resource.NonRetryableError(err)
 		}


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSLambdaFunction_importLocalFile_VPC
--- FAIL: TestAccAWSLambdaFunction_importLocalFile_VPC (16.48s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_lambda_function.lambda_function_test: 1 error(s) occurred:
        
        * aws_lambda_function.lambda_function_test: Error creating Lambda function: InvalidParameterValueException: The provided execution role does not have permissions to call CreateNetworkInterface on EC2
            status code: 400, request id: ddb1a6a7-48e4-11e7-9d99-9d3b481e3ff0
FAIL
```

Here's a snippet from the debug log proving this is the API call that returned the error:

```
---[ RESPONSE ]--------------------------------------
HTTP/1.1 400 Bad Request
Connection: close
Content-Length: 119
Content-Type: application/json
Date: Sun, 04 Jun 2017 05:15:46 GMT
X-Amzn-Errortype: InvalidParameterValueException
X-Amzn-Requestid: ddb1a6a7-48e4-11e7-9d99-9d3b481e3ff0


{"Type":"User","message":"The provided execution role does not have permissions to call CreateNetworkInterface on EC2"}
-----------------------------------------------------
```