### PR TITLE
Update docs to include old AWS env vars

### DIFF
--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -89,8 +89,8 @@ The following configuration options or environment variables are supported:
  * `acl` - [Canned
    ACL](https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl)
    to be applied to the state file.
- * `access_key` / `AWS_ACCESS_KEY_ID` - (Optional) AWS access key.
- * `secret_key` / `AWS_SECRET_ACCESS_KEY` - (Optional) AWS secret access key.
+ * `access_key` / `AWS_ACCESS_KEY_ID` / `AWS_ACCESS_KEY` - (Optional) AWS access key.
+ * `secret_key` / `AWS_SECRET_ACCESS_KEY` - `AWS_SECRET_KEY` (Optional) AWS secret access key.
  * `kms_key_id` - (Optional) The ARN of a KMS Key to use for encrypting
    the state.
  * `lock_table` - (Optional, Deprecated) Use `dynamodb_table` instead.


### PR DESCRIPTION
Looks like the old AWS env vars are still used. This is relevant as in order to make use of `AWS_SHARED_CREDENTIALS_FILE` / `AWS_PROFILE` you must unset _all_ other AWS vars.

Let me know if I should add more clarity to the documentation to this effect. Note that the companion PR https://github.com/terraform-providers/terraform-provider-aws/pull/937 has a bit more context.