### PR TITLE
prevent log output during init

### DIFF
--- a/config_unix.go
+++ b/config_unix.go
@@ -5,7 +5,6 @@ package main
 import (
 	"bytes"
 	"errors"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -33,7 +32,12 @@ func configDir() (string, error) {
 func homeDir() (string, error) {
 	// First prefer the HOME environmental variable
 	if home := os.Getenv("HOME"); home != "" {
-		log.Printf("[DEBUG] Detected home directory from env var: %s", home)
+
+		// FIXME: homeDir gets called from globalPluginDirs during init, before
+		// the logging is setup.  We should move meta initializtion outside of
+		// init, but in the meantime we just need to silence this output.
+		//log.Printf("[DEBUG] Detected home directory from env var: %s", home)
+
 		return home, nil
 	}
 


### PR DESCRIPTION
The extra output shouldn't be seen by the user, and is causing TFE to
fail.