### PR TITLE
applying a plan should use the refreshed state

### DIFF
--- a/backend/local/backend_local.go
+++ b/backend/local/backend_local.go
@@ -48,6 +48,10 @@ func (b *Local) context(op *backend.Operation) (*terraform.Context, state.State,
 	}
 
 	// Load our state
+	// By the time we get here, the backend creation code in "command" took
+	// care of making s.State() return a state compatible with our plan,
+	// if any, so we can safely pass this value in both the plan context
+	// and new context cases below.
 	opts.State = s.State()
 
 	// Build the context


### PR DESCRIPTION
When applying a plan, a copy of the plan's state is initially persisted to state storage, which may in turn increment the serial number. The apply operation stil uses the state stored in the plan, which may have a lower serial number.

Now we no longer use the plan state when building the apply context, but still perform a sanity check to ensure that the state be used is equivalent.

---

This is the same as #15421, but adapted to apply to the 0.9 line so we can release it before 0.10.0 final.