### PR TITLE
provider/alicloud: Fix vpc and vswitch bugs while creating vpc and vswitch

### DIFF
--- a/builtin/providers/alicloud/errors.go
+++ b/builtin/providers/alicloud/errors.go
@@ -36,6 +36,9 @@ const (
 	// ess
 	InvalidScalingGroupIdNotFound               = "InvalidScalingGroupId.NotFound"
 	IncorrectScalingConfigurationLifecycleState = "IncorrectScalingConfigurationLifecycleState"
+
+	//unknown Error
+	UnknownError = "UnknownError"
 )
 
 func GetNotFoundErrorFromString(str string) error {

--- a/builtin/providers/alicloud/resource_alicloud_vpc.go
+++ b/builtin/providers/alicloud/resource_alicloud_vpc.go
@@ -2,11 +2,11 @@ package alicloud
 
 import (
 	"fmt"
-	"strings"
-
+	"github.com/denverdino/aliyungo/common"
 	"github.com/denverdino/aliyungo/ecs"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
 	"time"
 )
 
@@ -73,9 +73,20 @@ func resourceAliyunVpcCreate(d *schema.ResourceData, meta interface{}) error {
 
 	ecsconn := meta.(*AliyunClient).ecsconn
 
-	vpc, err := ecsconn.CreateVpc(args)
+	var vpc *ecs.CreateVpcResponse
+	err = resource.Retry(3*time.Minute, func() *resource.RetryError {
+		resp, err := ecsconn.CreateVpc(args)
+		if err != nil {
+			if e, ok := err.(*common.Error); ok && (e.StatusCode == 400 || e.Code == UnknownError) {
+				return resource.RetryableError(fmt.Errorf("Vpc is still creating result from some unknown error -- try again"))
+			}
+			return resource.NonRetryableError(err)
+		}
+		vpc = resp
+		return nil
+	})
 	if err != nil {
-		return err
+		return fmt.Errorf("Create vpc got an error :%#v", err)
 	}
 
 	d.SetId(vpc.VpcId)


### PR DESCRIPTION
This PR fixed the vpc and vswitch bugs that there will raise error when creating multiple vpc or vswitch simultaneously, and the PR using retry to solve them.

The running results of vpc and vswitch testcase as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVpc -timeout 120m=== RUN   TestAccAlicloudVpc_basic
--- PASS: TestAccAlicloudVpc_basic (20.17s)
=== RUN   TestAccAlicloudVpc_update
--- PASS: TestAccAlicloudVpc_update (34.13s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  54.323s

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudVswitch -timeout 120m 
=== RUN   TestAccAlicloudVswitch_basic
--- PASS: TestAccAlicloudVswitch_basic (30.97s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  30.982s