### PR TITLE
doc(typo): fix title in aws_cloudwatch_log_subscription_filter

### DIFF
--- a/website/source/docs/providers/aws/r/cloudwatch_log_subscription_filter.html.markdown
+++ b/website/source/docs/providers/aws/r/cloudwatch_log_subscription_filter.html.markdown
@@ -6,7 +6,7 @@ description: |-
   Provides a CloudWatch Logs subscription filter.
 ---
 
-# aws\_cloudwatch\_logs\_subscription\_filter
+# aws\_cloudwatch\_log\_subscription\_filter
 
 Provides a CloudWatch Logs subscription filter resource.
 


### PR DESCRIPTION
Title should be `aws_cloudwatch_log_subscription_filter` instead of `aws_cloudwatch_logs_subscription_filter`