### PR TITLE
provider/google: Update compute_disk to read after update, always set size

### DIFF
--- a/builtin/providers/google/resource_compute_disk.go
+++ b/builtin/providers/google/resource_compute_disk.go
@@ -204,7 +204,7 @@ func resourceComputeDiskUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
-	return nil
+	return resourceComputeDiskRead(d, meta)
 }
 
 func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
@@ -259,10 +259,7 @@ func resourceComputeDiskRead(d *schema.ResourceData, meta interface{}) error {
 		imageUrlParts := strings.Split(disk.SourceImage, "/")
 		d.Set("image", imageUrlParts[len(imageUrlParts)-1])
 	}
-	if disk.SourceSnapshot != "" {
-		snapshotUrlParts := strings.Split(disk.SourceSnapshot, "/")
-		d.Set("snapshot", snapshotUrlParts[len(snapshotUrlParts)-1])
-	}
+	d.Set("snapshot", disk.SourceSnapshot)
 
 	return nil
 }

--- a/builtin/providers/google/resource_compute_disk_test.go
+++ b/builtin/providers/google/resource_compute_disk_test.go
@@ -304,7 +304,7 @@ resource "google_compute_instance" "bar" {
 	zone = "us-central1-a"
 
 	disk {
-		image = "debian-8"
+		image = "debian-8-jessie-v20170523"
 	}
 
 	disk {


### PR DESCRIPTION
A number of `compute_disk` acceptances test are failing because of mishandling of `snapshot`. We need to store the full link returned to us and not parse it, because we can't know what we got, but we'll always get the full url back. Should update docs too but I will have a follow up PR regarding waiting for size change that should address this and will come tomorrow.