### PR TITLE
Allow resizing of Google Cloud persistent disks

### DIFF
--- a/builtin/providers/google/resource_compute_disk_test.go
+++ b/builtin/providers/google/resource_compute_disk_test.go
@@ -32,6 +32,34 @@ func TestAccComputeDisk_basic(t *testing.T) {
 	})
 }
 
+func TestAccComputeDisk_updateSize(t *testing.T) {
+	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
+	var disk compute.Disk
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccComputeDisk_basic(diskName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeDiskExists(
+						"google_compute_disk.foobar", &disk),
+					resource.TestCheckResourceAttr("google_compute_disk.foobar", "size", "50"),
+				),
+			},
+			{
+				Config: testAccComputeDisk_resized(diskName),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckComputeDiskExists(
+						"google_compute_disk.foobar", &disk),
+					resource.TestCheckResourceAttr("google_compute_disk.foobar", "size", "100"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccComputeDisk_fromSnapshotURI(t *testing.T) {
 	diskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
 	firstDiskName := fmt.Sprintf("tf-test-%s", acctest.RandString(10))
@@ -207,6 +235,17 @@ resource "google_compute_disk" "foobar" {
 	name = "%s"
 	image = "debian-8-jessie-v20160803"
 	size = 50
+	type = "pd-ssd"
+	zone = "us-central1-a"
+}`, diskName)
+}
+
+func testAccComputeDisk_resized(diskName string) string {
+	return fmt.Sprintf(`
+resource "google_compute_disk" "foobar" {
+	name = "%s"
+	image = "debian-8-jessie-v20160803"
+	size = 100
 	type = "pd-ssd"
 	zone = "us-central1-a"
 }`, diskName)


### PR DESCRIPTION
```
make testacc TEST=./builtin/providers/google TESTARGS='-run=TestAccComputeDisk_updateSize'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/06/05 11:31:09 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google -v -run=TestAccComputeDisk_updateSize -timeout 120m
=== RUN   TestAccComputeDisk_updateSize
--- PASS: TestAccComputeDisk_updateSize (28.37s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/google	28.377s
```