### PR TITLE
Fixes the AWS networking example ensuring that subnets are created in the desired AZ

### DIFF
--- a/examples/aws-networking/subnet/subnet.tf
+++ b/examples/aws-networking/subnet/subnet.tf
@@ -1,6 +1,7 @@
 resource "aws_subnet" "main" {
   cidr_block = "${cidrsubnet(data.aws_vpc.target.cidr_block, 4, lookup(var.az_numbers, data.aws_availability_zone.target.name_suffix))}"
   vpc_id     = "${var.vpc_id}"
+  availability_zone = "${var.availability_zone}"
 }
 
 resource "aws_route_table" "main" {


### PR DESCRIPTION
The current AWS Networking example (https://github.com/hashicorp/terraform/tree/master/examples/aws-networking) should create the subnets in the availability zones specified in `module "primary_subnet"` & `module "secondary_subnet"` definitions in the [region/subnets.tf](https://github.com/hashicorp/terraform/blob/master/examples/aws-networking/region/subnets.tf) file but the subnet module ignores these (while it does set a `data` item in `variables.tf`, it isn't used in the creation of the resources).

**Current behaviour:** the subnets are created in random AZs including sometimes putting both in one zone (more common in Regions with only a couple of AZ. The plan/apply shows the AZ is `computed`. This is made more confusing by some of the naming/labelling that is correctly picking up the desired AZ suffixes.

**Desired behaviour:** the subnets should be created in the AZ specified in the module definition in [region/subnets.tf](https://github.com/hashicorp/terraform/blob/master/examples/aws-networking/region/subnets.tf)

This change corrects the behaviour of this example.

Tested using:
```
$ terraform -v
Terraform v0.9.8
```