### PR TITLE
Update resource_provisioner.go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ install:
 - go get github.com/kardianos/govendor
 script:
 - make vendor-status
+- make fmt
 - make test
 - make vet
 - GOOS=windows go build

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -561,16 +561,16 @@ func (p *provisioner) configureVaultsFunc(gemCmd string, knifeCmd string, confDi
 		for vault, items := range p.Vaults {
 			for _, item := range items {
 				
-+				removeCmd := fmt.Sprintf("%s vault remove %s %s -C %s -M client %s",
-+					knifeCmd,
-+					vault,
-+					item,
-+					p.NodeName,
-+					options,
-+				)
-+				if err := p.runCommand(o, comm, removeCmd); err != nil {
-+					return err
-+				}
+				removeCmd := fmt.Sprintf("%s vault remove %s %s -C %s -M client %s",
+					knifeCmd,
+					vault,
+					item,
+					p.NodeName,
+					options,
+				)
+				if err := p.runCommand(o, comm, removeCmd); err != nil {
+					return err
+				}
 				
 				updateCmd := fmt.Sprintf("%s vault update %s %s -C %s -M client %s",
 					knifeCmd,

--- a/builtin/provisioners/chef/resource_provisioner.go
+++ b/builtin/provisioners/chef/resource_provisioner.go
@@ -560,6 +560,18 @@ func (p *provisioner) configureVaultsFunc(gemCmd string, knifeCmd string, confDi
 
 		for vault, items := range p.Vaults {
 			for _, item := range items {
+				
++				removeCmd := fmt.Sprintf("%s vault remove %s %s -C %s -M client %s",
++					knifeCmd,
++					vault,
++					item,
++					p.NodeName,
++					options,
++				)
++				if err := p.runCommand(o, comm, removeCmd); err != nil {
++					return err
++				}
+				
 				updateCmd := fmt.Sprintf("%s vault update %s %s -C %s -M client %s",
 					knifeCmd,
 					vault,

--- a/builtin/provisioners/chef/resource_provisioner_test.go
+++ b/builtin/provisioners/chef/resource_provisioner_test.go
@@ -339,6 +339,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", windowsGemCmd): true,
+				fmt.Sprintf("%s vault remove vault1 item1 -C nodename1 -M client -c %s/client.rb "+
+					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
+				fmt.Sprintf("%s vault remove vault1 item2 -C nodename1 -M client -c %s/client.rb "+
+					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item2 -C nodename1 -M client -c %s/client.rb "+

--- a/builtin/provisioners/chef/resource_provisioner_test.go
+++ b/builtin/provisioners/chef/resource_provisioner_test.go
@@ -269,6 +269,8 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", linuxGemCmd): true,
+				fmt.Sprintf("%s vault remove vault1 item1 -C nodename1 -M client -c %s/client.rb "+
+					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 			},
@@ -292,6 +294,10 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", linuxGemCmd): true,
+				fmt.Sprintf("%s vault remove vault1 item1 -C nodename1 -M client -c %s/client.rb "+
+					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
+				fmt.Sprintf("%s vault remove vault1 item2 -C nodename1 -M client -c %s/client.rb "+
+					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", linuxKnifeCmd, linuxConfDir, linuxConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item2 -C nodename1 -M client -c %s/client.rb "+
@@ -316,6 +322,8 @@ func TestResourceProvider_configureVaults(t *testing.T) {
 
 			Commands: map[string]bool{
 				fmt.Sprintf("%s install chef-vault", windowsGemCmd): true,
+				fmt.Sprintf("%s vault remove vault1 item1 -C nodename1 -M client -c %s/client.rb "+
+					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 				fmt.Sprintf("%s vault update vault1 item1 -C nodename1 -M client -c %s/client.rb "+
 					"-u bob --key %s/bob.pem", windowsKnifeCmd, windowsConfDir, windowsConfDir): true,
 			},


### PR DESCRIPTION
This patch allow to correctly update chef-vaults when chef node needs to be recreated. If client with old key exists in chef-vault it will try to remove it first and then will add node with new key