### PR TITLE
provider/google: Add note about instance group restrictions in region backend service docs.

### DIFF
--- a/website/source/docs/providers/google/r/compute_region_backend_service.html.markdown
+++ b/website/source/docs/providers/google/r/compute_region_backend_service.html.markdown
@@ -9,8 +9,8 @@ description: |-
 # google\_compute\_region\_backend\_service
 
 A Region Backend Service defines a regionally-scoped group of virtual machines that will serve traffic for load balancing.
-
-See [backendServices](https://cloud.google.com/compute/docs/reference/latest/backendServices) documentation for more on this resource type, and [Internal Load Balancing](https://cloud.google.com/compute/docs/load-balancing/internal/) documentation for more details on usage.
+For more information see [the official documentation](https://cloud.google.com/compute/docs/load-balancing/internal/) 
+and [API](https://cloud.google.com/compute/docs/reference/latest/backendServices).
 
 ## Example Usage
 
@@ -75,7 +75,7 @@ The following arguments are supported:
 - - -
 
 * `backend` - (Optional) The list of backends that serve this BackendService.
-    See *Backend* below.
+    Structure is documented below.
 
 * `description` - (Optional) The textual description for the backend service.
 
@@ -96,11 +96,11 @@ The following arguments are supported:
     to a request before considering the request failed. Defaults to `30`.
 
 
-**Backend** supports the following attributes:
+The `backend` block supports:
 
 * `group` - (Required) The name or URI of a Compute Engine instance group
     (`google_compute_instance_group_manager.xyz.instance_group`) that can
-    receive traffic.
+    receive traffic. Instance groups must contain at least one instance.
 
 * `balancing_mode` - (Optional) Defines the strategy for balancing load.
     Defaults to `UTILIZATION`


### PR DESCRIPTION
Update the regional backend service documentation to reflect that instance groups cannot be empty.

Related to #15027 
@danawillow 