### PR TITLE
Add `workspace show` command

### DIFF
--- a/command/workspace_command.go
+++ b/command/workspace_command.go
@@ -35,6 +35,7 @@ Usage: terraform workspace
 
 Subcommands:
 
+    show      Show the current workspace name.
     list      List workspaces.
     select    Select a workspace.
     new       Create a new workspace.

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -155,6 +155,10 @@ func TestWorkspace_createAndShow(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}
 
+	showCmd = &WorkspaceShowCommand{}
+	ui = new(cli.MockUi)
+	showCmd.Meta = Meta{Ui: ui}
+
 	if code := showCmd.Run(nil); code != 0 {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 	}

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -99,7 +99,7 @@ func TestWorkspace_createAndList(t *testing.T) {
 	expected := "default\n  test_a\n  test_b\n* test_c"
 
 	if actual != expected {
-		t.Fatalf("\nexpcted: %q\nactual:  %q", expected, actual)
+		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
 	}
 }
 
@@ -134,7 +134,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	expected := "default"
 
 	if actual != expected {
-		t.Fatalf("\nexpcted: %q\nactual:  %q", expected, actual)
+		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
 	}
 
 	newCmd := &WorkspaceNewCommand{}
@@ -163,7 +163,7 @@ func TestWorkspace_createAndShow(t *testing.T) {
 	expected = "test_a"
 
 	if actual != expected {
-		t.Fatalf("\nexpcted: %q\nactual:  %q", expected, actual)
+		t.Fatalf("\nexpected: %q\nactual:  %q", expected, actual)
 	}
 }
 

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -103,6 +103,70 @@ func TestWorkspace_createAndList(t *testing.T) {
 	}
 }
 
+// Create some workspaces and test the show output.
+func TestWorkspace_createAndShow(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	os.MkdirAll(td, 0755)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// make sure a vars file doesn't interfere
+	err := ioutil.WriteFile(
+		DefaultVarsFilename,
+		[]byte(`foo = "bar"`),
+		0644,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make sure current workspace show outputs "default"
+	showCmd := &WorkspaceShowCommand{}
+	ui := new(cli.MockUi)
+	showCmd.Meta = Meta{Ui: ui}
+
+	if code := showCmd.Run(nil); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	}
+
+	actual := strings.TrimSpace(ui.OutputWriter.String())
+	expected := "default"
+
+	if actual != expected {
+		t.Fatalf("\nexpcted: %q\nactual:  %q", expected, actual)
+	}
+
+	newCmd := &WorkspaceNewCommand{}
+
+	env := []string{"test_a"}
+
+	// create test_a workspace
+	ui = new(cli.MockUi)
+	newCmd.Meta = Meta{Ui: ui}
+	if code := newCmd.Run(env); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	}
+
+	selCmd := &WorkspaceSelectCommand{}
+	ui = new(cli.MockUi)
+	selCmd.Meta = Meta{Ui: ui}
+	if code := selCmd.Run(env); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	}
+
+	if code := showCmd.Run(nil); code != 0 {
+		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
+	}
+
+	actual = strings.TrimSpace(ui.OutputWriter.String())
+	expected = "test_a"
+
+	if actual != expected {
+		t.Fatalf("\nexpcted: %q\nactual:  %q", expected, actual)
+	}
+}
+
 // Don't allow names that aren't URL safe
 func TestWorkspace_createInvalid(t *testing.T) {
 	// Create a temporary working directory that is empty

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -1,0 +1,37 @@
+package command
+
+import (
+	"strings"
+)
+
+type WorkspaceShowCommand struct {
+	Meta
+}
+
+func (c *WorkspaceShowCommand) Run(args []string) int {
+	args = c.Meta.process(args, true)
+
+	cmdFlags := c.Meta.flagSet("workspace show")
+	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }
+	if err := cmdFlags.Parse(args); err != nil {
+		return 1
+	}
+
+	workspace := c.Workspace()
+	c.Ui.Output(workspace)
+
+	return 1
+}
+
+func (c *WorkspaceShowCommand) Help() string {
+	helpText := `
+Usage: terraform workspace show
+
+  Show the name of the current workspace.
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *WorkspaceShowCommand) Synopsis() string {
+	return "Show the name of the current workspace"
+}

--- a/command/workspace_show.go
+++ b/command/workspace_show.go
@@ -20,7 +20,7 @@ func (c *WorkspaceShowCommand) Run(args []string) int {
 	workspace := c.Workspace()
 	c.Ui.Output(workspace)
 
-	return 1
+	return 0
 }
 
 func (c *WorkspaceShowCommand) Help() string {

--- a/commands.go
+++ b/commands.go
@@ -224,6 +224,12 @@ func init() {
 			}, nil
 		},
 
+		"workspace show": func() (cli.Command, error) {
+			return &command.WorkspaceShowCommand{
+				Meta: meta,
+			}, nil
+		},
+
 		"workspace new": func() (cli.Command, error) {
 			return &command.WorkspaceNewCommand{
 				Meta: meta,


### PR DESCRIPTION
I didn't see an easy way to display the current env (except for `env list` and the `*` next to the current env)

This pull request adds `terraform env show` which looks something like this:

```
mikehelmick@local [dev-env-show] ✅  bin/terraform env show
default
```