### PR TITLE
provider/alicloud: Remove 'device_name' from alicloud examples

### DIFF
--- a/examples/alicloud-ecs-image/main.tf
+++ b/examples/alicloud-ecs-image/main.tf
@@ -83,6 +83,5 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }
 

--- a/examples/alicloud-ecs-image/variables.tf
+++ b/examples/alicloud-ecs-image/variables.tf
@@ -32,7 +32,7 @@ variable "ecs_password" {
   default = "Test12345"
 }
 variable "availability_zones" {
-  default = "cn-beijing-b"
+  default = "cn-beijing-a"
 }
 variable "allocate_public_ip" {
   default = true
@@ -51,7 +51,4 @@ variable "disk_category" {
 }
 variable "disk_size" {
   default = "40"
-}
-variable "device_name" {
-  default = "/dev/xvdb"
 }

--- a/examples/alicloud-ecs-vpc/main.tf
+++ b/examples/alicloud-ecs-vpc/main.tf
@@ -39,7 +39,6 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }
 
 

--- a/examples/alicloud-ecs-vpc/variables.tf
+++ b/examples/alicloud-ecs-vpc/variables.tf
@@ -59,9 +59,6 @@ variable "disk_category" {
 variable "disk_size" {
   default = "40"
 }
-variable "device_name" {
-  default = "/dev/xvdb"
-}
 
 variable "vswitch_id" {
   default = ""

--- a/examples/alicloud-ecs/main.tf
+++ b/examples/alicloud-ecs/main.tf
@@ -72,5 +72,4 @@ resource "alicloud_disk_attachment" "instance-attachment" {
   count = "${var.count}"
   disk_id = "${element(alicloud_disk.disk.*.id, count.index)}"
   instance_id = "${element(alicloud_instance.instance.*.id, count.index)}"
-  device_name = "${var.device_name}"
 }

--- a/examples/alicloud-ecs/variables.tf
+++ b/examples/alicloud-ecs/variables.tf
@@ -47,9 +47,6 @@ variable "disk_category" {
 variable "disk_size" {
   default = "40"
 }
-variable "device_name" {
-  default = "/dev/xvdb"
-}
 
 variable "nic_type" {
   default = "internet"


### PR DESCRIPTION
The PR aims to remove 'device_name' from alicloud examples because of alicloud has decided to discard it from resource alicloud_disk_attachment. And disk's device would be specified automatically by system after attaching disks.