### PR TITLE
provider/aws: Change aws_kinesis_stream docs to not have id and name the same

### DIFF
--- a/website/source/docs/providers/aws/r/kinesis_stream.html.markdown
+++ b/website/source/docs/providers/aws/r/kinesis_stream.html.markdown
@@ -48,9 +48,9 @@ when creating a Kinesis stream. See [Amazon Kinesis Streams][2] for more.
 ## Attributes Reference
 
 * `id` - The unique Stream id
-* `name` - The unique Stream name (same as `id`)
+* `name` - The unique Stream name
 * `shard_count` - The count of Shards for this Stream
-* `arn` - The Amazon Resource Name (ARN) specifying the Stream
+* `arn` - The Amazon Resource Name (ARN) specifying the Stream (same as `id`)
 
 
 ## Import


### PR DESCRIPTION
Fixes: #15081