### PR TITLE
Allow ipv6_cidr_block to be assigned to peering_connection

### DIFF
--- a/builtin/providers/aws/resource_aws_route.go
+++ b/builtin/providers/aws/resource_aws_route.go
@@ -172,9 +172,17 @@ func resourceAwsRouteCreate(d *schema.ResourceData, meta interface{}) error {
 	case "vpc_peering_connection_id":
 		createOpts = &ec2.CreateRouteInput{
 			RouteTableId:           aws.String(d.Get("route_table_id").(string)),
-			DestinationCidrBlock:   aws.String(d.Get("destination_cidr_block").(string)),
 			VpcPeeringConnectionId: aws.String(d.Get("vpc_peering_connection_id").(string)),
 		}
+
+		if v, ok := d.GetOk("destination_cidr_block"); ok {
+			createOpts.DestinationCidrBlock = aws.String(v.(string))
+		}
+
+		if v, ok := d.GetOk("destination_ipv6_cidr_block"); ok {
+			createOpts.DestinationIpv6CidrBlock = aws.String(v.(string))
+		}
+
 	default:
 		return fmt.Errorf("An invalid target type specified: %s", setTarget)
 	}


### PR DESCRIPTION
I've encountered an issue when trying to use `destination_ipv6_cidr_block` with `vpc_peering_connection_id`. I believe this fixes #14564.

I'm not sure about whether `destination_ipv6_cidr_block` should be allowed together with other types (`nat_gateway_id`, `instance_id`, `network_interface_id`).

Also, I could not find any acceptance test for this functionality, so I've not added any new tests to cover this. I'm happy to add tests, however I might need guidance.