### PR TITLE
Make CA parameter optional

### DIFF
--- a/builtin/providers/docker/config.go
+++ b/builtin/providers/docker/config.go
@@ -20,15 +20,19 @@ type Config struct {
 // NewClient() returns a new Docker client.
 func (c *Config) NewClient() (*dc.Client, error) {
 	if c.Ca != "" || c.Cert != "" || c.Key != "" {
-		if c.Ca == "" || c.Cert == "" || c.Key == "" {
-			return nil, fmt.Errorf("ca_material, cert_material, and key_material must be specified")
+		if c.Cert == "" || c.Key == "" {
+			return nil, fmt.Errorf("cert_material, and key_material must be specified when using TLS connection")
 		}
 
 		if c.CertPath != "" {
-			return nil, fmt.Errorf("cert_path must not be specified")
+			return nil, fmt.Errorf("cert_path must not be specified when other TLS materials where specified")
 		}
 
-		return dc.NewTLSClientFromBytes(c.Host, []byte(c.Cert), []byte(c.Key), []byte(c.Ca))
+		if c.Ca == "" {
+			return dc.NewTLSClientFromBytes(c.Host, []byte(c.Cert), []byte(c.Key), nil)
+		} else {
+			return dc.NewTLSClientFromBytes(c.Host, []byte(c.Cert), []byte(c.Key), []byte(c.Ca))
+		}
 	}
 
 	if c.CertPath != "" {


### PR DESCRIPTION
Make ca_material settings optional, so we don't validate certificates of a server however server still validates our keys

Related to my issue #14982 