### PR TITLE
command: init -upgrade for modules and provider plugins

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -80,6 +80,39 @@ func TestInit_get(t *testing.T) {
 	}
 }
 
+func TestInit_getUpgradeModules(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	os.MkdirAll(td, 0755)
+	// copy.CopyDir(testFixturePath("init-get"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	c := &InitCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-get=true",
+		"-get-plugins=false",
+		"-upgrade",
+		testFixturePath("init-get"),
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("command did not complete successfully:\n%s", ui.ErrorWriter.String())
+	}
+
+	// Check output
+	output := ui.OutputWriter.String()
+	if !strings.Contains(output, "(update)") {
+		t.Fatalf("doesn't look like get upgrade: %s", output)
+	}
+}
+
 func TestInit_backend(t *testing.T) {
 	// Create a temporary working directory that is empty
 	td := tempDir(t)

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -5,7 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 
@@ -490,6 +492,98 @@ func TestInit_getProvider(t *testing.T) {
 	if _, err := os.Stat(betweenPath); os.IsNotExist(err) {
 		t.Fatal("provider 'between' not downloaded")
 	}
+}
+
+func TestInit_getUpgradePlugins(t *testing.T) {
+	// Create a temporary working directory that is empty
+	td := tempDir(t)
+	copy.CopyDir(testFixturePath("init-get-providers"), td)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	ui := new(cli.MockUi)
+	m := Meta{
+		testingOverrides: metaOverridesForProvider(testProvider()),
+		Ui:               ui,
+	}
+
+	installer := &mockProviderInstaller{
+		Providers: map[string][]string{
+			// looking for an exact version
+			"exact": []string{"1.2.3"},
+			// config requires >= 2.3.3
+			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
+			// config specifies
+			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
+		},
+
+		Dir: m.pluginDir(),
+	}
+
+	err := os.MkdirAll(m.pluginDir(), os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exactUnwanted := filepath.Join(m.pluginDir(), installer.FileName("exact", "0.0.1"))
+	err = ioutil.WriteFile(exactUnwanted, []byte{}, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	greaterThanUnwanted := filepath.Join(m.pluginDir(), installer.FileName("greater_than", "2.3.3"))
+	err = ioutil.WriteFile(greaterThanUnwanted, []byte{}, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	betweenOverride := installer.FileName("between", "2.3.4") // intentionally directly in cwd, and should override auto-install
+	err = ioutil.WriteFile(betweenOverride, []byte{}, os.ModePerm)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := &InitCommand{
+		Meta:              m,
+		providerInstaller: installer,
+	}
+
+	args := []string{
+		"-upgrade=true",
+	}
+	if code := c.Run(args); code != 0 {
+		t.Fatalf("command did not complete successfully:\n%s", ui.ErrorWriter.String())
+	}
+
+	files, err := ioutil.ReadDir(m.pluginDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !installer.PurgeUnusedCalled {
+		t.Errorf("init -upgrade didn't purge providers, but should have")
+	}
+
+	gotFilenames := make([]string, len(files))
+	for i, info := range files {
+		gotFilenames[i] = info.Name()
+	}
+	sort.Strings(gotFilenames)
+
+	wantFilenames := []string{
+		"lock.json",
+
+		// no "between" because the file in cwd overrides it
+
+		// The mock PurgeUnused doesn't actually purge anything, so the dir
+		// includes both our old and new versions.
+		"terraform-provider-exact_v0.0.1_x4",
+		"terraform-provider-exact_v1.2.3_x4",
+		"terraform-provider-greater_than_v2.3.3_x4",
+		"terraform-provider-greater_than_v2.3.4_x4",
+	}
+
+	if !reflect.DeepEqual(gotFilenames, wantFilenames) {
+		t.Errorf("wrong directory contents after upgrade\ngot:  %#v\nwant: %#v", gotFilenames, wantFilenames)
+	}
+
 }
 
 func TestInit_getProviderMissing(t *testing.T) {

--- a/plugin/discovery/meta_set.go
+++ b/plugin/discovery/meta_set.go
@@ -60,6 +60,24 @@ func (s PluginMetaSet) WithName(name string) PluginMetaSet {
 	return ns
 }
 
+// WithVersion returns the subset of metas that have the given version.
+//
+// This should be used only with the "valid" result from ValidateVersions;
+// it will ignore any plugin metas that have a invalid version strings.
+func (s PluginMetaSet) WithVersion(version Version) PluginMetaSet {
+	ns := make(PluginMetaSet)
+	for p := range s {
+		gotVersion, err := p.Version.Parse()
+		if err != nil {
+			continue
+		}
+		if gotVersion.Equal(version) {
+			ns.Add(p)
+		}
+	}
+	return ns
+}
+
 // ByName groups the metas in the set by their Names, returning a map.
 func (s PluginMetaSet) ByName() map[string]PluginMetaSet {
 	ret := make(map[string]PluginMetaSet)

--- a/plugin/discovery/version.go
+++ b/plugin/discovery/version.go
@@ -49,6 +49,10 @@ func (v Version) NewerThan(other Version) bool {
 	return v.raw.GreaterThan(other.raw)
 }
 
+func (v Version) Equal(other Version) bool {
+	return v.raw.Equal(other.raw)
+}
+
 // MinorUpgradeConstraintStr returns a ConstraintStr that would permit
 // minor upgrades relative to the receiving version.
 func (v Version) MinorUpgradeConstraintStr() ConstraintStr {


### PR DESCRIPTION
Now when -upgrade is provided to `terraform init` (and plugin installation isn't disabled) it will:
    
* ignore the contents of the auto-install plugin directory when deciding what is "available", thus causing anything there to be reinstalled, possibly at a newer version.
* if installation completes successfully, purge from the auto-install plugin directory any plugin-looking files that aren't in the set of chosen plugins.
    
As before, plugins outside of the auto-install directory are able to take precedence over the auto-install ones, and these will never be upgraded nor purged.
    
The thinking here is that the auto-install directory is an implementation detail directly managed by Terraform, and so it's Terraform's responsibility to automatically keep it clean as plugins are upgraded.
    
We don't yet have the `-plugin-dir` option implemented, but once it is it will circumvent all of this behavior and just expect providers to be already available in the given directory, meaning that nothing will be auto-installed, auto-upgraded or auto-purged.

----

This also includes an adapted version of @fatmcgav's work from #13852, creating a unified `-upgrade` option that gets everything up-to-date. The same option is used for both since we want to encourage by default _not_ surgically upgrading things, but rather using version pinning (both in the module `source`, with go-getter constraints, and providers using the `version` argument) to ensure that `-upgrade` will have an equivalent result to a fresh `init` in a new working directory.

In a pinch, though, single-type upgrades _are_ possibly by combining with other options:

* `-get=false -upgrade` to skip upgrading modules
* `-get-plugins=false -upgrade` to skip upgrading plugins
