### PR TITLE
Add task_parameters parameter to aws_ssm_maintenance_window_task resource

### DIFF
--- a/builtin/providers/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/builtin/providers/aws/resource_aws_ssm_maintenance_window_task.go
@@ -165,9 +165,10 @@ func expandAwsSsmTaskParameters(config []interface{}) map[string]*ssm.Maintenanc
 func flattenAwsSsmTaskParameters(taskParameters map[string]*ssm.MaintenanceWindowTaskParameterValueExpression) []interface{} {
 	result := make([]interface{}, 0, len(taskParameters))
 	for k, v := range taskParameters {
-		taskParam := make(map[string]interface{})
-		taskParam["name"] = k
-		taskParam["values"] = flattenStringList(v.Values)
+		taskParam := map[string]interface{}{
+			"name":   k,
+			"values": flattenStringList(v.Values),
+		}
 		result = append(result, taskParam)
 	}
 

--- a/builtin/providers/aws/resource_aws_ssm_maintenance_window_task.go
+++ b/builtin/providers/aws/resource_aws_ssm_maintenance_window_task.go
@@ -99,6 +99,25 @@ func resourceAwsSsmMaintenanceWindowTask() *schema.Resource {
 					},
 				},
 			},
+
+			"task_parameters": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"values": {
+							Type:     schema.TypeList,
+							Required: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+						},
+					},
+				},
+			},
 		},
 	}
 }
@@ -132,6 +151,29 @@ func flattenAwsSsmMaintenanceWindowLoggingInfo(loggingInfo *ssm.LoggingInfo) []i
 	return []interface{}{result}
 }
 
+func expandAwsSsmTaskParameters(config []interface{}) map[string]*ssm.MaintenanceWindowTaskParameterValueExpression {
+	params := make(map[string]*ssm.MaintenanceWindowTaskParameterValueExpression)
+	for _, v := range config {
+		paramConfig := v.(map[string]interface{})
+		params[paramConfig["name"].(string)] = &ssm.MaintenanceWindowTaskParameterValueExpression{
+			Values: expandStringList(paramConfig["values"].([]interface{})),
+		}
+	}
+	return params
+}
+
+func flattenAwsSsmTaskParameters(taskParameters map[string]*ssm.MaintenanceWindowTaskParameterValueExpression) []interface{} {
+	result := make([]interface{}, 0, len(taskParameters))
+	for k, v := range taskParameters {
+		taskParam := make(map[string]interface{})
+		taskParam["name"] = k
+		taskParam["values"] = flattenStringList(v.Values)
+		result = append(result, taskParam)
+	}
+
+	return result
+}
+
 func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta interface{}) error {
 	ssmconn := meta.(*AWSClient).ssmconn
 
@@ -153,6 +195,10 @@ func resourceAwsSsmMaintenanceWindowTaskCreate(d *schema.ResourceData, meta inte
 
 	if v, ok := d.GetOk("logging_info"); ok {
 		params.LoggingInfo = expandAwsSsmMaintenanceWindowLoggingInfo(v.([]interface{}))
+	}
+
+	if v, ok := d.GetOk("task_parameters"); ok {
+		params.TaskParameters = expandAwsSsmTaskParameters(v.([]interface{}))
 	}
 
 	resp, err := ssmconn.RegisterTaskWithMaintenanceWindow(params)
@@ -193,6 +239,12 @@ func resourceAwsSsmMaintenanceWindowTaskRead(d *schema.ResourceData, meta interf
 			if t.LoggingInfo != nil {
 				if err := d.Set("logging_info", flattenAwsSsmMaintenanceWindowLoggingInfo(t.LoggingInfo)); err != nil {
 					return fmt.Errorf("[DEBUG] Error setting logging_info error: %#v", err)
+				}
+			}
+
+			if t.TaskParameters != nil {
+				if err := d.Set("task_parameters", flattenAwsSsmTaskParameters(t.TaskParameters)); err != nil {
+					return fmt.Errorf("[DEBUG] Error setting task_parameters error: %#v", err)
 				}
 			}
 

--- a/builtin/providers/aws/resource_aws_ssm_maintenance_window_task_test.go
+++ b/builtin/providers/aws/resource_aws_ssm_maintenance_window_task_test.go
@@ -110,6 +110,10 @@ resource "aws_ssm_maintenance_window_task" "target" {
     key = "InstanceIds"
     values = ["${aws_instance.foo.id}"]
   }
+  task_parameters {
+    name = "commands"
+    values = ["pwd"]
+  }
 }
 
 resource "aws_instance" "foo" {

--- a/website/source/docs/providers/aws/r/ssm_maintenance_window.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_maintenance_window.html.markdown
@@ -29,7 +29,7 @@ The following arguments are supported:
 * `schedule` - (Required) The schedule of the Maintenance Window in the form of a [cron](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-maintenance-cron.html) or rate expression.
 * `cutoff` - (Required) The number of hours before the end of the Maintenance Window that Systems Manager stops scheduling new tasks for execution.
 * `duration` - (Required) The duration of the Maintenance Window in hours.
-* `allow_unregistered_targets` - (Optional) Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.
+* `allow_unassociated_targets` - (Optional) Whether targets must be registered with the Maintenance Window before tasks can be defined for those targets.
 
 ## Attributes Reference
 

--- a/website/source/docs/providers/aws/r/ssm_maintenance_window_task.html.markdown
+++ b/website/source/docs/providers/aws/r/ssm_maintenance_window_task.html.markdown
@@ -32,6 +32,10 @@ resource "aws_ssm_maintenance_window_task" "task" {
     key = "InstanceIds"
     values = ["${aws_instance.instance.id}"]
   }
+  task_parameters {
+    name = "commands"
+    values = ["pwd"]
+  }
 }
 
 resource "aws_instance" "instance" {
@@ -54,12 +58,18 @@ The following arguments are supported:
 * `targets` - (Required) The targets (either instances or window target ids). Instances are specified using Key=InstanceIds,Values=instanceid1,instanceid2. Window target ids are specified using Key=WindowTargetIds,Values=window target id1, window target id2.
 * `priority` - (Optional) The priority of the task in the Maintenance Window, the lower the number the higher the priority. Tasks in a Maintenance Window are scheduled in priority order with tasks that have the same priority scheduled in parallel.
 * `logging_info` - (Optional) A structure containing information about an Amazon S3 bucket to write instance-level logs to. Documented below.
+* `task_parameters` - (Optional) A structure containing information about parameters required by the particular `task_arn`. Documented below.
 
 `logging_info` supports the following:
 
 * `s3_bucket_name` - (Required)
 * `s3_region` - (Required)
 * `s3_bucket_prefix` - (Optional)
+
+`task_parameters` supports the following:
+
+* `name` - (Required)
+* `values` - (Required)
 
 ## Attributes Reference
 


### PR DESCRIPTION
This adds support for task_parameters to the aws_ssm_maintenance_window_task resource.

The [ssm:RegisterTaskWithMaintenanceWindow](http://docs.aws.amazon.com/systems-manager/latest/APIReference/API_RegisterTaskWithMaintenanceWindow.html) AWS API method includes a `TaskParameters` parameters, which isn't currently supported by TF. This adds support that parameter.

Additionally, the docs had an incorrect name for the `aws_ssm_maintenance_window`'s `allow_unregistered_targets` parameter (it was actually `allow_unassociated_targets` in the TF resource and the AWS API), so updating the doc to correct the name for that.