### PR TITLE
command: Add -check flag to fmt

### DIFF
--- a/command/fmt_test.go
+++ b/command/fmt_test.go
@@ -179,6 +179,60 @@ func TestFmt_nonDefaultOptions(t *testing.T) {
 	}
 }
 
+func TestFmt_check(t *testing.T) {
+	tempDir, err := fmtFixtureWriteDir()
+	if err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	ui := new(cli.MockUi)
+	c := &FmtCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			Ui:               ui,
+		},
+	}
+
+	args := []string{
+		"-check",
+		tempDir,
+	}
+	if code := c.Run(args); code != 3 {
+		t.Fatalf("wrong exit code. expected 3")
+	}
+
+	if actual := ui.OutputWriter.String(); !strings.Contains(actual, tempDir) {
+		t.Fatalf("expected:\n%s\n\nto include: %q", actual, tempDir)
+	}
+}
+
+func TestFmt_checkStdin(t *testing.T) {
+	input := new(bytes.Buffer)
+	input.Write(fmtFixture.input)
+
+	ui := new(cli.MockUi)
+	c := &FmtCommand{
+		Meta: Meta{
+			testingOverrides: metaOverridesForProvider(testProvider()),
+			Ui:               ui,
+		},
+		input: input,
+	}
+
+	args := []string{
+		"-check",
+		"-",
+	}
+	if code := c.Run(args); code != 3 {
+		t.Fatalf("wrong exit code. expected 3, got %d", code)
+	}
+
+	if ui.OutputWriter != nil {
+		t.Fatalf("expected no output, got: %q", ui.OutputWriter.String())
+	}
+}
+
 var fmtFixture = struct {
 	filename      string
 	input, golden []byte

--- a/website/docs/commands/fmt.html.markdown
+++ b/website/docs/commands/fmt.html.markdown
@@ -24,5 +24,7 @@ The command-line flags are all optional. The list of available flags are:
 
 * `-list=true` - List files whose formatting differs (disabled if using STDIN)
 * `-write=true` - Write result to source file instead of STDOUT (disabled if
-    using STDIN)
+    using STDIN or -check)
 * `-diff=false` - Display diffs of formatting changes
+* `-check=false` - Check if the input is formatted. Exit status will be 0 if
+    all input is properly formatted and non-zero otherwise.


### PR DESCRIPTION
This addresses #15304. There are a couple ways to solve this, but I chose to modify the `fmt` command with a `-check` flag that produces the desired behavior.

I chose not to put this functionality in `github.com/hashicorp/hcl/hcl/fmtcmd`, because that would have required a change to the API. That has broader implications. If the consensus is that said functionality would be useful outside of `terraform fmt`, I can move the logic to the `hcl` lib. 

Alternatively, `fmt` could have been updated to alter its return code without the `-check` flag - like `gofmt`. However, as pointed out, that changes the current behavior which could have a downstream impact. Additionally, the default semantics of `terraform fmt` are different from `gofmt`. Namely, `-write` defaults to `true` with `terraform fmt`, but `false` with `gofmt`. Unless that default were changed (which seems like bad idea), you would need to run `terraform fmt -write=false` to achieve the requested effect. `terraform fmt -check` seems simpler and more intuitive to me.