### PR TITLE
provider/aws: Add tag support for ebs_volume_snapshot

### DIFF
--- a/builtin/providers/aws/resource_aws_ami_test.go
+++ b/builtin/providers/aws/resource_aws_ami_test.go
@@ -193,6 +193,10 @@ resource "aws_ebs_volume" "foo" {
 
 resource "aws_ebs_snapshot" "foo" {
   volume_id = "${aws_ebs_volume.foo.id}"
+
+	tags {
+		Name = "testAccAmiConfig_basic"
+	}
 }
 
 resource "aws_ami" "foo" {
@@ -219,6 +223,9 @@ resource "aws_ebs_volume" "foo" {
 
 resource "aws_ebs_snapshot" "foo" {
   volume_id = "${aws_ebs_volume.foo.id}"
+	tags {
+		Name = "TestAccAWSAMI_snapshotSize"
+	}
 }
 
 resource "aws_ami" "foo" {

--- a/builtin/providers/aws/resource_aws_ebs_snapshot.go
+++ b/builtin/providers/aws/resource_aws_ebs_snapshot.go
@@ -53,6 +53,12 @@ func resourceAwsEbsSnapshot() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
+
+			"tags": {
+				Type:     schema.TypeMap,
+				Optional: true,
+				ForceNew: true,
+			},
 		},
 	}
 }
@@ -77,6 +83,10 @@ func resourceAwsEbsSnapshotCreate(d *schema.ResourceData, meta interface{}) erro
 	err = resourceAwsEbsSnapshotWaitForAvailable(d.Id(), conn)
 	if err != nil {
 		return err
+	}
+
+	if err := setTags(conn, d); err != nil {
+		log.Printf("[WARN] error setting tags: %s", err)
 	}
 
 	return resourceAwsEbsSnapshotRead(d, meta)
@@ -105,6 +115,10 @@ func resourceAwsEbsSnapshotRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("data_encryption_key_id", snapshot.DataEncryptionKeyId)
 	d.Set("kms_keey_id", snapshot.KmsKeyId)
 	d.Set("volume_size", snapshot.VolumeSize)
+
+	if err := d.Set("tags", tagsToMap(snapshot.Tags)); err != nil {
+		log.Printf("[WARN] error saving tags to state: %s", err)
+	}
 
 	return nil
 }

--- a/builtin/providers/aws/resource_aws_ebs_snapshot_test.go
+++ b/builtin/providers/aws/resource_aws_ebs_snapshot_test.go
@@ -20,6 +20,7 @@ func TestAccAWSEBSSnapshot_basic(t *testing.T) {
 				Config: testAccAwsEbsSnapshotConfig,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckSnapshotExists("aws_ebs_snapshot.test", &v),
+					testAccCheckTags(&v.Tags, "Name", "testAccAwsEbsSnapshotConfig"),
 				),
 			},
 		},
@@ -79,6 +80,10 @@ resource "aws_ebs_volume" "test" {
 
 resource "aws_ebs_snapshot" "test" {
 	volume_id = "${aws_ebs_volume.test.id}"
+
+	tags {
+		Name = "testAccAwsEbsSnapshotConfig"
+	}
 }
 `
 

--- a/website/source/docs/providers/aws/r/ebs_snapshot.html.md
+++ b/website/source/docs/providers/aws/r/ebs_snapshot.html.md
@@ -23,6 +23,10 @@ resource "aws_ebs_volume" "example" {
 
 resource "aws_ebs_snapshot" "example_snapshot" {
 	volume_id = "${aws_ebs_volume.example.id}"
+
+    tags {
+        Name = "HelloWorld_snap"
+    }
 }
 ```
 
@@ -32,6 +36,7 @@ The following arguments are supported:
 
 * `volume_id` - (Required) The Volume ID of which to make a snapshot.
 * `description` - (Optional) A description of what the snapshot is.
+* `tags` - (Optional) A mapping of tags to assign to the snapshot
 
 
 ## Attributes Reference
@@ -45,4 +50,4 @@ The following attributes are exported:
 * `volume_size` - The size of the drive in GiBs.
 * `kms_key_id` - The ARN for the KMS encryption key.
 * `data_encryption_key_id` - The data encryption key identifier for the snapshot.
-* `tags` - A mapping of tags for the resource.
+* `tags` - A mapping of tags for the snapshot.


### PR DESCRIPTION
I was surprised to find we don't support tags on `aws_ebs_snapshot`. Here I add that. Yay