### PR TITLE
GH-15354: Consul backend security options

### DIFF
--- a/website/docs/backends/types/consul.html.md
+++ b/website/docs/backends/types/consul.html.md
@@ -55,3 +55,6 @@ The following configuration options / environment variables are supported:
    communicating with Consul, in the format of either `user` or `user:pass`.
  * `gzip` - (Optional) `true` to compress the state data using gzip, or `false` (the default) to leave it uncompressed.
  * `lock` - (Optional) `false` to disable locking. This defaults to true, but will require session permissions with Consul to perform locking.
+ * `ca_file` / `CONSUL_CAFILE` - (Optional) A path to a PEM-encoded certificate authority used to verify the remote agent's certificate.
+ * `cert_file` / `CONSUL_CLIENT_CERT` - (Optional) A path to a PEM-encoded certificate provided to the remote agent; requires use of `key_file`.
+ * `key_file` / `CONSUL_CLIENT_KEY` - (Optional) A path to a PEM-encoded private key, required if `cert_file` is specified.


### PR DESCRIPTION
As per GH-15354 this pull-request allow to specify _ca_file_ _cert_file_ and _key_file_ in order to interact with a secured Consul backend.

Tested with consul 0.8.4