### PR TITLE
provider/alicloud: Fix security group rules bug

### DIFF
--- a/builtin/providers/alicloud/resource_alicloud_instance.go
+++ b/builtin/providers/alicloud/resource_alicloud_instance.go
@@ -42,7 +42,7 @@ func resourceAliyunInstance() *schema.Resource {
 			"security_groups": &schema.Schema{
 				Type:     schema.TypeSet,
 				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
+				Required: true,
 			},
 
 			"allocate_public_ip": &schema.Schema{

--- a/website/source/docs/providers/alicloud/r/instance.html.markdown
+++ b/website/source/docs/providers/alicloud/r/instance.html.markdown
@@ -57,7 +57,7 @@ The following arguments are supported:
 * `image_id` - (Required) The Image to use for the instance. ECS instance's image can be replaced via changing 'image_id'.
 * `instance_type` - (Required) The type of instance to start.
 * `io_optimized` - (Required) Valid values are `none`, `optimized`, If `optimized`, the launched ECS instance will be I/O optimized.
-* `security_groups` - (Optional)  A list of security group ids to associate with.
+* `security_groups` - (Required)  A list of security group ids to associate with.
 * `availability_zone` - (Optional) The Zone to start the instance in.
 * `instance_name` - (Optional) The name of the ECS. This instance_name can have a string of 2 to 128 characters, must contain only alphanumeric characters or hyphens, such as "-",".","_", and must not begin or end with a hyphen, and must not begin with http:// or https://. If not specified, 
 Terraform will autogenerate a default name is `ECS-Instance`.


### PR DESCRIPTION
This PR fixed security group rule bug that when authorizing rules for an existed security group or VPC's security group, its nic_tyep only is 'intranet'.

The testcast running result of security group rule as follows:

TF_ACC=1 go test ./alicloud -v -run=TestAccAlicloudSecurityGroupRule -timeout 120m
=== RUN   TestAccAlicloudSecurityGroupRule_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Ingress (4.90s)
=== RUN   TestAccAlicloudSecurityGroupRule_Egress
--- PASS: TestAccAlicloudSecurityGroupRule_Egress (5.63s)
=== RUN   TestAccAlicloudSecurityGroupRule_EgressDefaultNicType
--- PASS: TestAccAlicloudSecurityGroupRule_EgressDefaultNicType (4.66s)
=== RUN   TestAccAlicloudSecurityGroupRule_Vpc_Ingress
--- PASS: TestAccAlicloudSecurityGroupRule_Vpc_Ingress (27.14s)
=== RUN   TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp
--- PASS: TestAccAlicloudSecurityGroupRule_MissParameterSourceCidrIp (5.41s)
=== RUN   TestAccAlicloudSecurityGroupRule_SourceSecurityGroup
--- PASS: TestAccAlicloudSecurityGroupRule_SourceSecurityGroup (4.94s)
PASS
ok      github.com/alibaba/terraform-provider/alicloud  52.695s
