### PR TITLE
core: -target option to also select resources in descendant modules

### DIFF
--- a/terraform/graph_builder_plan.go
+++ b/terraform/graph_builder_plan.go
@@ -117,7 +117,15 @@ func (b *PlanGraphBuilder) Steps() []GraphTransformer {
 		&CountBoundaryTransformer{},
 
 		// Target
-		&TargetsTransformer{Targets: b.Targets},
+		&TargetsTransformer{
+			Targets: b.Targets,
+
+			// Resource nodes from config have not yet been expanded for
+			// "count", so we must apply targeting without indices. Exact
+			// targeting will be dealt with later when these resources
+			// DynamicExpand.
+			IgnoreIndices: true,
+		},
 
 		// Close opened plugin connections
 		&CloseProviderTransformer{},

--- a/terraform/graph_builder_refresh.go
+++ b/terraform/graph_builder_refresh.go
@@ -144,7 +144,15 @@ func (b *RefreshGraphBuilder) Steps() []GraphTransformer {
 		&ReferenceTransformer{},
 
 		// Target
-		&TargetsTransformer{Targets: b.Targets},
+		&TargetsTransformer{
+			Targets: b.Targets,
+
+			// Resource nodes from config have not yet been expanded for
+			// "count", so we must apply targeting without indices. Exact
+			// targeting will be dealt with later when these resources
+			// DynamicExpand.
+			IgnoreIndices: true,
+		},
 
 		// Close opened plugin connections
 		&CloseProviderTransformer{},

--- a/terraform/resource_address_test.go
+++ b/terraform/resource_address_test.go
@@ -304,6 +304,306 @@ func TestParseResourceAddress(t *testing.T) {
 	}
 }
 
+func TestResourceAddressContains(t *testing.T) {
+	tests := []struct {
+		Address *ResourceAddress
+		Other   *ResourceAddress
+		Want    bool
+	}{
+		{
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           0,
+			},
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"bar", "baz"},
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"bar", "baz"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			true,
+		},
+		{
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"bar", "baz", "foo", "pizza"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			true,
+		},
+
+		{
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "bar",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			false,
+		},
+		{
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			&ResourceAddress{
+				Mode:            config.DataResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			false,
+		},
+		{
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"baz"},
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			false,
+		},
+		{
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"baz", "bar"},
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			false,
+		},
+		{
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: true,
+				InstanceType:    TypePrimary,
+				Index:           0,
+			},
+			&ResourceAddress{
+				Mode:            config.ManagedResourceMode,
+				Type:            "aws_instance",
+				Name:            "foo",
+				InstanceTypeSet: false,
+				Index:           0,
+			},
+			false,
+		},
+		{
+			&ResourceAddress{
+				Path:            []string{"bar", "baz"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			&ResourceAddress{
+				Path:            []string{"bar"},
+				InstanceTypeSet: false,
+				Index:           -1,
+			},
+			false,
+		},
+		{
+			&ResourceAddress{
+				Type:         "aws_instance",
+				Name:         "foo",
+				Index:        1,
+				InstanceType: TypePrimary,
+				Mode:         config.ManagedResourceMode,
+			},
+			&ResourceAddress{
+				Type:         "aws_instance",
+				Name:         "foo",
+				Index:        -1,
+				InstanceType: TypePrimary,
+				Mode:         config.ManagedResourceMode,
+			},
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%s contains %s", test.Address, test.Other), func(t *testing.T) {
+			got := test.Address.Contains(test.Other)
+			if got != test.Want {
+				t.Errorf(
+					"wrong result\nrecv:  %s\ngiven: %s\ngot:   %#v\nwant:  %#v",
+					test.Address, test.Other,
+					got, test.Want,
+				)
+			}
+		})
+	}
+}
+
 func TestResourceAddressEquals(t *testing.T) {
 	cases := map[string]struct {
 		Address *ResourceAddress

--- a/terraform/test-fixtures/apply-targeted-module-recursive/child/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-recursive/child/main.tf
@@ -1,0 +1,3 @@
+module "subchild" {
+    source = "./subchild"
+}

--- a/terraform/test-fixtures/apply-targeted-module-recursive/child/subchild/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-recursive/child/subchild/main.tf
@@ -1,0 +1,3 @@
+resource "aws_instance" "foo" {
+    num = "2"
+}

--- a/terraform/test-fixtures/apply-targeted-module-recursive/main.tf
+++ b/terraform/test-fixtures/apply-targeted-module-recursive/main.tf
@@ -1,0 +1,3 @@
+module "child" {
+    source = "./child"
+}

--- a/terraform/transform_targets.go
+++ b/terraform/transform_targets.go
@@ -41,6 +41,12 @@ type TargetsTransformer struct {
 	// that already have the targets parsed
 	ParsedTargets []ResourceAddress
 
+	// If set, the index portions of resource addresses will be ignored
+	// for comparison. This is used when transforming a graph where
+	// counted resources have not yet been expanded, since otherwise
+	// the unexpanded nodes (which never have indices) would not match.
+	IgnoreIndices bool
+
 	// Set to true when we're in a `terraform destroy` or a
 	// `terraform plan -destroy`
 	Destroy bool
@@ -199,7 +205,12 @@ func (t *TargetsTransformer) nodeIsTarget(
 
 	addr := r.ResourceAddr()
 	for _, targetAddr := range addrs {
-		if targetAddr.Equals(addr) {
+		if t.IgnoreIndices {
+			// targetAddr is not a pointer, so we can safely mutate it without
+			// interfering with references elsewhere.
+			targetAddr.Index = -1
+		}
+		if targetAddr.Contains(addr) {
 			return true
 		}
 	}

--- a/website/docs/commands/apply.html.markdown
+++ b/website/docs/commands/apply.html.markdown
@@ -54,9 +54,9 @@ The command-line flags are all optional. The list of available flags are:
   [remote state](/docs/state/remote.html) is used.
 
 * `-target=resource` - A [Resource
-  Address](/docs/internals/resource-addressing.html) to target. Operation will
-  be limited to this resource and its dependencies. This flag can be used
-  multiple times.
+  Address](/docs/internals/resource-addressing.html) to target. For more
+  information, see
+  [the targeting docs from `terraform plan`](/docs/commands/plan.html#resource-targeting).
 
 * `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as

--- a/website/docs/commands/plan.html.markdown
+++ b/website/docs/commands/plan.html.markdown
@@ -63,9 +63,8 @@ The command-line flags are all optional. The list of available flags are:
   Ignored when [remote state](/docs/state/remote.html) is used.
 
 * `-target=resource` - A [Resource
-  Address](/docs/internals/resource-addressing.html) to target. Operation will
-  be limited to this resource and its dependencies. This flag can be used
-  multiple times.
+  Address](/docs/internals/resource-addressing.html) to target. This flag can
+  be used multiple times. See below for more information.
 
 * `-var 'foo=bar'` - Set a variable in the Terraform configuration. This flag
   can be set multiple times. Variable values are interpreted as
@@ -77,6 +76,37 @@ The command-line flags are all optional. The list of available flags are:
   "terraform.tfvars" is present, it will be automatically loaded first. Any
   files specified by `-var-file` override any values in a "terraform.tfvars".
   This flag can be used multiple times.
+
+## Resource Targeting
+
+The `-target` option can be used to focus Terraform's attention on only a
+subset of resources.
+[Resource Address](/docs/internals/resource-addressing.html) syntax is used
+to specify the constraint. The resource address is interpreted as follows:
+
+* If the given address has a _resource spec_, only the specified resource
+  is targeted. If the named resource uses `count` and no explicit index
+  is specified in the address, all of the instances sharing the given
+  resource name are targeted.
+
+* The the given address _does not_ have a resource spec, and instead just
+  specifies a module path, the target applies to all resources in the
+  specified module _and_ all of the descendent modules of the specified
+  module.
+
+This targeting capability is provided for exceptional circumstances, such
+as recovering from mistakes or working around Terraform limitations. It
+is *not recommended* to use `-target` for routine operations, since this can
+lead to undetected configuration drift and confusion about how the true state
+of resources relates to configuration.
+
+Instead of using `-target` as a means to operate on isolated portions of very
+large configurations, prefer instead to break large configurations into
+several smaller configurations that can each be independently applied.
+[Data sources](/docs/configuration/data-sources.html) can be used to access
+information about resources created in other configurations, allowing
+a complex system architecture to be broken down into more managable parts
+that can be updated independently.
 
 ## Security Warning
 


### PR DESCRIPTION
(This is adapted from #9236, originally submitted by @uhef. It is rebased and altered slightly in approach to be compatible with other changes that were made to `ResourceAddress` since the original PR was submitted.)

---

Previously the behavior for `-target` when given a module address was to target only resources directly within that module, ignoring any resources defined in child modules.

This behavior turned out to be counter-intuitive, since users expected the `-target` address to be interpreted hierarchically.

We'll now use a new `Contains` function for addresses, which provides a hierarchical "containment" concept that is more consistent with user expectations. In particular, it allows `module.foo` to match
`module.foo.module.bar.aws_instance.baz`, where before this would not have matched.

Since `Contains` isn't commutative (unlike `Equals`) this requires some special handling for targeting specific resource indices. When given an argument like `-target=aws_instance.foo[0]`, the initial graph construction (for both plan and refresh) is for the resource nodes from configuration, which
have not yet been expanded to separate indexed instances. Thus we need to do the first pass of `TargetsTransformer` in mode where indices are ignored, with the work then completed in the `DynamicExpand` method by re-applying the `TargetsTransformer` in index-sensitive mode within the dynamic subgraph.

This is a breaking change for anyone depending on the previous behavior of `-target`, since it will now select more resources than before. There is no way provided to obtain the previous behavior. Eventually we may support negative targeting, which could then combine with positive targets to regain the previous behavior as an explicit choice.

---

This addresses #5190.

This change intended to land in 0.10 so we can properly announce the breaking change in targeting behavior as part of that release.
