### PR TITLE
provider/newrelic: add tlsconfig settings

### DIFF
--- a/builtin/providers/newrelic/config.go
+++ b/builtin/providers/newrelic/config.go
@@ -15,7 +15,6 @@ type Config struct {
 	APIKey             string
 	APIURL             string
 	CACertFile         string
-	Debug              bool
 	InsecureSkipVerify bool
 }
 

--- a/builtin/providers/newrelic/config.go
+++ b/builtin/providers/newrelic/config.go
@@ -1,24 +1,47 @@
 package newrelic
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"log"
 
 	"github.com/hashicorp/terraform/helper/logging"
+	"github.com/hashicorp/terraform/helper/pathorcontents"
 	newrelic "github.com/paultyng/go-newrelic/api"
 )
 
 // Config contains New Relic provider settings
 type Config struct {
-	APIKey string
-	APIURL string
+	APIKey             string
+	APIURL             string
+	CACertFile         string
+	Debug              bool
+	InsecureSkipVerify bool
 }
 
 // Client returns a new client for accessing New Relic
 func (c *Config) Client() (*newrelic.Client, error) {
+	tlsCfg := &tls.Config{}
+	if c.CACertFile != "" {
+		caCert, _, err := pathorcontents.Read(c.CACertFile)
+		if err != nil {
+			log.Printf("Error reading CA Cert: %s", err)
+			return nil, err
+		}
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM([]byte(caCert))
+		tlsCfg.RootCAs = caCertPool
+	}
+
+	if c.InsecureSkipVerify {
+		tlsCfg.InsecureSkipVerify = true
+	}
+
 	nrConfig := newrelic.Config{
-		APIKey:  c.APIKey,
-		Debug:   logging.IsDebugOrHigher(),
-		BaseURL: c.APIURL,
+		APIKey:    c.APIKey,
+		BaseURL:   c.APIURL,
+		Debug:     logging.IsDebugOrHigher(),
+		TLSConfig: tlsCfg,
 	}
 
 	client := newrelic.New(nrConfig)

--- a/builtin/providers/newrelic/provider.go
+++ b/builtin/providers/newrelic/provider.go
@@ -22,6 +22,16 @@ func Provider() terraform.ResourceProvider {
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("NEWRELIC_API_URL", "https://api.newrelic.com/v2"),
 			},
+			"insecure_skip_verify": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NEWRELIC_API_SKIP_VERIFY", false),
+			},
+			"cacert_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("NEWRELIC_API_CACERT", ""),
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -41,8 +51,10 @@ func Provider() terraform.ResourceProvider {
 
 func providerConfigure(data *schema.ResourceData) (interface{}, error) {
 	config := Config{
-		APIKey: data.Get("api_key").(string),
-		APIURL: data.Get("api_url").(string),
+		APIKey:             data.Get("api_key").(string),
+		APIURL:             data.Get("api_url").(string),
+		InsecureSkipVerify: data.Get("insecure_skip_verify").(bool),
+		CACertFile:         data.Get("cacert_file").(string),
 	}
 	log.Println("[INFO] Initializing New Relic client")
 	return config.Client()

--- a/vendor/github.com/paultyng/go-newrelic/api/client.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/client.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/tls"
 	"fmt"
 
 	"github.com/tomnomnom/linkheader"
@@ -32,9 +33,10 @@ type ErrorDetail struct {
 
 // Config contains all the configuration data for the API Client
 type Config struct {
-	APIKey  string
-	BaseURL string
-	Debug   bool
+	APIKey    string
+	BaseURL   string
+	Debug     bool
+	TLSConfig *tls.Config
 }
 
 // New returns a new Client for the specified apiKey.
@@ -49,6 +51,9 @@ func New(config Config) Client {
 	r.SetHeader("X-Api-Key", config.APIKey)
 	r.SetHostURL(baseURL)
 
+	if config.TLSConfig != nil {
+		r.SetTLSClientConfig(config.TLSConfig)
+	}
 	if config.Debug {
 		r.SetDebug(true)
 	}

--- a/vendor/github.com/paultyng/go-newrelic/api/client.go
+++ b/vendor/github.com/paultyng/go-newrelic/api/client.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"crypto/tls"
 	"fmt"
 
 	"github.com/tomnomnom/linkheader"
@@ -33,10 +32,9 @@ type ErrorDetail struct {
 
 // Config contains all the configuration data for the API Client
 type Config struct {
-	APIKey    string
-	BaseURL   string
-	Debug     bool
-	TLSConfig *tls.Config
+	APIKey  string
+	BaseURL string
+	Debug   bool
 }
 
 // New returns a new Client for the specified apiKey.
@@ -51,9 +49,6 @@ func New(config Config) Client {
 	r.SetHeader("X-Api-Key", config.APIKey)
 	r.SetHostURL(baseURL)
 
-	if config.TLSConfig != nil {
-		r.SetTLSClientConfig(config.TLSConfig)
-	}
 	if config.Debug {
 		r.SetDebug(true)
 	}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -2859,10 +2859,10 @@
 			"revisionTime": "2016-08-11T16:27:25Z"
 		},
 		{
-			"checksumSHA1": "SUK6xOTZDwljlX/AoHAmgoz0e1E=",
+			"checksumSHA1": "7vm5aCcZ+zDxjz59QmGsXW4WVB4=",
 			"path": "github.com/paultyng/go-newrelic/api",
-			"revision": "5fbf16b273dd4b544c9588450c58711d9f46f912",
-			"revisionTime": "2017-03-27T18:23:21Z"
+			"revision": "bc2e8dde222f105cd020b3092150621081f1b4b5",
+			"revisionTime": "2017-06-13T01:30:23Z"
 		},
 		{
 			"checksumSHA1": "mUb0GqsJK4UDh3Kx8TobjzvDUG4=",

--- a/website/source/docs/providers/newrelic/index.html.markdown
+++ b/website/source/docs/providers/newrelic/index.html.markdown
@@ -69,3 +69,5 @@ resource "newrelic_alert_policy_channel" "alert_email" {
 The following arguments are supported:
 
 * `api_key` - (Required) Your New Relic API key.
+* `insecure_skip_verify` - (Optional) Trust self-signed SSL certificates. If omitted, the `NEWRELIC_API_SKIP_VERIFY` environment variable is used.
+* `cacert_file` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate. The `NEWRELIC_API_CACERT` environment variable can also be used.


### PR DESCRIPTION
## Provider/NewRelic Update

#### Overview
This PR adds the ability to skip the TLS verification from a remote agent, also trusting self-signed certs. Also, this allows a user to specify a path to a PEM-encoded certificate authority to verify the remote agent's certificate. This is useful if using the new relic terraform provider from behind a proxy.

#### Acceptance tests
I am unsure of how to add acceptance tests for these small changes.

#### Documentation Updates

*reason*: to reflect the changes of this PR
*version*: 0.9.7+

This PR reflects upstream changes to the [newrelic-api](https://github.com/paultyng/go-newrelic) written by the initial contributor of the new relic provider @paultyng, and is located at [PR-3](https://github.com/paultyng/go-newrelic/pull/3). I am unsure of how the `/vendor` folder is managed, but the upstream changes will have to be included. Would I include the corresponding `/vendor` changes in this pull request?

