### PR TITLE
provisioner/file: don’t use `d.GetOk` in validation functions

### DIFF
--- a/builtin/provisioners/file/resource_provisioner.go
+++ b/builtin/provisioners/file/resource_provisioner.go
@@ -78,18 +78,12 @@ func applyFn(ctx context.Context) error {
 	}
 }
 
-func validateFn(d *schema.ResourceData) (ws []string, es []error) {
-	numSrc := 0
-	if _, ok := d.GetOk("source"); ok == true {
-		numSrc++
+func validateFn(c *terraform.ResourceConfig) (ws []string, es []error) {
+	if !c.IsSet("source") && !c.IsSet("content") {
+		es = append(es, fmt.Errorf("Must provide one of 'source' or 'content'"))
 	}
-	if _, ok := d.GetOk("content"); ok == true {
-		numSrc++
-	}
-	if numSrc != 1 {
-		es = append(es, fmt.Errorf("Must provide one of 'content' or 'source'"))
-	}
-	return
+
+	return ws, es
 }
 
 // getSrc returns the file to use as source

--- a/builtin/provisioners/file/resource_provisioner_test.go
+++ b/builtin/provisioners/file/resource_provisioner_test.go
@@ -48,6 +48,21 @@ func TestResourceProvider_Validate_good_content(t *testing.T) {
 	}
 }
 
+func TestResourceProvider_Validate_good_unknown_variable_value(t *testing.T) {
+	c := testConfig(t, map[string]interface{}{
+		"content":     config.UnknownVariableValue,
+		"destination": "/tmp/bar",
+	})
+
+	warn, errs := Provisioner().Validate(c)
+	if len(warn) > 0 {
+		t.Fatalf("Warnings: %v", warn)
+	}
+	if len(errs) > 0 {
+		t.Fatalf("Errors: %v", errs)
+	}
+}
+
 func TestResourceProvider_Validate_bad_not_destination(t *testing.T) {
 	c := testConfig(t, map[string]interface{}{
 		"source": "nope",

--- a/helper/schema/provisioner.go
+++ b/helper/schema/provisioner.go
@@ -43,7 +43,7 @@ type Provisioner struct {
 
 	// ValidateFunc is a function for extended validation. This is optional
 	// and should be used when individual field validation is not enough.
-	ValidateFunc func(*ResourceData) ([]string, []error)
+	ValidateFunc func(*terraform.ResourceConfig) ([]string, []error)
 
 	stopCtx       context.Context
 	stopCtxCancel context.CancelFunc
@@ -121,32 +121,6 @@ func (p *Provisioner) Stop() error {
 	return nil
 }
 
-func (p *Provisioner) Validate(config *terraform.ResourceConfig) ([]string, []error) {
-	if err := p.InternalValidate(); err != nil {
-		return nil, []error{fmt.Errorf(
-			"Internal validation of the provisioner failed! This is always a bug\n"+
-				"with the provisioner itself, and not a user issue. Please report\n"+
-				"this bug:\n\n%s", err)}
-	}
-	w := []string{}
-	e := []error{}
-	if p.Schema != nil {
-		w2, e2 := schemaMap(p.Schema).Validate(config)
-		w = append(w, w2...)
-		e = append(e, e2...)
-	}
-	if p.ValidateFunc != nil {
-		data := &ResourceData{
-			schema: p.Schema,
-			config: config,
-		}
-		w2, e2 := p.ValidateFunc(data)
-		w = append(w, w2...)
-		e = append(e, e2...)
-	}
-	return w, e
-}
-
 // Apply implementation of terraform.ResourceProvisioner interface.
 func (p *Provisioner) Apply(
 	o terraform.UIOutput,
@@ -203,4 +177,28 @@ func (p *Provisioner) Apply(
 	ctx = context.WithValue(ctx, ProvOutputKey, o)
 	ctx = context.WithValue(ctx, ProvRawStateKey, s)
 	return p.ApplyFunc(ctx)
+}
+
+// Validate implements the terraform.ResourceProvisioner interface.
+func (p *Provisioner) Validate(c *terraform.ResourceConfig) (ws []string, es []error) {
+	if err := p.InternalValidate(); err != nil {
+		return nil, []error{fmt.Errorf(
+			"Internal validation of the provisioner failed! This is always a bug\n"+
+				"with the provisioner itself, and not a user issue. Please report\n"+
+				"this bug:\n\n%s", err)}
+	}
+
+	if p.Schema != nil {
+		w, e := schemaMap(p.Schema).Validate(c)
+		ws = append(ws, w...)
+		es = append(es, e...)
+	}
+
+	if p.ValidateFunc != nil {
+		w, e := p.ValidateFunc(c)
+		ws = append(ws, w...)
+		es = append(es, e...)
+	}
+
+	return ws, es
 }

--- a/helper/schema/provisioner_test.go
+++ b/helper/schema/provisioner_test.go
@@ -112,7 +112,7 @@ func TestProvisionerValidate(t *testing.T) {
 			P: &Provisioner{
 				Schema:    nil,
 				ApplyFunc: noopApply,
-				ValidateFunc: func(*ResourceData) (ws []string, errors []error) {
+				ValidateFunc: func(*terraform.ResourceConfig) (ws []string, errors []error) {
 					ws = append(ws, "Simple warning from provisioner ValidateFunc")
 					return
 				},


### PR DESCRIPTION
It turns out that `d.GetOk` also returns `false` when the user _did_ actually supply a value for it in the config, but the value itself needs to be evaluated before it can be used.

@mitchellh I must admit this is a bit different then my perception was about how (and when) to use `d.GetOk`.

I was fully under the impression that it would only return `false` if a value was not set in the config by the user and in all other cases it would return `true`. Regardless whether the value needed any kind of interpolation or evaluation.

That way you could always safely use this function to determine if the value you retrieved was put there by the user or was written back to the state during the execution of a `Read()` function of a resource.

The docs seem to (in part) support my assumptions:

```
GetOk returns the data for the given key and whether or not the key has
been set to a non-zero value at some point.
```

So did I read/understand it's usage incorrectly? And if so, is there a way to determine if a value is set by a user or that it was written back by the resource?

Or did I understand it correctly and should the current behaviour of `d.GetOk` be considered a bug? Thx!

_EDIT:_ Fixes #15177