### PR TITLE
provider/azurerm: Add diff supress func to azurerm_traffic_manager_endpoint.endpoint_location.

### DIFF
--- a/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint.go
+++ b/builtin/providers/azurerm/resource_arm_traffic_manager_endpoint.go
@@ -73,12 +73,13 @@ func resourceArmTrafficManagerEndpoint() *schema.Resource {
 				ValidateFunc: validation.IntBetween(1, 1000),
 			},
 
+			// when targeting an Azure resource the location of that resource will be set on the endpoint
 			"endpoint_location": {
-				Type:     schema.TypeString,
-				Optional: true,
-				// when targeting an Azure resource the location of that resource will be set on the endpoint
-				Computed:  true,
-				StateFunc: azureRMNormalizeLocation,
+				Type:             schema.TypeString,
+				Optional:         true,
+				Computed:         true,
+				StateFunc:        azureRMNormalizeLocation,
+				DiffSuppressFunc: azureRMSuppressLocationDiff,
 			},
 
 			"min_child_endpoints": {


### PR DESCRIPTION
The default locationSchema function applies the diff supression func. Since this resource cannot use the default schema it should also apply the diff suppression func to avoid normalization issues.