### PR TITLE
Add configurable workspace prefix for S3 Backend

### DIFF
--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -139,6 +139,13 @@ func New() backend.Backend {
 				Description: "The permissions applied when assuming a role.",
 				Default:     "",
 			},
+
+			"workspace_key_prefix": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "The prefix applied to the state path inside the bucket",
+				Default:     "env:",
+			},
 		},
 	}
 
@@ -160,6 +167,7 @@ type Backend struct {
 	acl                  string
 	kmsKeyID             string
 	ddbTable             string
+	workspaceKeyPrefix   string
 }
 
 func (b *Backend) configure(ctx context.Context) error {
@@ -175,6 +183,7 @@ func (b *Backend) configure(ctx context.Context) error {
 	b.serverSideEncryption = data.Get("encrypt").(bool)
 	b.acl = data.Get("acl").(string)
 	b.kmsKeyID = data.Get("kms_key_id").(string)
+	b.workspaceKeyPrefix = data.Get("workspace_key_prefix").(string)
 
 	b.ddbTable = data.Get("dynamodb_table").(string)
 	if b.ddbTable == "" {

--- a/backend/remote-state/s3/backend.go
+++ b/backend/remote-state/s3/backend.go
@@ -143,7 +143,7 @@ func New() backend.Backend {
 			"workspace_key_prefix": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "The prefix applied to the state path inside the bucket",
+				Description: "The prefix applied to the non-default state path inside the bucket",
 				Default:     "env:",
 			},
 		},

--- a/backend/remote-state/s3/backend_state.go
+++ b/backend/remote-state/s3/backend_state.go
@@ -14,16 +14,10 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-const (
-	// This will be used as directory name, the odd looking colon is simply to
-	// reduce the chance of name conflicts with existing objects.
-	keyEnvPrefix = "env:"
-)
-
 func (b *Backend) States() ([]string, error) {
 	params := &s3.ListObjectsInput{
 		Bucket: &b.bucketName,
-		Prefix: aws.String(keyEnvPrefix + "/"),
+		Prefix: aws.String(b.workspaceKeyPrefix + "/"),
 	}
 
 	resp, err := b.s3Client.ListObjects(params)
@@ -53,7 +47,7 @@ func (b *Backend) keyEnv(key string) string {
 	}
 
 	// shouldn't happen since we listed by prefix
-	if parts[0] != keyEnvPrefix {
+	if parts[0] != b.workspaceKeyPrefix {
 		return ""
 	}
 
@@ -179,7 +173,7 @@ func (b *Backend) path(name string) string {
 		return b.keyName
 	}
 
-	return strings.Join([]string{keyEnvPrefix, name, b.keyName}, "/")
+	return strings.Join([]string{b.workspaceKeyPrefix, name, b.keyName}, "/")
 }
 
 const errStateUnlock = `

--- a/backend/remote-state/s3/backend_test.go
+++ b/backend/remote-state/s3/backend_test.go
@@ -159,7 +159,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// put a state in an env directory name
-	client.path = keyEnvPrefix + "/error"
+	client.path = b.workspaceKeyPrefix + "/error"
 	stateMgr.WriteState(terraform.NewState())
 	if err := stateMgr.PersistState(); err != nil {
 		t.Fatal(err)
@@ -169,7 +169,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	}
 
 	// add state with the wrong key for an existing env
-	client.path = keyEnvPrefix + "/s2/notTestState"
+	client.path = b.workspaceKeyPrefix + "/s2/notTestState"
 	stateMgr.WriteState(terraform.NewState())
 	if err := stateMgr.PersistState(); err != nil {
 		t.Fatal(err)
@@ -202,7 +202,7 @@ func TestBackendExtraPaths(t *testing.T) {
 	s2 = s2Mgr.State()
 
 	// add a state with a key that matches an existing environment dir name
-	client.path = keyEnvPrefix + "/s2/"
+	client.path = b.workspaceKeyPrefix + "/s2/"
 	stateMgr.WriteState(terraform.NewState())
 	if err := stateMgr.PersistState(); err != nil {
 		t.Fatal(err)

--- a/website/docs/backends/types/s3.html.md
+++ b/website/docs/backends/types/s3.html.md
@@ -108,3 +108,6 @@ The following configuration options or environment variables are supported:
  * `assume_role_policy` - (Optional) The permissions applied when assuming a role.
  * `external_id` - (Optional) The external ID to use when assuming the role.
  * `session_name` - (Optional) The session name to use when assuming the role.
+ * `workspace_key_prefix` - (Optional) The prefix applied to the state path 
+   inside the bucket. This is only relevant when using a non-default workspace.
+   This defaults to "env:"


### PR DESCRIPTION
Fixes #13184, addresses part of #15358

@jbardin @apparentlymart this is my first foray into the world of Go so go please go easy :)

Does this address the points raised in the other issue? The tests still pass although I'm not sure how to add some specifically related to this. I've also tested it locally and it successfully migrated my dummy setup from the old state structure to the new.

```
$ tree
.
├── env: # Old structure
│   ├── testing
│   │   └── v1
│   │       └── terraform-remote-state-example
│   ├── testing2
│       └── v1
│           └── terraform-remote-state-example
├── terraform-state # New Structure
│   ├── testing
│   │   └── v1
│   │       └── terraform-remote-state-example
│   └── testing2
│       └── v1
│           └── terraform-remote-state-example
└── v1 # Default workspace
    └── terraform-remote-state-example
```

```
terraform {
  required_version = "~> 0.10"

  backend "s3" {
    bucket  = "rowleyaj-tf-state-demo"
    key     = "v1/terraform-remote-state-example"
    region  = "us-east-1"
    encrypt = true

    dynamodb_table = "rowleyaj-terraform-state-lock"
    workspace_key_prefix = "terraform-state"
  }
}
```