### PR TITLE
init with target dir should still write .terraform in the current directory

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -81,10 +80,6 @@ func (c *InitCommand) Run(args []string) int {
 	if len(args) == 1 {
 		path = args[0]
 	}
-	// Set the state out path to be the path requested for the module
-	// to be copied. This ensures any remote states gets setup in the
-	// proper directory.
-	c.Meta.dataDir = filepath.Join(path, DefaultDataDir)
 
 	// This will track whether we outputted anything so that we know whether
 	// to output a newline before the success message

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -305,12 +305,12 @@ func TestInit_targetSubdir(t *testing.T) {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 
-	if _, err := os.Stat(filepath.Join(td, "source", DefaultDataDir, DefaultStateFilename)); err != nil {
+	if _, err := os.Stat(filepath.Join(td, DefaultDataDir, DefaultStateFilename)); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 
 	// a data directory should not have been added to out working dir
-	if _, err := os.Stat(filepath.Join(td, DefaultDataDir)); !os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Join(td, "source", DefaultDataDir)); !os.IsNotExist(err) {
 		t.Fatalf("err: %s", err)
 	}
 }

--- a/command/meta.go
+++ b/command/meta.go
@@ -44,7 +44,8 @@ type Meta struct {
 	// Protected: commands can set these
 	//----------------------------------------------------------
 
-	// Modify the data directory location. Defaults to DefaultDataDir
+	// Modify the data directory location. This should be accessed through the
+	// DataDir method.
 	dataDir string
 
 	// Override certain behavior for tests within this package
@@ -159,6 +160,7 @@ func (m *Meta) Colorize() *colorstring.Colorize {
 }
 
 // DataDir returns the directory where local data will be stored.
+// Defaults to DefaultsDataDir in the current working directory.
 func (m *Meta) DataDir() string {
 	dataDir := DefaultDataDir
 	if m.dataDir != "" {
@@ -498,12 +500,7 @@ func (m *Meta) WorkspaceOverridden() (string, bool) {
 		return envVar, true
 	}
 
-	dataDir := m.dataDir
-	if m.dataDir == "" {
-		dataDir = DefaultDataDir
-	}
-
-	envData, err := ioutil.ReadFile(filepath.Join(dataDir, local.DefaultWorkspaceFile))
+	envData, err := ioutil.ReadFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile))
 	current := string(bytes.TrimSpace(envData))
 	if current == "" {
 		current = backend.DefaultStateName
@@ -520,17 +517,12 @@ func (m *Meta) WorkspaceOverridden() (string, bool) {
 // SetWorkspace saves the given name as the current workspace in the local
 // filesystem.
 func (m *Meta) SetWorkspace(name string) error {
-	dataDir := m.dataDir
-	if m.dataDir == "" {
-		dataDir = DefaultDataDir
-	}
-
-	err := os.MkdirAll(dataDir, 0755)
+	err := os.MkdirAll(m.DataDir(), 0755)
 	if err != nil {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(dataDir, local.DefaultWorkspaceFile), []byte(name), 0644)
+	err = ioutil.WriteFile(filepath.Join(m.DataDir(), local.DefaultWorkspaceFile), []byte(name), 0644)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Now that init can take a directory for configuration, the old behavior
of writing the .terraform data directory into the target path no longer
makes sense. 

Clean up all references to Meta.dataDir, and only use the getter method
in case we chose to dynamically override this at some point.