### PR TITLE
provider/aws: New resource: aws_security_group_attachment

### DIFF
--- a/builtin/providers/aws/provider.go
+++ b/builtin/providers/aws/provider.go
@@ -423,6 +423,7 @@ func Provider() terraform.ResourceProvider {
 			"aws_s3_bucket_object":                         resourceAwsS3BucketObject(),
 			"aws_s3_bucket_notification":                   resourceAwsS3BucketNotification(),
 			"aws_security_group":                           resourceAwsSecurityGroup(),
+			"aws_security_group_attachment":                resourceAwsSecurityGroupAttachment(),
 			"aws_default_security_group":                   resourceAwsDefaultSecurityGroup(),
 			"aws_security_group_rule":                      resourceAwsSecurityGroupRule(),
 			"aws_simpledb_domain":                          resourceAwsSimpleDBDomain(),

--- a/builtin/providers/aws/resource_aws_security_group_attachment.go
+++ b/builtin/providers/aws/resource_aws_security_group_attachment.go
@@ -1,0 +1,284 @@
+package aws
+
+import (
+	"fmt"
+	"log"
+	"reflect"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceAwsSecurityGroupAttachment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAwsSecurityGroupAttachmentCreate,
+		Read:   resourceAwsSecurityGroupAttachmentRead,
+		Delete: resourceAwsSecurityGroupAttachmentDelete,
+		Schema: map[string]*schema.Schema{
+			"security_group_id": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"instance_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"network_interface_id": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+		},
+	}
+}
+
+func resourceAwsSecurityGroupAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
+	var err error
+	switch {
+	case d.Get("instance_id").(string) != "":
+		err = attachSecurityGroupToInstance(d, meta)
+	case d.Get("network_interface_id").(string) != "":
+		err = attachSecurityGroupToInterface(d, meta)
+	default:
+		err = fmt.Errorf("one of instance_id or network_interface_id needs to be defined")
+	}
+	if err != nil {
+		return err
+	}
+
+	return resourceAwsSecurityGroupAttachmentRead(d, meta)
+}
+
+func attachSecurityGroupToInstance(d *schema.ResourceData, meta interface{}) error {
+	sgID := d.Get("security_group_id").(string)
+	instanceID := d.Get("instance_id").(string)
+
+	log.Printf("[INFO] Attaching security group %s to instance ID %s", sgID, instanceID)
+
+	conn := meta.(*AWSClient).ec2conn
+
+	iface, err := fetchPrimaryNetworkInterface(conn, instanceID)
+	if err != nil {
+		return err
+	}
+
+	return addSGToENI(conn, sgID, iface)
+}
+
+func fetchPrimaryNetworkInterface(conn *ec2.EC2, instanceID string) (*ec2.NetworkInterface, error) {
+	diParams := &ec2.DescribeInstancesInput{
+		InstanceIds: aws.StringSlice([]string{instanceID}),
+	}
+
+	diResp, err := conn.DescribeInstances(diParams)
+	if err != nil {
+		return nil, err
+	}
+
+	instance := diResp.Reservations[0].Instances[0]
+
+	var primaryInterface ec2.InstanceNetworkInterface
+	for _, ni := range instance.NetworkInterfaces {
+		if *ni.Attachment.DeviceIndex == 0 {
+			primaryInterface = *ni
+		}
+	}
+
+	if primaryInterface.NetworkInterfaceId == nil {
+		return nil, fmt.Errorf("instance ID %s, does not contain a primary network interface", instanceID)
+	}
+
+	return fetchNetworkInterface(conn, *primaryInterface.NetworkInterfaceId)
+}
+
+func fetchNetworkInterface(conn *ec2.EC2, ifaceID string) (*ec2.NetworkInterface, error) {
+	dniParams := &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: aws.StringSlice([]string{ifaceID}),
+	}
+
+	dniResp, err := conn.DescribeNetworkInterfaces(dniParams)
+	if err != nil {
+		return nil, err
+	}
+	return dniResp.NetworkInterfaces[0], nil
+}
+
+func attachSecurityGroupToInterface(d *schema.ResourceData, meta interface{}) error {
+	sgID := d.Get("security_group_id").(string)
+	interfaceID := d.Get("network_interface_id").(string)
+
+	log.Printf("[INFO] Attaching security group %s to network interface ID %s", sgID, interfaceID)
+
+	conn := meta.(*AWSClient).ec2conn
+
+	dniParams := &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: aws.StringSlice([]string{interfaceID}),
+	}
+
+	dniResp, err := conn.DescribeNetworkInterfaces(dniParams)
+	if err != nil {
+		return err
+	}
+
+	return addSGToENI(conn, sgID, dniResp.NetworkInterfaces[0])
+}
+
+func addSGToENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) error {
+	if sgExistsInENI(conn, sgID, iface) {
+		return fmt.Errorf("security group %s already attached to interface ID %s", sgID, *iface.NetworkInterfaceId)
+	}
+	var groupIDs []string
+	for _, v := range iface.Groups {
+		groupIDs = append(groupIDs, *v.GroupId)
+	}
+	groupIDs = append(groupIDs, sgID)
+	params := &ec2.ModifyNetworkInterfaceAttributeInput{
+		NetworkInterfaceId: iface.NetworkInterfaceId,
+		Groups:             aws.StringSlice(groupIDs),
+	}
+
+	_, err := conn.ModifyNetworkInterfaceAttribute(params)
+	return err
+}
+
+func sgExistsInENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) bool {
+	for _, v := range iface.Groups {
+		if *v.GroupId == sgID {
+			return true
+		}
+	}
+	return false
+}
+
+func resourceAwsSecurityGroupAttachmentRead(d *schema.ResourceData, meta interface{}) error {
+	switch {
+	case d.Get("instance_id").(string) != "":
+		return refreshSecurityGroupWithInstance(d, meta)
+	case d.Get("network_interface_id").(string) != "":
+		return refreshSecurityGroupWithInterface(d, meta)
+	}
+	return fmt.Errorf("one of instance_id or network_interface_id needs to be defined")
+}
+
+func refreshSecurityGroupWithInstance(d *schema.ResourceData, meta interface{}) error {
+	sgID := d.Get("security_group_id").(string)
+	instanceID := d.Get("instance_id").(string)
+
+	log.Printf("[INFO] Checking association of security group %s to instance ID %s", sgID, instanceID)
+
+	conn := meta.(*AWSClient).ec2conn
+
+	iface, err := fetchPrimaryNetworkInterface(conn, instanceID)
+	if err != nil {
+		return err
+	}
+
+	if sgExistsInENI(conn, sgID, iface) {
+		d.SetId(fmt.Sprintf("%s_%s", sgID, instanceID))
+	} else {
+		// The assocation does not exist when it should, taint this resource.
+		log.Printf("[WARN] Security group %s not associated with instance ID %s, tainting", sgID, instanceID)
+		d.SetId("")
+	}
+	return nil
+}
+
+func refreshSecurityGroupWithInterface(d *schema.ResourceData, meta interface{}) error {
+	sgID := d.Get("security_group_id").(string)
+	interfaceID := d.Get("network_interface_id").(string)
+
+	log.Printf("[INFO] Checking association of security group %s to network interface ID %s", sgID, interfaceID)
+
+	conn := meta.(*AWSClient).ec2conn
+
+	iface, err := fetchNetworkInterface(conn, interfaceID)
+	if err != nil {
+		return err
+	}
+
+	if sgExistsInENI(conn, sgID, iface) {
+		d.SetId(fmt.Sprintf("%s_%s", sgID, interfaceID))
+	} else {
+		// The assocation does not exist when it should, taint this resource.
+		log.Printf("[WARN] Security group %s not associated with network interface ID %s, tainting", sgID, interfaceID)
+		d.SetId("")
+	}
+	return nil
+}
+
+func resourceAwsSecurityGroupAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
+	var err error
+	switch {
+	case d.Get("instance_id").(string) != "":
+		err = detachSecurityGroupFromInstance(d, meta)
+	case d.Get("network_interface_id").(string) != "":
+		err = detachSecurityGroupFromInterface(d, meta)
+	}
+	if err != nil {
+		return err
+	}
+
+	// We are done. It's possible that the resource had a broken config and the
+	// switch fell through, but if that's the case, then there's nothing to do
+	// here anyway.
+	d.SetId("")
+	return nil
+}
+
+func detachSecurityGroupFromInstance(d *schema.ResourceData, meta interface{}) error {
+	sgID := d.Get("security_group_id").(string)
+	instanceID := d.Get("instance_id").(string)
+
+	log.Printf("[INFO] Removing security group %s from instance ID %s", sgID, instanceID)
+
+	conn := meta.(*AWSClient).ec2conn
+
+	iface, err := fetchPrimaryNetworkInterface(conn, instanceID)
+	if err != nil {
+		return err
+	}
+
+	return delSGFromENI(conn, sgID, iface)
+}
+
+func detachSecurityGroupFromInterface(d *schema.ResourceData, meta interface{}) error {
+	sgID := d.Get("security_group_id").(string)
+	interfaceID := d.Get("network_interface_id").(string)
+
+	log.Printf("[INFO] Removing security group %s from instance ID %s", sgID, interfaceID)
+
+	conn := meta.(*AWSClient).ec2conn
+
+	iface, err := fetchNetworkInterface(conn, interfaceID)
+	if err != nil {
+		return err
+	}
+
+	return delSGFromENI(conn, sgID, iface)
+}
+
+func delSGFromENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) error {
+	old := iface.Groups
+	var new []*string
+	for _, v := range iface.Groups {
+		if *v.GroupId == sgID {
+			continue
+		}
+		new = append(new, v.GroupId)
+	}
+	if reflect.DeepEqual(old, new) {
+		// The interface already didn't have the security group, nothing to do
+		return nil
+	}
+
+	params := &ec2.ModifyNetworkInterfaceAttributeInput{
+		NetworkInterfaceId: iface.NetworkInterfaceId,
+		Groups:             new,
+	}
+
+	_, err := conn.ModifyNetworkInterfaceAttribute(params)
+	return err
+}

--- a/builtin/providers/aws/resource_aws_security_group_attachment.go
+++ b/builtin/providers/aws/resource_aws_security_group_attachment.go
@@ -21,11 +21,6 @@ func resourceAwsSecurityGroupAttachment() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"instance_id": {
-				Type:     schema.TypeString,
-				Optional: true,
-				ForceNew: true,
-			},
 			"network_interface_id": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -36,74 +31,11 @@ func resourceAwsSecurityGroupAttachment() *schema.Resource {
 }
 
 func resourceAwsSecurityGroupAttachmentCreate(d *schema.ResourceData, meta interface{}) error {
-	var err error
-	switch {
-	case d.Get("instance_id").(string) != "":
-		err = attachSecurityGroupToInstance(d, meta)
-	case d.Get("network_interface_id").(string) != "":
-		err = attachSecurityGroupToInterface(d, meta)
-	default:
-		err = fmt.Errorf("one of instance_id or network_interface_id needs to be defined")
-	}
-	if err != nil {
+	if err := attachSecurityGroupToInterface(d, meta); err != nil {
 		return err
 	}
 
 	return resourceAwsSecurityGroupAttachmentRead(d, meta)
-}
-
-func attachSecurityGroupToInstance(d *schema.ResourceData, meta interface{}) error {
-	sgID := d.Get("security_group_id").(string)
-	instanceID := d.Get("instance_id").(string)
-
-	log.Printf("[INFO] Attaching security group %s to instance ID %s", sgID, instanceID)
-
-	conn := meta.(*AWSClient).ec2conn
-
-	iface, err := fetchPrimaryNetworkInterface(conn, instanceID)
-	if err != nil {
-		return err
-	}
-
-	return addSGToENI(conn, sgID, iface)
-}
-
-func fetchPrimaryNetworkInterface(conn *ec2.EC2, instanceID string) (*ec2.NetworkInterface, error) {
-	diParams := &ec2.DescribeInstancesInput{
-		InstanceIds: aws.StringSlice([]string{instanceID}),
-	}
-
-	diResp, err := conn.DescribeInstances(diParams)
-	if err != nil {
-		return nil, err
-	}
-
-	instance := diResp.Reservations[0].Instances[0]
-
-	var primaryInterface ec2.InstanceNetworkInterface
-	for _, ni := range instance.NetworkInterfaces {
-		if *ni.Attachment.DeviceIndex == 0 {
-			primaryInterface = *ni
-		}
-	}
-
-	if primaryInterface.NetworkInterfaceId == nil {
-		return nil, fmt.Errorf("instance ID %s, does not contain a primary network interface", instanceID)
-	}
-
-	return fetchNetworkInterface(conn, *primaryInterface.NetworkInterfaceId)
-}
-
-func fetchNetworkInterface(conn *ec2.EC2, ifaceID string) (*ec2.NetworkInterface, error) {
-	dniParams := &ec2.DescribeNetworkInterfacesInput{
-		NetworkInterfaceIds: aws.StringSlice([]string{ifaceID}),
-	}
-
-	dniResp, err := conn.DescribeNetworkInterfaces(dniParams)
-	if err != nil {
-		return nil, err
-	}
-	return dniResp.NetworkInterfaces[0], nil
 }
 
 func attachSecurityGroupToInterface(d *schema.ResourceData, meta interface{}) error {
@@ -124,6 +56,18 @@ func attachSecurityGroupToInterface(d *schema.ResourceData, meta interface{}) er
 	}
 
 	return addSGToENI(conn, sgID, dniResp.NetworkInterfaces[0])
+}
+
+func fetchNetworkInterface(conn *ec2.EC2, ifaceID string) (*ec2.NetworkInterface, error) {
+	dniParams := &ec2.DescribeNetworkInterfacesInput{
+		NetworkInterfaceIds: aws.StringSlice([]string{ifaceID}),
+	}
+
+	dniResp, err := conn.DescribeNetworkInterfaces(dniParams)
+	if err != nil {
+		return nil, err
+	}
+	return dniResp.NetworkInterfaces[0], nil
 }
 
 func addSGToENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) error {
@@ -154,36 +98,7 @@ func sgExistsInENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) bool
 }
 
 func resourceAwsSecurityGroupAttachmentRead(d *schema.ResourceData, meta interface{}) error {
-	switch {
-	case d.Get("instance_id").(string) != "":
-		return refreshSecurityGroupWithInstance(d, meta)
-	case d.Get("network_interface_id").(string) != "":
-		return refreshSecurityGroupWithInterface(d, meta)
-	}
-	return fmt.Errorf("one of instance_id or network_interface_id needs to be defined")
-}
-
-func refreshSecurityGroupWithInstance(d *schema.ResourceData, meta interface{}) error {
-	sgID := d.Get("security_group_id").(string)
-	instanceID := d.Get("instance_id").(string)
-
-	log.Printf("[INFO] Checking association of security group %s to instance ID %s", sgID, instanceID)
-
-	conn := meta.(*AWSClient).ec2conn
-
-	iface, err := fetchPrimaryNetworkInterface(conn, instanceID)
-	if err != nil {
-		return err
-	}
-
-	if sgExistsInENI(conn, sgID, iface) {
-		d.SetId(fmt.Sprintf("%s_%s", sgID, instanceID))
-	} else {
-		// The assocation does not exist when it should, taint this resource.
-		log.Printf("[WARN] Security group %s not associated with instance ID %s, tainting", sgID, instanceID)
-		d.SetId("")
-	}
-	return nil
+	return refreshSecurityGroupWithInterface(d, meta)
 }
 
 func refreshSecurityGroupWithInterface(d *schema.ResourceData, meta interface{}) error {
@@ -210,38 +125,12 @@ func refreshSecurityGroupWithInterface(d *schema.ResourceData, meta interface{})
 }
 
 func resourceAwsSecurityGroupAttachmentDelete(d *schema.ResourceData, meta interface{}) error {
-	var err error
-	switch {
-	case d.Get("instance_id").(string) != "":
-		err = detachSecurityGroupFromInstance(d, meta)
-	case d.Get("network_interface_id").(string) != "":
-		err = detachSecurityGroupFromInterface(d, meta)
-	}
-	if err != nil {
+	if err := detachSecurityGroupFromInterface(d, meta); err != nil {
 		return err
 	}
 
-	// We are done. It's possible that the resource had a broken config and the
-	// switch fell through, but if that's the case, then there's nothing to do
-	// here anyway.
 	d.SetId("")
 	return nil
-}
-
-func detachSecurityGroupFromInstance(d *schema.ResourceData, meta interface{}) error {
-	sgID := d.Get("security_group_id").(string)
-	instanceID := d.Get("instance_id").(string)
-
-	log.Printf("[INFO] Removing security group %s from instance ID %s", sgID, instanceID)
-
-	conn := meta.(*AWSClient).ec2conn
-
-	iface, err := fetchPrimaryNetworkInterface(conn, instanceID)
-	if err != nil {
-		return err
-	}
-
-	return delSGFromENI(conn, sgID, iface)
 }
 
 func detachSecurityGroupFromInterface(d *schema.ResourceData, meta interface{}) error {

--- a/builtin/providers/aws/resource_aws_security_group_attachment.go
+++ b/builtin/providers/aws/resource_aws_security_group_attachment.go
@@ -71,7 +71,7 @@ func fetchNetworkInterface(conn *ec2.EC2, ifaceID string) (*ec2.NetworkInterface
 }
 
 func addSGToENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) error {
-	if sgExistsInENI(conn, sgID, iface) {
+	if sgExistsInENI(sgID, iface) {
 		return fmt.Errorf("security group %s already attached to interface ID %s", sgID, *iface.NetworkInterfaceId)
 	}
 	var groupIDs []string
@@ -88,7 +88,7 @@ func addSGToENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) error {
 	return err
 }
 
-func sgExistsInENI(conn *ec2.EC2, sgID string, iface *ec2.NetworkInterface) bool {
+func sgExistsInENI(sgID string, iface *ec2.NetworkInterface) bool {
 	for _, v := range iface.Groups {
 		if *v.GroupId == sgID {
 			return true
@@ -114,7 +114,7 @@ func refreshSecurityGroupWithInterface(d *schema.ResourceData, meta interface{})
 		return err
 	}
 
-	if sgExistsInENI(conn, sgID, iface) {
+	if sgExistsInENI(sgID, iface) {
 		d.SetId(fmt.Sprintf("%s_%s", sgID, interfaceID))
 	} else {
 		// The assocation does not exist when it should, taint this resource.

--- a/builtin/providers/aws/resource_aws_security_group_attachment_test.go
+++ b/builtin/providers/aws/resource_aws_security_group_attachment_test.go
@@ -1,0 +1,86 @@
+package aws
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccAwsSecurityGroupAttachment_basic(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAwsSecurityGroupAttachmentConfig(true),
+				Check:  checkSecurityGroupAttachment(true),
+			},
+			resource.TestStep{
+				Config: testAccAwsSecurityGroupAttachmentConfig(false),
+				Check:  checkSecurityGroupAttachment(false),
+			},
+		},
+	})
+}
+
+func testAccAwsSecurityGroupAttachmentConfig(attach bool) string {
+	baseConfig := `
+data "aws_ami" "ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*"]
+  }
+
+  owners = ["amazon"]
+}
+
+resource "aws_instance" "instance" {
+  instance_type = "t2.micro"
+  ami           = "${data.aws_ami.ami.id}"
+
+  tags = {
+    "type" = "terraform-test-instance"
+  }
+}
+
+resource "aws_security_group" "sg" {
+  tags = {
+    "type" = "terraform-test-security-group"
+  }
+}
+`
+	optionalConfig := `
+resource "aws_security_group_attachment" "sg_attachment" {
+  security_group_id    = "${aws_security_group.sg.id}"
+  network_interface_id = "${aws_instance.instance.primary_network_interface_id}"
+}
+`
+
+	if attach {
+		return baseConfig + optionalConfig
+	}
+	return baseConfig
+}
+
+func checkSecurityGroupAttachment(expected bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		conn := testAccProvider.Meta().(*AWSClient).ec2conn
+
+		interfaceID := s.Modules[0].Resources["aws_instance.instance"].Primary.Attributes["primary_network_interface_id"]
+		sgID := s.Modules[0].Resources["aws_security_group.sg"].Primary.ID
+
+		iface, err := fetchNetworkInterface(conn, interfaceID)
+		if err != nil {
+			return err
+		}
+		actual := sgExistsInENI(sgID, iface)
+		if expected != actual {
+			return fmt.Errorf("expected existence of security group in ENI to be %t, got %t", expected, actual)
+		}
+		return nil
+	}
+}

--- a/website/source/docs/providers/aws/r/security_group_attachment.html.markdown
+++ b/website/source/docs/providers/aws/r/security_group_attachment.html.markdown
@@ -1,0 +1,94 @@
+---
+layout: "aws"
+page_title: "AWS: aws_security_group_rule"
+sidebar_current: "docs-aws-resource-security-group-rule"
+description: |-
+  Associates a security group with a network interface.
+---
+
+# aws\_security\_group\_attachment
+
+This resource attaches a security group to an Elastic Network Interface (ENI).
+It can be used to attach a security group to any existing ENI, be it a
+secondary ENI or one attached as the primary interface on an instance.
+
+~> **NOTE on instances, interfaces, and security groups:** Terraform currently
+provides the capability to assign security groups via the [`aws_instance`][1]
+and the [`aws_network_interface`][2] resources. Using this resource in
+conjunction with security groups provided in-line in these resources will cause
+conflicts, and will lead to spurious diffs and undefined behavior - please use
+one or the other.
+
+[1]: /docs/providers/aws/d/instance.html
+[2]: /docs/providers/aws/r/network_interface.html
+
+## Example Usage
+
+The following provides a very basic example of setting up an instance (provided
+by `instance`) in the default security group, creating a security group
+(provided by `sg`) and then attaching the security group to `instance`'s
+primary network interface via the `aws_security_group_attachment` resource,
+named `sg_attachment`:
+
+```hcl
+data "aws_ami" "ami" {
+  most_recent = true
+
+  filter {
+    name   = "name"
+    values = ["amzn-ami-hvm-*"]
+  }
+
+  owners = ["amazon"]
+}
+
+resource "aws_instance" "instance" {
+  instance_type = "t2.micro"
+  ami           = "${data.aws_ami.ami.id}"
+
+  tags = {
+    "type" = "terraform-test-instance"
+  }
+}
+
+resource "aws_security_group" "sg" {
+  tags = {
+    "type" = "terraform-test-security-group"
+  }
+}
+
+resource "aws_security_group_attachment" "sg_attachment" {
+  security_group_id    = "${aws_security_group.sg.id}"
+  network_interface_id = "${aws_instance.instance.primary_network_interface_id}"
+}
+```
+
+In this example, `instance` is provided by the `aws_instance` data source,
+fetching an external instance, possibly not managed by Terraform.
+`sg_attachment` then attaches to the output instance's `network_interface_id`:
+
+```hcl
+data "aws_instance" "instance" {
+  instance_id = "i-1234567890abcdef0"
+}
+
+resource "aws_security_group" "sg" {
+  tags = {
+    "type" = "terraform-test-security-group"
+  }
+}
+
+resource "aws_security_group_attachment" "sg_attachment" {
+  security_group_id    = "${aws_security_group.sg.id}"
+  network_interface_id = "${data.aws_instance.instance.network_interface_id}"
+}
+```
+
+## Argument Reference
+
+ * `security_group_id` - (Required) The ID of the security group.
+ * `network_interface_id` - (Required) The ID of the network interface to attach to.
+
+## Output Reference
+
+There are no outputs for this resource.

--- a/website/source/layouts/aws.erb
+++ b/website/source/layouts/aws.erb
@@ -1349,7 +1349,7 @@
                 </li>
 
 
-                <li<%= sidebar_current("docs-aws-resource-(default|customer|egress-only-internet-gateway|flow|internet-gateway|main-route|network|route-|security-group|subnet|vpc|vpn)") %>>
+                <li<%= sidebar_current("docs-aws-resource-(default|customer|egress-only-internet-gateway|flow|internet-gateway|main-route|network|route-|security-group|security-group-attachment|subnet|vpc|vpn)") %>>
                     <a href="#">VPC Resources</a>
                     <ul class="nav nav-visible">
 
@@ -1429,6 +1429,10 @@
 
                         <li<%= sidebar_current("docs-aws-resource-security-group") %>>
                             <a href="/docs/providers/aws/r/security_group.html">aws_security_group</a>
+                        </li>
+                        
+                        <li<%= sidebar_current("docs-aws-resource-security-group-attachment") %>>
+                            <a href="/docs/providers/aws/r/security_group_attachment.html">aws_security_group_attachment</a>
                         </li>
 
                         <li<%= sidebar_current("docs-aws-resource-security-group-rule") %>>


### PR DESCRIPTION
This adds the `aws_security_group_attachment` resource, allowing one to attach security groups to ENIs outside of an `aws_instance` or `aws_network_interface` resource.

Use cases:
 * More granular management of security groups
 * Attachment of security groups to instances not managed by Terraform (the use case that prompted me to write this)

Docs and tests included!
