### PR TITLE
[docs] Group/prefix HashiCorp providers.

### DIFF
--- a/website/source/docs/providers/consul/index.html.markdown
+++ b/website/source/docs/providers/consul/index.html.markdown
@@ -1,14 +1,14 @@
 ---
 layout: "consul"
-page_title: "Provider: Consul"
+page_title: "Provider: HashiCorp Consul"
 sidebar_current: "docs-consul-index"
 description: |-
-  Consul is a tool for service discovery, configuration and orchestration. The Consul provider exposes resources used to interact with a Consul cluster. Configuration of the provider is optional, as it provides defaults for all arguments.
+  HashiCorp Consul is a tool for service discovery, configuration and orchestration. The Consul provider exposes resources used to interact with a Consul cluster. Configuration of the provider is optional, as it provides defaults for all arguments.
 ---
 
-# Consul Provider
+# HashiCorp Consul Provider
 
-[Consul](https://www.consul.io) is a tool for service discovery, configuration
+[HashiCorp Consul](https://www.consul.io) is a tool for service discovery, configuration
 and orchestration. The Consul provider exposes resources used to interact with a
 Consul cluster. Configuration of the provider is optional, as it provides
 defaults for all arguments.

--- a/website/source/docs/providers/nomad/index.html.markdown
+++ b/website/source/docs/providers/nomad/index.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "nomad"
-page_title: "Provider: Nomad"
+page_title: "Provider: HashiCorp Nomad"
 sidebar_current: "docs-nomad-index"
 description: |-
   HashiCorp Nomad is a cluster scheduler. The Nomad provider exposes resources to interact with a Nomad cluster.

--- a/website/source/docs/providers/nomad/index.html.markdown
+++ b/website/source/docs/providers/nomad/index.html.markdown
@@ -3,12 +3,12 @@ layout: "nomad"
 page_title: "Provider: Nomad"
 sidebar_current: "docs-nomad-index"
 description: |-
-  Nomad is a cluster scheduler. The Nomad provider exposes resources to interact with a Nomad cluster.
+  HashiCorp Nomad is a cluster scheduler. The Nomad provider exposes resources to interact with a Nomad cluster.
 ---
 
-# Nomad Provider
+# HashiCorp Nomad Provider
 
-[Nomad](https://www.nomadproject.io) is a cluster scheduler. The Nomad
+[HashiCorp Nomad](https://www.nomadproject.io) is a cluster scheduler. The Nomad
 provider exposes resources to interact with a Nomad cluster.
 
 Use the navigation to the left to read about the available resources.

--- a/website/source/docs/providers/terraform-enterprise/index.html.markdown
+++ b/website/source/docs/providers/terraform-enterprise/index.html.markdown
@@ -1,9 +1,9 @@
 ---
 layout: "terraform-enterprise"
-page_title: "Provider: Terraform Enterprise"
+page_title: "Provider: HashiCorp Terraform Enterprise"
 sidebar_current: "docs-terraform-enterprise-index"
 description: |-
-  The Terraform Enterprise provider is used to interact with configuration,
+  The HashiCorp Terraform Enterprise provider is used to interact with configuration,
   artifacts, and metadata managed by the Terraform Enterprise service.
 ---
 

--- a/website/source/docs/providers/terraform-enterprise/index.html.markdown
+++ b/website/source/docs/providers/terraform-enterprise/index.html.markdown
@@ -7,9 +7,9 @@ description: |-
   artifacts, and metadata managed by the Terraform Enterprise service.
 ---
 
-# Terraform Enterprise Provider
+# HashiCorp Terraform Enterprise Provider
 
-The Terraform Enterprise provider is used to interact with resources,
+The HashiCorp Terraform Enterprise provider is used to interact with resources,
 configuration, artifacts, and metadata managed by
 [Terraform Enterprise](https://www.terraform.io/docs/providers/index.html).
 The provider needs to be configured with the proper credentials before it can

--- a/website/source/docs/providers/terraform/index.html.markdown
+++ b/website/source/docs/providers/terraform/index.html.markdown
@@ -3,12 +3,12 @@ layout: "terraform"
 page_title: "Provider: Terraform"
 sidebar_current: "docs-terraform-index"
 description: |-
-  The Terraform provider is used to access meta data from shared infrastructure.
+  The HashiCorp Terraform provider is used to access meta data from shared infrastructure.
 ---
 
-# Terraform Provider
+# HashiCorp Terraform Provider
 
-The terraform provider provides access to outputs from the Terraform state
+The HashiCorp Terraform provider provides access to outputs from the Terraform state
 of shared infrastructure.
 
 Use the navigation to the left to read about the available data sources.

--- a/website/source/docs/providers/terraform/index.html.markdown
+++ b/website/source/docs/providers/terraform/index.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "terraform"
-page_title: "Provider: Terraform"
+page_title: "Provider: HashiCorp Terraform"
 sidebar_current: "docs-terraform-index"
 description: |-
   The HashiCorp Terraform provider is used to access meta data from shared infrastructure.

--- a/website/source/docs/providers/vault/index.html.markdown
+++ b/website/source/docs/providers/vault/index.html.markdown
@@ -3,12 +3,12 @@ layout: "vault"
 page_title: "Provider: Vault"
 sidebar_current: "docs-vault-index"
 description: |-
-  The Vault provider allows Terraform to read from, write to, and configure Hashicorp Vault
+  The HashiCorp Vault provider allows Terraform to read from, write to, and configure Hashicorp Vault.
 ---
 
-# Vault Provider
+# HashiCorp Vault Provider
 
-The Vault provider allows Terraform to read from, write to, and configure
+The HashiCorp Vault provider allows Terraform to read from, write to, and configure
 [Hashicorp Vault](https://vaultproject.io/).
 
 ~> **Important** Interacting with Vault from Terraform causes any secrets
@@ -148,4 +148,3 @@ resource "vault_generic_secret" "example" {
 EOT
 }
 ```
-

--- a/website/source/docs/providers/vault/index.html.markdown
+++ b/website/source/docs/providers/vault/index.html.markdown
@@ -1,6 +1,6 @@
 ---
 layout: "vault"
-page_title: "Provider: Vault"
+page_title: "Provider: HashiCorp Vault"
 sidebar_current: "docs-vault-index"
 description: |-
   The HashiCorp Vault provider allows Terraform to read from, write to, and configure Hashicorp Vault.

--- a/website/source/layouts/consul.erb
+++ b/website/source/layouts/consul.erb
@@ -7,7 +7,7 @@
                 </li>
 
         <li<%= sidebar_current("docs-consul-index") %>>
-        <a href="/docs/providers/consul/index.html">Consul Provider</a>
+        <a href="/docs/providers/consul/index.html">HashiCorp Consul Provider</a>
                 </li>
 
         <li<%= sidebar_current("docs-consul-data-source") %>>

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -228,10 +228,6 @@
             <a href="/docs/providers/cobbler/index.html">Cobbler</a>
           </li>
 
-          <li<%= sidebar_current("docs-providers-consul") %>>
-            <a href="/docs/providers/consul/index.html">Consul</a>
-          </li>
-
           <li<%= sidebar_current("docs-providers-datadog") %>>
             <a href="/docs/providers/datadog/index.html">Datadog</a>
           </li>
@@ -284,6 +280,26 @@
             <a href="/docs/providers/grafana/index.html">Grafana</a>
           </li>
 
+          <li<%= sidebar_current("docs-providers-consul") %>>
+            <a href="/docs/providers/consul/index.html">HashiCorp Consul</a>
+          </li>
+
+          <li<%= sidebar_current("docs-providers-nomad") %>>
+            <a href="/docs/providers/nomad/index.html">HashiCorp Nomad</a>
+          </li>
+
+          <li<%= sidebar_current("docs-providers-terraform") %>>
+            <a href="/docs/providers/terraform/index.html">HashiCorp Terraform</a>
+          </li>
+
+          <li<%= sidebar_current("docs-providers-terraform-enterprise") %>>
+            <a href="/docs/providers/terraform-enterprise/index.html">HashiCorp Terraform Enterprise</a>
+          </li>
+
+          <li<%= sidebar_current("docs-providers-vault") %>>
+            <a href="/docs/providers/vault/index.html">HashiCorp Vault</a>
+          </li>
+
           <li<%= sidebar_current("docs-providers-heroku") %>>
             <a href="/docs/providers/heroku/index.html">Heroku</a>
           </li>
@@ -326,10 +342,6 @@
 
           <li<%= sidebar_current("docs-providers-newrelic") %>>
             <a href="/docs/providers/newrelic/index.html">New Relic</a>
-          </li>
-
-          <li<%= sidebar_current("docs-providers-nomad") %>>
-            <a href="/docs/providers/nomad/index.html">Nomad</a>
           </li>
 
           <li<%= sidebar_current("docs-providers-ns1") %>>
@@ -424,14 +436,6 @@
             <a href="/docs/providers/template/index.html">Template</a>
           </li>
 
-          <li<%= sidebar_current("docs-providers-terraform") %>>
-            <a href="/docs/providers/terraform/index.html">Terraform</a>
-          </li>
-
-          <li<%= sidebar_current("docs-providers-terraform-enterprise") %>>
-            <a href="/docs/providers/terraform-enterprise/index.html">Terraform Enterprise</a>
-          </li>
-
           <li<%= sidebar_current("docs-providers-tls") %>>
             <a href="/docs/providers/tls/index.html">TLS</a>
           </li>
@@ -442,10 +446,6 @@
 
           <li<%= sidebar_current("docs-providers-ultradns") %>>
             <a href="/docs/providers/ultradns/index.html">UltraDNS</a>
-          </li>
-
-          <li<%= sidebar_current("docs-providers-vault") %>>
-            <a href="/docs/providers/vault/index.html">Vault</a>
           </li>
 
           <li<%= sidebar_current("docs-providers-vcd") %>>

--- a/website/source/layouts/nomad.erb
+++ b/website/source/layouts/nomad.erb
@@ -7,7 +7,7 @@
         </li>
 
         <li<%= sidebar_current("docs-nomad-index") %>>
-          <a href="/docs/providers/nomad/index.html">Nomad Provider</a>
+          <a href="/docs/providers/nomad/index.html">HashiCorp Nomad Provider</a>
         </li>
 
         <li<%= sidebar_current("docs-nomad-resource") %>>

--- a/website/source/layouts/terraform-enterprise.erb
+++ b/website/source/layouts/terraform-enterprise.erb
@@ -6,7 +6,7 @@
       </li>
 
       <li<%= sidebar_current("docs-terraform-enterprise-index") %>>
-        <a class="back" href="/docs/providers/terraform-enterprise/index.html">Terraform Enterprise Provider</a>
+        <a class="back" href="/docs/providers/terraform-enterprise/index.html">HashiCorp Terraform Enterprise Provider</a>
       </li>
 
       <h4>Data Sources</h4>

--- a/website/source/layouts/terraform.erb
+++ b/website/source/layouts/terraform.erb
@@ -7,7 +7,7 @@
         </li>
 
         <li<%= sidebar_current("docs-terraform-index") %>>
-          <a href="/docs/providers/terraform/index.html">Terraform Provider</a>
+          <a href="/docs/providers/terraform/index.html">HashiCorp Terraform Provider</a>
         </li>
 
         <li<%= sidebar_current("docs-terraform-datasource") %>>

--- a/website/source/layouts/vault.erb
+++ b/website/source/layouts/vault.erb
@@ -7,7 +7,7 @@
                 </li>
 
                 <li<%= sidebar_current("docs-vault-index") %>>
-                    <a href="/docs/providers/vault/index.html">Vault Provider</a>
+                    <a href="/docs/providers/vault/index.html">HashiCorp Vault Provider</a>
                 </li>
 
                 <li<%= sidebar_current("docs-vault-datasource") %>>


### PR DESCRIPTION
This PR groups the HashiCorp providers in the documentation so that they're easier to find or discover. Also changes the main heading and description on each of the product pages to be consistent.