### PR TITLE
Add import for `google_sql_database_instance`

### DIFF
--- a/builtin/providers/google/import_sql_database_instance_test.go
+++ b/builtin/providers/google/import_sql_database_instance_test.go
@@ -1,0 +1,57 @@
+package google
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/acctest"
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+// Test importing a first generation database
+func TestAccGoogleSqlDatabaseInstance_importBasic(t *testing.T) {
+	resourceName := "google_sql_database_instance.instance"
+	databaseID := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_basic, databaseID),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+// Test importing a second generation database
+func TestAccGoogleSqlDatabaseInstance_importBasic3(t *testing.T) {
+	resourceName := "google_sql_database_instance.instance"
+	databaseID := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGoogleSqlDatabaseInstanceDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: fmt.Sprintf(
+					testGoogleSqlDatabaseInstance_basic3, databaseID),
+			},
+
+			resource.TestStep{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}

--- a/builtin/providers/google/resource_sql_database_instance_test.go
+++ b/builtin/providers/google/resource_sql_database_instance_test.go
@@ -621,7 +621,7 @@ resource "google_sql_database_instance" "instance" {
 var testGoogleSqlDatabaseInstance_basic3 = `
 resource "google_sql_database_instance" "instance" {
 	name = "tf-lw-%d"
-	region = "us-central"
+	region = "us-central1"
 	settings {
 		tier = "db-f1-micro"
 	}

--- a/website/source/docs/providers/google/r/sql_database_instance.html.markdown
+++ b/website/source/docs/providers/google/r/sql_database_instance.html.markdown
@@ -142,7 +142,7 @@ when an Instance can automatically restart to apply updates. It supports:
 
 * `hour` - (Optional) Hour of day (`0-23`), ignored if `day` not set
 
-* `update_track` - (Optional) Receive updates earlier (`canary`) or later 
+* `update_track` - (Optional) Receive updates earlier (`canary`) or later
 (`stable`)
 
 The optional `replica_configuration` block must have `master_instance_name` set
@@ -194,3 +194,11 @@ exported:
 
 * `settings.version` - Used to make sure changes to the `settings` block are
     atomic.
+
+## Import
+
+Database instances can be imported using the `name`, e.g.
+
+```
+$ terraform import google_sql_database_instance.instance instance_name
+```


### PR DESCRIPTION
In reference to https://github.com/hashicorp/terraform/issues/15087 and possibly addressing https://github.com/hashicorp/terraform/issues/15201. 

```
$ make testacc TEST=./builtin/providers/google/ TESTARGS='-run=TestAccGoogleSqlDatabaseInstance'
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
2017/06/09 18:08:53 Generated command/internal_plugin_list.go
TF_ACC=1 go test ./builtin/providers/google/ -v -run=TestAccGoogleSqlDatabaseInstance -timeout 120m
=== RUN   TestAccGoogleSqlDatabaseInstance_importBasic
--- PASS: TestAccGoogleSqlDatabaseInstance_importBasic (62.56s)
=== RUN   TestAccGoogleSqlDatabaseInstance_importBasic3
--- PASS: TestAccGoogleSqlDatabaseInstance_importBasic3 (372.11s)
=== RUN   TestAccGoogleSqlDatabaseInstance_basic
--- PASS: TestAccGoogleSqlDatabaseInstance_basic (61.93s)
=== RUN   TestAccGoogleSqlDatabaseInstance_basic2
--- PASS: TestAccGoogleSqlDatabaseInstance_basic2 (62.80s)
=== RUN   TestAccGoogleSqlDatabaseInstance_basic3
--- PASS: TestAccGoogleSqlDatabaseInstance_basic3 (466.07s)
=== RUN   TestAccGoogleSqlDatabaseInstance_settings_basic
--- PASS: TestAccGoogleSqlDatabaseInstance_settings_basic (41.16s)
=== RUN   TestAccGoogleSqlDatabaseInstance_slave
--- PASS: TestAccGoogleSqlDatabaseInstance_slave (651.39s)
=== RUN   TestAccGoogleSqlDatabaseInstance_diskspecs
--- PASS: TestAccGoogleSqlDatabaseInstance_diskspecs (370.50s)
=== RUN   TestAccGoogleSqlDatabaseInstance_maintenance
--- PASS: TestAccGoogleSqlDatabaseInstance_maintenance (351.21s)
=== RUN   TestAccGoogleSqlDatabaseInstance_settings_upgrade
--- PASS: TestAccGoogleSqlDatabaseInstance_settings_upgrade (60.53s)
=== RUN   TestAccGoogleSqlDatabaseInstance_settings_downgrade
--- PASS: TestAccGoogleSqlDatabaseInstance_settings_downgrade (47.26s)
=== RUN   TestAccGoogleSqlDatabaseInstance_authNets
--- PASS: TestAccGoogleSqlDatabaseInstance_authNets (77.29s)
=== RUN   TestAccGoogleSqlDatabaseInstance_multipleOperations
--- PASS: TestAccGoogleSqlDatabaseInstance_multipleOperations (81.16s)
PASS
ok      github.com/hashicorp/terraform/builtin/providers/google 2705.998s
```