### PR TITLE
provider/aws: Fix Beanstalk App Version acceptance test

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_application_version_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_application_version_test.go
@@ -113,10 +113,10 @@ resource "aws_elastic_beanstalk_application" "default" {
 }
 
 resource "aws_elastic_beanstalk_application_version" "default" {
-  application = "tf-test-name-%d"
+  application = "${aws_elastic_beanstalk_application.default.name}"
   name = "tf-test-version-label"
   bucket = "${aws_s3_bucket.default.id}"
   key = "${aws_s3_bucket_object.default.id}"
  }
- `, randInt, randInt, randInt)
+ `, randInt, randInt)
 }


### PR DESCRIPTION
This is to address the following test failure (likely caused by race condition):

```
=== RUN   TestAccAWSBeanstalkEnv_version_label
--- FAIL: TestAccAWSBeanstalkEnv_version_label (372.11s)
    testing.go:280: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_application_version.default: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_application_version.default: InvalidParameterValue: No Application named 'tf-test-name-3608794125069207226' found.
            status code: 400, request id: 3e206972-48ed-11e7-88fc-83faf60662ac
```

We'll see in the coming days/weeks if it's eventual consistency or not.