### PR TITLE
state: more robust handling of state Serial

### DIFF
--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -272,6 +272,14 @@ func TestApply_defaultState(t *testing.T) {
 		},
 	}
 
+	// create an existing state file
+	localState := &state.LocalState{Path: statePath}
+	if err := localState.WriteState(terraform.NewState()); err != nil {
+		t.Fatal(err)
+	}
+
+	serial := localState.State().Serial
+
 	args := []string{
 		testFixturePath("apply"),
 	}
@@ -286,6 +294,10 @@ func TestApply_defaultState(t *testing.T) {
 	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
+	}
+
+	if state.Serial <= serial {
+		t.Fatalf("serial was not incremented. previous:%d, current%d", serial, state.Serial)
 	}
 }
 
@@ -540,10 +552,8 @@ func TestApply_plan_backup(t *testing.T) {
 		t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter.String())
 	}
 
-	{
-		// Should have a backup file
-		testStateRead(t, backupPath)
-	}
+	// Should have a backup file
+	testStateRead(t, backupPath)
 }
 
 func TestApply_plan_noBackup(t *testing.T) {

--- a/command/apply_test.go
+++ b/command/apply_test.go
@@ -45,16 +45,7 @@ func TestApply(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
@@ -292,16 +283,7 @@ func TestApply_defaultState(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
@@ -360,16 +342,7 @@ func TestApply_error(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
@@ -484,13 +457,7 @@ func TestApply_noArgs(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
+	state := testStateRead(t, statePath)
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -538,16 +505,7 @@ func TestApply_plan(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
@@ -584,16 +542,7 @@ func TestApply_plan_backup(t *testing.T) {
 
 	{
 		// Should have a backup file
-		f, err := os.Open(backupPath)
-		if err != nil {
-			t.Fatalf("err: %s", err)
-		}
-
-		_, err = terraform.ReadState(f)
-		f.Close()
-		if err != nil {
-			t.Fatalf("err: %s", err)
-		}
+		testStateRead(t, backupPath)
 	}
 }
 
@@ -732,16 +681,7 @@ func TestApply_planWithVarFile(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
@@ -847,31 +787,13 @@ func TestApply_refresh(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
 
 	// Should have a backup file
-	f, err = os.Open(statePath + DefaultBackupExtension)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	backupState, err := terraform.ReadState(f)
-	f.Close()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	backupState := testStateRead(t, statePath+DefaultBackupExtension)
 
 	actualStr := strings.TrimSpace(backupState.String())
 	expectedStr := strings.TrimSpace(originalState.String())
@@ -953,16 +875,7 @@ func TestApply_shutdown(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
@@ -1035,31 +948,12 @@ func TestApply_state(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
 
-	// Should have a backup file
-	f, err = os.Open(statePath + DefaultBackupExtension)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	backupState, err := terraform.ReadState(f)
-	f.Close()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	backupState := testStateRead(t, statePath+DefaultBackupExtension)
 
 	// nil out the ConnInfo since that should not be restored
 	originalState.RootModule().Resources["test_instance.foo"].Primary.Ephemeral.ConnInfo = nil
@@ -1142,17 +1036,7 @@ func TestApply_stateFuture(t *testing.T) {
 		t.Fatal("should fail")
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	newState, err := terraform.ReadState(f)
-	f.Close()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
+	newState := testStateRead(t, statePath)
 	if !newState.Equal(originalState) {
 		t.Fatalf("bad: %#v", newState)
 	}
@@ -1422,31 +1306,12 @@ func TestApply_backup(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
 
-	// Should have a backup file
-	f, err = os.Open(backupPath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-
-	backupState, err := terraform.ReadState(f)
-	f.Close()
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	backupState := testStateRead(t, backupPath)
 
 	actual := backupState.RootModule().Resources["test_instance.foo"]
 	expected := originalState.RootModule().Resources["test_instance.foo"]
@@ -1504,22 +1369,13 @@ func TestApply_disableBackup(t *testing.T) {
 		t.Fatalf("err: %s", err)
 	}
 
-	f, err := os.Open(statePath)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
-	defer f.Close()
-
-	state, err := terraform.ReadState(f)
-	if err != nil {
-		t.Fatalf("err: %s", err)
-	}
+	state := testStateRead(t, statePath)
 	if state == nil {
 		t.Fatal("state should not be nil")
 	}
 
 	// Ensure there is no backup
-	_, err = os.Stat(statePath + DefaultBackupExtension)
+	_, err := os.Stat(statePath + DefaultBackupExtension)
 	if err == nil || !os.IsNotExist(err) {
 		t.Fatalf("backup should not exist")
 	}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -238,9 +238,9 @@ func testStateRead(t *testing.T, path string) *terraform.State {
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
+	defer f.Close()
 
 	newState, err := terraform.ReadState(f)
-	f.Close()
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/command/command_test.go
+++ b/command/command_test.go
@@ -160,7 +160,6 @@ func testReadPlan(t *testing.T, path string) *terraform.Plan {
 // testState returns a test State structure that we use for a lot of tests.
 func testState() *terraform.State {
 	state := &terraform.State{
-		Version: 2,
 		Modules: []*terraform.ModuleState{
 			&terraform.ModuleState{
 				Path: []string{"root"},
@@ -177,20 +176,7 @@ func testState() *terraform.State {
 		},
 	}
 	state.Init()
-
-	// Write and read the state so that it is properly initialized. We
-	// do this since we didn't call the normal NewState constructor.
-	var buf bytes.Buffer
-	if err := terraform.WriteState(state, &buf); err != nil {
-		panic(err)
-	}
-
-	result, err := terraform.ReadState(&buf)
-	if err != nil {
-		panic(err)
-	}
-
-	return result
+	return state
 }
 
 func testStateFile(t *testing.T, s *terraform.State) string {

--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -186,6 +186,7 @@ func TestWorkspace_createWithState(t *testing.T) {
 	}
 
 	newState := envState.State()
+	originalState.Version = newState.Version // the round-trip through the state manager implicitly populates version
 	if !originalState.Equal(newState) {
 		t.Fatalf("states not equal\norig: %s\nnew: %s", originalState, newState)
 	}

--- a/state/inmem.go
+++ b/state/inmem.go
@@ -32,8 +32,18 @@ func (s *InmemState) WriteState(state *terraform.State) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	state.IncrementSerialMaybe(s.state)
+	state = state.DeepCopy()
+
+	if s.state != nil {
+		state.Serial = s.state.Serial
+
+		if !s.state.MarshalEqual(state) {
+			state.Serial++
+		}
+	}
+
 	s.state = state
+
 	return nil
 }
 

--- a/state/remote/state.go
+++ b/state/remote/state.go
@@ -2,6 +2,7 @@ package remote
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 
 	"github.com/hashicorp/terraform/state"
@@ -33,7 +34,28 @@ func (s *State) WriteState(state *terraform.State) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.state = state
+	if s.readState != nil && !state.SameLineage(s.readState) {
+		return fmt.Errorf("incompatible state lineage; given %s but want %s", state.Lineage, s.readState.Lineage)
+	}
+
+	// We create a deep copy of the state here, because the caller also has
+	// a reference to the given object and can potentially go on to mutate
+	// it after we return, but we want the snapshot at this point in time.
+	s.state = state.DeepCopy()
+
+	// Force our new state to have the same serial as our read state. We'll
+	// update this if PersistState is called later. (We don't require nor trust
+	// the caller to properly maintain serial for transient state objects since
+	// the rest of Terraform treats state as an openly mutable object.)
+	//
+	// If we have no read state then we assume we're either writing a new
+	// state for the first time or we're migrating a state from elsewhere,
+	// and in both cases we wish to retain the lineage and serial from
+	// the given state.
+	if s.readState != nil {
+		s.state.Serial = s.readState.Serial
+	}
+
 	return nil
 }
 
@@ -58,7 +80,7 @@ func (s *State) RefreshState() error {
 	}
 
 	s.state = state
-	s.readState = state
+	s.readState = s.state.DeepCopy() // our states must be separate instances so we can track changes
 	return nil
 }
 
@@ -67,14 +89,28 @@ func (s *State) PersistState() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.state.IncrementSerialMaybe(s.readState)
+	if !s.state.MarshalEqual(s.readState) {
+		// Our new state does not marshal as byte-for-byte identical to
+		// the old, so we need to increment the serial.
+		// Note that in WriteState we force the serial to match that of
+		// s.readState, if we have a readState.
+		s.state.Serial++
+	}
 
 	var buf bytes.Buffer
 	if err := terraform.WriteState(s.state, &buf); err != nil {
 		return err
 	}
 
-	return s.Client.Put(buf.Bytes())
+	err := s.Client.Put(buf.Bytes())
+	if err != nil {
+		return err
+	}
+
+	// After we've successfully persisted, what we just wrote is our new
+	// reference state until someone calls RefreshState again.
+	s.readState = s.state.DeepCopy()
+	return nil
 }
 
 // Lock calls the Client's Lock method if it's implemented.

--- a/state/testing.go
+++ b/state/testing.go
@@ -10,125 +10,126 @@ import (
 // TestState is a helper for testing state implementations. It is expected
 // that the given implementation is pre-loaded with the TestStateInitial
 // state.
-func TestState(t *testing.T, s interface{}) {
-	reader, ok := s.(StateReader)
-	if !ok {
-		t.Fatalf("must at least be a StateReader")
+func TestState(t *testing.T, s State) {
+	if err := s.RefreshState(); err != nil {
+		t.Fatalf("err: %s", err)
 	}
 
-	// If it implements refresh, refresh
-	if rs, ok := s.(StateRefresher); ok {
-		if err := rs.RefreshState(); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-	}
-
-	// current will track our current state
-	current := TestStateInitial()
-
-	// Check that the initial state is correct
-	if state := reader.State(); !current.Equal(state) {
-		t.Fatalf("not initial:\n%#v\n\n%#v", state, current)
+	// Check that the initial state is correct.
+	// These do have different Lineages, but we will replace current below.
+	initial := TestStateInitial()
+	if state := s.State(); !state.Equal(initial) {
+		t.Fatalf("state does not match expected initial state:\n%#v\n\n%#v", state, initial)
 	}
 
 	// Now we've proven that the state we're starting with is an initial
 	// state, we'll complete our work here with that state, since otherwise
 	// further writes would violate the invariant that we only try to write
 	// states that share the same lineage as what was initially written.
-	current = reader.State()
+	current := s.State()
 
 	// Write a new state and verify that we have it
-	if ws, ok := s.(StateWriter); ok {
-		current.AddModuleState(&terraform.ModuleState{
-			Path: []string{"root"},
-			Outputs: map[string]*terraform.OutputState{
-				"bar": &terraform.OutputState{
-					Type:      "string",
-					Sensitive: false,
-					Value:     "baz",
-				},
+	current.AddModuleState(&terraform.ModuleState{
+		Path: []string{"root"},
+		Outputs: map[string]*terraform.OutputState{
+			"bar": &terraform.OutputState{
+				Type:      "string",
+				Sensitive: false,
+				Value:     "baz",
 			},
-		})
+		},
+	})
 
-		if err := ws.WriteState(current); err != nil {
-			t.Fatalf("err: %s", err)
-		}
+	if err := s.WriteState(current); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-		if actual := reader.State(); !actual.Equal(current) {
-			t.Fatalf("bad:\n%#v\n\n%#v", actual, current)
-		}
+	if actual := s.State(); !actual.Equal(current) {
+		t.Fatalf("bad:\n%#v\n\n%#v", actual, current)
 	}
 
 	// Test persistence
-	if ps, ok := s.(StatePersister); ok {
-		if err := ps.PersistState(); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-
-		// Refresh if we got it
-		if rs, ok := s.(StateRefresher); ok {
-			if err := rs.RefreshState(); err != nil {
-				t.Fatalf("err: %s", err)
-			}
-		}
-
-		// Just set the serials the same... Then compare.
-		actual := reader.State()
-		if !actual.Equal(current) {
-			t.Fatalf("bad: %#v\n\n%#v", actual, current)
-		}
+	if err := s.PersistState(); err != nil {
+		t.Fatalf("err: %s", err)
 	}
 
-	// If we can write and persist then verify that the serial
-	// is only incremented on change.
-	writer, writeOk := s.(StateWriter)
-	persister, persistOk := s.(StatePersister)
-	if writeOk && persistOk {
-		// Same serial
-		serial := reader.State().Serial
-		if err := writer.WriteState(current); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		if err := persister.PersistState(); err != nil {
-			t.Fatalf("err: %s", err)
-		}
+	// Refresh if we got it
+	if err := s.RefreshState(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-		if reader.State().Serial != serial {
-			t.Fatalf("serial changed after persisting with no changes: got %d, want %d", reader.State().Serial, serial)
-		}
+	if s.State().Lineage != current.Lineage {
+		t.Fatalf("Lineage changed from %s to %s", s.State().Lineage, current.Lineage)
+	}
 
-		// Change the serial
-		current = current.DeepCopy()
-		current.Modules = []*terraform.ModuleState{
-			&terraform.ModuleState{
-				Path: []string{"root", "somewhere"},
-				Outputs: map[string]*terraform.OutputState{
-					"serialCheck": &terraform.OutputState{
-						Type:      "string",
-						Sensitive: false,
-						Value:     "true",
-					},
+	// Just set the serials the same... Then compare.
+	actual := s.State()
+	if !actual.Equal(current) {
+		t.Fatalf("bad: %#v\n\n%#v", actual, current)
+	}
+
+	// Same serial
+	serial := s.State().Serial
+	if err := s.WriteState(current); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := s.PersistState(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+
+	if s.State().Serial != serial {
+		t.Fatalf("serial changed after persisting with no changes: got %d, want %d", s.State().Serial, serial)
+	}
+
+	// Change the serial
+	current = current.DeepCopy()
+	current.Modules = []*terraform.ModuleState{
+		&terraform.ModuleState{
+			Path: []string{"root", "somewhere"},
+			Outputs: map[string]*terraform.OutputState{
+				"serialCheck": &terraform.OutputState{
+					Type:      "string",
+					Sensitive: false,
+					Value:     "true",
 				},
 			},
-		}
-		if err := writer.WriteState(current); err != nil {
-			t.Fatalf("err: %s", err)
-		}
-		if err := persister.PersistState(); err != nil {
-			t.Fatalf("err: %s", err)
-		}
+		},
+	}
+	if err := s.WriteState(current); err != nil {
+		t.Fatalf("err: %s", err)
+	}
+	if err := s.PersistState(); err != nil {
+		t.Fatalf("err: %s", err)
+	}
 
-		if reader.State().Serial <= serial {
-			t.Fatalf("serial incorrect after persisting with changes: got %d, want > %d", reader.State().Serial, serial)
-		}
+	if s.State().Serial <= serial {
+		t.Fatalf("serial incorrect after persisting with changes: got %d, want > %d", s.State().Serial, serial)
+	}
 
-		// Check that State() returns a copy by modifying the copy and comparing
-		// to the current state.
-		stateCopy := reader.State()
-		stateCopy.Serial++
-		if reflect.DeepEqual(stateCopy, current) {
-			t.Fatal("State() should return a copy")
-		}
+	if s.State().Version != current.Version {
+		t.Fatalf("Version changed from %d to %d", s.State().Version, current.Version)
+	}
+
+	if s.State().TFVersion != current.TFVersion {
+		t.Fatalf("TFVersion changed from %s to %s", s.State().TFVersion, current.TFVersion)
+	}
+
+	// verify that Lineage doesn't change along with Serial, or during copying.
+	if s.State().Lineage != current.Lineage {
+		t.Fatalf("Lineage changed from %s to %s", s.State().Lineage, current.Lineage)
+	}
+
+	// Check that State() returns a copy by modifying the copy and comparing
+	// to the current state.
+	stateCopy := s.State()
+	stateCopy.Serial++
+	if reflect.DeepEqual(stateCopy, s.State()) {
+		t.Fatal("State() should return a copy")
+	}
+
+	// our current expected state should also marhsal identically to the persisted state
+	if current.MarshalEqual(s.State()) {
+		t.Fatalf("Persisted state altered unexpectedly. Expected: %#v\b Got: %#v", current, s.State())
 	}
 }
 

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -677,6 +677,7 @@ func (s *State) init() {
 	if s.Version == 0 {
 		s.Version = StateVersion
 	}
+
 	if s.moduleByPath(rootModulePath) == nil {
 		s.addModule(rootModulePath)
 	}

--- a/terraform/state.go
+++ b/terraform/state.go
@@ -533,6 +533,43 @@ func (s *State) equal(other *State) bool {
 	return true
 }
 
+// MarshalEqual is similar to Equal but provides a stronger definition of
+// "equal", where two states are equal if and only if their serialized form
+// is byte-for-byte identical.
+//
+// This is primarily useful for callers that are trying to save snapshots
+// of state to persistent storage, allowing them to detect when a new
+// snapshot must be taken.
+//
+// Note that the serial number and lineage are included in the serialized form,
+// so it's the caller's responsibility to properly manage these attributes
+// so that this method is only called on two states that have the same
+// serial and lineage, unless detecting such differences is desired.
+func (s *State) MarshalEqual(other *State) bool {
+	if s == nil && other == nil {
+		return true
+	} else if s == nil || other == nil {
+		return false
+	}
+
+	recvBuf := &bytes.Buffer{}
+	otherBuf := &bytes.Buffer{}
+
+	err := WriteState(s, recvBuf)
+	if err != nil {
+		// should never happen, since we're writing to a buffer
+		panic(err)
+	}
+
+	err = WriteState(other, otherBuf)
+	if err != nil {
+		// should never happen, since we're writing to a buffer
+		panic(err)
+	}
+
+	return bytes.Equal(recvBuf.Bytes(), otherBuf.Bytes())
+}
+
 type StateAgeComparison int
 
 const (
@@ -603,36 +640,16 @@ func (s *State) SameLineage(other *State) bool {
 // DeepCopy performs a deep copy of the state structure and returns
 // a new structure.
 func (s *State) DeepCopy() *State {
+	if s == nil {
+		return nil
+	}
+
 	copy, err := copystructure.Config{Lock: true}.Copy(s)
 	if err != nil {
 		panic(err)
 	}
 
 	return copy.(*State)
-}
-
-// IncrementSerialMaybe increments the serial number of this state
-// if it different from the other state.
-func (s *State) IncrementSerialMaybe(other *State) {
-	if s == nil {
-		return
-	}
-	if other == nil {
-		return
-	}
-	s.Lock()
-	defer s.Unlock()
-
-	if s.Serial > other.Serial {
-		return
-	}
-	if other.TFVersion != s.TFVersion || !s.equal(other) {
-		if other.Serial > s.Serial {
-			s.Serial = other.Serial
-		}
-
-		s.Serial++
-	}
 }
 
 // FromFutureTerraform checks if this state was written by a Terraform


### PR DESCRIPTION
Previously we relied on a constellation of coincidences for everything to work out correctly with state serials. In particular, callers needed to be very careful about mutating states (or not) because many different bits of code shared pointers to the same objects.

Here we move to a model where all of the state managers always use distinct instances of state, copied when `WriteState` is called. This means that they are truly a snapshot of the state as it was at that call, even if the caller goes on mutating the state that was passed.

We also adjust the handling of serials so that the state managers ignore any serials in incoming states and instead just treat each Persist as the next version after what was most recently Refreshed.

(An exception exists for when nothing has been refreshed, e.g. because we are writing a state to a location for the first time. In that case we _do_ trust the caller, since the given state is either a new state or it's a copy of something we're migrating from elsewhere with its state and lineage intact.)

The intent here is to allow the rest of Terraform to not worry about serials and state identity, and instead just treat the state as a mutable structure. We'll just snapshot it occasionally, when `WriteState` is called,
and deal with serials _only_ at persist time.

This is intended as a more robust version of #15423, which was a quick hotfix to an issue that resulted from our previous slopping handling of state serials but arguably makes the problem worse by depending on an additional coincidental behavior of the local backend's apply
implementation.
