### PR TITLE
vendor: govendor fetch github.com/hashicorp/hil/...

### DIFF
--- a/vendor/github.com/hashicorp/hil/scanner/scanner.go
+++ b/vendor/github.com/hashicorp/hil/scanner/scanner.go
@@ -395,6 +395,12 @@ func scanLiteral(s string, startPos ast.Pos, nested bool) (string, *Token) {
 					pos.Column = pos.Column + 2
 					litLen = litLen + 2
 					continue
+				} else if follow == '\\' {
+					// \\ escapes \
+					// so we will consume both characters here.
+					pos.Column = pos.Column + 2
+					litLen = litLen + 2
+					continue
 				}
 			}
 		}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1356,26 +1356,26 @@
 		{
 			"checksumSHA1": "M09yxoBoCEtG7EcHR8aEWLzMMJc=",
 			"path": "github.com/hashicorp/hil",
-			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
-			"revisionTime": "2017-05-12T21:33:05Z"
+			"revision": "fa9f258a92500514cc8e9c67020487709df92432",
+			"revisionTime": "2017-02-13T18:49:38Z"
 		},
 		{
 			"checksumSHA1": "0S0KeBcfqVFYBPeZkuJ4fhQ5mCA=",
 			"path": "github.com/hashicorp/hil/ast",
-			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
-			"revisionTime": "2017-05-12T21:33:05Z"
+			"revision": "fa9f258a92500514cc8e9c67020487709df92432",
+			"revisionTime": "2017-02-13T18:49:38Z"
 		},
 		{
 			"checksumSHA1": "P5PZ3k7SmqWmxgJ8Q0gLzeNpGhE=",
 			"path": "github.com/hashicorp/hil/parser",
-			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
-			"revisionTime": "2017-05-12T21:33:05Z"
+			"revision": "fa9f258a92500514cc8e9c67020487709df92432",
+			"revisionTime": "2017-02-13T18:49:38Z"
 		},
 		{
-			"checksumSHA1": "DC1k5kOua4oFqmo+JRt0YzfP44o=",
+			"checksumSHA1": "ekmuVa77ebGDPXI+4FaskrID8lQ=",
 			"path": "github.com/hashicorp/hil/scanner",
-			"revision": "fac2259da677551de1fb92b844c4d020a38d8468",
-			"revisionTime": "2017-05-12T21:33:05Z"
+			"revision": "fa9f258a92500514cc8e9c67020487709df92432",
+			"revisionTime": "2017-02-13T18:49:38Z"
 		},
 		{
 			"checksumSHA1": "vt+P9D2yWDO3gdvdgCzwqunlhxU=",


### PR DESCRIPTION
This includes a fix to the scanner to correctly parse quoted strings that end with escaped backslashes, from hashicorp/hil#49.