### PR TITLE
New CIDR Provider

### DIFF
--- a/builtin/providers/cidr/datasource_cidr_network.go
+++ b/builtin/providers/cidr/datasource_cidr_network.go
@@ -1,0 +1,118 @@
+package cidr
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net"
+	"strconv"
+
+	goc "github.com/apparentlymart/go-cidr/cidr"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+type subnetMask struct {
+	Name string
+	Mask int
+}
+
+func dataSourceNetwork() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceNetworkRead,
+
+		Schema: map[string]*schema.Schema{
+			"cidr_block": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The CIDR Block for the entire network (aka supernet)",
+				Required:    true,
+			},
+			"subnet": &schema.Schema{
+				Type:        schema.TypeList,
+				Description: "The desired subnet masks to create",
+				Required:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:     schema.TypeString,
+							Required: true,
+						},
+						"mask": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+					},
+				},
+			},
+			"subnet_cidrs": &schema.Schema{
+				Type:        schema.TypeMap,
+				Description: "Map keyed by subnet name returning the value of the network in CIDR notation",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceNetworkRead(d *schema.ResourceData, meta interface{}) error {
+	var masterCIDRList []*net.IPNet
+	rawSubnetMasks := d.Get("subnet").([]interface{})
+	subnetMasks := expandSubnetMasks(rawSubnetMasks)
+	cBlock := d.Get("cidr_block").(string)
+	_, startNet, err := net.ParseCIDR(cBlock)
+	if err != nil {
+		return fmt.Errorf("Error parsing CIDR %v for cidr_network\n", err)
+	}
+	d.SetId(hashID(cBlock, subnetMasks))
+
+	currentSubnet, _ := goc.PreviousSubnet(startNet, subnetMasks[0].Mask)
+	subnetCIDRs, subnets, err := calculateSubnets(currentSubnet, subnetMasks)
+	if err != nil {
+		return fmt.Errorf("Error [ %v ] calculating subnets for cidr_network\n", err)
+	}
+	masterCIDRList = subnets
+	d.Set("subnet_cidrs", subnetCIDRs)
+	networkErr := goc.VerifyNoOverlap(masterCIDRList, startNet)
+	if networkErr != nil {
+		return networkErr
+	}
+	return nil
+}
+
+func calculateSubnets(currentSubnet *net.IPNet,
+	subnetMasks []*subnetMask) (map[string]string, []*net.IPNet, error) {
+
+	subnetCIDRs := make(map[string]string)
+	subnets := make([]*net.IPNet, len(subnetMasks))
+	for i, s := range subnetMasks {
+		tmpSubnet, rollover := goc.NextSubnet(currentSubnet, s.Mask)
+		if rollover {
+			return nil, nil, fmt.Errorf("Next from %s exceeded maximum value\n", currentSubnet.String())
+		}
+		currentSubnet = tmpSubnet
+		subnets[i] = currentSubnet
+		subnetCIDRs[s.Name] = currentSubnet.String()
+	}
+	return subnetCIDRs, subnets, nil
+}
+
+func expandSubnetMasks(rawSubnetMasks []interface{}) []*subnetMask {
+	subnetMasks := make([]*subnetMask, len(rawSubnetMasks))
+	for i, sRaw := range rawSubnetMasks {
+		data := sRaw.(map[string]interface{})
+		subnetMask := &subnetMask{
+			Mask: data["mask"].(int),
+			Name: data["name"].(string),
+		}
+		subnetMasks[i] = subnetMask
+	}
+	return subnetMasks
+}
+
+func hashID(cBlock string, subnetMasks []*subnetMask) string {
+	h := sha256.New()
+	h.Write([]byte(cBlock))
+	for _, s := range subnetMasks {
+		h.Write([]byte(s.Name))
+		h.Write([]byte(strconv.Itoa(s.Mask)))
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/builtin/providers/cidr/datasource_cidr_network_test.go
+++ b/builtin/providers/cidr/datasource_cidr_network_test.go
@@ -1,0 +1,248 @@
+package cidr
+
+import (
+	"fmt"
+	"net"
+	"testing"
+
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestCidrNetwork(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			r.TestStep{
+				Config: networks,
+				Check: r.ComposeTestCheckFunc(
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.private_az1", "10.0.0.0/24"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.private_az2", "10.0.1.0/24"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.private_az3", "10.0.2.0/24"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.public_az1", "10.0.3.0/25"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.public_az2", "10.0.3.128/25"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.public_az3", "10.0.4.0/25"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.elb_az1", "10.0.4.128/28"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.elb_az2", "10.0.4.144/28"),
+					r.TestCheckResourceAttr("data.cidr_network.cake", "subnet_cidrs.elb_az3", "10.0.4.160/28"),
+					r.TestCheckResourceAttr("data.cidr_network.order", "subnet_cidrs.private_az1", "10.0.0.0/28"),
+					r.TestCheckResourceAttr("data.cidr_network.order", "subnet_cidrs.private_az2", "10.0.1.0/24"),
+					r.TestCheckResourceAttr("data.cidr_network.order", "subnet_cidrs.elb_az1", "10.0.2.0/28"),
+					r.TestCheckResourceAttr("data.cidr_network.order", "subnet_cidrs.elb_az2", "10.0.2.32/27"),
+				),
+			},
+		},
+	},
+	)
+}
+
+type testCase struct {
+	CurrentSubnet string
+	Zones         int
+	SubnetMasks   []*subnetMask
+	CIDRByZone    []map[string]string
+	CIDRByName    map[string]string
+	CIDRList      []string
+}
+
+func TestCalculateSubnets(t *testing.T) {
+	failCases := []*testCase{
+		&testCase{
+			CurrentSubnet: "255.255.255.0/24",
+			Zones:         1,
+			SubnetMasks: []*subnetMask{
+				&subnetMask{Name: "private", Mask: 27},
+				&subnetMask{Name: "public", Mask: 28},
+				&subnetMask{Name: "nat", Mask: 29},
+				&subnetMask{Name: "4_special", Mask: 22},
+			},
+		},
+		&testCase{
+			CurrentSubnet: "255.255.252.0/24",
+			Zones:         1,
+			SubnetMasks: []*subnetMask{
+				&subnetMask{Name: "private", Mask: 27},
+				&subnetMask{Name: "public", Mask: 24},
+				&subnetMask{Name: "nat", Mask: 29},
+				&subnetMask{Name: "4_special", Mask: 22},
+			},
+		},
+	}
+	testCases := []*testCase{
+		&testCase{
+			CurrentSubnet: "9.255.255.0/24",
+			Zones:         1,
+			SubnetMasks: []*subnetMask{
+				&subnetMask{Name: "private", Mask: 24},
+				&subnetMask{Name: "public", Mask: 25},
+				&subnetMask{Name: "nat", Mask: 26},
+				&subnetMask{Name: "4_special", Mask: 27},
+			},
+			CIDRList: []string{
+				"10.0.0.0/24",
+				"10.0.1.0/25",
+				"10.0.1.128/26",
+				"10.0.1.192/27",
+			},
+			CIDRByName: map[string]string{
+				"private":   "10.0.0.0/24",
+				"public":    "10.0.1.0/25",
+				"nat":       "10.0.1.128/26",
+				"4_special": "10.0.1.192/27",
+			},
+		},
+		&testCase{
+			CurrentSubnet: "192.168.7.0/24",
+			Zones:         1,
+			SubnetMasks: []*subnetMask{
+				&subnetMask{Name: "private", Mask: 24},
+				&subnetMask{Name: "public", Mask: 25},
+				&subnetMask{Name: "nat", Mask: 26},
+				&subnetMask{Name: "4_special", Mask: 27},
+			},
+			CIDRList: []string{
+				"192.168.8.0/24",
+				"192.168.9.0/25",
+				"192.168.9.128/26",
+				"192.168.9.192/27",
+			},
+			CIDRByName: map[string]string{
+				"private":   "192.168.8.0/24",
+				"public":    "192.168.9.0/25",
+				"nat":       "192.168.9.128/26",
+				"4_special": "192.168.9.192/27",
+			},
+		},
+		&testCase{
+			CurrentSubnet: "2001:db8:c001:b9c0::/58",
+			Zones:         1,
+			SubnetMasks: []*subnetMask{
+				&subnetMask{Name: "private", Mask: 58},
+				&subnetMask{Name: "public", Mask: 58},
+				&subnetMask{Name: "nat", Mask: 58},
+				&subnetMask{Name: "4_special", Mask: 58},
+			},
+			CIDRList: []string{
+				"2001:db8:c001:ba00::/58",
+				"2001:db8:c001:ba40::/58",
+				"2001:db8:c001:ba80::/58",
+				"2001:db8:c001:bac0::/58",
+			},
+			CIDRByName: map[string]string{
+				"private":   "2001:db8:c001:ba00::/58",
+				"public":    "2001:db8:c001:ba40::/58",
+				"nat":       "2001:db8:c001:ba80::/58",
+				"4_special": "2001:db8:c001:bac0::/58",
+			},
+		},
+	}
+
+	for _, tc := range failCases {
+		_, IPNet, err := net.ParseCIDR(tc.CurrentSubnet)
+		if err != nil {
+			t.Errorf("Failed to parse %s\n", tc.CurrentSubnet)
+		}
+		_, _, fail := calculateSubnets(IPNet, tc.SubnetMasks)
+		if fail == nil {
+			t.Errorf("calculateSubnets should have failed starting at %s\n", tc.CurrentSubnet)
+		}
+	}
+	for _, tc := range testCases {
+		_, IPNet, err := net.ParseCIDR(tc.CurrentSubnet)
+		if err != nil {
+			t.Errorf("Failed to parse %s\n", tc.CurrentSubnet)
+		}
+		cByName, _, err := calculateSubnets(IPNet, tc.SubnetMasks)
+		if err != nil {
+			t.Errorf("calculateSubnets with failed %v\n", err)
+		}
+		for name, got := range cByName {
+			if got != tc.CIDRByName[name] {
+				t.Errorf("Got %v, expected %v\n", got, tc.CIDRByName[name])
+			}
+		}
+	}
+}
+
+func outputCheckNetwork(s *terraform.State) error {
+	answers := [][]string{
+		[]string{"private_subnet1", "192.168.0.0/24"},
+		[]string{"private_subnet2", "192.168.1.0/24"},
+		[]string{"private_subnet3", "192.168.2.0/24"},
+		[]string{"public_subnet1", "192.168.3.0/25"},
+		[]string{"public_subnet2", "192.168.3.128/25"},
+		[]string{"public_subnet3", "192.168.4.0/25"},
+		[]string{"elb_subnet1", "192.168.4.128/28"},
+		[]string{"elb_subnet2", "192.168.4.144/28"},
+		[]string{"elb_subnet3", "192.168.4.160/28"},
+	}
+	for _, ans := range answers {
+		got := s.RootModule().Outputs[ans[0]]
+		if ans[1] != got.Value {
+			fmt.Printf("Outputs %v\n", s.RootModule().Outputs)
+			return fmt.Errorf("Output expected %s, got %s\n", ans[1], got.Value)
+		}
+	}
+	return nil
+}
+
+const networks = `
+data "cidr_network" "cake" {
+	cidr_block = "10.0.0.0/21"
+	subnet {
+		mask = 24
+		name = "private_az1" 
+	}
+	subnet {
+		mask = 24
+		name = "private_az2" 
+	}
+	subnet {
+		mask = 24
+		name = "private_az3" 
+	}
+	subnet {
+		mask = 25
+		name = "public_az1"
+	} 
+	subnet {
+		mask = 25
+		name = "public_az2"
+	}
+	subnet {
+		mask = 25
+		name = "public_az3"
+	} 
+	subnet {
+		mask = 28
+		name = "elb_az1" 
+	}
+	subnet {
+		mask = 28
+		name = "elb_az2" 
+	}
+	subnet {
+		mask = 28
+		name = "elb_az3" 
+	}
+}
+data "cidr_network" "order" {
+	cidr_block = "10.0.0.0/21"
+	subnet {
+		mask = 28
+		name = "private_az1" 
+	}
+	subnet {
+		mask = 24
+		name = "private_az2" 
+	}
+	subnet {
+		mask = 28
+		name = "elb_az1" 
+	}
+	subnet {
+		mask = 27
+		name = "elb_az2" 
+	}
+}
+`

--- a/builtin/providers/cidr/datasource_cidr_subnet.go
+++ b/builtin/providers/cidr/datasource_cidr_subnet.go
@@ -1,0 +1,110 @@
+package cidr
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+
+	goc "github.com/apparentlymart/go-cidr/cidr"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceSubnet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceSubnetRead,
+
+		Schema: map[string]*schema.Schema{
+			"cidr_block": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The CIDR block for the entire network (aka supernet)",
+				Required:    true,
+			},
+			"start_after": &schema.Schema{
+				Type:        schema.TypeString,
+				Description: "The subnet in CIDR notation to offset subnet creation by",
+				Optional:    true,
+			},
+			"subnet_count": &schema.Schema{
+				Type:        schema.TypeInt,
+				Description: "The number of subnets to create",
+				Default:     1,
+				Optional:    true,
+			},
+			"subnet_mask": &schema.Schema{
+				Type:        schema.TypeInt,
+				Description: "The desired subnet mask to use for creation",
+				Required:    true,
+			},
+			"max_subnet": &schema.Schema{
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
+			},
+			"subnet_cidrs": &schema.Schema{
+				Type:        schema.TypeList,
+				Description: "The set of subnets in CIDR notation",
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+		},
+	}
+}
+
+func dataSourceSubnetRead(d *schema.ResourceData, meta interface{}) error {
+	d.SetId(subnetId(d))
+	subnetCount := d.Get("subnet_count").(int)
+	subnets := make([]*net.IPNet, subnetCount)
+	subnetCIDRs := make([]string, subnetCount)
+	mask := d.Get("subnet_mask").(int)
+
+	_, startNet, perr := net.ParseCIDR(d.Get("cidr_block").(string))
+	if perr != nil {
+		return fmt.Errorf("cidr_block parse error %v\n", perr)
+	}
+
+	var currentSubnet *net.IPNet
+	startAfter, sap := d.GetOk("start_after")
+	if sap {
+		_, offsetSubnet, perr := net.ParseCIDR(startAfter.(string))
+		if perr != nil {
+			return fmt.Errorf("start_after %v resulted in parse error %v\n", startAfter, perr)
+		}
+		currentSubnet = offsetSubnet
+	} else {
+		currentSubnet, _ = goc.PreviousSubnet(startNet, mask)
+	}
+	for i := 0; i < subnetCount; i++ {
+		tmpSubnet, rollover := goc.NextSubnet(currentSubnet, mask)
+		if rollover {
+			return fmt.Errorf("Next from %s exceeded maximum value\n", currentSubnet.String())
+		}
+		currentSubnet = tmpSubnet
+		subnets[i] = currentSubnet
+		subnetCIDRs[i] = currentSubnet.String()
+	}
+	nerr := goc.VerifyNoOverlap(subnets, startNet)
+	if nerr != nil {
+		return fmt.Errorf("Network is invalid: [ %v ]", nerr)
+	}
+
+	d.Set("subnet_cidrs", subnetCIDRs)
+	d.Set("max_subnet", subnetCIDRs[subnetCount-1])
+	return nil
+}
+
+func subnetId(d *schema.ResourceData) string {
+	id := d.Get("cidr_block").(string)
+	startAfter, sap := d.GetOk("start_after")
+	if sap {
+		id = id + startAfter.(string)
+	}
+	subnetCount, scp := d.GetOk("subnet_count")
+	if scp {
+		id = id + strconv.Itoa(subnetCount.(int))
+	}
+	mask := d.Get("subnet_mask").(int)
+	id = id + strconv.Itoa(mask)
+	return strconv.Itoa(hashcode.String(id))
+}

--- a/builtin/providers/cidr/datasource_cidr_subnet_test.go
+++ b/builtin/providers/cidr/datasource_cidr_subnet_test.go
@@ -1,0 +1,144 @@
+package cidr
+
+import (
+	"fmt"
+	"testing"
+
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestCidrSubnet(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			r.TestStep{
+				Config: subnets,
+				Check:  r.ComposeTestCheckFunc(efficientSubnetCheck),
+			},
+		},
+	},
+	)
+}
+func TestCidrSubnetWaste(t *testing.T) {
+	r.UnitTest(t, r.TestCase{
+		Providers: testProviders,
+		Steps: []r.TestStep{
+			r.TestStep{
+				Config: wasteOfSpace,
+				Check:  r.ComposeTestCheckFunc(wastedSubnetCheck),
+			},
+		},
+	},
+	)
+}
+
+func wastedSubnetCheck(s *terraform.State) error {
+	answers := [][]string{
+		[]string{"private_subnet1", "192.168.0.0/28"},
+		[]string{"private_subnet2", "192.168.0.16/28"},
+		[]string{"private_subnet3", "192.168.0.32/28"},
+		[]string{"private_max", "192.168.0.32/28"},
+		[]string{"public_subnet1", "192.168.0.128/25"},
+		[]string{"public_subnet2", "192.168.1.0/25"},
+		[]string{"public_max", "192.168.1.0/25"},
+		[]string{"elb_subnet1", "192.168.4.0/22"},
+		[]string{"elb_max", "192.168.4.0/22"},
+	}
+	return checkAnswers(answers, s.RootModule().Outputs)
+}
+
+func efficientSubnetCheck(s *terraform.State) error {
+	answers := [][]string{
+		[]string{"private_subnet1", "192.168.0.0/24"},
+		[]string{"private_subnet2", "192.168.1.0/24"},
+		[]string{"private_subnet3", "192.168.2.0/24"},
+		[]string{"private_max", "192.168.2.0/24"},
+		[]string{"public_subnet1", "192.168.3.0/25"},
+		[]string{"public_subnet2", "192.168.3.128/25"},
+		[]string{"public_subnet3", "192.168.4.0/25"},
+		[]string{"public_max", "192.168.4.0/25"},
+		[]string{"elb_subnet1", "192.168.4.128/28"},
+		[]string{"elb_subnet2", "192.168.4.144/28"},
+		[]string{"elb_subnet3", "192.168.4.160/28"},
+		[]string{"elb_max", "192.168.4.160/28"},
+	}
+	return checkAnswers(answers, s.RootModule().Outputs)
+}
+
+func checkAnswers(expected [][]string, actual map[string]*terraform.OutputState) error {
+	for _, ans := range expected {
+		got := actual[ans[0]]
+		if ans[1] != got.Value {
+			fmt.Printf("Outputs %v\n", actual)
+			return fmt.Errorf("Output expected %s, got %s\n", ans[1], got.Value)
+		}
+	}
+	return nil
+}
+
+const subnets = `
+data "cidr_subnet" "private" {
+	cidr_block = "192.168.0.0/21"
+	subnet_mask = 24 
+	subnet_count = 3
+}
+
+data "cidr_subnet" "public" {
+	cidr_block = "192.168.0.0/21"
+	subnet_mask = 25
+	subnet_count = 3
+	start_after = "${data.cidr_subnet.private.max_subnet}"
+}
+
+data "cidr_subnet" "elb" {
+	cidr_block = "192.168.0.0/21"
+	subnet_mask = 28
+	subnet_count = 3
+	start_after = "${data.cidr_subnet.public.max_subnet}"
+}
+
+output "public_subnet1"  { value = "${data.cidr_subnet.public.subnet_cidrs[0]}" }
+output "public_subnet2"  { value = "${data.cidr_subnet.public.subnet_cidrs[1]}" }
+output "public_subnet3"  { value = "${data.cidr_subnet.public.subnet_cidrs[2]}" }
+output "public_max"      { value = "${data.cidr_subnet.public.max_subnet}" }
+output "private_subnet1" { value = "${data.cidr_subnet.private.subnet_cidrs[0]}" }
+output "private_subnet2" { value = "${data.cidr_subnet.private.subnet_cidrs[1]}" }
+output "private_subnet3" { value = "${data.cidr_subnet.private.subnet_cidrs[2]}" }
+output "private_max"     { value = "${data.cidr_subnet.private.max_subnet}" }
+output "elb_subnet1"     { value = "${data.cidr_subnet.elb.subnet_cidrs[0]}" }
+output "elb_subnet2"     { value = "${data.cidr_subnet.elb.subnet_cidrs[1]}" }
+output "elb_subnet3"     { value = "${data.cidr_subnet.elb.subnet_cidrs[2]}" }
+output "elb_max"         { value = "${data.cidr_subnet.elb.max_subnet}" }
+`
+
+const wasteOfSpace = `
+data "cidr_subnet" "private" {
+	cidr_block = "192.168.0.0/21"
+	subnet_mask = 28 
+	subnet_count = 3
+}
+
+data "cidr_subnet" "public" {
+	cidr_block = "192.168.0.0/21"
+	subnet_mask = 25
+	subnet_count = 2
+	start_after = "${data.cidr_subnet.private.max_subnet}"
+}
+
+data "cidr_subnet" "elb" {
+	cidr_block = "192.168.0.0/21"
+	subnet_mask = 22
+	start_after = "${data.cidr_subnet.public.max_subnet}"
+}
+
+output "public_subnet1"  { value = "${data.cidr_subnet.public.subnet_cidrs[0]}" }
+output "public_subnet2"  { value = "${data.cidr_subnet.public.subnet_cidrs[1]}" }
+output "public_max"      { value = "${data.cidr_subnet.public.max_subnet}" }
+output "private_subnet1" { value = "${data.cidr_subnet.private.subnet_cidrs[0]}" }
+output "private_subnet2" { value = "${data.cidr_subnet.private.subnet_cidrs[1]}" }
+output "private_subnet3" { value = "${data.cidr_subnet.private.subnet_cidrs[2]}" }
+output "private_max"     { value = "${data.cidr_subnet.private.max_subnet}" }
+output "elb_subnet1"     { value = "${data.cidr_subnet.elb.subnet_cidrs[0]}" }
+output "elb_max"         { value = "${data.cidr_subnet.elb.max_subnet}" }
+`

--- a/builtin/providers/cidr/provider.go
+++ b/builtin/providers/cidr/provider.go
@@ -1,0 +1,15 @@
+package cidr
+
+import (
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func Provider() terraform.ResourceProvider {
+	return &schema.Provider{
+		DataSourcesMap: map[string]*schema.Resource{
+			"cidr_network": dataSourceNetwork(),
+			"cidr_subnet":  dataSourceSubnet(),
+		},
+	}
+}

--- a/builtin/providers/cidr/provider_test.go
+++ b/builtin/providers/cidr/provider_test.go
@@ -1,0 +1,45 @@
+package cidr
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+var testProviders = map[string]terraform.ResourceProvider{
+	"cidr": Provider(),
+}
+var testAccProviders map[string]terraform.ResourceProvider
+var testAccProvider *schema.Provider
+var testAccAwsProvider *schema.Provider
+
+func init() {
+	testAccProvider = Provider().(*schema.Provider)
+	testAccProviders = map[string]terraform.ResourceProvider{
+		"cidr": testAccProvider,
+	}
+}
+
+func TestProvider(t *testing.T) {
+	if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+}
+
+func testAccPreCheck(t *testing.T) {
+	if v := os.Getenv("AWS_PROFILE"); v == "" {
+		if v := os.Getenv("AWS_ACCESS_KEY_ID"); v == "" {
+			t.Fatal("AWS_ACCESS_KEY_ID must be set for acceptance tests")
+		}
+		if v := os.Getenv("AWS_SECRET_ACCESS_KEY"); v == "" {
+			t.Fatal("AWS_SECRET_ACCESS_KEY must be set for acceptance tests")
+		}
+	}
+	if v := os.Getenv("AWS_DEFAULT_REGION"); v == "" {
+		log.Println("[INFO] Test: Using us-west-2 as test region")
+		os.Setenv("AWS_DEFAULT_REGION", "us-west-2")
+	}
+}


### PR DESCRIPTION
This PR adds a new provider called CIDR. The purpose is to ease the pain in dividing up a network into subnets. The interpolation language provides some support, but this provider adds support to carve up IP space by subnet masks in CIDR notations for both IPv6 and IPv4. Many customers probably do not mind the one time effort of carving up IP space, my employer happens to have many VPCs and we manage non-overlapping IP space. Using just the interpolation cidr functions is possible, but not very elegant. This provider was designed to simplify that process.

The provider adds two data sources:

1. Subnet - simple data source to define sequential subnets from a network and offset. Subnets can be easily linked together by referencing one another.
2. Network - simple data source for teams that want to define the network in one place. This requires some repetition because arrays of maps are not available. The benefit is control over ordering versus the subnet approach.

See the documentation and test cases for examples.

I needed to add some networking helper functions: NextSubnet, PreviousSubnet, NetworkValidate, Increment IP, and Decrement IP. I have them in a helper module initially, but I will open a PR against [go-cidr](https://github.com/apparentlymart/go-cidr) and link in the first comment. 