### PR TITLE
command: init to allow plugin init without backend init

### DIFF
--- a/command/init_test.go
+++ b/command/init_test.go
@@ -474,7 +474,9 @@ func TestInit_getProvider(t *testing.T) {
 		providerInstaller: installer,
 	}
 
-	args := []string{}
+	args := []string{
+		"-backend=false", // should be possible to install plugins without backend init
+	}
 	if code := c.Run(args); code != 0 {
 		t.Fatalf("bad: \n%s", ui.ErrorWriter.String())
 	}


### PR DESCRIPTION
Previously init would crash if given these options:

```
    -backend=false -get-plugins=true
```

This is because the state is used as a source of provider dependency information, and we need to instantiate the backend to get the state.

To avoid the crash, we now use the following adjusted behavior:

- if `-backend=true`, we behave as before

- if `-backend=false`, we instead try to instantiate the backend the same way any other command would, without modifying its configuration

- if we're able to instantiate the backend, we use it to fetch state for dependency resolution purposes

- if the backend is not instantiable then we assume it's not yet configured and proceed with a nil state, which may cause us to see an incomplete picture of the dependencies but still allows the install to succeed. Subsequently running `terraform plan` will not work until the backend is (re-)initialized, so the incomplete picture of required plugins is safe.

Installing plugins without an initialized backend is an edge-case, but we allow it here because it's safe to do so and may be useful if someone simply wants to test that their provider version constraints are resolvable, without changing anything else.
