### PR TITLE
command/format: minor adjustments to plan rendering

### DIFF
--- a/command/format/plan_test.go
+++ b/command/format/plan_test.go
@@ -121,7 +121,7 @@ func TestPlan_rootDataSource(t *testing.T) {
 
 	expected := strings.TrimSpace(`
  <= data.type.name
-    A: "B"
+      A: "B"
 	`)
 	if actual != expected {
 		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, actual)
@@ -162,7 +162,7 @@ func TestPlan_nestedDataSource(t *testing.T) {
 
 	expected := strings.TrimSpace(`
  <= module.nested.data.type.name
-    A: "B"
+      A: "B"
 	`)
 	if actual != expected {
 		t.Fatalf("expected:\n\n%s\n\ngot:\n\n%s", expected, actual)

--- a/terraform/resource_address.go
+++ b/terraform/resource_address.go
@@ -248,6 +248,28 @@ func ParseResourceAddress(s string) (*ResourceAddress, error) {
 	}, nil
 }
 
+// ParseResourceAddressForInstanceDiff creates a ResourceAddress for a
+// resource name as described in a module diff.
+//
+// For historical reasons a different addressing format is used in this
+// context. The internal format should not be shown in the UI and instead
+// this function should be used to translate to a ResourceAddress and
+// then, where appropriate, use the String method to produce a canonical
+// resource address string for display in the UI.
+//
+// The given path slice must be empty (or nil) for the root module, and
+// otherwise consist of a sequence of module names traversing down into
+// the module tree. If a non-nil path is provided, the caller must not
+// modify its underlying array after passing it to this function.
+func ParseResourceAddressForInstanceDiff(path []string, key string) (*ResourceAddress, error) {
+	addr, err := parseResourceAddressInternal(key)
+	if err != nil {
+		return nil, err
+	}
+	addr.Path = path
+	return addr, nil
+}
+
 // Contains returns true if and only if the given node is contained within
 // the receiver.
 //


### PR DESCRIPTION
This change makes various minor adjustments to the rendering of plans in the output of `terraform plan`:
    
- Resources are identified using the standard resource address syntax, rather than exposing the legacy internal representation used in the module diff resource keys. This fixes #8713.
    
- Subjectively, having square brackets in the addresses made it look more visually "off" when the same name but with different indices were shown together with differing-length "symbols", so the symbols are now all padded and right-aligned to three characters for consistent layout across all operations.
    
- The `-/+` action is now more visually distinct, using several different colors to help communicate what it will do and including a more obvious `(new resource required)` marker to help draw attention to this not being just an update diff. This fixes #15350.
    
- The resources are now sorted in a manner that sorts index `[10]` after index `[9]`, rather than after index `[1]` as we did before. This makes it easier to scan the list and avoids the common confusion where it seems that there are only 10 items when in fact there are 11-20 items with all the tens hiding further up in the list.

Certainly there are many more significant changes that could be made in this area, but this is just intended to be a small, low-risk change to deal with some minor annoyances.

---

Here's a screenshot, though it's made to look more weird by the strange mismatching saturation levels I apparently have configured in my terminal:

![tf-diff-tweaks](https://user-images.githubusercontent.com/20180/27413595-3a45d8a2-56b1-11e7-8f7d-3f6bb2a6bb7a.png)

These are all just regular primary VT100 colors in practice.
