### PR TITLE
command: purge unused plugins as a side effect of plugin installation

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -282,7 +282,7 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 		return err
 	}
 
-	if upgrade {
+	{
 		// Purge any auto-installed plugins that aren't being used.
 		purged, err := c.providerInstaller.PurgeUnused(chosen)
 		if err != nil {

--- a/command/init_test.go
+++ b/command/init_test.go
@@ -479,6 +479,10 @@ func TestInit_getProvider(t *testing.T) {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}
 
+	if !installer.PurgeUnusedCalled {
+		t.Errorf("init didn't purge providers, but should have")
+	}
+
 	// check that we got the providers for our config
 	exactPath := filepath.Join(c.pluginDir(), installer.FileName("exact", "1.2.3"))
 	if _, err := os.Stat(exactPath); os.IsNotExist(err) {


### PR DESCRIPTION
Previously we only did this when _upgrading_, but that's unnecessarily specific and confusing since e.g. plugins can get upgraded implicitly by constraint changes, which would not then trigger the purge process.

Instead, we'll assume that the user is able to easily re-download plugins that were purged here, or if they need more specific guarantees they will manage manually a plugin directory and disable the auto-install behavior using `-plugin-dir`.