### PR TITLE
remove "~> 0.0" constraint suggestions

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -303,7 +303,7 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 			continue
 		}
 
-		if req.Versions.Unconstrained() {
+		if req.Versions.Unconstrained() && meta.Version != discovery.VersionZero {
 			// meta.Version.MustParse is safe here because our "chosen" metas
 			// were already filtered for validity of versions.
 			constraintSuggestions[name] = meta.Version.MustParse().MinorUpgradeConstraintStr()

--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -153,7 +153,7 @@ func ResolvePluginPaths(paths []string) PluginMetaSet {
 
 		parts := strings.SplitN(baseName, "_v", 2)
 		name := parts[0]
-		version := "0.0.0"
+		version := VersionZero
 		if len(parts) == 2 {
 			version = parts[1]
 		}

--- a/plugin/discovery/meta_set.go
+++ b/plugin/discovery/meta_set.go
@@ -186,7 +186,7 @@ func (s PluginMetaSet) OverridePaths(paths map[string]string) PluginMetaSet {
 	for name, path := range paths {
 		ret.Add(PluginMeta{
 			Name:    name,
-			Version: "0.0.0",
+			Version: VersionZero,
 			Path:    path,
 		})
 	}

--- a/plugin/discovery/meta_set_test.go
+++ b/plugin/discovery/meta_set_test.go
@@ -402,14 +402,14 @@ func TestPluginMetaSetOverridePaths(t *testing.T) {
 	}
 	if !ns.Has(PluginMeta{
 		Name:    "foo",
-		Version: "0.0.0",
+		Version: VersionZero,
 		Path:    "override-foo",
 	}) {
 		t.Errorf("new set is missing 'foo' override")
 	}
 	if !ns.Has(PluginMeta{
 		Name:    "fun",
-		Version: "0.0.0",
+		Version: VersionZero,
 		Path:    "override-fun",
 	}) {
 		t.Errorf("new set is missing 'fun' override")

--- a/plugin/discovery/version.go
+++ b/plugin/discovery/version.go
@@ -7,6 +7,8 @@ import (
 	version "github.com/hashicorp/go-version"
 )
 
+const VersionZero = "0.0.0"
+
 // A VersionStr is a string containing a possibly-invalid representation
 // of a semver version number. Call Parse on it to obtain a real Version
 // object, or discover that it is invalid.


### PR DESCRIPTION
Don't suggest constraints when the available plugin isn't versioned.

Add zero version const for comparisons.