### PR TITLE
providers/heroku: direct oauth authorizations through Terraform

### DIFF
--- a/builtin/providers/heroku/provider.go
+++ b/builtin/providers/heroku/provider.go
@@ -30,6 +30,7 @@ func Provider() terraform.ResourceProvider {
 			"heroku_addon":             resourceHerokuAddon(),
 			"heroku_app":               resourceHerokuApp(),
 			"heroku_app_feature":       resourceHerokuAppFeature(),
+			"heroku_authorization":     resourceHerokuAuthorization(),
 			"heroku_cert":              resourceHerokuCert(),
 			"heroku_domain":            resourceHerokuDomain(),
 			"heroku_drain":             resourceHerokuDrain(),

--- a/builtin/providers/heroku/resource_heroku_authorization.go
+++ b/builtin/providers/heroku/resource_heroku_authorization.go
@@ -1,0 +1,115 @@
+package heroku
+
+import (
+	"context"
+	"log"
+
+	heroku "github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceHerokuAuthorization() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceHerokuAuthorizationCreate,
+		Read:   resourceHerokuAuthorizationRead,
+		Delete: resourceHerokuAuthorizationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"scope": {
+				Type: schema.TypeList,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Optional: true,
+				Computed: true,
+				ForceNew: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "Managed by Terraform",
+				ForceNew: true,
+			},
+			// --- Computed properties ---
+			"id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceHerokuAuthorizationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	authorization, err := client.OAuthAuthorizationInfo(context.TODO(), d.Id())
+	if err != nil {
+		return err
+	}
+
+	d.SetId(authorization.ID)
+	d.Set("id", authorization.ID)
+	d.Set("scope", authorization.Scope)
+	// TODO Missing in generated struct, but present in the API
+	// d.Set("description", authorization.Description)
+	if authorization.AccessToken != nil {
+		d.Set("token", authorization.AccessToken.Token)
+	} else {
+		d.Set("token", nil)
+	}
+
+	return nil
+}
+
+func resourceHerokuAuthorizationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	description := d.Get("description").(string)
+	scope := []string{}
+	for _, v := range d.Get("scope").([]interface{}) {
+		scope = append(scope, v.(string))
+	}
+	if len(scope) == 0 {
+		scope = []string{"global"}
+	}
+
+	opts := heroku.OAuthAuthorizationCreateOpts{
+		Description: &description,
+		Scope:       scope,
+	}
+	if len(scope) > 0 {
+		opts.Scope = scope
+	}
+
+	log.Printf("[DEBUG] OAuth Authorization configuration: %#v", opts)
+
+	authorization, err := client.OAuthAuthorizationCreate(context.TODO(), opts)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(authorization.ID)
+
+	return resourceHerokuAuthorizationRead(d, meta)
+}
+
+func resourceHerokuAuthorizationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*heroku.Service)
+
+	id := d.Id()
+	description := d.Get("description").(string)
+
+	log.Printf("[INFO] Deleting authorization %s (%s)", id, description)
+
+	_, err := client.OAuthAuthorizationDelete(context.TODO(), id)
+	if err != nil {
+		return err
+	}
+
+	d.SetId("")
+	return nil
+}

--- a/builtin/providers/heroku/resource_heroku_authorization_test.go
+++ b/builtin/providers/heroku/resource_heroku_authorization_test.go
@@ -1,0 +1,152 @@
+package heroku
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/cyberdelia/heroku-go/v3"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccHerokuAuth_Basic(t *testing.T) {
+	var auth heroku.OAuthAuthorization
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAuthorizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAuthorizationConfig_basic(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAuthorizationExists("heroku_authorization.foobar", &auth),
+					testAccCheckHerokuAuthorizationHasToken(&auth),
+				),
+			},
+		},
+	})
+}
+
+func TestAccHerokuAuth_Scopes(t *testing.T) {
+	var auth heroku.OAuthAuthorization
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckHerokuAuthorizationDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckHerokuAuthorizationConfig_scopes(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckHerokuAuthorizationExists("heroku_authorization.foobar", &auth),
+					testAccCheckHerokuAuthorizationHasToken(&auth),
+					testAccCheckHerokuAuthorizationHasScope(&auth),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckHerokuAuthorizationConfig_basic() string {
+	return `
+resource "heroku_authorization" "foobar" {
+}`
+}
+
+func testAccCheckHerokuAuthorizationConfig_scopes() string {
+	return `
+resource "heroku_authorization" "foobar" {
+	scope = [ "identity", "read" ]
+}`
+}
+
+func testAccCheckHerokuAuthorizationExists(n string, auth *heroku.OAuthAuthorization) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		client := testAccProvider.Meta().(*heroku.Service)
+
+		foundAuth, err := client.OAuthAuthorizationInfo(context.TODO(), rs.Primary.ID)
+		if err != nil {
+			return err
+		}
+
+		if foundAuth.ID != rs.Primary.ID {
+			return fmt.Errorf("Authorization not found")
+		}
+
+		*auth = *foundAuth
+
+		return nil
+	}
+}
+
+func testAccCheckHerokuAuthorizationHasToken(auth *heroku.OAuthAuthorization) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["heroku_authorization.foobar"]
+		if !ok {
+			return fmt.Errorf("Not found: heroku_authorization.foobar")
+		}
+
+		if token, ok := rs.Primary.Attributes["token"]; ok {
+			if auth.AccessToken == nil {
+				return fmt.Errorf("Unable to match token: API response missing token fields")
+			}
+
+			if token != auth.AccessToken.Token {
+				return fmt.Errorf("Resource token not equal to API token")
+			}
+
+			return nil
+		} else {
+			return fmt.Errorf("Resource had no token")
+		}
+	}
+}
+
+func testAccCheckHerokuAuthorizationHasScope(auth *heroku.OAuthAuthorization) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources["heroku_authorization.foobar"]
+		if !ok {
+			return fmt.Errorf("Not found: heroku_authorization.foobar")
+		}
+
+		if expected, found := strconv.Itoa(len(auth.Scope)), rs.Primary.Attributes["scope.#"]; expected != found {
+			return fmt.Errorf("Found wrong number of scopes (expected %s, found %s)", expected, found)
+		}
+		for index, expected := range auth.Scope {
+			key := fmt.Sprintf("scope.%d", index)
+			found := rs.Primary.Attributes[key]
+
+			if expected != found {
+				return fmt.Errorf("Found unexpected scope at index %d (expected %q, found %q", index, expected, found)
+			}
+		}
+		return nil
+	}
+}
+
+func testAccCheckHerokuAuthorizationDestroy(s *terraform.State) error {
+	client := testAccProvider.Meta().(*heroku.Service)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "heroku_authorization" {
+			continue
+		}
+
+		_, err := client.OAuthAuthorizationInfo(context.TODO(), rs.Primary.ID)
+
+		if err == nil {
+			return fmt.Errorf("Authorization still exists: %s", rs.Primary.ID)
+		}
+	}
+
+	return nil
+}

--- a/website/source/docs/providers/heroku/r/authorization.html.markdown
+++ b/website/source/docs/providers/heroku/r/authorization.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "heroku"
+page_title: "Heroku: heroku_authorization"
+sidebar_current: "docs-heroku-resource-authorization"
+description: |-
+  Provides a Heroku OAuth Authorization resource. This can be used to create and manage direct authorizations on Heroku.
+---
+
+# heroku\_authorization
+
+Provides a Heroku OAuth Authorization resource. This can be used to
+create and manage direct authorizations on Heroku.
+
+## Example Usage
+
+```hcl
+# Create a new Heroku authorization
+resource "heroku_authorization" "default" {
+  description = "Example Identity Token"
+  scope = [ "identity" ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `description` - (Optional) A human-readable description of the authorization.
+* `scope` - (Optional) The [OAuth scopes](https://devcenter.heroku.com/articles/oauth#scopes) to grant.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `id` - The ID of the token.
+* `token` - The secret OAuth token created by this resource.


### PR DESCRIPTION
This supports only the simplest workflow: exchanging Terraform's Heroku credentials for an OAuth token in the designated scopes. It does not support the full range of Heroku OAuth features, such as client-specific authorizations or client management.

I'm using this to create (and destroy) an OAuth authorization for an app deployed this way. The app requires an OAuth token to access the Heroku API, and using my own primary API token is inappropriate.

To run the acceptance tests, given a Heroku account and the CLI:

    export HEROKU_EMAIL=$(heroku auth:whoami)
    export HEROKU_API_KEY=$(heroku auth:token)
    export TF_ACC=1
    go test -v ./builtin/providers/heroku -run 'TestAccHerokuAuth.*'