### PR TITLE
provider/aws: Expose reason of EMR cluster termination

### DIFF
--- a/builtin/providers/aws/resource_aws_emr_cluster.go
+++ b/builtin/providers/aws/resource_aws_emr_cluster.go
@@ -831,6 +831,13 @@ func resourceAwsEMRClusterStateRefreshFunc(d *schema.ResourceData, meta interfac
 			log.Printf("[DEBUG] EMR Cluster status (%s): %s", d.Id(), *resp.Cluster.Status)
 		}
 
-		return emrc, *emrc.Status.State, nil
+		status := emrc.Status
+		if *status.State == "TERMINATING" {
+			reason := *status.StateChangeReason
+			return emrc, *status.State, fmt.Errorf("EMR Cluster is terminating. %s: %s",
+				*reason.Code, *reason.Message)
+		}
+
+		return emrc, *status.State, nil
 	}
 }


### PR DESCRIPTION
This is related to the following test failure from today:

```
=== RUN   TestAccAWSAppautoScalingTarget_emrCluster
--- FAIL: TestAccAWSAppautoScalingTarget_emrCluster (652.43s)
    testing.go:280: Step 0 error: Error applying: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: 1 error(s) occurred:
        
        * aws_emr_cluster.tf-test-cluster: [WARN] Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": unexpected state 'TERMINATING', wanted target 'WAITING, RUNNING'. last error: %!s(<nil>)
```

Even though we cannot prevent failures like this we should at least expose the reason of the failure.

Related: https://github.com/hashicorp/terraform/issues/13600

### Before

* aws_emr_cluster.emr-test-cluster: 1 error(s) occurred:

* aws_emr_cluster.emr-test-cluster: [WARN] Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": unexpected state 'TERMINATING', wanted target 'WAITING, RUNNING'. last error: %!s(<nil>)

### After

* aws_emr_cluster.emr-test-cluster: 1 error(s) occurred:

* aws_emr_cluster.emr-test-cluster: [WARN] Error waiting for EMR Cluster state to be "WAITING" or "RUNNING": EMR Cluster is terminating. VALIDATION_ERROR: The subnet configuration was invalid: No route to any external sources detected in Route Table for Subnet: subnet-8d91a7ea for VPC: vpc-012dc867
