### PR TITLE
Update link to canned GCS ACL's

### DIFF
--- a/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
@@ -36,7 +36,7 @@ resource "google_storage_bucket_acl" "image-store-acl" {
 
 - - -
 
-* `predefined_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control#predefined-acl) to apply. Must be set if `role_entity` is not.
+* `predefined_acl` - (Optional) The [canned GCS ACL](https://cloud.google.com/storage/docs/access-control/lists#predefined-acl) to apply. Must be set if `role_entity` is not.
 
 * `role_entity` - (Optional) List of role/entity pairs in the form `ROLE:entity`. See [GCS Bucket ACL documentation](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls)  for more details. Must be set if `predefined_acl` is not.
 


### PR DESCRIPTION
This points to the new location for the list of canned ACL's.