### PR TITLE
provider/google: Make google_compute_autoscaler use Update instead of Patch.

### DIFF
--- a/builtin/providers/google/import_compute_autoscaler_test.go
+++ b/builtin/providers/google/import_compute_autoscaler_test.go
@@ -3,19 +3,26 @@ package google
 import (
 	"testing"
 
+	"fmt"
+	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
 )
 
-func TestAccAutoscaler_importBasic(t *testing.T) {
+func TestAccComputeAutoscaler_importBasic(t *testing.T) {
 	resourceName := "google_compute_autoscaler.foobar"
+
+	var it_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var tp_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var igm_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
+	var autoscaler_name = fmt.Sprintf("autoscaler-test-%s", acctest.RandString(10))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckAutoscalerDestroy,
+		CheckDestroy: testAccCheckComputeAutoscalerDestroy,
 		Steps: []resource.TestStep{
 			resource.TestStep{
-				Config: testAccAutoscaler_basic,
+				Config: testAccComputeAutoscaler_basic(it_name, tp_name, igm_name, autoscaler_name),
 			},
 
 			resource.TestStep{

--- a/builtin/providers/google/resource_compute_autoscaler.go
+++ b/builtin/providers/google/resource_compute_autoscaler.go
@@ -269,7 +269,6 @@ func flattenAutoscalingPolicy(policy *compute.AutoscalingPolicy) []map[string]in
 		for _, customMetricUtilization := range policy.CustomMetricUtilizations {
 			metricUtil := make(map[string]interface{})
 			metricUtil["target"] = customMetricUtilization.UtilizationTarget
-
 			metricUtils = append(metricUtils, metricUtil)
 		}
 		policyMap["metric"] = metricUtils
@@ -299,7 +298,7 @@ func resourceComputeAutoscalerRead(d *schema.ResourceData, meta interface{}) err
 		return err
 	}
 	if resource == nil {
-		log.Printf("[WARN] Removing Autoscalar %q because it's gone", d.Get("name").(string))
+		log.Printf("[WARN] Removing Autoscaler %q because it's gone", d.Get("name").(string))
 		d.SetId("")
 		return nil
 	}
@@ -332,7 +331,7 @@ func resourceComputeAutoscalerUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
-	op, err := config.clientCompute.Autoscalers.Patch(
+	op, err := config.clientCompute.Autoscalers.Update(
 		project, zone, scaler).Do()
 	if err != nil {
 		return fmt.Errorf("Error updating Autoscaler: %s", err)


### PR DESCRIPTION
It looks like our vendored code thinks that Patch has "autoscaler" as an optional field, but the [documentation](https://cloud.google.com/compute/docs/reference/latest/autoscalers/patch) suggests that it is required. It probably regressed when we vendored a [new copy of the client code](https://github.com/hashicorp/terraform/commit/c9640e40dfb7b282246ea18af4bfac0384d60b78#diff-981842c12447ae1d1f29443c53b63787R336) around a month ago.

We didn't catch this because the `_update` test didn't perform an `Update` - it performed a `Destroy` followed by a `Create` instead. This PR updates the tests so that an actual `Update` is performed.

Patch doesn't make much sense in this context - we pass in an entire copy of the resource, so we should be using Update anyways.

Fixes: #15056
@danawillow 