### PR TITLE
core: Skip provider checksum validation based on env var

### DIFF
--- a/command/init.go
+++ b/command/init.go
@@ -206,6 +206,10 @@ func (c *InitCommand) Run(args []string) int {
 		state = sMgr.State()
 	}
 
+	if v := os.Getenv(ProviderSkipVerifyEnvVar); v != "" {
+		c.ignorePluginChecksum = true
+	}
+
 	// Now that we have loaded all modules, check the module tree for missing providers.
 	err = c.getProviders(path, state, flagUpgrade)
 	if err != nil {
@@ -330,6 +334,9 @@ func (c *InitCommand) getProviders(path string, state *terraform.State, upgrade 
 			return err
 		}
 		digests[name] = digest
+		if c.ignorePluginChecksum {
+			digests[name] = nil
+		}
 	}
 	err = c.providerPluginsLock().Write(digests)
 	if err != nil {

--- a/terraform/context.go
+++ b/terraform/context.go
@@ -65,7 +65,8 @@ type ContextOpts struct {
 
 	// If non-nil, will apply as additional constraints on the provider
 	// plugins that will be requested from the provider resolver.
-	ProviderSHA256s map[string][]byte
+	ProviderSHA256s    map[string][]byte
+	SkipProviderVerify bool
 
 	UIInput UIInput
 }
@@ -185,7 +186,7 @@ func NewContext(opts *ContextOpts) (*Context, error) {
 		var err error
 		deps := ModuleTreeDependencies(opts.Module, state)
 		reqd := deps.AllPluginRequirements()
-		if opts.ProviderSHA256s != nil {
+		if opts.ProviderSHA256s != nil && !opts.SkipProviderVerify {
 			reqd.LockExecutables(opts.ProviderSHA256s)
 		}
 		providers, err = resourceProviderFactories(opts.ProviderResolver, reqd)


### PR DESCRIPTION
Skips checksum validation if the `TF_SKIP_PROVIDER_VERIFY` environment variable is set. Undocumented variable, as the primary goal is to significantly improve the local provider development workflow.