### PR TITLE
helper/schema: fix issue reading Timeout data on delete operations 

### DIFF
--- a/helper/schema/resource.go
+++ b/helper/schema/resource.go
@@ -142,6 +142,12 @@ func (r *Resource) Apply(
 		if err := rt.DiffDecode(d); err != nil {
 			log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
 		}
+	} else if s != nil {
+		if _, ok := s.Meta[TimeoutKey]; ok {
+			if err := rt.StateDecode(s); err != nil {
+				log.Printf("[ERR] Error decoding ResourceTimeout: %s", err)
+			}
+		}
 	} else {
 		log.Printf("[DEBUG] No meta timeoutkey found in Apply()")
 	}


### PR DESCRIPTION
Timeout information is read from config and encoded into state. On delete, the config information isn't there, so we were failing to read it and then failing to respect the `Delete` timeout setting. This was original reported in https://github.com/hashicorp/terraform/issues/14444. This PR fixes that by reading the Timeout meta data from state, if it's not first found in the config. 

I've included `TestResourceApply_Timeout_destroy`, which checks the value of `TimeoutDelete` inside the delete method, and fails on `master`. 

Fixes https://github.com/terraform-providers/terraform-provider-aws/issues/767

------

Original fix part of https://github.com/hashicorp/terraform/pull/14396, but after our repo split, ~I couldn't get the patch to apply even after butchering it locally 😦~ I kind of fixed the attribution by adding `--author=` in there

This is just the helper/schema part of that pr – the ASG timeout addition I think I can get to apply in terraform-providers/terraform-provider-aws 

cc @jringuette for being super awesome and fixing this, I'm sorry I couldn't get the attribution right 🐼 