### PR TITLE
Verify plugins can execute

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -416,6 +416,12 @@ func TestInit_getProvider(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
+	// make the sure the name isn't discoverable as a provider
+	testProviderPath := "./test-provider-bin"
+	if err := createTestProviderBin(testProviderPath); err != nil {
+		t.Fatal(err)
+	}
+
 	getter := &mockGetProvider{
 		Providers: map[string][]string{
 			// looking for an exact version
@@ -424,6 +430,11 @@ func TestInit_getProvider(t *testing.T) {
 			"greater_than": []string{"2.3.4", "2.3.3", "2.3.0"},
 			// config specifies
 			"between": []string{"3.4.5", "2.3.4", "1.2.3"},
+		},
+		Bins: map[string]string{
+			"exact":        testProviderPath,
+			"greater_than": testProviderPath,
+			"between":      testProviderPath,
 		},
 	}
 

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -234,6 +234,19 @@ func provisionerFactory(client *plugin.Client) terraform.ResourceProvisionerFact
 	}
 }
 
+// execChosen takes the final list of plugins and verifies that they can be
+// executed with execPlugins.
+func execChosen(plugins map[string]discovery.PluginMeta) error {
+	metas := make(discovery.PluginMetaSet)
+
+	for _, p := range plugins {
+		metas.Add(p)
+	}
+
+	_, err := execPlugins(metas)
+	return err
+}
+
 // execPlugins filters the listed plugins, removing files that aren't usable,
 // either due to permissions, plugin protocol version, or are otherwise
 // invalid. The returned error can be safely ignored if one only wants to

--- a/command/plugins_test.go
+++ b/command/plugins_test.go
@@ -1,9 +1,15 @@
 package command
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"testing"
 
 	"github.com/hashicorp/terraform/plugin/discovery"
 )
@@ -14,6 +20,10 @@ type mockGetProvider struct {
 	// A map of provider names to available versions.
 	// The tests expect the versions to be in order from newest to oldest.
 	Providers map[string][]string
+
+	// optionally supply a path to a binary to source for the providers, or an
+	// empty placeholder file will be created.
+	Bins map[string]string
 }
 
 func (m mockGetProvider) FileName(provider, version string) string {
@@ -43,14 +53,102 @@ func (m mockGetProvider) GetProvider(dst, provider string, req discovery.Constra
 			// provider filename
 			name := m.FileName(provider, v)
 			path := filepath.Join(dst, name)
-			f, err := os.Create(path)
+
+			// create an empty file by default
+			var source io.Reader = bytes.NewBuffer(nil)
+
+			if bin := m.Bins[provider]; bin != "" {
+				// copy the binary to the destination
+				b, err := os.Open(bin)
+				if err != nil {
+					return err
+				}
+				defer b.Close()
+				source = b
+			}
+
+			f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
 				return fmt.Errorf("error fetching provider: %s", err)
 			}
-			f.Close()
+			defer f.Close()
+
+			if _, err := io.Copy(f, source); err != nil {
+				return err
+			}
 			return nil
 		}
 	}
 
 	return fmt.Errorf("no suitable version for provider %q found with constraints %s", provider, req)
+}
+
+func TestExecPlugins(t *testing.T) {
+	td := tempDir(t)
+	os.MkdirAll(td, 0755)
+	defer os.RemoveAll(td)
+	defer testChdir(t, td)()
+
+	// make some invalid plugins
+	if err := ioutil.WriteFile("terraform-provider-nonexecutable_v1.2.3", []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := ioutil.WriteFile("terraform-provider-notplugin_v1.2.3", []byte("#!/bin/bash\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// create a valid plugin
+	if err := createTestProviderBin("./terraform-provider-test_v2.3.4_x4"); err != nil {
+		t.Fatal(err)
+	}
+
+	plugins := make(discovery.PluginMetaSet)
+	nonExecMeta := discovery.PluginMeta{
+		Name:    "notexecutable",
+		Version: "1.2.3",
+		Path:    "./terraform-provider-nonexecutable_v1.2.3",
+	}
+	notPluginMeta := discovery.PluginMeta{
+		Name:    "notplugin",
+		Version: "1.2.3",
+		Path:    "./terraform-provider-notplugin_v1.2.3",
+	}
+	testPluginMeta := discovery.PluginMeta{
+		Name:    "test",
+		Version: "2.3.4",
+		Path:    "./terraform-provider-test_v2.3.4_x4",
+	}
+	plugins.Add(nonExecMeta)
+	plugins.Add(notPluginMeta)
+	plugins.Add(testPluginMeta)
+
+	filtered, err := execPlugins(plugins)
+	if filtered.Count() != 1 {
+		t.Fatalf("expected 1 plugins, got %d: %#v\n", filtered.Count(), filtered)
+	}
+
+	if err == nil {
+		t.Fatal("expected errors")
+	}
+
+	if !filtered.Has(testPluginMeta) {
+		t.Fatalf("the test plugin should be the only valid plugin. got: %#v", filtered)
+	}
+}
+
+// compile a test provider
+func createTestProviderBin(path string) error {
+	args := []string{"build", "-o", path, "github.com/hashicorp/terraform/builtin/bins/provider-test"}
+	cmd := exec.Command("go", args...)
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %s", err, output)
+	}
+
+	if len(output) > 0 {
+		log.Printf("[INFO] provider compilation output: %s", string(output))
+	}
+
+	return nil
 }


### PR DESCRIPTION
The `init` command should verify that plugins are executable, and have a matching protocol version.

While at some point we may want to filter all the available plugins,
this starts with a simpler UI where specifying an invalid plugin will
be called out immediately, rather than ignored with debug logging as the
only way to diagnose the issue. This also avoids excessive slowness and
UI output if there are numerous old/incompatible plugins in the search path. 