### PR TITLE
provider/aws: Guard against panic when no aws_default_vpc found

### DIFF
--- a/builtin/providers/aws/resource_aws_default_vpc.go
+++ b/builtin/providers/aws/resource_aws_default_vpc.go
@@ -1,6 +1,7 @@
 package aws
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -37,7 +38,7 @@ func resourceAwsDefaultVpcCreate(d *schema.ResourceData, meta interface{}) error
 	conn := meta.(*AWSClient).ec2conn
 	req := &ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
-			&ec2.Filter{
+			{
 				Name:   aws.String("isDefault"),
 				Values: aws.StringSlice([]string{"true"}),
 			},
@@ -47,6 +48,10 @@ func resourceAwsDefaultVpcCreate(d *schema.ResourceData, meta interface{}) error
 	resp, err := conn.DescribeVpcs(req)
 	if err != nil {
 		return err
+	}
+
+	if resp.Vpcs == nil || len(resp.Vpcs) == 0 {
+		return fmt.Errorf("No default VPC found in this region.")
 	}
 
 	d.SetId(aws.StringValue(resp.Vpcs[0].VpcId))


### PR DESCRIPTION
Found as part of #15065, when there is no default VPC, Terraform will
throw a panic. This prevents that as a user should never get that

```
% make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSDefaultVpc_'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/06/05 12:16:09 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSDefaultVpc_basic -timeout 120m
=== RUN   TestAccAWSDefaultVpc_basic
--- PASS: TestAccAWSDefaultVpc_basic (44.65s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	44.669s
```