### PR TITLE
allow hidden tf json

### DIFF
--- a/config/loader.go
+++ b/config/loader.go
@@ -218,7 +218,8 @@ func dirFiles(dir string) ([]string, []string, error) {
 // isIgnoredFile returns true or false depending on whether the
 // provided file name is a file that should be ignored.
 func isIgnoredFile(name string) bool {
-	return strings.HasPrefix(name, ".") || // Unix-like hidden files
+	// Unix-like hidden files, excepting tf.json
+	return (strings.HasPrefix(name, ".") && !strings.HasSuffix(name, ".tf.json")) ||
 		strings.HasSuffix(name, "~") || // vim
 		strings.HasPrefix(name, "#") && strings.HasSuffix(name, "#") // emacs
 }


### PR DESCRIPTION
Because of the limitations of HCL (namely, there's no way to "inherit" from common configurations), I decided to write a wrapper for terraform which allows me to write configs as python dictionaries, and generate tf-json from them. I write e.g. `terrapy plan -out nextplan`, and the wrapper walks through files of the form `foo_tf.py`, spits out some json, and then invokes `terraform plan -out nextplan`.

I would prefer if the generated json files could be hidden, so they didn't clutter up the directory. Unfortunately, terraform's loader ignores all hidden files. I would have preferred to add a terraformrc option to allow hidden files, but since terraformrc is written in HCL, the loader code has to be available before the configuration can be read, which means the code has to become more complicated, and we have to start doing runtime mutation of the config, which I don't like.

The simplest solution seems to be to allow hidden tf.json, since it's supposed to be machine-generable anyway. I could append an extra bit, so only `.generated.tf.json` is allowed, or perhaps print a warning that a hidden file is being added to the configuration if desired by the reviewer to prevent people being confused by files they might forget about, but I doubt this is likely to come up.