### PR TITLE
Fix a couple races

### DIFF
--- a/command/workspace_command_test.go
+++ b/command/workspace_command_test.go
@@ -74,14 +74,14 @@ func TestWorkspace_createAndList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newCmd := &WorkspaceNewCommand{}
-
 	envs := []string{"test_a", "test_b", "test_c"}
 
 	// create multiple workspaces
 	for _, env := range envs {
 		ui := new(cli.MockUi)
-		newCmd.Meta = Meta{Ui: ui}
+		newCmd := &WorkspaceNewCommand{
+			Meta: Meta{Ui: ui},
+		}
 		if code := newCmd.Run([]string{env}); code != 0 {
 			t.Fatalf("bad: %d\n\n%s", code, ui.ErrorWriter)
 		}
@@ -179,14 +179,14 @@ func TestWorkspace_createInvalid(t *testing.T) {
 	defer os.RemoveAll(td)
 	defer testChdir(t, td)()
 
-	newCmd := &WorkspaceNewCommand{}
-
 	envs := []string{"test_a*", "test_b/foo", "../../../test_c", "好_d"}
 
 	// create multiple workspaces
 	for _, env := range envs {
 		ui := new(cli.MockUi)
-		newCmd.Meta = Meta{Ui: ui}
+		newCmd := &WorkspaceNewCommand{
+			Meta: Meta{Ui: ui},
+		}
 		if code := newCmd.Run([]string{env}); code == 0 {
 			t.Fatalf("expected failure: \n%s", ui.OutputWriter)
 		}

--- a/helper/shadow/value.go
+++ b/helper/shadow/value.go
@@ -26,6 +26,14 @@ type Value struct {
 	valueSet bool
 }
 
+func (v *Value) Lock() {
+	v.lock.Lock()
+}
+
+func (v *Value) Unlock() {
+	v.lock.Unlock()
+}
+
 // Close closes the value. This can never fail. For a definition of
 // "close" see the struct docs.
 func (w *Value) Close() error {


### PR DESCRIPTION
Nothing major in the primary code path.

Some tests that shouldn't have been reusing a struct value were causing a race with the improved error scanner loop.

shadow.Value was being copied without a lock by copystructure. 