### PR TITLE
provider/aws: Fix race condition in Beanstalk acc test

### DIFF
--- a/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
+++ b/builtin/providers/aws/resource_aws_elastic_beanstalk_environment_test.go
@@ -945,7 +945,7 @@ resource "aws_elastic_beanstalk_application" "default" {
 }
 
 resource "aws_elastic_beanstalk_application_version" "default" {
-  application = "tf-test-name-%d"
+  application = "${aws_elastic_beanstalk_application.default.name}"
   name = "tf-test-version-label"
   bucket = "${aws_s3_bucket.default.id}"
   key = "${aws_s3_bucket_object.default.id}"
@@ -957,7 +957,7 @@ resource "aws_elastic_beanstalk_environment" "default" {
   version_label = "${aws_elastic_beanstalk_application_version.default.name}"
   solution_stack_name = "64bit Amazon Linux running Python"
 }
-`, randInt, randInt, randInt, randInt)
+`, randInt, randInt, randInt)
 }
 
 func testAccBeanstalkEnvApplicationVersionConfigUpdate(randInt int) string {
@@ -978,7 +978,7 @@ resource "aws_elastic_beanstalk_application" "default" {
 }
 
 resource "aws_elastic_beanstalk_application_version" "default" {
-  application = "tf-test-name-%d"
+  application = "${aws_elastic_beanstalk_application.default.name}"
   name = "tf-test-version-label-v2"
   bucket = "${aws_s3_bucket.default.id}"
   key = "${aws_s3_bucket_object.default.id}"
@@ -990,5 +990,5 @@ resource "aws_elastic_beanstalk_environment" "default" {
   version_label = "${aws_elastic_beanstalk_application_version.default.name}"
   solution_stack_name = "64bit Amazon Linux running Python"
 }
-`, randInt, randInt, randInt, randInt)
+`, randInt, randInt, randInt)
 }


### PR DESCRIPTION
Similar to https://github.com/hashicorp/terraform/pull/15083 - this is to fix the following test failure:

```
=== RUN   TestAccAWSBeanstalkEnv_version_label
--- FAIL: TestAccAWSBeanstalkEnv_version_label (381.45s)
    testing.go:280: Step 1 error: Error applying: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_application_version.default: 1 error(s) occurred:
        
        * aws_elastic_beanstalk_application_version.default: InvalidParameterValue: No Application named 'tf-test-name-69597012152946852' found.
            status code: 400, request id: 1e32ff6e-4a7f-11e7-847e-d3bbf7943c8b
```