### PR TITLE
applying a plan should use the refreshed state

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -49,6 +49,10 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 	}
 
 	// Load our state
+	// By the time we get here, the backend creation code in "command" took
+	// care of making s.State() return a state compatible with our plan,
+	// if any, so we can safely pass this value in both the plan context
+	// and new context cases below.
 	opts.State = s.State()
 
 	// Build the context

--- a/terraform/plan.go
+++ b/terraform/plan.go
@@ -43,7 +43,11 @@ type Plan struct {
 // Context returns a Context with the data encapsulated in this plan.
 //
 // The following fields in opts are overridden by the plan: Config,
-// Diff, State, Variables.
+// Diff, Variables.
+//
+// If State is not provided, it is set from the plan. If it _is_ provided,
+// it must be Equal to the state stored in plan, but may have a newer
+// serial.
 func (p *Plan) Context(opts *ContextOpts) (*Context, error) {
 	var err error
 	opts, err = p.contextOpts(opts)
@@ -60,8 +64,21 @@ func (p *Plan) contextOpts(base *ContextOpts) (*ContextOpts, error) {
 
 	opts.Diff = p.Diff
 	opts.Module = p.Module
-	opts.State = p.State
 	opts.Targets = p.Targets
+
+	// If we are given a state in "base" then we'll use it, and otherwise
+	// we'll fall back on the state stashed in the plan. We do this because
+	// sometimes the caller has already persisted the plan's state by the
+	// time we get here, and we don't want to regress to the plan-time state
+	// serial if so.
+	if opts.State == nil {
+		opts.State = p.State
+	} else if !opts.State.Equal(p.State) {
+		// Even if we're overriding the state, it should be logically equal
+		// to what's in plan. The only valid change to have made by the time
+		// we get here is to have incremented the serial.
+		return nil, errors.New("plan state and ContextOpts state are not equal")
+	}
 
 	opts.ProviderSHA256s = p.ProviderSHA256s
 

--- a/terraform/plan_test.go
+++ b/terraform/plan_test.go
@@ -133,7 +133,7 @@ func TestPlanContextOptsOverrideStateBad(t *testing.T) {
 
 	_, err := plan.contextOpts(base)
 	if err == nil {
-		t.Fatalf("plan.contextOpts succeeded; want error due to non-equal state", err)
+		t.Fatal("plan.contextOpts succeeded; want error due to non-equal state")
 	}
 }
 

--- a/terraform/plan_test.go
+++ b/terraform/plan_test.go
@@ -50,6 +50,93 @@ func TestPlanContextOpts(t *testing.T) {
 	}
 }
 
+func TestPlanContextOptsOverrideStateGood(t *testing.T) {
+	plan := &Plan{
+		Diff: &Diff{
+			Modules: []*ModuleDiff{
+				{
+					Path: []string{"test"},
+				},
+			},
+		},
+		Module: module.NewTree("test", nil),
+		State: &State{
+			TFVersion: "sigil",
+			Serial:    1,
+		},
+		Vars:    map[string]interface{}{"foo": "bar"},
+		Targets: []string{"baz"},
+
+		TerraformVersion: VersionString(),
+		ProviderSHA256s: map[string][]byte{
+			"test": []byte("placeholder"),
+		},
+	}
+
+	base := &ContextOpts{
+		State: &State{
+			TFVersion: "sigil",
+			Serial:    2,
+		},
+	}
+
+	got, err := plan.contextOpts(base)
+	if err != nil {
+		t.Fatalf("error creating context: %s", err)
+	}
+
+	want := &ContextOpts{
+		Diff:            plan.Diff,
+		Module:          plan.Module,
+		State:           base.State,
+		Variables:       plan.Vars,
+		Targets:         plan.Targets,
+		ProviderSHA256s: plan.ProviderSHA256s,
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("wrong result\ngot:  %#v\nwant %#v", got, want)
+	}
+}
+
+func TestPlanContextOptsOverrideStateBad(t *testing.T) {
+	plan := &Plan{
+		Diff: &Diff{
+			Modules: []*ModuleDiff{
+				{
+					Path: []string{"test"},
+				},
+			},
+		},
+		Module: module.NewTree("test", nil),
+		State: &State{
+			TFVersion: "sigil",
+			Serial:    1,
+			Version:   2,
+		},
+		Vars:    map[string]interface{}{"foo": "bar"},
+		Targets: []string{"baz"},
+
+		TerraformVersion: VersionString(),
+		ProviderSHA256s: map[string][]byte{
+			"test": []byte("placeholder"),
+		},
+	}
+
+	base := &ContextOpts{
+		State: &State{
+			TFVersion: "sigil",
+			Serial:    2,
+			Version:   3,
+		},
+	}
+
+	_, err := plan.contextOpts(base)
+	if err == nil {
+		t.Fatalf("plan.contextOpts succeeded; want error due to non-equal state", err)
+	}
+}
+
 func TestReadWritePlan(t *testing.T) {
 	plan := &Plan{
 		Module: testModule(t, "new-good"),


### PR DESCRIPTION
When applying a plan, a copy of the plan's state is initially persisted
to state storage, which may in turn increment the serial number. The
apply operation stil uses the state stored in the plan, which may have a
lower serial number.

Now we no longer use the plan state when building the apply context, but
still perform a sanity check to ensure that the state be used is
equivalent.

TODO: test case