### PR TITLE
Correct to and from backends when migrating

### DIFF
--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -1082,8 +1082,8 @@ func (m *Meta) backend_C_r_S_changed(
 	if !copy {
 		copy, err = m.confirm(&terraform.InputOpts{
 			Id:          "backend-migrate-to-new",
-			Query:       fmt.Sprintf("Do you want to copy the state from %q?", c.Type),
-			Description: strings.TrimSpace(fmt.Sprintf(inputBackendMigrateChange, c.Type, s.Backend.Type)),
+			Query:       fmt.Sprintf("Do you want to copy the state from %q?", s.Backend.Type),
+			Description: strings.TrimSpace(fmt.Sprintf(inputBackendMigrateChange, s.Backend.Type, c.Type)),
 		})
 		if err != nil {
 			return nil, fmt.Errorf(


### PR DESCRIPTION
Fixes #15306 

Display correct to and from backends in copy message when
migrating to new remote state

There are no existing tests I can find that test output of messages. Is that
something desirable to test?