### PR TITLE
provider/google: SQL Database Importability

### DIFF
--- a/website/docs/import/importability.html.md
+++ b/website/docs/import/importability.html.md
@@ -206,6 +206,8 @@ To make a resource importable, please see the
 * google_compute_target_pool
 * google_dns_managed_zone
 * google_project
+* google_sql_database_instance
+* google_sql_database
 * google_sql_user
 * google_storage_bucket
 


### PR DESCRIPTION
Add `google_sql_database` and `google_sql_database_instance` to Importability page.

@danawillow
https://github.com/terraform-providers/terraform-provider-google/pull/11
https://github.com/terraform-providers/terraform-provider-google/pull/12