### PR TITLE
Fix file provisioner #15177 Must provide one of 'content' or 'source'

### DIFF
--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -80,12 +80,16 @@ func applyFn(ctx context.Context) error {
 
 func validateFn(d *schema.ResourceData) (ws []string, es []error) {
 	numSrc := 0
-	if _, ok := d.GetOk("source"); ok == true {
+	content := d.Get("content").(string)
+	source := d.Get("source").(string)
+
+	if content != "" {
 		numSrc++
 	}
-	if _, ok := d.GetOk("content"); ok == true {
+	if source != "" {
 		numSrc++
 	}
+
 	if numSrc != 1 {
 		es = append(es, fmt.Errorf("Must provide one of 'content' or 'source'"))
 	}


### PR DESCRIPTION
it seems [GetOk](https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_data.go#L89) fail to return `ok` in the following part:
https://github.com/hashicorp/terraform/blob/master/helper/schema/resource_data.go#L91

The struct is:
```
r: {${data.template_file.config.rendered} <nil> true true 0xc4203c12c0}
```

Which means `r.Exists` and `r.Computed` but expecting `r.Exists && !r.Computed`
I was able to make a workaround with the following code. 
Feel free to close or refactor if that doesn't fit your view. 