### PR TITLE
Correct openstack_lbaas_* to openstack_lb_* sidebars to reflect correct resource type names.

### DIFF
--- a/website/source/layouts/openstack.erb
+++ b/website/source/layouts/openstack.erb
@@ -136,17 +136,17 @@
             <li<%= sidebar_current("docs-openstack-resource-lb-loadbalancer-v2") %>>
               <a href="/docs/providers/openstack/r/lb_loadbalancer_v2.html">openstack_lb_loadbalancer_v2</a>
             </li>
-            <li<%= sidebar_current("docs-openstack-resource-lbaas-listener-v2") %>>
-              <a href="/docs/providers/openstack/r/lb_listener_v2.html">openstack_lbaas_listener_v2</a>
+            <li<%= sidebar_current("docs-openstack-resource-lb-listener-v2") %>>
+              <a href="/docs/providers/openstack/r/lb_listener_v2.html">openstack_lb_listener_v2</a>
             </li>
-            <li<%= sidebar_current("docs-openstack-resource-lbaas-pool-v2") %>>
-              <a href="/docs/providers/openstack/r/lb_pool_v2.html">openstack_lbaas_pool_v2</a>
+            <li<%= sidebar_current("docs-openstack-resource-lb-pool-v2") %>>
+              <a href="/docs/providers/openstack/r/lb_pool_v2.html">openstack_lb_pool_v2</a>
             </li>
-            <li<%= sidebar_current("docs-openstack-resource-lbaas-member-v2") %>>
-              <a href="/docs/providers/openstack/r/lb_member_v2.html">openstack_lbaas_member_v2</a>
+            <li<%= sidebar_current("docs-openstack-resource-lb-member-v2") %>>
+              <a href="/docs/providers/openstack/r/lb_member_v2.html">openstack_lb_member_v2</a>
             </li>
-            <li<%= sidebar_current("docs-openstack-resource-lbaas-monitor-v2") %>>
-              <a href="/docs/providers/openstack/r/lb_monitor_v2.html">openstack_lbaas_monitor_v2</a>
+            <li<%= sidebar_current("docs-openstack-resource-lb-monitor-v2") %>>
+              <a href="/docs/providers/openstack/r/lb_monitor_v2.html">openstack_lb_monitor_v2</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
I missed this update earlier in PR #14196 