### PR TITLE
provider/aws: Raise timeout for DHCP opts creation

### DIFF
--- a/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
+++ b/builtin/providers/aws/resource_aws_vpc_dhcp_options.go
@@ -126,7 +126,7 @@ func resourceAwsVpcDhcpOptionsCreate(d *schema.ResourceData, meta interface{}) e
 		Pending: []string{"pending"},
 		Target:  []string{"created"},
 		Refresh: resourceDHCPOptionsStateRefreshFunc(conn, d.Id()),
-		Timeout: 1 * time.Minute,
+		Timeout: 5 * time.Minute,
 	}
 	if _, err := stateConf.WaitForState(); err != nil {
 		return fmt.Errorf(


### PR DESCRIPTION
This is to address the following test failure:

```
=== RUN   TestAccAWSDHCPOptions_importBasic
--- FAIL: TestAccAWSDHCPOptions_importBasic (4.55s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_vpc_dhcp_options.foo: 1 error(s) occurred:
        
        * aws_vpc_dhcp_options.foo: Error waiting for DHCP Options (dopt-901858f7) to become available: InvalidDhcpOptionID.NotFound: The dhcpOption ID 'dopt-901858f7' does not exist
            status code: 400, request id: 3ad6e7c3-b5de-493e-baf0-1150e2b6478d
```