### PR TITLE
Adds example of subdir notation for generic git

### DIFF
--- a/website/source/docs/modules/sources.html.markdown
+++ b/website/source/docs/modules/sources.html.markdown
@@ -160,6 +160,16 @@ module "consul" {
 }
 ```
 
+Subdirectories within the repository can also be referenced:
+
+```hcl
+module "consul" {
+  source = "git::https://hashicorp.com/consul.git//subdir"
+}
+```
+
+**Note:** The double-slash, `//`, is important. It is what tells Terraform that this is the separator for a subdirectory, and not part of the repository itself.
+
 Terraform will cache the module locally by default `terraform get` is run, so successive updates to master or a specified branch will not be factored into future plans. Run `terraform get -update=true` to get the latest version of the branch. This is handy in development, but potentially bothersome in production if you don't have control of the repository.
 
 ## Generic Mercurial Repository


### PR DESCRIPTION
The subdirectory notation for git is shown for github and bitbucket, but not for generic git. I've just repeated it again for generic git.

I suspect it's the same notation for mercurial as well, but I'm not a mercurial user and don't have a way to verify it.