### PR TITLE
Local, relocatable, fast-building website copy

### DIFF
--- a/website/Makefile
+++ b/website/Makefile
@@ -7,6 +7,7 @@ build:
 		--rm \
 		--tty \
 		--volume "$(shell pwd):/website" \
+		-e MM_ENV=$(MM_ENV) \
 		hashicorp/middleman-hashicorp:${VERSION} \
 		bundle exec middleman build --verbose --clean
 

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,6 +1,10 @@
 VERSION?="0.3.22"
 
 build:
+ifeq ($(MM_ENV),local_build)
+	@echo "==> modifying source/ for local build"
+	@./scripts/prepare-local-build.sh
+endif
 	@echo "==> Starting build in Docker..."
 	@docker run \
 		--interactive \
@@ -10,6 +14,11 @@ build:
 		-e MM_ENV=$(MM_ENV) \
 		hashicorp/middleman-hashicorp:${VERSION} \
 		bundle exec middleman build --verbose --clean
+ifeq ($(MM_ENV),local_build)
+	@echo "==> removing changes to source/"
+	@git checkout source
+endif
+
 
 website:
 	@echo "==> Starting website in Docker..."

--- a/website/README.md
+++ b/website/README.md
@@ -22,3 +22,17 @@ Then open up `http://localhost:4567`. Note that some URLs you may need to append
 
 [middleman]: https://www.middlemanapp.com
 [terraform]: https://www.terraform.io
+
+## Building a Local Copy
+
+Building a local copy (which can be read off the filesystem, rather
+than served by a local web server) is somewhat more complicated.
+
+1. Install [Docker](https://docs.docker.com/engine/installation/)
+2. Clone this repo
+3. run `MM_ENV=local_build make build`
+
+WARNING: In order to avoid accidentally committing huge quantities of
+changes, setting `MM_ENV=local_build` will wipe out all changes to
+source/ after building, so make sure anything you want to save is
+committed.

--- a/website/config.rb
+++ b/website/config.rb
@@ -6,6 +6,13 @@ activate :hashicorp do |h|
   h.github_slug = "hashicorp/terraform"
 end
 
+configure :build do
+  if local_build?
+    set :relative_links, true
+    activate :relative_assets
+  end
+end
+
 helpers do
   # Returns the FQDN of the image URL.
   #
@@ -96,5 +103,11 @@ helpers do
     end
 
     return classes.join(" ")
+  end
+
+  # Returns true iff environment is set to local_build
+  # @return Boolean
+  def local_build?
+    ENV['MM_ENV'] == 'local_build'
   end
 end

--- a/website/config.rb
+++ b/website/config.rb
@@ -110,4 +110,10 @@ helpers do
   def local_build?
     ENV['MM_ENV'] == 'local_build'
   end
+
+  # Returns path to root (for nav link)
+  # @return String
+  def path_to_root
+    local_build? ? '/index.html' : '/'
+  end
 end

--- a/website/scripts/prepare-local-build.sh
+++ b/website/scripts/prepare-local-build.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+scriptdir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd $scriptdir/..
+
+# transform regular anchor links to link_to helpers
+find source -name *.erb -exec \
+sed -r -i -e 's/<a href="\/([^"]+)">([^<]+)<\/a>/<%= link_to "\2", "\/\1" %>/' {} \;
+
+# transform anchor links with class attributes to link_to helpers
+find source -name *.erb -exec \
+sed -r -i -e \
+'s/<a class="([^"]+)" href="\/([^"]+)">([^<]+)<\/a>/<%= link_to "\3", "\/\2", :class => "\1" %>/' {} \;

--- a/website/source/assets/javascripts/local_application.js
+++ b/website/source/assets/javascripts/local_application.js
@@ -1,0 +1,4 @@
+//= require jquery
+
+//= require hashicorp/mega-nav
+//= require hashicorp/sidebar

--- a/website/source/layouts/_sidebar.erb
+++ b/website/source/layouts/_sidebar.erb
@@ -18,9 +18,7 @@
 
   <ul class="external nav sidebar-nav">
     <li>
-      <a href="/downloads.html">
-        <%= inline_svg "download.svg" %> Download
-      </a>
+      <%= link_to "#{inline_svg 'download.svg'} Download", "/downloads.html" %>
     </li>
     <li>
       <a href="https://github.com/hashicorp/terraform">

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -32,7 +32,12 @@
     <!--[if lt IE 9]>
       <%= javascript_include_tag "ie-compat" %>
     <![endif]-->
-    <%= javascript_include_tag "application" %>
+
+    <% if local_build? %>
+      <%= javascript_include_tag "local_application" %>
+    <% else %>
+      <%= javascript_include_tag "application" %>
+    <% end %>
 
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -118,16 +123,19 @@
       </div>
     </div>
 
-    <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    <% if not local_build? %>
+      <script>
+       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                                m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      ga('create', 'UA-53231375-1', 'terraform.io');
-      ga('require', 'linkid');
-      ga('send', 'pageview', location.pathname);
-    </script>
+       ga('create', 'UA-53231375-1', 'terraform.io');
+       ga('require', 'linkid');
+       ga('send', 'pageview', location.pathname);
+      </script>
+    <% end %>
+
 
     <script type="application/ld+json">
       {

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -63,9 +63,7 @@
           <div class="col-xs-12">
             <div class="navbar-header">
               <div class="navbar-brand">
-                <a href="/">
-                  <%= inline_svg "logo-text.svg", height: 50, class: "logo" %>
-                </a>
+                <%= link_to "#{inline_svg 'logo-text.svg', height: 50, class: 'logo'}", path_to_root %>
               </div>
               <button class="navbar-toggle" type="button">
                 <span class="sr-only">Toggle navigation</span>
@@ -83,9 +81,7 @@
                   <li><a href="/community.html">Community</a></li>
                   <li><a href="https://www.hashicorp.com/products/terraform/?utm_source=oss&utm_medium=header-nav&utm_campaign=terraform">Enterprise</a></li>
                   <li>
-                    <a href="/downloads.html">
-                      <%= inline_svg "download.svg" %> Download
-                    </a>
+                    <%= link_to "#{inline_svg 'download.svg'} Download", "/downloads.html" %>
                   </li>
                   <li>
                     <a href="https://github.com/hashicorp/terraform">


### PR DESCRIPTION
(maybe) See previous prs #15054 and #15046 

To address @sethvargo's concerns about the previous attempt to make it possible to build the docs for use off the local filesystem, rather than actually checking in changes to all links on the website, we just use sed-in-place to change them all to link_to helpers to before executing the local build (except for a few special cases where anchors are wrapped around `inline_svg` calls).

We also revert the source directory after running a local build, to prevent people from accidentally checking in all the changes @sethvargo wanted to prevent in the first place. Since the primary use-case here is packaging released versions of the website/docs (people who want to preview docs locally should use `make website`), this shouldn't be a major problem.