### PR TITLE
config: Added explode function to cut a list into smaller lists

### DIFF
--- a/config/interpolate_funcs_test.go
+++ b/config/interpolate_funcs_test.go
@@ -2106,6 +2106,44 @@ func TestInterpolateFuncElement(t *testing.T) {
 	})
 }
 
+func TestInterpolateFuncChunklist(t *testing.T) {
+	testFunction(t, testFunctionConfig{
+		Cases: []testFunctionCase{
+			// normal usage
+			{
+				`${chunklist(list("a", "b", "c"), 1)}`,
+				[]interface{}{
+					[]interface{}{"a"},
+					[]interface{}{"b"},
+					[]interface{}{"c"},
+				},
+				false,
+			},
+			// `size` is pair and the list has an impair number of items
+			{
+				`${chunklist(list("a", "b", "c"), 2)}`,
+				[]interface{}{
+					[]interface{}{"a", "b"},
+					[]interface{}{"c"},
+				},
+				false,
+			},
+			// list made of the same list, since size is 0
+			{
+				`${chunklist(list("a", "b", "c"), 0)}`,
+				[]interface{}{[]interface{}{"a", "b", "c"}},
+				false,
+			},
+			// negative size of chunks
+			{
+				`${chunklist(list("a", "b", "c"), -1)}`,
+				nil,
+				true,
+			},
+		},
+	})
+}
+
 func TestInterpolateFuncBasename(t *testing.T) {
 	testFunction(t, testFunctionConfig{
 		Cases: []testFunctionCase{

--- a/website/docs/configuration/interpolation.html.md
+++ b/website/docs/configuration/interpolation.html.md
@@ -230,6 +230,11 @@ The supported built-in functions are:
       * `element(aws_subnet.foo.*.id, count.index)`
       * `element(var.list_of_strings, 2)`
 
+  * `chunklist(list, size)` - Returns the `list` items chunked by `size`.
+      Examples:
+      * `list(aws_subnet.foo.*.id, 1)`: will outputs `[["id1"], ["id2"], ["id3"]]`
+      * `list(var.list_of_strings, 2)`: will outputs `[["id1", "id2"], ["id3", "id4"], ["id5"]`
+
   * `file(path)` - Reads the contents of a file into the string. Variables
       in this file are _not_ interpolated. The contents of the file are
       read as-is. The `path` is interpreted relative to the working directory.


### PR DESCRIPTION
## Description
The PR implements the explode function (the name isn't that good, can't find a good one: chunker, listexplode, ...). I do like `listexplode` but any better name would be welcomed!

@apparentlymart this follows what we spoke about on Slack, i.e. the highly dynamic structure that needs to be transformed in a highly dynamic structure. After we spoke, didn't plan to sort this out, but I wanted to learn more about the core, functions etc, so here this work. (spoil: I LOVE the ast-related API ❤️ )

## TODOs
- [x] Add the function
- [x] Add tests
- [x] Add the documentation