### PR TITLE
provider/aws: Revoke default ipv6 egress rule for aws_security_group

### DIFF
--- a/builtin/providers/aws/resource_aws_security_group.go
+++ b/builtin/providers/aws/resource_aws_security_group.go
@@ -295,6 +295,34 @@ func resourceAwsSecurityGroupCreate(d *schema.ResourceData, meta interface{}) er
 				d.Id(), err)
 		}
 
+		log.Printf("[DEBUG] Revoking default IPv6 egress rule for Security Group for %s", d.Id())
+		req = &ec2.RevokeSecurityGroupEgressInput{
+			GroupId: createResp.GroupId,
+			IpPermissions: []*ec2.IpPermission{
+				{
+					FromPort: aws.Int64(int64(0)),
+					ToPort:   aws.Int64(int64(0)),
+					Ipv6Ranges: []*ec2.Ipv6Range{
+						{
+							CidrIpv6: aws.String("::/0"),
+						},
+					},
+					IpProtocol: aws.String("-1"),
+				},
+			},
+		}
+
+		_, err = conn.RevokeSecurityGroupEgress(req)
+		if err != nil {
+			//If we have a NotFound, then we are trying to remove the default IPv6 egress of a non-IPv6
+			//enabled SG
+			if ec2err, ok := err.(awserr.Error); ok && ec2err.Code() != "InvalidPermission.NotFound" {
+				return fmt.Errorf(
+					"Error revoking default IPv6 egress rule for Security Group (%s): %s",
+					d.Id(), err)
+			}
+		}
+
 	}
 
 	return resourceAwsSecurityGroupUpdate(d, meta)


### PR DESCRIPTION
Fixes: #14522

To follow similar work in IPv4, we are now going to revoke the default
IPv6 egress rule from an empty AWS security group

```
% make testacc TEST=./builtin/providers/aws/ TESTARGS='-run=TestAccAWSSecurityGroup_ipv4andipv6Egress'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/06/05 14:01:52 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSSecurityGroup_ipv4andipv6Egress -timeout 120m
=== RUN   TestAccAWSSecurityGroup_ipv4andipv6Egress
--- PASS: TestAccAWSSecurityGroup_ipv4andipv6Egress (63.39s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	63.423s
```