### PR TITLE
provider/google: Update bucket storage docs introductions

### DIFF
--- a/website/source/docs/providers/google/r/storage_bucket.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # google\_storage\_bucket
 
-Creates a new bucket in Google cloud storage service (GCS). Currently, it will not change location nor ACL once a bucket has been created with Terraform. For more information see 
+Creates a new bucket in Google cloud storage service (GCS). 
+Once a bucket has been created, its location can't be changed.
+[ACLs](https://cloud.google.com/storage/docs/access-control/lists) can be applied using the `google_storage_bucket_acl` resource.
+For more information see 
 [the official documentation](https://cloud.google.com/storage/docs/overview) 
 and 
 [API](https://cloud.google.com/storage/docs/json_api/v1/buckets).

--- a/website/source/docs/providers/google/r/storage_bucket.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # google\_storage\_bucket
 
-Creates a new bucket in Google cloud storage service(GCS). Currently, it will not change location nor ACL once a bucket has been created with Terraform. For more information see [the official documentation](https://cloud.google.com/storage/docs/overview) and [API](https://cloud.google.com/storage/docs/json_api/v1/buckets).
+Creates a new bucket in Google cloud storage service (GCS). Currently, it will not change location nor ACL once a bucket has been created with Terraform. For more information see 
+[the official documentation](https://cloud.google.com/storage/docs/overview) 
+and 
+[API](https://cloud.google.com/storage/docs/json_api/v1/buckets).
 
 
 ## Example Usage

--- a/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # google\_storage\_bucket\_acl
 
-Creates a new bucket ACL in Google cloud storage service(GCS).
+Creates a new bucket ACL in Google cloud storage service(GCS). For more information see 
+[the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
+and 
+[API](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls).
 
 ## Example Usage
 

--- a/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket_acl.html.markdown
@@ -8,7 +8,7 @@ description: |-
 
 # google\_storage\_bucket\_acl
 
-Creates a new bucket ACL in Google cloud storage service(GCS). For more information see 
+Creates a new bucket ACL in Google cloud storage service (GCS). For more information see 
 [the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
 and 
 [API](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls).

--- a/website/source/docs/providers/google/r/storage_bucket_object.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket_object.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # google\_storage\_bucket\_object
 
-Creates a new object inside an existing bucket in Google cloud storage service (GCS). Currently, it does not support creating custom ACLs. For more information see [the official documentation](https://cloud.google.com/storage/docs/overview) and [API](https://cloud.google.com/storage/docs/json_api).
+Creates a new object inside an existing bucket in Google cloud storage service (GCS). Currently, it does not support creating custom ACLs. For more information see 
+[the official documentation](https://cloud.google.com/storage/docs/key-terms#objects) 
+and 
+[API](https://cloud.google.com/storage/docs/json_api/v1/objects).
 
 
 ## Example Usage

--- a/website/source/docs/providers/google/r/storage_bucket_object.html.markdown
+++ b/website/source/docs/providers/google/r/storage_bucket_object.html.markdown
@@ -8,7 +8,9 @@ description: |-
 
 # google\_storage\_bucket\_object
 
-Creates a new object inside an existing bucket in Google cloud storage service (GCS). Currently, it does not support creating custom ACLs. For more information see 
+Creates a new object inside an existing bucket in Google cloud storage service (GCS). 
+[ACLs](https://cloud.google.com/storage/docs/access-control/lists) can be applied using the `google_storage_object_acl` resource.
+ For more information see 
 [the official documentation](https://cloud.google.com/storage/docs/key-terms#objects) 
 and 
 [API](https://cloud.google.com/storage/docs/json_api/v1/objects).

--- a/website/source/docs/providers/google/r/storage_object_acl.html.markdown
+++ b/website/source/docs/providers/google/r/storage_object_acl.html.markdown
@@ -8,7 +8,10 @@ description: |-
 
 # google\_storage\_object\_acl
 
-Creates a new object ACL in Google cloud storage service (GCS)
+Creates a new object ACL in Google cloud storage service (GCS). For more information see 
+[the official documentation](https://cloud.google.com/storage/docs/access-control/lists) 
+and 
+[API](https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls).
 
 ## Example Usage
 


### PR DESCRIPTION
Minor formatting changes + adding related links to overview documentation and API specifications for GCS resources other than `google_storage_bucket`.

@danawillow 