### PR TITLE
allow instance metrics collection in aws-ecs-alb example

### DIFF
--- a/examples/aws-ecs-alb/instance-profile-policy.json
+++ b/examples/aws-ecs-alb/instance-profile-policy.json
@@ -9,7 +9,8 @@
         "ecs:DiscoverPollEndpoint",
         "ecs:Poll",
         "ecs:RegisterContainerInstance",
-        "ecs:Submit*"
+        "ecs:Submit*",
+        "ecs:StartTelemetrySession"
       ],
       "Resource": [
         "*"


### PR DESCRIPTION
The StartTelemetrySession action has to be enabled for metrics collection by the ECS agent