### PR TITLE
Replace lock_table with dynamodb_table in backend description

### DIFF
--- a/website/source/docs/backends/types/s3.html.md
+++ b/website/source/docs/backends/types/s3.html.md
@@ -14,7 +14,8 @@ Stores the state as a given key in a given bucket on
 [Amazon S3](https://aws.amazon.com/s3/).
 This backend also supports state locking via
 [Dynamo DB](https://aws.amazon.com/dynamodb/). Enable locking by setting the
-`lock_table` key to a Dynamo DB table to use for the locks.
+`dynamodb_table` key to a Dynamo DB table to use for state locking and
+consistency.
 
 ~> **Warning!** It is highly recommended that you enable
 [Bucket Versioning](http://docs.aws.amazon.com/AmazonS3/latest/UG/enable-bucket-versioning.html)


### PR DESCRIPTION
Pull request #14949 updated the documentation to change
`lock_table` to `dynamodb_table`, but missed the general
description at the top of the file. This commit updates
the general description so that users know the recommendation
is to use the new `dynamodb_table` key instead of the deprecated
`lock_table` key.