### PR TITLE
command: don't prompt for state migration if TF_INPUT is set

### DIFF
--- a/command/meta.go
+++ b/command/meta.go
@@ -402,8 +402,8 @@ func (m *Meta) uiHook() *UiHook {
 
 // confirm asks a yes/no confirmation.
 func (m *Meta) confirm(opts *terraform.InputOpts) (bool, error) {
-	if !m.input {
-		return false, errors.New("input disabled")
+	if !m.Input() {
+		return false, errors.New("input is disabled")
 	}
 	for {
 		v, err := m.UIInput().Input(opts)


### PR DESCRIPTION
The "confirm" method was directly checking the meta struct's input field, but that only represents the `-input` command line flag, and doesn't consider the `TF_INPUT` environment variable.

By calling the `Input` method instead, we check both.

This fixes #15338.