### PR TITLE
The "Private Bitbucket Repos" example did not work for me. I had to s…

### DIFF
--- a/website/docs/modules/sources.html.markdown
+++ b/website/docs/modules/sources.html.markdown
@@ -120,7 +120,7 @@ You can also specify branches and version withs the ?ref query
 
 ```hcl
 module "consul" {
-  source = "git::https://bitbucket.org/foocompany/module_name.git?hotfix
+  source = "git::https://bitbucket.org/foocompany/module_name.git?ref=hotfix
 }
 ```
 


### PR DESCRIPTION
The "Private Bitbucket Repos" example did not work for me. I had to specify the "ref=" URL param for this to work otherwise Terraform produced the following error:

Error loading Terraform: Error downloading modules: error downloading 'ssh://git@bitbucket.org/acme/foo.git?bar': /usr/bin/git exited with 128: Cloning into '.terraform/modules/yadayada'...
invalid command syntax.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
