### PR TITLE
Make sure import uses complete plugin path

### DIFF
--- a/command/import.go
+++ b/command/import.go
@@ -112,9 +112,16 @@ func (c *ImportCommand) Run(args []string) int {
 		return 1
 	}
 
+	// Check for user-supplied plugin path
+	if c.pluginPath, err = c.loadPluginPath(); err != nil {
+		c.Ui.Error(fmt.Sprintf("Error loading plugin path: %s", err))
+		return 1
+	}
+
 	// Load the backend
 	b, err := c.Backend(&BackendOpts{
-		Config: mod.Config(),
+		Config:     mod.Config(),
+		ForceLocal: true,
 	})
 	if err != nil {
 		c.Ui.Error(fmt.Sprintf("Failed to load backend: %s", err))

--- a/plugin/discovery/find.go
+++ b/plugin/discovery/find.go
@@ -53,13 +53,13 @@ func findPluginPaths(kind string, dirs []string) []string {
 			continue
 		}
 
-		log.Printf("[DEBUG] checking for plugins in %q", dir)
+		log.Printf("[DEBUG] checking for %s in %q", kind, dir)
 
 		for _, item := range items {
 			fullName := item.Name()
 
 			if !strings.HasPrefix(fullName, prefix) {
-				log.Printf("[DEBUG] skipping %q, not a plugin", fullName)
+				log.Printf("[DEBUG] skipping %q, not a %s", fullName, kind)
 				continue
 			}
 
@@ -71,7 +71,7 @@ func findPluginPaths(kind string, dirs []string) []string {
 					continue
 				}
 
-				log.Printf("[DEBUG] found plugin %q", fullName)
+				log.Printf("[DEBUG] found %s %q", kind, fullName)
 				ret = append(ret, filepath.Clean(absPath))
 				continue
 			}
@@ -83,7 +83,7 @@ func findPluginPaths(kind string, dirs []string) []string {
 				continue
 			}
 
-			log.Printf("[WARNING] found legacy plugin %q", fullName)
+			log.Printf("[WARNING] found legacy %s %q", kind, fullName)
 
 			ret = append(ret, filepath.Clean(absPath))
 		}


### PR DESCRIPTION
Import was only searching the current directory for plugins. Make sure it uses the Complete path, including any `-plugin-dir` directories provided during init.