### PR TITLE
provider/aws: Fixes elasticsearch error setting policy (#6438)

### DIFF
--- a/builtin/providers/aws/resource_aws_elasticsearch_domain.go
+++ b/builtin/providers/aws/resource_aws_elasticsearch_domain.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/errwrap"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
+	"strings"
 )
 
 func resourceAwsElasticSearchDomain() *schema.Resource {
@@ -220,11 +221,27 @@ func resourceAwsElasticSearchDomainCreate(d *schema.ResourceData, meta interface
 	}
 
 	log.Printf("[DEBUG] Creating ElasticSearch domain: %s", input)
-	out, err := conn.CreateElasticsearchDomain(&input)
+
+	// IAM Roles can take some time to propagate if set in AccessPolicies and created in the same terraform
+	var out *elasticsearch.CreateElasticsearchDomainOutput
+	err := resource.Retry(30*time.Second, func() *resource.RetryError {
+		var err error
+		out, err = conn.CreateElasticsearchDomain(&input)
+		if err != nil {
+			if awsErr, ok := err.(awserr.Error); ok {
+				if awsErr.Code() == "InvalidTypeException" && strings.Contains(awsErr.Message(), "Error setting policy") {
+					log.Printf("[DEBUG] Retrying creation of ElasticSearch domain %s", *input.DomainName)
+					return resource.RetryableError(err)
+				}
+			}
+			return resource.NonRetryableError(err)
+		}
+		return nil
+	})
+
 	if err != nil {
 		return err
 	}
-
 	d.SetId(*out.DomainStatus.ARN)
 
 	log.Printf("[DEBUG] Waiting for ElasticSearch domain %q to be created", d.Id())


### PR DESCRIPTION
Fixes: #6438

Creating an elastic search domain with a policy


**Acceptance test**
```bash
make dev
==> Checking that code complies with gofmt requirements...
go generate $(go list ./... | grep -v /terraform/vendor/)
Generated command/internal_plugin_list.go
```
```
$ go generate $(go list ./... | grep -v /terraform/vendor/)
 Generated command/internal_plugin_list.go

$ TF_ACC=1 go test ./builtin/providers/aws/ -v -run=TestAccAWSElasticSearchDomain_policy -timeout 120m
=== RUN   TestAccAWSElasticSearchDomain_policy
--- PASS: TestAccAWSElasticSearchDomain_policy (1098.95s)
PASS
ok  	github.com/hashicorp/terraform/builtin/providers/aws	1098.969s
```
## Steps to reproduce issue #6438 

### Using the aws CLI

1. Create a file `policy.json`
Contents of policy json:
```javascript
	{
      "Version": "2012-10-17",
      "Statement": [
        {
          "Action": "sts:AssumeRole",
          "Principal": {
            "Service": "ec2.amazonaws.com"
          },
          "Effect": "Allow",
          "Sid": ""
        }
      ]
    }
```

2. Run command `aws iam create-role` and `aws es create-elasticsearch-domain`

`aws iam create-role --role-name ed-test-1 --assume-role-policy-document file://policy.json && aws es create-elasticsearch-domain --region us-west-2 --domain-name "ed-test-1" --ebs-options 'EBSEnabled=true,VolumeSize=10' --access-policies '{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::288840537196:role/ed-test-1"},"Action":"es:*","Resource":"arn:aws:es:*"}]}'`

Expected: no error and resources to have been created
Actual: 
```bash
An error occurred (InvalidTypeException) when calling the CreateElasticsearchDomain operation: Error setting policy: [{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::288840537196:role/ed-test-1"},"Action":"es:*","Resource":"arn:aws:es:*"}]}]
```

### Using terraform
```hcl
resource "aws_elasticsearch_domain" "example" {
  domain_name = "tf-test-1"
   ebs_options {
    ebs_enabled = true
    volume_size = 10
  }
  access_policies = <<CONFIG
  {
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
	"AWS": "${aws_iam_role.example_role.arn}"
      },
      "Action": "es:*",
      "Resource": "arn:aws:es:*"
    }
  ]
  }
CONFIG
}
resource "aws_iam_role" "example_role" {
  name = "es-domain-role-1"
  assume_role_policy = "${data.aws_iam_policy_document.instance-assume-role-policy.json}"
}
data "aws_iam_policy_document" "instance-assume-role-policy" {
  statement {
    actions = ["sts:AssumeRole"]
    principals {
      type        = "Service"
      identifiers = ["ec2.amazonaws.com"]
    }
  }
}
```
Expected: no error and resources to have been created
Actual:
```bash
Error applying plan:

1 error(s) occurred:

* aws_elasticsearch_domain.elastic: 1 error(s) occurred:

* aws_elasticsearch_domain.elastic: InvalidTypeException: Error setting policy: [{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "AWS": ["arn:aws:iam::13884053156:role/es-domain-role-1"]
      },
      "Action": "es:*",
      "Resource": "arn:aws:es:eu-west-1:13884053156:domain/tf-test-1/*"
    }
  ]
}
]
	status code: 409, request id: 4070cc55-49e2-11e7-a4d9-15d110862029

Terraform does not automatically rollback in the face of errors.
Instead, your Terraform state file has been partially updated with
any resources that successfully completed. Please address the error
above and apply again to incrementally change your infrastructure.
make: *** [apply] Error 1
```