### PR TITLE
provider/github: Add merge types to repository resource

### DIFF
--- a/builtin/providers/github/resource_github_repository.go
+++ b/builtin/providers/github/resource_github_repository.go
@@ -48,17 +48,17 @@ func resourceGithubRepository() *schema.Resource {
 			"allow_merge_commit": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default: true,
+				Default:  true,
 			},
 			"allow_squash_merge": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default: true,
+				Default:  true,
 			},
 			"allow_rebase_merge": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default: true,
+				Default:  true,
 			},
 			"has_downloads": {
 				Type:     schema.TypeBool,
@@ -111,17 +111,17 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	autoInit := d.Get("auto_init").(bool)
 
 	repo := &github.Repository{
-		Name:         &name,
-		Description:  &description,
-		Homepage:     &homepageUrl,
-		Private:      &private,
-		HasIssues:    &hasIssues,
-		HasWiki:      &hasWiki,
+		Name:             &name,
+		Description:      &description,
+		Homepage:         &homepageUrl,
+		Private:          &private,
+		HasIssues:        &hasIssues,
+		HasWiki:          &hasWiki,
 		AllowMergeCommit: &allowMergeCommit,
 		AllowSquashMerge: &allowSquashMerge,
 		AllowRebaseMerge: &allowRebaseMerge,
-		HasDownloads: &hasDownloads,
-		AutoInit:     &autoInit,
+		HasDownloads:     &hasDownloads,
+		AutoInit:         &autoInit,
 	}
 
 	return repo
@@ -175,7 +175,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("svn_url", repo.SVNURL)
 	d.Set("git_clone_url", repo.GitURL)
 	d.Set("http_clone_url", repo.CloneURL)
-	
+
 	return nil
 }
 

--- a/builtin/providers/github/resource_github_repository.go
+++ b/builtin/providers/github/resource_github_repository.go
@@ -45,6 +45,21 @@ func resourceGithubRepository() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
+			"allow_merge_commit": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default: true,
+			},
+			"allow_squash_merge": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default: true,
+			},
+			"allow_rebase_merge": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default: true,
+			},
 			"has_downloads": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -89,6 +104,9 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 	private := d.Get("private").(bool)
 	hasIssues := d.Get("has_issues").(bool)
 	hasWiki := d.Get("has_wiki").(bool)
+	allowMergeCommit := d.Get("allow_merge_commit").(bool)
+	allowSquashMerge := d.Get("allow_squash_merge").(bool)
+	allowRebaseMerge := d.Get("allow_rebase_merge").(bool)
 	hasDownloads := d.Get("has_downloads").(bool)
 	autoInit := d.Get("auto_init").(bool)
 
@@ -99,6 +117,9 @@ func resourceGithubRepositoryObject(d *schema.ResourceData) *github.Repository {
 		Private:      &private,
 		HasIssues:    &hasIssues,
 		HasWiki:      &hasWiki,
+		AllowMergeCommit: &allowMergeCommit,
+		AllowSquashMerge: &allowSquashMerge,
+		AllowRebaseMerge: &allowRebaseMerge,
 		HasDownloads: &hasDownloads,
 		AutoInit:     &autoInit,
 	}
@@ -144,6 +165,9 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("private", repo.Private)
 	d.Set("has_issues", repo.HasIssues)
 	d.Set("has_wiki", repo.HasWiki)
+	d.Set("allow_merge_commit", repo.AllowMergeCommit)
+	d.Set("allow_squash_merge", repo.AllowSquashMerge)
+	d.Set("allow_rebase_merge", repo.AllowRebaseMerge)
 	d.Set("has_downloads", repo.HasDownloads)
 	d.Set("full_name", repo.FullName)
 	d.Set("default_branch", repo.DefaultBranch)
@@ -151,6 +175,7 @@ func resourceGithubRepositoryRead(d *schema.ResourceData, meta interface{}) erro
 	d.Set("svn_url", repo.SVNURL)
 	d.Set("git_clone_url", repo.GitURL)
 	d.Set("http_clone_url", repo.CloneURL)
+	
 	return nil
 }
 

--- a/builtin/providers/github/resource_github_repository_test.go
+++ b/builtin/providers/github/resource_github_repository_test.go
@@ -33,6 +33,9 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						Homepage:      "http://example.com/",
 						HasIssues:     true,
 						HasWiki:       true,
+						AllowMergeCommit: false,
+						AllowSquashMerge: false,
+						AllowRebaseMerge: false,
 						HasDownloads:  true,
 						DefaultBranch: "master",
 					}),
@@ -46,6 +49,9 @@ func TestAccGithubRepository_basic(t *testing.T) {
 						Name:          name,
 						Description:   "Updated " + description,
 						Homepage:      "http://example.com/",
+						AllowMergeCommit: true,
+						AllowSquashMerge: true,
+						AllowRebaseMerge: true,
 						DefaultBranch: "master",
 					}),
 				),
@@ -104,6 +110,9 @@ type testAccGithubRepositoryExpectedAttributes struct {
 	Private      bool
 	HasIssues    bool
 	HasWiki      bool
+	AllowMergeCommit bool
+	AllowSquashMerge bool
+	AllowRebaseMerge bool
 	HasDownloads bool
 
 	DefaultBranch string
@@ -129,6 +138,15 @@ func testAccCheckGithubRepositoryAttributes(repo *github.Repository, want *testA
 		}
 		if *repo.HasWiki != want.HasWiki {
 			return fmt.Errorf("got has wiki %#v; want %#v", *repo.HasWiki, want.HasWiki)
+		}
+		if *repo.AllowMergeCommit != want.AllowMergeCommit {
+			return fmt.Errorf("got allow merge commit %#v; want %#v", *repo.AllowMergeCommit, want.AllowMergeCommit)
+		}
+		if *repo.AllowSquashMerge != want.AllowSquashMerge {
+			return fmt.Errorf("got allow squash merge %#v; want %#v", *repo.AllowSquashMerge, want.AllowSquashMerge)
+		}
+		if *repo.AllowRebaseMerge != want.AllowRebaseMerge {
+			return fmt.Errorf("got allow rebase merge %#v; want %#v", *repo.AllowRebaseMerge, want.AllowRebaseMerge)
 		}
 		if *repo.HasDownloads != want.HasDownloads {
 			return fmt.Errorf("got has downloads %#v; want %#v", *repo.HasDownloads, want.HasDownloads)
@@ -208,6 +226,9 @@ resource "github_repository" "foo" {
 
   has_issues = true
   has_wiki = true
+  allow_merge_commit = false
+  allow_squash_merge = false
+  allow_rebase_merge = false
   has_downloads = true
 }
 `, randString, randString)
@@ -226,6 +247,9 @@ resource "github_repository" "foo" {
 
   has_issues = false
   has_wiki = false
+  allow_merge_commit = true
+  allow_squash_merge = true
+  allow_rebase_merge = true
   has_downloads = false
 }
 `, randString, randString)

--- a/builtin/providers/github/resource_github_repository_test.go
+++ b/builtin/providers/github/resource_github_repository_test.go
@@ -28,16 +28,16 @@ func TestAccGithubRepository_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubRepositoryExists("github_repository.foo", &repo),
 					testAccCheckGithubRepositoryAttributes(&repo, &testAccGithubRepositoryExpectedAttributes{
-						Name:          name,
-						Description:   description,
-						Homepage:      "http://example.com/",
-						HasIssues:     true,
-						HasWiki:       true,
+						Name:             name,
+						Description:      description,
+						Homepage:         "http://example.com/",
+						HasIssues:        true,
+						HasWiki:          true,
 						AllowMergeCommit: false,
 						AllowSquashMerge: false,
 						AllowRebaseMerge: false,
-						HasDownloads:  true,
-						DefaultBranch: "master",
+						HasDownloads:     true,
+						DefaultBranch:    "master",
 					}),
 				),
 			},
@@ -46,13 +46,13 @@ func TestAccGithubRepository_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGithubRepositoryExists("github_repository.foo", &repo),
 					testAccCheckGithubRepositoryAttributes(&repo, &testAccGithubRepositoryExpectedAttributes{
-						Name:          name,
-						Description:   "Updated " + description,
-						Homepage:      "http://example.com/",
+						Name:             name,
+						Description:      "Updated " + description,
+						Homepage:         "http://example.com/",
 						AllowMergeCommit: true,
 						AllowSquashMerge: true,
 						AllowRebaseMerge: true,
-						DefaultBranch: "master",
+						DefaultBranch:    "master",
 					}),
 				),
 			},
@@ -104,16 +104,16 @@ func testAccCheckGithubRepositoryExists(n string, repo *github.Repository) resou
 }
 
 type testAccGithubRepositoryExpectedAttributes struct {
-	Name         string
-	Description  string
-	Homepage     string
-	Private      bool
-	HasIssues    bool
-	HasWiki      bool
+	Name             string
+	Description      string
+	Homepage         string
+	Private          bool
+	HasIssues        bool
+	HasWiki          bool
 	AllowMergeCommit bool
 	AllowSquashMerge bool
 	AllowRebaseMerge bool
-	HasDownloads bool
+	HasDownloads     bool
 
 	DefaultBranch string
 }

--- a/website/source/docs/providers/github/r/repository.html.markdown
+++ b/website/source/docs/providers/github/r/repository.html.markdown
@@ -44,6 +44,12 @@ The following arguments are supported:
 * `has_wiki` - (Optional) Set to `true` to enable the Github Wiki features on
   the repository.
 
+* `allow_merge_commit` - (Optional) Set to `false` to disable merge commits on the repository.
+
+* `allow_squash_merge` - (Optional) Set to `false` to disable squash merges on the repository.
+
+* `allow_rebase_merge` - (Optional) Set to `false` to disable rebase merges on the repository.
+
 * `has_downloads` - (Optional) Set to `true` to enable the (deprecated)
   downloads features on the repository.
 


### PR DESCRIPTION
Adding merge types to the GitHub Repository resource so that users can control when the repository allows Squash merges, Rebase merges and/or Merge commits.

Fixes #15183 