### PR TITLE
better UI output for requesting plugin related init

### DIFF
--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -421,9 +421,12 @@ const errPluginInit = `
 [yellow]Reason: Could not satisfy plugin requirements.
 
 Plugins are external binaries that Terraform uses to access and manipulate
-resources. If this message is showing up, it means that the configuration you
-have references plugins which can't be located, don't satisfy the version
-constraints, or are otherwise incompatible.
+resources. The configuration provided requires plugins which can't be located,
+don't satisfy the version constraints, or are otherwise incompatible.
 
 [reset][red]%s
+
+[reset][yellow]Terraform automatically discovers provider requirements from your
+configuration, including providers used in child modules. To see the
+requirements and constraints from each module, run "terraform providers".
 `

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -412,20 +412,18 @@ func (b *Local) stateWorkspaceDir() string {
 func (b *Local) pluginInitRequired(providerErr *terraform.ResourceProviderError) {
 	b.CLI.Output(b.Colorize().Color(fmt.Sprintf(
 		strings.TrimSpace(errPluginInit)+"\n",
-		"Could not satisfy plugin requirements",
 		providerErr)))
 }
 
+// this relies on multierror to format the plugin errors below the copy
 const errPluginInit = `
 [reset][bold][yellow]Plugin reinitialization required. Please run "terraform init".[reset]
-[yellow]Reason: %s
+[yellow]Reason: Could not satisfy plugin requirements.
 
 Plugins are external binaries that Terraform uses to access and manipulate
 resources. If this message is showing up, it means that the configuration you
 have references plugins which can't be located, don't satisfy the version
 constraints, or are otherwise incompatible.
 
-The errors encountered discovering plugins are:
-
-%s
+[reset][red]%s
 `

--- a/backend/local/backend.go
+++ b/backend/local/backend.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/hashicorp/terraform/backend"
@@ -407,3 +408,24 @@ func (b *Local) stateWorkspaceDir() string {
 
 	return DefaultWorkspaceDir
 }
+
+func (b *Local) pluginInitRequired(providerErr *terraform.ResourceProviderError) {
+	b.CLI.Output(b.Colorize().Color(fmt.Sprintf(
+		strings.TrimSpace(errPluginInit)+"\n",
+		"Could not satisfy plugin requirements",
+		providerErr)))
+}
+
+const errPluginInit = `
+[reset][bold][yellow]Plugin reinitialization required. Please run "terraform init".[reset]
+[yellow]Reason: %s
+
+Plugins are external binaries that Terraform uses to access and manipulate
+resources. If this message is showing up, it means that the configuration you
+have references plugins which can't be located, don't satisfy the version
+constraints, or are otherwise incompatible.
+
+The errors encountered discovering plugins are:
+
+%s
+`

--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"strings"
@@ -57,6 +58,15 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 	} else {
 		tfCtx, err = terraform.NewContext(&opts)
 	}
+
+	// any errors resolving plugins returns this
+	if rpe, ok := err.(*terraform.ResourceProviderError); ok {
+		b.pluginInitRequired(rpe)
+		// we wrote the full UI error here, so return a generic error for flow
+		// control in the command.
+		return nil, nil, errors.New("error satisfying plugin requirements")
+	}
+
 	if err != nil {
 		return nil, nil, err
 	}

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -46,7 +46,7 @@ func (r *multiVersionProviderResolver) ResolveProviders(
 	var errs []error
 
 	chosen := choosePlugins(r.Available, reqd)
-	for name := range reqd {
+	for name, req := range reqd {
 		if newest, available := chosen[name]; available {
 			digest, err := newest.SHA256()
 			if err != nil {
@@ -54,7 +54,7 @@ func (r *multiVersionProviderResolver) ResolveProviders(
 				continue
 			}
 			if !reqd[name].AcceptsSHA256(digest) {
-				errs = append(errs, fmt.Errorf("provider.%s: checksum mismatch", name))
+				errs = append(errs, fmt.Errorf("provider.%s: new or changed plugin executable", name))
 				continue
 			}
 
@@ -63,19 +63,23 @@ func (r *multiVersionProviderResolver) ResolveProviders(
 		} else {
 			msg := fmt.Sprintf("provider.%s: no suitable version installed", name)
 
-			if req := reqd[name]; req.Versions.String() != "" {
-				foundVersions := []string{}
-				for meta := range r.Available.WithName(name) {
-					foundVersions = append(foundVersions, fmt.Sprintf("%q", meta.Version))
-				}
-
-				found := "none"
-				if len(foundVersions) > 0 {
-					found = strings.Join(foundVersions, ", ")
-				}
-
-				msg += fmt.Sprintf("\n  version requirements: %q\n  versions found: %s", req.Versions, found)
+			required := req.Versions.String()
+			// no version is unconstrained
+			if required == "" {
+				required = "(any version)"
 			}
+
+			foundVersions := []string{}
+			for meta := range r.Available.WithName(name) {
+				foundVersions = append(foundVersions, fmt.Sprintf("%q", meta.Version))
+			}
+
+			found := "none"
+			if len(foundVersions) > 0 {
+				found = strings.Join(foundVersions, ", ")
+			}
+
+			msg += fmt.Sprintf("\n  version requirements: %q\n  versions installed: %s", required, found)
 
 			errs = append(errs, errors.New(msg))
 		}

--- a/command/plugins.go
+++ b/command/plugins.go
@@ -53,12 +53,7 @@ func (r *multiVersionProviderResolver) ResolveProviders(
 				continue
 			}
 			if !reqd[name].AcceptsSHA256(digest) {
-				// This generic error message is intended to avoid troubling
-				// users with implementation details. The main useful point
-				// here is that they need to run "terraform init" to
-				// fix this, which is covered by the UI code reporting these
-				// error messages.
-				errs = append(errs, fmt.Errorf("provider.%s: installed but not yet initialized", name))
+				errs = append(errs, fmt.Errorf("provider.%s: checksum mismatch", name))
 				continue
 			}
 

--- a/terraform/context_refresh_test.go
+++ b/terraform/context_refresh_test.go
@@ -2,6 +2,7 @@ package terraform
 
 import (
 	"reflect"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -861,7 +862,7 @@ func TestContext2Refresh_unknownProvider(t *testing.T) {
 		t.Fatal("successfully created context; want error")
 	}
 
-	if !strings.Contains(err.Error(), "Can't satisfy provider requirements") {
+	if !regexp.MustCompile(`provider ".+" is not available`).MatchString(err.Error()) {
 		t.Fatalf("wrong error: %s", err)
 	}
 }


### PR DESCRIPTION
During plan and apply, because the provider constraints need to be built
from a plan, they are not checked until the terraform.Context is
created. Since the context is always requested by the backend during the
Operation, the backend needs to be responsible for generating contextual
error messages for the user.

Instead of formatting the ResolveProviders errors during NewContext,
return a special error type, ResourceProviderError to signal that
init will be required. The backend can then extract and format the
errors.

This also provides some more detail, like specifying a checksum mismatch, and showing the required and found versions of plugins. 

![checksum_mismatch](https://user-images.githubusercontent.com/35067/27452988-c4f2a3ac-5762-11e7-96ff-23f6b924b5f5.png)
![wrong_version](https://user-images.githubusercontent.com/35067/27452992-c6eb6d88-5762-11e7-8ac6-e24216f0c082.png)
![not_installed](https://user-images.githubusercontent.com/35067/27452995-c9038f56-5762-11e7-8d59-6fb6a663f0bf.png)


