### PR TITLE
ux with no plugins

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -155,8 +155,7 @@ func (c *InitCommand) Run(args []string) int {
 			// in which case we choose not to show this.
 			if conf.Terraform != nil && conf.Terraform.Backend != nil {
 				c.Ui.Output(c.Colorize().Color(fmt.Sprintf(
-					"[reset][bold]" +
-						"Initializing the backend...")))
+					"\n[reset][bold]Initializing the backend...")))
 			}
 
 			opts := &BackendOpts{
@@ -184,10 +183,6 @@ func (c *InitCommand) Run(args []string) int {
 			"Error refreshing state: %s", err))
 		return 1
 	}
-
-	c.Ui.Output(c.Colorize().Color(
-		"[reset][bold]Initializing provider plugins...",
-	))
 
 	err = c.getProviders(path, sMgr.State(), flagUpgrade)
 	if err != nil {
@@ -229,7 +224,17 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 	} else {
 		available = c.providerPluginSet()
 	}
+
 	requirements := terraform.ModuleTreeDependencies(mod, state).AllPluginRequirements()
+	if len(requirements) == 0 {
+		// nothing to initialize
+		return nil
+	}
+
+	c.Ui.Output(c.Colorize().Color(
+		"\n[reset][bold]Initializing provider plugins...",
+	))
+
 	missing := c.missingPlugins(available, requirements)
 
 	var errs error

--- a/command/meta_backend.go
+++ b/command/meta_backend.go
@@ -946,8 +946,7 @@ func (m *Meta) backend_C_R_s(
 	}
 
 	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset][green]\n\n"+
-			strings.TrimSpace(successBackendSet), s.Backend.Type)))
+		"[reset][green]\n"+strings.TrimSpace(successBackendSet), s.Backend.Type)))
 
 	return b, nil
 }
@@ -1050,8 +1049,7 @@ func (m *Meta) backend_C_r_s(
 	}
 
 	m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-		"[reset][green]\n\n"+
-			strings.TrimSpace(successBackendSet), s.Backend.Type)))
+		"[reset][green]\n"+strings.TrimSpace(successBackendSet), s.Backend.Type)))
 
 	// Return the backend
 	return b, nil
@@ -1148,8 +1146,7 @@ func (m *Meta) backend_C_r_S_changed(
 
 	if output {
 		m.Ui.Output(m.Colorize().Color(fmt.Sprintf(
-			"[reset][green]\n\n"+
-				strings.TrimSpace(successBackendSet), s.Backend.Type)))
+			"[reset][green]\n"+strings.TrimSpace(successBackendSet), s.Backend.Type)))
 	}
 
 	return b, nil

--- a/command/push_test.go
+++ b/command/push_test.go
@@ -4,12 +4,10 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -123,15 +121,21 @@ func TestPush_goodBackendInit(t *testing.T) {
 		// Expected weird behavior, doesn't affect unpackaging
 		".terraform/",
 		".terraform/",
-		".terraform/plugins/",
-		fmt.Sprintf(".terraform/plugins/%s_%s/", runtime.GOOS, runtime.GOARCH),
-		fmt.Sprintf(".terraform/plugins/%s_%s/lock.json", runtime.GOOS, runtime.GOARCH),
+
+		// this config contains no plugins
+		// TODO: we should add one or more plugins to this test config, just to
+		// verfy the pushed data. The expected additional files are listed below:
+		//
+		//".terraform/plugins/",
+		//fmt.Sprintf(".terraform/plugins/%s_%s/", runtime.GOOS, runtime.GOARCH),
+		//fmt.Sprintf(".terraform/plugins/%s_%s/lock.json", runtime.GOOS, runtime.GOARCH),
+
 		".terraform/terraform.tfstate",
 		".terraform/terraform.tfstate",
 		"main.tf",
 	}
 	if !reflect.DeepEqual(actual, expected) {
-		t.Fatalf("bad: %#v", actual)
+		t.Fatalf("expected: %#v\ngot: %#v", expected, actual)
 	}
 
 	variables := make(map[string]interface{})


### PR DESCRIPTION
Don't show plugin init message if there aren't any.
Fix the whitespace around backend init messages to match other output. 