### PR TITLE
command/providers: Avoid crash when no configs found

### DIFF
--- a/command/providers.go
+++ b/command/providers.go
@@ -24,6 +24,7 @@ func (c *ProvidersCommand) Synopsis() string {
 }
 
 func (c *ProvidersCommand) Run(args []string) int {
+	c.Meta.process(args, false)
 
 	cmdFlags := c.Meta.flagSet("providers")
 	cmdFlags.Usage = func() { c.Ui.Error(c.Help()) }

--- a/command/providers.go
+++ b/command/providers.go
@@ -43,6 +43,13 @@ func (c *ProvidersCommand) Run(args []string) int {
 		c.Ui.Error(fmt.Sprintf("Failed to load root config module: %s", err))
 		return 1
 	}
+	if root == nil {
+		c.Ui.Error(fmt.Sprintf(
+			"No configuration files found in the directory: %s\n\n"+
+				"This command requires configuration to run.",
+			configPath))
+		return 1
+	}
 
 	// Validate the config (to ensure the version constraints are valid)
 	err = root.Validate()

--- a/command/providers_test.go
+++ b/command/providers_test.go
@@ -41,3 +41,33 @@ func TestProviders(t *testing.T) {
 		t.Errorf("output missing provider.baz\n\n%s", output)
 	}
 }
+
+func TestProviders_noConfigs(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := os.Chdir(testFixturePath("")); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.Chdir(cwd)
+
+	ui := new(cli.MockUi)
+	c := &ProvidersCommand{
+		Meta: Meta{
+			Ui: ui,
+		},
+	}
+
+	args := []string{}
+	if code := c.Run(args); code == 0 {
+		t.Fatal("expected command to return non-zero exit code" +
+			" when no configs are available")
+	}
+
+	output := ui.ErrorWriter.String()
+	expectedErrMsg := "No configuration files found"
+	if !strings.Contains(output, expectedErrMsg) {
+		t.Errorf("Expected error message: %s\nGiven output: %s", expectedErrMsg, output)
+	}
+}


### PR DESCRIPTION
If you run `terraform providers` in a path where there are no configs it crashes:

```
$ terraform providers
2017/06/10 10:15:52 [DEBUG] Detected home directory from env var: /Users/radeksimko
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x158ce12]

goroutine 1 [running]:
github.com/hashicorp/terraform/config/module.(*Tree).Loaded(0x0, 0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/config/module/tree.go:118 +0xb2
github.com/hashicorp/terraform/config/module.(*Tree).Validate(0x0, 0xc42001a004, 0x59)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/config/module/tree.go:279 +0x7c
github.com/hashicorp/terraform/command.(*ProvidersCommand).Run(0xc420203a40, 0xc42000a270, 0x0, 0x0, 0xc420568b90)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/command/providers.go:48 +0x239
github.com/hashicorp/terraform/vendor/github.com/mitchellh/cli.(*CLI).Run(0xc42021c180, 0xc42021c180, 0xc420703ce0, 0x1)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/vendor/github.com/mitchellh/cli/cli.go:154 +0x1a8
main.wrappedMain(0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/main.go:188 +0xa81
main.realMain(0x0)
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/main.go:95 +0xbb
main.main()
	/Users/radeksimko/gopath/src/github.com/hashicorp/terraform/main.go:31 +0x38
```

This PR is fixing it by showing error and also enables colouring as it was disabled due to forgotten one-liner for processing meta-parameters.