### PR TITLE
provider/azurerm: Add missing resources to importability section

### DIFF
--- a/website/source/docs/import/importability.html.md
+++ b/website/source/docs/import/importability.html.md
@@ -107,20 +107,54 @@ To make a resource importable, please see the
 * aws_vpn_connection
 * aws_vpn_gateway
 
-
 ### Azure (Resource Manager)
 
 * azurerm_availability_set
-* azurerm_express_route_circuit
+* azurerm_cdn_endpoint
+* azurerm_cdn_profile
+* azurerm_container_registry
+* azurerm_dns_a_record
+* azurerm_dns_aaaa_record
+* azurerm_dns_cname_record
+* azurerm_dns_mx_record
+* azurerm_dns_ns_record
+* azurerm_dns_srv_record
+* azurerm_dns_txt_record
 * azurerm_dns_zone
+* azurerm_eventhub
+* azurerm_eventhub_authorization_rule
+* azurerm_eventhub_consumer_group
+* azurerm_eventhub_namespace
+* azurerm_express_route_circuit
+* azurerm_loadbalancer
+* azurerm_loadbalancer_backend_address_pool
+* azurerm_loadbalancer_nat_pool
+* azurerm_loadbalancer_nat_rule
+* azurerm_loadbalancer_probe
+* azurerm_loadbalancer_rule
 * azurerm_local_network_gateway
+* azurerm_managed_disk
+* azurerm_network_interface
 * azurerm_network_security_group
 * azurerm_network_security_rule
 * azurerm_public_ip
 * azurerm_resource_group
+* azurerm_route
+* azurerm_route_table
+* azurerm_servicebus_namespace
+* azurerm_servicebus_subscription
+* azurerm_servicebus_topic
 * azurerm_sql_firewall_rule
+* azurerm_sql_server
 * azurerm_storage_account
+* azurerm_subnet
+* azurerm_traffic_manager_endpoint
+* azurerm_traffic_manager_profile
+* azurerm_virtual_machine
+* azurerm_virtual_machine_extension
+* azurerm_virtual_machine_scale_set
 * azurerm_virtual_network
+* azurerm_virtual_network_peering
 
 ### Circonus
 


### PR DESCRIPTION
First of all, thanks for Terraform!

While reading the docs I noticed an inconsistency between `Import` section under each resource document and the `Resource Importability` document.

Example:

* [Import azurerm_virtual_machine](https://www.terraform.io/docs/providers/azurerm/r/virtual_machine.html#import)
* [Resource Importability](https://www.terraform.io/docs/import/importability.html#azure-resource-manager-)

This PR is based on other documentation that might be outdated as well. How I get there:

```console
$ git grep "terraform import azurerm"
```
[Output](https://gist.github.com/thiagocaiubi/6a527fe658351e7db56e1e89b0afa334)

Every resource that has an `Import` section with an example was promoted to `Resource Importability` section.

Edit:

This kind of documentation can encourage more people to migrate their actual orchestration to Terraform.